### PR TITLE
Make `needs_normalization` into a `TypeFoldable` method

### DIFF
--- a/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
+++ b/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
@@ -52,7 +52,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let value = self.erase_regions(value);
         debug!(?value);
 
-        if !value.has_projections() {
+        if !value.needs_normalization(param_env.reveal()) {
             value
         } else {
             value.fold_with(&mut NormalizeAfterErasingRegionsFolder { tcx: self, param_env })
@@ -84,7 +84,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let value = self.erase_regions(value);
         debug!(?value);
 
-        if !value.has_projections() {
+        if !value.needs_normalization(param_env.reveal()) {
             Ok(value)
         } else {
             let mut folder = TryNormalizeAfterErasingRegionsFolder::new(self, param_env);

--- a/compiler/rustc_middle/src/ty/visit.rs
+++ b/compiler/rustc_middle/src/ty/visit.rs
@@ -160,6 +160,19 @@ pub trait TypeVisitable<'tcx>: fmt::Debug + Clone {
     fn still_further_specializable(&self) -> bool {
         self.has_type_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE)
     }
+
+    fn needs_normalization(&self, reveal: ty::Reveal) -> bool {
+        match reveal {
+            ty::Reveal::UserFacing => {
+                self.has_type_flags(TypeFlags::HAS_TY_PROJECTION | TypeFlags::HAS_CT_PROJECTION)
+            }
+            ty::Reveal::All => self.has_type_flags(
+                TypeFlags::HAS_TY_PROJECTION
+                    | TypeFlags::HAS_TY_OPAQUE
+                    | TypeFlags::HAS_CT_PROJECTION,
+            ),
+        }
+    }
 }
 
 pub trait TypeSuperVisitable<'tcx>: TypeVisitable<'tcx> {
@@ -537,7 +550,7 @@ struct FoundFlags;
 
 // FIXME: Optimize for checking for infer flags
 struct HasTypeFlagsVisitor {
-    flags: ty::TypeFlags,
+    flags: TypeFlags,
 }
 
 impl std::fmt::Debug for HasTypeFlagsVisitor {

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -285,7 +285,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
 
         let infcx = self.selcx.infcx();
 
-        if obligation.predicate.has_projections() {
+        if obligation.predicate.needs_normalization(obligation.param_env.reveal()) {
             let mut obligations = Vec::new();
             let predicate = crate::traits::project::try_normalize_with_depth_to(
                 &mut self.selcx,

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/normalize.rs
@@ -13,7 +13,11 @@ where
     type QueryResponse = T;
 
     fn try_fast_path(_tcx: TyCtxt<'tcx>, key: &ParamEnvAnd<'tcx, Self>) -> Option<T> {
-        if !key.value.value.has_projections() { Some(key.value.value) } else { None }
+        if !key.value.value.needs_normalization(key.param_env.reveal()) {
+            Some(key.value.value)
+        } else {
+            None
+        }
     }
 
     fn perform_query(

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -431,9 +431,9 @@ fn layout_of_uncached<'tcx>(
 
         // Arrays and slices.
         ty::Array(element, mut count) => {
-            if count.has_projections() {
+            if count.needs_normalization(param_env.reveal()) {
                 count = tcx.normalize_erasing_regions(param_env, count);
-                if count.has_projections() {
+                if count.needs_normalization(param_env.reveal()) {
                     return Err(LayoutError::Unknown(ty));
                 }
             }


### PR DESCRIPTION
This makes checks for needing normalization a bit more accurate in a `Reveal::UserFacing` mode, but it may be less expensive just to do the normalization fold unconditionally, so let's see what perf says.

r? @ghost