### PR TITLE
Fix search result bottom border color

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -886,7 +886,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	/* A little margin ensures the browser's outlining of focused links has room to display. */
 	margin-left: 2px;
 	margin-right: 2px;
-	border-bottom: 1px solid var(--border-color);
+	border-bottom: 1px solid var(--search-result-border-color);
 	gap: 1em;
 }
 

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -38,6 +38,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--sidebar-link-color: #53b1db;
 	--sidebar-current-link-background-color: transparent;
 	--search-result-link-focus-background-color: #3c3c3c;
+	--search-result-border-color: #aaa3;
 	--stab-background-color: #314559;
 	--stab-code-color: #e6e1cf;
 	--search-color: #fff;

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -33,6 +33,7 @@
 	--sidebar-link-color: #fdbf35;
 	--sidebar-current-link-background-color: #444;
 	--search-result-link-focus-background-color: #616161;
+	--search-result-border-color: #aaa3;
 	--stab-background-color: #314559;
 	--stab-code-color: #e6e1cf;
 	--search-color: #111;

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -33,6 +33,7 @@
 	--sidebar-link-color: #356da4;
 	--sidebar-current-link-background-color: #fff;
 	--search-result-link-focus-background-color: #ccc;
+	--search-result-border-color: #aaa3;
 	--stab-background-color: #fff5d6;
 	--stab-code-color: #000;
 	--search-color: #000;

--- a/src/test/rustdoc-gui/search-result-color.goml
+++ b/src/test/rustdoc-gui/search-result-color.goml
@@ -78,7 +78,7 @@ assert-css: (
 // Checking the color of the bottom border.
 assert-css: (
     ".search-results > a",
-    {"border-bottom-color": "rgb(92, 103, 115)"}
+    {"border-bottom-color": "rgba(170, 170, 170, 0.2)"}
 )
 
 // Checking the color of "keyword" text.
@@ -190,7 +190,7 @@ assert-css: (
 // Checking the color of the bottom border.
 assert-css: (
     ".search-results > a",
-    {"border-bottom-color": "rgb(224, 224, 224)"}
+    {"border-bottom-color": "rgba(170, 170, 170, 0.2)"}
 )
 
 // Checking the color for "keyword" text.
@@ -287,7 +287,7 @@ assert-css: (
 // Checking the color of the bottom border.
 assert-css: (
     ".search-results > a",
-    {"border-bottom-color": "rgb(224, 224, 224)"}
+    {"border-bottom-color": "rgba(170, 170, 170, 0.2)"}
 )
 
 // Checking the color for "keyword" text.


### PR DESCRIPTION
It reverts a color change while keeping the improvement made in #103938.

I think it'll need to be backported once merged too.

r? @notriddle 