### PR TITLE
Better debug logs for borrowck constraint graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
  "declare_clippy_lint",
  "if_chain",
  "itertools",
- "pulldown-cmark 0.9.2",
+ "pulldown-cmark",
  "quine-mc_cluskey",
  "regex-syntax",
  "rustc-semver",
@@ -2003,15 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "http-auth"
-<<<<<<< HEAD
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5430cacd7a1f9a02fbeb350dfc81a0e5ed42d81f3398cb0ba184017f85bdcfbc"
-=======
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b40b39d66c28829a0cf4d09f7e139ff8201f7500a5083732848ed3b4b4d850"
->>>>>>> 570ad623189 (remove cfgs)
 dependencies = [
  "memchr",
 ]
@@ -2561,7 +2555,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "opener",
- "pulldown-cmark 0.9.2",
+ "pulldown-cmark",
  "regex",
  "serde",
  "serde_json",
@@ -2578,7 +2572,7 @@ dependencies = [
  "anyhow",
  "handlebars 3.5.5",
  "pretty_assertions",
- "pulldown-cmark 0.7.2",
+ "pulldown-cmark",
  "same-file",
  "serde_json",
  "url",
@@ -3273,17 +3267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca36dea94d187597e104a5c8e4b07576a8a45aa5db48a65e12940d3eb7461f55"
-dependencies = [
- "bitflags",
- "memchr",
- "unicase",
 ]
 
 [[package]]
@@ -4589,7 +4572,7 @@ name = "rustc_resolve"
 version = "0.0.0"
 dependencies = [
  "bitflags",
- "pulldown-cmark 0.9.2",
+ "pulldown-cmark",
  "rustc_arena",
  "rustc_ast",
  "rustc_ast_pretty",
@@ -6277,7 +6260,6 @@ checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-<<<<<<< HEAD
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
@@ -6299,29 +6281,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
-=======
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
->>>>>>> 570ad623189 (remove cfgs)
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6331,15 +6290,9 @@ checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-<<<<<<< HEAD
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
-=======
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
->>>>>>> 570ad623189 (remove cfgs)
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,9 +2003,15 @@ dependencies = [
 
 [[package]]
 name = "http-auth"
+<<<<<<< HEAD
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5430cacd7a1f9a02fbeb350dfc81a0e5ed42d81f3398cb0ba184017f85bdcfbc"
+=======
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b40b39d66c28829a0cf4d09f7e139ff8201f7500a5083732848ed3b4b4d850"
+>>>>>>> 570ad623189 (remove cfgs)
 dependencies = [
  "memchr",
 ]
@@ -6271,6 +6277,7 @@ checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
+<<<<<<< HEAD
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
@@ -6292,6 +6299,29 @@ name = "windows_x86_64_gnu"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+=======
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+>>>>>>> 570ad623189 (remove cfgs)
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6301,9 +6331,15 @@ checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
+<<<<<<< HEAD
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+=======
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+>>>>>>> 570ad623189 (remove cfgs)
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
  "declare_clippy_lint",
  "if_chain",
  "itertools",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.2",
  "quine-mc_cluskey",
  "regex-syntax",
  "rustc-semver",
@@ -2003,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "http-auth"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b40b39d66c28829a0cf4d09f7e139ff8201f7500a5083732848ed3b4b4d850"
+checksum = "5430cacd7a1f9a02fbeb350dfc81a0e5ed42d81f3398cb0ba184017f85bdcfbc"
 dependencies = [
  "memchr",
 ]
@@ -2555,7 +2555,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "opener",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.2",
  "regex",
  "serde",
  "serde_json",
@@ -2572,7 +2572,7 @@ dependencies = [
  "anyhow",
  "handlebars 3.5.5",
  "pretty_assertions",
- "pulldown-cmark",
+ "pulldown-cmark 0.7.2",
  "same-file",
  "serde_json",
  "url",
@@ -3267,6 +3267,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca36dea94d187597e104a5c8e4b07576a8a45aa5db48a65e12940d3eb7461f55"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -4572,7 +4583,7 @@ name = "rustc_resolve"
 version = "0.0.0"
 dependencies = [
  "bitflags",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.2",
  "rustc_arena",
  "rustc_ast",
  "rustc_ast_pretty",

--- a/compiler/rustc_borrowck/src/constraints/mod.rs
+++ b/compiler/rustc_borrowck/src/constraints/mod.rs
@@ -17,7 +17,7 @@ pub(crate) mod graph;
 /// constraints of the form `R1: R2`. Each constraint is identified by
 /// a unique `OutlivesConstraintIndex` and you can index into the set
 /// (`constraint_set[i]`) to access the constraint details.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct OutlivesConstraintSet<'tcx> {
     outlives: IndexVec<OutlivesConstraintIndex, OutlivesConstraint<'tcx>>,
 }

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -97,6 +97,7 @@ use nll::{PoloniusOutput, ToRegionVid};
 use place_ext::PlaceExt;
 use places_conflict::{places_conflict, PlaceConflictBias};
 use region_infer::RegionInferenceContext;
+#[cfg(debug_assertions)]
 use renumber::RegionCtxt;
 
 // FIXME(eddyb) perhaps move this somewhere more centrally.

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -97,7 +97,6 @@ use nll::{PoloniusOutput, ToRegionVid};
 use place_ext::PlaceExt;
 use places_conflict::{places_conflict, PlaceConflictBias};
 use region_infer::RegionInferenceContext;
-#[cfg(debug_assertions)]
 use renumber::RegionCtxt;
 
 // FIXME(eddyb) perhaps move this somewhere more centrally.
@@ -488,28 +487,14 @@ pub struct BodyWithBorrowckFacts<'tcx> {
 
 pub struct BorrowckInferCtxt<'cx, 'tcx> {
     pub(crate) infcx: &'cx InferCtxt<'tcx>,
-
-    #[cfg(debug_assertions)]
     pub(crate) reg_var_to_origin: RefCell<FxHashMap<ty::RegionVid, RegionCtxt>>,
 }
 
 impl<'cx, 'tcx> BorrowckInferCtxt<'cx, 'tcx> {
-    #[cfg(not(debug_assertions))]
-    pub(crate) fn new(infcx: &'cx InferCtxt<'tcx>) -> Self {
-        BorrowckInferCtxt { infcx }
-    }
-
-    #[cfg(debug_assertions)]
     pub(crate) fn new(infcx: &'cx InferCtxt<'tcx>) -> Self {
         BorrowckInferCtxt { infcx, reg_var_to_origin: RefCell::new(Default::default()) }
     }
 
-    #[cfg(not(debug_assertions))]
-    pub(crate) fn next_region_var(&self, origin: RegionVariableOrigin) -> ty::Region<'tcx> {
-        self.infcx.next_region_var(origin)
-    }
-
-    #[cfg(debug_assertions)]
     pub(crate) fn next_region_var(
         &self,
         origin: RegionVariableOrigin,
@@ -533,12 +518,6 @@ impl<'cx, 'tcx> BorrowckInferCtxt<'cx, 'tcx> {
         next_region
     }
 
-    #[cfg(not(debug_assertions))]
-    pub(crate) fn next_nll_region_var(&self, origin: NllRegionVariableOrigin) -> ty::Region<'tcx> {
-        self.infcx.next_nll_region_var(origin)
-    }
-
-    #[cfg(debug_assertions)]
     #[instrument(skip(self), level = "debug")]
     pub(crate) fn next_nll_region_var(
         &self,

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -25,7 +25,9 @@ use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
 use rustc_index::bit_set::ChunkedBitSet;
 use rustc_index::vec::IndexVec;
-use rustc_infer::infer::{DefiningAnchor, InferCtxt, NllRegionVariableOrigin, TyCtxtInferExt};
+use rustc_infer::infer::{
+    DefiningAnchor, InferCtxt, NllRegionVariableOrigin, RegionVariableOrigin, TyCtxtInferExt,
+};
 use rustc_middle::mir::{
     traversal, Body, ClearCrossCrate, Local, Location, Mutability, NonDivergingIntrinsic, Operand,
     Place, PlaceElem, PlaceRef, VarDebugInfoContents,
@@ -95,6 +97,7 @@ use nll::{PoloniusOutput, ToRegionVid};
 use place_ext::PlaceExt;
 use places_conflict::{places_conflict, PlaceConflictBias};
 use region_infer::RegionInferenceContext;
+use renumber::RegionCtxt;
 
 // FIXME(eddyb) perhaps move this somewhere more centrally.
 #[derive(Debug)]
@@ -168,10 +171,10 @@ fn do_mir_borrowck<'tcx>(
     return_body_with_facts: bool,
 ) -> (BorrowCheckResult<'tcx>, Option<Box<BodyWithBorrowckFacts<'tcx>>>) {
     let def = input_body.source.with_opt_param().as_local().unwrap();
-
     debug!(?def);
 
     let tcx = infcx.tcx;
+    let infcx = BorrowckInferCtxt::new(infcx);
     let param_env = tcx.param_env(def.did);
 
     let mut local_names = IndexVec::from_elem(None, &input_body.local_decls);
@@ -219,7 +222,7 @@ fn do_mir_borrowck<'tcx>(
     let mut body_owned = input_body.clone();
     let mut promoted = input_promoted.clone();
     let free_regions =
-        nll::replace_regions_in_mir(infcx, param_env, &mut body_owned, &mut promoted);
+        nll::replace_regions_in_mir(&infcx, param_env, &mut body_owned, &mut promoted);
     let body = &body_owned; // no further changes
 
     let location_table_owned = LocationTable::new(body);
@@ -257,7 +260,7 @@ fn do_mir_borrowck<'tcx>(
         opt_closure_req,
         nll_errors,
     } = nll::compute_regions(
-        infcx,
+        &infcx,
         free_regions,
         body,
         &promoted,
@@ -272,12 +275,12 @@ fn do_mir_borrowck<'tcx>(
 
     // Dump MIR results into a file, if that is enabled. This let us
     // write unit-tests, as well as helping with debugging.
-    nll::dump_mir_results(infcx, &body, &regioncx, &opt_closure_req);
+    nll::dump_mir_results(&infcx, &body, &regioncx, &opt_closure_req);
 
     // We also have a `#[rustc_regions]` annotation that causes us to dump
     // information.
     nll::dump_annotation(
-        infcx,
+        &infcx,
         &body,
         &regioncx,
         &opt_closure_req,
@@ -321,7 +324,7 @@ fn do_mir_borrowck<'tcx>(
 
         if let Err((move_data, move_errors)) = move_data_results {
             let mut promoted_mbcx = MirBorrowckCtxt {
-                infcx,
+                infcx: &infcx,
                 param_env,
                 body: promoted_body,
                 move_data: &move_data,
@@ -350,7 +353,7 @@ fn do_mir_borrowck<'tcx>(
     }
 
     let mut mbcx = MirBorrowckCtxt {
-        infcx,
+        infcx: &infcx,
         param_env,
         body,
         move_data: &mdpe.move_data,
@@ -482,22 +485,81 @@ pub struct BodyWithBorrowckFacts<'tcx> {
     pub location_table: LocationTable,
 }
 
-struct BorrowckInferCtxt<'cx, 'tcx> {
+pub struct BorrowckInferCtxt<'cx, 'tcx> {
     pub(crate) infcx: &'cx InferCtxt<'tcx>,
 
     #[cfg(debug_assertions)]
-    pub(crate) _reg_var_to_origin: RefCell<FxHashMap<ty::Region<'tcx>, NllRegionVariableOrigin>>,
+    pub(crate) reg_var_to_origin: RefCell<FxHashMap<ty::RegionVid, RegionCtxt>>,
 }
 
 impl<'cx, 'tcx> BorrowckInferCtxt<'cx, 'tcx> {
     #[cfg(not(debug_assertions))]
-    pub(crate) fn _new(infcx: &'cx InferCtxt<'tcx>) -> Self {
+    pub(crate) fn new(infcx: &'cx InferCtxt<'tcx>) -> Self {
         BorrowckInferCtxt { infcx }
     }
 
     #[cfg(debug_assertions)]
-    pub(crate) fn _new(infcx: &'cx InferCtxt<'tcx>) -> Self {
-        BorrowckInferCtxt { infcx, _reg_var_to_origin: RefCell::new(Default::default()) }
+    pub(crate) fn new(infcx: &'cx InferCtxt<'tcx>) -> Self {
+        BorrowckInferCtxt { infcx, reg_var_to_origin: RefCell::new(Default::default()) }
+    }
+
+    #[cfg(not(debug_assertions))]
+    pub(crate) fn next_region_var(&self, origin: RegionVariableOrigin) -> ty::Region<'tcx> {
+        self.infcx.next_region_var(origin)
+    }
+
+    #[cfg(debug_assertions)]
+    pub(crate) fn next_region_var(
+        &self,
+        origin: RegionVariableOrigin,
+        ctxt: RegionCtxt,
+    ) -> ty::Region<'tcx> {
+        let next_region = self.infcx.next_region_var(origin);
+        let vid = next_region
+            .try_get_var()
+            .unwrap_or_else(|| bug!("expected RegionKind::RegionVar on {:?}", next_region));
+
+        debug!("inserting vid {:?} with origin {:?} into var_to_origin", vid, origin);
+        let mut var_to_origin = self.reg_var_to_origin.borrow_mut();
+        let prev = var_to_origin.insert(vid, ctxt);
+        debug!("var_to_origin after insertion: {:?}", var_to_origin);
+
+        // This only makes sense if not called in a canonicalization context. If this
+        // ever changes we either want to get rid of `BorrowckInferContext::reg_var_to_origin`
+        // or modify how we track nll region vars for that map.
+        assert!(matches!(prev, None));
+
+        next_region
+    }
+
+    #[cfg(not(debug_assertions))]
+    pub(crate) fn next_nll_region_var(&self, origin: NllRegionVariableOrigin) -> ty::Region<'tcx> {
+        self.infcx.next_nll_region_var(origin)
+    }
+
+    #[cfg(debug_assertions)]
+    #[instrument(skip(self), level = "debug")]
+    pub(crate) fn next_nll_region_var(
+        &self,
+        origin: NllRegionVariableOrigin,
+        ctxt: RegionCtxt,
+    ) -> ty::Region<'tcx> {
+        let next_region = self.infcx.next_nll_region_var(origin.clone());
+        let vid = next_region
+            .try_get_var()
+            .unwrap_or_else(|| bug!("expected RegionKind::RegionVar on {:?}", next_region));
+
+        debug!("inserting vid {:?} with origin {:?} into var_to_origin", vid, origin);
+        let mut var_to_origin = self.reg_var_to_origin.borrow_mut();
+        let prev = var_to_origin.insert(vid, ctxt);
+        debug!("var_to_origin after insertion: {:?}", var_to_origin);
+
+        // This only makes sense if not called in a canonicalization context. If this
+        // ever changes we either want to get rid of `BorrowckInferContext::reg_var_to_origin`
+        // or modify how we track nll region vars for that map.
+        assert!(matches!(prev, None));
+
+        next_region
     }
 }
 
@@ -510,7 +572,7 @@ impl<'cx, 'tcx> Deref for BorrowckInferCtxt<'cx, 'tcx> {
 }
 
 struct MirBorrowckCtxt<'cx, 'tcx> {
-    infcx: &'cx InferCtxt<'tcx>,
+    infcx: &'cx BorrowckInferCtxt<'cx, 'tcx>,
     param_env: ParamEnv<'tcx>,
     body: &'cx Body<'tcx>,
     move_data: &'cx MoveData<'tcx>,

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -505,7 +505,7 @@ impl<'cx, 'tcx> BorrowckInferCtxt<'cx, 'tcx> {
     {
         let next_region = self.infcx.next_region_var(origin);
         let vid = next_region
-            .try_get_var()
+            .as_var()
             .unwrap_or_else(|| bug!("expected RegionKind::RegionVar on {:?}", next_region));
 
         if cfg!(debug_assertions) {
@@ -534,7 +534,7 @@ impl<'cx, 'tcx> BorrowckInferCtxt<'cx, 'tcx> {
     {
         let next_region = self.infcx.next_nll_region_var(origin.clone());
         let vid = next_region
-            .try_get_var()
+            .as_var()
             .unwrap_or_else(|| bug!("expected RegionKind::RegionVar on {:?}", next_region));
 
         if cfg!(debug_assertions) {

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -263,6 +263,7 @@ pub(crate) fn compute_regions<'cx, 'tcx>(
     }
 
     let mut regioncx = RegionInferenceContext::new(
+        infcx,
         var_origins,
         universal_regions,
         placeholder_indices,

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -257,11 +257,6 @@ pub(crate) fn compute_regions<'cx, 'tcx>(
         borrow_set,
     );
 
-    if cfg!(debug_assertions) {
-        let var_to_origin = infcx.reg_var_to_origin.borrow();
-        debug!("var_to_origin: {:#?}", var_to_origin);
-    }
-
     let mut regioncx = RegionInferenceContext::new(
         infcx,
         var_origins,

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -5,7 +5,6 @@
 use rustc_data_structures::vec_map::VecMap;
 use rustc_hir::def_id::LocalDefId;
 use rustc_index::vec::IndexVec;
-use rustc_infer::infer::InferCtxt;
 use rustc_middle::mir::{create_dump_file, dump_enabled, dump_mir, PassWhere};
 use rustc_middle::mir::{
     BasicBlock, Body, ClosureOutlivesSubject, ClosureRegionRequirements, LocalKind, Location,
@@ -37,7 +36,7 @@ use crate::{
     renumber,
     type_check::{self, MirTypeckRegionConstraints, MirTypeckResults},
     universal_regions::UniversalRegions,
-    Upvar,
+    BorrowckInferCtxt, Upvar,
 };
 
 pub type PoloniusOutput = Output<RustcFacts>;
@@ -58,7 +57,7 @@ pub(crate) struct NllOutput<'tcx> {
 /// `compute_regions`.
 #[instrument(skip(infcx, param_env, body, promoted), level = "debug")]
 pub(crate) fn replace_regions_in_mir<'tcx>(
-    infcx: &InferCtxt<'tcx>,
+    infcx: &BorrowckInferCtxt<'_, 'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     body: &mut Body<'tcx>,
     promoted: &mut IndexVec<Promoted, Body<'tcx>>,
@@ -157,7 +156,7 @@ fn populate_polonius_move_facts(
 ///
 /// This may result in errors being reported.
 pub(crate) fn compute_regions<'cx, 'tcx>(
-    infcx: &InferCtxt<'tcx>,
+    infcx: &BorrowckInferCtxt<'_, 'tcx>,
     universal_regions: UniversalRegions<'tcx>,
     body: &Body<'tcx>,
     promoted: &IndexVec<Promoted, Body<'tcx>>,
@@ -258,6 +257,11 @@ pub(crate) fn compute_regions<'cx, 'tcx>(
         borrow_set,
     );
 
+    if cfg!(debug_assertions) {
+        let var_to_origin = infcx.reg_var_to_origin.borrow();
+        debug!("var_to_origin: {:#?}", var_to_origin);
+    }
+
     let mut regioncx = RegionInferenceContext::new(
         var_origins,
         universal_regions,
@@ -322,7 +326,7 @@ pub(crate) fn compute_regions<'cx, 'tcx>(
 }
 
 pub(super) fn dump_mir_results<'tcx>(
-    infcx: &InferCtxt<'tcx>,
+    infcx: &BorrowckInferCtxt<'_, 'tcx>,
     body: &Body<'tcx>,
     regioncx: &RegionInferenceContext<'tcx>,
     closure_region_requirements: &Option<ClosureRegionRequirements<'_>>,
@@ -372,7 +376,7 @@ pub(super) fn dump_mir_results<'tcx>(
 #[allow(rustc::diagnostic_outside_of_impl)]
 #[allow(rustc::untranslatable_diagnostic)]
 pub(super) fn dump_annotation<'tcx>(
-    infcx: &InferCtxt<'tcx>,
+    infcx: &BorrowckInferCtxt<'_, 'tcx>,
     body: &Body<'tcx>,
     regioncx: &RegionInferenceContext<'tcx>,
     closure_region_requirements: &Option<ClosureRegionRequirements<'_>>,

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -244,7 +244,6 @@ pub enum ExtraConstraintInfo {
     PlaceholderFromPredicate(Span),
 }
 
-#[cfg(debug_assertions)]
 #[instrument(skip(infcx, sccs), level = "debug")]
 fn sccs_info<'cx, 'tcx>(
     infcx: &'cx BorrowckInferCtxt<'cx, 'tcx>,
@@ -278,7 +277,7 @@ fn sccs_info<'cx, 'tcx>(
         .map(|(scc_idx, region_ctxts)| {
             let repr = region_ctxts
                 .into_iter()
-                .max_by(|x, y| x._preference_value().cmp(&y._preference_value()))
+                .max_by(|x, y| x.preference_value().cmp(&y.preference_value()))
                 .unwrap();
 
             (ConstraintSccIndex::from_usize(scc_idx), repr)
@@ -334,10 +333,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         let fr_static = universal_regions.fr_static;
         let constraint_sccs = Rc::new(constraints.compute_sccs(&constraint_graph, fr_static));
 
-        #[cfg(debug_assertions)]
-        {
-            sccs_info(_infcx, constraint_sccs.clone());
-        }
+        sccs_info(_infcx, constraint_sccs.clone());
 
         let mut scc_values =
             RegionValues::new(elements, universal_regions.len(), &placeholder_indices);

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -34,6 +34,7 @@ use crate::{
     },
     type_check::{free_region_relations::UniversalRegionRelations, Locations},
     universal_regions::UniversalRegions,
+    BorrowckInferCtxt,
 };
 
 mod dump_mir;
@@ -243,6 +244,59 @@ pub enum ExtraConstraintInfo {
     PlaceholderFromPredicate(Span),
 }
 
+#[cfg(debug_assertions)]
+#[instrument(skip(infcx, sccs), level = "debug")]
+fn sccs_info<'cx, 'tcx>(
+    infcx: &'cx BorrowckInferCtxt<'cx, 'tcx>,
+    sccs: Rc<Sccs<RegionVid, ConstraintSccIndex>>,
+) {
+    use crate::renumber::RegionCtxt;
+
+    let var_to_origin = infcx.reg_var_to_origin.borrow();
+    let num_components = sccs.scc_data.ranges.len();
+    let mut components = vec![FxHashSet::default(); num_components];
+
+    for (reg_var_idx, scc_idx) in sccs.scc_indices.iter().enumerate() {
+        let reg_var = ty::RegionVid::from_usize(reg_var_idx);
+        let origin = var_to_origin.get(&reg_var).unwrap_or_else(|| &RegionCtxt::Unknown);
+        components[scc_idx.as_usize()].insert(*origin);
+    }
+
+    debug!(
+        "strongly connected components: {:#?}",
+        components
+            .iter()
+            .enumerate()
+            .map(|(idx, origin)| { (ConstraintSccIndex::from_usize(idx), origin) })
+            .collect::<Vec<_>>()
+    );
+
+    // Now let's calculate the best representative for each component
+    let components_representatives = components
+        .into_iter()
+        .enumerate()
+        .map(|(scc_idx, region_ctxts)| {
+            let repr = region_ctxts
+                .into_iter()
+                .max_by(|x, y| x._preference_value().cmp(&y._preference_value()))
+                .unwrap();
+
+            (ConstraintSccIndex::from_usize(scc_idx), repr)
+        })
+        .collect::<FxHashMap<_, _>>();
+
+    let mut scc_node_to_edges = FxHashMap::default();
+    for (scc_idx, repr) in components_representatives.iter() {
+        let edges_range = sccs.scc_data.ranges[*scc_idx].clone();
+        let edges = &sccs.scc_data.all_successors[edges_range];
+        let edge_representatives =
+            edges.iter().map(|scc_idx| components_representatives[scc_idx]).collect::<Vec<_>>();
+        scc_node_to_edges.insert((scc_idx, repr), edge_representatives);
+    }
+
+    debug!("SCC edges {:#?}", scc_node_to_edges);
+}
+
 impl<'tcx> RegionInferenceContext<'tcx> {
     /// Creates a new region inference context with a total of
     /// `num_region_variables` valid inference variables; the first N
@@ -251,7 +305,8 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     ///
     /// The `outlives_constraints` and `type_tests` are an initial set
     /// of constraints produced by the MIR type check.
-    pub(crate) fn new(
+    pub(crate) fn new<'cx>(
+        _infcx: &BorrowckInferCtxt<'cx, 'tcx>,
         var_infos: VarInfos,
         universal_regions: Rc<UniversalRegions<'tcx>>,
         placeholder_indices: Rc<PlaceholderIndices>,
@@ -263,6 +318,11 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         liveness_constraints: LivenessValues<RegionVid>,
         elements: &Rc<RegionValueElements>,
     ) -> Self {
+        debug!("universal_regions: {:#?}", universal_regions);
+        debug!("outlives constraints: {:#?}", outlives_constraints);
+        debug!("placeholder_indices: {:#?}", placeholder_indices);
+        debug!("type tests: {:#?}", type_tests);
+
         // Create a RegionDefinition for each inference variable.
         let definitions: IndexVec<_, _> = var_infos
             .iter()
@@ -273,6 +333,11 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         let constraint_graph = Frozen::freeze(constraints.graph(definitions.len()));
         let fr_static = universal_regions.fr_static;
         let constraint_sccs = Rc::new(constraints.compute_sccs(&constraint_graph, fr_static));
+
+        #[cfg(debug_assertions)]
+        {
+            sccs_info(_infcx, constraint_sccs.clone());
+        }
 
         let mut scc_values =
             RegionValues::new(elements, universal_regions.len(), &placeholder_indices);

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -244,7 +244,6 @@ pub enum ExtraConstraintInfo {
     PlaceholderFromPredicate(Span),
 }
 
-#[cfg(debug_assertions)]
 #[instrument(skip(infcx, sccs), level = "debug")]
 fn sccs_info<'cx, 'tcx>(
     infcx: &'cx BorrowckInferCtxt<'cx, 'tcx>,
@@ -271,10 +270,10 @@ fn sccs_info<'cx, 'tcx>(
         components[scc_idx.as_usize()].insert((reg_var, *origin));
     }
 
-    let mut components_str = "strongly connected components:";
+    let mut components_str = "strongly connected components:".to_string();
     for (scc_idx, reg_vars_origins) in components.iter().enumerate() {
         let regions_info = reg_vars_origins.clone().into_iter().collect::<Vec<_>>();
-        components_str.push(&format(
+        components_str.push_str(&format!(
             "{:?}: {:?})",
             ConstraintSccIndex::from_usize(scc_idx),
             regions_info,
@@ -346,8 +345,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         let fr_static = universal_regions.fr_static;
         let constraint_sccs = Rc::new(constraints.compute_sccs(&constraint_graph, fr_static));
 
-        #[cfg(debug_assertions)]
-        sccs_info(_infcx, constraint_sccs.clone());
+        if cfg!(debug_assertions) {
+            sccs_info(_infcx, constraint_sccs.clone());
+        }
 
         let mut scc_values =
             RegionValues::new(elements, universal_regions.len(), &placeholder_indices);

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -261,10 +261,10 @@ fn sccs_info<'cx, 'tcx>(
     }
     debug!(debug_str);
 
-    let num_components = sccs.scc_data.ranges.len();
+    let num_components = sccs.scc_data().ranges().len();
     let mut components = vec![FxHashSet::default(); num_components];
 
-    for (reg_var_idx, scc_idx) in sccs.scc_indices.iter().enumerate() {
+    for (reg_var_idx, scc_idx) in sccs.scc_indices().iter().enumerate() {
         let reg_var = ty::RegionVid::from_usize(reg_var_idx);
         let origin = var_to_origin.get(&reg_var).unwrap_or_else(|| &RegionCtxt::Unknown);
         components[scc_idx.as_usize()].insert((reg_var, *origin));
@@ -298,8 +298,8 @@ fn sccs_info<'cx, 'tcx>(
 
     let mut scc_node_to_edges = FxHashMap::default();
     for (scc_idx, repr) in components_representatives.iter() {
-        let edges_range = sccs.scc_data.ranges[*scc_idx].clone();
-        let edges = &sccs.scc_data.all_successors[edges_range];
+        let edges_range = sccs.scc_data().ranges()[*scc_idx].clone();
+        let edges = &sccs.scc_data().all_successors()[edges_range];
         let edge_representatives =
             edges.iter().map(|scc_idx| components_representatives[scc_idx]).collect::<Vec<_>>();
         scc_node_to_edges.insert((scc_idx, repr), edge_representatives);

--- a/compiler/rustc_borrowck/src/region_infer/values.rs
+++ b/compiler/rustc_borrowck/src/region_infer/values.rs
@@ -181,7 +181,7 @@ impl<N: Idx> LivenessValues<N> {
 /// Maps from `ty::PlaceholderRegion` values that are used in the rest of
 /// rustc to the internal `PlaceholderIndex` values that are used in
 /// NLL.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct PlaceholderIndices {
     indices: FxIndexSet<ty::PlaceholderRegion>,
 }

--- a/compiler/rustc_borrowck/src/renumber.rs
+++ b/compiler/rustc_borrowck/src/renumber.rs
@@ -1,18 +1,23 @@
+<<<<<<< HEAD
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
+=======
+use crate::BorrowckInferCtxt;
+>>>>>>> 2464f768a17 (collect region contexts during mir renumbering)
 use rustc_index::vec::IndexVec;
-use rustc_infer::infer::{InferCtxt, NllRegionVariableOrigin};
+use rustc_infer::infer::NllRegionVariableOrigin;
 use rustc_middle::mir::visit::{MutVisitor, TyContext};
 use rustc_middle::mir::Constant;
 use rustc_middle::mir::{Body, Location, Promoted};
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeFoldable};
+use rustc_span::Symbol;
 
 /// Replaces all free regions appearing in the MIR with fresh
 /// inference variables, returning the number of variables created.
 #[instrument(skip(infcx, body, promoted), level = "debug")]
 pub fn renumber_mir<'tcx>(
-    infcx: &InferCtxt<'tcx>,
+    infcx: &BorrowckInferCtxt<'_, 'tcx>,
     body: &mut Body<'tcx>,
     promoted: &mut IndexVec<Promoted, Body<'tcx>>,
 ) {
@@ -29,8 +34,9 @@ pub fn renumber_mir<'tcx>(
 
 /// Replaces all regions appearing in `value` with fresh inference
 /// variables.
+#[cfg(not(debug_assertions))]
 #[instrument(skip(infcx), level = "debug")]
-pub fn renumber_regions<'tcx, T>(infcx: &InferCtxt<'tcx>, value: T) -> T
+pub(crate) fn renumber_regions<'tcx, T>(infcx: &BorrowckInferCtxt<'_, 'tcx>, value: T) -> T
 where
     T: TypeFoldable<'tcx>,
 {
@@ -40,11 +46,73 @@ where
     })
 }
 
+/// Replaces all regions appearing in `value` with fresh inference
+/// variables.
+#[cfg(debug_assertions)]
+#[instrument(skip(infcx), level = "debug")]
+pub(crate) fn renumber_regions<'tcx, T>(
+    infcx: &BorrowckInferCtxt<'_, 'tcx>,
+    value: T,
+    ctxt: RegionCtxt,
+) -> T
+where
+    T: TypeFoldable<'tcx>,
+{
+    infcx.tcx.fold_regions(value, |_region, _depth| {
+        let origin = NllRegionVariableOrigin::Existential { from_forall: false };
+        infcx.next_nll_region_var(origin, ctxt)
+    })
+}
+
+#[cfg(debug_assertions)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub(crate) enum RegionCtxt {
+    Location(Location),
+    TyContext(TyContext),
+    Free(Symbol),
+    Bound(Symbol),
+    LateBound(Symbol),
+    Existential(Option<Symbol>),
+    Placeholder(Symbol),
+    Unknown,
+}
+
+#[cfg(debug_assertions)]
+impl RegionCtxt {
+    /// Used to determine the representative of a component in the strongly connected
+    /// constraint graph
+    /// FIXME: don't use underscore here. Got a 'not used' error for some reason
+    pub(crate) fn _preference_value(self) -> usize {
+        let _anon = Symbol::intern("anon");
+
+        match self {
+            RegionCtxt::Unknown => 1,
+            RegionCtxt::Existential(None) => 2,
+            RegionCtxt::Existential(Some(_anon))
+            | RegionCtxt::Free(_anon)
+            | RegionCtxt::Bound(_anon)
+            | RegionCtxt::LateBound(_anon) => 2,
+            RegionCtxt::Location(_) => 3,
+            RegionCtxt::TyContext(_) => 4,
+            _ => 5,
+        }
+    }
+}
+
 struct NllVisitor<'a, 'tcx> {
-    infcx: &'a InferCtxt<'tcx>,
+    infcx: &'a BorrowckInferCtxt<'a, 'tcx>,
 }
 
 impl<'a, 'tcx> NllVisitor<'a, 'tcx> {
+    #[cfg(debug_assertions)]
+    fn renumber_regions<T>(&mut self, value: T, ctxt: RegionCtxt) -> T
+    where
+        T: TypeFoldable<'tcx>,
+    {
+        renumber_regions(self.infcx, value, ctxt)
+    }
+
+    #[cfg(not(debug_assertions))]
     fn renumber_regions<T>(&mut self, value: T) -> T
     where
         T: TypeFoldable<'tcx>,
@@ -58,13 +126,23 @@ impl<'a, 'tcx> MutVisitor<'tcx> for NllVisitor<'a, 'tcx> {
         self.infcx.tcx
     }
 
+    #[cfg(not(debug_assertions))]
     #[instrument(skip(self), level = "debug")]
-    fn visit_ty(&mut self, ty: &mut Ty<'tcx>, ty_context: TyContext) {
+    fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _ty_context: TyContext) {
         *ty = self.renumber_regions(*ty);
 
         debug!(?ty);
     }
 
+    #[cfg(debug_assertions)]
+    #[instrument(skip(self), level = "debug")]
+    fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _ty_context: TyContext) {
+        *ty = self.renumber_regions(*ty, RegionCtxt::TyContext(_ty_context));
+
+        debug!(?ty);
+    }
+
+    #[cfg(not(debug_assertions))]
     #[instrument(skip(self), level = "debug")]
     fn visit_substs(&mut self, substs: &mut SubstsRef<'tcx>, location: Location) {
         *substs = self.renumber_regions(*substs);
@@ -72,6 +150,15 @@ impl<'a, 'tcx> MutVisitor<'tcx> for NllVisitor<'a, 'tcx> {
         debug!(?substs);
     }
 
+    #[cfg(debug_assertions)]
+    #[instrument(skip(self), level = "debug")]
+    fn visit_substs(&mut self, substs: &mut SubstsRef<'tcx>, location: Location) {
+        *substs = self.renumber_regions(*substs, RegionCtxt::Location(location));
+
+        debug!(?substs);
+    }
+
+    #[cfg(not(debug_assertions))]
     #[instrument(skip(self), level = "debug")]
     fn visit_region(&mut self, region: &mut ty::Region<'tcx>, location: Location) {
         let old_region = *region;
@@ -80,10 +167,28 @@ impl<'a, 'tcx> MutVisitor<'tcx> for NllVisitor<'a, 'tcx> {
         debug!(?region);
     }
 
+    #[cfg(debug_assertions)]
+    #[instrument(skip(self), level = "debug")]
+    fn visit_region(&mut self, region: &mut ty::Region<'tcx>, location: Location) {
+        let old_region = *region;
+        *region = self.renumber_regions(old_region, RegionCtxt::Location(location));
+
+        debug!(?region);
+    }
+
+    #[cfg(not(debug_assertions))]
     #[instrument(skip(self), level = "debug")]
     fn visit_constant(&mut self, constant: &mut Constant<'tcx>, _location: Location) {
         let literal = constant.literal;
         constant.literal = self.renumber_regions(literal);
+        debug!("constant: {:#?}", constant);
+    }
+
+    #[cfg(debug_assertions)]
+    #[instrument(skip(self), level = "debug")]
+    fn visit_constant(&mut self, constant: &mut Constant<'tcx>, _location: Location) {
+        let literal = constant.literal;
+        constant.literal = self.renumber_regions(literal, RegionCtxt::Location(_location));
         debug!("constant: {:#?}", constant);
     }
 }

--- a/compiler/rustc_borrowck/src/renumber.rs
+++ b/compiler/rustc_borrowck/src/renumber.rs
@@ -62,14 +62,12 @@ pub(crate) enum RegionCtxt {
     LateBound(BoundRegionInfo),
     Existential(Option<Symbol>),
     Placeholder(BoundRegionInfo),
-    #[cfg(debug_assertions)]
     Unknown,
 }
 
 impl RegionCtxt {
     /// Used to determine the representative of a component in the strongly connected
     /// constraint graph
-    #[cfg(debug_assertions)]
     pub(crate) fn preference_value(self) -> usize {
         let _anon = Symbol::intern("anon");
 

--- a/compiler/rustc_borrowck/src/renumber.rs
+++ b/compiler/rustc_borrowck/src/renumber.rs
@@ -1,9 +1,6 @@
-<<<<<<< HEAD
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
-=======
 use crate::BorrowckInferCtxt;
->>>>>>> 2464f768a17 (collect region contexts during mir renumbering)
 use rustc_index::vec::IndexVec;
 use rustc_infer::infer::NllRegionVariableOrigin;
 use rustc_middle::mir::visit::{MutVisitor, TyContext};

--- a/compiler/rustc_borrowck/src/renumber.rs
+++ b/compiler/rustc_borrowck/src/renumber.rs
@@ -8,6 +8,7 @@ use rustc_middle::mir::Constant;
 use rustc_middle::mir::{Body, Location, Promoted};
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeFoldable};
+#[cfg(debug_assertions)]
 use rustc_span::Symbol;
 
 /// Replaces all free regions appearing in the MIR with fresh

--- a/compiler/rustc_borrowck/src/renumber.rs
+++ b/compiler/rustc_borrowck/src/renumber.rs
@@ -8,7 +8,6 @@ use rustc_middle::mir::Constant;
 use rustc_middle::mir::{Body, Location, Promoted};
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeFoldable};
-#[cfg(debug_assertions)]
 use rustc_span::{Span, Symbol};
 
 /// Replaces all free regions appearing in the MIR with fresh
@@ -32,21 +31,6 @@ pub fn renumber_mir<'tcx>(
 
 /// Replaces all regions appearing in `value` with fresh inference
 /// variables.
-#[cfg(not(debug_assertions))]
-#[instrument(skip(infcx), level = "debug")]
-pub(crate) fn renumber_regions<'tcx, T>(infcx: &BorrowckInferCtxt<'_, 'tcx>, value: T) -> T
-where
-    T: TypeFoldable<'tcx>,
-{
-    infcx.tcx.fold_regions(value, |_region, _depth| {
-        let origin = NllRegionVariableOrigin::Existential { from_forall: false };
-        infcx.next_nll_region_var(origin)
-    })
-}
-
-/// Replaces all regions appearing in `value` with fresh inference
-/// variables.
-#[cfg(debug_assertions)]
 #[instrument(skip(infcx), level = "debug")]
 pub(crate) fn renumber_regions<'tcx, T>(
     infcx: &BorrowckInferCtxt<'_, 'tcx>,
@@ -62,14 +46,12 @@ where
     })
 }
 
-#[cfg(debug_assertions)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) enum BoundRegionInfo {
     Name(Symbol),
     Span(Span),
 }
 
-#[cfg(debug_assertions)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) enum RegionCtxt {
     Location(Location),
@@ -82,12 +64,11 @@ pub(crate) enum RegionCtxt {
     Unknown,
 }
 
-#[cfg(debug_assertions)]
 impl RegionCtxt {
     /// Used to determine the representative of a component in the strongly connected
     /// constraint graph
     /// FIXME: don't use underscore here. Got a 'not used' error for some reason
-    pub(crate) fn _preference_value(self) -> usize {
+    pub(crate) fn preference_value(self) -> usize {
         let _anon = Symbol::intern("anon");
 
         match self {
@@ -106,20 +87,11 @@ struct NllVisitor<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> NllVisitor<'a, 'tcx> {
-    #[cfg(debug_assertions)]
     fn renumber_regions<T>(&mut self, value: T, ctxt: RegionCtxt) -> T
     where
         T: TypeFoldable<'tcx>,
     {
         renumber_regions(self.infcx, value, ctxt)
-    }
-
-    #[cfg(not(debug_assertions))]
-    fn renumber_regions<T>(&mut self, value: T) -> T
-    where
-        T: TypeFoldable<'tcx>,
-    {
-        renumber_regions(self.infcx, value)
     }
 }
 
@@ -128,15 +100,6 @@ impl<'a, 'tcx> MutVisitor<'tcx> for NllVisitor<'a, 'tcx> {
         self.infcx.tcx
     }
 
-    #[cfg(not(debug_assertions))]
-    #[instrument(skip(self), level = "debug")]
-    fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _ty_context: TyContext) {
-        *ty = self.renumber_regions(*ty);
-
-        debug!(?ty);
-    }
-
-    #[cfg(debug_assertions)]
     #[instrument(skip(self), level = "debug")]
     fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _ty_context: TyContext) {
         *ty = self.renumber_regions(*ty, RegionCtxt::TyContext(_ty_context));
@@ -144,15 +107,6 @@ impl<'a, 'tcx> MutVisitor<'tcx> for NllVisitor<'a, 'tcx> {
         debug!(?ty);
     }
 
-    #[cfg(not(debug_assertions))]
-    #[instrument(skip(self), level = "debug")]
-    fn visit_substs(&mut self, substs: &mut SubstsRef<'tcx>, location: Location) {
-        *substs = self.renumber_regions(*substs);
-
-        debug!(?substs);
-    }
-
-    #[cfg(debug_assertions)]
     #[instrument(skip(self), level = "debug")]
     fn visit_substs(&mut self, substs: &mut SubstsRef<'tcx>, location: Location) {
         *substs = self.renumber_regions(*substs, RegionCtxt::Location(location));
@@ -160,16 +114,6 @@ impl<'a, 'tcx> MutVisitor<'tcx> for NllVisitor<'a, 'tcx> {
         debug!(?substs);
     }
 
-    #[cfg(not(debug_assertions))]
-    #[instrument(skip(self), level = "debug")]
-    fn visit_region(&mut self, region: &mut ty::Region<'tcx>, location: Location) {
-        let old_region = *region;
-        *region = self.renumber_regions(old_region);
-
-        debug!(?region);
-    }
-
-    #[cfg(debug_assertions)]
     #[instrument(skip(self), level = "debug")]
     fn visit_region(&mut self, region: &mut ty::Region<'tcx>, location: Location) {
         let old_region = *region;
@@ -178,15 +122,6 @@ impl<'a, 'tcx> MutVisitor<'tcx> for NllVisitor<'a, 'tcx> {
         debug!(?region);
     }
 
-    #[cfg(not(debug_assertions))]
-    #[instrument(skip(self), level = "debug")]
-    fn visit_constant(&mut self, constant: &mut Constant<'tcx>, _location: Location) {
-        let literal = constant.literal;
-        constant.literal = self.renumber_regions(literal);
-        debug!("constant: {:#?}", constant);
-    }
-
-    #[cfg(debug_assertions)]
     #[instrument(skip(self), level = "debug")]
     fn visit_constant(&mut self, constant: &mut Constant<'tcx>, _location: Location) {
         let literal = constant.literal;

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -64,7 +64,7 @@ use crate::{
     region_infer::TypeTest,
     type_check::free_region_relations::{CreateResult, UniversalRegionRelations},
     universal_regions::{DefiningTy, UniversalRegions},
-    Upvar,
+    BorrowckInferCtxt, Upvar,
 };
 
 macro_rules! span_mirbug {
@@ -123,7 +123,7 @@ mod relate_tys;
 /// - `move_data` -- move-data constructed when performing the maybe-init dataflow analysis
 /// - `elements` -- MIR region map
 pub(crate) fn type_check<'mir, 'tcx>(
-    infcx: &InferCtxt<'tcx>,
+    infcx: &BorrowckInferCtxt<'_, 'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     body: &Body<'tcx>,
     promoted: &IndexVec<Promoted, Body<'tcx>>,
@@ -845,7 +845,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
 /// way, it accrues region constraints -- these can later be used by
 /// NLL region checking.
 struct TypeChecker<'a, 'tcx> {
-    infcx: &'a InferCtxt<'tcx>,
+    infcx: &'a BorrowckInferCtxt<'a, 'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     last_span: Span,
     body: &'a Body<'tcx>,
@@ -998,7 +998,7 @@ impl Locations {
 
 impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
     fn new(
-        infcx: &'a InferCtxt<'tcx>,
+        infcx: &'a BorrowckInferCtxt<'a, 'tcx>,
         body: &'a Body<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
         region_bound_pairs: &'a RegionBoundPairs<'tcx>,

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -4,11 +4,12 @@ use rustc_infer::traits::PredicateObligations;
 use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::ty::relate::TypeRelation;
 use rustc_middle::ty::{self, Ty};
-use rustc_span::Span;
+use rustc_span::{Span, Symbol};
 use rustc_trait_selection::traits::query::Fallible;
 
 use crate::constraints::OutlivesConstraint;
 use crate::diagnostics::UniverseInfo;
+use crate::renumber::RegionCtxt;
 use crate::type_check::{InstantiateOpaqueType, Locations, TypeChecker};
 
 impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
@@ -100,23 +101,69 @@ impl<'tcx> TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> 
         universe
     }
 
-    fn next_existential_region_var(&mut self, from_forall: bool) -> ty::Region<'tcx> {
+    #[instrument(skip(self), level = "debug")]
+    fn next_existential_region_var(
+        &mut self,
+        from_forall: bool,
+        _name: Option<Symbol>,
+    ) -> ty::Region<'tcx> {
         let origin = NllRegionVariableOrigin::Existential { from_forall };
-        self.type_checker.infcx.next_nll_region_var(origin)
+
+        #[cfg(not(debug_assertions))]
+        let reg_var = self.type_checker.infcx.next_nll_region_var(origin);
+
+        #[cfg(debug_assertions)]
+        let reg_var =
+            self.type_checker.infcx.next_nll_region_var(origin, RegionCtxt::Existential(_name));
+
+        reg_var
     }
 
+    #[instrument(skip(self), level = "debug")]
     fn next_placeholder_region(&mut self, placeholder: ty::PlaceholderRegion) -> ty::Region<'tcx> {
-        self.type_checker
+        let reg = self
+            .type_checker
             .borrowck_context
             .constraints
-            .placeholder_region(self.type_checker.infcx, placeholder)
+            .placeholder_region(self.type_checker.infcx, placeholder);
+
+        #[cfg(debug_assertions)]
+        {
+            let name = match placeholder.name {
+                ty::BoundRegionKind::BrAnon(_) => Symbol::intern("anon"),
+                ty::BoundRegionKind::BrNamed(_, name) => name,
+                ty::BoundRegionKind::BrEnv => Symbol::intern("env"),
+            };
+
+            let reg_var = reg
+                .try_get_var()
+                .unwrap_or_else(|| bug!("expected region {:?} to be of kind ReVar", reg));
+            let mut var_to_origin = self.type_checker.infcx.reg_var_to_origin.borrow_mut();
+            let prev = var_to_origin.insert(reg_var, RegionCtxt::Placeholder(name));
+            assert!(matches!(prev, None));
+        }
+
+        reg
     }
 
+    #[instrument(skip(self), level = "debug")]
     fn generalize_existential(&mut self, universe: ty::UniverseIndex) -> ty::Region<'tcx> {
-        self.type_checker.infcx.next_nll_region_var_in_universe(
+        let reg = self.type_checker.infcx.next_nll_region_var_in_universe(
             NllRegionVariableOrigin::Existential { from_forall: false },
             universe,
-        )
+        );
+
+        #[cfg(debug_assertions)]
+        {
+            let reg_var = reg
+                .try_get_var()
+                .unwrap_or_else(|| bug!("expected region {:?} to be of kind ReVar", reg));
+            let mut var_to_origin = self.type_checker.infcx.reg_var_to_origin.borrow_mut();
+            let prev = var_to_origin.insert(reg_var, RegionCtxt::Existential(None));
+            assert!(matches!(prev, None));
+        }
+
+        reg
     }
 
     fn push_outlives(

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -130,9 +130,8 @@ impl<'tcx> TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> 
             ty::BoundRegionKind::BrEnv => BoundRegionInfo::Name(Symbol::intern("env")),
         };
 
-        let reg_var = reg
-            .try_get_var()
-            .unwrap_or_else(|| bug!("expected region {:?} to be of kind ReVar", reg));
+        let reg_var =
+            reg.as_var().unwrap_or_else(|| bug!("expected region {:?} to be of kind ReVar", reg));
         let mut var_to_origin = self.type_checker.infcx.reg_var_to_origin.borrow_mut();
         let prev = var_to_origin.insert(reg_var, RegionCtxt::Placeholder(reg_info));
         assert!(matches!(prev, None));
@@ -147,9 +146,8 @@ impl<'tcx> TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> 
             universe,
         );
 
-        let reg_var = reg
-            .try_get_var()
-            .unwrap_or_else(|| bug!("expected region {:?} to be of kind ReVar", reg));
+        let reg_var =
+            reg.as_var().unwrap_or_else(|| bug!("expected region {:?} to be of kind ReVar", reg));
 
         if cfg!(debug_assertions) {
             let mut var_to_origin = self.type_checker.infcx.reg_var_to_origin.borrow_mut();

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -10,7 +10,7 @@ use rustc_trait_selection::traits::query::Fallible;
 use crate::constraints::OutlivesConstraint;
 use crate::diagnostics::UniverseInfo;
 #[cfg(debug_assertions)]
-use crate::renumber::RegionCtxt;
+use crate::renumber::{BoundRegionInfo, RegionCtxt};
 use crate::type_check::{InstantiateOpaqueType, Locations, TypeChecker};
 
 impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
@@ -130,17 +130,19 @@ impl<'tcx> TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> 
 
         #[cfg(debug_assertions)]
         {
-            let name = match placeholder.name {
-                ty::BoundRegionKind::BrAnon(_) => Symbol::intern("anon"),
-                ty::BoundRegionKind::BrNamed(_, name) => name,
-                ty::BoundRegionKind::BrEnv => Symbol::intern("env"),
+            let reg_info = match placeholder.name {
+                // FIXME Probably better to use the `Span` here
+                ty::BoundRegionKind::BrAnon(_, Some(span)) => BoundRegionInfo::Span(span),
+                ty::BoundRegionKind::BrAnon(..) => BoundRegionInfo::Name(Symbol::intern("anon")),
+                ty::BoundRegionKind::BrNamed(_, name) => BoundRegionInfo::Name(name),
+                ty::BoundRegionKind::BrEnv => BoundRegionInfo::Name(Symbol::intern("env")),
             };
 
             let reg_var = reg
                 .try_get_var()
                 .unwrap_or_else(|| bug!("expected region {:?} to be of kind ReVar", reg));
             let mut var_to_origin = self.type_checker.infcx.reg_var_to_origin.borrow_mut();
-            let prev = var_to_origin.insert(reg_var, RegionCtxt::Placeholder(name));
+            let prev = var_to_origin.insert(reg_var, RegionCtxt::Placeholder(reg_info));
             assert!(matches!(prev, None));
         }
 

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -9,6 +9,7 @@ use rustc_trait_selection::traits::query::Fallible;
 
 use crate::constraints::OutlivesConstraint;
 use crate::diagnostics::UniverseInfo;
+#[cfg(debug_assertions)]
 use crate::renumber::RegionCtxt;
 use crate::type_check::{InstantiateOpaqueType, Locations, TypeChecker};
 

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -20,15 +20,18 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::{BodyOwnerKind, HirId};
 use rustc_index::vec::{Idx, IndexVec};
-use rustc_infer::infer::{InferCtxt, NllRegionVariableOrigin};
+use rustc_infer::infer::NllRegionVariableOrigin;
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::{
     self, DefIdTree, InlineConstSubsts, InlineConstSubstsParts, RegionVid, Ty, TyCtxt,
 };
 use rustc_middle::ty::{InternalSubsts, SubstsRef};
+use rustc_span::Symbol;
 use std::iter;
 
 use crate::nll::ToRegionVid;
+use crate::renumber::RegionCtxt;
+use crate::BorrowckInferCtxt;
 
 #[derive(Debug)]
 pub struct UniversalRegions<'tcx> {
@@ -224,7 +227,7 @@ impl<'tcx> UniversalRegions<'tcx> {
     /// signature. This will also compute the relationships that are
     /// known between those regions.
     pub fn new(
-        infcx: &InferCtxt<'tcx>,
+        infcx: &BorrowckInferCtxt<'_, 'tcx>,
         mir_def: ty::WithOptConstParam<LocalDefId>,
         param_env: ty::ParamEnv<'tcx>,
     ) -> Self {
@@ -385,7 +388,7 @@ impl<'tcx> UniversalRegions<'tcx> {
 }
 
 struct UniversalRegionsBuilder<'cx, 'tcx> {
-    infcx: &'cx InferCtxt<'tcx>,
+    infcx: &'cx BorrowckInferCtxt<'cx, 'tcx>,
     mir_def: ty::WithOptConstParam<LocalDefId>,
     mir_hir_id: HirId,
     param_env: ty::ParamEnv<'tcx>,
@@ -403,7 +406,13 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
         assert_eq!(FIRST_GLOBAL_INDEX, self.infcx.num_region_vars());
 
         // Create the "global" region that is always free in all contexts: 'static.
+        #[cfg(not(debug_assertions))]
         let fr_static = self.infcx.next_nll_region_var(FR).to_region_vid();
+        #[cfg(debug_assertions)]
+        let fr_static = self
+            .infcx
+            .next_nll_region_var(FR, RegionCtxt::Free(Symbol::intern("static")))
+            .to_region_vid();
 
         // We've now added all the global regions. The next ones we
         // add will be external.
@@ -480,6 +489,7 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
                     LangItem::VaList,
                     Some(self.infcx.tcx.def_span(self.mir_def.did)),
                 );
+                let reg_vid = self.infcx.next_nll_region_var(FR, RegionCtxt::Free(Symbol::intern("c-variadic")).to_region_vid();
                 let region =
                     self.infcx.tcx.mk_re_var(self.infcx.next_nll_region_var(FR).to_region_vid());
                 let va_list_ty =
@@ -491,7 +501,14 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
             }
         }
 
+        #[cfg(not(debug_assertions))]
         let fr_fn_body = self.infcx.next_nll_region_var(FR).to_region_vid();
+        #[cfg(debug_assertions)]
+        let fr_fn_body = self
+            .infcx
+            .next_nll_region_var(FR, RegionCtxt::Free(Symbol::intern("fn_body")))
+            .to_region_vid();
+
         let num_universals = self.infcx.num_region_vars();
 
         debug!("build: global regions = {}..{}", FIRST_GLOBAL_INDEX, first_extern_index);
@@ -718,7 +735,8 @@ trait InferCtxtExt<'tcx> {
     );
 }
 
-impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
+impl<'cx, 'tcx> InferCtxtExt<'tcx> for BorrowckInferCtxt<'cx, 'tcx> {
+    #[cfg(not(debug_assertions))]
     fn replace_free_regions_with_nll_infer_vars<T>(
         &self,
         origin: NllRegionVariableOrigin,
@@ -727,9 +745,33 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
     where
         T: TypeFoldable<'tcx>,
     {
-        self.tcx.fold_regions(value, |_region, _depth| self.next_nll_region_var(origin))
+        self.tcx.fold_regions(value, |_region, _depth| self.infcx.next_nll_region_var(origin))
     }
 
+    #[cfg(debug_assertions)]
+    #[instrument(skip(self), level = "debug")]
+    fn replace_free_regions_with_nll_infer_vars<T>(
+        &self,
+        origin: NllRegionVariableOrigin,
+        value: T,
+    ) -> T
+    where
+        T: TypeFoldable<'tcx>,
+    {
+        self.infcx.tcx.fold_regions(value, |region, _depth| {
+            let name = match region.get_name() {
+                Some(name) => name,
+                _ => Symbol::intern("anon"),
+            };
+            debug!(?region, ?name);
+
+            let reg_var = self.next_nll_region_var(origin, RegionCtxt::Free(name));
+
+            reg_var
+        })
+    }
+
+    #[cfg(not(debug_assertions))]
     #[instrument(level = "debug", skip(self, indices))]
     fn replace_bound_regions_with_nll_infer_vars<T>(
         &self,
@@ -752,6 +794,38 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
         value
     }
 
+    #[cfg(debug_assertions)]
+    #[instrument(level = "debug", skip(self, indices))]
+    fn replace_bound_regions_with_nll_infer_vars<T>(
+        &self,
+        origin: NllRegionVariableOrigin,
+        all_outlive_scope: LocalDefId,
+        value: ty::Binder<'tcx, T>,
+        indices: &mut UniversalRegionIndices<'tcx>,
+    ) -> T
+    where
+        T: TypeFoldable<'tcx>,
+    {
+        let (value, _map) = self.tcx.replace_late_bound_regions(value, |br| {
+            debug!(?br);
+            let liberated_region = self.tcx.mk_region(ty::ReFree(ty::FreeRegion {
+                scope: all_outlive_scope.to_def_id(),
+                bound_region: br.kind,
+            }));
+
+            let name = match br.kind.get_name() {
+                Some(name) => name,
+                _ => Symbol::intern("anon"),
+            };
+
+            let region_vid = self.next_nll_region_var(origin, RegionCtxt::Bound(name));
+            indices.insert_late_bound_region(liberated_region, region_vid.to_region_vid());
+            debug!(?liberated_region, ?region_vid);
+            region_vid
+        });
+        value
+    }
+
     /// Finds late-bound regions that do not appear in the parameter listing and adds them to the
     /// indices vector. Typically, we identify late-bound regions as we process the inputs and
     /// outputs of the closure/function. However, sometimes there are late-bound regions which do
@@ -761,6 +835,7 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
     /// entries for them and store them in the indices map. This code iterates over the complete
     /// set of late-bound regions and checks for any that we have not yet seen, adding them to the
     /// inputs vector.
+    #[cfg(not(debug_assertions))]
     #[instrument(skip(self, indices))]
     fn replace_late_bound_regions_with_nll_infer_vars_in_recursive_scope(
         &self,
@@ -787,6 +862,38 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
             debug!(?r);
             if !indices.indices.contains_key(&r) {
                 let region_vid = self.next_nll_region_var(FR);
+                debug!(?region_vid);
+                indices.insert_late_bound_region(r, region_vid.to_region_vid());
+            }
+        });
+    }
+
+    /// Finds late-bound regions that do not appear in the parameter listing and adds them to the
+    /// indices vector. Typically, we identify late-bound regions as we process the inputs and
+    /// outputs of the closure/function. However, sometimes there are late-bound regions which do
+    /// not appear in the fn parameters but which are nonetheless in scope. The simplest case of
+    /// this are unused functions, like fn foo<'a>() { } (see e.g., #51351). Despite not being used,
+    /// users can still reference these regions (e.g., let x: &'a u32 = &22;), so we need to create
+    /// entries for them and store them in the indices map. This code iterates over the complete
+    /// set of late-bound regions and checks for any that we have not yet seen, adding them to the
+    /// inputs vector.
+    #[cfg(debug_assertions)]
+    #[instrument(skip(self, indices))]
+    fn replace_late_bound_regions_with_nll_infer_vars(
+        &self,
+        mir_def_id: LocalDefId,
+        indices: &mut UniversalRegionIndices<'tcx>,
+    ) {
+        let typeck_root_def_id = self.tcx.typeck_root_def_id(mir_def_id.to_def_id());
+        for_each_late_bound_region_defined_on(self.tcx, typeck_root_def_id, |r| {
+            debug!(?r);
+            if !indices.indices.contains_key(&r) {
+                let name = match r.get_name() {
+                    Some(name) => name,
+                    _ => Symbol::intern("anon"),
+                };
+
+                let region_vid = self.next_nll_region_var(FR, RegionCtxt::LateBound(name));
                 debug!(?region_vid);
                 indices.insert_late_bound_region(r, region_vid.to_region_vid());
             }

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -26,10 +26,12 @@ use rustc_middle::ty::{
     self, DefIdTree, InlineConstSubsts, InlineConstSubstsParts, RegionVid, Ty, TyCtxt,
 };
 use rustc_middle::ty::{InternalSubsts, SubstsRef};
+#[cfg(debug_assertions)]
 use rustc_span::Symbol;
 use std::iter;
 
 use crate::nll::ToRegionVid;
+#[cfg(debug_assertions)]
 use crate::renumber::RegionCtxt;
 use crate::BorrowckInferCtxt;
 

--- a/compiler/rustc_data_structures/src/graph/scc/mod.rs
+++ b/compiler/rustc_data_structures/src/graph/scc/mod.rs
@@ -21,26 +21,34 @@ mod tests;
 pub struct Sccs<N: Idx, S: Idx> {
     /// For each node, what is the SCC index of the SCC to which it
     /// belongs.
-    pub scc_indices: IndexVec<N, S>,
+    scc_indices: IndexVec<N, S>,
 
     /// Data about each SCC.
-    pub scc_data: SccData<S>,
+    scc_data: SccData<S>,
 }
 
 pub struct SccData<S: Idx> {
     /// For each SCC, the range of `all_successors` where its
     /// successors can be found.
-    pub ranges: IndexVec<S, Range<usize>>,
+    ranges: IndexVec<S, Range<usize>>,
 
     /// Contains the successors for all the Sccs, concatenated. The
     /// range of indices corresponding to a given SCC is found in its
     /// SccData.
-    pub all_successors: Vec<S>,
+    all_successors: Vec<S>,
 }
 
 impl<N: Idx, S: Idx + Ord> Sccs<N, S> {
     pub fn new(graph: &(impl DirectedGraph<Node = N> + WithNumNodes + WithSuccessors)) -> Self {
         SccsConstruction::construct(graph)
+    }
+
+    pub fn scc_indices(&self) -> &IndexVec<N, S> {
+        &self.scc_indices
+    }
+
+    pub fn scc_data(&self) -> &SccData<S> {
+        &self.scc_data
     }
 
     /// Returns the number of SCCs in the graph.
@@ -113,6 +121,14 @@ impl<S: Idx> SccData<S> {
     /// Number of SCCs,
     fn len(&self) -> usize {
         self.ranges.len()
+    }
+
+    pub fn ranges(&self) -> &IndexVec<S, Range<usize>> {
+        &self.ranges
+    }
+
+    pub fn all_successors(&self) -> &Vec<S> {
+        &self.all_successors
     }
 
     /// Returns the successors of the given SCC.

--- a/compiler/rustc_data_structures/src/graph/scc/mod.rs
+++ b/compiler/rustc_data_structures/src/graph/scc/mod.rs
@@ -21,21 +21,21 @@ mod tests;
 pub struct Sccs<N: Idx, S: Idx> {
     /// For each node, what is the SCC index of the SCC to which it
     /// belongs.
-    scc_indices: IndexVec<N, S>,
+    pub scc_indices: IndexVec<N, S>,
 
     /// Data about each SCC.
-    scc_data: SccData<S>,
+    pub scc_data: SccData<S>,
 }
 
-struct SccData<S: Idx> {
+pub struct SccData<S: Idx> {
     /// For each SCC, the range of `all_successors` where its
     /// successors can be found.
-    ranges: IndexVec<S, Range<usize>>,
+    pub ranges: IndexVec<S, Range<usize>>,
 
     /// Contains the successors for all the Sccs, concatenated. The
     /// range of indices corresponding to a given SCC is found in its
     /// SccData.
-    all_successors: Vec<S>,
+    pub all_successors: Vec<S>,
 }
 
 impl<N: Idx, S: Idx + Ord> Sccs<N, S> {

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -318,11 +318,7 @@ impl<'tcx> InferCtxt<'tcx> {
 
                 // Screen out `'a: 'a` cases.
                 let ty::OutlivesPredicate(k1, r2) = r_c.0;
-                if k1 != r2.into() {
-                    Some(r_c)
-                } else {
-                    None
-                }
+                if k1 != r2.into() { Some(r_c) } else { None }
             }),
         );
 

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -27,7 +27,7 @@ use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::relate::TypeRelation;
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind};
 use rustc_middle::ty::{self, BoundVar, ToPredicate, Ty, TyCtxt};
-use rustc_span::Span;
+use rustc_span::{Span, Symbol};
 use std::fmt::Debug;
 use std::iter;
 
@@ -318,7 +318,11 @@ impl<'tcx> InferCtxt<'tcx> {
 
                 // Screen out `'a: 'a` cases.
                 let ty::OutlivesPredicate(k1, r2) = r_c.0;
-                if k1 != r2.into() { Some(r_c) } else { None }
+                if k1 != r2.into() {
+                    Some(r_c)
+                } else {
+                    None
+                }
             }),
         );
 
@@ -683,7 +687,11 @@ impl<'tcx> TypeRelatingDelegate<'tcx> for QueryTypeRelatingDelegate<'_, 'tcx> {
         self.infcx.create_next_universe()
     }
 
-    fn next_existential_region_var(&mut self, from_forall: bool) -> ty::Region<'tcx> {
+    fn next_existential_region_var(
+        &mut self,
+        from_forall: bool,
+        _name: Option<Symbol>,
+    ) -> ty::Region<'tcx> {
         let origin = NllRegionVariableOrigin::Existential { from_forall };
         self.infcx.next_nll_region_var(origin)
     }

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1111,11 +1111,13 @@ impl<'tcx> InferCtxt<'tcx> {
     }
 
     /// Just a convenient wrapper of `next_region_var` for using during NLL.
+    #[instrument(skip(self), level = "debug")]
     pub fn next_nll_region_var(&self, origin: NllRegionVariableOrigin) -> ty::Region<'tcx> {
         self.next_region_var(RegionVariableOrigin::Nll(origin))
     }
 
     /// Just a convenient wrapper of `next_region_var` for using during NLL.
+    #[instrument(skip(self), level = "debug")]
     pub fn next_nll_region_var_in_universe(
         &self,
         origin: NllRegionVariableOrigin,

--- a/compiler/rustc_infer/src/infer/nll_relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/nll_relate/mod.rs
@@ -31,7 +31,7 @@ use rustc_middle::ty::error::TypeError;
 use rustc_middle::ty::relate::{self, Relate, RelateResult, TypeRelation};
 use rustc_middle::ty::visit::{ir::TypeVisitor, TypeSuperVisitable, TypeVisitable};
 use rustc_middle::ty::{self, InferConst, Ty, TyCtxt};
-use rustc_span::Span;
+use rustc_span::{Span, Symbol};
 use std::fmt::Debug;
 use std::ops::ControlFlow;
 
@@ -100,7 +100,11 @@ pub trait TypeRelatingDelegate<'tcx> {
     /// we will invoke this method to instantiate `'a` with an
     /// inference variable (though `'b` would be instantiated first,
     /// as a placeholder).
-    fn next_existential_region_var(&mut self, was_placeholder: bool) -> ty::Region<'tcx>;
+    fn next_existential_region_var(
+        &mut self,
+        was_placeholder: bool,
+        name: Option<Symbol>,
+    ) -> ty::Region<'tcx>;
 
     /// Creates a new region variable representing a
     /// higher-ranked region that is instantiated universally.
@@ -188,7 +192,7 @@ where
                     let placeholder = ty::PlaceholderRegion { universe, name: br.kind };
                     delegate.next_placeholder_region(placeholder)
                 } else {
-                    delegate.next_existential_region_var(true)
+                    delegate.next_existential_region_var(true, br.kind.get_name())
                 }
             }
         };

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -1214,7 +1214,7 @@ impl<'tcx> MirVisitable<'tcx> for Option<Terminator<'tcx>> {
 
 /// Extra information passed to `visit_ty` and friends to give context
 /// about where the type etc appears.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum TyContext {
     LocalDecl {
         /// The index of the local variable we are visiting.

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1752,7 +1752,7 @@ impl<'tcx> Region<'tcx> {
         matches!(self.kind(), ty::ReVar(_))
     }
 
-    pub fn try_get_var(self) -> Option<RegionVid> {
+    pub fn as_var(self) -> Option<RegionVid> {
         match self.kind() {
             ty::ReVar(vid) => Some(vid),
             _ => None,

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1751,6 +1751,13 @@ impl<'tcx> Region<'tcx> {
     pub fn is_var(self) -> bool {
         matches!(self.kind(), ty::ReVar(_))
     }
+
+    pub fn try_get_var(self) -> Option<RegionVid> {
+        match self.kind() {
+            ty::ReVar(vid) => Some(vid),
+            _ => None,
+        }
+    }
 }
 
 /// Type utilities


### PR DESCRIPTION
It's really cumbersome to work with `RegionVar`s when trying to debug borrowck code or when trying to understand how the borrowchecker works. This PR collects some region information (behind `cfg(debug_assertions)`) for created `RegionVar`s (NLL region vars, this PR doesn't touch canonicalization) and prints the nodes and edges of the strongly connected constraints graph using representatives that use that region information (either lifetime names, locations in MIR or spans).