### PR TITLE
Improve unexpected close and mismatch delimiter hint in TokenTreesReader

### DIFF
--- a/compiler/rustc_parse/src/lexer/diagnostics.rs
+++ b/compiler/rustc_parse/src/lexer/diagnostics.rs
@@ -1,0 +1,119 @@
+use super::UnmatchedBrace;
+use rustc_ast::token::Delimiter;
+use rustc_errors::Diagnostic;
+use rustc_span::source_map::SourceMap;
+use rustc_span::Span;
+
+#[derive(Default)]
+pub struct TokenTreeDiagInfo {
+    /// Stack of open delimiters and their spans. Used for error message.
+    pub open_braces: Vec<(Delimiter, Span)>,
+    pub unmatched_braces: Vec<UnmatchedBrace>,
+
+    /// Used only for error recovery when arriving to EOF with mismatched braces.
+    pub last_unclosed_found_span: Option<Span>,
+
+    /// Collect empty block spans that might have been auto-inserted by editors.
+    pub empty_block_spans: Vec<Span>,
+
+    /// Collect the spans of braces (Open, Close). Used only
+    /// for detecting if blocks are empty and only braces.
+    pub matching_block_spans: Vec<(Span, Span)>,
+}
+
+pub fn same_identation_level(sm: &SourceMap, open_sp: Span, close_sp: Span) -> bool {
+    match (sm.span_to_margin(open_sp), sm.span_to_margin(close_sp)) {
+        (Some(open_padding), Some(close_padding)) => open_padding == close_padding,
+        _ => false,
+    }
+}
+
+// When we get a `)` or `]` for `{`, we should emit help message here
+// it's more friendly compared to report `unmatched error` in later phase
+pub fn report_missing_open_delim(
+    err: &mut Diagnostic,
+    unmatched_braces: &[UnmatchedBrace],
+) -> bool {
+    let mut reported_missing_open = false;
+    for unmatch_brace in unmatched_braces.iter() {
+        if let Some(delim) = unmatch_brace.found_delim
+            && matches!(delim, Delimiter::Parenthesis | Delimiter::Bracket)
+        {
+            let missed_open = match delim {
+                Delimiter::Parenthesis => "(",
+                Delimiter::Bracket => "[",
+                _ => unreachable!(),
+            };
+            err.span_label(
+                unmatch_brace.found_span.shrink_to_lo(),
+                format!("missing open `{}` for this delimiter", missed_open),
+            );
+            reported_missing_open = true;
+        }
+    }
+    reported_missing_open
+}
+
+pub fn report_suspicious_mismatch_block(
+    err: &mut Diagnostic,
+    diag_info: &TokenTreeDiagInfo,
+    sm: &SourceMap,
+    delim: Delimiter,
+) {
+    if report_missing_open_delim(err, &diag_info.unmatched_braces) {
+        return;
+    }
+
+    let mut matched_spans: Vec<(Span, bool)> = diag_info
+        .matching_block_spans
+        .iter()
+        .map(|&(open, close)| (open.with_hi(close.lo()), same_identation_level(sm, open, close)))
+        .collect();
+
+    // sort by `lo`, so the large block spans in the front
+    matched_spans.sort_by(|a, b| a.0.lo().cmp(&b.0.lo()));
+
+    // We use larger block whose identation is well to cover those inner mismatched blocks
+    // O(N^2) here, but we are on error reporting path, so it is fine
+    for i in 0..matched_spans.len() {
+        let (block_span, same_ident) = matched_spans[i];
+        if same_ident {
+            for j in i + 1..matched_spans.len() {
+                let (inner_block, inner_same_ident) = matched_spans[j];
+                if block_span.contains(inner_block) && !inner_same_ident {
+                    matched_spans[j] = (inner_block, true);
+                }
+            }
+        }
+    }
+
+    // Find the inner-most span candidate for final report
+    let candidate_span =
+        matched_spans.into_iter().rev().find(|&(_, same_ident)| !same_ident).map(|(span, _)| span);
+
+    if let Some(block_span) = candidate_span {
+        err.span_label(block_span.shrink_to_lo(), "this delimiter might not be properly closed...");
+        err.span_label(
+            block_span.shrink_to_hi(),
+            "...as it matches this but it has different indentation",
+        );
+
+        // If there is a empty block in the mismatched span, note it
+        if delim == Delimiter::Brace {
+            for span in diag_info.empty_block_spans.iter() {
+                if block_span.contains(*span) {
+                    err.span_label(*span, "block is empty, you might have not meant to close it");
+                    break;
+                }
+            }
+        }
+    } else {
+        // If there is no suspicious span, give the last properly closed block may help
+        if let Some(parent) = diag_info.matching_block_spans.last()
+            && diag_info.open_braces.last().is_none()
+            && diag_info.empty_block_spans.iter().all(|&sp| sp != parent.0.to(parent.1)) {
+                err.span_label(parent.0, "this opening brace...");
+                err.span_label(parent.1, "...matches this closing brace");
+        }
+    }
+}

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -17,6 +17,7 @@ use rustc_session::parse::ParseSess;
 use rustc_span::symbol::{sym, Symbol};
 use rustc_span::{edition::Edition, BytePos, Pos, Span};
 
