### PR TITLE
rustdoc: Add copy to the description of repeat

### DIFF
--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -458,7 +458,7 @@ impl<T> [T] {
         hack::into_vec(self)
     }
 
-    /// Creates a vector by repeating a slice `n` times.
+    /// Creates a vector by copying a slice `n` times.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Small nit, but it's more clear to say `copy` here instead of defining `repeat` in terms of itself.