### PR TITLE
rustdoc: Add mutable to the description

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3667,7 +3667,8 @@ impl<T> [T] {
         unsafe { self.align_to() }
     }
 
-    /// Split a slice into a prefix, a middle of aligned SIMD types, and a suffix.
+    /// Split a mutable slice into a mutable prefix, a middle of aligned SIMD types,
+    /// and a mutable suffix.
     ///
     /// This is a safe wrapper around [`slice::align_to_mut`], so has the same weak
     /// postconditions as that method.  You're only assured that


### PR DESCRIPTION
Add mutable the description to differentiate [as_simd](https://github.com/rust-lang/rust/blob/master/library/core/src/slice/mod.rs#L3654) from [as_simd_mut](https://github.com/rust-lang/rust/blob/master/library/core/src/slice/mod.rs#L3654).