### PR TITLE
Make mir opt unused file check blessable

### DIFF
--- a/src/tools/tidy/src/mir_opt_tests.rs
+++ b/src/tools/tidy/src/mir_opt_tests.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-fn check_unused_files(path: &Path, bad: &mut bool) {
+fn check_unused_files(path: &Path, bless: bool, bad: &mut bool) {
     let mut rs_files = Vec::<PathBuf>::new();
     let mut output_files = HashSet::<PathBuf>::new();
     let files = walkdir::WalkDir::new(&path.join("test/mir-opt")).into_iter();
@@ -27,11 +27,15 @@ fn check_unused_files(path: &Path, bad: &mut bool) {
 
     for extra in output_files {
         if extra.file_name() != Some("README.md".as_ref()) {
-            tidy_error!(
-                bad,
-                "the following output file is not associated with any mir-opt test, you can remove it: {}",
-                extra.display()
-            );
+            if !bless {
+                tidy_error!(
+                    bad,
+                    "the following output file is not associated with any mir-opt test, you can remove it: {}",
+                    extra.display()
+                );
+            } else {
+                let _ = std::fs::remove_file(extra);
+            }
         }
     }
 }
@@ -65,6 +69,6 @@ fn check_dash_files(path: &Path, bless: bool, bad: &mut bool) {
 }
 
 pub fn check(path: &Path, bless: bool, bad: &mut bool) {
-    check_unused_files(path, bad);
+    check_unused_files(path, bless, bad);
     check_dash_files(path, bless, bad);
 }


### PR DESCRIPTION
Makes it slightly nicer to work with.

Can't write automated test but tested locally via

```
$ touch src/test/mir-opt/random
$ x test tidy // shows failure
$ x test tidy --bless // file gone
```

r? @jyn514 