### PR TITLE
Enable profiler in dist-s390x-linux

### DIFF
--- a/src/ci/docker/host-x86_64/dist-s390x-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-s390x-linux/Dockerfile
@@ -28,5 +28,5 @@ ENV \
 
 ENV HOSTS=s390x-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --enable-lld --disable-docs
+ENV RUST_CONFIGURE_ARGS --enable-extended --enable-lld --enable-profiler --disable-docs
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS


### PR DESCRIPTION
Build the profiler runtime to allow using -C profile-generate and -C instrument-coverage on s390x-linux.

I've verified in a local build that the runtime builds and the profiler is working fine on the platform.