### PR TITLE
Recover from function pointer types with generic parameter list

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/parser.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parser.ftl
@@ -375,3 +375,12 @@ parser_async_move_order_incorrect = the order of `move` and `async` is incorrect
 
 parser_double_colon_in_bound = expected `:` followed by trait or lifetime
     .suggestion = use single colon
+
+parser_fn_ptr_with_generics = function pointer types may not have generic parameters
+    .suggestion = consider moving the lifetime {$arity ->
+        [one] parameter
+        *[other] parameters
+    } to {$for_param_list_exists ->
+        [true] the
+        *[false] a
+    } `for` parameter list

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1278,3 +1278,24 @@ pub(crate) struct DoubleColonInBound {
     #[suggestion(code = ": ", applicability = "machine-applicable")]
     pub between: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(parser_fn_ptr_with_generics)]
+pub(crate) struct FnPtrWithGenerics {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: Option<FnPtrWithGenericsSugg>,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(suggestion, applicability = "maybe-incorrect")]
+pub(crate) struct FnPtrWithGenericsSugg {
+    #[suggestion_part(code = "{snippet}")]
+    pub left: Span,
+    pub snippet: String,
+    #[suggestion_part(code = "")]
+    pub right: Span,
+    pub arity: usize,
+    pub for_param_list_exists: bool,
+}

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(array_windows)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
+#![feature(iter_intersperse)]
 #![feature(let_chains)]
 #![feature(never_type)]
 #![feature(rustc_attrs)]

--- a/src/test/ui/parser/recover-fn-ptr-with-generics.rs
+++ b/src/test/ui/parser/recover-fn-ptr-with-generics.rs
@@ -1,0 +1,31 @@
+fn main() {
+    type Predicate = fn<'a>(&'a str) -> bool;
+    //~^ ERROR function pointer types may not have generic parameters
+
+    type Identity = fn<T>(T) -> T;
+    //~^ ERROR function pointer types may not have generic parameters
+    //~| ERROR cannot find type `T` in this scope
+    //~| ERROR cannot find type `T` in this scope
+
+    let _: fn<const N: usize, 'e, Q, 'f>();
+    //~^ ERROR function pointer types may not have generic parameters
+
+    let _: for<'outer> fn<'inner>();
+    //~^ ERROR function pointer types may not have generic parameters
+
+    let _: for<> fn<'r>();
+    //~^ ERROR function pointer types may not have generic parameters
+
+    type Hmm = fn<>();
+    //~^ ERROR function pointer types may not have generic parameters
+
+    let _: extern fn<'a: 'static>();
+    //~^ ERROR function pointer types may not have generic parameters
+    //~| ERROR lifetime bounds cannot be used in this context
+
+    let _: for<'any> extern "C" fn<'u>();
+    //~^ ERROR function pointer types may not have generic parameters
+
+    type QuiteBroken = fn<const>();
+    //~^ ERROR expected identifier, found `>`
+}

--- a/src/test/ui/parser/recover-fn-ptr-with-generics.stderr
+++ b/src/test/ui/parser/recover-fn-ptr-with-generics.stderr
@@ -1,0 +1,111 @@
+error: function pointer types may not have generic parameters
+  --> $DIR/recover-fn-ptr-with-generics.rs:2:24
+   |
+LL |     type Predicate = fn<'a>(&'a str) -> bool;
+   |                        ^^^^
+   |
+help: consider moving the lifetime parameter to a `for` parameter list
+   |
+LL -     type Predicate = fn<'a>(&'a str) -> bool;
+LL +     type Predicate = for<'a> fn(&'a str) -> bool;
+   |
+
+error: function pointer types may not have generic parameters
+  --> $DIR/recover-fn-ptr-with-generics.rs:5:23
+   |
+LL |     type Identity = fn<T>(T) -> T;
+   |                       ^^^
+
+error: function pointer types may not have generic parameters
+  --> $DIR/recover-fn-ptr-with-generics.rs:10:14
+   |
+LL |     let _: fn<const N: usize, 'e, Q, 'f>();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider moving the lifetime parameters to a `for` parameter list
+   |
+LL -     let _: fn<const N: usize, 'e, Q, 'f>();
+LL +     let _: for<'e, 'f> fn();
+   |
+
+error: function pointer types may not have generic parameters
+  --> $DIR/recover-fn-ptr-with-generics.rs:13:26
+   |
+LL |     let _: for<'outer> fn<'inner>();
+   |                          ^^^^^^^^
+   |
+help: consider moving the lifetime parameter to the `for` parameter list
+   |
+LL -     let _: for<'outer> fn<'inner>();
+LL +     let _: for<'outer, 'inner> fn();
+   |
+
+error: function pointer types may not have generic parameters
+  --> $DIR/recover-fn-ptr-with-generics.rs:16:20
+   |
+LL |     let _: for<> fn<'r>();
+   |                    ^^^^
+   |
+help: consider moving the lifetime parameter to the `for` parameter list
+   |
+LL -     let _: for<> fn<'r>();
+LL +     let _: for<'r> fn();
+   |
+
+error: function pointer types may not have generic parameters
+  --> $DIR/recover-fn-ptr-with-generics.rs:19:18
+   |
+LL |     type Hmm = fn<>();
+   |                  ^^
+
+error: function pointer types may not have generic parameters
+  --> $DIR/recover-fn-ptr-with-generics.rs:22:21
+   |
+LL |     let _: extern fn<'a: 'static>();
+   |                     ^^^^^^^^^^^^^
+   |
+help: consider moving the lifetime parameter to a `for` parameter list
+   |
+LL -     let _: extern fn<'a: 'static>();
+LL +     let _: for<'a> extern fn();
+   |
+
+error: function pointer types may not have generic parameters
+  --> $DIR/recover-fn-ptr-with-generics.rs:26:35
+   |
+LL |     let _: for<'any> extern "C" fn<'u>();
+   |                                   ^^^^
+   |
+help: consider moving the lifetime parameter to the `for` parameter list
+   |
+LL -     let _: for<'any> extern "C" fn<'u>();
+LL +     let _: for<'any, 'u> extern "C" fn();
+   |
+
+error: expected identifier, found `>`
+  --> $DIR/recover-fn-ptr-with-generics.rs:29:32
+   |
+LL |     type QuiteBroken = fn<const>();
+   |                                ^ expected identifier
+
+error: lifetime bounds cannot be used in this context
+  --> $DIR/recover-fn-ptr-with-generics.rs:22:26
+   |
+LL |     let _: extern fn<'a: 'static>();
+   |                          ^^^^^^^
+
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/recover-fn-ptr-with-generics.rs:5:27
+   |
+LL |     type Identity = fn<T>(T) -> T;
+   |                           ^ not found in this scope
+
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/recover-fn-ptr-with-generics.rs:5:33
+   |
+LL |     type Identity = fn<T>(T) -> T;
+   |                                 ^ not found in this scope
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Give a more helpful error when encountering function pointer types with a generic parameter list like `fn<'a>(&'a str) -> bool` or `fn<T>(T) -> T` and suggest moving lifetime parameters to a `for<>` parameter list.

I've added a bunch of extra code to properly handle (unlikely?) corner cases like `for<'a> fn<'b>()` (where there already exists a `for<>` parameter list) correctly suggesting `for<'a, 'b> fn()` (merging the lists). If you deem this useless, I can simplify the code by suggesting nothing at all in this case.

I am quite open to suggestions regarding the wording of the diagnostic messages.

Fixes #103487.
@rustbot label A-diagnostics
r? diagnostics