### PR TITLE
More accurately report error when formal and expected signature types differ

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -30,6 +30,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected_ty_expr: Option<&'tcx hir::Expr<'tcx>>,
         error: Option<TypeError<'tcx>>,
     ) {
+        if expr_ty == expected {
+            return;
+        }
+
         self.annotate_expected_due_to_let_ty(err, expr, error);
 
         // Use `||` to give these suggestions a precedence

--- a/src/test/ui/argument-suggestions/formal-and-expected-differ.rs
+++ b/src/test/ui/argument-suggestions/formal-and-expected-differ.rs
@@ -1,0 +1,25 @@
+pub trait Foo {
+    type T;
+}
+
+impl Foo for i32 {
+    type T = f32;
+}
+
+pub struct U<T1, T2>(T1, S<T2>)
+where
+    T1: Foo<T = T2>;
+
+pub struct S<T>(T);
+
+fn main() {
+    // The error message here isn't great -- it has to do with the fact that the
+    // `expected_inputs_for_expected_output` deduced inputs differs from the inputs
+    // that we infer from the constraints of the signature.
+    //
+    // I am not really sure what the best way of presenting this error message is,
+    // since right now it just suggests changing `3u32` <=> `3f32` back and forth.
+    let _: U<_, u32> = U(1, S(3u32));
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+}

--- a/src/test/ui/argument-suggestions/formal-and-expected-differ.stderr
+++ b/src/test/ui/argument-suggestions/formal-and-expected-differ.stderr
@@ -1,0 +1,30 @@
+error[E0308]: mismatched types
+  --> $DIR/formal-and-expected-differ.rs:22:29
+   |
+LL |     let _: U<_, u32> = U(1, S(3u32));
+   |                        -    ^^^^^^^ expected `f32`, found `u32`
+   |                        |
+   |                        arguments to this struct are incorrect
+   |
+   = note: expected struct `S<f32>`
+              found struct `S<u32>`
+note: tuple struct defined here
+  --> $DIR/formal-and-expected-differ.rs:9:12
+   |
+LL | pub struct U<T1, T2>(T1, S<T2>)
+   |            ^
+
+error[E0308]: mismatched types
+  --> $DIR/formal-and-expected-differ.rs:22:24
+   |
+LL |     let _: U<_, u32> = U(1, S(3u32));
+   |            ---------   ^^^^^^^^^^^^^ expected `u32`, found `f32`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `U<_, u32>`
+              found struct `U<i32, f32>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #104242