### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,9 +489,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 dependencies = [
  "jobserver",
 ]

--- a/compiler/rustc_ast/src/util/literal.rs
+++ b/compiler/rustc_ast/src/util/literal.rs
@@ -2,12 +2,9 @@
 
 use crate::ast::{self, Lit, LitKind};
 use crate::token::{self, Token};
-
-use rustc_lexer::unescape::{unescape_byte, unescape_char};
-use rustc_lexer::unescape::{unescape_byte_literal, unescape_literal, Mode};
+use rustc_lexer::unescape::{byte_from_char, unescape_byte, unescape_char, unescape_literal, Mode};
 use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::Span;
-
 use std::ascii;
 
 pub enum LitError {
@@ -109,13 +106,11 @@ impl LitKind {
                 let s = symbol.as_str();
                 let mut buf = Vec::with_capacity(s.len());
                 let mut error = Ok(());
-                unescape_byte_literal(&s, Mode::ByteStr, &mut |_, unescaped_byte| {
-                    match unescaped_byte {
-                        Ok(c) => buf.push(c),
-                        Err(err) => {
-                            if err.is_fatal() {
-                                error = Err(LitError::LexerError);
-                            }
+                unescape_literal(&s, Mode::ByteStr, &mut |_, c| match c {
+                    Ok(c) => buf.push(byte_from_char(c)),
+                    Err(err) => {
+                        if err.is_fatal() {
+                            error = Err(LitError::LexerError);
                         }
                     }
                 });
@@ -127,13 +122,11 @@ impl LitKind {
                 let bytes = if s.contains('\r') {
                     let mut buf = Vec::with_capacity(s.len());
                     let mut error = Ok(());
-                    unescape_byte_literal(&s, Mode::RawByteStr, &mut |_, unescaped_byte| {
-                        match unescaped_byte {
-                            Ok(c) => buf.push(c),
-                            Err(err) => {
-                                if err.is_fatal() {
-                                    error = Err(LitError::LexerError);
-                                }
+                    unescape_literal(&s, Mode::RawByteStr, &mut |_, c| match c {
+                        Ok(c) => buf.push(byte_from_char(c)),
+                        Err(err) => {
+                            if err.is_fatal() {
+                                error = Err(LitError::LexerError);
                             }
                         }
                     });

--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -47,7 +47,10 @@ passes_no_coverage_not_coverable =
 
 passes_should_be_applied_to_fn =
     attribute should be applied to a function definition
-    .label = not a function definition
+    .label = {$on_crate ->
+        [true] cannot be applied to crates
+        *[false] not a function definition
+    }
 
 passes_naked_tracked_caller =
     cannot use `#[track_caller]` with `#[naked]`

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -52,7 +52,6 @@ impl Emitter for AnnotateSnippetEmitterWriter {
         let (mut primary_span, suggestions) = self.primary_span_formatted(&diag, &fluent_args);
 
         self.fix_multispans_in_extern_macros_and_render_macro_backtrace(
-            &self.source_map,
             &mut primary_span,
             &mut children,
             &diag.level,

--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -203,13 +203,13 @@ pub enum RawStrError {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Base {
     /// Literal starts with "0b".
-    Binary,
+    Binary = 2,
     /// Literal starts with "0o".
-    Octal,
-    /// Literal starts with "0x".
-    Hexadecimal,
+    Octal = 8,
     /// Literal doesn't contain a prefix.
-    Decimal,
+    Decimal = 10,
+    /// Literal starts with "0x".
+    Hexadecimal = 16,
 }
 
 /// `rustc` allows files to have a shebang, e.g. "#!/usr/bin/rustrun",

--- a/compiler/rustc_lexer/src/unescape.rs
+++ b/compiler/rustc_lexer/src/unescape.rs
@@ -83,8 +83,8 @@ where
     match mode {
         Mode::Char | Mode::Byte => {
             let mut chars = src.chars();
-            let result = unescape_char_or_byte(&mut chars, mode == Mode::Byte);
-            callback(0..(src.len() - chars.as_str().len()), result);
+            let res = unescape_char_or_byte(&mut chars, mode == Mode::Byte);
+            callback(0..(src.len() - chars.as_str().len()), res);
         }
         Mode::Str | Mode::ByteStr => unescape_str_or_byte_str(src, mode == Mode::ByteStr, callback),
         Mode::RawStr | Mode::RawByteStr => {
@@ -263,7 +263,7 @@ where
     // them in the range computation.
     while let Some(c) = chars.next() {
         let start = src.len() - chars.as_str().len() - c.len_utf8();
-        let result = match c {
+        let res = match c {
             '\\' => {
                 match chars.clone().next() {
                     Some('\n') => {
@@ -284,7 +284,7 @@ where
             _ => ascii_check(c, is_byte),
         };
         let end = src.len() - chars.as_str().len();
-        callback(start..end, result);
+        callback(start..end, res);
     }
 
     fn skip_ascii_whitespace<F>(chars: &mut Chars<'_>, start: usize, callback: &mut F)
@@ -329,12 +329,12 @@ where
     // doesn't have to worry about skipping any chars.
     while let Some(c) = chars.next() {
         let start = src.len() - chars.as_str().len() - c.len_utf8();
-        let result = match c {
+        let res = match c {
             '\r' => Err(EscapeError::BareCarriageReturnInRawString),
             _ => ascii_check(c, is_byte),
         };
         let end = src.len() - chars.as_str().len();
-        callback(start..end, result);
+        callback(start..end, res);
     }
 }
 

--- a/compiler/rustc_lexer/src/unescape.rs
+++ b/compiler/rustc_lexer/src/unescape.rs
@@ -93,19 +93,6 @@ where
     }
 }
 
-/// Takes a contents of a byte, byte string or raw byte string (without quotes)
-/// and produces a sequence of bytes or errors.
-/// Values are returned through invoking of the provided callback.
-pub fn unescape_byte_literal<F>(src: &str, mode: Mode, callback: &mut F)
-where
-    F: FnMut(Range<usize>, Result<u8, EscapeError>),
-{
-    debug_assert!(mode.is_byte());
-    unescape_literal(src, mode, &mut |range, result| {
-        callback(range, result.map(byte_from_char));
-    })
-}
-
 /// Takes a contents of a char literal (without quotes), and returns an
 /// unescaped char or an error
 pub fn unescape_char(src: &str) -> Result<char, (usize, EscapeError)> {
@@ -351,7 +338,8 @@ where
     }
 }
 
-fn byte_from_char(c: char) -> u8 {
+#[inline]
+pub fn byte_from_char(c: char) -> u8 {
     let res = c as u32;
     debug_assert!(res <= u8::MAX as u32, "guaranteed because of Mode::ByteStr");
     res as u8

--- a/compiler/rustc_lexer/src/unescape.rs
+++ b/compiler/rustc_lexer/src/unescape.rs
@@ -84,12 +84,9 @@ where
         Mode::Char | Mode::Byte => {
             let mut chars = src.chars();
             let result = unescape_char_or_byte(&mut chars, mode == Mode::Byte);
-            // The Chars iterator moved forward.
             callback(0..(src.len() - chars.as_str().len()), result);
         }
         Mode::Str | Mode::ByteStr => unescape_str_or_byte_str(src, mode == Mode::ByteStr, callback),
-        // NOTE: Raw strings do not perform any explicit character escaping, here we
-        // only translate CRLF to LF and produce errors on bare CR.
         Mode::RawStr | Mode::RawByteStr => {
             unescape_raw_str_or_raw_byte_str(src, mode == Mode::RawByteStr, callback)
         }
@@ -333,7 +330,7 @@ where
 /// Takes a contents of a string literal (without quotes) and produces a
 /// sequence of characters or errors.
 /// NOTE: Raw strings do not perform any explicit character escaping, here we
-/// only translate CRLF to LF and produce errors on bare CR.
+/// only produce errors on bare CR.
 fn unescape_raw_str_or_raw_byte_str<F>(src: &str, is_byte: bool, callback: &mut F)
 where
     F: FnMut(Range<usize>, Result<char, EscapeError>),

--- a/compiler/rustc_lexer/src/unescape.rs
+++ b/compiler/rustc_lexer/src/unescape.rs
@@ -52,10 +52,8 @@ pub enum EscapeError {
 
     /// Unicode escape code in byte literal.
     UnicodeEscapeInByte,
-    /// Non-ascii character in byte literal.
+    /// Non-ascii character in byte literal, byte string literal, or raw byte string literal.
     NonAsciiCharInByte,
-    /// Non-ascii character in byte string literal.
-    NonAsciiCharInByteString,
 
     /// After a line ending with '\', the next line contains whitespace
     /// characters that are not skipped.
@@ -349,8 +347,7 @@ where
         let start = src.len() - chars.as_str().len() - c.len_utf8();
         let result = match c {
             '\r' => Err(EscapeError::BareCarriageReturnInRawString),
-            c if is_byte && !c.is_ascii() => Err(EscapeError::NonAsciiCharInByteString),
-            c => Ok(c),
+            _ => ascii_check(c, is_byte),
         };
         let end = src.len() - chars.as_str().len();
         callback(start..end, result);

--- a/compiler/rustc_lexer/src/unescape/tests.rs
+++ b/compiler/rustc_lexer/src/unescape/tests.rs
@@ -246,10 +246,10 @@ fn test_unescape_byte_good() {
 fn test_unescape_byte_str_good() {
     fn check(literal_text: &str, expected: &[u8]) {
         let mut buf = Ok(Vec::with_capacity(literal_text.len()));
-        unescape_byte_literal(literal_text, Mode::ByteStr, &mut |range, c| {
+        unescape_literal(literal_text, Mode::ByteStr, &mut |range, c| {
             if let Ok(b) = &mut buf {
                 match c {
-                    Ok(c) => b.push(c),
+                    Ok(c) => b.push(byte_from_char(c)),
                     Err(e) => buf = Err((range, e)),
                 }
             }
@@ -280,15 +280,13 @@ fn test_unescape_raw_str() {
 
 #[test]
 fn test_unescape_raw_byte_str() {
-    fn check(literal: &str, expected: &[(Range<usize>, Result<u8, EscapeError>)]) {
+    fn check(literal: &str, expected: &[(Range<usize>, Result<char, EscapeError>)]) {
         let mut unescaped = Vec::with_capacity(literal.len());
-        unescape_byte_literal(literal, Mode::RawByteStr, &mut |range, res| {
-            unescaped.push((range, res))
-        });
+        unescape_literal(literal, Mode::RawByteStr, &mut |range, res| unescaped.push((range, res)));
         assert_eq!(unescaped, expected);
     }
 
     check("\r", &[(0..1, Err(EscapeError::BareCarriageReturnInRawString))]);
     check("🦀", &[(0..4, Err(EscapeError::NonAsciiCharInByte))]);
-    check("🦀a", &[(0..4, Err(EscapeError::NonAsciiCharInByte)), (4..5, Ok(byte_from_char('a')))]);
+    check("🦀a", &[(0..4, Err(EscapeError::NonAsciiCharInByte)), (4..5, Ok('a'))]);
 }

--- a/compiler/rustc_lexer/src/unescape/tests.rs
+++ b/compiler/rustc_lexer/src/unescape/tests.rs
@@ -289,9 +289,6 @@ fn test_unescape_raw_byte_str() {
     }
 
     check("\r", &[(0..1, Err(EscapeError::BareCarriageReturnInRawString))]);
-    check("🦀", &[(0..4, Err(EscapeError::NonAsciiCharInByteString))]);
-    check(
-        "🦀a",
-        &[(0..4, Err(EscapeError::NonAsciiCharInByteString)), (4..5, Ok(byte_from_char('a')))],
-    );
+    check("🦀", &[(0..4, Err(EscapeError::NonAsciiCharInByte))]);
+    check("🦀a", &[(0..4, Err(EscapeError::NonAsciiCharInByte)), (4..5, Ok(byte_from_char('a')))]);
 }

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -363,55 +363,55 @@ impl<'a> StringReader<'a> {
     fn cook_lexer_literal(
         &self,
         start: BytePos,
-        suffix_start: BytePos,
+        end: BytePos,
         kind: rustc_lexer::LiteralKind,
     ) -> (token::LitKind, Symbol) {
-        // prefix means `"` or `br"` or `r###"`, ...
-        let (lit_kind, mode, prefix_len, postfix_len) = match kind {
+        match kind {
             rustc_lexer::LiteralKind::Char { terminated } => {
                 if !terminated {
                     self.sess.span_diagnostic.span_fatal_with_code(
-                        self.mk_sp(start, suffix_start),
+                        self.mk_sp(start, end),
                         "unterminated character literal",
                         error_code!(E0762),
                     )
                 }
-                (token::Char, Mode::Char, 1, 1) // ' '
+                self.cook_quoted(token::Char, Mode::Char, start, end, 1, 1) // ' '
             }
             rustc_lexer::LiteralKind::Byte { terminated } => {
                 if !terminated {
                     self.sess.span_diagnostic.span_fatal_with_code(
-                        self.mk_sp(start + BytePos(1), suffix_start),
+                        self.mk_sp(start + BytePos(1), end),
                         "unterminated byte constant",
                         error_code!(E0763),
                     )
                 }
-                (token::Byte, Mode::Byte, 2, 1) // b' '
+                self.cook_quoted(token::Byte, Mode::Byte, start, end, 2, 1) // b' '
             }
             rustc_lexer::LiteralKind::Str { terminated } => {
                 if !terminated {
                     self.sess.span_diagnostic.span_fatal_with_code(
-                        self.mk_sp(start, suffix_start),
+                        self.mk_sp(start, end),
                         "unterminated double quote string",
                         error_code!(E0765),
                     )
                 }
-                (token::Str, Mode::Str, 1, 1) // " "
+                self.cook_quoted(token::Str, Mode::Str, start, end, 1, 1) // " "
             }
             rustc_lexer::LiteralKind::ByteStr { terminated } => {
                 if !terminated {
                     self.sess.span_diagnostic.span_fatal_with_code(
-                        self.mk_sp(start + BytePos(1), suffix_start),
+                        self.mk_sp(start + BytePos(1), end),
                         "unterminated double quote byte string",
                         error_code!(E0766),
                     )
                 }
-                (token::ByteStr, Mode::ByteStr, 2, 1) // b" "
+                self.cook_quoted(token::ByteStr, Mode::ByteStr, start, end, 2, 1) // b" "
             }
             rustc_lexer::LiteralKind::RawStr { n_hashes } => {
                 if let Some(n_hashes) = n_hashes {
                     let n = u32::from(n_hashes);
-                    (token::StrRaw(n_hashes), Mode::RawStr, 2 + n, 1 + n) // r##" "##
+                    let kind = token::StrRaw(n_hashes);
+                    self.cook_quoted(kind, Mode::RawStr, start, end, 2 + n, 1 + n) // r##" "##
                 } else {
                     self.report_raw_str_error(start, 1);
                 }
@@ -419,56 +419,47 @@ impl<'a> StringReader<'a> {
             rustc_lexer::LiteralKind::RawByteStr { n_hashes } => {
                 if let Some(n_hashes) = n_hashes {
                     let n = u32::from(n_hashes);
-                    (token::ByteStrRaw(n_hashes), Mode::RawByteStr, 3 + n, 1 + n) // br##" "##
+                    let kind = token::ByteStrRaw(n_hashes);
+                    self.cook_quoted(kind, Mode::RawByteStr, start, end, 3 + n, 1 + n) // br##" "##
                 } else {
                     self.report_raw_str_error(start, 2);
                 }
             }
             rustc_lexer::LiteralKind::Int { base, empty_int } => {
-                return if empty_int {
+                if empty_int {
                     self.sess
                         .span_diagnostic
                         .struct_span_err_with_code(
-                            self.mk_sp(start, suffix_start),
+                            self.mk_sp(start, end),
                             "no valid digits found for number",
                             error_code!(E0768),
                         )
                         .emit();
                     (token::Integer, sym::integer(0))
                 } else {
-                    self.validate_int_literal(base, start, suffix_start);
-                    (token::Integer, self.symbol_from_to(start, suffix_start))
-                };
+                    self.validate_int_literal(base, start, end);
+                    (token::Integer, self.symbol_from_to(start, end))
+                }
             }
             rustc_lexer::LiteralKind::Float { base, empty_exponent } => {
                 if empty_exponent {
                     self.err_span_(start, self.pos, "expected at least one digit in exponent");
                 }
-
                 match base {
-                    Base::Hexadecimal => self.err_span_(
-                        start,
-                        suffix_start,
-                        "hexadecimal float literal is not supported",
-                    ),
+                    Base::Hexadecimal => {
+                        self.err_span_(start, end, "hexadecimal float literal is not supported")
+                    }
                     Base::Octal => {
-                        self.err_span_(start, suffix_start, "octal float literal is not supported")
+                        self.err_span_(start, end, "octal float literal is not supported")
                     }
                     Base::Binary => {
-                        self.err_span_(start, suffix_start, "binary float literal is not supported")
+                        self.err_span_(start, end, "binary float literal is not supported")
                     }
-                    _ => (),
+                    _ => {}
                 }
-
-                let id = self.symbol_from_to(start, suffix_start);
-                return (token::Float, id);
+                (token::Float, self.symbol_from_to(start, end))
             }
-        };
-        let content_start = start + BytePos(prefix_len);
-        let content_end = suffix_start - BytePos(postfix_len);
-        let id = self.symbol_from_to(content_start, content_end);
-        self.validate_literal_escape(mode, content_start, content_end, prefix_len, postfix_len);
-        (lit_kind, id)
+        }
     }
 
     #[inline]
@@ -659,20 +650,22 @@ impl<'a> StringReader<'a> {
         )
     }
 
-    fn validate_literal_escape(
+    fn cook_quoted(
         &self,
+        kind: token::LitKind,
         mode: Mode,
-        content_start: BytePos,
-        content_end: BytePos,
+        start: BytePos,
+        end: BytePos,
         prefix_len: u32,
         postfix_len: u32,
-    ) {
+    ) -> (token::LitKind, Symbol) {
+        let content_start = start + BytePos(prefix_len);
+        let content_end = end - BytePos(postfix_len);
         let lit_content = self.str_from_to(content_start, content_end);
         unescape::unescape_literal(lit_content, mode, &mut |range, result| {
             // Here we only check for errors. The actual unescaping is done later.
             if let Err(err) = result {
-                let span_with_quotes = self
-                    .mk_sp(content_start - BytePos(prefix_len), content_end + BytePos(postfix_len));
+                let span_with_quotes = self.mk_sp(start, end);
                 let (start, end) = (range.start as u32, range.end as u32);
                 let lo = content_start + BytePos(start);
                 let hi = lo + BytePos(end - start);
@@ -688,6 +681,7 @@ impl<'a> StringReader<'a> {
                 );
             }
         });
+        (kind, Symbol::intern(lit_content))
     }
 
     fn validate_int_literal(&self, base: Base, content_start: BytePos, content_end: BytePos) {

--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -108,7 +108,7 @@ pub(crate) fn emit_unescape_error(
             }
 
             if !has_help {
-                let (prefix, msg) = if mode.is_bytes() {
+                let (prefix, msg) = if mode.is_byte() {
                     ("b", "if you meant to write a byte string literal, use double quotes")
                 } else {
                     ("", "if you meant to write a `str` literal, use double quotes")
@@ -142,7 +142,7 @@ pub(crate) fn emit_unescape_error(
         EscapeError::EscapeOnlyChar => {
             let (c, char_span) = last_char();
 
-            let msg = if mode.is_bytes() {
+            let msg = if mode.is_byte() {
                 "byte constant must be escaped"
             } else {
                 "character constant must be escaped"
@@ -182,11 +182,11 @@ pub(crate) fn emit_unescape_error(
             let (c, span) = last_char();
 
             let label =
-                if mode.is_bytes() { "unknown byte escape" } else { "unknown character escape" };
+                if mode.is_byte() { "unknown byte escape" } else { "unknown character escape" };
             let ec = escaped_char(c);
             let mut diag = handler.struct_span_err(span, &format!("{}: `{}`", label, ec));
             diag.span_label(span, label);
-            if c == '{' || c == '}' && !mode.is_bytes() {
+            if c == '{' || c == '}' && !mode.is_byte() {
                 diag.help(
                     "if used in a formatting string, curly braces are escaped with `{{` and `}}`",
                 );
@@ -196,7 +196,7 @@ pub(crate) fn emit_unescape_error(
                      version control settings",
                 );
             } else {
-                if !mode.is_bytes() {
+                if !mode.is_byte() {
                     diag.span_suggestion(
                         span_with_quotes,
                         "if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal",
@@ -231,7 +231,7 @@ pub(crate) fn emit_unescape_error(
                 .emit();
         }
         EscapeError::NonAsciiCharInByte => {
-            assert!(mode.is_bytes());
+            assert!(mode.is_byte());
             let (c, span) = last_char();
             let mut err = handler.struct_span_err(span, "non-ASCII character in byte constant");
             let postfix = if unicode_width::UnicodeWidthChar::width(c).unwrap_or(1) == 0 {
@@ -271,7 +271,7 @@ pub(crate) fn emit_unescape_error(
             err.emit();
         }
         EscapeError::NonAsciiCharInByteString => {
-            assert!(mode.is_bytes());
+            assert!(mode.is_byte());
             let (c, span) = last_char();
             let postfix = if unicode_width::UnicodeWidthChar::width(c).unwrap_or(1) == 0 {
                 format!(" but is {:?}", c)

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -119,13 +119,13 @@ impl CheckAttrVisitor<'_> {
                 }
                 sym::naked => self.check_naked(hir_id, attr, span, target),
                 sym::rustc_legacy_const_generics => {
-                    self.check_rustc_legacy_const_generics(&attr, span, target, item)
+                    self.check_rustc_legacy_const_generics(hir_id, &attr, span, target, item)
                 }
                 sym::rustc_lint_query_instability => {
-                    self.check_rustc_lint_query_instability(&attr, span, target)
+                    self.check_rustc_lint_query_instability(hir_id, &attr, span, target)
                 }
                 sym::rustc_lint_diagnostics => {
-                    self.check_rustc_lint_diagnostics(&attr, span, target)
+                    self.check_rustc_lint_diagnostics(hir_id, &attr, span, target)
                 }
                 sym::rustc_lint_opt_ty => self.check_rustc_lint_opt_ty(&attr, span, target),
                 sym::rustc_lint_opt_deny_field_access => {
@@ -135,7 +135,9 @@ impl CheckAttrVisitor<'_> {
                 | sym::rustc_dirty
                 | sym::rustc_if_this_changed
                 | sym::rustc_then_this_would_need => self.check_rustc_dirty_clean(&attr),
-                sym::cmse_nonsecure_entry => self.check_cmse_nonsecure_entry(attr, span, target),
+                sym::cmse_nonsecure_entry => {
+                    self.check_cmse_nonsecure_entry(hir_id, attr, span, target)
+                }
                 sym::collapse_debuginfo => self.check_collapse_debuginfo(attr, span, target),
                 sym::const_trait => self.check_const_trait(attr, span, target),
                 sym::must_not_suspend => self.check_must_not_suspend(&attr, span, target),
@@ -386,6 +388,7 @@ impl CheckAttrVisitor<'_> {
                 self.tcx.sess.emit_err(errors::AttrShouldBeAppliedToFn {
                     attr_span: attr.span,
                     defn_span: span,
+                    on_crate: hir_id == CRATE_HIR_ID,
                 });
                 false
             }
@@ -393,7 +396,13 @@ impl CheckAttrVisitor<'_> {
     }
 
     /// Checks if `#[cmse_nonsecure_entry]` is applied to a function definition.
-    fn check_cmse_nonsecure_entry(&self, attr: &Attribute, span: Span, target: Target) -> bool {
+    fn check_cmse_nonsecure_entry(
+        &self,
+        hir_id: HirId,
+        attr: &Attribute,
+        span: Span,
+        target: Target,
+    ) -> bool {
         match target {
             Target::Fn
             | Target::Method(MethodKind::Trait { body: true } | MethodKind::Inherent) => true,
@@ -401,6 +410,7 @@ impl CheckAttrVisitor<'_> {
                 self.tcx.sess.emit_err(errors::AttrShouldBeAppliedToFn {
                     attr_span: attr.span,
                     defn_span: span,
+                    on_crate: hir_id == CRATE_HIR_ID,
                 });
                 false
             }
@@ -465,9 +475,11 @@ impl CheckAttrVisitor<'_> {
                 true
             }
             _ => {
-                self.tcx
-                    .sess
-                    .emit_err(errors::TrackedCallerWrongLocation { attr_span, defn_span: span });
+                self.tcx.sess.emit_err(errors::TrackedCallerWrongLocation {
+                    attr_span,
+                    defn_span: span,
+                    on_crate: hir_id == CRATE_HIR_ID,
+                });
                 false
             }
         }
@@ -576,6 +588,7 @@ impl CheckAttrVisitor<'_> {
                 self.tcx.sess.emit_err(errors::AttrShouldBeAppliedToFn {
                     attr_span: attr.span,
                     defn_span: span,
+                    on_crate: hir_id == CRATE_HIR_ID,
                 });
                 false
             }
@@ -1240,7 +1253,7 @@ impl CheckAttrVisitor<'_> {
                     UNUSED_ATTRIBUTES,
                     hir_id,
                     attr.span,
-                    errors::Cold { span },
+                    errors::Cold { span, on_crate: hir_id == CRATE_HIR_ID },
                 );
             }
         }
@@ -1376,6 +1389,7 @@ impl CheckAttrVisitor<'_> {
     /// Checks if `#[rustc_legacy_const_generics]` is applied to a function and has a valid argument.
     fn check_rustc_legacy_const_generics(
         &self,
+        hir_id: HirId,
         attr: &Attribute,
         span: Span,
         target: Target,
@@ -1386,6 +1400,7 @@ impl CheckAttrVisitor<'_> {
             self.tcx.sess.emit_err(errors::AttrShouldBeAppliedToFn {
                 attr_span: attr.span,
                 defn_span: span,
+                on_crate: hir_id == CRATE_HIR_ID,
             });
             return false;
         }
@@ -1450,12 +1465,19 @@ impl CheckAttrVisitor<'_> {
 
     /// Helper function for checking that the provided attribute is only applied to a function or
     /// method.
-    fn check_applied_to_fn_or_method(&self, attr: &Attribute, span: Span, target: Target) -> bool {
+    fn check_applied_to_fn_or_method(
+        &self,
+        hir_id: HirId,
+        attr: &Attribute,
+        span: Span,
+        target: Target,
+    ) -> bool {
         let is_function = matches!(target, Target::Fn | Target::Method(..));
         if !is_function {
             self.tcx.sess.emit_err(errors::AttrShouldBeAppliedToFn {
                 attr_span: attr.span,
                 defn_span: span,
+                on_crate: hir_id == CRATE_HIR_ID,
             });
             false
         } else {
@@ -1467,17 +1489,24 @@ impl CheckAttrVisitor<'_> {
     /// or method.
     fn check_rustc_lint_query_instability(
         &self,
+        hir_id: HirId,
         attr: &Attribute,
         span: Span,
         target: Target,
     ) -> bool {
-        self.check_applied_to_fn_or_method(attr, span, target)
+        self.check_applied_to_fn_or_method(hir_id, attr, span, target)
     }
 
     /// Checks that the `#[rustc_lint_diagnostics]` attribute is only applied to a function or
     /// method.
-    fn check_rustc_lint_diagnostics(&self, attr: &Attribute, span: Span, target: Target) -> bool {
-        self.check_applied_to_fn_or_method(attr, span, target)
+    fn check_rustc_lint_diagnostics(
+        &self,
+        hir_id: HirId,
+        attr: &Attribute,
+        span: Span,
+        target: Target,
+    ) -> bool {
+        self.check_applied_to_fn_or_method(hir_id, attr, span, target)
     }
 
     /// Checks that the `#[rustc_lint_opt_ty]` attribute is only applied to a struct.

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -79,6 +79,7 @@ pub struct AttrShouldBeAppliedToFn {
     pub attr_span: Span,
     #[label]
     pub defn_span: Span,
+    pub on_crate: bool,
 }
 
 #[derive(Diagnostic)]
@@ -95,6 +96,7 @@ pub struct TrackedCallerWrongLocation {
     pub attr_span: Span,
     #[label]
     pub defn_span: Span,
+    pub on_crate: bool,
 }
 
 #[derive(Diagnostic)]
@@ -365,6 +367,7 @@ pub struct MustNotSuspend {
 pub struct Cold {
     #[label]
     pub span: Span,
+    pub on_crate: bool,
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -241,10 +241,12 @@ impl<'a> Resolver<'a> {
         ));
 
         err.span_label(span, format!("`{}` re{} here", name, new_participle));
-        err.span_label(
-            self.session.source_map().guess_head_span(old_binding.span),
-            format!("previous {} of the {} `{}` here", old_noun, old_kind, name),
-        );
+        if !old_binding.span.is_dummy() && old_binding.span != span {
+            err.span_label(
+                self.session.source_map().guess_head_span(old_binding.span),
+                format!("previous {} of the {} `{}` here", old_noun, old_kind, name),
+            );
+        }
 
         // See https://github.com/rust-lang/rust/issues/32354
         use NameBindingKind::Import;

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -797,14 +797,16 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
         err.code(rustc_errors::error_code!(E0411));
         err.span_label(span, "`Self` is only available in impls, traits, and type definitions");
         if let Some(item_kind) = self.diagnostic_metadata.current_item {
-            err.span_label(
-                item_kind.ident.span,
-                format!(
-                    "`Self` not allowed in {} {}",
-                    item_kind.kind.article(),
-                    item_kind.kind.descr()
-                ),
-            );
+            if !item_kind.ident.span.is_dummy() {
+                err.span_label(
+                    item_kind.ident.span,
+                    format!(
+                        "`Self` not allowed in {} {}",
+                        item_kind.kind.article(),
+                        item_kind.kind.descr()
+                    ),
+                );
+            }
         }
         true
     }

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -855,7 +855,8 @@ impl SourceMap {
     /// Returns a new span representing the next character after the end-point of this span.
     /// Special cases:
     /// - if span is a dummy one, returns the same span
-    /// - if next_point reached the end of source, return span with lo = hi
+    /// - if next_point reached the end of source, return a span exceeding the end of source,
+    ///   which means sm.span_to_snippet(next_point) will get `Err`
     /// - respect multi-byte characters
     pub fn next_point(&self, sp: Span) -> Span {
         if sp.is_dummy() {
@@ -864,9 +865,6 @@ impl SourceMap {
         let start_of_next_point = sp.hi().0;
 
         let width = self.find_width_of_character_at_span(sp, true);
-        if width == 0 {
-            return Span::new(sp.hi(), sp.hi(), sp.ctxt(), None);
-        }
         // If the width is 1, then the next span should only contain the next char besides current ending.
         // However, in the case of a multibyte character, where the width != 1, the next span should
         // span multiple bytes to include the whole character.
@@ -938,7 +936,7 @@ impl SourceMap {
         // Ensure indexes are also not malformed.
         if start_index > end_index || end_index > source_len - 1 {
             debug!("find_width_of_character_at_span: source indexes are malformed");
-            return 0;
+            return 1;
         }
 
         let src = local_begin.sf.external_src.borrow();

--- a/compiler/rustc_span/src/source_map/tests.rs
+++ b/compiler/rustc_span/src/source_map/tests.rs
@@ -511,16 +511,17 @@ fn test_next_point() {
     assert_eq!(span.lo().0, 4);
     assert_eq!(span.hi().0, 5);
 
-    // A non-empty span at the last byte should advance to create an empty
-    // span pointing at the end of the file.
+    // Reaching to the end of file, return a span that will get error with `span_to_snippet`
     let span = Span::with_root_ctxt(BytePos(4), BytePos(5));
     let span = sm.next_point(span);
     assert_eq!(span.lo().0, 5);
-    assert_eq!(span.hi().0, 5);
+    assert_eq!(span.hi().0, 6);
+    assert!(sm.span_to_snippet(span).is_err());
 
-    // Empty span pointing just past the last byte.
+    // Reaching to the end of file, return a span that will get error with `span_to_snippet`
     let span = Span::with_root_ctxt(BytePos(5), BytePos(5));
     let span = sm.next_point(span);
     assert_eq!(span.lo().0, 5);
-    assert_eq!(span.hi().0, 5);
+    assert_eq!(span.hi().0, 6);
+    assert!(sm.span_to_snippet(span).is_err());
 }

--- a/compiler/rustc_target/src/spec/windows_gnullvm_base.rs
+++ b/compiler/rustc_target/src/spec/windows_gnullvm_base.rs
@@ -1,4 +1,5 @@
-use crate::spec::{cvs, Cc, LinkerFlavor, Lld, TargetOptions};
+use crate::spec::{cvs, Cc, DebuginfoKind, LinkerFlavor, Lld, SplitDebuginfo, TargetOptions};
+use std::borrow::Cow;
 
 pub fn opts() -> TargetOptions {
     // We cannot use `-nodefaultlibs` because compiler-rt has to be passed
@@ -36,7 +37,10 @@ pub fn opts() -> TargetOptions {
         eh_frame_header: false,
         no_default_libraries: false,
         has_thread_local: true,
-
+        // FIXME(davidtwco): Support Split DWARF on Windows GNU - may require LLVM changes to
+        // output DWO, despite using DWARF, doesn't use ELF..
+        debuginfo_kind: DebuginfoKind::Pdb,
+        supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
         ..Default::default()
     }
 }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2438,17 +2438,6 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             | ObligationCauseCode::ExprBindingObligation(item_def_id, span, ..) => {
                 let item_name = tcx.def_path_str(item_def_id);
                 let mut multispan = MultiSpan::from(span);
-                if let Some(ident) = tcx.opt_item_ident(item_def_id) {
-                    let sm = tcx.sess.source_map();
-                    let same_line =
-                        match (sm.lookup_line(ident.span.hi()), sm.lookup_line(span.lo())) {
-                            (Ok(l), Ok(r)) => l.line == r.line,
-                            _ => true,
-                        };
-                    if !ident.span.overlaps(span) && !same_line {
-                        multispan.push_span_label(ident.span, "required by a bound in this");
-                    }
-                }
                 let descr = format!("required by a bound in `{}`", item_name);
                 if span != DUMMY_SP {
                     let msg = format!("required by this bound in `{}`", item_name);

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -20,7 +20,7 @@ compiler_builtins = "0.1.0"
 cfg-if = "0.1.8"
 
 [build-dependencies]
-cc = "1.0.69"
+cc = "1.0.74"
 
 [features]
 

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -118,6 +118,9 @@ ENV TARGETS=$TARGETS,armv7-unknown-linux-gnueabi
 ENV TARGETS=$TARGETS,armv7-unknown-linux-musleabi
 ENV TARGETS=$TARGETS,i686-unknown-freebsd
 ENV TARGETS=$TARGETS,x86_64-unknown-none
+ENV TARGETS=$TARGETS,aarch64-unknown-uefi
+ENV TARGETS=$TARGETS,i686-unknown-uefi
+ENV TARGETS=$TARGETS,x86_64-unknown-uefi
 
 # As per https://bugs.launchpad.net/ubuntu/+source/gcc-defaults/+bug/1300211
 # we need asm in the search path for gcc-8 (for gnux32) but not in the search path of the

--- a/src/doc/rustc/src/linker-plugin-lto.md
+++ b/src/doc/rustc/src/linker-plugin-lto.md
@@ -131,24 +131,47 @@ able to get around this problem by setting `-Clinker=lld-link` in RUSTFLAGS
 
 ## Toolchain Compatibility
 
-<!-- NOTE: to update the below table, you can use this shell script:
+<!-- NOTE: to update the below table, you can use this Python script:
 
-```sh
-rustup toolchain install --profile minimal nightly
-MINOR_VERSION=$(rustc +nightly --version | cut -d . -f 2)
-LOWER_BOUND=66
+```python
+from collections import defaultdict
+import subprocess
 
-llvm_version() {
-    toolchain="$1"
-    printf "Rust $toolchain    |    Clang "
-    rustc +"$toolchain" -Vv | grep LLVM | cut -d ':' -f 2 | tr -d ' '
-}
+def minor_version(version):
+    return int(version.split('.')[1])
 
-for version in `seq $LOWER_BOUND $((MINOR_VERSION - 2))`; do
-    toolchain=1.$version.0
-    rustup toolchain install --no-self-update --profile  minimal $toolchain >/dev/null 2>&1
-    llvm_version $toolchain
-done
+INSTALL_TOOLCHAIN = ["rustup", "toolchain", "install", "--profile", "minimal"]
+subprocess.run(INSTALL_TOOLCHAIN + ["nightly"])
+
+LOWER_BOUND = 65
+NIGHTLY_VERSION = minor_version(subprocess.run(
+    ["rustc", "+nightly", "--version"],
+    capture_output=True,
+    text=True).stdout)
+
+def llvm_version(toolchain):
+    version_text = subprocess.run(
+        ["rustc", "+{}".format(toolchain), "-Vv"],
+        capture_output=True,
+        text=True).stdout
+    return int(version_text.split("LLVM")[1].split(':')[1].split('.')[0])
+
+version_map = defaultdict(lambda: [])
+for version in range(LOWER_BOUND, NIGHTLY_VERSION - 1):
+    toolchain = "1.{}.0".format(version)
+    subprocess.run(
+        INSTALL_TOOLCHAIN + ["--no-self-update", toolchain],
+        capture_output=True)
+    version_map[llvm_version(toolchain)].append(version)
+
+print("| Rust Version | Clang Version |")
+print("|--------------|---------------|")
+for clang, rust in sorted(version_map.items()):
+    if len(rust) > 1:
+        rust_range = "1.{} - 1.{}".format(rust[0], rust[-1])
+    else:
+        rust_range = "1.{}       ".format(rust[0])
+    print("| {}  |      {}       |".format(rust_range, clang))
 ```
 
 -->
@@ -166,37 +189,13 @@ The following table shows known good combinations of toolchain versions.
 
 | Rust Version | Clang Version |
 |--------------|---------------|
-| Rust 1.34    |    Clang 8    |
-| Rust 1.35    |    Clang 8    |
-| Rust 1.36    |    Clang 8    |
-| Rust 1.37    |    Clang 8    |
-| Rust 1.38    |    Clang 9    |
-| Rust 1.39    |    Clang 9    |
-| Rust 1.40    |    Clang 9    |
-| Rust 1.41    |    Clang 9    |
-| Rust 1.42    |    Clang 9    |
-| Rust 1.43    |    Clang 9    |
-| Rust 1.44    |    Clang 9    |
-| Rust 1.45    |    Clang 10   |
-| Rust 1.46    |    Clang 10   |
-| Rust 1.47    |    Clang 11   |
-| Rust 1.48    |    Clang 11   |
-| Rust 1.49    |    Clang 11   |
-| Rust 1.50    |    Clang 11   |
-| Rust 1.51    |    Clang 11   |
-| Rust 1.52    |    Clang 12   |
-| Rust 1.53    |    Clang 12   |
-| Rust 1.54    |    Clang 12   |
-| Rust 1.55    |    Clang 12   |
-| Rust 1.56    |    Clang 13   |
-| Rust 1.57    |    Clang 13   |
-| Rust 1.58    |    Clang 13   |
-| Rust 1.59    |    Clang 13   |
-| Rust 1.60    |    Clang 14   |
-| Rust 1.61    |    Clang 14   |
-| Rust 1.62    |    Clang 14   |
-| Rust 1.63    |    Clang 14   |
-| Rust 1.64    |    Clang 14   |
-| Rust 1.65    |    Clang 15   |
+| 1.34 - 1.37  |       8       |
+| 1.38 - 1.44  |       9       |
+| 1.45 - 1.46  |      10       |
+| 1.47 - 1.51  |      11       |
+| 1.52 - 1.55  |      12       |
+| 1.56 - 1.59  |      13       |
+| 1.60 - 1.64  |      14       |
+| 1.65         |      15       |
 
 Note that the compatibility policy for this feature might change in the future.

--- a/src/doc/rustc/src/linker-plugin-lto.md
+++ b/src/doc/rustc/src/linker-plugin-lto.md
@@ -136,7 +136,7 @@ able to get around this problem by setting `-Clinker=lld-link` in RUSTFLAGS
 ```sh
 rustup toolchain install --profile minimal nightly
 MINOR_VERSION=$(rustc +nightly --version | cut -d . -f 2)
-LOWER_BOUND=61
+LOWER_BOUND=66
 
 llvm_version() {
     toolchain="$1"
@@ -193,5 +193,10 @@ The following table shows known good combinations of toolchain versions.
 | Rust 1.58    |    Clang 13   |
 | Rust 1.59    |    Clang 13   |
 | Rust 1.60    |    Clang 14   |
+| Rust 1.61    |    Clang 14   |
+| Rust 1.62    |    Clang 14   |
+| Rust 1.63    |    Clang 14   |
+| Rust 1.64    |    Clang 14   |
+| Rust 1.65    |    Clang 15   |
 
 Note that the compatibility policy for this feature might change in the future.

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -128,6 +128,7 @@ target | std | notes
 [`aarch64-linux-android`](platform-support/android.md) | ✓ | ARM64 Android
 `aarch64-unknown-none-softfloat` | * | Bare ARM64, softfloat
 `aarch64-unknown-none` | * | Bare ARM64, hardfloat
+[`aarch64-unknown-uefi`](platform-support/unknown-uefi.md) | * | ARM64 UEFI
 [`arm-linux-androideabi`](platform-support/android.md) | ✓ | ARMv7 Android
 `arm-unknown-linux-musleabi` | ✓ | ARMv6 Linux with MUSL
 `arm-unknown-linux-musleabihf` | ✓ | ARMv6 Linux with MUSL, hardfloat
@@ -149,6 +150,7 @@ target | std | notes
 [`i686-linux-android`](platform-support/android.md) | ✓ | 32-bit x86 Android
 `i686-unknown-freebsd` | ✓ | 32-bit FreeBSD
 `i686-unknown-linux-musl` | ✓ | 32-bit Linux with MUSL
+[`i686-unknown-uefi`](platform-support/unknown-uefi.md) | * | 32-bit UEFI
 `mips-unknown-linux-musl` | ✓ | MIPS Linux with MUSL
 `mips64-unknown-linux-muslabi64` | ✓ | MIPS64 Linux, n64 ABI, MUSL
 `mips64el-unknown-linux-muslabi64` | ✓ | MIPS64 (LE) Linux, n64 ABI, MUSL
@@ -181,6 +183,7 @@ target | std | notes
 `x86_64-unknown-linux-gnux32` | ✓ | 64-bit Linux (x32 ABI) (kernel 4.15, glibc 2.27)
 [`x86_64-unknown-none`](platform-support/x86_64-unknown-none.md) | * | Freestanding/bare-metal x86_64, softfloat
 `x86_64-unknown-redox` | ✓ | Redox OS
+[`x86_64-unknown-uefi`](platform-support/unknown-uefi.md) | * | 64-bit UEFI
 
 [Fortanix ABI]: https://edp.fortanix.com/
 
@@ -213,7 +216,6 @@ target | std | host | notes
 [`aarch64-pc-windows-gnullvm`](platform-support/pc-windows-gnullvm.md) | ✓ | ✓ |
 `aarch64-unknown-freebsd` | ✓ | ✓ | ARM64 FreeBSD
 `aarch64-unknown-hermit` | ✓ |  | ARM64 HermitCore
-[`aarch64-unknown-uefi`](platform-support/unknown-uefi.md) | * |  | ARM64 UEFI
 `aarch64-unknown-linux-gnu_ilp32` | ✓ | ✓ | ARM64 Linux (ILP32 ABI)
 `aarch64-unknown-netbsd` | ✓ | ✓ |
 [`aarch64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | ARM64 OpenBSD
@@ -252,7 +254,6 @@ target | std | host | notes
 `i686-unknown-haiku` | ✓ | ✓ | 32-bit Haiku
 `i686-unknown-netbsd` | ✓ | ✓ | NetBSD/i386 with SSE2
 [`i686-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | 32-bit OpenBSD
-[`i686-unknown-uefi`](platform-support/unknown-uefi.md) | * |  | 32-bit UEFI
 `i686-uwp-windows-gnu` | ? |  |
 `i686-uwp-windows-msvc` | ? |  |
 `i686-wrs-vxworks` | ? |  |
@@ -311,7 +312,6 @@ target | std | host | notes
 `x86_64-unknown-l4re-uclibc` | ? |  |
 `x86_64-unknown-none-linuxkernel` | * |  | Linux kernel modules
 [`x86_64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | 64-bit OpenBSD
-[`x86_64-unknown-uefi`](platform-support/unknown-uefi.md) | * |  | 64-bit UEFI
 `x86_64-uwp-windows-gnu` | ✓ |  |
 `x86_64-uwp-windows-msvc` | ✓ |  |
 `x86_64-wrs-vxworks` | ? |  |

--- a/src/doc/rustc/src/platform-support/unknown-uefi.md
+++ b/src/doc/rustc/src/platform-support/unknown-uefi.md
@@ -1,6 +1,6 @@
 # `*-unknown-uefi`
 
-**Tier: 3**
+**Tier: 2**
 
 Unified Extensible Firmware Interface (UEFI) targets for application, driver,
 and core UEFI binaries.
@@ -72,28 +72,14 @@ target = ["x86_64-unknown-uefi"]
 
 ## Building Rust programs
 
-Rust does not yet ship pre-compiled artifacts for this target. To compile for
-this target, you will either need to build Rust with the target enabled (see
-"Building rust for UEFI targets" above), or build your own copy of `core` by
-using `build-std`, `cargo-buildx`, or similar.
-
-A native build with the unstable `build-std`-feature can be achieved via:
+Starting with Rust 1.67, precompiled artifacts are provided via
+`rustup`. For example, to use `x86_64-unknown-uefi`:
 
 ```sh
-cargo +nightly build \
-    -Zbuild-std=core,compiler_builtins \
-    -Zbuild-std-features=compiler-builtins-mem \
-    --target x86_64-unknown-uefi
-```
-
-Alternatively, you can install `cargo-xbuild` via
-`cargo install --force cargo-xbuild` and build for the UEFI targets via:
-
-```sh
-cargo \
-    +nightly \
-    xbuild \
-    --target x86_64-unknown-uefi
+# install cross-compile toolchain
+rustup target add x86_64-unknown-uefi
+# target flag may be used with any cargo or rustc command
+cargo build --target x86_64-unknown-uefi
 ```
 
 ## Testing
@@ -167,18 +153,10 @@ The following code is a valid UEFI application returning immediately upon
 execution with an exit code of 0. A panic handler is provided. This is executed
 by rust on panic. For simplicity, we simply end up in an infinite loop.
 
-Note that as of rust-1.31.0, all features used here are stabilized. No unstable
-features are required, nor do we rely on nightly compilers. However, if you do
-not compile rustc for the UEFI targets, you need a nightly compiler to support
-the `-Z build-std` flag.
-
 This example can be compiled as binary crate via `cargo`:
 
 ```sh
-cargo +nightly build \
-    -Zbuild-std=core,compiler_builtins \
-    -Zbuild-std-features=compiler-builtins-mem \
-    --target x86_64-unknown-uefi
+cargo build --target x86_64-unknown-uefi
 ```
 
 ```rust,ignore (platform-specific,eh-personality-is-unstable)

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -854,7 +854,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	background-size: 20px;
 	background-position: calc(100% - 2px) 56%;
 	/* image is black color, themes should apply a "filter" property to change the color */
-	background-image: url("down-arrow-2d685a4bae708e15.svg");
+	background-image: url("down-arrow-927217e04c7463ac.svg");
 }
 #crate-search > option {
 	font-size: 1rem;

--- a/src/test/ui/asm/naked-invalid-attr.stderr
+++ b/src/test/ui/asm/naked-invalid-attr.stderr
@@ -36,7 +36,7 @@ error: attribute should be applied to a function definition
   --> $DIR/naked-invalid-attr.rs:5:1
    |
 LL | #![naked]
-   | ^^^^^^^^^
+   | ^^^^^^^^^ cannot be applied to crates
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/associated-types/associated-types-eq-hr.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-hr.stderr
@@ -14,9 +14,6 @@ LL |     type A = &'a usize;
 note: required by a bound in `foo`
   --> $DIR/associated-types-eq-hr.rs:45:36
    |
-LL | fn foo<T>()
-   |    --- required by a bound in this
-LL | where
 LL |     T: for<'x> TheTrait<&'x isize, A = &'x isize>,
    |                                    ^^^^^^^^^^^^^ required by this bound in `foo`
 
@@ -36,9 +33,6 @@ LL |     type A = &'a isize;
 note: required by a bound in `bar`
   --> $DIR/associated-types-eq-hr.rs:52:36
    |
-LL | fn bar<T>()
-   |    --- required by a bound in this
-LL | where
 LL |     T: for<'x> TheTrait<&'x isize, A = &'x usize>,
    |                                    ^^^^^^^^^^^^^ required by this bound in `bar`
 

--- a/src/test/ui/associated-types/defaults-suitability.stderr
+++ b/src/test/ui/associated-types/defaults-suitability.stderr
@@ -25,9 +25,6 @@ note: required by a bound in `Tr2::Ty`
    |
 LL |     Self::Ty: Clone,
    |               ^^^^^ required by this bound in `Tr2::Ty`
-LL | {
-LL |     type Ty = NotClone;
-   |          -- required by a bound in this
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL | #[derive(Clone)]
@@ -73,9 +70,6 @@ note: required by a bound in `D::Assoc`
    |
 LL |     Self::Assoc: IsU8<Self::Assoc>,
    |                  ^^^^^^^^^^^^^^^^^ required by this bound in `D::Assoc`
-...
-LL |     type Assoc = NotClone;
-   |          ----- required by a bound in this
 
 error[E0277]: the trait bound `<Self as Foo2<T>>::Baz: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:65:23
@@ -122,9 +116,6 @@ note: required by a bound in `Foo3::Baz`
    |
 LL |     Self::Baz: Clone,
    |                ^^^^^ required by this bound in `Foo3::Baz`
-...
-LL |     type Baz = T;
-   |          --- required by a bound in this
 help: consider further restricting type parameter `T`
    |
 LL |     Self::Baz: Clone, T: std::clone::Clone

--- a/src/test/ui/associated-types/hr-associated-type-bound-1.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-1.stderr
@@ -8,9 +8,6 @@ LL |     type U = str;
 note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-1.rs:3:33
    |
-LL | trait X<'a>
-   |       - required by a bound in this
-LL | where
 LL |     for<'b> <Self as X<'b>>::U: Clone,
    |                                 ^^^^^ required by this bound in `X`
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-object.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-object.stderr
@@ -7,9 +7,6 @@ LL | fn f<'a, T: X<'a> + ?Sized>(x: &<T as X<'a>>::U) {
 note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-object.rs:3:33
    |
-LL | trait X<'a>
-   |       - required by a bound in this
-LL | where
 LL |     for<'b> <Self as X<'b>>::U: Clone,
    |                                 ^^^^^ required by this bound in `X`
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-param-1.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-param-1.stderr
@@ -8,9 +8,6 @@ LL |     type V = str;
 note: required by a bound in `Y`
   --> $DIR/hr-associated-type-bound-param-1.rs:4:36
    |
-LL | trait Y<'a, T: ?Sized>
-   |       - required by a bound in this
-...
 LL |     for<'b> <Self as Y<'b, T>>::V: Clone,
    |                                    ^^^^^ required by this bound in `Y`
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-param-2.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-param-2.stderr
@@ -8,9 +8,6 @@ LL |     T: Z<'a, u16>,
 note: required by a bound in `Z`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |
-LL | trait Z<'a, T: ?Sized>
-   |       - required by a bound in this
-...
 LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
    |                                   ^^^^^ required by this bound in `Z`
 
@@ -24,9 +21,6 @@ LL |     type W = str;
 note: required by a bound in `Z`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |
-LL | trait Z<'a, T: ?Sized>
-   |       - required by a bound in this
-...
 LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
    |                                   ^^^^^ required by this bound in `Z`
 
@@ -40,9 +34,6 @@ LL |     T: Z<'a, u16>,
 note: required by a bound in `Z`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |
-LL | trait Z<'a, T: ?Sized>
-   |       - required by a bound in this
-...
 LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
    |                                   ^^^^^ required by this bound in `Z`
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-param-3.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-param-3.stderr
@@ -8,9 +8,6 @@ LL |     type U = str;
 note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-param-3.rs:4:33
    |
-LL | trait X<'a, T>
-   |       - required by a bound in this
-...
 LL |     for<'b> <T as X<'b, T>>::U: Clone,
    |                                 ^^^^^ required by this bound in `X`
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-param-4.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-param-4.stderr
@@ -8,9 +8,6 @@ LL |     type U = str;
 note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-param-4.rs:4:36
    |
-LL | trait X<'a, T>
-   |       - required by a bound in this
-...
 LL |     for<'b> <(T,) as X<'b, T>>::U: Clone,
    |                                    ^^^^^ required by this bound in `X`
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-param-5.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-param-5.stderr
@@ -8,9 +8,6 @@ LL |     type U = str;
 note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-param-5.rs:17:45
    |
-LL | trait X<'a, T: Cycle + for<'b> X<'b, T>>
-   |       - required by a bound in this
-...
 LL |     for<'b> <T::Next as X<'b, T::Next>>::U: Clone,
    |                                             ^^^^^ required by this bound in `X`
 
@@ -24,9 +21,6 @@ LL |     type U = str;
 note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-param-5.rs:17:45
    |
-LL | trait X<'a, T: Cycle + for<'b> X<'b, T>>
-   |       - required by a bound in this
-...
 LL |     for<'b> <T::Next as X<'b, T::Next>>::U: Clone,
    |                                             ^^^^^ required by this bound in `X`
 

--- a/src/test/ui/associated-types/hr-associated-type-projection-1.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-projection-1.stderr
@@ -9,9 +9,6 @@ LL | impl<T: Copy + std::ops::Deref> UnsafeCopy<'_, T> for T {
 note: required by a bound in `UnsafeCopy`
   --> $DIR/hr-associated-type-projection-1.rs:3:64
    |
-LL | trait UnsafeCopy<'a, T: Copy>
-   |       ---------- required by a bound in this
-LL | where
 LL |     for<'b> <Self as UnsafeCopy<'b, T>>::Item: std::ops::Deref<Target = T>,
    |                                                                ^^^^^^^^^^ required by this bound in `UnsafeCopy`
 help: consider further restricting this bound

--- a/src/test/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
+++ b/src/test/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
@@ -21,9 +21,6 @@ note: required by a bound in `Baz::Assoc`
    |
 LL |     Self::Assoc: Bar,
    |                  ^^^ required by this bound in `Baz::Assoc`
-LL | {
-LL |     type Assoc;
-   |          ----- required by a bound in this
 
 error[E0277]: the trait bound `bool: Bar` is not satisfied
   --> $DIR/point-at-type-on-obligation-failure-2.rs:30:18
@@ -36,9 +33,6 @@ note: required by a bound in `Bat::Assoc`
    |
 LL |     <Self as Bat>::Assoc: Bar,
    |                           ^^^ required by this bound in `Bat::Assoc`
-LL | {
-LL |     type Assoc;
-   |          ----- required by a bound in this
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/attributes/key-value-non-ascii.rs
+++ b/src/test/ui/attributes/key-value-non-ascii.rs
@@ -1,4 +1,4 @@
 #![feature(rustc_attrs)]
 
-#[rustc_dummy = b"ﬃ.rs"] //~ ERROR non-ASCII character in byte constant
+#[rustc_dummy = b"ﬃ.rs"] //~ ERROR non-ASCII character in byte string literal
 fn main() {}

--- a/src/test/ui/attributes/key-value-non-ascii.stderr
+++ b/src/test/ui/attributes/key-value-non-ascii.stderr
@@ -1,8 +1,8 @@
-error: non-ASCII character in byte constant
+error: non-ASCII character in byte string literal
   --> $DIR/key-value-non-ascii.rs:3:19
    |
 LL | #[rustc_dummy = b"ﬃ.rs"]
-   |                   ^ byte constant must be ASCII
+   |                   ^ must be ASCII
    |
 help: if you meant to use the UTF-8 encoding of 'ﬃ', use \xHH escapes
    |

--- a/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
+++ b/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
@@ -11,8 +11,6 @@ LL |     with_closure(|x: u32, y: i32| {
 note: required by a bound in `with_closure`
   --> $DIR/expect-infer-var-appearing-twice.rs:2:14
    |
-LL | fn with_closure<F, A>(_: F)
-   |    ------------ required by a bound in this
 LL |     where F: FnOnce(A, A)
    |              ^^^^^^^^^^^^ required by this bound in `with_closure`
 

--- a/src/test/ui/const-generics/defaults/wfness.stderr
+++ b/src/test/ui/const-generics/defaults/wfness.stderr
@@ -22,9 +22,6 @@ LL | fn foo() -> DependentDefaultWfness {
 note: required by a bound in `WhereClause`
   --> $DIR/wfness.rs:8:9
    |
-LL | struct WhereClause<const N: u8 = 2>
-   |        ----------- required by a bound in this
-LL | where
 LL |     (): Trait<N>;
    |         ^^^^^^^^ required by this bound in `WhereClause`
 

--- a/src/test/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.full.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.full.stderr
@@ -9,8 +9,6 @@ LL |     let x: Arr<{usize::MAX}> = Arr {};
 note: required by a bound in `Arr`
   --> $DIR/issue-72819-generic-in-const-eval.rs:8:39
    |
-LL | struct Arr<const N: usize>
-   |        --- required by a bound in this
 LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                                       ^^^^^^ required by this bound in `Arr`
 
@@ -25,8 +23,6 @@ LL |     let x: Arr<{usize::MAX}> = Arr {};
 note: required by a bound in `Arr`
   --> $DIR/issue-72819-generic-in-const-eval.rs:8:39
    |
-LL | struct Arr<const N: usize>
-   |        --- required by a bound in this
 LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                                       ^^^^^^ required by this bound in `Arr`
 

--- a/src/test/ui/const-generics/generic_const_exprs/obligation-cause.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/obligation-cause.rs
@@ -8,7 +8,6 @@ struct Is<const V: bool>;
 impl True for Is<true> {}
 
 fn g<T>()
-//~^ NOTE required by a bound in this
 where
     Is<{ std::mem::size_of::<T>() == 0 }>: True,
     //~^ NOTE required by a bound in `g`

--- a/src/test/ui/const-generics/generic_const_exprs/obligation-cause.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/obligation-cause.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/obligation-cause.rs:20:5
+  --> $DIR/obligation-cause.rs:19:5
    |
 LL |     g::<usize>();
    |     ^^^^^^^^^^ expected `false`, found `true`
@@ -7,11 +7,8 @@ LL |     g::<usize>();
    = note: expected constant `false`
               found constant `true`
 note: required by a bound in `g`
-  --> $DIR/obligation-cause.rs:13:44
+  --> $DIR/obligation-cause.rs:12:44
    |
-LL | fn g<T>()
-   |    - required by a bound in this
-...
 LL |     Is<{ std::mem::size_of::<T>() == 0 }>: True,
    |                                            ^^^^ required by this bound in `g`
 

--- a/src/test/ui/const-generics/issues/issue-67185-2.stderr
+++ b/src/test/ui/const-generics/issues/issue-67185-2.stderr
@@ -34,9 +34,6 @@ LL | impl Foo for FooImpl {}
 note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:15:25
    |
-LL | trait Foo
-   |       --- required by a bound in this
-...
 LL |     <u8 as Baz>::Quaks: Bar,
    |                         ^^^ required by this bound in `Foo`
 
@@ -52,9 +49,6 @@ LL | impl Foo for FooImpl {}
 note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:14:30
    |
-LL | trait Foo
-   |       --- required by a bound in this
-LL | where
 LL |     [<u8 as Baz>::Quaks; 2]: Bar,
    |                              ^^^ required by this bound in `Foo`
 
@@ -70,9 +64,6 @@ LL | fn f(_: impl Foo) {}
 note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:14:30
    |
-LL | trait Foo
-   |       --- required by a bound in this
-LL | where
 LL |     [<u8 as Baz>::Quaks; 2]: Bar,
    |                              ^^^ required by this bound in `Foo`
 
@@ -88,9 +79,6 @@ LL | fn f(_: impl Foo) {}
 note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:15:25
    |
-LL | trait Foo
-   |       --- required by a bound in this
-...
 LL |     <u8 as Baz>::Quaks: Bar,
    |                         ^^^ required by this bound in `Foo`
 

--- a/src/test/ui/const-generics/issues/issue-73260.stderr
+++ b/src/test/ui/const-generics/issues/issue-73260.stderr
@@ -9,9 +9,6 @@ LL |     let x: Arr<{usize::MAX}> = Arr {};
 note: required by a bound in `Arr`
   --> $DIR/issue-73260.rs:6:37
    |
-LL | struct Arr<const N: usize>
-   |        --- required by a bound in this
-LL | where
 LL |     Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                                     ^^^^^^ required by this bound in `Arr`
 
@@ -26,9 +23,6 @@ LL |     let x: Arr<{usize::MAX}> = Arr {};
 note: required by a bound in `Arr`
   --> $DIR/issue-73260.rs:6:37
    |
-LL | struct Arr<const N: usize>
-   |        --- required by a bound in this
-LL | where
 LL |     Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                                     ^^^^^^ required by this bound in `Arr`
 

--- a/src/test/ui/const-generics/issues/issue-79674.stderr
+++ b/src/test/ui/const-generics/issues/issue-79674.stderr
@@ -9,9 +9,6 @@ LL |     requires_distinct("str", 12);
 note: required by a bound in `requires_distinct`
   --> $DIR/issue-79674.rs:23:37
    |
-LL | fn requires_distinct<A, B>(_a: A, _b: B) where
-   |    ----------------- required by a bound in this
-LL |     A: MiniTypeId, B: MiniTypeId,
 LL |     Lift<{is_same_type::<A, B>()}>: IsFalse {}
    |                                     ^^^^^^^ required by this bound in `requires_distinct`
 

--- a/src/test/ui/const-generics/issues/issue-86530.stderr
+++ b/src/test/ui/const-generics/issues/issue-86530.stderr
@@ -9,9 +9,6 @@ LL |     z(" ");
 note: required by a bound in `z`
   --> $DIR/issue-86530.rs:10:8
    |
-LL | fn z<T>(t: T)
-   |    - required by a bound in this
-LL | where
 LL |     T: X,
    |        ^ required by this bound in `z`
 

--- a/src/test/ui/const-generics/occurs-check/unused-substs-1.stderr
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-1.stderr
@@ -8,9 +8,6 @@ LL |     let _ = A;
 note: required by a bound in `A`
   --> $DIR/unused-substs-1.rs:9:11
    |
-LL | struct A<const N: usize>
-   |        - required by a bound in this
-LL | where
 LL |     A<N>: Bar<N>;
    |           ^^^^^^ required by this bound in `A`
 

--- a/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -110,19 +110,19 @@ error: attribute should be applied to an `extern crate` item
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:25:1
    |
 LL | #![no_link]
-   | ^^^^^^^^^^^
+   | ^^^^^^^^^^^ not an `extern crate` item
 
 error: attribute should be applied to a free function, impl method or static
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:27:1
    |
 LL | #![export_name = "2200"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ not a free function, impl method or static
 
 error[E0518]: attribute should be applied to function or closure
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:29:1
    |
 LL | #![inline]
-   | ^^^^^^^^^^
+   | ^^^^^^^^^^ not a function or closure
 
 error: `macro_export` attribute cannot be used at crate level
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:12:1

--- a/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
@@ -1,6 +1,6 @@
 //~ NOTE not a function
 //~| NOTE not a foreign function or static
-//~| NOTE not a function or static
+//~| NOTE cannot be applied to crates
 //~| NOTE not an `extern` block
 // This test enumerates as many compiler-builtin ungated attributes as
 // possible (that is, all the mutually compatible ones), and checks

--- a/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -403,7 +403,7 @@ warning: attribute should be applied to a function definition
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:62:1
    |
 LL | #![cold]
-   | ^^^^^^^^
+   | ^^^^^^^^ cannot be applied to crates
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
@@ -411,7 +411,7 @@ warning: attribute should be applied to an `extern` block with non-Rust ABI
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:64:1
    |
 LL | #![link()]
-   | ^^^^^^^^^^
+   | ^^^^^^^^^^ not an `extern` block
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
@@ -419,7 +419,7 @@ warning: attribute should be applied to a foreign function or static
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:66:1
    |
 LL | #![link_name = "1900"]
-   | ^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^ not a foreign function or static
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
@@ -427,7 +427,7 @@ warning: attribute should be applied to a function or static
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:69:1
    |
 LL | #![link_section = "1800"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ not a function or static
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 

--- a/src/test/ui/fmt/unicode-escape-spans.rs
+++ b/src/test/ui/fmt/unicode-escape-spans.rs
@@ -1,0 +1,19 @@
+fn main() {
+    // 1 byte in UTF-8
+    format!("\u{000041}{a}"); //~ ERROR cannot find value
+    format!("\u{0041}{a}"); //~ ERROR cannot find value
+    format!("\u{41}{a}"); //~ ERROR cannot find value
+    format!("\u{0}{a}"); //~ ERROR cannot find value
+
+    // 2 bytes
+    format!("\u{0df}{a}"); //~ ERROR cannot find value
+    format!("\u{df}{a}"); //~ ERROR cannot find value
+
+    // 3 bytes
+    format!("\u{00211d}{a}"); //~ ERROR cannot find value
+    format!("\u{211d}{a}"); //~ ERROR cannot find value
+
+    // 4 bytes
+    format!("\u{1f4a3}{a}"); //~ ERROR cannot find value
+    format!("\u{10ffff}{a}"); //~ ERROR cannot find value
+}

--- a/src/test/ui/fmt/unicode-escape-spans.stderr
+++ b/src/test/ui/fmt/unicode-escape-spans.stderr
@@ -1,0 +1,63 @@
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/unicode-escape-spans.rs:3:25
+   |
+LL |     format!("\u{000041}{a}");
+   |                         ^ not found in this scope
+
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/unicode-escape-spans.rs:4:23
+   |
+LL |     format!("\u{0041}{a}");
+   |                       ^ not found in this scope
+
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/unicode-escape-spans.rs:5:21
+   |
+LL |     format!("\u{41}{a}");
+   |                     ^ not found in this scope
+
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/unicode-escape-spans.rs:6:20
+   |
+LL |     format!("\u{0}{a}");
+   |                    ^ not found in this scope
+
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/unicode-escape-spans.rs:9:22
+   |
+LL |     format!("\u{0df}{a}");
+   |                      ^ not found in this scope
+
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/unicode-escape-spans.rs:10:21
+   |
+LL |     format!("\u{df}{a}");
+   |                     ^ not found in this scope
+
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/unicode-escape-spans.rs:13:25
+   |
+LL |     format!("\u{00211d}{a}");
+   |                         ^ not found in this scope
+
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/unicode-escape-spans.rs:14:23
+   |
+LL |     format!("\u{211d}{a}");
+   |                       ^ not found in this scope
+
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/unicode-escape-spans.rs:17:24
+   |
+LL |     format!("\u{1f4a3}{a}");
+   |                        ^ not found in this scope
+
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/unicode-escape-spans.rs:18:25
+   |
+LL |     format!("\u{10ffff}{a}");
+   |                         ^ not found in this scope
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/generator/generator-yielding-or-returning-itself.stderr
+++ b/src/test/ui/generator/generator-yielding-or-returning-itself.stderr
@@ -18,8 +18,6 @@ LL | |     })
 note: required by a bound in `want_cyclic_generator_return`
   --> $DIR/generator-yielding-or-returning-itself.rs:10:36
    |
-LL | pub fn want_cyclic_generator_return<T>(_: T)
-   |        ---------------------------- required by a bound in this
 LL |     where T: Generator<Yield = (), Return = T>
    |                                    ^^^^^^^^^^ required by this bound in `want_cyclic_generator_return`
 
@@ -43,8 +41,6 @@ LL | |     })
 note: required by a bound in `want_cyclic_generator_yield`
   --> $DIR/generator-yielding-or-returning-itself.rs:23:24
    |
-LL | pub fn want_cyclic_generator_yield<T>(_: T)
-   |        --------------------------- required by a bound in this
 LL |     where T: Generator<Yield = T, Return = ()>
    |                        ^^^^^^^^^ required by this bound in `want_cyclic_generator_yield`
 

--- a/src/test/ui/generic-associated-types/bugs/issue-88460.stderr
+++ b/src/test/ui/generic-associated-types/bugs/issue-88460.stderr
@@ -10,9 +10,6 @@ LL |     test(Foo);
 note: required by a bound in `test`
   --> $DIR/issue-88460.rs:15:27
    |
-LL | fn test<T>(value: T)
-   |    ---- required by a bound in this
-...
 LL |     for<'a> T::Assoc<'a>: Marker,
    |                           ^^^^^^ required by this bound in `test`
 

--- a/src/test/ui/generic-associated-types/issue-101020.stderr
+++ b/src/test/ui/generic-associated-types/issue-101020.stderr
@@ -14,9 +14,6 @@ LL | impl<'a, T, F: 'a> FuncInput<'a, F> for T where F: Foo<T> {}
 note: required by a bound in `LendingIterator::consume`
   --> $DIR/issue-101020.rs:9:33
    |
-LL |     fn consume<F>(self, _f: F)
-   |        ------- required by a bound in this
-...
 LL |         for<'a> Self::Item<'a>: FuncInput<'a, Self::Item<'a>>,
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `LendingIterator::consume`
 

--- a/src/test/ui/higher-rank-trait-bounds/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -9,8 +9,6 @@ LL |     want_bar_for_any_ccx(b);
 note: required by a bound in `want_bar_for_any_ccx`
   --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:32:15
    |
-LL | fn want_bar_for_any_ccx<B>(b: &B)
-   |    -------------------- required by a bound in this
 LL |     where B : for<'ccx> Bar<'ccx>
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_bar_for_any_ccx`
 help: consider further restricting this bound

--- a/src/test/ui/higher-rank-trait-bounds/hrtb-higher-ranker-supertraits.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/hrtb-higher-ranker-supertraits.stderr
@@ -9,8 +9,6 @@ LL |     want_foo_for_any_tcx(f);
 note: required by a bound in `want_foo_for_any_tcx`
   --> $DIR/hrtb-higher-ranker-supertraits.rs:22:15
    |
-LL | fn want_foo_for_any_tcx<F>(f: &F)
-   |    -------------------- required by a bound in this
 LL |     where F : for<'tcx> Foo<'tcx>
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_foo_for_any_tcx`
 help: consider further restricting this bound
@@ -29,8 +27,6 @@ LL |     want_bar_for_any_ccx(b);
 note: required by a bound in `want_bar_for_any_ccx`
   --> $DIR/hrtb-higher-ranker-supertraits.rs:39:15
    |
-LL | fn want_bar_for_any_ccx<B>(b: &B)
-   |    -------------------- required by a bound in this
 LL |     where B : for<'ccx> Bar<'ccx>
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_bar_for_any_ccx`
 help: consider further restricting this bound

--- a/src/test/ui/higher-rank-trait-bounds/issue-62203-hrtb-ice.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/issue-62203-hrtb-ice.stderr
@@ -24,9 +24,6 @@ LL |     type O = T::Output;
 note: required by a bound in `T1::m`
   --> $DIR/issue-62203-hrtb-ice.rs:27:51
    |
-LL |     fn m<'a, B: Ty<'a>, F>(&self, f: F) -> Unit1
-   |        - required by a bound in this
-LL |     where
 LL |         F: for<'r> T0<'r, (<Self as Ty<'r>>::V,), O = <B as Ty<'r>>::V>,
    |                                                   ^^^^^^^^^^^^^^^^^^^^ required by this bound in `T1::m`
 
@@ -52,9 +49,6 @@ LL | impl<'a, A, T> T0<'a, A> for L<T>
 note: required by a bound in `T1::m`
   --> $DIR/issue-62203-hrtb-ice.rs:27:12
    |
-LL |     fn m<'a, B: Ty<'a>, F>(&self, f: F) -> Unit1
-   |        - required by a bound in this
-LL |     where
 LL |         F: for<'r> T0<'r, (<Self as Ty<'r>>::V,), O = <B as Ty<'r>>::V>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `T1::m`
 

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.stderr
@@ -12,9 +12,6 @@ LL | impl<B: BufferMut, C> BufferUdpStateContext<B> for C {}
 note: required by a bound in `StackContext`
   --> $DIR/issue-89118.rs:9:14
    |
-LL | trait StackContext
-   |       ------------ required by a bound in this
-LL | where
 LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StackContext`
 
@@ -32,9 +29,6 @@ LL | impl<B: BufferMut, C> BufferUdpStateContext<B> for C {}
 note: required by a bound in `EthernetWorker`
   --> $DIR/issue-89118.rs:28:14
    |
-LL | struct EthernetWorker<C>(C)
-   |        -------------- required by a bound in this
-LL | where
 LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EthernetWorker`
 
@@ -52,9 +46,6 @@ LL | impl<B: BufferMut, C> BufferUdpStateContext<B> for C {}
 note: required by a bound in `StackContext`
   --> $DIR/issue-89118.rs:9:14
    |
-LL | trait StackContext
-   |       ------------ required by a bound in this
-LL | where
 LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StackContext`
 

--- a/src/test/ui/implied-bounds/issue-100690.rs
+++ b/src/test/ui/implied-bounds/issue-100690.rs
@@ -4,7 +4,6 @@
 use std::io;
 
 fn real_dispatch<T, F>(f: F) -> Result<(), io::Error>
-//~^ NOTE required by a bound in this
 where
     F: FnOnce(&mut UIView<T>) -> Result<(), io::Error> + Send + 'static,
     //~^ NOTE required by this bound in `real_dispatch`

--- a/src/test/ui/implied-bounds/issue-100690.stderr
+++ b/src/test/ui/implied-bounds/issue-100690.stderr
@@ -1,5 +1,5 @@
 error[E0277]: expected a `FnOnce<(&mut UIView<'_, T>,)>` closure, found `F`
-  --> $DIR/issue-100690.rs:37:23
+  --> $DIR/issue-100690.rs:36:23
    |
 LL |         real_dispatch(f)
    |         ------------- ^ expected an `FnOnce<(&mut UIView<'_, T>,)>` closure, found `F`
@@ -9,11 +9,8 @@ LL |         real_dispatch(f)
    = note: expected a closure with arguments `(&mut UIView<'a, T>,)`
               found a closure with arguments `(&mut UIView<'_, T>,)`
 note: required by a bound in `real_dispatch`
-  --> $DIR/issue-100690.rs:9:8
+  --> $DIR/issue-100690.rs:8:8
    |
-LL | fn real_dispatch<T, F>(f: F) -> Result<(), io::Error>
-   |    ------------- required by a bound in this
-...
 LL |     F: FnOnce(&mut UIView<T>) -> Result<(), io::Error> + Send + 'static,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `real_dispatch`
 

--- a/src/test/ui/issues/issue-60218.stderr
+++ b/src/test/ui/issues/issue-60218.stderr
@@ -9,9 +9,6 @@ LL |     trigger_error(vec![], |x: &u32| x)
 note: required by a bound in `trigger_error`
   --> $DIR/issue-60218.rs:13:72
    |
-LL | pub fn trigger_error<I, F>(iterable: I, functor: F)
-   |        ------------- required by a bound in this
-...
 LL | for<'t> <Map<<&'t I as IntoIterator>::IntoIter, F> as Iterator>::Item: Foo,
    |                                                                        ^^^ required by this bound in `trigger_error`
 

--- a/src/test/ui/issues/issue-69396-const-no-type-in-macro.stderr
+++ b/src/test/ui/issues/issue-69396-const-no-type-in-macro.stderr
@@ -2,10 +2,7 @@ error[E0428]: the name `A` is defined multiple times
   --> $DIR/issue-69396-const-no-type-in-macro.rs:4:13
    |
 LL |               const A = "A".$fn();
-   |               ^^^^^^^^^^^^^^^^^^^^
-   |               |
-   |               `A` redefined here
-   |               previous definition of the value `A` here
+   |               ^^^^^^^^^^^^^^^^^^^^ `A` redefined here
 ...
 LL | / suite! {
 LL | |     len;

--- a/src/test/ui/issues/issue-69683.stderr
+++ b/src/test/ui/issues/issue-69683.stderr
@@ -29,9 +29,6 @@ note: required by a bound in `Foo::foo`
    |
 LL |     u8: Element<I>,
    |         ^^^^^^^^^^ required by this bound in `Foo::foo`
-LL | {
-LL |     fn foo(self, x: <u8 as Element<I>>::Array);
-   |        --- required by a bound in this
 help: try using a fully qualified path to specify the expected types
    |
 LL |     <u16 as Foo<I>>::foo(0u16, b);

--- a/src/test/ui/iterators/collect-into-array.rs
+++ b/src/test/ui/iterators/collect-into-array.rs
@@ -1,5 +1,4 @@
 fn main() {
-    //~^ NOTE required by a bound in this
     let whatever: [u32; 10] = (0..10).collect();
     //~^ ERROR an array of type `[u32; 10]` cannot be built directly from an iterator
     //~| NOTE try collecting into a `Vec<{integer}>`, then using `.try_into()`

--- a/src/test/ui/iterators/collect-into-array.stderr
+++ b/src/test/ui/iterators/collect-into-array.stderr
@@ -1,5 +1,5 @@
 error[E0277]: an array of type `[u32; 10]` cannot be built directly from an iterator
-  --> $DIR/collect-into-array.rs:3:31
+  --> $DIR/collect-into-array.rs:2:31
    |
 LL |     let whatever: [u32; 10] = (0..10).collect();
    |                               ^^^^^^^ ------- required by a bound introduced by this call

--- a/src/test/ui/iterators/collect-into-slice.rs
+++ b/src/test/ui/iterators/collect-into-slice.rs
@@ -1,6 +1,4 @@
 fn process_slice(data: &[i32]) {
-    //~^ NOTE required by a bound in this
-    //~| NOTE required by a bound in this
     todo!()
 }
 

--- a/src/test/ui/iterators/collect-into-slice.stderr
+++ b/src/test/ui/iterators/collect-into-slice.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
-  --> $DIR/collect-into-slice.rs:8:9
+  --> $DIR/collect-into-slice.rs:6:9
    |
 LL |     let some_generated_vec = (0..10).collect();
    |         ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -9,7 +9,7 @@ LL |     let some_generated_vec = (0..10).collect();
    = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
-  --> $DIR/collect-into-slice.rs:8:38
+  --> $DIR/collect-into-slice.rs:6:38
    |
 LL |     let some_generated_vec = (0..10).collect();
    |                                      ^^^^^^^ doesn't have a size known at compile-time
@@ -22,7 +22,7 @@ LL |     fn collect<B: FromIterator<Self::Item>>(self) -> B
    |                ^ required by this bound in `collect`
 
 error[E0277]: a slice of type `[i32]` cannot be built since `[i32]` has no definite size
-  --> $DIR/collect-into-slice.rs:8:30
+  --> $DIR/collect-into-slice.rs:6:30
    |
 LL |     let some_generated_vec = (0..10).collect();
    |                              ^^^^^^^ ------- required by a bound introduced by this call

--- a/src/test/ui/mismatched_types/issue-47706.stderr
+++ b/src/test/ui/mismatched_types/issue-47706.stderr
@@ -29,9 +29,6 @@ LL |     foo(Qux::Bar);
 note: required by a bound in `foo`
   --> $DIR/issue-47706.rs:22:8
    |
-LL | fn foo<F>(f: F)
-   |    --- required by a bound in this
-LL | where
 LL |     F: Fn(),
    |        ^^^^ required by this bound in `foo`
 

--- a/src/test/ui/parser/byte-literals.rs
+++ b/src/test/ui/parser/byte-literals.rs
@@ -7,6 +7,6 @@ pub fn main() {
     b'\x0Z';  //~ ERROR invalid character in numeric character escape: `Z`
     b'	';  //~ ERROR byte constant must be escaped
     b''';  //~ ERROR byte constant must be escaped
-    b'é';  //~ ERROR non-ASCII character in byte constant
+    b'é';  //~ ERROR non-ASCII character in byte literal
     b'a  //~ ERROR unterminated byte constant [E0763]
 }

--- a/src/test/ui/parser/byte-literals.stderr
+++ b/src/test/ui/parser/byte-literals.stderr
@@ -32,11 +32,11 @@ error: byte constant must be escaped: `'`
 LL |     b''';
    |       ^ help: escape the character: `\'`
 
-error: non-ASCII character in byte constant
+error: non-ASCII character in byte literal
   --> $DIR/byte-literals.rs:10:7
    |
 LL |     b'é';
-   |       ^ byte constant must be ASCII
+   |       ^ must be ASCII
    |
 help: if you meant to use the unicode code point for 'é', use a \xHH escape
    |

--- a/src/test/ui/parser/byte-string-literals.rs
+++ b/src/test/ui/parser/byte-string-literals.rs
@@ -3,7 +3,7 @@ static FOO: &'static [u8] = b"\f";  //~ ERROR unknown byte escape
 pub fn main() {
     b"\f";  //~ ERROR unknown byte escape
     b"\x0Z";  //~ ERROR invalid character in numeric character escape: `Z`
-    b"é";  //~ ERROR non-ASCII character in byte constant
-    br##"é"##;  //~ ERROR raw byte string must be ASCII
+    b"é";  //~ ERROR non-ASCII character in byte string literal
+    br##"é"##;  //~ ERROR non-ASCII character in raw byte string literal
     b"a  //~ ERROR unterminated double quote byte string
 }

--- a/src/test/ui/parser/byte-string-literals.stderr
+++ b/src/test/ui/parser/byte-string-literals.stderr
@@ -20,18 +20,18 @@ error: invalid character in numeric character escape: `Z`
 LL |     b"\x0Z";
    |          ^ invalid character in numeric character escape
 
-error: non-ASCII character in byte constant
+error: non-ASCII character in byte string literal
   --> $DIR/byte-string-literals.rs:6:7
    |
 LL |     b"é";
-   |       ^ byte constant must be ASCII
+   |       ^ must be ASCII
    |
 help: if you meant to use the unicode code point for 'é', use a \xHH escape
    |
 LL |     b"\xE9";
    |       ~~~~
 
-error: raw byte string must be ASCII
+error: non-ASCII character in raw byte string literal
   --> $DIR/byte-string-literals.rs:7:10
    |
 LL |     br##"é"##;

--- a/src/test/ui/parser/issue-103451.rs
+++ b/src/test/ui/parser/issue-103451.rs
@@ -1,0 +1,5 @@
+// error-pattern: this file contains an unclosed delimiter
+// error-pattern: expected value, found struct `R`
+struct R { }
+struct S {
+    x: [u8; R

--- a/src/test/ui/parser/issue-103451.stderr
+++ b/src/test/ui/parser/issue-103451.stderr
@@ -1,0 +1,32 @@
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-103451.rs:5:15
+   |
+LL | struct S {
+   |          - unclosed delimiter
+LL |     x: [u8; R
+   |        -      ^
+   |        |
+   |        unclosed delimiter
+
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-103451.rs:5:15
+   |
+LL | struct S {
+   |          - unclosed delimiter
+LL |     x: [u8; R
+   |        -      ^
+   |        |
+   |        unclosed delimiter
+
+error[E0423]: expected value, found struct `R`
+  --> $DIR/issue-103451.rs:5:13
+   |
+LL | struct R { }
+   | ------------ `R` defined here
+LL | struct S {
+LL |     x: [u8; R
+   |             ^ help: use struct literal syntax instead: `R {}`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0423`.

--- a/src/test/ui/parser/raw/raw-byte-string-literals.rs
+++ b/src/test/ui/parser/raw/raw-byte-string-literals.rs
@@ -2,6 +2,6 @@
 
 pub fn main() {
     br"a"; //~ ERROR bare CR not allowed in raw string
-    br"é";  //~ ERROR raw byte string must be ASCII
+    br"é";  //~ ERROR non-ASCII character in raw byte string literal
     br##~"a"~##;  //~ ERROR only `#` is allowed in raw string delimitation
 }

--- a/src/test/ui/parser/raw/raw-byte-string-literals.stderr
+++ b/src/test/ui/parser/raw/raw-byte-string-literals.stderr
@@ -4,7 +4,7 @@ error: bare CR not allowed in raw string
 LL |     br"a";
    |         ^
 
-error: raw byte string must be ASCII
+error: non-ASCII character in raw byte string literal
   --> $DIR/raw-byte-string-literals.rs:5:8
    |
 LL |     br"é";

--- a/src/test/ui/parser/unicode-control-codepoints.rs
+++ b/src/test/ui/parser/unicode-control-codepoints.rs
@@ -14,15 +14,15 @@ fn main() {
     println!("{:?}", r##"/*‮ } ⁦if isAdmin⁩ ⁦ begin admins only "##);
     //~^ ERROR unicode codepoint changing visible direction of text present in literal
     println!("{:?}", b"/*‮ } ⁦if isAdmin⁩ ⁦ begin admins only ");
-    //~^ ERROR non-ASCII character in byte constant
-    //~| ERROR non-ASCII character in byte constant
-    //~| ERROR non-ASCII character in byte constant
-    //~| ERROR non-ASCII character in byte constant
+    //~^ ERROR non-ASCII character in byte string literal
+    //~| ERROR non-ASCII character in byte string literal
+    //~| ERROR non-ASCII character in byte string literal
+    //~| ERROR non-ASCII character in byte string literal
     println!("{:?}", br##"/*‮ } ⁦if isAdmin⁩ ⁦ begin admins only "##);
-    //~^ ERROR raw byte string must be ASCII
-    //~| ERROR raw byte string must be ASCII
-    //~| ERROR raw byte string must be ASCII
-    //~| ERROR raw byte string must be ASCII
+    //~^ ERROR non-ASCII character in raw byte string literal
+    //~| ERROR non-ASCII character in raw byte string literal
+    //~| ERROR non-ASCII character in raw byte string literal
+    //~| ERROR non-ASCII character in raw byte string literal
     println!("{:?}", '‮');
     //~^ ERROR unicode codepoint changing visible direction of text present in literal
 }

--- a/src/test/ui/parser/unicode-control-codepoints.stderr
+++ b/src/test/ui/parser/unicode-control-codepoints.stderr
@@ -14,69 +14,69 @@ LL |     println!("{:?}", b"us\u{202B}e\u{202A}r");
    |
    = help: unicode escape sequences cannot be used as a byte or in a byte string
 
-error: non-ASCII character in byte constant
+error: non-ASCII character in byte string literal
   --> $DIR/unicode-control-codepoints.rs:16:26
    |
 LL |     println!("{:?}", b"/* } if isAdmin  begin admins only ");
-   |                          ^ byte constant must be ASCII but is '\u{202e}'
+   |                          ^ must be ASCII but is '\u{202e}'
    |
 help: if you meant to use the UTF-8 encoding of '\u{202e}', use \xHH escapes
    |
 LL |     println!("{:?}", b"/*\xE2\x80\xAE } if isAdmin  begin admins only ");
    |                          ~~~~~~~~~~~~
 
-error: non-ASCII character in byte constant
+error: non-ASCII character in byte string literal
   --> $DIR/unicode-control-codepoints.rs:16:30
    |
 LL |     println!("{:?}", b"/* } if isAdmin  begin admins only ");
-   |                             ^ byte constant must be ASCII but is '\u{2066}'
+   |                             ^ must be ASCII but is '\u{2066}'
    |
 help: if you meant to use the UTF-8 encoding of '\u{2066}', use \xHH escapes
    |
 LL |     println!("{:?}", b"/* } \xE2\x81\xA6if isAdmin  begin admins only ");
    |                             ~~~~~~~~~~~~
 
-error: non-ASCII character in byte constant
+error: non-ASCII character in byte string literal
   --> $DIR/unicode-control-codepoints.rs:16:41
    |
 LL |     println!("{:?}", b"/* } if isAdmin  begin admins only ");
-   |                                       ^ byte constant must be ASCII but is '\u{2069}'
+   |                                       ^ must be ASCII but is '\u{2069}'
    |
 help: if you meant to use the UTF-8 encoding of '\u{2069}', use \xHH escapes
    |
 LL |     println!("{:?}", b"/* } if isAdmin\xE2\x81\xA9  begin admins only ");
    |                                       ~~~~~~~~~~~~
 
-error: non-ASCII character in byte constant
+error: non-ASCII character in byte string literal
   --> $DIR/unicode-control-codepoints.rs:16:43
    |
 LL |     println!("{:?}", b"/* } if isAdmin  begin admins only ");
-   |                                        ^ byte constant must be ASCII but is '\u{2066}'
+   |                                        ^ must be ASCII but is '\u{2066}'
    |
 help: if you meant to use the UTF-8 encoding of '\u{2066}', use \xHH escapes
    |
 LL |     println!("{:?}", b"/* } if isAdmin \xE2\x81\xA6 begin admins only ");
    |                                        ~~~~~~~~~~~~
 
-error: raw byte string must be ASCII
+error: non-ASCII character in raw byte string literal
   --> $DIR/unicode-control-codepoints.rs:21:29
    |
 LL |     println!("{:?}", br##"/* } if isAdmin  begin admins only "##);
    |                             ^ must be ASCII but is '\u{202e}'
 
-error: raw byte string must be ASCII
+error: non-ASCII character in raw byte string literal
   --> $DIR/unicode-control-codepoints.rs:21:33
    |
 LL |     println!("{:?}", br##"/* } if isAdmin  begin admins only "##);
    |                                ^ must be ASCII but is '\u{2066}'
 
-error: raw byte string must be ASCII
+error: non-ASCII character in raw byte string literal
   --> $DIR/unicode-control-codepoints.rs:21:44
    |
 LL |     println!("{:?}", br##"/* } if isAdmin  begin admins only "##);
    |                                          ^ must be ASCII but is '\u{2069}'
 
-error: raw byte string must be ASCII
+error: non-ASCII character in raw byte string literal
   --> $DIR/unicode-control-codepoints.rs:21:46
    |
 LL |     println!("{:?}", br##"/* } if isAdmin  begin admins only "##);

--- a/src/test/ui/suggestions/imm-ref-trait-object-literal-bound-regions.stderr
+++ b/src/test/ui/suggestions/imm-ref-trait-object-literal-bound-regions.stderr
@@ -11,9 +11,6 @@ LL |     foo::<S>(s);
 note: required by a bound in `foo`
   --> $DIR/imm-ref-trait-object-literal-bound-regions.rs:11:20
    |
-LL | fn foo<X>(_: X)
-   |    --- required by a bound in this
-LL | where
 LL |     for<'b> &'b X: Trait,
    |                    ^^^^^ required by this bound in `foo`
 

--- a/src/test/ui/suggestions/issue-84973.stderr
+++ b/src/test/ui/suggestions/issue-84973.stderr
@@ -11,9 +11,6 @@ note: required by a bound in `Other::<'a, G>::new`
    |
 LL |     G: SomeTrait,
    |        ^^^^^^^^^ required by this bound in `Other::<'a, G>::new`
-LL | {
-LL |     pub fn new(g: G) -> Self {
-   |            --- required by a bound in this
 help: consider borrowing here
    |
 LL |     let o = Other::new(&f);

--- a/src/test/ui/suggestions/multibyte-escapes.rs
+++ b/src/test/ui/suggestions/multibyte-escapes.rs
@@ -2,17 +2,17 @@
 
 fn main() {
     b'µ';
-    //~^ ERROR: non-ASCII character in byte constant
+    //~^ ERROR: non-ASCII character in byte literal
     //~| HELP: if you meant to use the unicode code point for 'µ', use a \xHH escape
-    //~| NOTE: byte constant must be ASCII
+    //~| NOTE: must be ASCII
 
     b'字';
-    //~^ ERROR: non-ASCII character in byte constant
+    //~^ ERROR: non-ASCII character in byte literal
     //~| NOTE: this multibyte character does not fit into a single byte
-    //~| NOTE: byte constant must be ASCII
+    //~| NOTE: must be ASCII
 
     b"字";
-    //~^ ERROR: non-ASCII character in byte constant
+    //~^ ERROR: non-ASCII character in byte string literal
     //~| HELP: if you meant to use the UTF-8 encoding of '字', use \xHH escapes
-    //~| NOTE: byte constant must be ASCII
+    //~| NOTE: must be ASCII
 }

--- a/src/test/ui/suggestions/multibyte-escapes.stderr
+++ b/src/test/ui/suggestions/multibyte-escapes.stderr
@@ -1,28 +1,28 @@
-error: non-ASCII character in byte constant
+error: non-ASCII character in byte literal
   --> $DIR/multibyte-escapes.rs:4:7
    |
 LL |     b'µ';
-   |       ^ byte constant must be ASCII
+   |       ^ must be ASCII
    |
 help: if you meant to use the unicode code point for 'µ', use a \xHH escape
    |
 LL |     b'\xB5';
    |       ~~~~
 
-error: non-ASCII character in byte constant
+error: non-ASCII character in byte literal
   --> $DIR/multibyte-escapes.rs:9:7
    |
 LL |     b'字';
    |       ^^
    |       |
-   |       byte constant must be ASCII
+   |       must be ASCII
    |       this multibyte character does not fit into a single byte
 
-error: non-ASCII character in byte constant
+error: non-ASCII character in byte string literal
   --> $DIR/multibyte-escapes.rs:14:7
    |
 LL |     b"字";
-   |       ^^ byte constant must be ASCII
+   |       ^^ must be ASCII
    |
 help: if you meant to use the UTF-8 encoding of '字', use \xHH escapes
    |

--- a/src/test/ui/traits/multidispatch-convert-ambig-dest.stderr
+++ b/src/test/ui/traits/multidispatch-convert-ambig-dest.stderr
@@ -28,8 +28,6 @@ LL | impl Convert<i16> for i32 {
 note: required by a bound in `test`
   --> $DIR/multidispatch-convert-ambig-dest.rs:21:11
    |
-LL | fn test<T,U>(_: T, _: U)
-   |    ---- required by a bound in this
 LL | where T : Convert<U>
    |           ^^^^^^^^^^ required by this bound in `test`
 help: consider specifying the generic arguments

--- a/src/test/ui/traits/object/enforce-supertrait-projection.stderr
+++ b/src/test/ui/traits/object/enforce-supertrait-projection.stderr
@@ -15,9 +15,6 @@ LL |     foo::<A, B, dyn Trait<A = A, B = B>>(x)
 note: required by a bound in `foo`
   --> $DIR/enforce-supertrait-projection.rs:15:8
    |
-LL | fn foo<A, B, T: ?Sized>(x: T::A) -> B
-   |    --- required by a bound in this
-LL | where
 LL |     T: Trait<B = B>,
    |        ^^^^^^^^^^^^ required by this bound in `foo`
 

--- a/src/test/ui/transmutability/arrays/should_require_well_defined_layout.stderr
+++ b/src/test/ui/transmutability/arrays/should_require_well_defined_layout.stderr
@@ -8,9 +8,6 @@ LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
@@ -30,9 +27,6 @@ LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
@@ -52,9 +46,6 @@ LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
@@ -74,9 +65,6 @@ LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
@@ -96,9 +84,6 @@ LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
@@ -118,9 +103,6 @@ LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume::ALIGNMENT

--- a/src/test/ui/transmutability/enums/repr/primitive_reprs_should_have_correct_length.stderr
+++ b/src/test/ui/transmutability/enums/repr/primitive_reprs_should_have_correct_length.stderr
@@ -8,9 +8,6 @@ LL |         assert::is_transmutable::<Smaller, Current, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -31,9 +28,6 @@ LL |         assert::is_transmutable::<Current, Larger, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -54,9 +48,6 @@ LL |         assert::is_transmutable::<Smaller, Current, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -77,9 +68,6 @@ LL |         assert::is_transmutable::<Current, Larger, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -100,9 +88,6 @@ LL |         assert::is_transmutable::<Smaller, Current, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -123,9 +108,6 @@ LL |         assert::is_transmutable::<Current, Larger, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -146,9 +128,6 @@ LL |         assert::is_transmutable::<Smaller, Current, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -169,9 +148,6 @@ LL |         assert::is_transmutable::<Current, Larger, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -192,9 +168,6 @@ LL |         assert::is_transmutable::<Smaller, Current, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -215,9 +188,6 @@ LL |         assert::is_transmutable::<Current, Larger, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -238,9 +208,6 @@ LL |         assert::is_transmutable::<Smaller, Current, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -261,9 +228,6 @@ LL |         assert::is_transmutable::<Current, Larger, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -284,9 +248,6 @@ LL |         assert::is_transmutable::<Smaller, Current, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -307,9 +268,6 @@ LL |         assert::is_transmutable::<Current, Larger, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -330,9 +288,6 @@ LL |         assert::is_transmutable::<Smaller, Current, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -353,9 +308,6 @@ LL |         assert::is_transmutable::<Current, Larger, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -376,9 +328,6 @@ LL |         assert::is_transmutable::<Smaller, Current, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -399,9 +348,6 @@ LL |         assert::is_transmutable::<Current, Larger, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -422,9 +368,6 @@ LL |         assert::is_transmutable::<Smaller, Current, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -445,9 +388,6 @@ LL |         assert::is_transmutable::<Current, Larger, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {

--- a/src/test/ui/transmutability/enums/repr/should_require_well_defined_layout.stderr
+++ b/src/test/ui/transmutability/enums/repr/should_require_well_defined_layout.stderr
@@ -8,9 +8,6 @@ LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -31,9 +28,6 @@ LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -54,9 +48,6 @@ LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -77,9 +68,6 @@ LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -100,9 +88,6 @@ LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -123,9 +108,6 @@ LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {

--- a/src/test/ui/transmutability/enums/should_pad_variants.stderr
+++ b/src/test/ui/transmutability/enums/should_pad_variants.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_transmutable::<Src, Dst, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/should_pad_variants.rs:13:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume::ALIGNMENT

--- a/src/test/ui/transmutability/enums/should_respect_endianness.stderr
+++ b/src/test/ui/transmutability/enums/should_respect_endianness.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_transmutable::<Src, Unexpected>();
 note: required by a bound in `is_transmutable`
   --> $DIR/should_respect_endianness.rs:14:14
    |
-LL |       pub fn is_transmutable<Src, Dst>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume::ALIGNMENT

--- a/src/test/ui/transmutability/primitives/bool.stderr
+++ b/src/test/ui/transmutability/primitives/bool.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_transmutable::<u8, bool>();
 note: required by a bound in `is_transmutable`
   --> $DIR/bool.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 

--- a/src/test/ui/transmutability/primitives/numbers.stderr
+++ b/src/test/ui/transmutability/primitives/numbers.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_transmutable::<   i8,   i16>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -24,9 +21,6 @@ LL |     assert::is_transmutable::<   i8,   u16>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -40,9 +34,6 @@ LL |     assert::is_transmutable::<   i8,   i32>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -56,9 +47,6 @@ LL |     assert::is_transmutable::<   i8,   f32>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -72,9 +60,6 @@ LL |     assert::is_transmutable::<   i8,   u32>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -88,9 +73,6 @@ LL |     assert::is_transmutable::<   i8,   u64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -104,9 +86,6 @@ LL |     assert::is_transmutable::<   i8,   i64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -120,9 +99,6 @@ LL |     assert::is_transmutable::<   i8,   f64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -136,9 +112,6 @@ LL |     assert::is_transmutable::<   i8,  u128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -152,9 +125,6 @@ LL |     assert::is_transmutable::<   i8,  i128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -168,9 +138,6 @@ LL |     assert::is_transmutable::<   u8,   i16>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -184,9 +151,6 @@ LL |     assert::is_transmutable::<   u8,   u16>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -200,9 +164,6 @@ LL |     assert::is_transmutable::<   u8,   i32>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -216,9 +177,6 @@ LL |     assert::is_transmutable::<   u8,   f32>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -232,9 +190,6 @@ LL |     assert::is_transmutable::<   u8,   u32>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -248,9 +203,6 @@ LL |     assert::is_transmutable::<   u8,   u64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -264,9 +216,6 @@ LL |     assert::is_transmutable::<   u8,   i64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -280,9 +229,6 @@ LL |     assert::is_transmutable::<   u8,   f64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -296,9 +242,6 @@ LL |     assert::is_transmutable::<   u8,  u128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -312,9 +255,6 @@ LL |     assert::is_transmutable::<   u8,  i128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -328,9 +268,6 @@ LL |     assert::is_transmutable::<  i16,   i32>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -344,9 +281,6 @@ LL |     assert::is_transmutable::<  i16,   f32>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -360,9 +294,6 @@ LL |     assert::is_transmutable::<  i16,   u32>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -376,9 +307,6 @@ LL |     assert::is_transmutable::<  i16,   u64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -392,9 +320,6 @@ LL |     assert::is_transmutable::<  i16,   i64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -408,9 +333,6 @@ LL |     assert::is_transmutable::<  i16,   f64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -424,9 +346,6 @@ LL |     assert::is_transmutable::<  i16,  u128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -440,9 +359,6 @@ LL |     assert::is_transmutable::<  i16,  i128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -456,9 +372,6 @@ LL |     assert::is_transmutable::<  u16,   i32>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -472,9 +385,6 @@ LL |     assert::is_transmutable::<  u16,   f32>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -488,9 +398,6 @@ LL |     assert::is_transmutable::<  u16,   u32>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -504,9 +411,6 @@ LL |     assert::is_transmutable::<  u16,   u64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -520,9 +424,6 @@ LL |     assert::is_transmutable::<  u16,   i64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -536,9 +437,6 @@ LL |     assert::is_transmutable::<  u16,   f64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -552,9 +450,6 @@ LL |     assert::is_transmutable::<  u16,  u128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -568,9 +463,6 @@ LL |     assert::is_transmutable::<  u16,  i128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -584,9 +476,6 @@ LL |     assert::is_transmutable::<  i32,   u64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -600,9 +489,6 @@ LL |     assert::is_transmutable::<  i32,   i64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -616,9 +502,6 @@ LL |     assert::is_transmutable::<  i32,   f64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -632,9 +515,6 @@ LL |     assert::is_transmutable::<  i32,  u128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -648,9 +528,6 @@ LL |     assert::is_transmutable::<  i32,  i128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -664,9 +541,6 @@ LL |     assert::is_transmutable::<  f32,   u64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -680,9 +554,6 @@ LL |     assert::is_transmutable::<  f32,   i64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -696,9 +567,6 @@ LL |     assert::is_transmutable::<  f32,   f64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -712,9 +580,6 @@ LL |     assert::is_transmutable::<  f32,  u128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -728,9 +593,6 @@ LL |     assert::is_transmutable::<  f32,  i128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -744,9 +606,6 @@ LL |     assert::is_transmutable::<  u32,   u64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -760,9 +619,6 @@ LL |     assert::is_transmutable::<  u32,   i64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -776,9 +632,6 @@ LL |     assert::is_transmutable::<  u32,   f64>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -792,9 +645,6 @@ LL |     assert::is_transmutable::<  u32,  u128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -808,9 +658,6 @@ LL |     assert::is_transmutable::<  u32,  i128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -824,9 +671,6 @@ LL |     assert::is_transmutable::<  u64,  u128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -840,9 +684,6 @@ LL |     assert::is_transmutable::<  u64,  i128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -856,9 +697,6 @@ LL |     assert::is_transmutable::<  i64,  u128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -872,9 +710,6 @@ LL |     assert::is_transmutable::<  i64,  i128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -888,9 +723,6 @@ LL |     assert::is_transmutable::<  f64,  u128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -904,9 +736,6 @@ LL |     assert::is_transmutable::<  f64,  i128>();
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 

--- a/src/test/ui/transmutability/primitives/unit.stderr
+++ b/src/test/ui/transmutability/primitives/unit.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_transmutable::<(), u8, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/unit.rs:12:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume::ALIGNMENT

--- a/src/test/ui/transmutability/references.stderr
+++ b/src/test/ui/transmutability/references.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_maybe_transmutable::<&'static Unit, &'static Unit>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/references.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {

--- a/src/test/ui/transmutability/structs/repr/should_require_well_defined_layout.stderr
+++ b/src/test/ui/transmutability/structs/repr/should_require_well_defined_layout.stderr
@@ -8,9 +8,6 @@ LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -31,9 +28,6 @@ LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -54,9 +48,6 @@ LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -77,9 +68,6 @@ LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -100,9 +88,6 @@ LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -123,9 +108,6 @@ LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -146,9 +128,6 @@ LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -169,9 +148,6 @@ LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -192,9 +168,6 @@ LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -215,9 +188,6 @@ LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -238,9 +208,6 @@ LL |         assert::is_maybe_transmutable::<repr_c, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -261,9 +228,6 @@ LL |         assert::is_maybe_transmutable::<u128, repr_c>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {

--- a/src/test/ui/transmutability/unions/repr/should_require_well_defined_layout.stderr
+++ b/src/test/ui/transmutability/unions/repr/should_require_well_defined_layout.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_maybe_transmutable::<repr_rust, ()>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {
@@ -31,9 +28,6 @@ LL |     assert::is_maybe_transmutable::<u128, repr_rust>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
-LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume {

--- a/src/test/ui/transmutability/unions/should_pad_variants.stderr
+++ b/src/test/ui/transmutability/unions/should_pad_variants.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_transmutable::<Src, Dst, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/should_pad_variants.rs:13:14
    |
-LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
-LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
 LL | |             Assume::ALIGNMENT

--- a/src/test/ui/transmutability/unions/should_reject_contraction.stderr
+++ b/src/test/ui/transmutability/unions/should_reject_contraction.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_transmutable::<Superset, Subset>();
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_contraction.rs:13:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 

--- a/src/test/ui/transmutability/unions/should_reject_disjoint.stderr
+++ b/src/test/ui/transmutability/unions/should_reject_disjoint.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_maybe_transmutable::<A, B>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_reject_disjoint.rs:13:14
    |
-LL |     pub fn is_maybe_transmutable<Src, Dst>()
-   |            --------------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY.and(Assume::VALIDITY) }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
 
@@ -24,9 +21,6 @@ LL |     assert::is_maybe_transmutable::<B, A>();
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_reject_disjoint.rs:13:14
    |
-LL |     pub fn is_maybe_transmutable<Src, Dst>()
-   |            --------------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY.and(Assume::VALIDITY) }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
 

--- a/src/test/ui/transmutability/unions/should_reject_intersecting.stderr
+++ b/src/test/ui/transmutability/unions/should_reject_intersecting.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_transmutable::<A, B>();
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_intersecting.rs:14:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
@@ -24,9 +21,6 @@ LL |     assert::is_transmutable::<B, A>();
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_intersecting.rs:14:14
    |
-LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 

--- a/src/test/ui/transmutability/visibility/should_reject_if_dst_has_private_field.stderr
+++ b/src/test/ui/transmutability/visibility/should_reject_if_dst_has_private_field.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_transmutable::<src::Src, dst::Dst, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_if_dst_has_private_field.rs:13:14
    |
-LL |     pub fn is_transmutable<Src, Dst, Context>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context> // safety is NOT assumed
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 

--- a/src/test/ui/transmutability/visibility/should_reject_if_dst_has_private_variant.stderr
+++ b/src/test/ui/transmutability/visibility/should_reject_if_dst_has_private_variant.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_transmutable::<src::Src, dst::Dst, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_if_dst_has_private_variant.rs:13:14
    |
-LL |     pub fn is_transmutable<Src, Dst, Context>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context> // safety is NOT assumed
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 

--- a/src/test/ui/transmutability/visibility/should_reject_if_dst_has_unreachable_field.stderr
+++ b/src/test/ui/transmutability/visibility/should_reject_if_dst_has_unreachable_field.stderr
@@ -8,9 +8,6 @@ LL |     assert::is_transmutable::<src::Src, dst::Dst, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_if_dst_has_unreachable_field.rs:15:14
    |
-LL |     pub fn is_transmutable<Src, Dst, Context>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context> // safety is NOT assumed
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 

--- a/src/test/ui/transmutability/visibility/should_reject_if_dst_has_unreachable_ty.stderr
+++ b/src/test/ui/transmutability/visibility/should_reject_if_dst_has_unreachable_ty.stderr
@@ -20,9 +20,6 @@ LL |     assert::is_transmutable::<src::Src, dst::Dst, Context>();
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_if_dst_has_unreachable_ty.rs:15:14
    |
-LL |     pub fn is_transmutable<Src, Dst, Context>()
-   |            --------------- required by a bound in this
-LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context> // safety is NOT assumed
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-infer-fn-once-move-from-projection.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-infer-fn-once-move-from-projection.stderr
@@ -13,8 +13,6 @@ LL |     foo(c);
 note: required by a bound in `foo`
   --> $DIR/unboxed-closures-infer-fn-once-move-from-projection.rs:4:14
    |
-LL | fn foo<F>(f: F)
-   |    --- required by a bound in this
 LL |     where F: Fn()
    |              ^^^^ required by this bound in `foo`
 

--- a/src/test/ui/unsized/issue-71659.stderr
+++ b/src/test/ui/unsized/issue-71659.stderr
@@ -9,9 +9,6 @@ LL |     let x = x.cast::<[i32]>();
 note: required by a bound in `Cast::cast`
   --> $DIR/issue-71659.rs:19:15
    |
-LL |     fn cast<T: ?Sized>(&self) -> &T
-   |        ---- required by a bound in this
-LL |     where
 LL |         Self: CastTo<T>,
    |               ^^^^^^^^^ required by this bound in `Cast::cast`
 

--- a/src/test/ui/where-clauses/higher-ranked-fn-type.quiet.stderr
+++ b/src/test/ui/where-clauses/higher-ranked-fn-type.quiet.stderr
@@ -7,9 +7,6 @@ LL |     called()
 note: required by a bound in `called`
   --> $DIR/higher-ranked-fn-type.rs:12:25
    |
-LL | fn called()
-   |    ------ required by a bound in this
-LL | where
 LL |     for<'b> fn(&'b ()): Foo,
    |                         ^^^ required by this bound in `called`
 

--- a/src/test/ui/where-clauses/higher-ranked-fn-type.verbose.stderr
+++ b/src/test/ui/where-clauses/higher-ranked-fn-type.verbose.stderr
@@ -7,9 +7,6 @@ LL |     called()
 note: required by a bound in `called`
   --> $DIR/higher-ranked-fn-type.rs:12:25
    |
-LL | fn called()
-   |    ------ required by a bound in this
-LL | where
 LL |     for<'b> fn(&'b ()): Foo,
    |                         ^^^ required by this bound in `called`
 

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -64,6 +64,7 @@ static TARGETS: &[&str] = &[
     "aarch64-unknown-none",
     "aarch64-unknown-none-softfloat",
     "aarch64-unknown-redox",
+    "aarch64-unknown-uefi",
     "arm-linux-androideabi",
     "arm-unknown-linux-gnueabi",
     "arm-unknown-linux-gnueabihf",
@@ -99,6 +100,7 @@ static TARGETS: &[&str] = &[
     "i686-unknown-freebsd",
     "i686-unknown-linux-gnu",
     "i686-unknown-linux-musl",
+    "i686-unknown-uefi",
     "m68k-unknown-linux-gnu",
     "mips-unknown-linux-gnu",
     "mips-unknown-linux-musl",
@@ -155,6 +157,7 @@ static TARGETS: &[&str] = &[
     "x86_64-unknown-none",
     "x86_64-unknown-redox",
     "x86_64-unknown-hermit",
+    "x86_64-unknown-uefi",
 ];
 
 /// This allows the manifest to contain rust-docs for hosts that don't build

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -365,6 +365,23 @@ impl Checker {
             }
         });
 
+        self.check_intra_doc_links(file, &pretty_path, &source, report);
+
+        // we don't need the source anymore,
+        // so drop to reduce memory-usage
+        match self.cache.get_mut(&pretty_path).unwrap() {
+            FileEntry::HtmlFile { source, .. } => *source = Rc::new(String::new()),
+            _ => unreachable!("must be html file"),
+        }
+    }
+
+    fn check_intra_doc_links(
+        &mut self,
+        file: &Path,
+        pretty_path: &str,
+        source: &str,
+        report: &mut Report,
+    ) {
         // Search for intra-doc links that rustdoc didn't warn about
         // FIXME(#77199, 77200) Rustdoc should just warn about these directly.
         // NOTE: only looks at one line at a time; in practice this should find most links
@@ -378,12 +395,6 @@ impl Checker {
                     println!("{}", &broken_link[0]);
                 }
             }
-        }
-        // we don't need the source anymore,
-        // so drop to reduce memory-usage
-        match self.cache.get_mut(&pretty_path).unwrap() {
-            FileEntry::HtmlFile { source, .. } => *source = Rc::new(String::new()),
-            _ => unreachable!("must be html file"),
         }
     }
 

--- a/src/tools/rust-analyzer/crates/syntax/src/validation.rs
+++ b/src/tools/rust-analyzer/crates/syntax/src/validation.rs
@@ -5,9 +5,7 @@
 mod block;
 
 use rowan::Direction;
-use rustc_lexer::unescape::{
-    self, unescape_byte, unescape_byte_literal, unescape_char, unescape_literal, Mode,
-};
+use rustc_lexer::unescape::{self, unescape_byte, unescape_char, unescape_literal, Mode};
 
 use crate::{
     algo,
@@ -143,7 +141,7 @@ fn validate_literal(literal: ast::Literal, acc: &mut Vec<SyntaxError>) {
         ast::LiteralKind::ByteString(s) => {
             if !s.is_raw() {
                 if let Some(without_quotes) = unquote(text, 2, '"') {
-                    unescape_byte_literal(without_quotes, Mode::ByteStr, &mut |range, char| {
+                    unescape_literal(without_quotes, Mode::ByteStr, &mut |range, char| {
                         if let Err(err) = char {
                             push_err(2, (range.start, err));
                         }


### PR DESCRIPTION
Successful merges:

 - #103521 (Avoid possible infinite  loop when next_point reaching the end of file)
 - #103651 (Fix `rustc_parse_format` spans following escaped utf-8 multibyte chars)
 - #103744 (Upgrade cc for working is_flag_supported on cross-compiles)
 - #103919 (Unescaping cleanups)
 - #103933 (Promote {aarch64,i686,x86_64}-unknown-uefi to Tier 2)
 - #103952 (Don't intra linkcheck reference)
 - #103955 (Update linker-plugin-lto.md to contain up to Rust 1.65)
 - #103970 (Unhide unknown spans)
 - #104067 (fix debuginfo for windows_gnullvm_base.rs)
 - #104114 (Fix invalid background-image file name)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=103521,103651,103744,103919,103933,103952,103955,103970,104067,104114)
<!-- homu-ignore:end -->