### PR TITLE
Make `Hash`, `Hasher` and `BuildHasher` `#[const_trait]` and make `Sip` const `Hasher`

### DIFF
--- a/library/core/src/hash/mod.rs
+++ b/library/core/src/hash/mod.rs
@@ -567,7 +567,7 @@ pub trait Hasher {
 }
 
 #[stable(feature = "indirect_hasher_impl", since = "1.22.0")]
-#[rustc_const_unstable(feature = "const_hash", issue = "none")]
+#[rustc_const_unstable(feature = "const_hash", issue = "104061")]
 impl<H: ~const Hasher + ?Sized> const Hasher for &mut H {
     fn finish(&self) -> u64 {
         (**self).finish()
@@ -776,7 +776,7 @@ impl<H> fmt::Debug for BuildHasherDefault<H> {
 }
 
 #[stable(since = "1.7.0", feature = "build_hasher")]
-#[rustc_const_unstable(feature = "const_hash", issue = "none")]
+#[rustc_const_unstable(feature = "const_hash", issue = "104061")]
 impl<H: ~const Default + Hasher> const BuildHasher for BuildHasherDefault<H> {
     type Hasher = H;
 
@@ -819,7 +819,7 @@ mod impls {
     macro_rules! impl_write {
         ($(($ty:ident, $meth:ident),)*) => {$(
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+            #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
             impl const Hash for $ty {
                 #[inline]
                 fn hash<H: ~const Hasher>(&self, state: &mut H) {
@@ -856,7 +856,7 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     impl const Hash for bool {
         #[inline]
         fn hash<H: ~const Hasher>(&self, state: &mut H) {
@@ -865,7 +865,7 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     impl const Hash for char {
         #[inline]
         fn hash<H: ~const Hasher>(&self, state: &mut H) {
@@ -874,7 +874,7 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     impl const Hash for str {
         #[inline]
         fn hash<H: ~const Hasher>(&self, state: &mut H) {
@@ -883,7 +883,7 @@ mod impls {
     }
 
     #[stable(feature = "never_hash", since = "1.29.0")]
-    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     impl const Hash for ! {
         #[inline]
         fn hash<H: ~const Hasher>(&self, _: &mut H) {
@@ -894,7 +894,7 @@ mod impls {
     macro_rules! impl_hash_tuple {
         () => (
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+            #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
             impl const Hash for () {
                 #[inline]
                 fn hash<H: ~const Hasher>(&self, _state: &mut H) {}
@@ -905,7 +905,7 @@ mod impls {
             maybe_tuple_doc! {
                 $($name)+ @
                 #[stable(feature = "rust1", since = "1.0.0")]
-                #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+                #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
                 impl<$($name: ~const Hash),+> const Hash for ($($name,)+) where last_type!($($name,)+): ?Sized {
                     #[allow(non_snake_case)]
                     #[inline]
@@ -952,7 +952,7 @@ mod impls {
     impl_hash_tuple! { T B C D E F G H I J K L }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     impl<T: ~const Hash> const Hash for [T] {
         #[inline]
         fn hash<H: ~const Hasher>(&self, state: &mut H) {
@@ -962,7 +962,7 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     impl<T: ?Sized + ~const Hash> const Hash for &T {
         #[inline]
         fn hash<H: ~const Hasher>(&self, state: &mut H) {
@@ -971,7 +971,7 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     impl<T: ?Sized + ~const Hash> const Hash for &mut T {
         #[inline]
         fn hash<H: Hasher>(&self, state: &mut H) {

--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -138,6 +138,7 @@ const unsafe fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
         out |= (unsafe { *buf.get_unchecked(start + i) } as u64) << (i * 8);
         i += 1;
     }
+    //FIXME(fee1-dead): use debug_assert_eq
     debug_assert!(i == len);
     out
 }

--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -150,7 +150,7 @@ impl SipHasher {
         since = "1.13.0",
         note = "use `std::collections::hash_map::DefaultHasher` instead"
     )]
-    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     #[must_use]
     pub const fn new() -> SipHasher {
         SipHasher::new_with_keys(0, 0)
@@ -163,7 +163,7 @@ impl SipHasher {
         since = "1.13.0",
         note = "use `std::collections::hash_map::DefaultHasher` instead"
     )]
-    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     #[must_use]
     pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher {
         SipHasher(SipHasher24 { hasher: Hasher::new_with_keys(key0, key1) })
@@ -178,7 +178,7 @@ impl SipHasher13 {
         since = "1.13.0",
         note = "use `std::collections::hash_map::DefaultHasher` instead"
     )]
-    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     pub const fn new() -> SipHasher13 {
         SipHasher13::new_with_keys(0, 0)
     }
@@ -190,7 +190,7 @@ impl SipHasher13 {
         since = "1.13.0",
         note = "use `std::collections::hash_map::DefaultHasher` instead"
     )]
-    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher13 {
         SipHasher13 { hasher: Hasher::new_with_keys(key0, key1) }
     }
@@ -224,7 +224,7 @@ impl<S: Sip> Hasher<S> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_hash", issue = "none")]
+#[rustc_const_unstable(feature = "const_hash", issue = "104061")]
 impl const super::Hasher for SipHasher {
     #[inline]
     fn write(&mut self, msg: &[u8]) {
@@ -243,7 +243,7 @@ impl const super::Hasher for SipHasher {
 }
 
 #[unstable(feature = "hashmap_internals", issue = "none")]
-#[rustc_const_unstable(feature = "const_hash", issue = "none")]
+#[rustc_const_unstable(feature = "const_hash", issue = "104061")]
 impl const super::Hasher for SipHasher13
 where
     Hasher<Sip13Rounds>: ~const super::Hasher,

--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -244,10 +244,7 @@ impl const super::Hasher for SipHasher {
 
 #[unstable(feature = "hashmap_internals", issue = "none")]
 #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
-impl const super::Hasher for SipHasher13
-where
-    Hasher<Sip13Rounds>: ~const super::Hasher,
-{
+impl const super::Hasher for SipHasher13 {
     #[inline]
     fn write(&mut self, msg: &[u8]) {
         self.hasher.write(msg)

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -112,6 +112,7 @@
 #![feature(const_float_bits_conv)]
 #![feature(const_float_classify)]
 #![feature(const_fmt_arguments_new)]
+#![feature(const_hash)]
 #![feature(const_heap)]
 #![feature(const_convert)]
 #![feature(const_index_range_slice_index)]

--- a/library/core/tests/hash/sip.rs
+++ b/library/core/tests/hash/sip.rs
@@ -8,7 +8,6 @@ use core::{mem, slice};
 struct Bytes<'a>(&'a [u8]);
 
 impl<'a> Hash for Bytes<'a> {
-    #[allow(unused_must_use)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         let Bytes(v) = *self;
         state.write(v);
@@ -22,6 +21,20 @@ fn hash_with<H: Hasher, T: Hash>(mut st: H, x: &T) -> u64 {
 
 fn hash<T: Hash>(x: &T) -> u64 {
     hash_with(SipHasher::new(), x)
+}
+
+#[test]
+const fn test_const_sip() {
+    let val1 = 0x45;
+    let val2 = 0xfeed;
+
+    const fn const_hash<T: ~const Hash>(x: &T) -> u64 {
+        let mut st = SipHasher::new();
+        x.hash(&mut st);
+        st.finish()
+    }
+
+    assert!(const_hash(&(val1)) != const_hash(&(val2)));
 }
 
 #[test]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -11,6 +11,7 @@
 #![feature(const_caller_location)]
 #![feature(const_cell_into_inner)]
 #![feature(const_convert)]
+#![feature(const_hash)]
 #![feature(const_heap)]
 #![feature(const_maybe_uninit_as_mut_ptr)]
 #![feature(const_maybe_uninit_assume_init_read)]

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -3161,14 +3161,16 @@ impl DefaultHasher {
     #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
     #[inline]
     #[allow(deprecated)]
+    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
     #[must_use]
-    pub fn new() -> DefaultHasher {
+    pub const fn new() -> DefaultHasher {
         DefaultHasher(SipHasher13::new_with_keys(0, 0))
     }
 }
 
 #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
-impl Default for DefaultHasher {
+#[rustc_const_unstable(feature = "const_hash", issue = "none")]
+impl const Default for DefaultHasher {
     /// Creates a new `DefaultHasher` using [`new`].
     /// See its documentation for more.
     ///
@@ -3180,7 +3182,8 @@ impl Default for DefaultHasher {
 }
 
 #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
-impl Hasher for DefaultHasher {
+#[rustc_const_unstable(feature = "const_hash", issue = "none")]
+impl const Hasher for DefaultHasher {
     // The underlying `SipHasher13` doesn't override the other
     // `write_*` methods, so it's ok not to forward them here.
 

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -3161,7 +3161,7 @@ impl DefaultHasher {
     #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
     #[inline]
     #[allow(deprecated)]
-    #[rustc_const_unstable(feature = "const_hash", issue = "none")]
+    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     #[must_use]
     pub const fn new() -> DefaultHasher {
         DefaultHasher(SipHasher13::new_with_keys(0, 0))
@@ -3169,7 +3169,7 @@ impl DefaultHasher {
 }
 
 #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
-#[rustc_const_unstable(feature = "const_hash", issue = "none")]
+#[rustc_const_unstable(feature = "const_hash", issue = "104061")]
 impl const Default for DefaultHasher {
     /// Creates a new `DefaultHasher` using [`new`].
     /// See its documentation for more.
@@ -3182,7 +3182,7 @@ impl const Default for DefaultHasher {
 }
 
 #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
-#[rustc_const_unstable(feature = "const_hash", issue = "none")]
+#[rustc_const_unstable(feature = "const_hash", issue = "104061")]
 impl const Hasher for DefaultHasher {
     // The underlying `SipHasher13` doesn't override the other
     // `write_*` methods, so it's ok not to forward them here.

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -314,6 +314,7 @@
 #![feature(maybe_uninit_uninit_array)]
 #![feature(const_maybe_uninit_uninit_array)]
 #![feature(const_waker)]
+#![feature(const_hash)]
 //
 // Library features (alloc):
 #![feature(alloc_layout_extra)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -314,7 +314,6 @@
 #![feature(maybe_uninit_uninit_array)]
 #![feature(const_maybe_uninit_uninit_array)]
 #![feature(const_waker)]
-#![feature(const_hash)]
 //
 // Library features (alloc):
 #![feature(alloc_layout_extra)]
@@ -353,6 +352,7 @@
 //
 // Only for const-ness:
 #![feature(const_collections_with_hasher)]
+#![feature(const_hash)]
 #![feature(const_io_structs)]
 #![feature(const_ip)]
 #![feature(const_ipv4)]


### PR DESCRIPTION
This PR enables using Hashes in const context.

r? @fee1-dead 