+mod diagnostics;
 mod tokentrees;
 mod unescape_error_reporting;
 mod unicode_chars;

--- a/tests/ui/parser/deli-ident-issue-1.rs
+++ b/tests/ui/parser/deli-ident-issue-1.rs
@@ -1,0 +1,25 @@
+// error-pattern: this file contains an unclosed delimiter
+#![feature(let_chains)]
+trait Demo {}
+
+impl dyn Demo {
+    pub fn report(&self) -> u32 {
+        let sum = |a: u32,
+                   b: u32,
+                   c: u32| {
+            a + b + c
+        };
+        sum(1, 2, 3)
+    }
+
+    fn check(&self, val: Option<u32>, num: Option<u32>) {
+        if let Some(b) = val
+        && let Some(c) = num {
+        && b == c {
+            //~^ ERROR expected struct
+            //~| ERROR mismatched types
+        }
+    }
+}
+
+fn main() { } //~ ERROR this file contains an unclosed delimiter

--- a/tests/ui/parser/deli-ident-issue-1.rs
+++ b/tests/ui/parser/deli-ident-issue-1.rs
@@ -1,4 +1,3 @@
-// error-pattern: this file contains an unclosed delimiter
 #![feature(let_chains)]
 trait Demo {}
 

--- a/tests/ui/parser/deli-ident-issue-1.stderr
+++ b/tests/ui/parser/deli-ident-issue-1.stderr
@@ -1,26 +1,26 @@
 error: this file contains an unclosed delimiter
-  --> $DIR/deli-ident-issue-1.rs:25:66
+  --> $DIR/deli-ident-issue-1.rs:24:66
    |
 LL | impl dyn Demo {
    |               - unclosed delimiter
 ...
-LL |                    c: u32| {
-   |                            - this delimiter might not be properly closed...
-LL |             a + b + c
-LL |         };
-   |         - ...as it matches this but it has different indentation
+LL |         && let Some(c) = num {
+   |                              - this delimiter might not be properly closed...
+...
+LL |     }
+   |     - ...as it matches this but it has different indentation
 ...
 LL | fn main() { }
    |                                                                  ^
 
 error[E0574]: expected struct, variant or union type, found local variable `c`
-  --> $DIR/deli-ident-issue-1.rs:18:17
+  --> $DIR/deli-ident-issue-1.rs:17:17
    |
 LL |         && b == c {
    |                 ^ not a struct, variant or union type
 
 error[E0308]: mismatched types
-  --> $DIR/deli-ident-issue-1.rs:18:9
+  --> $DIR/deli-ident-issue-1.rs:17:9
    |
 LL |       fn check(&self, val: Option<u32>, num: Option<u32>) {
    |                                                           - expected `()` because of default return type

--- a/tests/ui/parser/deli-ident-issue-1.stderr
+++ b/tests/ui/parser/deli-ident-issue-1.stderr
@@ -1,0 +1,37 @@
+error: this file contains an unclosed delimiter
+  --> $DIR/deli-ident-issue-1.rs:25:66
+   |
+LL | impl dyn Demo {
+   |               - unclosed delimiter
+...
+LL |                    c: u32| {
+   |                            - this delimiter might not be properly closed...
+LL |             a + b + c
+LL |         };
+   |         - ...as it matches this but it has different indentation
+...
+LL | fn main() { }
+   |                                                                  ^
+
+error[E0574]: expected struct, variant or union type, found local variable `c`
+  --> $DIR/deli-ident-issue-1.rs:18:17
+   |
+LL |         && b == c {
+   |                 ^ not a struct, variant or union type
+
+error[E0308]: mismatched types
+  --> $DIR/deli-ident-issue-1.rs:18:9
+   |
+LL |       fn check(&self, val: Option<u32>, num: Option<u32>) {
+   |                                                           - expected `()` because of default return type
+...
+LL | /         && b == c {
+LL | |
+LL | |
+LL | |         }
+   | |_________^ expected `()`, found `bool`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0574.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/parser/deli-ident-issue-2.rs
+++ b/tests/ui/parser/deli-ident-issue-2.rs
@@ -1,0 +1,7 @@
+fn main() {
+    if 1 < 2 {
+        let _a = vec!]; //~ ERROR mismatched closing delimiter
+    }
+} //~ ERROR unexpected closing delimiter
+
+fn main() {}

--- a/tests/ui/parser/deli-ident-issue-2.stderr
+++ b/tests/ui/parser/deli-ident-issue-2.stderr
@@ -1,0 +1,21 @@
+error: unexpected closing delimiter: `}`
+  --> $DIR/deli-ident-issue-2.rs:5:1
+   |
+LL | fn main() {
+   |           - this opening brace...
+...
+LL |     }
+   |     - ...matches this closing brace
+LL | }
+   | ^ unexpected closing delimiter
+
+error: mismatched closing delimiter: `]`
+  --> $DIR/deli-ident-issue-2.rs:2:14
+   |
+LL |     if 1 < 2 {
+   |              ^ unclosed delimiter
+LL |         let _a = vec!];
+   |                      ^ mismatched closing delimiter
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/parser/deli-ident-issue-2.stderr
+++ b/tests/ui/parser/deli-ident-issue-2.stderr
@@ -1,11 +1,9 @@
 error: unexpected closing delimiter: `}`
   --> $DIR/deli-ident-issue-2.rs:5:1
    |
-LL | fn main() {
-   |           - this opening brace...
-...
+LL |         let _a = vec!];
+   |                      - missing open `[` for this delimiter
 LL |     }
-   |     - ...matches this closing brace
 LL | }
    | ^ unexpected closing delimiter
 

--- a/tests/ui/parser/issue-68987-unmatch-issue-1.rs
+++ b/tests/ui/parser/issue-68987-unmatch-issue-1.rs
@@ -1,0 +1,12 @@
+// This file has unexpected closing delimiter,
+
+fn func(o: Option<u32>) {
+    match o {
+        Some(_x) => {}   // Extra '}'
+            let _ = if true {};
+        }
+        None => {}
+    }
+} //~ ERROR unexpected closing delimiter
+
+fn main() {}

--- a/tests/ui/parser/issue-68987-unmatch-issue-1.stderr
+++ b/tests/ui/parser/issue-68987-unmatch-issue-1.stderr
@@ -1,0 +1,11 @@
+error: unexpected closing delimiter: `}`
+  --> $DIR/issue-68987-unmatch-issue-1.rs:10:1
+   |
+LL |         None => {}
+   |                 -- block is empty, you might have not meant to close it
+LL |     }
+LL | }
+   | ^ unexpected closing delimiter
+
+error: aborting due to previous error
+

