### PR TITLE
fix fn/const items implied bounds and wf check

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -1,5 +1,6 @@
 use rustc_data_structures::frozen::Frozen;
 use rustc_data_structures::transitive_relation::{TransitiveRelation, TransitiveRelationBuilder};
+use rustc_hir::def::DefKind;
 use rustc_infer::infer::canonical::QueryRegionConstraints;
 use rustc_infer::infer::outlives;
 use rustc_infer::infer::outlives::env::RegionBoundPairs;
@@ -195,7 +196,9 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
 
     #[instrument(level = "debug", skip(self))]
     pub(crate) fn create(mut self) -> CreateResult<'tcx> {
-        let span = self.infcx.tcx.def_span(self.universal_regions.defining_ty.def_id());
+        let tcx = self.infcx.tcx;
+        let defining_ty_def_id = self.universal_regions.defining_ty.def_id().expect_local();
+        let span = tcx.def_span(defining_ty_def_id);
 
         // Insert the facts we know from the predicates. Why? Why not.
         let param_env = self.param_env;
@@ -273,6 +276,26 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
             }
 
             normalized_inputs_and_output.push(norm_ty);
+        }
+
+        // Add implied bounds from impl header.
+        if matches!(tcx.def_kind(defining_ty_def_id), DefKind::AssocFn | DefKind::AssocConst) {
+            for &(ty, _) in tcx.assumed_wf_types(tcx.local_parent(defining_ty_def_id)) {
+                let Ok(TypeOpOutput { output: norm_ty, constraints: c, .. }) = self
+                    .param_env
+                    .and(type_op::normalize::Normalize::new(ty))
+                    .fully_perform(self.infcx, span)
+                else {
+                    tcx.sess.delay_span_bug(span, &format!("failed to normalize {ty:?}"));
+                    continue;
+                };
+                constraints.extend(c);
+
+                // We currently add implied bounds from the normalized ty only.
+                // This is more conservative and matches wfcheck behavior.
+                let c = self.add_implied_bounds(norm_ty);
+                constraints.extend(c);
+            }
         }
 
         for c in constraints {

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -414,6 +414,16 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for TypeVerifier<'a, 'b, 'tcx> {
                     instantiated_predicates,
                     locations,
                 );
+
+                assert!(!matches!(
+                    tcx.impl_of_method(def_id).map(|imp| tcx.def_kind(imp)),
+                    Some(DefKind::Impl { of_trait: true })
+                ));
+                self.cx.prove_predicates(
+                    args.types().map(|ty| ty::ClauseKind::WellFormed(ty.into())),
+                    locations,
+                    ConstraintCategory::Boring,
+                );
             }
         }
     }

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/prove_predicate.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/prove_predicate.rs
@@ -30,6 +30,23 @@ impl<'tcx> super::QueryTypeOp<'tcx> for ProvePredicate<'tcx> {
             }
         }
 
+        if let ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(arg)) =
+            key.value.predicate.kind().skip_binder()
+        {
+            match arg.as_type()?.kind() {
+                ty::Param(_)
+                | ty::Bool
+                | ty::Char
+                | ty::Int(_)
+                | ty::Float(_)
+                | ty::Str
+                | ty::Uint(_) => {
+                    return Some(());
+                }
+                _ => {}
+            }
+        }
+
         None
     }
 

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -3052,8 +3052,9 @@ where
 #[stable(feature = "hash_extend_copy", since = "1.4.0")]
 impl<'a, K, V, S> Extend<(&'a K, &'a V)> for HashMap<K, V, S>
 where
