### PR TITLE
Const Compare for Tuples

### DIFF
--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -22,7 +22,8 @@ macro_rules! tuple_impls {
         maybe_tuple_doc! {
             $($T)+ @
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl<$($T:PartialEq),+> PartialEq for ($($T,)+)
+            #[rustc_const_unstable(feature = "const_cmp", issue = "92391")]
+            impl<$($T: ~const PartialEq),+> const PartialEq for ($($T,)+)
             where
                 last_type!($($T,)+): ?Sized
             {
@@ -40,7 +41,7 @@ macro_rules! tuple_impls {
         maybe_tuple_doc! {
             $($T)+ @
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl<$($T:Eq),+> Eq for ($($T,)+)
+            impl<$($T: Eq),+> Eq for ($($T,)+)
             where
                 last_type!($($T,)+): ?Sized
             {}
@@ -49,7 +50,8 @@ macro_rules! tuple_impls {
         maybe_tuple_doc! {
             $($T)+ @
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl<$($T:PartialOrd + PartialEq),+> PartialOrd for ($($T,)+)
+            #[rustc_const_unstable(feature = "const_cmp", issue = "92391")]
+            impl<$($T: ~const PartialOrd + ~const PartialEq),+> const PartialOrd for ($($T,)+)
             where
                 last_type!($($T,)+): ?Sized
             {
@@ -79,7 +81,8 @@ macro_rules! tuple_impls {
         maybe_tuple_doc! {
             $($T)+ @
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl<$($T:Ord),+> Ord for ($($T,)+)
+            #[rustc_const_unstable(feature = "const_cmp", issue = "92391")]
+            impl<$($T: ~const Ord),+> const Ord for ($($T,)+)
             where
                 last_type!($($T,)+): ?Sized
             {

--- a/src/test/ui/consts/fn_trait_refs.rs
+++ b/src/test/ui/consts/fn_trait_refs.rs
@@ -1,4 +1,4 @@
-// build-pass
+// check-pass
 
 #![feature(const_fn_trait_ref_impls)]
 #![feature(fn_traits)]
@@ -60,21 +60,18 @@ const fn test(i: i32) -> i32 {
     i + 1
 }
 
-const fn main() {
+fn main() {
     const fn one() -> i32 {
         1
     };
     const fn two() -> i32 {
         2
     };
+    const _: () = {
+        let test_one = test_fn(one);
+        assert!(test_one == (1, 1, 1));
 
-    // FIXME(const_cmp_tuple)
-    let test_one = test_fn(one);
-    assert!(test_one.0 == 1);
-    assert!(test_one.1 == 1);
-    assert!(test_one.2 == 1);
-
-    let test_two = test_fn_mut(two);
-    assert!(test_two.0 == 1);
-    assert!(test_two.1 == 1);
+        let test_two = test_fn_mut(two);
+        assert!(test_two == (2, 2));
+    };
 }


### PR DESCRIPTION
Makes the impls for Tuples of ~const `PartialEq` types also `PartialEq`, impls for Tuples of ~const `PartialOrd` types also `PartialOrd`, for Tuples of ~const `Ord` types also `Ord`.

behind the `#![feature(const_cmp)]` gate.

~~Do not merge before #104113 is merged because I want to use this feature to clean up the new test that I added there.~~

r? @fee1-dead 