--- a/tests/ui/parser/issue-68987-unmatch-issue-1.stderr
+++ b/tests/ui/parser/issue-68987-unmatch-issue-1.stderr
@@ -1,9 +1,14 @@
 error: unexpected closing delimiter: `}`
   --> $DIR/issue-68987-unmatch-issue-1.rs:10:1
    |
-LL |         None => {}
-   |                 -- block is empty, you might have not meant to close it
-LL |     }
+LL |     match o {
+   |             - this delimiter might not be properly closed...
+LL |         Some(_x) => {}   // Extra '}'
+   |                     -- block is empty, you might have not meant to close it
+LL |             let _ = if true {};
+LL |         }
+   |         - ...as it matches this but it has different indentation
+...
 LL | }
    | ^ unexpected closing delimiter
 

--- a/tests/ui/parser/issue-68987-unmatch-issue-2.rs
+++ b/tests/ui/parser/issue-68987-unmatch-issue-2.rs
@@ -1,0 +1,14 @@
+// FIXME: this case need more work to fix
+// currently the TokenTree matching ')' with '{', which is not user friendly for diagnostics
+async fn obstest() -> Result<> {
+    let obs_connect = || -> Result<(), MyError) { //~ ERROR mismatched closing delimiter
+        async {
+        }
+    }
+
+    if let Ok(version, scene_list) = obs_connect() {
+
+    } else {
+
+    }
+} //~ ERROR unexpected closing delimiter

