### PR TITLE
Implement TryFrom<&str> for numerical types, bool and char

### DIFF
--- a/library/core/src/char/convert.rs
+++ b/library/core/src/char/convert.rs
@@ -194,6 +194,20 @@ impl FromStr for char {
     }
 }
 
+impl<'a> TryFrom<&'a str> for char {
+    type Error = ParseCharError;
+
+    #[inline]
+    fn try_from(s: &'a str) -> Result<Self, Self::Err> {
+        let mut chars = s.chars();
+        match (chars.next(), chars.next()) {
+            (None, _) => Err(ParseCharError { kind: CharErrorKind::EmptyString }),
+            (Some(c), None) => Ok(c),
+            _ => Err(ParseCharError { kind: CharErrorKind::TooManyChars }),
+        }
+    }
+}
+
 #[inline]
 const fn char_try_from_u32(i: u32) -> Result<char, CharTryFromError> {
     // This is an optimized version of the check

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -3,6 +3,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::ascii;
+use crate::convert::TryFrom;
 use crate::error::Error;
 use crate::intrinsics;
 use crate::mem;
@@ -1076,6 +1077,18 @@ macro_rules! from_str_radix_int_impl {
     )*}
 }
 from_str_radix_int_impl! { isize i8 i16 i32 i64 i128 usize u8 u16 u32 u64 u128 }
+
+macro_rules! try_from_str_radix_int_impl {
+    ($($t:ty)*) => {$(
+        impl<'a> TryFrom<&'a str> for $t {
+            type Error = ParseIntError;
+            fn try_from(src: &'a str) -> Result<Self, ParseIntError> {
+                from_str_radix(src, 10)
+            }
+        }
+    )*}
+}
+try_from_str_radix_int_impl! { isize i8 i16 i32 i64 i128 usize u8 u16 u32 u64 u128 }
 
 macro_rules! impl_helper_for {
     ($($t:ty)*) => ($(impl FromStrRadixHelper for $t {

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -194,6 +194,23 @@ macro_rules! from_str_radix_nzint_impl {
 from_str_radix_nzint_impl! { NonZeroU8 NonZeroU16 NonZeroU32 NonZeroU64 NonZeroU128 NonZeroUsize
 NonZeroI8 NonZeroI16 NonZeroI32 NonZeroI64 NonZeroI128 NonZeroIsize }
 
+macro_rules! try_from_str_radix_nzint_impl {
+    ($($t:ty)*) => {$(
+        impl<'a> TryFrom<&'a str> for $t {
+            type Error = ParseIntError;
+            fn try_from(src: &'a str) -> Result<Self, Self::Err> {
+                Self::new(from_str_radix(src, 10)?)
+                    .ok_or(ParseIntError {
+                        kind: IntErrorKind::Zero
+                    })
+            }
+        }
+    )*}
+}
+
+try_from_str_radix_nzint_impl! { NonZeroU8 NonZeroU16 NonZeroU32 NonZeroU64 NonZeroU128 NonZeroUsize
+NonZeroI8 NonZeroI16 NonZeroI32 NonZeroI64 NonZeroI128 NonZeroIsize }
+
 macro_rules! nonzero_leading_trailing_zeros {
     ( $( $Ty: ident($Uint: ty) , $LeadingTestExpr:expr ;)+ ) => {
         $(

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1,5 +1,6 @@
 //! Definitions of integer that is known not to equal zero.
 
+use crate::convert::TryFrom;
 use crate::fmt;
 use crate::ops::{BitOr, BitOrAssign, Div, Rem};
 use crate::str::FromStr;

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -1,6 +1,7 @@
 //! Trait implementations for `str`.
 
 use crate::cmp::Ordering;
+use crate::convert::TryFrom;
 use crate::ops;
 use crate::ptr;
 use crate::slice::SliceIndex;
@@ -404,11 +405,19 @@ unsafe impl const SliceIndex<str> for ops::RangeInclusive<usize> {
     type Output = str;
     #[inline]
     fn get(self, slice: &str) -> Option<&Self::Output> {
-        if *self.end() == usize::MAX { None } else { self.into_slice_range().get(slice) }
+        if *self.end() == usize::MAX {
+            None
+        } else {
+            self.into_slice_range().get(slice)
+        }
     }
     #[inline]
     fn get_mut(self, slice: &mut str) -> Option<&mut Self::Output> {
-        if *self.end() == usize::MAX { None } else { self.into_slice_range().get_mut(slice) }
+        if *self.end() == usize::MAX {
+            None
+        } else {
+            self.into_slice_range().get_mut(slice)
+        }
     }
     #[inline]
     unsafe fn get_unchecked(self, slice: *const str) -> *const Self::Output {
@@ -456,11 +465,19 @@ unsafe impl const SliceIndex<str> for ops::RangeToInclusive<usize> {
     type Output = str;
     #[inline]
     fn get(self, slice: &str) -> Option<&Self::Output> {
-        if self.end == usize::MAX { None } else { (..self.end + 1).get(slice) }
+        if self.end == usize::MAX {
+            None
+        } else {
+            (..self.end + 1).get(slice)
+        }
     }
     #[inline]
     fn get_mut(self, slice: &mut str) -> Option<&mut Self::Output> {
-        if self.end == usize::MAX { None } else { (..self.end + 1).get_mut(slice) }
+        if self.end == usize::MAX {
+            None
+        } else {
+            (..self.end + 1).get_mut(slice)
+        }
     }
     #[inline]
     unsafe fn get_unchecked(self, slice: *const str) -> *const Self::Output {
@@ -599,6 +616,41 @@ impl FromStr for bool {
     /// ```
     #[inline]
     fn from_str(s: &str) -> Result<bool, ParseBoolError> {
+        match s {
+            "true" => Ok(true),
+            "false" => Ok(false),
+            _ => Err(ParseBoolError),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a str> for bool {
+    type Error = ParseBoolError;
+
+    /// Parse a `bool` from a string.
+    ///
+    /// The only accepted values are `"true"` and `"false"`. Any other input
+    /// will return an error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    ///
+    /// assert_eq!(FromStr::from_str("true"), Ok(true));
+    /// assert_eq!(FromStr::from_str("false"), Ok(false));
+    /// assert!(<bool as FromStr>::from_str("not even a boolean").is_err());
+    /// ```
+    ///
+    /// Note, in many cases, the `.parse()` method on `str` is more proper.
+    ///
+    /// ```
+    /// assert_eq!("true".parse(), Ok(true));
+    /// assert_eq!("false".parse(), Ok(false));
+    /// assert!("not even a boolean".parse::<bool>().is_err());
+    /// ```
+    #[inline]
+    fn try_from(s: &'a str) -> Result<bool, ParseBoolError> {
         match s {
             "true" => Ok(true),
             "false" => Ok(false),


### PR DESCRIPTION
As `TryFrom` is a generic interface for fallible conversion, the standard library types should support it as well.

ACP: https://github.com/rust-lang/libs-team/issues/132 [Accepted]