### PR TITLE
Check generics parity before collecting return-position `impl Trait`s in trait

### DIFF
--- a/src/test/ui/impl-trait/in-trait/trait-more-generics-than-impl.rs
+++ b/src/test/ui/impl-trait/in-trait/trait-more-generics-than-impl.rs
@@ -10,7 +10,6 @@ trait Foo {
 impl Foo for S {
     fn bar() -> impl Sized {}
     //~^ ERROR method `bar` has 0 type parameters but its trait declaration has 1 type parameter
-    //~| ERROR method `bar` has 0 type parameters but its trait declaration has 1 type parameter
 }
 
 fn main() {

--- a/src/test/ui/impl-trait/in-trait/trait-more-generics-than-impl.rs
+++ b/src/test/ui/impl-trait/in-trait/trait-more-generics-than-impl.rs
@@ -1,0 +1,18 @@
+#![feature(return_position_impl_trait_in_trait)]
+#![allow(incomplete_features)]
+
+struct S;
+
+trait Foo {
+    fn bar<T>() -> impl Sized;
+}
+
+impl Foo for S {
+    fn bar() -> impl Sized {}
+    //~^ ERROR method `bar` has 0 type parameters but its trait declaration has 1 type parameter
+    //~| ERROR method `bar` has 0 type parameters but its trait declaration has 1 type parameter
+}
+
+fn main() {
+    S::bar();
+}

--- a/src/test/ui/impl-trait/in-trait/trait-more-generics-than-impl.stderr
+++ b/src/test/ui/impl-trait/in-trait/trait-more-generics-than-impl.stderr
@@ -1,0 +1,21 @@
+error[E0049]: method `bar` has 0 type parameters but its trait declaration has 1 type parameter
+  --> $DIR/trait-more-generics-than-impl.rs:11:11
+   |
+LL |     fn bar<T>() -> impl Sized;
+   |            - expected 1 type parameter
+...
+LL |     fn bar() -> impl Sized {}
+   |           ^ found 0 type parameters
+
+error[E0049]: method `bar` has 0 type parameters but its trait declaration has 1 type parameter
+  --> $DIR/trait-more-generics-than-impl.rs:11:11
+   |
+LL |     fn bar<T>() -> impl Sized;
+   |            - expected 1 type parameter
+...
+LL |     fn bar() -> impl Sized {}
+   |           ^ found 0 type parameters
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0049`.

--- a/src/test/ui/impl-trait/in-trait/trait-more-generics-than-impl.stderr
+++ b/src/test/ui/impl-trait/in-trait/trait-more-generics-than-impl.stderr
@@ -7,15 +7,6 @@ LL |     fn bar<T>() -> impl Sized;
 LL |     fn bar() -> impl Sized {}
    |           ^ found 0 type parameters
 
-error[E0049]: method `bar` has 0 type parameters but its trait declaration has 1 type parameter
-  --> $DIR/trait-more-generics-than-impl.rs:11:11
-   |
-LL |     fn bar<T>() -> impl Sized;
-   |            - expected 1 type parameter
-...
-LL |     fn bar() -> impl Sized {}
-   |           ^ found 0 type parameters
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0049`.


### PR DESCRIPTION
The only thing is that this duplicates the error message for number of generics mismatch, but we already deduplicate that error message in Cargo. I could add a flag to delay the error if the reviewer cares.

Fixes #104281

Also drive-by adds a few comments to the `collect_trait_impl_trait_tys` method, and removes an unused argument from `compare_number_of_generics`.