### PR TITLE
Enable internal feature when testing Clippy

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -694,7 +694,11 @@ impl Step for Clippy {
         let compiler = builder.compiler(stage, host);
 
         builder
-            .ensure(tool::Clippy { compiler, target: self.host, extra_features: Vec::new() })
+            .ensure(tool::Clippy {
+                compiler,
+                target: self.host,
+                extra_features: vec!["internal".into()],
+            })
             .expect("in-tree tool");
         let mut cargo = tool::prepare_tool_cargo(
             builder,
@@ -704,7 +708,7 @@ impl Step for Clippy {
             "test",
             "src/tools/clippy",
             SourceType::InTree,
-            &[],
+            &["internal".into()],
         );
 
         cargo.env("RUSTC_TEST_SUITE", builder.rustc(compiler));

--- a/src/tools/clippy/tests/ui-internal/unnecessary_def_path_hardcoded_path.stderr
+++ b/src/tools/clippy/tests/ui-internal/unnecessary_def_path_hardcoded_path.stderr
@@ -1,12 +1,3 @@
-error: hardcoded path to a language item
-  --> $DIR/unnecessary_def_path_hardcoded_path.rs:11:40
-   |
-LL |     const DEREF_MUT_TRAIT: [&str; 4] = ["core", "ops", "deref", "DerefMut"];
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: convert all references to use `LangItem::DerefMut`
-   = note: `-D clippy::unnecessary-def-path` implied by `-D warnings`
-
 error: hardcoded path to a diagnostic item
   --> $DIR/unnecessary_def_path_hardcoded_path.rs:10:36
    |
@@ -14,6 +5,7 @@ LL |     const DEREF_TRAIT: [&str; 4] = ["core", "ops", "deref", "Deref"];
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: convert all references to use `sym::Deref`
+   = note: `-D clippy::unnecessary-def-path` implied by `-D warnings`
 
 error: hardcoded path to a diagnostic item
   --> $DIR/unnecessary_def_path_hardcoded_path.rs:12:43
@@ -22,6 +14,14 @@ LL |     const DEREF_TRAIT_METHOD: [&str; 5] = ["core", "ops", "deref", "Deref",
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: convert all references to use `sym::deref_method`
+
+error: hardcoded path to a language item
+  --> $DIR/unnecessary_def_path_hardcoded_path.rs:11:40
+   |
+LL |     const DEREF_MUT_TRAIT: [&str; 4] = ["core", "ops", "deref", "DerefMut"];
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: convert all references to use `LangItem::DerefMut`
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Clippy has internal lints, that only get build and tested, when the `internal` feature is enabled. Those tests are just regular UI tests, but split out from the normal UI tests, because they usually don't have to be touched when changing something in Clippy. However, changes to Rust internals often require updates of the internal lints, just as for the Rest of the Clippy codebase. Currently I fix this fallout during the sync. But this can lead to sync blockers in rare occasions.

Blocked on #104006, because it will fail Clippy build/tests until that is merged.

This will prevent fallouts like the one in https://github.com/rust-lang/rust/pull/103603

r? @jyn514 