### PR TITLE
Don't ICE with inline const errors during MIR build

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -577,6 +577,9 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                     self.errors.push(PatternError::ConstParamInPattern(span));
                     return PatKind::Wild;
                 }
+                ConstKind::Error(_) => {
+                    return PatKind::Wild;
+                }
                 _ => bug!("Expected ConstKind::Param"),
             },
             mir::ConstantKind::Val(_, _) => self.const_to_pat(value, id, span, false).kind,

--- a/src/test/ui/consts/invalid-inline-const-in-match-arm.rs
+++ b/src/test/ui/consts/invalid-inline-const-in-match-arm.rs
@@ -1,0 +1,9 @@
+#![allow(incomplete_features)]
+#![feature(inline_const_pat)]
+
+fn main() {
+    match () {
+        const { (|| {})() } => {}
+        //~^ ERROR cannot call non-const closure in constants
+    }
+}

--- a/src/test/ui/consts/invalid-inline-const-in-match-arm.stderr
+++ b/src/test/ui/consts/invalid-inline-const-in-match-arm.stderr
@@ -1,0 +1,12 @@
+error[E0015]: cannot call non-const closure in constants
+  --> $DIR/invalid-inline-const-in-match-arm.rs:6:17
+   |
+LL |         const { (|| {})() } => {}
+   |                 ^^^^^^^^^
+   |
+   = note: closures need an RFC before allowed to be called in constants
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0015`.


### PR DESCRIPTION
Fixes #104277