### PR TITLE
Use `DefId` instead of `Span` in `BrAnon` to avoid stable hashing collisions

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -214,7 +214,7 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
 
     fn re_infer(&self, def: Option<&ty::GenericParamDef>, span: Span) -> Option<ty::Region<'tcx>> {
         let v = match def {
-            Some(def) => infer::EarlyBoundRegion(span, def.name),
+            Some(def) => infer::EarlyBoundRegion(span, def.def_id),
             None => infer::MiscVariable(span),
         };
         Some(self.next_region_var(v))

--- a/compiler/rustc_infer/src/errors/note_and_explain.rs
+++ b/compiler/rustc_infer/src/errors/note_and_explain.rs
@@ -89,11 +89,11 @@ impl<'a> DescriptionCtx<'a> {
                             };
                             me.span = Some(sp);
                         }
-                        ty::BrAnon(idx, span) => {
+                        ty::BrAnon(idx, def_id) => {
                             me.kind = "anon_num_here";
                             me.num_arg = idx+1;
-                            me.span = match span {
-                                Some(_) => span,
+                            me.span = match def_id {
+                                Some(def_id) => Some(tcx.def_span(def_id)),
                                 None => Some(tcx.def_span(scope)),
                             }
                         },

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -211,10 +211,10 @@ fn msg_span_from_early_bound_and_free_regions<'tcx>(
                         };
                         (text, sp)
                     }
-                    ty::BrAnon(idx, span) => (
+                    ty::BrAnon(idx, def_id) => (
                         format!("the anonymous lifetime #{} defined here", idx + 1),
-                        match span {
-                            Some(span) => span,
+                        match def_id {
+                            Some(def_id) => tcx.def_span(def_id),
                             None => tcx.def_span(scope)
                         }
                     ),
@@ -3048,7 +3048,9 @@ impl<'tcx> InferCtxt<'tcx> {
                 br_string(br),
                 self.tcx.associated_item(def_id).name
             ),
-            infer::EarlyBoundRegion(_, name) => format!(" for lifetime parameter `{}`", name),
+            infer::EarlyBoundRegion(_, def_id) => {
+                format!(" for lifetime parameter `{}`", self.tcx.item_name(def_id))
+            }
             infer::UpvarRegion(ref upvar_id, _) => {
                 let var_name = self.tcx.hir().name(upvar_id.var_path.hir_id);
                 format!(" for capture of `{}` by closure", var_name)

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_relation.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_relation.rs
@@ -22,14 +22,16 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
                     ty::BrNamed(def_id, symbol) => {
                         (Some(self.tcx().def_span(def_id)), Some(symbol))
                     }
-                    ty::BrAnon(_, span) => (*span, None),
+                    ty::BrAnon(_, Some(def_id)) => (Some(self.tcx().def_span(def_id)), None),
+                    ty::BrAnon(_, None) => (None, None),
                     ty::BrEnv => (None, None),
                 };
                 let (sup_span, sup_symbol) = match sup_name {
                     ty::BrNamed(def_id, symbol) => {
                         (Some(self.tcx().def_span(def_id)), Some(symbol))
                     }
-                    ty::BrAnon(_, span) => (*span, None),
+                    ty::BrAnon(_, Some(def_id)) => (Some(self.tcx().def_span(def_id)), None),
+                    ty::BrAnon(_, None) => (None, None),
                     ty::BrEnv => (None, None),
                 };
                 match (sub_span, sup_span, sub_symbol, sup_symbol) {

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -33,7 +33,6 @@ use rustc_middle::ty::visit::TypeVisitable;
 pub use rustc_middle::ty::IntVarValue;
 use rustc_middle::ty::{self, GenericParamDefKind, InferConst, Ty, TyCtxt};
 use rustc_middle::ty::{ConstVid, FloatVid, IntVid, TyVid};
-use rustc_span::symbol::Symbol;
 use rustc_span::{Span, DUMMY_SP};
 
 use std::cell::{Cell, RefCell};
@@ -470,7 +469,7 @@ pub enum RegionVariableOrigin {
     Coercion(Span),
 
     /// Region variables created as the values for early-bound regions
-    EarlyBoundRegion(Span, Symbol),
+    EarlyBoundRegion(Span, DefId),
 
     /// Region variables created for bound regions
     /// in a function or method that is called
@@ -1181,7 +1180,7 @@ impl<'tcx> InferCtxt<'tcx> {
             GenericParamDefKind::Lifetime => {
                 // Create a region inference variable for the given
                 // region parameter definition.
-                self.next_region_var(EarlyBoundRegion(span, param.name)).into()
+                self.next_region_var(EarlyBoundRegion(span, param.def_id)).into()
             }
             GenericParamDefKind::Type { .. } => {
                 // Create a type inference variable for the given

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -59,7 +59,7 @@ pub struct FreeRegion {
 #[derive(HashStable)]
 pub enum BoundRegionKind {
     /// An anonymous region parameter for a given fn (&T)
-    BrAnon(u32, Option<Span>),
+    BrAnon(u32, Option<DefId>),
 
     /// Named region parameters for functions (a in &'a T)
     ///

--- a/src/test/ui/generic-associated-types/bugs/issue-100013.stderr
+++ b/src/test/ui/generic-associated-types/bugs/issue-100013.stderr
@@ -9,15 +9,15 @@ LL | |     }
    | |_____^
    |
 note: the lifetime defined here...
-  --> $DIR/issue-100013.rs:17:38
+  --> $DIR/issue-100013.rs:9:21
    |
-LL |         let x = None::<I::Future<'_, '_>>; // a type referencing GAT
-   |                                      ^^
+LL |     type Future<'s, 'cx>: Send
+   |                     ^^^
 note: ...must outlive the lifetime defined here
-  --> $DIR/issue-100013.rs:17:34
+  --> $DIR/issue-100013.rs:9:17
    |
-LL |         let x = None::<I::Future<'_, '_>>; // a type referencing GAT
-   |                                  ^^
+LL |     type Future<'s, 'cx>: Send
+   |                 ^^
    = note: this is a known limitation that will be removed in the future (see issue #100013 <https://github.com/rust-lang/rust/issues/100013> for more information)
 
 error: lifetime bound not satisfied


### PR DESCRIPTION
Recent reports of ICEs due to the fact that `BrAnon` regions now capture spans, which apparently sometimes can `StableHash` into identical values but `Hash` into different values, causing collisions in dep nodes that are not covered by identical cache entries.

We can avoid this by just using a `DefId` instead ~which doesn't affect diagnostics~ **edit:** this is not true. 

I have no idea how to turn #104271, #104255, or #104238 into a MCVE, though, but local testing shows that the projects build without ICE after this change.

This brings up a bigger question about whether we should be rejecting `Span`s from query keys (or at least being much more careful about them)...

Fixes #104271
Fixes #104255
Fixes #104238

cc #103171 @cjgillot @jackh726 