### PR TITLE
Make {str,[u8]}::eq_ignore_ascii_case const

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2449,7 +2449,7 @@ extern "rust-intrinsic" {
     ///     const fn compiletime() -> i32 { 2 }
     ///
     ///     unsafe {
-    //          // ⚠ This code violates the required equivalence of `compiletime`
+    ///         // ⚠ This code violates the required equivalence of `compiletime`
     ///         // and `runtime`.
     ///         const_eval_select((), compiletime, runtime)
     ///     }

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -146,6 +146,7 @@
 #![feature(const_replace)]
 #![feature(const_size_of_val)]
 #![feature(const_size_of_val_raw)]
+#![feature(const_slice_eq_ignore_ascii_case)]
 #![feature(const_slice_from_raw_parts_mut)]
 #![feature(const_slice_from_ref)]
 #![feature(const_slice_index)]

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2391,9 +2391,10 @@ impl str {
     /// assert!(!"Ferrös".eq_ignore_ascii_case("FERRÖS"));
     /// ```
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
+    #[rustc_const_unstable(feature = "const_slice_eq_ignore_ascii_case", issue = "none")]
     #[must_use]
     #[inline]
-    pub fn eq_ignore_ascii_case(&self, other: &str) -> bool {
+    pub const fn eq_ignore_ascii_case(&self, other: &str) -> bool {
         self.as_bytes().eq_ignore_ascii_case(other.as_bytes())
     }
 

--- a/library/core/tests/ascii.rs
+++ b/library/core/tests/ascii.rs
@@ -17,6 +17,19 @@ fn test_is_ascii() {
 }
 
 #[test]
+fn test_is_ascii_const() {
+    const _: () = {
+        assert!(b"".is_ascii());
+        assert!(b"banana\0\x7F".is_ascii());
+        assert!(!b"Vi\xe1\xbb\x87t Nam".is_ascii());
+
+        assert!("".is_ascii());
+        assert!("banana\0\u{7F}".is_ascii());
+        assert!(!"ประเทศไทย中华Việt Nam".is_ascii());
+    };
+}
+
+#[test]
 fn test_to_ascii_uppercase() {
     assert_eq!("url()URL()uRl()ürl".to_ascii_uppercase(), "URL()URL()URL()üRL");
     assert_eq!("hıKß".to_ascii_uppercase(), "HıKß");
@@ -110,6 +123,19 @@ fn test_eq_ignore_ascii_case() {
                 .eq_ignore_ascii_case(&from_u32(lower).unwrap().to_string())
         );
     }
+}
+
+#[test]
+fn test_eq_ignore_ascii_case_const() {
+    const _: () = {
+        assert!("url()URL()uRl()Ürl".eq_ignore_ascii_case("url()url()url()Ürl"));
+        assert!(!"Ürl".eq_ignore_ascii_case("ürl"));
+        // Dotted capital I, Kelvin sign, Sharp S.
+        assert!("HİKß".eq_ignore_ascii_case("hİKß"));
+        assert!(!"İ".eq_ignore_ascii_case("i"));
+        assert!(!"K".eq_ignore_ascii_case("k"));
+        assert!(!"ß".eq_ignore_ascii_case("s"));
+    };
 }
 
 #[test]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -19,6 +19,7 @@
 #![feature(const_pointer_is_aligned)]
 #![feature(const_ptr_as_ref)]
 #![feature(const_ptr_write)]
+#![feature(const_slice_eq_ignore_ascii_case)]
 #![feature(const_trait_impl)]
 #![feature(const_likely)]
 #![feature(const_location_fields)]


### PR DESCRIPTION
Both of these can trivially be implemented with already-const-stable language constructs/functions, so I figured it would make sense to make them const. I was going to make `make_ascii_{upper,lower}case` const too, but I realized that requires const_mut_refs and `u8/char::make_ascii_*case` aren't even unstably const under that, so I figured I'd leave that for after that's stabilized. Also, unfortunately, neither of the existing implementations can just have `const` added (*maybe* `is_ascii`, but it'd need a bunch of extra unstably-const ptr methods), and also `eq_ignore_ascii_case` codegen'd worse with the const-friendly while loop version, so I had to use `const_eval_select` for both.