--- a/tests/ui/parser/issue-68987-unmatch-issue-2.stderr
+++ b/tests/ui/parser/issue-68987-unmatch-issue-2.stderr
@@ -1,11 +1,9 @@
 error: unexpected closing delimiter: `}`
   --> $DIR/issue-68987-unmatch-issue-2.rs:14:1
    |
-LL |     } else {
-   |            - this opening brace...
-LL |
-LL |     }
-   |     - ...matches this closing brace
+LL |     let obs_connect = || -> Result<(), MyError) {
+   |                                               - missing open `(` for this delimiter
+...
 LL | }
    | ^ unexpected closing delimiter
 

--- a/tests/ui/parser/issue-68987-unmatch-issue-2.stderr
+++ b/tests/ui/parser/issue-68987-unmatch-issue-2.stderr
@@ -1,0 +1,21 @@
+error: unexpected closing delimiter: `}`
+  --> $DIR/issue-68987-unmatch-issue-2.rs:14:1
+   |
+LL |     } else {
+   |            - this opening brace...
+LL |
+LL |     }
+   |     - ...matches this closing brace
+LL | }
+   | ^ unexpected closing delimiter
+
+error: mismatched closing delimiter: `)`
+  --> $DIR/issue-68987-unmatch-issue-2.rs:3:32
+   |
+LL | async fn obstest() -> Result<> {
+   |                                ^ unclosed delimiter
+LL |     let obs_connect = || -> Result<(), MyError) {
+   |                                               ^ mismatched closing delimiter
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/parser/issue-68987-unmatch-issue-3.rs
+++ b/tests/ui/parser/issue-68987-unmatch-issue-3.rs
@@ -1,0 +1,8 @@
+// the `{` is closed with `)`, there is a missing `(`
+fn f(i: u32, j: u32) {
+    let res = String::new();
+    let mut cnt = i;
+    while cnt < j {
+        write!&mut res, " "); //~ ERROR mismatched closing delimiter
+    }
+} //~ ERROR unexpected closing delimiter

--- a/tests/ui/parser/issue-68987-unmatch-issue-3.stderr
+++ b/tests/ui/parser/issue-68987-unmatch-issue-3.stderr
@@ -1,0 +1,21 @@
+error: unexpected closing delimiter: `}`
+  --> $DIR/issue-68987-unmatch-issue-3.rs:8:1
+   |
+LL | fn f(i: u32, j: u32) {
+   |                      - this opening brace...
+...
+LL |     }
+   |     - ...matches this closing brace
+LL | }
+   | ^ unexpected closing delimiter
+
+error: mismatched closing delimiter: `)`
+  --> $DIR/issue-68987-unmatch-issue-3.rs:5:19
+   |
+LL |     while cnt < j {
+   |                   ^ unclosed delimiter
+LL |         write!&mut res, " ");
+   |                            ^ mismatched closing delimiter
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/parser/issue-68987-unmatch-issue-3.stderr
+++ b/tests/ui/parser/issue-68987-unmatch-issue-3.stderr
@@ -1,11 +1,9 @@
 error: unexpected closing delimiter: `}`
   --> $DIR/issue-68987-unmatch-issue-3.rs:8:1
    |
-LL | fn f(i: u32, j: u32) {
-   |                      - this opening brace...
-...
+LL |         write!&mut res, " ");
+   |                            - missing open `(` for this delimiter
 LL |     }
-   |     - ...matches this closing brace
 LL | }
    | ^ unexpected closing delimiter
 

--- a/tests/ui/parser/issue-68987-unmatch-issue.rs
+++ b/tests/ui/parser/issue-68987-unmatch-issue.rs
@@ -1,0 +1,12 @@
+// This file has unexpected closing delimiter,
+
+fn func(o: Option<u32>) {
+    match o {
+        Some(_x) =>   // Missing '{'
+            let _ = if true {};
+        }
+        None => {}
+    }
+} //~ ERROR unexpected closing delimiter
+
+fn main() {}

