### PR TITLE
Remove the old `ValidAlign` name

### DIFF
--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -7,8 +7,8 @@
 use crate::cmp;
 use crate::error::Error;
 use crate::fmt;
-use crate::mem::{self, ValidAlign};
-use crate::ptr::NonNull;
+use crate::mem;
+use crate::ptr::{Alignment, NonNull};
 
 // While this function is used in one place and its implementation
 // could be inlined, the previous attempts to do so made rustc
@@ -46,7 +46,7 @@ pub struct Layout {
     //
     // (However, we do not analogously require `align >= sizeof(void*)`,
     //  even though that is *also* a requirement of `posix_memalign`.)
-    align: ValidAlign,
+    align: Alignment,
 }
 
 impl Layout {
@@ -71,11 +71,11 @@ impl Layout {
         }
 
         // SAFETY: just checked that align is a power of two.
-        Layout::from_size_valid_align(size, unsafe { ValidAlign::new_unchecked(align) })
+        Layout::from_size_alignment(size, unsafe { Alignment::new_unchecked(align) })
     }
 
     #[inline(always)]
-    const fn max_size_for_align(align: ValidAlign) -> usize {
+    const fn max_size_for_align(align: Alignment) -> usize {
         // (power-of-two implies align != 0.)
 
         // Rounded up size is:
@@ -95,7 +95,7 @@ impl Layout {
 
     /// Internal helper constructor to skip revalidating alignment validity.
     #[inline]
-    const fn from_size_valid_align(size: usize, align: ValidAlign) -> Result<Self, LayoutError> {
+    const fn from_size_alignment(size: usize, align: Alignment) -> Result<Self, LayoutError> {
         if size > Self::max_size_for_align(align) {
             return Err(LayoutError);
         }
@@ -117,7 +117,7 @@ impl Layout {
     #[rustc_allow_const_fn_unstable(ptr_alignment_type)]
     pub const unsafe fn from_size_align_unchecked(size: usize, align: usize) -> Self {
         // SAFETY: the caller is required to uphold the preconditions.
-        unsafe { Layout { size, align: ValidAlign::new_unchecked(align) } }
+        unsafe { Layout { size, align: Alignment::new_unchecked(align) } }
     }
 
     /// The minimum size in bytes for a memory block of this layout.
@@ -321,7 +321,7 @@ impl Layout {
         let alloc_size = padded_size.checked_mul(n).ok_or(LayoutError)?;
 
         // The safe constructor is called here to enforce the isize size limit.
-        Layout::from_size_valid_align(alloc_size, self.align).map(|layout| (layout, padded_size))
+        Layout::from_size_alignment(alloc_size, self.align).map(|layout| (layout, padded_size))
     }
 
     /// Creates a layout describing the record for `self` followed by
@@ -379,7 +379,7 @@ impl Layout {
         let new_size = offset.checked_add(next.size()).ok_or(LayoutError)?;
 
         // The safe constructor is called here to enforce the isize size limit.
-        let layout = Layout::from_size_valid_align(new_size, new_align)?;
+        let layout = Layout::from_size_alignment(new_size, new_align)?;
         Ok((layout, offset))
     }
 
@@ -400,7 +400,7 @@ impl Layout {
     pub fn repeat_packed(&self, n: usize) -> Result<Self, LayoutError> {
         let size = self.size().checked_mul(n).ok_or(LayoutError)?;
         // The safe constructor is called here to enforce the isize size limit.
-        Layout::from_size_valid_align(size, self.align)
+        Layout::from_size_alignment(size, self.align)
     }
 
     /// Creates a layout describing the record for `self` followed by
@@ -414,7 +414,7 @@ impl Layout {
     pub fn extend_packed(&self, next: Self) -> Result<Self, LayoutError> {
         let new_size = self.size().checked_add(next.size()).ok_or(LayoutError)?;
         // The safe constructor is called here to enforce the isize size limit.
-        Layout::from_size_valid_align(new_size, self.align)
+        Layout::from_size_alignment(new_size, self.align)
     }
 
     /// Creates a layout describing the record for a `[T; n]`.
@@ -425,10 +425,10 @@ impl Layout {
     #[inline]
     pub fn array<T>(n: usize) -> Result<Self, LayoutError> {
         // Reduce the amount of code we need to monomorphize per `T`.
-        return inner(mem::size_of::<T>(), ValidAlign::of::<T>(), n);
+        return inner(mem::size_of::<T>(), Alignment::of::<T>(), n);
 
         #[inline]
-        fn inner(element_size: usize, align: ValidAlign, n: usize) -> Result<Layout, LayoutError> {
+        fn inner(element_size: usize, align: Alignment, n: usize) -> Result<Layout, LayoutError> {
             // We need to check two things about the size:
             //  - That the total size won't overflow a `usize`, and
             //  - That the total size still fits in an `isize`.
@@ -443,7 +443,7 @@ impl Layout {
 
             // SAFETY: We just checked above that the `array_size` will not
             // exceed `isize::MAX` even when rounded up to the alignment.
-            // And `ValidAlign` guarantees it's a power of two.
+            // And `Alignment` guarantees it's a power of two.
             unsafe { Ok(Layout::from_size_align_unchecked(array_size, align.as_usize())) }
         }
     }

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -21,11 +21,6 @@ mod maybe_uninit;
 #[stable(feature = "maybe_uninit", since = "1.36.0")]
 pub use maybe_uninit::MaybeUninit;
 
-// FIXME: This is left here for now to avoid complications around pending reverts.
-// Once <https://github.com/rust-lang/rust/issues/101899> is fully resolved,
-// this should be removed and the references in `alloc::Layout` updated.
-pub(crate) use ptr::Alignment as ValidAlign;
-
 mod transmutability;
 #[unstable(feature = "transmutability", issue = "99571")]
 pub use transmutability::{Assume, BikeshedIntrinsicFrom};


### PR DESCRIPTION
Since it looks like there won't be any reverts needed in `Layout` for https://github.com/rust-lang/rust/issues/101899#issuecomment-1290805223, finish off this change that I'd left out of #102072.

r? @thomcc 
cc tracking issue #102070


