### PR TITLE
Change `bindings_with_variant_name` to deny-by-default

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -708,7 +708,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```rust,compile_fail
     /// pub enum Enum {
     ///     Foo,
     ///     Bar,

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -743,7 +743,7 @@ declare_lint! {
     /// [identifier pattern]: https://doc.rust-lang.org/reference/patterns.html#identifier-patterns
     /// [path pattern]: https://doc.rust-lang.org/reference/patterns.html#path-patterns
     pub BINDINGS_WITH_VARIANT_NAME,
-    Warn,
+    Deny,
     "detects pattern bindings with the same name as one of the matched variants"
 }
 

--- a/tests/ui/issues/issue-19100.fixed
+++ b/tests/ui/issues/issue-19100.fixed
@@ -1,4 +1,3 @@
-// run-pass
 // run-rustfix
 
 #![allow(non_snake_case)]
@@ -16,11 +15,11 @@ impl Foo {
         match self {
             &
 Foo::Bar if true
-//~^ WARN pattern binding `Bar` is named the same as one of the variants of the type `Foo`
+//~^ ERROR pattern binding `Bar` is named the same as one of the variants of the type `Foo`
 => println!("bar"),
             &
 Foo::Baz if false
-//~^ WARN pattern binding `Baz` is named the same as one of the variants of the type `Foo`
+//~^ ERROR pattern binding `Baz` is named the same as one of the variants of the type `Foo`
 => println!("baz"),
 _ => ()
         }

--- a/tests/ui/issues/issue-19100.rs
+++ b/tests/ui/issues/issue-19100.rs
@@ -1,4 +1,3 @@
-// run-pass
 // run-rustfix
 
 #![allow(non_snake_case)]
@@ -16,11 +15,11 @@ impl Foo {
         match self {
             &
 Bar if true
-//~^ WARN pattern binding `Bar` is named the same as one of the variants of the type `Foo`
+//~^ ERROR pattern binding `Bar` is named the same as one of the variants of the type `Foo`
 => println!("bar"),
             &
 Baz if false
-//~^ WARN pattern binding `Baz` is named the same as one of the variants of the type `Foo`
+//~^ ERROR pattern binding `Baz` is named the same as one of the variants of the type `Foo`
 => println!("baz"),
 _ => ()
         }

--- a/tests/ui/issues/issue-19100.stderr
+++ b/tests/ui/issues/issue-19100.stderr
@@ -1,17 +1,17 @@
-warning[E0170]: pattern binding `Bar` is named the same as one of the variants of the type `Foo`
-  --> $DIR/issue-19100.rs:18:1
+error[E0170]: pattern binding `Bar` is named the same as one of the variants of the type `Foo`
+  --> $DIR/issue-19100.rs:17:1
    |
 LL | Bar if true
    | ^^^ help: to match on the variant, qualify the path: `Foo::Bar`
    |
-   = note: `#[warn(bindings_with_variant_name)]` on by default
+   = note: `#[deny(bindings_with_variant_name)]` on by default
 
-warning[E0170]: pattern binding `Baz` is named the same as one of the variants of the type `Foo`
-  --> $DIR/issue-19100.rs:22:1
+error[E0170]: pattern binding `Baz` is named the same as one of the variants of the type `Foo`
+  --> $DIR/issue-19100.rs:21:1
    |
 LL | Baz if false
    | ^^^ help: to match on the variant, qualify the path: `Foo::Baz`
 
-warning: 2 warnings emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0170`.

--- a/tests/ui/lint/issue-30302.rs
+++ b/tests/ui/lint/issue-30302.rs
@@ -11,7 +11,7 @@ enum Stack<T> {
 fn is_empty<T>(s: Stack<T>) -> bool {
     match s {
         Nil => true,
-//~^ WARN pattern binding `Nil` is named the same as one of the variants of the type `Stack`
+//~^ ERROR pattern binding `Nil` is named the same as one of the variants of the type `Stack`
         _ => false
 //~^ ERROR unreachable pattern
     }

--- a/tests/ui/lint/issue-30302.stderr
+++ b/tests/ui/lint/issue-30302.stderr
@@ -1,10 +1,10 @@
-warning[E0170]: pattern binding `Nil` is named the same as one of the variants of the type `Stack`
+error[E0170]: pattern binding `Nil` is named the same as one of the variants of the type `Stack`
   --> $DIR/issue-30302.rs:13:9
    |
 LL |         Nil => true,
    |         ^^^ help: to match on the variant, qualify the path: `Stack::Nil`
    |
-   = note: `#[warn(bindings_with_variant_name)]` on by default
+   = note: `#[deny(bindings_with_variant_name)]` on by default
 
 error: unreachable pattern
   --> $DIR/issue-30302.rs:15:9