--- a/tests/ui/parser/issue-68987-unmatch-issue.stderr
+++ b/tests/ui/parser/issue-68987-unmatch-issue.stderr
@@ -1,0 +1,11 @@
+error: unexpected closing delimiter: `}`
+  --> $DIR/issue-68987-unmatch-issue.rs:10:1
+   |
+LL |         None => {}
+   |                 -- block is empty, you might have not meant to close it
+LL |     }
+LL | }
+   | ^ unexpected closing delimiter
+
+error: aborting due to previous error
+

--- a/tests/ui/parser/issue-68987-unmatch-issue.stderr
+++ b/tests/ui/parser/issue-68987-unmatch-issue.stderr
@@ -1,9 +1,14 @@
 error: unexpected closing delimiter: `}`
   --> $DIR/issue-68987-unmatch-issue.rs:10:1
    |
-LL |         None => {}
-   |                 -- block is empty, you might have not meant to close it
-LL |     }
+LL |     match o {
+   |             - this delimiter might not be properly closed...
+LL |         Some(_x) =>   // Missing '{'
+LL |             let _ = if true {};
+   |                             -- block is empty, you might have not meant to close it
+LL |         }
+   |         - ...as it matches this but it has different indentation
+...
 LL | }
    | ^ unexpected closing delimiter
 

