### PR TITLE
Specify that `break` cannot be used outside of loop *or* labeled block

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -451,8 +451,14 @@ passes_break_inside_async_block =
     .async_block_label = enclosing `async` block
 
 passes_outside_loop =
-    `{$name}` outside of a loop
-    .label = cannot `{$name}` outside of a loop
+    `{$name}` outside of a loop{$is_break ->
+        [true] {" or labeled block"}
+        *[false] {""}
+    }
+    .label = cannot `{$name}` outside of a loop{$is_break ->
+        [true] {" or labeled block"}
+        *[false] {""}
+    }
 
 passes_unlabeled_in_labeled_block =
     unlabeled `{$cf_type}` inside of a labeled block

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -956,6 +956,7 @@ pub struct OutsideLoop<'a> {
     #[label]
     pub span: Span,
     pub name: &'a str,
+    pub is_break: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_passes/src/loops.rs
+++ b/compiler/rustc_passes/src/loops.rs
@@ -193,7 +193,7 @@ impl<'a, 'hir> CheckLoopVisitor<'a, 'hir> {
                 self.sess.emit_err(BreakInsideAsyncBlock { span, closure_span, name });
             }
             Normal | AnonConst => {
-                self.sess.emit_err(OutsideLoop { span, name });
+                self.sess.emit_err(OutsideLoop { span, name, is_break: name == "break" });
             }
         }
     }

--- a/src/test/ui/array-slice-vec/array-break-length.stderr
+++ b/src/test/ui/array-slice-vec/array-break-length.stderr
@@ -1,8 +1,8 @@
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/array-break-length.rs:3:17
    |
 LL |         |_: [_; break]| {}
-   |                 ^^^^^ cannot `break` outside of a loop
+   |                 ^^^^^ cannot `break` outside of a loop or labeled block
 
 error[E0268]: `continue` outside of a loop
   --> $DIR/array-break-length.rs:7:17

--- a/src/test/ui/closures/closure-array-break-length.stderr
+++ b/src/test/ui/closures/closure-array-break-length.stderr
@@ -10,11 +10,11 @@ error[E0268]: `continue` outside of a loop
 LL |     while |_: [_; continue]| {} {}
    |                   ^^^^^^^^ cannot `continue` outside of a loop
 
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/closure-array-break-length.rs:6:19
    |
 LL |     while |_: [_; break]| {} {}
-   |                   ^^^^^ cannot `break` outside of a loop
+   |                   ^^^^^ cannot `break` outside of a loop or labeled block
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/error-codes/E0268.stderr
+++ b/src/test/ui/error-codes/E0268.stderr
@@ -1,8 +1,8 @@
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/E0268.rs:2:5
    |
 LL |     break;
-   |     ^^^^^ cannot `break` outside of a loop
+   |     ^^^^^ cannot `break` outside of a loop or labeled block
 
 error: aborting due to previous error
 

--- a/src/test/ui/for-loop-while/break-outside-loop.stderr
+++ b/src/test/ui/for-loop-while/break-outside-loop.stderr
@@ -9,11 +9,11 @@ LL |             break 'lab;
    |
    = note: labels are unreachable through functions, closures, async blocks and modules
 
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/break-outside-loop.rs:10:15
    |
 LL |     let pth = break;
-   |               ^^^^^ cannot `break` outside of a loop
+   |               ^^^^^ cannot `break` outside of a loop or labeled block
 
 error[E0268]: `continue` outside of a loop
   --> $DIR/break-outside-loop.rs:11:17
@@ -38,11 +38,11 @@ LL |             if cond() { break }
 LL |             if cond() { continue }
    |                         ^^^^^^^^ cannot `continue` inside of a closure
 
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/break-outside-loop.rs:24:25
    |
 LL |     let unconstrained = break;
-   |                         ^^^^^ cannot `break` outside of a loop
+   |                         ^^^^^ cannot `break` outside of a loop or labeled block
 
 error[E0267]: `break` inside of a closure
   --> $DIR/break-outside-loop.rs:30:13

