### PR TITLE
Vec::push_with_ref

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1853,6 +1853,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// let int_ref = vec.push_with_ref(3);
     /// assert_eq!(vec.last(), int_ref);
     /// ```
+    #[cfg(not(no_global_oom_handling))]
     #[inline]
     #[unstable(feature = "vec_push_with_ref", issue = "104075")]
     pub fn push_with_ref(&mut self, value: T) -> &T {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1840,6 +1840,34 @@ impl<T, A: Allocator> Vec<T, A> {
         }
     }
 
+    /// Appends an element to the back of a collection and returns a reference to the new element.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut vec = vec![1, 2];
+    /// let int_ref = vec.push_with_ref(3);
+    /// assert_eq!(vec.last(), int_ref);
+    /// ```
+    #[inline]
+    #[unstable(feature = "vec_push_with_ref", issue = "104075")]
+    pub fn push_with_ref(&mut self, value: T) -> &T {
+        // This will panic or abort if we would allocate > isize::MAX bytes
+        // or if the length increment would overflow for zero-sized types.
+        if self.len == self.buf.capacity() {
+            self.buf.reserve_for_push(self.len);
+        }
+        unsafe {
+            let end = self.as_mut_ptr().add(self.len);
+            ptr::write(end, value);
+            self.len += 1;
+            &*end as &T
+        }
+    }
     /// Appends an element if there is sufficient spare capacity, otherwise an error is returned
     /// with the element.
     ///


### PR DESCRIPTION
This PR adds Vec::push_with_ref function under the vec_push_with_ref feature gate

issue: https://github.com/rust-lang/rust/issues/104075#issue-1437560016

Current status: Not currently working, May need to be renamed