### PR TITLE
Move most of unwind's build script to lib.rs

### DIFF
--- a/library/unwind/build.rs
+++ b/library/unwind/build.rs
@@ -21,29 +21,5 @@ fn main() {
         if has_unwind {
             println!("cargo:rustc-cfg=feature=\"system-llvm-libunwind\"");
         }
-    } else if target.contains("freebsd") {
-        println!("cargo:rustc-link-lib=gcc_s");
-    } else if target.contains("netbsd") {
-        println!("cargo:rustc-link-lib=gcc_s");
-    } else if target.contains("openbsd") {
-        if target.contains("sparc64") {
-            println!("cargo:rustc-link-lib=gcc");
-        } else {
-            println!("cargo:rustc-link-lib=c++abi");
-        }
-    } else if target.contains("solaris") {
-        println!("cargo:rustc-link-lib=gcc_s");
-    } else if target.contains("illumos") {
-        println!("cargo:rustc-link-lib=gcc_s");
-    } else if target.contains("dragonfly") {
-        println!("cargo:rustc-link-lib=gcc_pic");
-    } else if target.ends_with("pc-windows-gnu") {
-        // This is handled in the target spec with late_link_args_[static|dynamic]
-    } else if target.contains("uwp-windows-gnu") {
-        println!("cargo:rustc-link-lib=unwind");
-    } else if target.contains("haiku") {
-        println!("cargo:rustc-link-lib=gcc_s");
-    } else if target.contains("redox") {
-        // redox is handled in lib.rs
     }
 }

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -103,3 +103,27 @@ extern "C" {}
 #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
 #[link(name = "unwind", kind = "static", modifiers = "-bundle")]
 extern "C" {}
+
+#[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+#[link(name = "gcc_s")]
+extern "C" {}
+
+#[cfg(all(target_os = "openbsd", target_arch = "sparc64"))]
+#[link(name = "gcc")]
+extern "C" {}
+
+#[cfg(all(target_os = "openbsd", not(target_arch = "sparc64")))]
+#[link(name = "c++abi")]
+extern "C" {}
+
+#[cfg(any(target_os = "solaris", target_os = "illumos"))]
+#[link(name = "gcc_s")]
+extern "C" {}
+
+#[cfg(target_os = "dragonfly")]
+#[link(name = "gcc_pic")]
+extern "C" {}
+
+#[cfg(target_os = "haiku")]
+#[link(name = "gcc_s")]
+extern "C" {}


### PR DESCRIPTION
Only the android libunwind detection remains in the build script

* Reduces dependence on build scripts for building the standard library
* Reduces dependence on exact target names in favor of using semantic cfg(target_*) usage.
* Keeps almost all code related to linking of the unwinder in one file