### PR TITLE
doc: Add mutable to the description

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3524,8 +3524,8 @@ impl<T> [T] {
         }
     }
 
-    /// Transmute the slice to a slice of another type, ensuring alignment of the types is
-    /// maintained.
+    /// Transmute the mutable slice to a mutable slice of another type, ensuring alignment of the
+    /// types is maintained.
     ///
     /// This method splits the slice into three distinct slices: prefix, correctly aligned middle
     /// slice of a new type, and the suffix slice. The method may make the middle slice the greatest


### PR DESCRIPTION
`mutable` is missing from the description.  Currently the description for [align_to](https://github.com/rust-lang/rust/blob/master/library/core/src/slice/mod.rs#L3498) is the same as [align_to_mut](https://github.com/rust-lang/rust/blob/master/library/core/src/slice/mod.rs#L3559)