### PR TITLE
Encapsulate interpreter stack(s) a bit better

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -222,17 +222,13 @@ pub trait Machine<'mir, 'tcx>: Sized {
     ///
     /// Due to borrow checker trouble, we indicate the `frame` as an index rather than an `&mut
     /// Frame`.
-    #[inline]
     fn access_local_mut<'a>(
         ecx: &'a mut InterpCx<'mir, 'tcx, Self>,
         frame: usize,
         local: mir::Local,
     ) -> InterpResult<'tcx, &'a mut Operand<Self::Provenance>>
     where
-        'tcx: 'mir,
-    {
-        ecx.stack_mut()[frame].locals[local].access_mut()
-    }
+        'tcx: 'mir;
 
     /// Called before a basic block terminator is executed.
     /// You can use this to detect endlessly running programs.
@@ -394,10 +390,22 @@ pub trait Machine<'mir, 'tcx>: Sized {
         ecx: &'a InterpCx<'mir, 'tcx, Self>,
     ) -> &'a [Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra>];
 
-    /// Mutably borrow the current thread's stack.
-    fn stack_mut<'a>(
+    fn push_frame(
+        ecx: &mut InterpCx<'mir, 'tcx, Self>,
+        frame: Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra>,
+    );
+
+    fn pop_frame(
+        ecx: &mut InterpCx<'mir, 'tcx, Self>,
+    ) -> Option<Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra>>;
+
+    fn frame<'a>(
+        ecx: &'a InterpCx<'mir, 'tcx, Self>,
+    ) -> &'a Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra>;
+
+    fn frame_mut<'a>(
         ecx: &'a mut InterpCx<'mir, 'tcx, Self>,
-    ) -> &'a mut Vec<Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra>>;
+    ) -> &'a mut Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra>;
 
     /// Called immediately after a stack frame got pushed and its locals got initialized.
     fn after_stack_push(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx> {

--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -517,7 +517,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 };
                 match res {
                     Err(err) => {
-                        self.stack_mut().pop();
+                        self.pop_frame();
                         Err(err)
                     }
                     Ok(()) => Ok(()),

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -305,11 +305,29 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine<'mir, 'tcx>
         &ecx.machine.stack
     }
 
-    #[inline(always)]
-    fn stack_mut<'a>(
+    fn push_frame(
+        ecx: &mut InterpCx<'mir, 'tcx, Self>,
+        frame: Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra>,
+    ) {
+        ecx.machine.stack.push(frame);
+    }
+
+    fn pop_frame(
+        ecx: &mut InterpCx<'mir, 'tcx, Self>,
+    ) -> Option<Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra>> {
+        ecx.machine.stack.pop()
+    }
+
+    fn frame<'a>(
+        ecx: &'a InterpCx<'mir, 'tcx, Self>,
+    ) -> &'a Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra> {
+        ecx.machine.stack.last().expect("no call frames exist")
+    }
+
+    fn frame_mut<'a>(
         ecx: &'a mut InterpCx<'mir, 'tcx, Self>,
-    ) -> &'a mut Vec<Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra>> {
-        &mut ecx.machine.stack
+    ) -> &'a mut Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra> {
+        ecx.machine.stack.last_mut().expect("no call frames exist")
     }
 }
 

--- a/src/tools/miri/src/concurrency/mod.rs
+++ b/src/tools/miri/src/concurrency/mod.rs
@@ -6,3 +6,4 @@ pub mod init_once;
 pub mod thread;
 mod vector_clock;
 pub mod weak_memory;
+mod stack;

--- a/src/tools/miri/src/concurrency/stack.rs
+++ b/src/tools/miri/src/concurrency/stack.rs
@@ -1,0 +1,47 @@
+use crate::*;
+
+/// An encapsulated call stack, so encapsulated to enable efficient caching of metadata about the
+/// contained `Frame`.
+pub struct Stack<'mir, 'tcx> {
+    frames: Vec<Frame<'mir, 'tcx, Provenance, FrameData<'tcx>>>,
+}
+
+impl<'mir, 'tcx> Stack<'mir, 'tcx> {
+    pub fn new() -> Self {
+        Stack { frames: Vec::new() }
+    }
+
+    /// Does this `Stack` contain any `Frame`s?
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    /// Borrow the call frames of a `Stack`.
+    pub fn frames(&self) -> &[Frame<'mir, 'tcx, Provenance, FrameData<'tcx>>] {
+        &self.frames[..]
+    }
+
+    /// Mutably borrow the call frames of a `Stack`.
+    pub fn frames_mut(&mut self) -> &mut [Frame<'mir, 'tcx, Provenance, FrameData<'tcx>>] {
+        &mut self.frames[..]
+    }
+
+    /// Push a new `Frame` onto a `Stack`.
+    pub fn push(&mut self, frame: Frame<'mir, 'tcx, Provenance, FrameData<'tcx>>) {
+        self.frames.push(frame);
+    }
+
+    /// Try to pop a `Frame` from a `Stack`.
+    pub fn pop(&mut self) -> Option<Frame<'mir, 'tcx, Provenance, FrameData<'tcx>>> {
+        self.frames.pop()
+    }
+}
+
+impl VisitTags for Stack<'_, '_> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        let Stack { frames } = self;
+        for frame in frames {
+            frame.visit_tags(visit);
+        }
+    }
+}


### PR DESCRIPTION
This is what I was referring to in https://github.com/rust-lang/miri/pull/2647#discussion_r1014497718. We no longer hand out a `&mut Vec<Frame>` anywhere, so we get control over exactly how and where frames are added to or removed from the stack. All the better-not-be-inconsistent state can be put in a small module that is easy to reason about.

r? @RalfJung 