@@ -21,6 +21,6 @@ note: the lint level is defined here
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0170`.

--- a/tests/ui/lint/lint-uppercase-variables.rs
+++ b/tests/ui/lint/lint-uppercase-variables.rs
@@ -21,18 +21,18 @@ fn main() {
     match foo::Foo::Foo {
         Foo => {}
     //~^ ERROR variable `Foo` should have a snake case name
-    //~^^ WARN `Foo` is named the same as one of the variants of the type `foo::Foo`
+    //~^^ ERROR `Foo` is named the same as one of the variants of the type `foo::Foo`
     //~^^^ WARN unused variable: `Foo`
     }
 
     let Foo = foo::Foo::Foo;
     //~^ ERROR variable `Foo` should have a snake case name
-    //~^^ WARN `Foo` is named the same as one of the variants of the type `foo::Foo`
+    //~^^ ERROR `Foo` is named the same as one of the variants of the type `foo::Foo`
     //~^^^ WARN unused variable: `Foo`
 
     fn in_param(Foo: foo::Foo) {}
     //~^ ERROR variable `Foo` should have a snake case name
-    //~^^ WARN `Foo` is named the same as one of the variants of the type `foo::Foo`
+    //~^^ ERROR `Foo` is named the same as one of the variants of the type `foo::Foo`
     //~^^^ WARN unused variable: `Foo`
 
     test(1);

--- a/tests/ui/lint/lint-uppercase-variables.stderr
+++ b/tests/ui/lint/lint-uppercase-variables.stderr
@@ -1,18 +1,18 @@
-warning[E0170]: pattern binding `Foo` is named the same as one of the variants of the type `foo::Foo`
+error[E0170]: pattern binding `Foo` is named the same as one of the variants of the type `foo::Foo`
   --> $DIR/lint-uppercase-variables.rs:22:9
    |
 LL |         Foo => {}
    |         ^^^ help: to match on the variant, qualify the path: `foo::Foo::Foo`
    |
-   = note: `#[warn(bindings_with_variant_name)]` on by default
+   = note: `#[deny(bindings_with_variant_name)]` on by default
 
-warning[E0170]: pattern binding `Foo` is named the same as one of the variants of the type `foo::Foo`
+error[E0170]: pattern binding `Foo` is named the same as one of the variants of the type `foo::Foo`
   --> $DIR/lint-uppercase-variables.rs:28:9
    |
 LL |     let Foo = foo::Foo::Foo;
    |         ^^^ help: to match on the variant, qualify the path: `foo::Foo::Foo`
 
-warning[E0170]: pattern binding `Foo` is named the same as one of the variants of the type `foo::Foo`
+error[E0170]: pattern binding `Foo` is named the same as one of the variants of the type `foo::Foo`
   --> $DIR/lint-uppercase-variables.rs:33:17
    |
 LL |     fn in_param(Foo: foo::Foo) {}
@@ -85,6 +85,6 @@ error: variable `Foo` should have a snake case name
 LL |     fn in_param(Foo: foo::Foo) {}
    |                 ^^^ help: convert the identifier to snake case (notice the capitalization): `foo`
 
