### PR TITLE
Add test for impl of `available_parallelism()`

### DIFF
--- a/src/test/ui/thread-available_parallelism.rs
+++ b/src/test/ui/thread-available_parallelism.rs
@@ -1,0 +1,12 @@
+// run-pass
+// this is an ignore list on purpose so that new platforms don't miss it:
+//ignore-vxworks
+//ignore-redox
+//ignore-l4re
+
+// check that std::thread::available_parallelism returns a valid value
+
+fn main() {
+    std::thread::available_parallelism().expect(
+        "should return a value on all platforms that are not ignored");
+}


### PR DESCRIPTION
This checks that `std::thread::available_parallelism()` returns `Ok(NonZeroUsize)`. With this test maintainers of targets(OS) can check if they have implemented this function (or decide to ignore it).

Not sure how to deal with the ignore list right now:

- tier 1's should all implement the feature already ✔️ 
- tier 2's mostly do as well, but not e.g. `ios`, `wasi` -- should we add them to the ignore list or let the maintainers do that (so that they are informed)?
- tier 3's will certainly sometimes not implement it, my suggestion is to not add them to the ignore list
- I've added only `vxworks`, `redox` and `l4re` to the ignore list because this is documented already in `library/std/src/sys/unix/thread.rs` ([code](https://github.com/rust-lang/rust/blob/9b735a7132acd58b3bd34c084e9ca5b4ca7450a2/library/std/src/sys/unix/thread.rs#L403))

We could also check the value against e.g. `cat /proc/cpuinfo | grep process or | wc`  but I don't know if this is required (how much sense it makes) and if this would play well with e.g. cgroups on Linux.

r? @thomcc 