### PR TITLE
Pass `considering_regions` to normalize query

### DIFF
--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -587,6 +587,11 @@ impl<'tcx> InferCtxtBuilder<'tcx> {
         self
     }
 
+    pub fn considering_regions(mut self, c: bool) -> Self {
+        self.considering_regions = c;
+        self
+    }
+
     pub fn with_normalize_fn_sig_for_diagnostic(
         mut self,
         fun: Lrc<dyn Fn(&InferCtxt<'tcx>, ty::PolyFnSig<'tcx>) -> ty::PolyFnSig<'tcx>>,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1857,12 +1857,12 @@ rustc_queries! {
 
     /// Do not call this query directly: invoke `normalize` instead.
     query normalize_projection_ty(
-        goal: CanonicalProjectionGoal<'tcx>
+        key: CanonicalProjectionGoal<'tcx>
     ) -> Result<
         &'tcx Canonical<'tcx, canonical::QueryResponse<'tcx, NormalizationResult<'tcx>>>,
         NoSolution,
     > {
-        desc { "normalizing `{}`", goal.value.value }
+        desc { "normalizing `{}` {}", key.value.value.projection_ty, if key.value.value.considering_regions { "considering regions" } else { "modulo regions" } }
         remap_env_constness
     }
 

--- a/compiler/rustc_middle/src/traits/query.rs
+++ b/compiler/rustc_middle/src/traits/query.rs
@@ -78,7 +78,14 @@ pub mod type_op {
 }
 
 pub type CanonicalProjectionGoal<'tcx> =
-    Canonical<'tcx, ty::ParamEnvAnd<'tcx, ty::ProjectionTy<'tcx>>>;
+    Canonical<'tcx, ty::ParamEnvAnd<'tcx, ProjectionGoal<'tcx>>>;
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, HashStable, Lift)]
+#[derive(TypeFoldable, TypeVisitable)]
+pub struct ProjectionGoal<'tcx> {
+    pub projection_ty: ty::ProjectionTy<'tcx>,
+    pub considering_regions: bool,
+}
 
 pub type CanonicalTyGoal<'tcx> = Canonical<'tcx, ty::ParamEnvAnd<'tcx, Ty<'tcx>>>;
 

--- a/compiler/rustc_traits/src/normalize_erasing_regions.rs
+++ b/compiler/rustc_traits/src/normalize_erasing_regions.rs
@@ -27,7 +27,7 @@ fn try_normalize_after_erasing_regions<'tcx, T: TypeFoldable<'tcx> + PartialEq +
     goal: ParamEnvAnd<'tcx, T>,
 ) -> Result<T, NoSolution> {
     let ParamEnvAnd { param_env, value } = goal;
-    let infcx = tcx.infer_ctxt().build();
+    let infcx = tcx.infer_ctxt().ignoring_regions().build();
     let cause = ObligationCause::dummy();
     match infcx.at(&cause, param_env).normalize(value) {
         Ok(Normalized { value: normalized_value, obligations: normalized_obligations }) => {


### PR DESCRIPTION
This means that `normalize_erasing_regions`'s inner `InferCtxt` has `ignoring_regions` set. I'm not sure what the perf implication of possibly having to call normalize twice is, though, since the query key is now split up with a true/false `considering_regions` mode.

r? @ghost