### PR TITLE
Normalize types when deducing closure signature from supertraits

### DIFF
--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -10,6 +10,7 @@ use rustc_hir_analysis::astconv::AstConv;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::infer::LateBoundRegionConversionTime;
 use rustc_infer::infer::{InferOk, InferResult};
+use rustc_macros::{TypeFoldable, TypeVisitable};
 use rustc_middle::ty::subst::InternalSubsts;
 use rustc_middle::ty::visit::TypeVisitable;
 use rustc_middle::ty::{self, Ty};
@@ -22,7 +23,7 @@ use std::cmp;
 use std::iter;
 
 /// What signature do we *expect* the closure to have from context?
-#[derive(Debug)]
+#[derive(Debug, Clone, TypeFoldable, TypeVisitable)]
 struct ExpectedSig<'tcx> {
     /// Span that gave us this expectation, if we know that.
     cause_span: Option<Span>,
@@ -241,9 +242,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if expected_sig.is_none()
                 && let ty::PredicateKind::Projection(proj_predicate) = bound_predicate.skip_binder()
             {
-                expected_sig = self.deduce_sig_from_projection(
+                expected_sig = self.normalize_associated_types_in(
+                    obligation.cause.span,
+                    self.deduce_sig_from_projection(
                     Some(obligation.cause.span),
-                    bound_predicate.rebind(proj_predicate),
+                        bound_predicate.rebind(proj_predicate),
+                    ),
                 );
             }
 

--- a/src/test/ui/closures/supertrait-hint-references-assoc-ty.rs
+++ b/src/test/ui/closures/supertrait-hint-references-assoc-ty.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+pub trait Fn0: Fn(i32) -> Self::Out {
+    type Out;
+}
+
+impl<F: Fn(i32) -> ()> Fn0 for F {
+    type Out = ();
+}
+
+pub fn closure_typer(_: impl Fn0) {}
+
+fn main() {
+    closure_typer(move |x| {
+        let _: i64 = x.into();
+    });
+}


### PR DESCRIPTION
Elaborated supertraits should be normalized, since there's no guarantee they don't contain projections :sweat_smile: 

Fixes #104025
r? types