### PR TITLE
fix sysroot issue which appears for ci downloaded rustc

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1122,13 +1122,18 @@ impl Step for Sysroot {
     fn run(self, builder: &Builder<'_>) -> Interned<PathBuf> {
         let compiler = self.compiler;
         let host_dir = builder.out.join(&compiler.host.triple);
-        let sysroot = if compiler.stage == 0 {
-            host_dir.join("stage0-sysroot")
-        } else if builder.download_rustc() {
-            host_dir.join("ci-rustc-sysroot")
-        } else {
-            host_dir.join(format!("stage{}", compiler.stage))
+
+        let sysroot_dir = |stage| {
+            if stage == 0 {
+                host_dir.join("stage0-sysroot")
+            } else if builder.download_rustc() && compiler.stage != builder.top_stage {
+                host_dir.join("ci-rustc-sysroot")
+            } else {
+                host_dir.join(format!("stage{}", stage))
+            }
         };
+        let sysroot = sysroot_dir(compiler.stage);
+
         let _ = fs::remove_dir_all(&sysroot);
         t!(fs::create_dir_all(&sysroot));
 
@@ -1139,9 +1144,15 @@ impl Step for Sysroot {
                 "Cross-compiling is not yet supported with `download-rustc`",
             );
 
-            // #102002, cleanup stage1 and stage0-sysroot folders when using download-rustc so people don't use old versions of the toolchain by accident.
-            let _ = fs::remove_dir_all(host_dir.join("stage1"));
-            let _ = fs::remove_dir_all(host_dir.join("stage0-sysroot"));
+            // #102002, cleanup old toolchain folders when using download-rustc so people don't use them by accident.
+            for stage in 0..=2 {
+                if stage != compiler.stage {
+                    let dir = sysroot_dir(stage);
+                    if !dir.ends_with("ci-rustc-sysroot") {
+                        let _ = fs::remove_dir_all(dir);
+                    }
+                }
+            }
 
             // Copy the compiler into the correct sysroot.
             let ci_rustc_dir =


### PR DESCRIPTION
Currently when compiler is downloaded rather than compiled, sysroot is being `ci-rustc-sysroot` because of https://github.com/rust-lang/rust/blob/7eef946fc0e0eff40e588eab77b09b287accbec3/src/bootstrap/compile.rs#L1125-L1131 this.

And rustdoc is overriding the downloaded one at the end of the process.

With the condition I add, we simply check if the current compiler stage is target build stage, if so use the proper sysroot instead of `ci-rustc-sysroot`.

Resolves #103206