### PR TITLE
Improve spans with `use crate::{self}`

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -469,9 +469,11 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                         }
 
                         // Replace `use foo::{ self };` with `use foo;`
+                        let self_span = source.ident.span;
                         source = module_path.pop().unwrap();
                         if rename.is_none() {
-                            ident = source.ident;
+                            // Keep the span of `self`, but the name of `foo`
+                            ident = Ident { name: source.ident.name, span: self_span };
                         }
                     }
                 } else {

--- a/src/test/ui/use/use-crate-self.rs
+++ b/src/test/ui/use/use-crate-self.rs
@@ -1,0 +1,4 @@
+use crate::{self};
+        //~^ ERROR crate root imports need to be explicitly named: `use crate as name;`
+
+fn main() {}

--- a/src/test/ui/use/use-crate-self.stderr
+++ b/src/test/ui/use/use-crate-self.stderr
@@ -1,0 +1,8 @@
+error: crate root imports need to be explicitly named: `use crate as name;`
+  --> $DIR/use-crate-self.rs:1:13
+   |
+LL | use crate::{self};
+   |             ^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #104276.

The error becomes:
```
error: crate root imports need to be explicitly named: `use crate as name;`
 --> src/lib.rs.rs:1:13
  |
1 | use crate::{self};
  |             ^^^^

warning: unused import: `self`
 --> src/lib.rs:1:13
  |
1 | use crate::{self};
  |             ^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```