-    K: Eq + Hash + Copy,
-    V: Copy,
+    // FIXME(aliemjay): the bound `+ 'a` should not be necessary.
+    K: Eq + Hash + Copy + 'a,
+    V: Copy + 'a,
     S: BuildHasher,
 {
     #[inline]

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -3052,9 +3052,8 @@ where
 #[stable(feature = "hash_extend_copy", since = "1.4.0")]
 impl<'a, K, V, S> Extend<(&'a K, &'a V)> for HashMap<K, V, S>
 where
-    // FIXME(aliemjay): the bound `+ 'a` should not be necessary.
-    K: Eq + Hash + Copy + 'a,
-    V: Copy + 'a,
+    K: Eq + Hash + Copy,
+    V: Copy,
     S: BuildHasher,
 {
     #[inline]

--- a/tests/ui/borrowck/fn-item-check-trait-ref.rs
+++ b/tests/ui/borrowck/fn-item-check-trait-ref.rs
@@ -1,0 +1,15 @@
+// The method `assert_static` should be callable only for static values,
+// because the impl has an implied bound `where T: 'static`.
+
+// check-fail
+
+trait AnyStatic<Witness>: Sized {
+    fn assert_static(self) {}
+}
+
+impl<T> AnyStatic<&'static T> for T {}
+
+fn main() {
+    (&String::new()).assert_static();
+    //~^ ERROR temporary value dropped while borrowed
+}

--- a/tests/ui/borrowck/fn-item-check-trait-ref.stderr
+++ b/tests/ui/borrowck/fn-item-check-trait-ref.stderr
@@ -1,0 +1,12 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/fn-item-check-trait-ref.rs:13:7
+   |
+LL |     (&String::new()).assert_static();
+   |     --^^^^^^^^^^^^^------------------ temporary value is freed at the end of this statement
+   |     | |
+   |     | creates a temporary value which is freed while still in use
+   |     argument requires that borrow lasts for `'static`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/borrowck/fn-item-check-type-params.rs
+++ b/tests/ui/borrowck/fn-item-check-type-params.rs
@@ -1,0 +1,57 @@
+// Regression test for #104005.
+//
+// Previously, different borrowck implementations used to disagree here.
+// The status of each is documented on `fn test_*`.
+
+// check-fail
+
+use std::fmt::Display;
+
+trait Displayable {
+    fn display(self) -> Box<dyn Display>;
+}
+
+impl<T: Display> Displayable for (T, Option<&'static T>) {
+    fn display(self) -> Box<dyn Display> {
+        Box::new(self.0)
+    }
+}
+
+fn extend_lt<T, U>(val: T) -> Box<dyn Display>
+where
+    (T, Option<U>): Displayable,
+{
+    Displayable::display((val, None))
+}
+
+// AST: fail
+// HIR: pass
+// MIR: pass
+pub fn test_call<'a>(val: &'a str) {
+    extend_lt(val);
+    //~^ ERROR borrowed data escapes outside of function
+}
+
+// AST: fail
+// HIR: fail
+// MIR: pass
+pub fn test_coercion<'a>() {
+    let _: fn(&'a str) -> _ = extend_lt;
+    //~^ ERROR lifetime may not live long enough
+}
+
+// AST: fail
+// HIR: fail
+// MIR: fail
+pub fn test_arg() {
+    fn want<I, O>(_: I, _: impl Fn(I) -> O) {}
+    want(&String::new(), extend_lt);
+    //~^ ERROR temporary value dropped while borrowed
+}
+
+// An exploit of the unsoundness.
+fn main() {
+    let val = extend_lt(&String::from("blah blah blah"));
+    //~^ ERROR temporary value dropped while borrowed
+    println!("{}", val);
+}

--- a/tests/ui/borrowck/fn-item-check-type-params.stderr
+++ b/tests/ui/borrowck/fn-item-check-type-params.stderr
@@ -1,0 +1,43 @@
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/fn-item-check-type-params.rs:31:5
+   |
+LL | pub fn test_call<'a>(val: &'a str) {
+   |                  --  --- `val` is a reference that is only valid in the function body
+   |                  |
+   |                  lifetime `'a` defined here
+LL |     extend_lt(val);
+   |     ^^^^^^^^^^^^^^
+   |     |
+   |     `val` escapes the function body here
+   |     argument requires that `'a` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> $DIR/fn-item-check-type-params.rs:39:12
+   |
+LL | pub fn test_coercion<'a>() {
+   |                      -- lifetime `'a` defined here
+LL |     let _: fn(&'a str) -> _ = extend_lt;
+   |            ^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/fn-item-check-type-params.rs:48:11
+   |
+LL |     want(&String::new(), extend_lt);
+   |     ------^^^^^^^^^^^^^------------- temporary value is freed at the end of this statement
+   |     |     |
+   |     |     creates a temporary value which is freed while still in use
+   |     argument requires that borrow lasts for `'static`
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/fn-item-check-type-params.rs:54:26
+   |
+LL |     let val = extend_lt(&String::from("blah blah blah"));
+   |               -----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
+   |               |          |
+   |               |          creates a temporary value which is freed while still in use
+   |               argument requires that borrow lasts for `'static`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0521, E0716.
+For more information about an error, try `rustc --explain E0521`.

--- a/tests/ui/higher-ranked/trait-bounds/issue-59311.rs
+++ b/tests/ui/higher-ranked/trait-bounds/issue-59311.rs
@@ -17,6 +17,7 @@ where
     v.t(|| {});
     //~^ ERROR: higher-ranked lifetime error
     //~| ERROR: higher-ranked lifetime error
+    //~| ERROR: higher-ranked lifetime error
 }
 
 fn main() {}

--- a/tests/ui/higher-ranked/trait-bounds/issue-59311.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/issue-59311.stderr
@@ -7,6 +7,15 @@ LL |     v.t(|| {});
    = note: could not prove `{closure@$DIR/issue-59311.rs:17:9: 17:11} well-formed`
 
 error: higher-ranked lifetime error
+  --> $DIR/issue-59311.rs:17:5
+   |
+LL |     v.t(|| {});
+   |     ^^^^^^^^^^
+   |
+   = note: could not prove `{closure@$DIR/issue-59311.rs:17:9: 17:11} well-formed`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: higher-ranked lifetime error
   --> $DIR/issue-59311.rs:17:9
    |
 LL |     v.t(|| {});
@@ -14,5 +23,5 @@ LL |     v.t(|| {});
    |
    = note: could not prove `for<'a> &'a V: 'static`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy.rs
+++ b/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy.rs
@@ -1,9 +1,7 @@
-// check-pass
-// known-bug: #84591
+// issue: #84591
 
-// Should fail. Subtrait can incorrectly extend supertrait lifetimes even when
-// supertrait has weaker implied bounds than subtrait. Strongly related to
-// issue #25860.
+// Subtrait was able to incorrectly extend supertrait lifetimes even when
+// supertrait had weaker implied bounds than subtrait.
 
 trait Subtrait<T>: Supertrait {}
 trait Supertrait {
@@ -34,6 +32,7 @@ fn main() {
     {
         let x = "Hello World".to_string();
         subs_to_soup((x.as_str(), &mut d));
+        //~^ does not live long enough
     }
     println!("{}", d);
 }

--- a/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy.stderr
+++ b/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy.stderr
@@ -1,0 +1,16 @@
+error[E0597]: `x` does not live long enough
+  --> $DIR/implied-bounds-on-trait-hierarchy.rs:34:23
+   |
+LL |         let x = "Hello World".to_string();
+   |             - binding `x` declared here
+LL |         subs_to_soup((x.as_str(), &mut d));
+   |                       ^ borrowed value does not live long enough
+LL |
+LL |     }
+   |     - `x` dropped here while still borrowed
+LL |     println!("{}", d);
+   |                    - borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/lifetimes/lifetime-errors/issue_74400.rs
+++ b/tests/ui/lifetimes/lifetime-errors/issue_74400.rs
@@ -11,6 +11,8 @@ fn f<T, S>(data: &[T], key: impl Fn(&T) -> S) {
 fn g<T>(data: &[T]) {
     f(data, identity)
     //~^ ERROR the parameter type
+    //~| ERROR the parameter type
+    //~| ERROR the parameter type
     //~| ERROR mismatched types
     //~| ERROR implementation of `FnOnce` is not general
 }

--- a/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
@@ -12,6 +12,36 @@ help: consider adding an explicit lifetime bound
 LL | fn g<T: 'static>(data: &[T]) {
    |       +++++++++
 
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/issue_74400.rs:12:5
+   |
+LL |     f(data, identity)
+   |     ^^^^^^^^^^^^^^^^^
+   |     |
+   |     the parameter type `T` must be valid for the static lifetime...
+   |     ...so that the type `T` will meet its required lifetime bounds
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider adding an explicit lifetime bound
+   |
+LL | fn g<T: 'static>(data: &[T]) {
+   |       +++++++++
+
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/issue_74400.rs:12:5
+   |
+LL |     f(data, identity)
+   |     ^^^^^^^^^^^^^^^^^
+   |     |
+   |     the parameter type `T` must be valid for the static lifetime...
+   |     ...so that the type `T` will meet its required lifetime bounds
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider adding an explicit lifetime bound
+   |
+LL | fn g<T: 'static>(data: &[T]) {
+   |       +++++++++
+
 error[E0308]: mismatched types
   --> $DIR/issue_74400.rs:12:5
    |
@@ -35,7 +65,7 @@ LL |     f(data, identity)
    = note: `fn(&'2 T) -> &'2 T {identity::<&'2 T>}` must implement `FnOnce<(&'1 T,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 T,)>`, for some specific lifetime `'2`
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0308, E0310.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/wf-nested.fail.stderr
+++ b/tests/ui/type-alias-impl-trait/wf-nested.fail.stderr
@@ -1,5 +1,5 @@
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/wf-nested.rs:55:27
+  --> $DIR/wf-nested.rs:57:27
    |
 LL |     type InnerOpaque<T> = impl Sized;
    |                           ^^^^^^^^^^

--- a/tests/ui/type-alias-impl-trait/wf-nested.pass_sound.stderr
+++ b/tests/ui/type-alias-impl-trait/wf-nested.pass_sound.stderr
@@ -12,6 +12,21 @@ help: consider adding an explicit lifetime bound
 LL |     fn test<T: 'static>() {
    |              +++++++++
 
-error: aborting due to previous error
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/wf-nested.rs:46:17
+   |
+LL |         let _ = outer.get();
+   |                 ^^^^^^^^^^^
+   |                 |
+   |                 the parameter type `T` must be valid for the static lifetime...
+   |                 ...so that the type `T` will meet its required lifetime bounds
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider adding an explicit lifetime bound
+   |
+LL |     fn test<T: 'static>() {
+   |              +++++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0310`.

--- a/tests/ui/type-alias-impl-trait/wf-nested.rs
+++ b/tests/ui/type-alias-impl-trait/wf-nested.rs
@@ -43,7 +43,9 @@ mod pass_sound {
 
     fn test<T>() {
         let outer = define::<T>();
-        let _ = outer.get(); //[pass_sound]~ ERROR `T` may not live long enough
+        let _ = outer.get();
+        //[pass_sound]~^ ERROR `T` may not live long enough
+        //[pass_sound]~| ERROR `T` may not live long enough
     }
 }
 

--- a/tests/ui/wf/wf-associated-const.rs
+++ b/tests/ui/wf/wf-associated-const.rs
@@ -1,8 +1,5 @@
 // check that associated consts can assume the impl header is well-formed.
 
-// FIXME(aliemjay): we should check the impl header is WF at the use site
-// but we currently don't in some cases. This is *unsound*.
-
 trait Foo<'a, 'b, T>: Sized {
     const EVIL: fn(u: &'b u32) -> &'a u32;
 }
@@ -27,11 +24,13 @@ impl<'a, 'b> Evil<'a, 'b> {
 // *check* that it holds at the use site.
 
 fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
-    <()>::EVIL(b) // FIXME: should be an error
+    <()>::EVIL(b)
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
-    <IndirectEvil>::EVIL(b) // FIXME: should be an error
+    <IndirectEvil>::EVIL(b)
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {

--- a/tests/ui/wf/wf-associated-const.rs
+++ b/tests/ui/wf/wf-associated-const.rs
@@ -1,0 +1,42 @@
+// check that associated consts can assume the impl header is well-formed.
+
+// FIXME(aliemjay): we should check the impl header is WF at the use site
+// but we currently don't in some cases. This is *unsound*.
+
+trait Foo<'a, 'b, T>: Sized {
+    const EVIL: fn(u: &'b u32) -> &'a u32;
+}
+
+struct Evil<'a, 'b: 'a>(Option<&'a &'b ()>);
+
+impl<'a, 'b> Foo<'a, 'b, Evil<'a, 'b>> for () {
+    const EVIL: fn(&'b u32) -> &'a u32 = { |u| u };
+}
+
+struct IndirectEvil<'a, 'b: 'a>(Option<&'a &'b ()>);
+
+impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
+    const EVIL: fn(&'b u32) -> &'a u32 = { |u| u };
+}
+
+impl<'a, 'b> Evil<'a, 'b> {
+    const INHERENT_EVIL: fn(&'b u32) -> &'a u32 = { |u| u };
+}
+
+// while static methods can *assume* this, we should still
+// *check* that it holds at the use site.
+
+fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
+    <()>::EVIL(b) // FIXME: should be an error
+}
+
+fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
+    <IndirectEvil>::EVIL(b) // FIXME: should be an error
+}
+
+fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
+    <Evil>::INHERENT_EVIL(b)
+    //~^ ERROR lifetime may not live long enough
+}
+
+fn main() {}

--- a/tests/ui/wf/wf-associated-const.stderr
+++ b/tests/ui/wf/wf-associated-const.stderr
@@ -1,0 +1,14 @@
+error: lifetime may not live long enough
+  --> $DIR/wf-associated-const.rs:38:5
+   |
+LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
+   |                  --  -- lifetime `'b` defined here
+   |                  |
+   |                  lifetime `'a` defined here
+LL |     <Evil>::INHERENT_EVIL(b)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+
+error: aborting due to previous error
+

--- a/tests/ui/wf/wf-associated-const.stderr
+++ b/tests/ui/wf/wf-associated-const.stderr
@@ -1,5 +1,29 @@
 error: lifetime may not live long enough
-  --> $DIR/wf-associated-const.rs:38:5
+  --> $DIR/wf-associated-const.rs:27:5
+   |
+LL | fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
+   |         --  -- lifetime `'b` defined here
+   |         |
+   |         lifetime `'a` defined here
+LL |     <()>::EVIL(b)
+   |     ^^^^^^^^^^^^^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+
+error: lifetime may not live long enough
+  --> $DIR/wf-associated-const.rs:32:5
+   |
+LL | fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
+   |                  --  -- lifetime `'b` defined here
+   |                  |
+   |                  lifetime `'a` defined here
+LL |     <IndirectEvil>::EVIL(b)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+
+error: lifetime may not live long enough
+  --> $DIR/wf-associated-const.rs:37:5
    |
 LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |                  --  -- lifetime `'b` defined here
@@ -10,5 +34,5 @@ LL |     <Evil>::INHERENT_EVIL(b)
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: aborting due to previous error
+error: aborting due to 3 previous errors
 

--- a/tests/ui/wf/wf-in-fn-type-implicit.rs
+++ b/tests/ui/wf/wf-in-fn-type-implicit.rs
@@ -1,11 +1,7 @@
-// check-pass
-// known-bug: #104005
+// issue: #104005
 
-// Should fail. Function type parameters with implicit type annotations are not
-// checked for well-formedness, which allows incorrect borrowing.
-
-// In contrast, user annotations are always checked for well-formedness, and the
-// commented code below is correctly rejected by the borrow checker.
+// Function type parameters with implicit type annotations were not
+// checked for well-formedness, which allowed incorrect borrowing.
 
 use std::fmt::Display;
 
@@ -27,11 +23,8 @@ where
 }
 
 fn main() {
-    // *incorrectly* compiles
+    // This used to compile
     let val = extend_lt(&String::from("blah blah blah"));
+    //~^ ERROR temporary value dropped while borrowed
     println!("{}", val);
-
-    // *correctly* fails to compile
-    // let val = extend_lt::<_, &_>(&String::from("blah blah blah"));
-    // println!("{}", val);
 }

--- a/tests/ui/wf/wf-in-fn-type-implicit.stderr
+++ b/tests/ui/wf/wf-in-fn-type-implicit.stderr
@@ -1,0 +1,12 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/wf-in-fn-type-implicit.rs:27:26
+   |
+LL |     let val = extend_lt(&String::from("blah blah blah"));
+   |               -----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
+   |               |          |
+   |               |          creates a temporary value which is freed while still in use
+   |               argument requires that borrow lasts for `'static`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/wf/wf-static-method.rs
+++ b/tests/ui/wf/wf-static-method.rs
@@ -1,8 +1,4 @@
-// check that static methods don't get to assume their trait-ref
-// is well-formed.
-// FIXME(#27579): this is just a bug. However, our checking with
-// static inherent methods isn't quite working - need to
-// fix that before removing the check.
+// check that static methods can assume their trait-ref is well-formed.
 
 trait Foo<'a, 'b, T>: Sized {
     fn make_me() -> Self { loop {} }
@@ -15,7 +11,6 @@ impl<'a, 'b> Foo<'a, 'b, Evil<'a, 'b>> for () {
     fn make_me() -> Self { }
     fn static_evil(u: &'b u32) -> &'a u32 {
         u
-        //~^ ERROR lifetime may not live long enough
     }
 }
 
@@ -25,7 +20,6 @@ impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
     fn make_me() -> Self { IndirectEvil(None) }
     fn static_evil(u: &'b u32) -> &'a u32 {
         let me = Self::make_me();
-        //~^ ERROR lifetime may not live long enough
         loop {} // (`me` could be used for the lifetime transmute).
     }
 }
@@ -33,12 +27,11 @@ impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
 impl<'a, 'b> Evil<'a, 'b> {
     fn inherent_evil(u: &'b u32) -> &'a u32 {
         u
-        //~^ ERROR lifetime may not live long enough
     }
 }
 
-// while static methods don't get to *assume* this, we still
-// *check* that they hold.
+// while static methods can *assume* this, we should still
+// *check* that it holds at the use site.
 
 fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
     <()>::static_evil(b)

--- a/tests/ui/wf/wf-static-method.stderr
+++ b/tests/ui/wf/wf-static-method.stderr
@@ -1,44 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/wf-static-method.rs:17:9
-   |
-LL | impl<'a, 'b> Foo<'a, 'b, Evil<'a, 'b>> for () {
-   |      --  -- lifetime `'b` defined here
-   |      |
-   |      lifetime `'a` defined here
-...
-LL |         u
-   |         ^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-
-error: lifetime may not live long enough
-  --> $DIR/wf-static-method.rs:27:18
-   |
-LL | impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
-   |      --  -- lifetime `'b` defined here
-   |      |
-   |      lifetime `'a` defined here
-...
-LL |         let me = Self::make_me();
-   |                  ^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-
-error: lifetime may not live long enough
-  --> $DIR/wf-static-method.rs:35:9
-   |
-LL | impl<'a, 'b> Evil<'a, 'b> {
-   |      --  -- lifetime `'b` defined here
-   |      |
-   |      lifetime `'a` defined here
-LL |     fn inherent_evil(u: &'b u32) -> &'a u32 {
-LL |         u
-   |         ^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-
-error: lifetime may not live long enough
-  --> $DIR/wf-static-method.rs:44:5
+  --> $DIR/wf-static-method.rs:37:5
    |
 LL | fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |         --  -- lifetime `'b` defined here
@@ -50,7 +11,7 @@ LL |     <()>::static_evil(b)
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/wf-static-method.rs:49:5
+  --> $DIR/wf-static-method.rs:42:5
    |
 LL | fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |                  --  -- lifetime `'b` defined here
@@ -62,7 +23,7 @@ LL |     <IndirectEvil>::static_evil(b)
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/wf-static-method.rs:54:5
+  --> $DIR/wf-static-method.rs:47:5
    |
 LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |                  --  -- lifetime `'b` defined here
@@ -73,5 +34,5 @@ LL |     <Evil>::inherent_evil(b)
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: aborting due to 6 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
These are two distinct changes (edit: actually three, see below):
1. Wf-check all fn item args. This is a soundness fix.
Fixes #104005

2. Use implied bounds from impl header in borrowck of associated functions/consts. This strictly accepts more code and helps to mitigate the impact of other breaking changes.
Fixes #98852
Fixes #102611

The first is a breaking change and will likely have a big impact without the the second one. See the first commit for how it breaks libstd.

Landing the second one without the first will allow more incorrect code to pass. For example an exploit of #104005 would be as simple as:
```rust
use core::fmt::Display;

trait ExtendLt<Witness> {
    fn extend(self) -> Box<dyn Display>;
}

impl<T: Display> ExtendLt<&'static T> for T {
    fn extend(self) -> Box<dyn Display> {
        Box::new(self)
    }
}

fn main() {
    let val = (&String::new()).extend();
    println!("{val}");
}
```

The third change is to to check WF of user type annotations before normalizing them (fixes #104764, fixes #104763). It is mutually dependent on the second change above: an attempt to land it separately in #104746 caused several crater regressions that can all be mitigated by using the implied from the impl header. It is also necessary for the soundness of associated consts that use the implied bounds of impl header. See #104763 and how the third commit fixes the soundness issue in `tests/ui/wf/wf-associated-const.rs` that was introduces by the previous commit.

cc @lcnr
r? types