### PR TITLE
Fix build of std for thumbv7a-pc-windows-msvc

### DIFF
--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -42,7 +42,8 @@ cfg_if::cfg_if! {
         // L4Re is unix family but does not yet support unwinding.
         #[path = "dummy.rs"]
         mod real_imp;
-    } else if #[cfg(target_env = "msvc")] {
+    } else if #[cfg(all(target_env = "msvc", not(target_arch = "arm")))] {
+        // LLVM does not support unwinding on 32 bit ARM msvc (thumbv7a-pc-windows-msvc)
         #[path = "seh.rs"]
         mod real_imp;
     } else if #[cfg(any(


### PR DESCRIPTION
Attempting to build std for the tier-3 target `thumbv7a-pc-windows-msvc` fails with the following error:
```
Building stage1 std artifacts (x86_64-pc-windows-msvc -> thumbv7a-pc-windows-msvc)
..
LLVM ERROR: WinEH not implemented for this target
error: could not compile `panic_unwind`
```

EH (unwinding) is not supported by LLVM for 32 bit arm msvc targets. This changes panic unwind to use the dummy implementation for `thumbv7a-pc-windows-msvc`.