### PR TITLE
Fix invalid background-image file name

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -854,7 +854,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	background-size: 20px;
 	background-position: calc(100% - 2px) 56%;
 	/* image is black color, themes should apply a "filter" property to change the color */
-	background-image: url("down-arrow-2d685a4bae708e15.svg");
+	background-image: url("down-arrow-927217e04c7463ac.svg");
 }
 #crate-search > option {
 	font-size: 1rem;


### PR DESCRIPTION
This is a follow-up of https://github.com/rust-lang/rust/pull/101702.

Apparently the image hash was the wrong one. You can see the error in https://doc.rust-lang.org/nightly/core/primitive.u16.html?search=hello too.

I really need to check if I can adds check for resources load errors in `browser-ui-test`.

cc @jsha 
r? @notriddle 