### PR TITLE
Clarify licensing situation of MPSC and SPSC queue

### DIFF
--- a/library/std/src/sync/mpsc/mpsc_queue.rs
+++ b/library/std/src/sync/mpsc/mpsc_queue.rs
@@ -8,8 +8,15 @@
 //! method, and see the method for more information about it. Due to this
 //! caveat, this queue might not be appropriate for all use-cases.
 
-// https://www.1024cores.net/home/lock-free-algorithms
-//                          /queues/non-intrusive-mpsc-node-based-queue
+// The original implementation is based off:
+// https://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue
+//
+// Note that back when the code was imported, it was licensed under the BSD-2-Clause license:
+// http://web.archive.org/web/20110411011612/https://www.1024cores.net/home/lock-free-algorithms/queues/unbounded-spsc-queue
+//
+// The original author of the code agreed to relicense it under `MIT OR Apache-2.0` in 2017, so as
+// of today the license of this file is the same as the rest of the codebase:
+// https://github.com/rust-lang/rust/pull/42149
 
 #[cfg(all(test, not(target_os = "emscripten")))]
 mod tests;

--- a/library/std/src/sync/mpsc/spsc_queue.rs
+++ b/library/std/src/sync/mpsc/spsc_queue.rs
@@ -4,7 +4,15 @@
 //! concurrently between two threads. This data structure is safe to use and
 //! enforces the semantics that there is one pusher and one popper.
 
+// The original implementation is based off:
 // https://www.1024cores.net/home/lock-free-algorithms/queues/unbounded-spsc-queue
+//
+// Note that back when the code was imported, it was licensed under the BSD-2-Clause license:
+// http://web.archive.org/web/20110411011612/https://www.1024cores.net/home/lock-free-algorithms/queues/unbounded-spsc-queue
+//
+// The original author of the code agreed to relicense it under `MIT OR Apache-2.0` in 2017, so as
+// of today the license of this file is the same as the rest of the codebase:
+// https://github.com/rust-lang/rust/pull/42149
 
 #[cfg(all(test, not(target_os = "emscripten")))]
 mod tests;


### PR DESCRIPTION
Originally, these two files were licensed under the `BSD-2-Clause` license, as they were based off sample code on a blog licensing those snippets under that license:

* `library/std/src/sync/mpsc/mpsc_queue.rs`
* `library/std/src/sync/mpsc/spsc_queue.rs`

In 2017 though, the author of that blog agreed to relicense their code under the standard `MIT OR Apache-2.0` license in https://github.com/rust-lang/rust/pull/42149. This PR clarifies the situation in the files by expanding the comment at the top of the file.

r? @pnkfelix 