### PR TITLE
Display help message when fluent arg was referenced incorrectly

### DIFF
--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -30,7 +30,8 @@ use intl_memoizer::concurrent::IntlLangMemoizer;
 #[cfg(not(parallel_compiler))]
 use intl_memoizer::IntlLangMemoizer;
 
-pub use fluent_bundle::{FluentArgs, FluentError, FluentValue};
+pub use fluent_bundle::{self, FluentArgs, FluentError, FluentValue};
+
 pub use unic_langid::{langid, LanguageIdentifier};
 
 // Generates `DEFAULT_LOCALE_RESOURCES` static and `fluent_generated` module.


### PR DESCRIPTION
The fluent argument syntax is a little special and easy to get wrong, so we emit a small help message when someone gets it wrong.

Example:
```
parser_mismatched_closing_delimiter = mismatched closing delimiter: `${delimiter}`
```
panics with
```
thread 'rustc' panicked at 'Encountered errors while formatting message for `parser_mismatched_closing_delimiter`
help: Argument `delimiter` exists but was not referenced correctly. Try using `{$delimiter}` instead
attr: `None`
args: `FluentArgs([("delimiter", String("}"))])`
errors: `[ResolverError(Reference(Message { id: "delimiter", attribute: None }))]`', compiler/rustc_errors/src/translation.rs:123:21
```

fixes #103539