### PR TITLE
UI tests can be assigned to T-compiler

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -573,6 +573,7 @@ fallback = [
 "/src/llvm-project" =                        ["@cuviper"]
 "/src/rustdoc-json-types" =                  ["rustdoc"]
 "/src/stage0.json" =                         ["bootstrap"]
+"/src/test/ui" =                             ["compiler"]
 "/src/tools/cargo" =                         ["@ehuss", "@joshtriplett"]
 "/src/tools/compiletest" =                   ["bootstrap"]
 "/src/tools/linkchecker" =                   ["@ehuss"]


### PR DESCRIPTION
It's my understanding that while not *all* `src/test/ui` tests are compiler-related, the bulk of them are, so I think it makes sense for this to go to the compiler triagebot category (T-compiler and T-compiler-contributors) instead of fallback, which consists of just @Mark-Simulacrum. Though if anyone diagrees, feel free to close this PR.