--- a/tests/ui/parser/issue-81827.stderr
+++ b/tests/ui/parser/issue-81827.stderr
@@ -2,8 +2,9 @@ error: this file contains an unclosed delimiter
   --> $DIR/issue-81827.rs:11:27
    |
 LL | fn r()->i{0|{#[cfg(r(0{]0
-   |          -  -             ^
-   |          |  |
+   |          -  -          -  ^
+   |          |  |          |
+   |          |  |          missing open `[` for this delimiter
    |          |  unclosed delimiter
    |          unclosed delimiter
 
@@ -11,8 +12,9 @@ error: this file contains an unclosed delimiter
   --> $DIR/issue-81827.rs:11:27
    |
 LL | fn r()->i{0|{#[cfg(r(0{]0
-   |          -  -             ^
-   |          |  |
+   |          -  -          -  ^
+   |          |  |          |
+   |          |  |          missing open `[` for this delimiter
    |          |  unclosed delimiter
    |          unclosed delimiter
 

--- a/tests/ui/parser/issues/issue-62973.stderr
+++ b/tests/ui/parser/issues/issue-62973.stderr
@@ -2,8 +2,10 @@ error: this file contains an unclosed delimiter
   --> $DIR/issue-62973.rs:8:2
    |
 LL | fn p() { match s { v, E { [) {) }
-   |        -         - unclosed delimiter
-   |        |
+   |        -         -         -  - missing open `(` for this delimiter
+   |        |         |         |
+   |        |         |         missing open `(` for this delimiter
+   |        |         unclosed delimiter
    |        unclosed delimiter
 LL |
 LL |
@@ -13,8 +15,10 @@ error: this file contains an unclosed delimiter
   --> $DIR/issue-62973.rs:8:2
    |
 LL | fn p() { match s { v, E { [) {) }
-   |        -         - unclosed delimiter
-   |        |
+   |        -         -         -  - missing open `(` for this delimiter
+   |        |         |         |
+   |        |         |         missing open `(` for this delimiter
+   |        |         unclosed delimiter
    |        unclosed delimiter
 LL |
 LL |

--- a/tests/ui/parser/issues/issue-63116.stderr
+++ b/tests/ui/parser/issues/issue-63116.stderr
@@ -2,8 +2,9 @@ error: this file contains an unclosed delimiter
   --> $DIR/issue-63116.rs:3:18
    |
 LL | impl W <s(f;Y(;]
-   |          -       ^
-   |          |
+   |          -     - ^
+   |          |     |
+   |          |     missing open `[` for this delimiter
    |          unclosed delimiter
 
 error: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `;`

--- a/tests/ui/parser/issues/issue-69259.rs
+++ b/tests/ui/parser/issues/issue-69259.rs
@@ -1,0 +1,3 @@
+fn main() {}
+
+fn f) {} //~ ERROR unexpected closing delimiter

--- a/tests/ui/parser/issues/issue-69259.stderr
+++ b/tests/ui/parser/issues/issue-69259.stderr
@@ -1,11 +1,6 @@
 error: unexpected closing delimiter: `)`
   --> $DIR/issue-69259.rs:3:5
    |
-LL | fn main() {}
-   |           -- ...matches this closing brace
-   |           |
-   |           this opening brace...
-LL |
 LL | fn f) {}
    |     ^ unexpected closing delimiter
 

--- a/tests/ui/parser/issues/issue-69259.stderr
+++ b/tests/ui/parser/issues/issue-69259.stderr
@@ -1,0 +1,13 @@
+error: unexpected closing delimiter: `)`
+  --> $DIR/issue-69259.rs:3:5
+   |
+LL | fn main() {}
+   |           -- ...matches this closing brace
+   |           |
+   |           this opening brace...
+LL |
+LL | fn f) {}
+   |     ^ unexpected closing delimiter
+
+error: aborting due to previous error
+

--- a/tests/ui/parser/issues/issue-70583-block-is-empty-1.stderr
+++ b/tests/ui/parser/issues/issue-70583-block-is-empty-1.stderr
@@ -2,10 +2,10 @@ error: unexpected closing delimiter: `}`
   --> $DIR/issue-70583-block-is-empty-1.rs:20:1
    |
 LL | fn struct_generic(x: Vec<i32>) {
-   |                                - this opening brace...
+   |                                - this delimiter might not be properly closed...
 ...
 LL |     }
-   |     - ...matches this closing brace
+   |     - ...as it matches this but it has different indentation
 LL | }
    | ^ unexpected closing delimiter
 

--- a/tests/ui/parser/issues/issue-70583-block-is-empty-2.stderr
+++ b/tests/ui/parser/issues/issue-70583-block-is-empty-2.stderr
@@ -1,8 +1,12 @@
 error: unexpected closing delimiter: `}`
   --> $DIR/issue-70583-block-is-empty-2.rs:14:1
    |
+LL |         match self {
+   |                    - this delimiter might not be properly closed...
 LL |             ErrorHandled::Reported => {}}
-   |                                       -- block is empty, you might have not meant to close it
+   |                                       --- ...as it matches this but it has different indentation
+   |                                       |
+   |                                       block is empty, you might have not meant to close it
 ...
 LL | }
    | ^ unexpected closing delimiter

--- a/tests/ui/parser/macro-mismatched-delim-paren-brace.stderr
+++ b/tests/ui/parser/macro-mismatched-delim-paren-brace.stderr
@@ -2,10 +2,10 @@ error: unexpected closing delimiter: `}`
   --> $DIR/macro-mismatched-delim-paren-brace.rs:5:1
    |
 LL | fn main() {
-   |           - this opening brace...
+   |           - this delimiter might not be properly closed...
 ...
 LL |     }
-   |     - ...matches this closing brace
+   |     - ...as it matches this but it has different indentation
 LL | }
    | ^ unexpected closing delimiter
 

--- a/tests/ui/typeck/issue-91334.stderr
+++ b/tests/ui/typeck/issue-91334.stderr
@@ -2,8 +2,9 @@ error: this file contains an unclosed delimiter
   --> $DIR/issue-91334.rs:10:23
    |
 LL | fn f(){||yield(((){),
-   |       -       -       ^
-   |       |       |
+   |       -       -    -  ^
+   |       |       |    |
+   |       |       |    missing open `(` for this delimiter
    |       |       unclosed delimiter
    |       unclosed delimiter
 
@@ -11,8 +12,9 @@ error: this file contains an unclosed delimiter
   --> $DIR/issue-91334.rs:10:23
    |
 LL | fn f(){||yield(((){),
-   |       -       -       ^
-   |       |       |
+   |       -       -    -  ^
+   |       |       |    |
+   |       |       |    missing open `(` for this delimiter
    |       |       unclosed delimiter
    |       unclosed delimiter
 


### PR DESCRIPTION
Fixes #103882
Fixes #68987
Fixes #69259

The inner indentation mismatching will be covered by outer block, the new added function `report_error_prone_delim_block` will find out the error prone candidates for reporting.
