### PR TITLE
Fix ICE when negative impl is collected during eager mono

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1336,6 +1336,10 @@ fn create_mono_items_for_default_impls<'tcx>(
 ) {
     match item.kind {
         hir::ItemKind::Impl(ref impl_) => {
+            if matches!(impl_.polarity, hir::ImplPolarity::Negative(_)) {
+                return;
+            }
+
             for param in impl_.generics.params {
                 match param.kind {
                     hir::GenericParamKind::Lifetime { .. } => {}

--- a/src/test/ui/traits/negative-impls/eager-mono.rs
+++ b/src/test/ui/traits/negative-impls/eager-mono.rs
@@ -1,0 +1,12 @@
+// build-pass
+// compile-flags:-C link-dead-code=y
+
+#![feature(negative_impls)]
+
+trait Foo {
+    fn foo() {}
+}
+
+impl !Foo for () {}
+
+fn main() {}


### PR DESCRIPTION
```rust
trait Foo {
    fn foo() {}
}

impl !Foo for () {}
```

This code will currently cause an ICE when mono collection mode is "eager" (with `-C link-dead-code=y` or `-Z print-mono-items=eager`.