### PR TITLE
Add a few known-bug tests

### DIFF
--- a/src/test/incremental/issue-101518.rs
+++ b/src/test/incremental/issue-101518.rs
@@ -1,0 +1,31 @@
+// revisions: cfail1
+// should-ice
+// error-pattern: forcing query
+// known-bug: #101518
+
+#[derive(PartialEq, Eq)]
+struct Id<'a> {
+    ns: &'a str,
+}
+fn visit_struct() {
+    let id = Id { ns: "random1" };
+    const FLAG: Id<'static> = Id {
+        ns: "needs_to_be_the_same",
+    };
+    match id {
+        FLAG => {}
+        _ => {}
+    }
+}
+fn visit_struct2() {
+    let id = Id { ns: "random2" };
+    const FLAG: Id<'static> = Id {
+        ns: "needs_to_be_the_same",
+    };
+    match id {
+        FLAG => {}
+        _ => {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/async-reference-generality.rs
+++ b/src/test/ui/borrowck/async-reference-generality.rs
@@ -1,0 +1,35 @@
+// check-fail
+// known-bug: #99492
+// edition: 2021
+
+use std::marker::PhantomData;
+
+pub struct Struct<I, T>(PhantomData<fn() -> <Self as It>::Item>)
+where
+    Self: It;
+
+impl<I> It for Struct<I, I::Item>
+where
+    I: It,
+{
+    type Item = ();
+}
+
+pub trait It {
+    type Item;
+}
+
+fn f() -> impl Send {
+    async {
+        let _x = Struct::<Empty<&'static ()>, _>(PhantomData);
+        async {}.await;
+    }
+}
+
+pub struct Empty<T>(PhantomData<fn() -> T>);
+
+impl<T> It for Empty<T> {
+    type Item = T;
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/async-reference-generality.stderr
+++ b/src/test/ui/borrowck/async-reference-generality.stderr
@@ -1,0 +1,27 @@
+error[E0308]: mismatched types
+  --> $DIR/async-reference-generality.rs:23:5
+   |
+LL | /     async {
+LL | |         let _x = Struct::<Empty<&'static ()>, _>(PhantomData);
+LL | |         async {}.await;
+LL | |     }
+   | |_____^ one type is more general than the other
+   |
+   = note: expected reference `&()`
+              found reference `&()`
+
+error[E0308]: mismatched types
+  --> $DIR/async-reference-generality.rs:23:5
+   |
+LL | /     async {
+LL | |         let _x = Struct::<Empty<&'static ()>, _>(PhantomData);
+LL | |         async {}.await;
+LL | |     }
+   | |_____^ one type is more general than the other
+   |
+   = note: expected reference `&()`
+              found reference `&()`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90950.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90950.rs
@@ -1,0 +1,53 @@
+// check-fail
+// known-bug: #90950
+
+trait Yokeable<'a>: 'static {
+    type Output: 'a;
+}
+
+
+trait IsCovariant<'a> {}
+
+struct Yoke<Y: for<'a> Yokeable<'a>> {
+    data: Y,
+}
+
+
+// impl<Y: for<'a> Yokeable<'a>> Yoke<Y> {
+//     fn project<Y2: for<'a> Yokeable<'a>>(
+//         &self,
+//         f: for<'a> fn(<Y as Yokeable<'a>>::Output, &'a (),
+//     ) -> <Y2 as Yokeable<'a>>::Output) -> Yoke<Y2> {
+//         unimplemented!()
+//     }
+// }
+
+fn upcast<Y>(x: Yoke<Y>) -> Yoke<Box<dyn IsCovariant<'static> + 'static>> where
+    Y: for<'a> Yokeable<'a>,
+    for<'a> <Y as Yokeable<'a>>::Output: IsCovariant<'a>
+    {
+    // x.project(|data, _| {
+    //     Box::new(data)
+    // })
+    unimplemented!()
+}
+
+
+impl<'a> Yokeable<'a> for Box<dyn IsCovariant<'static> + 'static> {
+    type Output = Box<dyn IsCovariant<'a> + 'a>;
+}
+
+// this impl is mostly an example and unnecessary for the pure repro
+use std::borrow::*;
+impl<'a, T: ToOwned + ?Sized> Yokeable<'a> for Cow<'static, T> {
+    type Output = Cow<'a, T>;
+}
+impl<'a, T: ToOwned + ?Sized> IsCovariant<'a> for Cow<'a, T> {}
+
+
+
+fn upcast_yoke(y: Yoke<Cow<'static, str>>) -> Yoke<Box<dyn IsCovariant<'static> + 'static>> {
+    upcast(y)
+}
+
+fn main() {}

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90950.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90950.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `for<'a> <_ as Yokeable<'a>>::Output: IsCovariant<'a>` is not satisfied
+  --> $DIR/issue-90950.rs:50:12
+   |
+LL |     upcast(y)
+   |     ------ ^ the trait `for<'a> IsCovariant<'a>` is not implemented for `<_ as Yokeable<'a>>::Output`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `IsCovariant<'a>` is implemented for `std::borrow::Cow<'a, T>`
+note: required by a bound in `upcast`
+  --> $DIR/issue-90950.rs:27:42
+   |
+LL | fn upcast<Y>(x: Yoke<Y>) -> Yoke<Box<dyn IsCovariant<'static> + 'static>> where
+   |    ------ required by a bound in this
+LL |     Y: for<'a> Yokeable<'a>,
+LL |     for<'a> <Y as Yokeable<'a>>::Output: IsCovariant<'a>
+   |                                          ^^^^^^^^^^^^^^^ required by this bound in `upcast`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/norm-before-method-resolution.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/norm-before-method-resolution.rs
@@ -1,0 +1,23 @@
+// check-fail
+// known-bug: #89196
+
+// Should pass, but we normalize and check bounds before we resolve the generics
+// of the function (which we know because of the return type).
+
+trait Trait<'a> {
+    type Out;
+}
+
+impl<'a, T> Trait<'a> for T {
+    type Out = T;
+}
+
+fn weird_bound<X>() -> X
+    where
+        for<'a> X: Trait<'a>,
+        for<'a> <X as Trait<'a>>::Out: Copy
+{ todo!() }
+
+fn main() {
+    let _: () = weird_bound();
+}

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/norm-before-method-resolution.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/norm-before-method-resolution.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `for<'a> <_ as Trait<'a>>::Out: Copy` is not satisfied
+  --> $DIR/norm-before-method-resolution.rs:22:17
+   |
+LL |     let _: () = weird_bound();
+   |                 ^^^^^^^^^^^ the trait `for<'a> Copy` is not implemented for `<_ as Trait<'a>>::Out`
+   |
+note: required by a bound in `weird_bound`
+  --> $DIR/norm-before-method-resolution.rs:18:40
+   |
+LL | fn weird_bound<X>() -> X
+   |    ----------- required by a bound in this
+...
+LL |         for<'a> <X as Trait<'a>>::Out: Copy
+   |                                        ^^^^ required by this bound in `weird_bound`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/never_type/exhaustive_patterns.rs
+++ b/src/test/ui/never_type/exhaustive_patterns.rs
@@ -1,0 +1,21 @@
+// check-fail
+// known-bug: #104034
+
+#![feature(exhaustive_patterns, never_type)]
+
+mod inner {
+    pub struct Wrapper<T>(T);
+}
+
+enum Either<A, B> {
+    A(A),
+    B(inner::Wrapper<B>),
+}
+
+fn foo() -> Either<(), !> {
+    Either::A(())
+}
+
+fn main() {
+    let Either::A(()) = foo();
+}

--- a/src/test/ui/never_type/exhaustive_patterns.stderr
+++ b/src/test/ui/never_type/exhaustive_patterns.stderr
@@ -1,0 +1,25 @@
+error[E0005]: refutable pattern in local binding: `Either::B(_)` not covered
+  --> $DIR/exhaustive_patterns.rs:20:9
+   |
+LL |     let Either::A(()) = foo();
+   |         ^^^^^^^^^^^^^ pattern `Either::B(_)` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+note: `Either<(), !>` defined here
+  --> $DIR/exhaustive_patterns.rs:12:5
+   |
+LL | enum Either<A, B> {
+   |      ------
+LL |     A(A),
+LL |     B(inner::Wrapper<B>),
+   |     ^ not covered
+   = note: the matched value is of type `Either<(), !>`
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |     if let Either::A(()) = foo() { todo!() }
+   |     ++                           ~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0005`.

--- a/src/test/ui/nll/user-annotations/ascribed-type-wf.rs
+++ b/src/test/ui/nll/user-annotations/ascribed-type-wf.rs
@@ -1,0 +1,16 @@
+// check-pass
+// known-bug: #101350
+
+trait Trait {
+    type Ty;
+}
+
+impl Trait for &'static () {
+    type Ty = ();
+}
+
+fn extend<'a>() {
+    None::<<&'a () as Trait>::Ty>;
+}
+
+fn main() {}

--- a/src/test/ui/traits/suggest-fully-qualified-closure.rs
+++ b/src/test/ui/traits/suggest-fully-qualified-closure.rs
@@ -1,0 +1,24 @@
+// check-fail
+// known-bug: #103705
+// normalize-stderr-test "\[closure@.*\]" -> "[closure@]"
+// normalize-stderr-test "\+* ~" -> "+++ ~"
+
+// The output of this currently suggests writing a closure in the qualified path.
+
+trait MyTrait<T> {
+   fn lol<F:FnOnce()>(&self, f:F) -> u16;
+}
+
+struct Qqq;
+
+impl MyTrait<u32> for Qqq{
+   fn lol<F:FnOnce()>(&self, _f:F) -> u16 { 5 }
+}
+impl MyTrait<u64> for Qqq{
+   fn lol<F:FnOnce()>(&self, _f:F) -> u16 { 6 }
+}
+
+fn main() {
+    let q = Qqq;
+    q.lol(||());
+}

--- a/src/test/ui/traits/suggest-fully-qualified-closure.stderr
+++ b/src/test/ui/traits/suggest-fully-qualified-closure.stderr
@@ -1,0 +1,34 @@
+error[E0282]: type annotations needed
+  --> $DIR/suggest-fully-qualified-closure.rs:23:7
+   |
+LL |     q.lol(||());
+   |       ^^^
+   |
+help: try using a fully qualified path to specify the expected types
+   |
+LL |     <Qqq as MyTrait<T>>::lol::<[closure@]>(&q, ||());
+   |     +++ ~
+
+error[E0283]: type annotations needed
+  --> $DIR/suggest-fully-qualified-closure.rs:23:7
+   |
+LL |     q.lol(||());
+   |       ^^^
+   |
+note: multiple `impl`s satisfying `Qqq: MyTrait<_>` found
+  --> $DIR/suggest-fully-qualified-closure.rs:14:1
+   |
+LL | impl MyTrait<u32> for Qqq{
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | impl MyTrait<u64> for Qqq{
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+help: try using a fully qualified path to specify the expected types
+   |
+LL |     <Qqq as MyTrait<T>>::lol::<[closure@]>(&q, ||());
+   |     +++ ~
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0282, E0283.
+For more information about an error, try `rustc --explain E0282`.

--- a/src/test/ui/typeck/issue-103899.rs
+++ b/src/test/ui/typeck/issue-103899.rs
@@ -1,0 +1,33 @@
+// check-fail
+// failure-status: 101
+// normalize-stderr-test "note: .*" -> ""
+// normalize-stderr-test "thread 'rustc' .*" -> ""
+// normalize-stderr-test " .*\n" -> ""
+// normalize-stderr-test "  .*\n" -> ""
+// known-bug: #103899
+
+trait BaseWithAssoc {
+    type Assoc;
+}
+
+trait WrapperWithAssoc {
+    type BaseAssoc: BaseWithAssoc;
+}
+
+struct Wrapper<B> {
+    inner: B,
+}
+
+struct ProjectToBase<T: BaseWithAssoc> {
+    data_type_h: T::Assoc,
+}
+
+struct DoubleProject<L: WrapperWithAssoc> {
+    buffer: Wrapper<ProjectToBase<L::BaseAssoc>>,
+}
+
+fn trigger<L: WrapperWithAssoc<BaseAssoc = ()>>() -> DoubleProject<L> {
+    loop {}
+}
+
+fn main() {}

--- a/src/test/ui/typeck/issue-103899.stderr
+++ b/src/test/ui/typeck/issue-103899.stderr
@@ -1,0 +1,12 @@
+
+stack
+error:
+
+
+
+
+
+
+
+
+query#0#1end


### PR DESCRIPTION
The labels of these tests should be changed from `S-bug-has-mcve` to `S-bug-has-test` once this is merged.

cc:
- #89196
- #90950
- #99492
- #101350
- #101518
- #103705
- #103899
- #104034

I couldn't reproduce the failures in #101962 and #100772 (so either these have started passing, or I didn't repro properly), so leaving those out for now.

#102065 was a bit more complicated, since it uses `rustc_private` and I didn't want to mess with that.