### PR TITLE
Emit error in `collecting_trait_impl_trait_tys` on mismatched signatures

### DIFF
--- a/src/test/ui/impl-trait/in-trait/method-signature-matches.rs
+++ b/src/test/ui/impl-trait/in-trait/method-signature-matches.rs
@@ -1,0 +1,51 @@
+// edition: 2021
+
+#![feature(return_position_impl_trait_in_trait, async_fn_in_trait)]
+#![allow(incomplete_features)]
+
+trait Uwu {
+    fn owo(x: ()) -> impl Sized;
+}
+
+impl Uwu for () {
+    fn owo(_: u8) {}
+    //~^ ERROR method `owo` has an incompatible type for trait
+}
+
+trait AsyncUwu {
+    async fn owo(x: ()) {}
+}
+
+impl AsyncUwu for () {
+    async fn owo(_: u8) {}
+    //~^ ERROR method `owo` has an incompatible type for trait
+}
+
+trait TooMuch {
+    fn calm_down_please() -> impl Sized;
+}
+
+impl TooMuch for () {
+    fn calm_down_please(_: (), _: (), _: ()) {}
+    //~^ ERROR method `calm_down_please` has 3 parameters but the declaration in trait `TooMuch::calm_down_please` has 0
+}
+
+trait TooLittle {
+    fn come_on_a_little_more_effort(_: (), _: (), _: ()) -> impl Sized;
+}
+
+impl TooLittle for () {
+    fn come_on_a_little_more_effort() {}
+    //~^ ERROR method `come_on_a_little_more_effort` has 0 parameters but the declaration in trait `TooLittle::come_on_a_little_more_effort` has 3
+}
+
+trait Lifetimes {
+    fn early<'early, T>(x: &'early T) -> impl Sized;
+}
+
+impl Lifetimes for () {
+    fn early<'late, T>(_: &'late ()) {}
+    //~^ ERROR method `early` has an incompatible type for trait
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/in-trait/method-signature-matches.stderr
+++ b/src/test/ui/impl-trait/in-trait/method-signature-matches.stderr
@@ -1,0 +1,84 @@
+error[E0053]: method `owo` has an incompatible type for trait
+  --> $DIR/method-signature-matches.rs:11:15
+   |
+LL |     fn owo(_: u8) {}
+   |               ^^
+   |               |
+   |               expected `()`, found `u8`
+   |               help: change the parameter type to match the trait: `()`
+   |
+note: type in trait
+  --> $DIR/method-signature-matches.rs:7:15
+   |
+LL |     fn owo(x: ()) -> impl Sized;
+   |               ^^
+   = note: expected fn pointer `fn(())`
+              found fn pointer `fn(u8)`
+
+error[E0053]: method `owo` has an incompatible type for trait
+  --> $DIR/method-signature-matches.rs:20:21
+   |
+LL |     async fn owo(_: u8) {}
+   |                     ^^
+   |                     |
+   |                     expected `()`, found `u8`
+   |                     help: change the parameter type to match the trait: `()`
+   |
+note: while checking the return type of the `async fn`
+  --> $DIR/method-signature-matches.rs:20:25
+   |
+LL |     async fn owo(_: u8) {}
+   |                         ^ checked the `Output` of this `async fn`, expected opaque type
+note: while checking the return type of the `async fn`
+  --> $DIR/method-signature-matches.rs:20:25
+   |
+LL |     async fn owo(_: u8) {}
+   |                         ^ checked the `Output` of this `async fn`, found opaque type
+note: type in trait
+  --> $DIR/method-signature-matches.rs:16:21
+   |
+LL |     async fn owo(x: ()) {}
+   |                     ^^
+   = note: expected fn pointer `fn(()) -> _`
+              found fn pointer `fn(u8) -> _`
+
+error[E0050]: method `calm_down_please` has 3 parameters but the declaration in trait `TooMuch::calm_down_please` has 0
+  --> $DIR/method-signature-matches.rs:29:28
+   |
+LL |     fn calm_down_please() -> impl Sized;
+   |     ------------------------------------ trait requires 0 parameters
+...
+LL |     fn calm_down_please(_: (), _: (), _: ()) {}
+   |                            ^^^^^^^^^^^^^^^^ expected 0 parameters, found 3
+
+error[E0050]: method `come_on_a_little_more_effort` has 0 parameters but the declaration in trait `TooLittle::come_on_a_little_more_effort` has 3
+  --> $DIR/method-signature-matches.rs:38:5
+   |
+LL |     fn come_on_a_little_more_effort(_: (), _: (), _: ()) -> impl Sized;
+   |                                        ---------------- trait requires 3 parameters
+...
+LL |     fn come_on_a_little_more_effort() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 3 parameters, found 0
+
+error[E0053]: method `early` has an incompatible type for trait
+  --> $DIR/method-signature-matches.rs:47:27
+   |
+LL |     fn early<'late, T>(_: &'late ()) {}
+   |                     -     ^^^^^^^^^
+   |                     |     |
+   |                     |     expected type parameter `T`, found `()`
+   |                     |     help: change the parameter type to match the trait: `&'early T`
+   |                     this type parameter
+   |
+note: type in trait
+  --> $DIR/method-signature-matches.rs:43:28
+   |
+LL |     fn early<'early, T>(x: &'early T) -> impl Sized;
+   |                            ^^^^^^^^^
+   = note: expected fn pointer `fn(&'early T)`
+              found fn pointer `fn(&())`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0050, E0053.
+For more information about an error, try `rustc --explain E0050`.


### PR DESCRIPTION
Previously, a `delay_span_bug` was isssued, failing normalization. This create a `TyKind::Error` in the signature, which caused `compare_predicate_entailment` to swallow its signature mismatch error, causing ICEs because no error was emitted.

fixes #104183

r? @compiler-errors 