-error: aborting due to 6 previous errors; 6 warnings emitted
+error: aborting due to 9 previous errors; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0170`.

--- a/tests/ui/pattern/issue-14221.rs
+++ b/tests/ui/pattern/issue-14221.rs
@@ -11,9 +11,9 @@ pub mod b {
     pub fn key(e: ::E) -> &'static str {
         match e {
             A => "A",
-//~^ WARN pattern binding `A` is named the same as one of the variants of the type `E`
+//~^ ERROR pattern binding `A` is named the same as one of the variants of the type `E`
             B => "B", //~ ERROR: unreachable pattern
-//~^ WARN pattern binding `B` is named the same as one of the variants of the type `E`
+//~^ ERROR pattern binding `B` is named the same as one of the variants of the type `E`
         }
     }
 }

--- a/tests/ui/pattern/issue-14221.stderr
+++ b/tests/ui/pattern/issue-14221.stderr
@@ -1,12 +1,12 @@
-warning[E0170]: pattern binding `A` is named the same as one of the variants of the type `E`
+error[E0170]: pattern binding `A` is named the same as one of the variants of the type `E`
   --> $DIR/issue-14221.rs:13:13
    |
 LL |             A => "A",
    |             ^ help: to match on the variant, qualify the path: `E::A`
    |
-   = note: `#[warn(bindings_with_variant_name)]` on by default
+   = note: `#[deny(bindings_with_variant_name)]` on by default
 
-warning[E0170]: pattern binding `B` is named the same as one of the variants of the type `E`
+error[E0170]: pattern binding `B` is named the same as one of the variants of the type `E`
   --> $DIR/issue-14221.rs:15:13
    |
 LL |             B => "B",
@@ -27,6 +27,6 @@ note: the lint level is defined here
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error; 2 warnings emitted
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0170`.

--- a/tests/ui/pattern/issue-67776-match-same-name-enum-variant-refs.rs
+++ b/tests/ui/pattern/issue-67776-match-same-name-enum-variant-refs.rs
@@ -1,7 +1,5 @@
 // Test for issue #67776: binding named the same as enum variant
-// should report a warning even when matching against a reference type
-
-// check-pass
+// should report an error even when matching against a reference type
 
 #![allow(unused_variables)]
 #![allow(non_snake_case)]
@@ -15,27 +13,27 @@ enum Foo {
 fn fn1(e: Foo) {
     match e {
         Bar => {},
-        //~^ WARNING named the same as one of the variants of the type `Foo`
+        //~^ ERROR named the same as one of the variants of the type `Foo`
         Baz => {},
-        //~^ WARNING named the same as one of the variants of the type `Foo`
+        //~^ ERROR named the same as one of the variants of the type `Foo`
     }
 }
 
 fn fn2(e: &Foo) {
     match e {
         Bar => {},
-        //~^ WARNING named the same as one of the variants of the type `Foo`
+        //~^ ERROR named the same as one of the variants of the type `Foo`
         Baz => {},
-        //~^ WARNING named the same as one of the variants of the type `Foo`
+        //~^ ERROR named the same as one of the variants of the type `Foo`
     }
 }
 
 fn fn3(e: &mut &&mut Foo) {
     match e {
         Bar => {},
-        //~^ WARNING named the same as one of the variants of the type `Foo`
+        //~^ ERROR named the same as one of the variants of the type `Foo`
         Baz => {},
-        //~^ WARNING named the same as one of the variants of the type `Foo`
+        //~^ ERROR named the same as one of the variants of the type `Foo`
     }
 }
 

--- a/tests/ui/pattern/issue-67776-match-same-name-enum-variant-refs.stderr
+++ b/tests/ui/pattern/issue-67776-match-same-name-enum-variant-refs.stderr
@@ -1,41 +1,41 @@
-warning[E0170]: pattern binding `Bar` is named the same as one of the variants of the type `Foo`
+error[E0170]: pattern binding `Bar` is named the same as one of the variants of the type `Foo`
+  --> $DIR/issue-67776-match-same-name-enum-variant-refs.rs:15:9
+   |
+LL |         Bar => {},
+   |         ^^^ help: to match on the variant, qualify the path: `Foo::Bar`
+   |
+   = note: `#[deny(bindings_with_variant_name)]` on by default
+
+error[E0170]: pattern binding `Baz` is named the same as one of the variants of the type `Foo`
   --> $DIR/issue-67776-match-same-name-enum-variant-refs.rs:17:9
    |
