### PR TITLE
Use 64 bits for incremental cache in-file positions

### DIFF
--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -119,12 +119,11 @@ pub type EncodedDepNodeIndex = Vec<(SerializedDepNodeIndex, AbsoluteBytePos)>;
 struct SourceFileIndex(u32);
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Encodable, Decodable)]
-pub struct AbsoluteBytePos(u32);
+pub struct AbsoluteBytePos(u64);
 
 impl AbsoluteBytePos {
     fn new(pos: usize) -> AbsoluteBytePos {
-        debug_assert!(pos <= u32::MAX as usize);
-        AbsoluteBytePos(pos as u32)
+        AbsoluteBytePos(pos.try_into().expect("Incremental cache file size overflowed u64."))
     }
 
     fn to_usize(self) -> usize {


### PR DESCRIPTION
We currently use a 32-bit integer to encode byte positions into the incremental cache.
This is not enough when the query chache file is >4GB.

As the overflow check was a `debug_assert`, it was removed in released compilers, making compilation succeed silently.
At the next compilation, cache decoding would try to read unrelated data because of garbled file position, triggering an ICE.

Fixes https://github.com/rust-lang/rust/issues/79786
(I'm closing that bug since it the original report and the subsequent questions are probably different instances. A new bug should be opened for new instances of that ICE.)