--- a/src/test/ui/issues/issue-28105.stderr
+++ b/src/test/ui/issues/issue-28105.stderr
@@ -4,11 +4,11 @@ error[E0268]: `continue` outside of a loop
 LL |     continue
    |     ^^^^^^^^ cannot `continue` outside of a loop
 
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/issue-28105.rs:6:5
    |
 LL |     break
-   |     ^^^^^ cannot `break` outside of a loop
+   |     ^^^^^ cannot `break` outside of a loop or labeled block
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -1,14 +1,14 @@
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/issue-43162.rs:3:5
    |
 LL |     break true;
-   |     ^^^^^^^^^^ cannot `break` outside of a loop
+   |     ^^^^^^^^^^ cannot `break` outside of a loop or labeled block
 
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/issue-43162.rs:7:5
    |
 LL |     break {};
-   |     ^^^^^^^^ cannot `break` outside of a loop
+   |     ^^^^^^^^ cannot `break` outside of a loop or labeled block
 
 error[E0308]: mismatched types
   --> $DIR/issue-43162.rs:1:13

--- a/src/test/ui/issues/issue-50576.stderr
+++ b/src/test/ui/issues/issue-50576.stderr
@@ -4,17 +4,17 @@ error[E0426]: use of undeclared label `'L`
 LL |     |bool: [u8; break 'L]| 0;
    |                       ^^ undeclared label `'L`
 
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/issue-50576.rs:2:17
    |
 LL |     |bool: [u8; break 'L]| 0;
-   |                 ^^^^^^^^ cannot `break` outside of a loop
+   |                 ^^^^^^^^ cannot `break` outside of a loop or labeled block
 
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/issue-50576.rs:5:16
    |
 LL |     Vec::<[u8; break]>::new();
-   |                ^^^^^ cannot `break` outside of a loop
+   |                ^^^^^ cannot `break` outside of a loop or labeled block
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-50581.stderr
+++ b/src/test/ui/issues/issue-50581.stderr
@@ -1,8 +1,8 @@
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/issue-50581.rs:2:14
    |
 LL |     |_: [u8; break]| ();
-   |              ^^^^^ cannot `break` outside of a loop
+   |              ^^^^^ cannot `break` outside of a loop or labeled block
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-83048.rs
+++ b/src/test/ui/issues/issue-83048.rs
@@ -1,5 +1,5 @@
 // compile-flags: -Z unpretty=thir-tree
 
 pub fn main() {
-    break; //~ ERROR: `break` outside of a loop [E0268]
+    break; //~ ERROR: `break` outside of a loop or labeled block [E0268]
 }

--- a/src/test/ui/issues/issue-83048.stderr
+++ b/src/test/ui/issues/issue-83048.stderr
@@ -1,8 +1,8 @@
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/issue-83048.rs:4:5
    |
 LL |     break;
-   |     ^^^^^ cannot `break` outside of a loop
+   |     ^^^^^ cannot `break` outside of a loop or labeled block
 
 error: aborting due to previous error
 

--- a/src/test/ui/track-diagnostics/track.stderr
+++ b/src/test/ui/track-diagnostics/track.stderr
@@ -5,11 +5,11 @@ LL |     break rust
    |           ^^^^ not found in this scope
 -Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:LL:CC
 
-error[E0268]: `break` outside of a loop
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/track.rs:LL:CC
    |
 LL |     break rust
-   |     ^^^^^^^^^^ cannot `break` outside of a loop
+   |     ^^^^^^^^^^ cannot `break` outside of a loop or labeled block
 -Ztrack-diagnostics: created at compiler/rustc_passes/src/loops.rs:LL:CC
 
 error: internal compiler error: It looks like you're trying to break rust; would you like some ICE?


### PR DESCRIPTION
Closes #103981

@rustbot label +A-diagnostics