### PR TITLE
[perf] Test mimalloc 2.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "curl"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,12 +1393,6 @@ name = "fs-err"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64db3e262960f0662f43a6366788d5f10f7f244b8f7d7d987f560baf5ded5c50"
-
-[[package]]
-name = "fs_extra"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 
 [[package]]
 name = "futf"
@@ -1868,17 +1868,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.0+5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f655c3ecfa6b0d03634595b4b54551d4bd5ac208b9e0124873949a7ab168f70b"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +1990,16 @@ name = "libm"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc093ab289b0bfda3aa1bdfab9c9542be29c7ef385cfcbe77f8c9813588eb48"
+dependencies = [
+ "cc",
+ "cty",
+]
 
 [[package]]
 name = "libnghttp2-sys"
@@ -3070,7 +3069,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 name = "rustc-main"
 version = "0.0.0"
 dependencies = [
- "jemalloc-sys",
+ "libmimalloc-sys",
  "rustc_codegen_ssa",
  "rustc_driver",
  "rustc_smir",

--- a/compiler/rustc/Cargo.toml
+++ b/compiler/rustc/Cargo.toml
@@ -13,13 +13,19 @@ rustc_codegen_ssa = { path = "../rustc_codegen_ssa" }
 # crate is intended to be used by stable MIR consumers, which are not in-tree
 rustc_smir = { path = "../rustc_smir" }
 
-[dependencies.jemalloc-sys]
-version = "0.5.0"
+# [dependencies.jemalloc-sys]
+# version = "0.5.0"
+# optional = true
+# features = ['unprefixed_malloc_on_supported_platforms']
+
+[dependencies.libmimalloc-sys]
+version = '0.1.26'
 optional = true
-features = ['unprefixed_malloc_on_supported_platforms']
+default-features = false
+features = ['extended', 'override']
 
 [features]
-jemalloc = ['jemalloc-sys']
+jemalloc = ['libmimalloc-sys']
 llvm = ['rustc_driver/llvm']
 max_level_info = ['rustc_driver/max_level_info']
 rustc_use_parallel_compiler = ['rustc_driver/rustc_use_parallel_compiler']

--- a/compiler/rustc/src/main.rs
+++ b/compiler/rustc/src/main.rs
@@ -28,37 +28,25 @@
 #[unix_sigpipe = "sig_dfl"]
 fn main() {
     // See the comment at the top of this file for an explanation of this.
-    #[cfg(feature = "jemalloc-sys")]
+    #[cfg(feature = "libmimalloc-sys")]
     {
         use std::os::raw::{c_int, c_void};
 
         #[used]
-        static _F1: unsafe extern "C" fn(usize, usize) -> *mut c_void = jemalloc_sys::calloc;
+        static _F1: unsafe extern "C" fn(usize, usize) -> *mut c_void = libmimalloc_sys::mi_calloc;
         #[used]
         static _F2: unsafe extern "C" fn(*mut *mut c_void, usize, usize) -> c_int =
-            jemalloc_sys::posix_memalign;
+            libmimalloc_sys::mi_posix_memalign;
         #[used]
-        static _F3: unsafe extern "C" fn(usize, usize) -> *mut c_void = jemalloc_sys::aligned_alloc;
+        static _F3: unsafe extern "C" fn(usize, usize) -> *mut c_void =
+            libmimalloc_sys::mi_aligned_alloc;
         #[used]
-        static _F4: unsafe extern "C" fn(usize) -> *mut c_void = jemalloc_sys::malloc;
+        static _F4: unsafe extern "C" fn(usize) -> *mut c_void = libmimalloc_sys::mi_malloc;
         #[used]
-        static _F5: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void = jemalloc_sys::realloc;
+        static _F5: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void =
+            libmimalloc_sys::mi_realloc;
         #[used]
-        static _F6: unsafe extern "C" fn(*mut c_void) = jemalloc_sys::free;
-
-        // On OSX, jemalloc doesn't directly override malloc/free, but instead
-        // registers itself with the allocator's zone APIs in a ctor. However,
-        // the linker doesn't seem to consider ctors as "used" when statically
-        // linking, so we need to explicitly depend on the function.
-        #[cfg(target_os = "macos")]
-        {
-            extern "C" {
-                fn _rjem_je_zone_register();
-            }
-
-            #[used]
-            static _F7: unsafe extern "C" fn() = _rjem_je_zone_register;
-        }
+        static _F6: unsafe extern "C" fn(*mut c_void) = libmimalloc_sys::mi_free;
     }
 
     rustc_driver::main()

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -65,7 +65,7 @@ extern crate test;
 // See docs in https://github.com/rust-lang/rust/blob/master/compiler/rustc/src/main.rs
 // about jemalloc.
 #[cfg(feature = "jemalloc")]
-extern crate jemalloc_sys;
+extern crate libmimalloc_sys;
 
 use std::default::Default;
 use std::env::{self, VarError};
@@ -130,28 +130,20 @@ pub fn main() {
         use std::os::raw::{c_int, c_void};
 
         #[used]
-        static _F1: unsafe extern "C" fn(usize, usize) -> *mut c_void = jemalloc_sys::calloc;
+        static _F1: unsafe extern "C" fn(usize, usize) -> *mut c_void = libmimalloc_sys::mi_calloc;
         #[used]
         static _F2: unsafe extern "C" fn(*mut *mut c_void, usize, usize) -> c_int =
-            jemalloc_sys::posix_memalign;
+            libmimalloc_sys::mi_posix_memalign;
         #[used]
-        static _F3: unsafe extern "C" fn(usize, usize) -> *mut c_void = jemalloc_sys::aligned_alloc;
+        static _F3: unsafe extern "C" fn(usize, usize) -> *mut c_void =
+            libmimalloc_sys::mi_aligned_alloc;
         #[used]
-        static _F4: unsafe extern "C" fn(usize) -> *mut c_void = jemalloc_sys::malloc;
+        static _F4: unsafe extern "C" fn(usize) -> *mut c_void = libmimalloc_sys::mi_malloc;
         #[used]
-        static _F5: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void = jemalloc_sys::realloc;
+        static _F5: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void =
+            libmimalloc_sys::mi_realloc;
         #[used]
-        static _F6: unsafe extern "C" fn(*mut c_void) = jemalloc_sys::free;
-
-        #[cfg(target_os = "macos")]
-        {
-            extern "C" {
-                fn _rjem_je_zone_register();
-            }
-
-            #[used]
-            static _F7: unsafe extern "C" fn() = _rjem_je_zone_register;
-        }
+        static _F6: unsafe extern "C" fn(*mut c_void) = libmimalloc_sys::mi_free;
     }
 
     rustc_driver::install_ice_hook();


### PR DESCRIPTION
Last time we tried mimalloc:
- we were comparing to a different release of jemalloc
- the 1.x version of mimalloc had interesting performance characteristics but max-rss regressions, that were supposed to be fixed in 2.x, which was apparently in beta at the time.

We'd like to have more up-to-date numbers for comparison. (My expectations: some perf improvements, but similar max-rss regressions as last time)