### PR TITLE
copy doc output files by format

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1345,7 +1345,13 @@ impl<'a> Builder<'a> {
             let my_out = match mode {
                 // This is the intended out directory for compiler documentation.
                 Mode::Rustc | Mode::ToolRustc => self.compiler_doc_out(target),
-                Mode::Std => out_dir.join(target.triple).join("doc"),
+                Mode::Std => {
+                    if self.config.cmd.json() {
+                        out_dir.join(target.triple).join("json-doc")
+                    } else {
+                        out_dir.join(target.triple).join("doc")
+                    }
+                }
                 _ => panic!("doc mode {:?} not expected", mode),
             };
             let rustdoc = self.rustdoc(compiler);

--- a/src/test/run-make/rustdoc-verify-output-files/Makefile
+++ b/src/test/run-make/rustdoc-verify-output-files/Makefile
@@ -1,0 +1,36 @@
+include ../../run-make-fulldeps/tools.mk
+
+OUTPUT_DIR := "$(TMPDIR)/rustdoc"
+TMP_OUTPUT_DIR := "$(TMPDIR)/tmp-rustdoc"
+
+all:
+	# Generate html docs
+	$(RUSTDOC) src/lib.rs --crate-name foobar --crate-type lib --out-dir $(OUTPUT_DIR)
+
+	# Copy first output for to check if it's exactly same after second compilation
+	cp -R $(OUTPUT_DIR) $(TMP_OUTPUT_DIR)
+
+	# Generate html docs once again on same output
+	$(RUSTDOC) src/lib.rs --crate-name foobar --crate-type lib --out-dir $(OUTPUT_DIR)
+
+	# Check if everything exactly same
+	$(DIFF) -r -q $(OUTPUT_DIR) $(TMP_OUTPUT_DIR)
+
+	# Generate json doc on the same output
+	$(RUSTDOC) src/lib.rs --crate-name foobar --crate-type lib --out-dir $(OUTPUT_DIR) -Z unstable-options --output-format json
+
+	# Check if expected json file is generated
+	[ -e $(OUTPUT_DIR)/foobar.json ]
+
+	# TODO
+	# We should re-generate json doc once again and compare the diff with previously
+	# generated one. Because layout of json docs changes in each compilation, we can't
+	# do that currently.
+	#
+	# See https://github.com/rust-lang/rust/issues/103785#issuecomment-1307425590 for details.
+
+	# remove generated json doc
+	rm $(OUTPUT_DIR)/foobar.json
+
+	# Check if json doc compilation broke any of the html files generated previously
+	$(DIFF) -r -q $(OUTPUT_DIR) $(TMP_OUTPUT_DIR)

--- a/src/test/run-make/rustdoc-verify-output-files/src/lib.rs
+++ b/src/test/run-make/rustdoc-verify-output-files/src/lib.rs
@@ -1,0 +1,1 @@
+// nothing to see here


### PR DESCRIPTION
This pr provides copying doc outputs by checking output format without removing output directory on each trigger.

Resolves #103785