### PR TITLE
Add `Identity` lang item

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -165,7 +165,7 @@ language_item_table! {
     DynMetadata,             sym::dyn_metadata,        dyn_metadata,               Target::Struct,         GenericRequirement::None;
 
     Freeze,                  sym::freeze,              freeze_trait,               Target::Trait,          GenericRequirement::Exact(0);
-    Identity,                sym::identity,            identity_trait,             Target::Trait,          GenericRequirement::Exact(0);
+    Identity,                sym::identity,            identity_type,             Target::AssocTy,          GenericRequirement::None;
 
     Drop,                    sym::drop,                drop_trait,                 Target::Trait,          GenericRequirement::None;
     Destruct,                sym::destruct,            destruct_trait,             Target::Trait,          GenericRequirement::None;

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -165,6 +165,7 @@ language_item_table! {
     DynMetadata,             sym::dyn_metadata,        dyn_metadata,               Target::Struct,         GenericRequirement::None;
 
     Freeze,                  sym::freeze,              freeze_trait,               Target::Trait,          GenericRequirement::Exact(0);
+    Identity,                sym::identity,            identity_trait,             Target::Trait,          GenericRequirement::Exact(0);
 
     Drop,                    sym::drop,                drop_trait,                 Target::Trait,          GenericRequirement::None;
     Destruct,                sym::destruct,            destruct_trait,             Target::Trait,          GenericRequirement::None;

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -2630,7 +2630,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 assert_eq!(opt_self_ty, None);
                 self.prohibit_generics(path.segments.split_last().unwrap().1.iter(), |_| {});
 
-                if let Some(identity_def_id) = tcx.lang_items().identity_type() {
+                if let Some(identity_def_id) = tcx.lang_items().identity_type() && std::env::var("TEST_WITH_IDENTITY").is_ok() {
                     let item_segment = path.segments.split_last().unwrap();
 
                     let substs = self.ast_path_substs_for_ty(span, def_id, item_segment.0);

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -790,6 +790,7 @@ symbols! {
         i64,
         i8,
         ident,
+        identity,
         identity_future,
         if_let,
         if_let_guard,

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -786,11 +786,15 @@ unsafe impl<T: ?Sized> Freeze for &mut T {}
 /// // becomes:
 /// type Foo = <Bar as Identity>::Identity;
 /// ```
-pub(crate) trait Identity: Sized {
+#[stable(feature = "pin", since = "1.33.0")]
+pub trait Identity: Sized {
     #[cfg_attr(not(bootstrap), lang = "identity")]
+    #[stable(feature = "pin", since = "1.33.0")]
+    /// lol
     type Identity;
 }
 
+#[stable(feature = "pin", since = "1.33.0")]
 impl<T> Identity for T {
     type Identity = T;
 }

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -787,15 +787,15 @@ unsafe impl<T: ?Sized> Freeze for &mut T {}
 /// type Foo = <Bar as Identity>::Identity;
 /// ```
 #[stable(feature = "pin", since = "1.33.0")]
-pub trait Identity: Sized {
+pub trait Identity {
     #[cfg_attr(not(bootstrap), lang = "identity")]
     #[stable(feature = "pin", since = "1.33.0")]
-    /// lol
-    type Identity;
+    /// doc
+    type Identity: ?Sized;
 }
 
 #[stable(feature = "pin", since = "1.33.0")]
-impl<T> Identity for T {
+impl<T: ?Sized> Identity for T {
     type Identity = T;
 }
 

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -779,6 +779,22 @@ unsafe impl<T: ?Sized> Freeze for *mut T {}
 unsafe impl<T: ?Sized> Freeze for &T {}
 unsafe impl<T: ?Sized> Freeze for &mut T {}
 
+/// Compiler-internal trait used to handle more easily trait aliases.
+/// They get generated like projections. For example:
+/// ```ignore (pseudo-code)
+/// type Foo = Bar;
+/// // becomes:
+/// type Foo = <Bar as Identity>::Identity;
+/// ```
+pub(crate) trait Identity: Sized {
+    #[cfg_attr(not(bootstrap), lang = "identity")]
+    type Identity;
+}
+
+impl<T> Identity for T {
+    type Identity = T;
+}
+
 /// Types that can be safely moved after being pinned.
 ///
 /// Rust itself has no notion of immovable types, and considers moves (e.g.,


### PR DESCRIPTION
This is another approach for https://github.com/rust-lang/rust/pull/97974 suggested by @oli-obk.

The plan with this is then to add the `TyAlias` variant into the rustc_type_ir `TyKind` enum.

cc @compiler-errors

r? @oli-obk