### PR TITLE
Upgrade `rand` to v0.8 in libstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4687,7 +4687,7 @@ dependencies = [
  "panic_abort",
  "panic_unwind",
  "profiler_builtins",
- "rand 0.7.3",
+ "rand 0.8.5",
  "rustc-demangle",
  "std_detect",
  "unwind",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -33,7 +33,7 @@ default-features = false
 features = ['read_core', 'elf', 'macho', 'pe', 'unaligned', 'archive']
 
 [dev-dependencies]
-rand = "0.7"
+rand = "0.8"
 
 [target.'cfg(any(all(target_family = "wasm", not(target_os = "emscripten")), all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
 dlmalloc = { version = "0.2.3", features = ['rustc-dep-of-std'] }

--- a/library/std/src/collections/hash/map/tests.rs
+++ b/library/std/src/collections/hash/map/tests.rs
@@ -714,12 +714,12 @@ fn test_entry_take_doesnt_corrupt() {
 
     // Populate the map with some items.
     for _ in 0..50 {
-        let x = rng.gen_range(-10, 10);
+        let x = rng.gen_range(-10..10);
         m.insert(x, ());
     }
 
     for _ in 0..1000 {
-        let x = rng.gen_range(-10, 10);
+        let x = rng.gen_range(-10..10);
         match m.entry(x) {
             Vacant(_) => {}
             Occupied(e) => {

--- a/library/std/tests/env.rs
+++ b/library/std/tests/env.rs
@@ -6,7 +6,10 @@ use rand::{thread_rng, Rng};
 
 fn make_rand_name() -> OsString {
     let rng = thread_rng();
-    let n = format!("TEST{}", rng.sample_iter(&Alphanumeric).take(10).collect::<String>());
+    let n = format!(
+        "TEST{}",
+        rng.sample_iter(&Alphanumeric).take(10).map(char::from).collect::<String>()
+    );
     let n = OsString::from(n);
     assert!(var_os(&n).is_none());
     n


### PR DESCRIPTION
This allows using a more modern `getrandom` for tier3 targets.

r? @thomcc 