-LL |         Bar => {},
-   |         ^^^ help: to match on the variant, qualify the path: `Foo::Bar`
-   |
-   = note: `#[warn(bindings_with_variant_name)]` on by default
-
-warning[E0170]: pattern binding `Baz` is named the same as one of the variants of the type `Foo`
-  --> $DIR/issue-67776-match-same-name-enum-variant-refs.rs:19:9
-   |
 LL |         Baz => {},
    |         ^^^ help: to match on the variant, qualify the path: `Foo::Baz`
 
-warning[E0170]: pattern binding `Bar` is named the same as one of the variants of the type `Foo`
+error[E0170]: pattern binding `Bar` is named the same as one of the variants of the type `Foo`
+  --> $DIR/issue-67776-match-same-name-enum-variant-refs.rs:24:9
+   |
+LL |         Bar => {},
+   |         ^^^ help: to match on the variant, qualify the path: `Foo::Bar`
+
+error[E0170]: pattern binding `Baz` is named the same as one of the variants of the type `Foo`
   --> $DIR/issue-67776-match-same-name-enum-variant-refs.rs:26:9
    |
-LL |         Bar => {},
-   |         ^^^ help: to match on the variant, qualify the path: `Foo::Bar`
-
-warning[E0170]: pattern binding `Baz` is named the same as one of the variants of the type `Foo`
-  --> $DIR/issue-67776-match-same-name-enum-variant-refs.rs:28:9
-   |
 LL |         Baz => {},
    |         ^^^ help: to match on the variant, qualify the path: `Foo::Baz`
 
-warning[E0170]: pattern binding `Bar` is named the same as one of the variants of the type `Foo`
+error[E0170]: pattern binding `Bar` is named the same as one of the variants of the type `Foo`
+  --> $DIR/issue-67776-match-same-name-enum-variant-refs.rs:33:9
+   |
+LL |         Bar => {},
+   |         ^^^ help: to match on the variant, qualify the path: `Foo::Bar`
+
+error[E0170]: pattern binding `Baz` is named the same as one of the variants of the type `Foo`
   --> $DIR/issue-67776-match-same-name-enum-variant-refs.rs:35:9
    |
-LL |         Bar => {},
-   |         ^^^ help: to match on the variant, qualify the path: `Foo::Bar`
-
-warning[E0170]: pattern binding `Baz` is named the same as one of the variants of the type `Foo`
-  --> $DIR/issue-67776-match-same-name-enum-variant-refs.rs:37:9
-   |
 LL |         Baz => {},
    |         ^^^ help: to match on the variant, qualify the path: `Foo::Baz`
 
-warning: 6 warnings emitted
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0170`.

--- a/tests/ui/suggestions/issue-88730.rs
+++ b/tests/ui/suggestions/issue-88730.rs
@@ -1,9 +1,8 @@
 #![allow(unused, nonstandard_style)]
-#![deny(bindings_with_variant_name)]
 
 // If an enum has two different variants,
 // then it cannot be matched upon in a function argument.
-// It still gets a warning, but no suggestions.
+// It still gets an error, but no suggestions.
 enum Foo {
     C,
     D,

--- a/tests/ui/suggestions/issue-88730.stderr
+++ b/tests/ui/suggestions/issue-88730.stderr
@@ -1,17 +1,13 @@
 error[E0170]: pattern binding `C` is named the same as one of the variants of the type `Foo`
-  --> $DIR/issue-88730.rs:12:8
+  --> $DIR/issue-88730.rs:11:8
    |
 LL | fn foo(C: Foo) {}
    |        ^
    |
-note: the lint level is defined here
-  --> $DIR/issue-88730.rs:2:9
-   |
-LL | #![deny(bindings_with_variant_name)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(bindings_with_variant_name)]` on by default
 
 error[E0170]: pattern binding `C` is named the same as one of the variants of the type `Foo`
-  --> $DIR/issue-88730.rs:15:9
+  --> $DIR/issue-88730.rs:14:9
    |
 LL |     let C = Foo::D;
    |         ^


### PR DESCRIPTION
Changed the `bindings_with_variant_name` lint to deny-by-default and fixed up the affected tests.

Addresses #103442.