### PR TITLE
Suggest removing unnecessary `.` to use a floating point literal

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -43,7 +43,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             || self.suggest_block_to_brackets_peeling_refs(err, expr, expr_ty, expected)
             || self.suggest_copied_or_cloned(err, expr, expr_ty, expected)
             || self.suggest_into(err, expr, expr_ty, expected)
-            || self.suggest_option_to_bool(err, expr, expr_ty, expected);
+            || self.suggest_option_to_bool(err, expr, expr_ty, expected)
+            || self.suggest_floating_point_literal(err, expr, expected);
 
         self.note_type_is_not_clone(err, expected, expr_ty, expr);
         self.note_need_for_fn_pointer(err, expected, expr_ty);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -374,7 +374,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 let annotation_span = ty.span;
                                 err.span_suggestion(
                                     annotation_span.with_hi(annotation_span.lo()),
-                                    format!("alternatively, consider changing the type annotation"),
+                                    "alternatively, consider changing the type annotation",
                                     suggest_annotation,
                                     Applicability::MaybeIncorrect,
                                 );

--- a/src/test/ui/suggestions/unnecessary_dot_for_floating_point_literal.rs
+++ b/src/test/ui/suggestions/unnecessary_dot_for_floating_point_literal.rs
@@ -1,6 +1,6 @@
 fn main() {
     let _: f64 = 0..10; //~ ERROR mismatched types
-    let _: f64 = 0..; //~ ERROR mismatched types
+    let _: f64 = 1..; //~ ERROR mismatched types
     let _: f64 = ..10; //~ ERROR mismatched types
     let _: f64 = std::ops::Range { start: 0, end: 1 }; //~ ERROR mismatched types
 }

--- a/src/test/ui/suggestions/unnecessary_dot_for_floating_point_literal.rs
+++ b/src/test/ui/suggestions/unnecessary_dot_for_floating_point_literal.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let _: f64 = 0..10; //~ ERROR mismatched types
+    let _: f64 = 0..; //~ ERROR mismatched types
+    let _: f64 = ..10; //~ ERROR mismatched types
+    let _: f64 = std::ops::Range { start: 0, end: 1 }; //~ ERROR mismatched types
+}

--- a/src/test/ui/suggestions/unnecessary_dot_for_floating_point_literal.stderr
+++ b/src/test/ui/suggestions/unnecessary_dot_for_floating_point_literal.stderr
@@ -1,0 +1,52 @@
+error[E0308]: mismatched types
+  --> $DIR/unnecessary_dot_for_floating_point_literal.rs:2:18
+   |
+LL |     let _: f64 = 0..10;
+   |            ---   ^^^^^ expected `f64`, found struct `std::ops::Range`
+   |            |
+   |            expected due to this
+   |
+   = note: expected type `f64`
+            found struct `std::ops::Range<{integer}>`
+help: remove the unnecessary `.` operator to to use a floating point literal
+   |
+LL -     let _: f64 = 0..10;
+LL +     let _: f64 = 0.10;
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/unnecessary_dot_for_floating_point_literal.rs:3:18
+   |
+LL |     let _: f64 = 0..;
+   |            ---   ^^^ expected `f64`, found struct `RangeFrom`
+   |            |
+   |            expected due to this
+   |
+   = note: expected type `f64`
+            found struct `RangeFrom<{integer}>`
+
+error[E0308]: mismatched types
+  --> $DIR/unnecessary_dot_for_floating_point_literal.rs:4:18
+   |
+LL |     let _: f64 = ..10;
+   |            ---   ^^^^ expected `f64`, found struct `RangeTo`
+   |            |
+   |            expected due to this
+   |
+   = note: expected type `f64`
+            found struct `RangeTo<{integer}>`
+
+error[E0308]: mismatched types
+  --> $DIR/unnecessary_dot_for_floating_point_literal.rs:5:18
+   |
+LL |     let _: f64 = std::ops::Range { start: 0, end: 1 };
+   |            ---   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `f64`, found struct `std::ops::Range`
+   |            |
+   |            expected due to this
+   |
+   = note: expected type `f64`
+            found struct `std::ops::Range<{integer}>`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/unnecessary_dot_for_floating_point_literal.stderr
+++ b/src/test/ui/suggestions/unnecessary_dot_for_floating_point_literal.stderr
@@ -8,22 +8,25 @@ LL |     let _: f64 = 0..10;
    |
    = note: expected type `f64`
             found struct `std::ops::Range<{integer}>`
-help: remove the unnecessary `.` operator to to use a floating point literal
+help: remove the unnecessary `.` operator for a floating point literal
    |
-LL -     let _: f64 = 0..10;
-LL +     let _: f64 = 0.10;
-   |
+LL |     let _: f64 = 0.10;
+   |                   ~
 
 error[E0308]: mismatched types
   --> $DIR/unnecessary_dot_for_floating_point_literal.rs:3:18
    |
-LL |     let _: f64 = 0..;
+LL |     let _: f64 = 1..;
    |            ---   ^^^ expected `f64`, found struct `RangeFrom`
    |            |
    |            expected due to this
    |
    = note: expected type `f64`
             found struct `RangeFrom<{integer}>`
+help: remove the unnecessary `.` operator for a floating point literal
+   |
+LL |     let _: f64 = 1.;
+   |                   ~
 
 error[E0308]: mismatched types
   --> $DIR/unnecessary_dot_for_floating_point_literal.rs:4:18
@@ -35,6 +38,10 @@ LL |     let _: f64 = ..10;
    |
    = note: expected type `f64`
             found struct `RangeTo<{integer}>`
+help: remove the unnecessary `.` operator and add an integer part for a floating point literal
+   |
+LL |     let _: f64 = 0.10;
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/unnecessary_dot_for_floating_point_literal.rs:5:18


### PR DESCRIPTION
Fixes a part of #101883