### PR TITLE
[perf] Make `#[link_name]` local only

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -342,7 +342,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         template!(List: r#"name = "...", /*opt*/ kind = "dylib|static|...", /*opt*/ wasm_import_module = "...", /*opt*/ import_name_type = "decorated|noprefix|undecorated""#),
         DuplicatesOk,
     ),
-    ungated!(link_name, Normal, template!(NameValueStr: "name"), FutureWarnPreceding),
+    ungated!(link_name, Normal, template!(NameValueStr: "name"), FutureWarnPreceding, @only_local: true),
     ungated!(no_link, Normal, template!(Word), WarnFollowing),
     ungated!(repr, Normal, template!(List: "C"), DuplicatesOk, @only_local: true),
     ungated!(export_name, Normal, template!(NameValueStr: "name"), FutureWarnPreceding),

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -15,7 +15,7 @@ use rustc_middle::ty::{
     layout::{LayoutOf, TyAndLayout},
     List, TyCtxt,
 };
-use rustc_span::{def_id::CrateNum, sym, Span, Symbol};
+use rustc_span::{def_id::CrateNum, Span, Symbol};
 use rustc_target::abi::{Align, FieldsShape, Size, Variants};
 use rustc_target::spec::abi::Abi;
 
@@ -936,7 +936,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
 
     fn item_link_name(&self, def_id: DefId) -> Symbol {
         let tcx = self.eval_context_ref().tcx;
-        match tcx.get_attrs(def_id, sym::link_name).filter_map(|a| a.value_str()).next() {
+        match tcx.codegen_fn_attrs(def_id).link_name {
             Some(name) => name,
             None => tcx.item_name(def_id),
         }


### PR DESCRIPTION
Test the perf impact (if any) and slight artifact size reduction by removing `#[link_name]` from metadata (esp. from `libstd`/`libcore`). 

Last time I tried this, CI failed because miri reads that attribute internally. But it can instead read the codegen fn attrs for that purpose, without changing anything else. That makes its tests pass.

r? @ghost