### PR TITLE
cleanup and dedupe CTFE and Miri error reporting

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -47,7 +47,7 @@ pub(crate) fn check_constants(fx: &mut FunctionCx<'_, '_, '_>) -> bool {
         if let Err(err) = fx.tcx.const_eval_resolve(ParamEnv::reveal_all(), unevaluated, None) {
             all_constants_ok = false;
             match err {
-                ErrorHandled::Reported(_) | ErrorHandled::Linted => {
+                ErrorHandled::Reported(_) => {
                     fx.tcx.sess.span_err(constant.span, "erroneous constant encountered");
                 }
                 ErrorHandled::TooGeneric => {

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -189,7 +189,7 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             all_consts_ok = false;
             match err {
                 // errored or at least linted
-                ErrorHandled::Reported(_) | ErrorHandled::Linted => {}
+                ErrorHandled::Reported(_) => {}
                 ErrorHandled::TooGeneric => {
                     span_bug!(const_.span, "codegen encountered polymorphic constant: {:?}", err)
                 }

--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -55,7 +55,7 @@ impl Error for ConstEvalErrKind {}
 /// When const-evaluation errors, this type is constructed with the resulting information,
 /// and then used to emit the error as a lint or hard error.
 #[derive(Debug)]
-pub struct ConstEvalErr<'tcx> {
+pub(super) struct ConstEvalErr<'tcx> {
     pub span: Span,
     pub error: InterpError<'tcx>,
     pub stacktrace: Vec<FrameInfo<'tcx>>,
@@ -82,8 +82,8 @@ impl<'tcx> ConstEvalErr<'tcx> {
         ConstEvalErr { error: error.into_kind(), stacktrace, span }
     }
 
-    pub fn report_as_error(&self, tcx: TyCtxtAt<'tcx>, message: &str) -> ErrorHandled {
-        self.struct_error(tcx, message, |_| {})
+    pub(super) fn report(&self, tcx: TyCtxtAt<'tcx>, message: &str) -> ErrorHandled {
+        self.report_decorated(tcx, message, |_| {})
     }
 
     /// Create a diagnostic for this const eval error.
@@ -95,7 +95,7 @@ impl<'tcx> ConstEvalErr<'tcx> {
     /// If `lint_root.is_some()` report it as a lint, else report it as a hard error.
     /// (Except that for some errors, we ignore all that -- see `must_error` below.)
     #[instrument(skip(self, tcx, decorate), level = "debug")]
-    pub fn struct_error(
+    pub(super) fn report_decorated(
         &self,
         tcx: TyCtxtAt<'tcx>,
         message: &str,

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -255,7 +255,7 @@ pub fn eval_to_const_value_raw_provider<'tcx>(
         return eval_nullary_intrinsic(tcx, key.param_env, def_id, substs).map_err(|error| {
             let span = tcx.def_span(def_id);
             let error = ConstEvalErr { error: error.into_kind(), stacktrace: vec![], span };
-            error.report_as_error(tcx.at(span), "could not evaluate nullary intrinsic")
+            error.report(tcx.at(span), "could not evaluate nullary intrinsic")
         });
     }
 
@@ -333,7 +333,7 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
                 }
             };
 
-            Err(err.report_as_error(ecx.tcx.at(err.span), &msg))
+            Err(err.report(ecx.tcx.at(err.span), &msg))
         }
         Ok(mplace) => {
             // Since evaluation had no errors, validate the resulting constant.
@@ -358,7 +358,7 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
             if let Err(error) = validation {
                 // Validation failed, report an error. This is always a hard error.
                 let err = ConstEvalErr::new(&ecx, error, None);
-                Err(err.struct_error(
+                Err(err.report_decorated(
                     ecx.tcx,
                     "it is undefined behavior to use this value",
                     |diag| {

--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -103,7 +103,7 @@ pub(crate) fn try_destructure_mir_constant<'tcx>(
 ) -> InterpResult<'tcx, mir::DestructuredConstant<'tcx>> {
     trace!("destructure_mir_constant: {:?}", val);
     let ecx = mk_eval_cx(tcx, DUMMY_SP, param_env, false);
-    let op = ecx.const_to_op(&val, None)?;
+    let op = ecx.eval_mir_constant(&val, None, None)?;
 
     // We go to `usize` as we cannot allocate anything bigger anyway.
     let (field_count, variant, down) = match val.ty().kind() {
@@ -139,7 +139,7 @@ pub(crate) fn deref_mir_constant<'tcx>(
     val: mir::ConstantKind<'tcx>,
 ) -> mir::ConstantKind<'tcx> {
     let ecx = mk_eval_cx(tcx, DUMMY_SP, param_env, false);
-    let op = ecx.const_to_op(&val, None).unwrap();
+    let op = ecx.eval_mir_constant(&val, None, None).unwrap();
     let mplace = ecx.deref_operand(&op).unwrap();
     if let Some(alloc_id) = mplace.ptr.provenance {
         assert_eq!(

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -177,8 +177,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     sym::type_name => self.tcx.mk_static_str(),
                     _ => bug!(),
                 };
-                let val =
-                    self.tcx.const_eval_global_id(self.param_env, gid, Some(self.tcx.span))?;
+                let val = self.ctfe_query(None, |tcx| {
+                    tcx.const_eval_global_id(self.param_env, gid, Some(tcx.span))
+                })?;
                 let val = self.const_val_to_op(val, ty, Some(dest.layout))?;
                 self.copy_op(&val, dest, /*allow_transmute*/ false)?;
             }

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -501,8 +501,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     throw_unsup!(ReadExternStatic(def_id));
                 }
 
-                // Use a precise span for better cycle errors.
-                (self.tcx.at(self.cur_span()).eval_static_initializer(def_id)?, Some(def_id))
+                // We don't give a span -- statics don't need that, they cannot be generic or associated.
+                let val = self.ctfe_query(None, |tcx| tcx.eval_static_initializer(def_id))?;
+                (val, Some(def_id))
             }
         };
         M::before_access_global(*self.tcx, &self.machine, id, alloc, def_id, is_write)?;

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -4,8 +4,9 @@
 use rustc_hir::def::Namespace;
 use rustc_middle::ty::layout::{LayoutOf, PrimitiveExt, TyAndLayout};
 use rustc_middle::ty::print::{FmtPrinter, PrettyPrinter};
-use rustc_middle::ty::{ConstInt, Ty};
+use rustc_middle::ty::{ConstInt, Ty, ValTree};
 use rustc_middle::{mir, ty};
+use rustc_span::Span;
 use rustc_target::abi::{self, Abi, Align, HasDataLayout, Size, TagEncoding};
 use rustc_target::abi::{VariantIdx, Variants};
 
@@ -527,14 +528,14 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Copy(place) | Move(place) => self.eval_place_to_op(place, layout)?,
 
             Constant(ref constant) => {
-                let val =
+                let c =
                     self.subst_from_current_frame_and_normalize_erasing_regions(constant.literal)?;
 
                 // This can still fail:
                 // * During ConstProp, with `TooGeneric` or since the `required_consts` were not all
                 //   checked yet.
                 // * During CTFE, since promoteds in `const`/`static` initializer bodies can fail.
-                self.const_to_op(&val, layout)?
+                self.eval_mir_constant(&c, Some(constant.span), layout)?
             }
         };
         trace!("{:?}: {:?}", mir_op, *op);
@@ -549,9 +550,35 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         ops.iter().map(|op| self.eval_operand(op, None)).collect()
     }
 
-    pub fn const_to_op(
+    fn eval_ty_constant(
+        &self,
+        val: ty::Const<'tcx>,
+        span: Option<Span>,
+    ) -> InterpResult<'tcx, ValTree<'tcx>> {
+        Ok(match val.kind() {
+            ty::ConstKind::Param(_) | ty::ConstKind::Placeholder(..) => {
+                throw_inval!(TooGeneric)
+            }
+            ty::ConstKind::Error(reported) => {
+                throw_inval!(AlreadyReported(reported))
+            }
+            ty::ConstKind::Unevaluated(uv) => {
+                let instance = self.resolve(uv.def, uv.substs)?;
+                let cid = GlobalId { instance, promoted: None };
+                self.ctfe_query(span, |tcx| tcx.eval_to_valtree(self.param_env.and(cid)))?
+                    .unwrap_or_else(|| bug!("unable to create ValTree for {uv:?}"))
+            }
+            ty::ConstKind::Bound(..) | ty::ConstKind::Infer(..) => {
+                span_bug!(self.cur_span(), "unexpected ConstKind in ctfe: {val:?}")
+            }
+            ty::ConstKind::Value(valtree) => valtree,
+        })
+    }
+
+    pub fn eval_mir_constant(
         &self,
         val: &mir::ConstantKind<'tcx>,
+        span: Option<Span>,
         layout: Option<TyAndLayout<'tcx>>,
     ) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
         // FIXME(const_prop): normalization needed b/c const prop lint in
@@ -563,44 +590,20 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let val = self.tcx.normalize_erasing_regions(self.param_env, *val);
         match val {
             mir::ConstantKind::Ty(ct) => {
-                match ct.kind() {
-                    ty::ConstKind::Param(_) | ty::ConstKind::Placeholder(..) => {
-                        throw_inval!(TooGeneric)
-                    }
-                    ty::ConstKind::Error(reported) => {
-                        throw_inval!(AlreadyReported(reported))
-                    }
-                    ty::ConstKind::Unevaluated(uv) => {
-                        // NOTE: We evaluate to a `ValTree` here as a check to ensure
-                        // we're working with valid constants, even though we never need it.
-                        let instance = self.resolve(uv.def, uv.substs)?;
-                        let cid = GlobalId { instance, promoted: None };
-                        let _valtree = self
-                            .tcx
-                            .eval_to_valtree(self.param_env.and(cid))?
-                            .unwrap_or_else(|| bug!("unable to create ValTree for {uv:?}"));
-
-                        Ok(self.eval_to_allocation(cid)?.into())
-                    }
-                    ty::ConstKind::Bound(..) | ty::ConstKind::Infer(..) => {
-                        span_bug!(self.cur_span(), "unexpected ConstKind in ctfe: {ct:?}")
-                    }
-                    ty::ConstKind::Value(valtree) => {
-                        let ty = ct.ty();
-                        let const_val = self.tcx.valtree_to_const_val((ty, valtree));
-                        self.const_val_to_op(const_val, ty, layout)
-                    }
-                }
+                let ty = ct.ty();
+                let valtree = self.eval_ty_constant(ct, span)?;
+                let const_val = self.tcx.valtree_to_const_val((ty, valtree));
+                self.const_val_to_op(const_val, ty, layout)
             }
             mir::ConstantKind::Val(val, ty) => self.const_val_to_op(val, ty, layout),
             mir::ConstantKind::Unevaluated(uv, _) => {
                 let instance = self.resolve(uv.def, uv.substs)?;
-                Ok(self.eval_to_allocation(GlobalId { instance, promoted: uv.promoted })?.into())
+                Ok(self.eval_global(GlobalId { instance, promoted: uv.promoted }, span)?.into())
             }
         }
     }
 
-    pub(crate) fn const_val_to_op(
+    pub(super) fn const_val_to_op(
         &self,
         val_val: ConstValue<'tcx>,
         ty: Ty<'tcx>,

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -16,8 +16,6 @@ pub enum ErrorHandled {
     /// Already reported an error for this evaluation, and the compilation is
     /// *guaranteed* to fail. Warnings/lints *must not* produce `Reported`.
     Reported(ErrorGuaranteed),
-    /// Already emitted a lint for this evaluation.
-    Linted,
     /// Don't emit an error, the evaluation failed because the MIR was generic
     /// and the substs didn't fully monomorphize it.
     TooGeneric,
@@ -89,18 +87,6 @@ fn print_backtrace(backtrace: &Backtrace) {
     eprintln!("\n\nAn error occurred in miri:\n{}", backtrace);
 }
 
-impl From<ErrorHandled> for InterpErrorInfo<'_> {
-    fn from(err: ErrorHandled) -> Self {
-        match err {
-            ErrorHandled::Reported(ErrorGuaranteed { .. }) | ErrorHandled::Linted => {
-                err_inval!(ReferencedConstant)
-            }
-            ErrorHandled::TooGeneric => err_inval!(TooGeneric),
-        }
-        .into()
-    }
-}
-
 impl From<ErrorGuaranteed> for InterpErrorInfo<'_> {
     fn from(err: ErrorGuaranteed) -> Self {
         InterpError::InvalidProgram(InvalidProgramInfo::AlreadyReported(err)).into()
@@ -138,9 +124,6 @@ impl<'tcx> From<InterpError<'tcx>> for InterpErrorInfo<'tcx> {
 pub enum InvalidProgramInfo<'tcx> {
     /// Resolution can fail if we are in a too generic context.
     TooGeneric,
-    /// Cannot compute this constant because it depends on another one
-    /// which already produced an error.
-    ReferencedConstant,
     /// Abort in case errors are already reported.
     AlreadyReported(ErrorGuaranteed),
     /// An error occurred during layout computation.
@@ -158,9 +141,11 @@ impl fmt::Display for InvalidProgramInfo<'_> {
         use InvalidProgramInfo::*;
         match self {
             TooGeneric => write!(f, "encountered overly generic constant"),
-            ReferencedConstant => write!(f, "referenced constant has errors"),
             AlreadyReported(ErrorGuaranteed { .. }) => {
-                write!(f, "encountered constants with type errors, stopping evaluation")
+                write!(
+                    f,
+                    "an error has already been reported elsewhere (this sould not usually be printed)"
+                )
             }
             Layout(ref err) => write!(f, "{err}"),
             FnAbiAdjustForForeignAbi(ref err) => write!(f, "{err}"),

--- a/compiler/rustc_middle/src/mir/interpret/queries.rs
+++ b/compiler/rustc_middle/src/mir/interpret/queries.rs
@@ -175,6 +175,8 @@ impl<'tcx> TyCtxt<'tcx> {
 
 impl<'tcx> TyCtxtAt<'tcx> {
     /// Evaluate a static's initializer, returning the allocation of the initializer's memory.
+    ///
+    /// The span is entirely ignored here, but still helpful for better query cycle errors.
     pub fn eval_static_initializer(
         self,
         def_id: DefId,
@@ -187,6 +189,8 @@ impl<'tcx> TyCtxtAt<'tcx> {
     }
 
     /// Evaluate anything constant-like, returning the allocation of the final memory.
+    ///
+    /// The span is entirely ignored here, but still helpful for better query cycle errors.
     fn eval_to_allocation(
         self,
         gid: GlobalId<'tcx>,

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2304,7 +2304,7 @@ impl<'tcx> ConstantKind<'tcx> {
                 // FIXME: We might want to have a `try_eval`-like function on `Unevaluated`
                 match tcx.const_eval_resolve(param_env, uneval, None) {
                     Ok(val) => Self::Val(val, ty),
-                    Err(ErrorHandled::TooGeneric | ErrorHandled::Linted) => self,
+                    Err(ErrorHandled::TooGeneric) => self,
                     Err(ErrorHandled::Reported(guar)) => {
                         Self::Ty(tcx.const_error_with_guaranteed(ty, guar))
                     }

--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -463,9 +463,7 @@ impl<'tcx> AdtDef<'tcx> {
             }
             Err(err) => {
                 let msg = match err {
-                    ErrorHandled::Reported(_) | ErrorHandled::Linted => {
-                        "enum discriminant evaluation failed"
-                    }
+                    ErrorHandled::Reported(_) => "enum discriminant evaluation failed",
                     ErrorHandled::TooGeneric => "enum discriminant depends on generics",
                 };
                 tcx.sess.delay_span_bug(tcx.def_span(expr_did), msg);

--- a/compiler/rustc_middle/src/ty/consts/kind.rs
+++ b/compiler/rustc_middle/src/ty/consts/kind.rs
@@ -226,7 +226,7 @@ impl<'tcx> ConstKind<'tcx> {
                         // (which may be identity substs, see above),
                         // can leak through `val` into the const we return.
                         Ok(val) => Some(Ok(EvalResult::ValTree(val?))),
-                        Err(ErrorHandled::TooGeneric | ErrorHandled::Linted) => None,
+                        Err(ErrorHandled::TooGeneric) => None,
                         Err(ErrorHandled::Reported(e)) => Some(Err(e)),
                     }
                 }
@@ -237,7 +237,7 @@ impl<'tcx> ConstKind<'tcx> {
                         // (which may be identity substs, see above),
                         // can leak through `val` into the const we return.
                         Ok(val) => Some(Ok(EvalResult::ConstVal(val))),
-                        Err(ErrorHandled::TooGeneric | ErrorHandled::Linted) => None,
+                        Err(ErrorHandled::TooGeneric) => None,
                         Err(ErrorHandled::Reported(e)) => Some(Err(e)),
                     }
                 }

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -471,7 +471,8 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             return None;
         }
 
-        self.ecx.const_to_op(&c.literal, None).ok()
+        // No span, we don't want errors to be shown.
+        self.ecx.eval_mir_constant(&c.literal, None, None).ok()
     }
 
     /// Returns the value, if any, of evaluating `place`.

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -773,7 +773,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
                     match self.tcx.const_eval_resolve(param_env, ct.expand(), None) {
                         // The `monomorphize` call should have evaluated that constant already.
                         Ok(val) => val,
-                        Err(ErrorHandled::Reported(_) | ErrorHandled::Linted) => return,
+                        Err(ErrorHandled::Reported(_)) => return,
                         Err(ErrorHandled::TooGeneric) => span_bug!(
                             self.body.source_info(location).span,
                             "collection encountered polymorphic constant: {:?}",
@@ -788,7 +788,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
                 match self.tcx.const_eval_resolve(param_env, uv, None) {
                     // The `monomorphize` call should have evaluated that constant already.
                     Ok(val) => val,
-                    Err(ErrorHandled::Reported(_) | ErrorHandled::Linted) => return,
+                    Err(ErrorHandled::Reported(_)) => return,
                     Err(ErrorHandled::TooGeneric) => span_bug!(
                         self.body.source_info(location).span,
                         "collection encountered polymorphic constant: {:?}",

--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -198,13 +198,6 @@ pub fn is_const_evaluatable<'tcx>(
                     .sess
                     .delay_span_bug(span, "Missing value for constant, but no error reported?"),
             )),
-            Err(ErrorHandled::Linted) => {
-                let reported = infcx
-                    .tcx
-                    .sess
-                    .delay_span_bug(span, "constant in type had error reported as lint");
-                Err(NotConstEvaluatable::Error(reported))
-            }
             Err(ErrorHandled::Reported(e)) => Err(NotConstEvaluatable::Error(e)),
             Ok(_) => Ok(()),
         }
@@ -254,11 +247,6 @@ pub fn is_const_evaluatable<'tcx>(
 
                 Err(err)
             },
-            Err(ErrorHandled::Linted) => {
-                let reported =
-                    infcx.tcx.sess.delay_span_bug(span, "constant in type had error reported as lint");
-                Err(NotConstEvaluatable::Error(reported))
-            }
             Err(ErrorHandled::Reported(e)) => Err(NotConstEvaluatable::Error(e)),
             Ok(_) => Ok(()),
         }

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -558,12 +558,6 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                                 NotConstEvaluatable::Error(reported),
                             )),
                         ),
-                        (Err(ErrorHandled::Linted), _) | (_, Err(ErrorHandled::Linted)) => {
-                            span_bug!(
-                                obligation.cause.span(),
-                                "ConstEquate: const_eval_resolve returned an unexpected error"
-                            )
-                        }
                         (Err(ErrorHandled::TooGeneric), _) | (_, Err(ErrorHandled::TooGeneric)) => {
                             if c1.has_non_region_infer() || c2.has_non_region_infer() {
                                 ProcessResult::Unchanged

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -727,12 +727,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         }
                         (Err(ErrorHandled::Reported(_)), _)
                         | (_, Err(ErrorHandled::Reported(_))) => Ok(EvaluatedToErr),
-                        (Err(ErrorHandled::Linted), _) | (_, Err(ErrorHandled::Linted)) => {
-                            span_bug!(
-                                obligation.cause.span(),
-                                "ConstEquate: const_eval_resolve returned an unexpected error"
-                            )
-                        }
                         (Err(ErrorHandled::TooGeneric), _) | (_, Err(ErrorHandled::TooGeneric)) => {
                             if c1.has_non_region_infer() || c2.has_non_region_infer() {
                                 Ok(EvaluatedToAmbig)

--- a/src/test/ui/associated-consts/defaults-cyclic-fail.stderr
+++ b/src/test/ui/associated-consts/defaults-cyclic-fail.stderr
@@ -1,14 +1,14 @@
 error[E0391]: cycle detected when const-evaluating + checking `Tr::A`
-  --> $DIR/defaults-cyclic-fail.rs:5:5
+  --> $DIR/defaults-cyclic-fail.rs:5:19
    |
 LL |     const A: u8 = Self::B;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^
    |
 note: ...which requires const-evaluating + checking `Tr::B`...
-  --> $DIR/defaults-cyclic-fail.rs:8:5
+  --> $DIR/defaults-cyclic-fail.rs:8:19
    |
 LL |     const B: u8 = Self::A;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^
    = note: ...which again requires const-evaluating + checking `Tr::A`, completing the cycle
 note: cycle used when const-evaluating + checking `main::promoted[1]`
   --> $DIR/defaults-cyclic-fail.rs:16:16

--- a/src/test/ui/associated-consts/defaults-not-assumed-fail.rs
+++ b/src/test/ui/associated-consts/defaults-not-assumed-fail.rs
@@ -31,8 +31,7 @@ impl Tr for u32 {
 fn main() {
     assert_eq!(<() as Tr>::A, 255);
     assert_eq!(<() as Tr>::B, 0);    // causes the error above
-    //~^ ERROR evaluation of constant value failed
-    //~| ERROR erroneous constant used
+    //~^ constant
 
     assert_eq!(<u8 as Tr>::A, 254);
     assert_eq!(<u8 as Tr>::B, 255);

--- a/src/test/ui/associated-consts/defaults-not-assumed-fail.stderr
+++ b/src/test/ui/associated-consts/defaults-not-assumed-fail.stderr
@@ -4,20 +4,36 @@ error[E0080]: evaluation of `<() as Tr>::B` failed
 LL |     const B: u8 = Self::A + 1;
    |                   ^^^^^^^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/defaults-not-assumed-fail.rs:33:16
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
-   |                ^^^^^^^^^^^^^ referenced constant has errors
+   |                ^^^^^^^^^^^^^
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/defaults-not-assumed-fail.rs:33:5
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+note: erroneous constant used
+  --> $DIR/defaults-not-assumed-fail.rs:33:5
+   |
+LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant used
+  --> $DIR/defaults-not-assumed-fail.rs:33:5
+   |
+LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
@@ -10,10 +10,10 @@ note: ...which requires const-evaluating + checking `IMPL_REF_BAR`...
 LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `IMPL_REF_BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:27
    |
 LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                           ^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
    |

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
@@ -10,10 +10,10 @@ note: ...which requires const-evaluating + checking `DEFAULT_REF_BAR`...
 LL | const DEFAULT_REF_BAR: u32 = <GlobalDefaultRef>::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `DEFAULT_REF_BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:11:1
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:11:30
    |
 LL | const DEFAULT_REF_BAR: u32 = <GlobalDefaultRef>::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `FooDefault::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
    |

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
@@ -10,10 +10,10 @@ note: ...which requires const-evaluating + checking `TRAIT_REF_BAR`...
 LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `TRAIT_REF_BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:28
    |
 LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
    |

--- a/src/test/ui/borrowck/issue-81899.rs
+++ b/src/test/ui/borrowck/issue-81899.rs
@@ -2,13 +2,14 @@
 // The `panic!()` below is important to trigger the fixed ICE.
 
 const _CONST: &[u8] = &f(&[], |_| {});
-//~^ ERROR constant
+//~^ constant
 
 const fn f<F>(_: &[u8], _: F) -> &[u8]
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR: evaluation of constant value failed
+    panic!() //~ ERROR evaluation of constant value failed
+    //~^ panic
 }
 
 fn main() {}

--- a/src/test/ui/borrowck/issue-81899.stderr
+++ b/src/test/ui/borrowck/issue-81899.stderr
@@ -12,12 +12,12 @@ LL |     panic!()
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/issue-81899.rs:4:23
    |
 LL | const _CONST: &[u8] = &f(&[], |_| {});
-   |                       ^^^^^^^^^^^^^^^ referenced constant has errors
+   |                       ^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/borrowck/issue-88434-minimal-example.rs
+++ b/src/test/ui/borrowck/issue-88434-minimal-example.rs
@@ -1,13 +1,14 @@
 // Regression test related to issue 88434
 
 const _CONST: &() = &f(&|_| {});
-//~^ ERROR constant
+//~^ constant
 
 const fn f<F>(_: &F)
 where
     F: FnMut(&u8),
 {
     panic!() //~ ERROR evaluation of constant value failed
+    //~^ panic
 }
 
 fn main() { }

--- a/src/test/ui/borrowck/issue-88434-minimal-example.stderr
+++ b/src/test/ui/borrowck/issue-88434-minimal-example.stderr
@@ -12,12 +12,12 @@ LL |     panic!()
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/issue-88434-minimal-example.rs:3:21
    |
 LL | const _CONST: &() = &f(&|_| {});
-   |                     ^^^^^^^^^^^ referenced constant has errors
+   |                     ^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/borrowck/issue-88434-removal-index-should-be-less.rs
+++ b/src/test/ui/borrowck/issue-88434-removal-index-should-be-less.rs
@@ -1,13 +1,14 @@
 // Regression test for issue 88434
 
 const _CONST: &[u8] = &f(&[], |_| {});
-//~^ ERROR constant
+//~^ constant
 
 const fn f<F>(_: &[u8], _: F) -> &[u8]
 where
     F: FnMut(&u8),
 {
     panic!() //~ ERROR evaluation of constant value failed
+    //~^ panic
 }
 
 fn main() { }

--- a/src/test/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
+++ b/src/test/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
@@ -12,12 +12,12 @@ LL |     panic!()
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/issue-88434-removal-index-should-be-less.rs:3:23
    |
 LL | const _CONST: &[u8] = &f(&[], |_| {});
-   |                       ^^^^^^^^^^^^^^^ referenced constant has errors
+   |                       ^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-err-late.rs
+++ b/src/test/ui/consts/const-err-late.rs
@@ -16,7 +16,5 @@ impl<T> S<T> {
 }
 
 fn main() {
-    black_box((S::<i32>::FOO, S::<u32>::FOO));
-    //~^ ERROR erroneous constant
-    //~| ERROR erroneous constant
+    black_box((S::<i32>::FOO, S::<u32>::FOO)); //~ constant
 }

--- a/src/test/ui/consts/const-err-late.stderr
+++ b/src/test/ui/consts/const-err-late.stderr
@@ -4,11 +4,17 @@ error[E0080]: evaluation of `S::<i32>::FOO` failed
 LL |     const FOO: u8 = [5u8][1];
    |                     ^^^^^^^^ index out of bounds: the length is 1 but the index is 1
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/const-err-late.rs:19:16
    |
 LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
-   |                ^^^^^^^^^^^^^ referenced constant has errors
+   |                ^^^^^^^^^^^^^
+
+note: erroneous constant used
+  --> $DIR/const-err-late.rs:19:16
+   |
+LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
+   |                ^^^^^^^^^^^^^
 
 error[E0080]: evaluation of `S::<u32>::FOO` failed
   --> $DIR/const-err-late.rs:13:21
@@ -16,12 +22,30 @@ error[E0080]: evaluation of `S::<u32>::FOO` failed
 LL |     const FOO: u8 = [5u8][1];
    |                     ^^^^^^^^ index out of bounds: the length is 1 but the index is 1
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/const-err-late.rs:19:31
    |
 LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
-   |                               ^^^^^^^^^^^^^ referenced constant has errors
+   |                               ^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+note: erroneous constant used
+  --> $DIR/const-err-late.rs:19:31
+   |
+LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
+   |                               ^^^^^^^^^^^^^
+
+note: erroneous constant used
+  --> $DIR/const-err-late.rs:19:16
+   |
+LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
+   |                ^^^^^^^^^^^^^
+
+note: erroneous constant used
+  --> $DIR/const-err-late.rs:19:31
+   |
+LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
+   |                               ^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-err-multi.rs
+++ b/src/test/ui/consts/const-err-multi.rs
@@ -1,11 +1,11 @@
 pub const A: i8 = -i8::MIN;
 //~^ ERROR constant
 pub const B: i8 = A;
-//~^ ERROR constant
+//~^ constant
 pub const C: u8 = A as u8;
-//~^ ERROR constant
+//~^ constant
 pub const D: i8 = 50 - A;
-//~^ ERROR constant
+//~^ constant
 
 fn main() {
     let _ = (A, B, C, D);

--- a/src/test/ui/consts/const-err-multi.stderr
+++ b/src/test/ui/consts/const-err-multi.stderr
@@ -4,24 +4,24 @@ error[E0080]: evaluation of constant value failed
 LL | pub const A: i8 = -i8::MIN;
    |                   ^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-err-multi.rs:3:19
    |
 LL | pub const B: i8 = A;
-   |                   ^ referenced constant has errors
+   |                   ^
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-err-multi.rs:5:19
    |
 LL | pub const C: u8 = A as u8;
-   |                   ^ referenced constant has errors
+   |                   ^
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-err-multi.rs:7:24
    |
 LL | pub const D: i8 = 50 - A;
-   |                        ^ referenced constant has errors
+   |                        ^
 
-error: aborting due to 4 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/erroneous-const.rs
+++ b/src/test/ui/consts/const-eval/erroneous-const.rs
@@ -10,7 +10,7 @@ const fn no_codegen<T>() {
     if false {
         // This bad constant is only used in dead code in a no-codegen function... and yet we still
         // must make sure that the build fails.
-        let _ = PrintName::<T>::VOID; //~ERROR could not evaluate static initializer
+        let _ = PrintName::<T>::VOID; //~ constant
     }
 }
 

--- a/src/test/ui/consts/const-eval/erroneous-const.stderr
+++ b/src/test/ui/consts/const-eval/erroneous-const.stderr
@@ -4,18 +4,12 @@ error[E0080]: evaluation of `PrintName::<i32>::VOID` failed
 LL |     const VOID: () = [()][2];
    |                      ^^^^^^^ index out of bounds: the length is 1 but the index is 2
 
-error[E0080]: could not evaluate static initializer
+note: erroneous constant used
   --> $DIR/erroneous-const.rs:13:17
    |
 LL |         let _ = PrintName::<T>::VOID;
    |                 ^^^^^^^^^^^^^^^^^^^^
-   |                 |
-   |                 referenced constant has errors
-   |                 inside `no_codegen::<i32>` at $DIR/erroneous-const.rs:13:17
-...
-LL | pub static FOO: () = no_codegen::<i32>();
-   |                      ------------------- inside `FOO` at $DIR/erroneous-const.rs:17:22
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/erroneous-const2.rs
+++ b/src/test/ui/consts/const-eval/erroneous-const2.rs
@@ -10,7 +10,7 @@ pub static FOO: () = {
     if false {
         // This bad constant is only used in dead code in a static initializer... and yet we still
         // must make sure that the build fails.
-        let _ = PrintName::<i32>::VOID; //~ERROR could not evaluate static initializer
+        let _ = PrintName::<i32>::VOID; //~ constant
     }
 };
 

--- a/src/test/ui/consts/const-eval/erroneous-const2.stderr
+++ b/src/test/ui/consts/const-eval/erroneous-const2.stderr
@@ -4,12 +4,12 @@ error[E0080]: evaluation of `PrintName::<i32>::VOID` failed
 LL |     const VOID: () = [()][2];
    |                      ^^^^^^^ index out of bounds: the length is 1 but the index is 2
 
-error[E0080]: could not evaluate static initializer
+note: erroneous constant used
   --> $DIR/erroneous-const2.rs:13:17
    |
 LL |         let _ = PrintName::<i32>::VOID;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                 ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/format.rs
+++ b/src/test/ui/consts/const-eval/format.rs
@@ -1,8 +1,6 @@
 const fn failure() {
     panic!("{:?}", 0);
     //~^ ERROR cannot call non-const formatting macro in constant functions
-    //~| ERROR erroneous constant used
-    //~| ERROR erroneous constant used
 }
 
 const fn print() {
@@ -10,8 +8,6 @@ const fn print() {
     //~^ ERROR cannot call non-const formatting macro in constant functions
     //~| ERROR `Arguments::<'a>::new_v1` is not yet stable as a const fn
     //~| ERROR cannot call non-const fn `_print` in constant functions
-    //~| ERROR erroneous constant used
-    //~| ERROR erroneous constant used
 }
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/format.stderr
+++ b/src/test/ui/consts/const-eval/format.stderr
@@ -8,7 +8,7 @@ LL |     panic!("{:?}", 0);
    = note: this error originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const formatting macro in constant functions
-  --> $DIR/format.rs:9:22
+  --> $DIR/format.rs:7:22
    |
 LL |     println!("{:?}", 0);
    |                      ^
@@ -17,7 +17,7 @@ LL |     println!("{:?}", 0);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `Arguments::<'a>::new_v1` is not yet stable as a const fn
-  --> $DIR/format.rs:9:5
+  --> $DIR/format.rs:7:5
    |
 LL |     println!("{:?}", 0);
    |     ^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |     println!("{:?}", 0);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const fn `_print` in constant functions
-  --> $DIR/format.rs:9:5
+  --> $DIR/format.rs:7:5
    |
 LL |     println!("{:?}", 0);
    |     ^^^^^^^^^^^^^^^^^^^
@@ -34,35 +34,62 @@ LL |     println!("{:?}", 0);
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/format.rs:2:12
    |
 LL |     panic!("{:?}", 0);
-   |            ^^^^^^ referenced constant has errors
+   |            ^^^^^^
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
+  --> $DIR/format.rs:2:12
+   |
+LL |     panic!("{:?}", 0);
+   |            ^^^^^^
+
+note: erroneous constant used
   --> $DIR/format.rs:2:20
    |
 LL |     panic!("{:?}", 0);
-   |                    ^ referenced constant has errors
+   |                    ^
    |
-   = note: this error originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this note originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: erroneous constant used
-  --> $DIR/format.rs:9:14
+note: erroneous constant used
+  --> $DIR/format.rs:2:20
+   |
+LL |     panic!("{:?}", 0);
+   |                    ^
+   |
+   = note: this note originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant used
+  --> $DIR/format.rs:7:14
    |
 LL |     println!("{:?}", 0);
-   |              ^^^^^^ referenced constant has errors
+   |              ^^^^^^
 
-error[E0080]: erroneous constant used
-  --> $DIR/format.rs:9:22
+note: erroneous constant used
+  --> $DIR/format.rs:7:14
    |
 LL |     println!("{:?}", 0);
-   |                      ^ referenced constant has errors
+   |              ^^^^^^
+
+note: erroneous constant used
+  --> $DIR/format.rs:7:22
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+LL |     println!("{:?}", 0);
+   |                      ^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 8 previous errors
+note: erroneous constant used
+  --> $DIR/format.rs:7:22
+   |
+LL |     println!("{:?}", 0);
+   |                      ^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-Some errors have detailed explanations: E0015, E0080.
-For more information about an error, try `rustc --explain E0015`.
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/consts/const-eval/issue-44578.rs
+++ b/src/test/ui/consts/const-eval/issue-44578.rs
@@ -23,6 +23,5 @@ impl Foo for u16 {
 
 fn main() {
     println!("{}", <Bar<u16, u8> as Foo>::AMT);
-    //~^ ERROR evaluation of constant value failed
-    //~| ERROR erroneous constant used
+    //~^ constant
 }

--- a/src/test/ui/consts/const-eval/issue-44578.stderr
+++ b/src/test/ui/consts/const-eval/issue-44578.stderr
@@ -4,20 +4,36 @@ error[E0080]: evaluation of `<Bar<u16, u8> as Foo>::AMT` failed
 LL |     const AMT: usize = [A::AMT][(A::AMT > B::AMT) as usize];
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the length is 1 but the index is 1
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/issue-44578.rs:25:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/issue-44578.rs:25:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+note: erroneous constant used
+  --> $DIR/issue-44578.rs:25:20
+   |
+LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant used
+  --> $DIR/issue-44578.rs:25:20
+   |
+LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/issue-50814-2.rs
+++ b/src/test/ui/consts/const-eval/issue-50814-2.rs
@@ -15,7 +15,7 @@ impl<T: C> Foo<T> for A<T> {
 }
 
 fn foo<T: C>() -> &'static usize {
-    &<A<T> as Foo<T>>::BAR //~ ERROR E0080
+    &<A<T> as Foo<T>>::BAR //~ constant
 }
 
 impl C for () {

--- a/src/test/ui/consts/const-eval/issue-50814-2.stderr
+++ b/src/test/ui/consts/const-eval/issue-50814-2.stderr
@@ -4,11 +4,11 @@ error[E0080]: evaluation of `<A<()> as Foo<()>>::BAR` failed
 LL |     const BAR: usize = [5, 6, 7][T::BOO];
    |                        ^^^^^^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 42
 
-error[E0080]: evaluation of `foo::<()>` failed
+note: erroneous constant used
   --> $DIR/issue-50814-2.rs:18:6
    |
 LL |     &<A<T> as Foo<T>>::BAR
-   |      ^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |      ^^^^^^^^^^^^^^^^^^^^^
 
 note: the above error was encountered while instantiating `fn foo::<()>`
   --> $DIR/issue-50814-2.rs:30:22
@@ -16,6 +16,6 @@ note: the above error was encountered while instantiating `fn foo::<()>`
 LL |     println!("{:x}", foo::<()>() as *const usize as usize);
    |                      ^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/issue-50814.rs
+++ b/src/test/ui/consts/const-eval/issue-50814.rs
@@ -18,7 +18,7 @@ impl<A: Unsigned, B: Unsigned> Unsigned for Sum<A, B> {
 
 fn foo<T>(_: T) -> &'static u8 {
     &Sum::<U8, U8>::MAX
-    //~^ ERROR evaluation of `foo::<i32>` failed [E0080]
+    //~^ constant
 }
 
 fn main() {

--- a/src/test/ui/consts/const-eval/issue-50814.stderr
+++ b/src/test/ui/consts/const-eval/issue-50814.stderr
@@ -4,11 +4,11 @@ error[E0080]: evaluation of `<Sum<U8, U8> as Unsigned>::MAX` failed
 LL |     const MAX: u8 = A::MAX + B::MAX;
    |                     ^^^^^^^^^^^^^^^ attempt to compute `u8::MAX + u8::MAX`, which would overflow
 
-error[E0080]: evaluation of `foo::<i32>` failed
+note: erroneous constant used
   --> $DIR/issue-50814.rs:20:6
    |
 LL |     &Sum::<U8, U8>::MAX
-   |      ^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |      ^^^^^^^^^^^^^^^^^^
 
 note: the above error was encountered while instantiating `fn foo::<i32>`
   --> $DIR/issue-50814.rs:25:5
@@ -16,6 +16,6 @@ note: the above error was encountered while instantiating `fn foo::<i32>`
 LL |     foo(0);
    |     ^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.rs
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.rs
@@ -11,6 +11,5 @@ impl PrintName {
 }
 
 fn main() {
-    let _ = PrintName::VOID;
-    //~^ ERROR erroneous constant used [E0080]
+    let _ = PrintName::VOID; //~ constant
 }

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -6,12 +6,18 @@ LL |     const VOID: ! = panic!();
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/panic-assoc-never-type.rs:14:13
    |
 LL |     let _ = PrintName::VOID;
-   |             ^^^^^^^^^^^^^^^ referenced constant has errors
+   |             ^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+note: erroneous constant used
+  --> $DIR/panic-assoc-never-type.rs:14:13
+   |
+LL |     let _ = PrintName::VOID;
+   |             ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.32bit.stderr
@@ -60,14 +60,14 @@ LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/ub-ref-ptr.rs:34:38
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:38:86
+  --> $DIR/ub-ref-ptr.rs:37:86
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
    |                                                                                      ^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into raw bytes
@@ -75,14 +75,14 @@ LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[us
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:38:85
+note: erroneous constant used
+  --> $DIR/ub-ref-ptr.rs:37:85
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
-   |                                                                                     ^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                                                                                     ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:42:1
+  --> $DIR/ub-ref-ptr.rs:40:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (address 0x539 is unallocated)
@@ -93,7 +93,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:45:1
+  --> $DIR/ub-ref-ptr.rs:43:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (address 0x539 is unallocated)
@@ -104,13 +104,13 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:48:41
+  --> $DIR/ub-ref-ptr.rs:46:41
    |
 LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:52:1
+  --> $DIR/ub-ref-ptr.rs:50:1
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered null pointer, but expected a function pointer
@@ -121,13 +121,13 @@ LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:54:38
+  --> $DIR/ub-ref-ptr.rs:52:38
    |
 LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:57:1
+  --> $DIR/ub-ref-ptr.rs:55:1
    |
 LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0xd[noalloc], but expected a function pointer
@@ -138,7 +138,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:59:1
+  --> $DIR/ub-ref-ptr.rs:57:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered alloc41, but expected a function pointer
@@ -148,6 +148,6 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
                ╾─alloc41─╼                                     │ ╾──╼
            }
 
-error: aborting due to 16 previous errors
+error: aborting due to 14 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.64bit.stderr
@@ -60,14 +60,14 @@ LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/ub-ref-ptr.rs:34:38
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:38:86
+  --> $DIR/ub-ref-ptr.rs:37:86
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
    |                                                                                      ^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into raw bytes
@@ -75,14 +75,14 @@ LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[us
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:38:85
+note: erroneous constant used
+  --> $DIR/ub-ref-ptr.rs:37:85
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
-   |                                                                                     ^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                                                                                     ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:42:1
+  --> $DIR/ub-ref-ptr.rs:40:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (address 0x539 is unallocated)
@@ -93,7 +93,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:45:1
+  --> $DIR/ub-ref-ptr.rs:43:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (address 0x539 is unallocated)
@@ -104,13 +104,13 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:48:41
+  --> $DIR/ub-ref-ptr.rs:46:41
    |
 LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:52:1
+  --> $DIR/ub-ref-ptr.rs:50:1
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered null pointer, but expected a function pointer
@@ -121,13 +121,13 @@ LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:54:38
+  --> $DIR/ub-ref-ptr.rs:52:38
    |
 LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:57:1
+  --> $DIR/ub-ref-ptr.rs:55:1
    |
 LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0xd[noalloc], but expected a function pointer
@@ -138,7 +138,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:59:1
+  --> $DIR/ub-ref-ptr.rs:57:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered alloc41, but expected a function pointer
@@ -148,6 +148,6 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
                ╾───────alloc41───────╼                         │ ╾──────╼
            }
 
-error: aborting due to 16 previous errors
+error: aborting due to 14 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.rs
@@ -33,11 +33,9 @@ const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
 
 const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
 //~^ ERROR evaluation of constant value failed
-//~| ERROR evaluation of constant value failed
 
 const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
 //~^ ERROR evaluation of constant value failed
-//~| ERROR evaluation of constant value failed
 
 const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
 //~^ ERROR it is undefined behavior to use this value

--- a/src/test/ui/consts/const-eval/ub-wide-ptr.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-wide-ptr.32bit.stderr
@@ -139,11 +139,11 @@ LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
                ╾─allocN─╼                                     │ ╾──╼
            }
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/ub-wide-ptr.rs:83:40
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:90:1
@@ -156,11 +156,11 @@ LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3
                ╾allocN─╼                                     │ ╾──╼
            }
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/ub-wide-ptr.rs:90:42
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:94:1
@@ -173,11 +173,11 @@ LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::tran
                ╾allocN─╼                                     │ ╾──╼
            }
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/ub-wide-ptr.rs:94:42
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/ub-wide-ptr.rs:102:1
@@ -292,6 +292,6 @@ error[E0080]: could not evaluate static initializer
 LL |     mem::transmute::<_, &dyn Trait>((&92u8, &3u64))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using allocN as vtable pointer but it does not point to a vtable
 
-error: aborting due to 32 previous errors
+error: aborting due to 29 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/ub-wide-ptr.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-wide-ptr.64bit.stderr
@@ -139,11 +139,11 @@ LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
                ╾───────allocN───────╼                         │ ╾──────╼
            }
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/ub-wide-ptr.rs:83:40
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:90:1
@@ -156,11 +156,11 @@ LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3
                ╾──────allocN───────╼                         │ ╾──────╼
            }
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/ub-wide-ptr.rs:90:42
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:94:1
@@ -173,11 +173,11 @@ LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::tran
                ╾──────allocN───────╼                         │ ╾──────╼
            }
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/ub-wide-ptr.rs:94:42
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/ub-wide-ptr.rs:102:1
@@ -292,6 +292,6 @@ error[E0080]: could not evaluate static initializer
 LL |     mem::transmute::<_, &dyn Trait>((&92u8, &3u64))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using allocN as vtable pointer but it does not point to a vtable
 
-error: aborting due to 32 previous errors
+error: aborting due to 29 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/ub-wide-ptr.rs
+++ b/src/test/ui/consts/const-eval/ub-wide-ptr.rs
@@ -82,18 +82,18 @@ const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)) };
 // bad data *inside* the slice
 const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
 //~^ ERROR it is undefined behavior to use this value
-//~| ERROR evaluation of constant value failed
+//~| constant
 
 // good MySliceBool
 const MYSLICE_GOOD: &MySliceBool = &MySlice(true, [false]);
 // bad: sized field is not okay
 const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
 //~^ ERROR it is undefined behavior to use this value
-//~| ERROR evaluation of constant value failed
+//~| constant
 // bad: unsized part is not okay
 const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
 //~^ ERROR it is undefined behavior to use this value
-//~| ERROR evaluation of constant value failed
+//~| constant
 
 // # raw slice
 const RAW_SLICE_VALID: *const [u8] = unsafe { mem::transmute((&42u8, 1usize)) }; // ok

--- a/src/test/ui/consts/const-eval/union-const-eval-field.rs
+++ b/src/test/ui/consts/const-eval/union-const-eval-field.rs
@@ -29,7 +29,6 @@ const fn read_field3() -> Field3 {
     //~^ ERROR evaluation of constant value failed
     //~| uninitialized
     FIELD3
-    //~^ ERROR erroneous constant used [E0080]
 }
 
 fn main() {

--- a/src/test/ui/consts/const-eval/union-const-eval-field.stderr
+++ b/src/test/ui/consts/const-eval/union-const-eval-field.stderr
@@ -4,12 +4,18 @@ error[E0080]: evaluation of constant value failed
 LL |     const FIELD3: Field3 = unsafe { UNION.field3 };
    |                                     ^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/union-const-eval-field.rs:31:5
    |
 LL |     FIELD3
-   |     ^^^^^^ referenced constant has errors
+   |     ^^^^^^
 
-error: aborting due to 2 previous errors
+note: erroneous constant used
+  --> $DIR/union-const-eval-field.rs:31:5
+   |
+LL |     FIELD3
+   |     ^^^^^^
+
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-float-bits-reject-conv.rs
+++ b/src/test/ui/consts/const-float-bits-reject-conv.rs
@@ -1,4 +1,5 @@
 // compile-flags: -Zmir-opt-level=0
+// error-pattern: cannot use f32::to_bits on a NaN
 #![feature(const_float_bits_conv)]
 #![feature(const_float_classify)]
 
@@ -25,22 +26,21 @@ fn f32() {
     // 0xA is 0b1010; 0x5 is 0b0101 -- so these two together clobbers all the mantissa bits
     // ...actually, let's just check that these break. :D
     const MASKED_NAN1: u32 = f32::NAN.to_bits() ^ 0x002A_AAAA;
+    //~^ inside
     const MASKED_NAN2: u32 = f32::NAN.to_bits() ^ 0x0055_5555;
+    //~^ inside
+
+    // The rest of the code is dead because the constants already fail to evaluate.
 
     const_assert!(f32::from_bits(MASKED_NAN1).is_nan());
-    //~^ ERROR evaluation of constant value failed
     const_assert!(f32::from_bits(MASKED_NAN1).is_nan());
-    //~^ ERROR evaluation of constant value failed
 
     // LLVM does not guarantee that loads and stores of NaNs preserve their exact bit pattern.
     // In practice, this seems to only cause a problem on x86, since the most widely used calling
     // convention mandates that floating point values are returned on the x87 FPU stack. See #73328.
-    if !cfg!(target_arch = "x86") {
-        const_assert!(f32::from_bits(MASKED_NAN1).to_bits(), MASKED_NAN1);
-        //~^ ERROR evaluation of constant value failed
-        const_assert!(f32::from_bits(MASKED_NAN2).to_bits(), MASKED_NAN2);
-        //~^ ERROR evaluation of constant value failed
-    }
+    // However, during CTFE we still preserve bit patterns (though that is not a guarantee).
+    const_assert!(f32::from_bits(MASKED_NAN1).to_bits(), MASKED_NAN1);
+    const_assert!(f32::from_bits(MASKED_NAN2).to_bits(), MASKED_NAN2);
 }
 
 fn f64() {
@@ -48,20 +48,18 @@ fn f64() {
     // 0xA is 0b1010; 0x5 is 0b0101 -- so these two together clobbers all the mantissa bits
     // ...actually, let's just check that these break. :D
     const MASKED_NAN1: u64 = f64::NAN.to_bits() ^ 0x000A_AAAA_AAAA_AAAA;
+    //~^ inside
     const MASKED_NAN2: u64 = f64::NAN.to_bits() ^ 0x0005_5555_5555_5555;
+    //~^ inside
+
+    // The rest of the code is dead because the constants already fail to evaluate.
 
     const_assert!(f64::from_bits(MASKED_NAN1).is_nan());
-    //~^ ERROR evaluation of constant value failed
     const_assert!(f64::from_bits(MASKED_NAN1).is_nan());
-    //~^ ERROR evaluation of constant value failed
 
     // See comment above.
-    if !cfg!(target_arch = "x86") {
-        const_assert!(f64::from_bits(MASKED_NAN1).to_bits(), MASKED_NAN1);
-        //~^ ERROR evaluation of constant value failed
-        const_assert!(f64::from_bits(MASKED_NAN2).to_bits(), MASKED_NAN2);
-        //~^ ERROR evaluation of constant value failed
-    }
+    const_assert!(f64::from_bits(MASKED_NAN1).to_bits(), MASKED_NAN1);
+    const_assert!(f64::from_bits(MASKED_NAN2).to_bits(), MASKED_NAN2);
 }
 
 fn main() {

--- a/src/test/ui/consts/const-float-bits-reject-conv.stderr
+++ b/src/test/ui/consts/const-float-bits-reject-conv.stderr
@@ -10,10 +10,10 @@ LL |                     panic!("const-eval error: cannot use f32::to_bits on a 
 LL |         unsafe { intrinsics::const_eval_select((self,), ct_f32_to_u32, rt_f32_to_u32) }
    |                  -------------------------------------------------------------------- inside `core::f32::<impl f32>::to_bits` at $SRC_DIR/core/src/num/f32.rs:LL:COL
    |
-  ::: $DIR/const-float-bits-reject-conv.rs:27:30
+  ::: $DIR/const-float-bits-reject-conv.rs:28:30
    |
 LL |     const MASKED_NAN1: u32 = f32::NAN.to_bits() ^ 0x002A_AAAA;
-   |                              ------------------ inside `f32::MASKED_NAN1` at $DIR/const-float-bits-reject-conv.rs:27:30
+   |                              ------------------ inside `f32::MASKED_NAN1` at $DIR/const-float-bits-reject-conv.rs:28:30
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -29,36 +29,36 @@ LL |                     panic!("const-eval error: cannot use f32::to_bits on a 
 LL |         unsafe { intrinsics::const_eval_select((self,), ct_f32_to_u32, rt_f32_to_u32) }
    |                  -------------------------------------------------------------------- inside `core::f32::<impl f32>::to_bits` at $SRC_DIR/core/src/num/f32.rs:LL:COL
    |
-  ::: $DIR/const-float-bits-reject-conv.rs:28:30
+  ::: $DIR/const-float-bits-reject-conv.rs:30:30
    |
 LL |     const MASKED_NAN2: u32 = f32::NAN.to_bits() ^ 0x0055_5555;
-   |                              ------------------ inside `f32::MASKED_NAN2` at $DIR/const-float-bits-reject-conv.rs:28:30
+   |                              ------------------ inside `f32::MASKED_NAN2` at $DIR/const-float-bits-reject-conv.rs:30:30
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-float-bits-reject-conv.rs:30:34
+note: erroneous constant used
+  --> $DIR/const-float-bits-reject-conv.rs:35:34
    |
 LL |     const_assert!(f32::from_bits(MASKED_NAN1).is_nan());
-   |                                  ^^^^^^^^^^^ referenced constant has errors
+   |                                  ^^^^^^^^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-float-bits-reject-conv.rs:32:34
+note: erroneous constant used
+  --> $DIR/const-float-bits-reject-conv.rs:36:34
    |
 LL |     const_assert!(f32::from_bits(MASKED_NAN1).is_nan());
-   |                                  ^^^^^^^^^^^ referenced constant has errors
+   |                                  ^^^^^^^^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-float-bits-reject-conv.rs:39:38
+note: erroneous constant used
+  --> $DIR/const-float-bits-reject-conv.rs:42:34
    |
-LL |         const_assert!(f32::from_bits(MASKED_NAN1).to_bits(), MASKED_NAN1);
-   |                                      ^^^^^^^^^^^ referenced constant has errors
+LL |     const_assert!(f32::from_bits(MASKED_NAN1).to_bits(), MASKED_NAN1);
+   |                                  ^^^^^^^^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-float-bits-reject-conv.rs:41:38
+note: erroneous constant used
+  --> $DIR/const-float-bits-reject-conv.rs:43:34
    |
-LL |         const_assert!(f32::from_bits(MASKED_NAN2).to_bits(), MASKED_NAN2);
-   |                                      ^^^^^^^^^^^ referenced constant has errors
+LL |     const_assert!(f32::from_bits(MASKED_NAN2).to_bits(), MASKED_NAN2);
+   |                                  ^^^^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/num/f64.rs:LL:COL
@@ -91,37 +91,37 @@ LL |                     panic!("const-eval error: cannot use f64::to_bits on a 
 LL |         unsafe { intrinsics::const_eval_select((self,), ct_f64_to_u64, rt_f64_to_u64) }
    |                  -------------------------------------------------------------------- inside `core::f64::<impl f64>::to_bits` at $SRC_DIR/core/src/num/f64.rs:LL:COL
    |
-  ::: $DIR/const-float-bits-reject-conv.rs:51:30
+  ::: $DIR/const-float-bits-reject-conv.rs:52:30
    |
 LL |     const MASKED_NAN2: u64 = f64::NAN.to_bits() ^ 0x0005_5555_5555_5555;
-   |                              ------------------ inside `f64::MASKED_NAN2` at $DIR/const-float-bits-reject-conv.rs:51:30
+   |                              ------------------ inside `f64::MASKED_NAN2` at $DIR/const-float-bits-reject-conv.rs:52:30
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-float-bits-reject-conv.rs:53:34
+note: erroneous constant used
+  --> $DIR/const-float-bits-reject-conv.rs:57:34
    |
 LL |     const_assert!(f64::from_bits(MASKED_NAN1).is_nan());
-   |                                  ^^^^^^^^^^^ referenced constant has errors
+   |                                  ^^^^^^^^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-float-bits-reject-conv.rs:55:34
+note: erroneous constant used
+  --> $DIR/const-float-bits-reject-conv.rs:58:34
    |
 LL |     const_assert!(f64::from_bits(MASKED_NAN1).is_nan());
-   |                                  ^^^^^^^^^^^ referenced constant has errors
+   |                                  ^^^^^^^^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-float-bits-reject-conv.rs:60:38
+note: erroneous constant used
+  --> $DIR/const-float-bits-reject-conv.rs:61:34
    |
-LL |         const_assert!(f64::from_bits(MASKED_NAN1).to_bits(), MASKED_NAN1);
-   |                                      ^^^^^^^^^^^ referenced constant has errors
+LL |     const_assert!(f64::from_bits(MASKED_NAN1).to_bits(), MASKED_NAN1);
+   |                                  ^^^^^^^^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-float-bits-reject-conv.rs:62:38
+note: erroneous constant used
+  --> $DIR/const-float-bits-reject-conv.rs:62:34
    |
-LL |         const_assert!(f64::from_bits(MASKED_NAN2).to_bits(), MASKED_NAN2);
-   |                                      ^^^^^^^^^^^ referenced constant has errors
+LL |     const_assert!(f64::from_bits(MASKED_NAN2).to_bits(), MASKED_NAN2);
+   |                                  ^^^^^^^^^^^
 
-error: aborting due to 12 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-integer-bool-ops.rs
+++ b/src/test/ui/consts/const-integer-bool-ops.rs
@@ -6,7 +6,7 @@ const X: usize = 42 && 39;
 //~| ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARR: [i32; X] = [99; 34];
-//~^ ERROR evaluation of constant value failed
+//~^ constant
 
 const X1: usize = 42 || 39;
 //~^ ERROR mismatched types
@@ -16,7 +16,7 @@ const X1: usize = 42 || 39;
 //~| ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARR1: [i32; X1] = [99; 47];
-//~^ ERROR evaluation of constant value failed
+//~^ constant
 
 const X2: usize = -42 || -39;
 //~^ ERROR mismatched types
@@ -26,7 +26,7 @@ const X2: usize = -42 || -39;
 //~| ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARR2: [i32; X2] = [99; 18446744073709551607];
-//~^ ERROR evaluation of constant value failed
+//~^ constant
 
 const X3: usize = -42 && -39;
 //~^ ERROR mismatched types
@@ -36,43 +36,43 @@ const X3: usize = -42 && -39;
 //~| ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARR3: [i32; X3] = [99; 6];
-//~^ ERROR evaluation of constant value failed
+//~^ constant
 
 const Y: usize = 42.0 == 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR: [i32; Y] = [99; 1];
-//~^ ERROR evaluation of constant value failed
+//~^ constant
 
 const Y1: usize = 42.0 >= 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR1: [i32; Y1] = [99; 1];
-//~^ ERROR evaluation of constant value failed
+//~^ constant
 
 const Y2: usize = 42.0 <= 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR2: [i32; Y2] = [99; 1];
-//~^ ERROR evaluation of constant value failed
+//~^ constant
 
 const Y3: usize = 42.0 > 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR3: [i32; Y3] = [99; 0];
-//~^ ERROR evaluation of constant value failed
+//~^ constant
 
 const Y4: usize = 42.0 < 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR4: [i32; Y4] = [99; 0];
-//~^ ERROR evaluation of constant value failed
+//~^ constant
 
 const Y5: usize = 42.0 != 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR5: [i32; Y5] = [99; 0];
-//~^ ERROR evaluation of constant value failed
+//~^ constant
 
 fn main() {
     let _ = ARR;

--- a/src/test/ui/consts/const-integer-bool-ops.stderr
+++ b/src/test/ui/consts/const-integer-bool-ops.stderr
@@ -16,11 +16,11 @@ error[E0308]: mismatched types
 LL | const X: usize = 42 && 39;
    |                  ^^^^^^^^ expected `usize`, found `bool`
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-integer-bool-ops.rs:8:18
    |
 LL | const ARR: [i32; X] = [99; 34];
-   |                  ^ referenced constant has errors
+   |                  ^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:11:19
@@ -40,11 +40,11 @@ error[E0308]: mismatched types
 LL | const X1: usize = 42 || 39;
    |                   ^^^^^^^^ expected `usize`, found `bool`
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-integer-bool-ops.rs:18:19
    |
 LL | const ARR1: [i32; X1] = [99; 47];
-   |                   ^^ referenced constant has errors
+   |                   ^^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:21:19
@@ -64,11 +64,11 @@ error[E0308]: mismatched types
 LL | const X2: usize = -42 || -39;
    |                   ^^^^^^^^^^ expected `usize`, found `bool`
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-integer-bool-ops.rs:28:19
    |
 LL | const ARR2: [i32; X2] = [99; 18446744073709551607];
-   |                   ^^ referenced constant has errors
+   |                   ^^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:31:19
@@ -88,11 +88,11 @@ error[E0308]: mismatched types
 LL | const X3: usize = -42 && -39;
    |                   ^^^^^^^^^^ expected `usize`, found `bool`
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-integer-bool-ops.rs:38:19
    |
 LL | const ARR3: [i32; X3] = [99; 6];
-   |                   ^^ referenced constant has errors
+   |                   ^^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:41:18
@@ -100,11 +100,11 @@ error[E0308]: mismatched types
 LL | const Y: usize = 42.0 == 42.0;
    |                  ^^^^^^^^^^^^ expected `usize`, found `bool`
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-integer-bool-ops.rs:44:19
    |
 LL | const ARRR: [i32; Y] = [99; 1];
-   |                   ^ referenced constant has errors
+   |                   ^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:47:19
@@ -112,11 +112,11 @@ error[E0308]: mismatched types
 LL | const Y1: usize = 42.0 >= 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-integer-bool-ops.rs:50:20
    |
 LL | const ARRR1: [i32; Y1] = [99; 1];
-   |                    ^^ referenced constant has errors
+   |                    ^^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:53:19
@@ -124,11 +124,11 @@ error[E0308]: mismatched types
 LL | const Y2: usize = 42.0 <= 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-integer-bool-ops.rs:56:20
    |
 LL | const ARRR2: [i32; Y2] = [99; 1];
-   |                    ^^ referenced constant has errors
+   |                    ^^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:59:19
@@ -136,11 +136,11 @@ error[E0308]: mismatched types
 LL | const Y3: usize = 42.0 > 42.0;
    |                   ^^^^^^^^^^^ expected `usize`, found `bool`
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-integer-bool-ops.rs:62:20
    |
 LL | const ARRR3: [i32; Y3] = [99; 0];
-   |                    ^^ referenced constant has errors
+   |                    ^^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:65:19
@@ -148,11 +148,11 @@ error[E0308]: mismatched types
 LL | const Y4: usize = 42.0 < 42.0;
    |                   ^^^^^^^^^^^ expected `usize`, found `bool`
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-integer-bool-ops.rs:68:20
    |
 LL | const ARRR4: [i32; Y4] = [99; 0];
-   |                    ^^ referenced constant has errors
+   |                    ^^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:71:19
@@ -160,13 +160,12 @@ error[E0308]: mismatched types
 LL | const Y5: usize = 42.0 != 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-integer-bool-ops.rs:74:20
    |
 LL | const ARRR5: [i32; Y5] = [99; 0];
-   |                    ^^ referenced constant has errors
+   |                    ^^
 
-error: aborting due to 28 previous errors
+error: aborting due to 18 previous errors
 
-Some errors have detailed explanations: E0080, E0308.
-For more information about an error, try `rustc --explain E0080`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/consts/const-len-underflow-separate-spans.rs
+++ b/src/test/ui/consts/const-len-underflow-separate-spans.rs
@@ -9,5 +9,5 @@ const LEN: usize = ONE - TWO;
 
 fn main() {
     let a: [i8; LEN] = unimplemented!();
-//~^ ERROR E0080
+//~^ constant
 }

--- a/src/test/ui/consts/const-len-underflow-separate-spans.stderr
+++ b/src/test/ui/consts/const-len-underflow-separate-spans.stderr
@@ -4,12 +4,12 @@ error[E0080]: evaluation of constant value failed
 LL | const LEN: usize = ONE - TWO;
    |                    ^^^^^^^^^ attempt to compute `1_usize - 2_usize`, which would overflow
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-len-underflow-separate-spans.rs:11:17
    |
 LL |     let a: [i8; LEN] = unimplemented!();
-   |                 ^^^ referenced constant has errors
+   |                 ^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-mut-refs/issue-76510.32bit.stderr
+++ b/src/test/ui/consts/const-mut-refs/issue-76510.32bit.stderr
@@ -19,13 +19,13 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
 LL | const S: &'static mut str = &mut " hello ";
    |                             ^^^^^^^^^^^^^^ cannot borrow as mutable
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/issue-76510.rs:11:70
    |
 LL |         let s = transmute::<(*const u8, usize), &ManuallyDrop<str>>((S.as_ptr(), 3));
-   |                                                                      ^ referenced constant has errors
+   |                                                                      ^
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0080, E0596, E0658, E0764.
-For more information about an error, try `rustc --explain E0080`.
+Some errors have detailed explanations: E0596, E0658, E0764.
+For more information about an error, try `rustc --explain E0596`.

--- a/src/test/ui/consts/const-mut-refs/issue-76510.64bit.stderr
+++ b/src/test/ui/consts/const-mut-refs/issue-76510.64bit.stderr
@@ -19,13 +19,13 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
 LL | const S: &'static mut str = &mut " hello ";
    |                             ^^^^^^^^^^^^^^ cannot borrow as mutable
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/issue-76510.rs:11:70
    |
 LL |         let s = transmute::<(*const u8, usize), &ManuallyDrop<str>>((S.as_ptr(), 3));
-   |                                                                      ^ referenced constant has errors
+   |                                                                      ^
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0080, E0596, E0658, E0764.
-For more information about an error, try `rustc --explain E0080`.
+Some errors have detailed explanations: E0596, E0658, E0764.
+For more information about an error, try `rustc --explain E0596`.

--- a/src/test/ui/consts/const-mut-refs/issue-76510.rs
+++ b/src/test/ui/consts/const-mut-refs/issue-76510.rs
@@ -9,7 +9,7 @@ const S: &'static mut str = &mut " hello ";
 
 const fn trigger() -> [(); unsafe {
         let s = transmute::<(*const u8, usize), &ManuallyDrop<str>>((S.as_ptr(), 3));
-        //~^ ERROR evaluation of constant value failed
+        //~^ constant
         0
     }] {
     [(); 0]

--- a/src/test/ui/consts/const-tup-index-span.rs
+++ b/src/test/ui/consts/const-tup-index-span.rs
@@ -4,7 +4,7 @@ const TUP: (usize,) = 5usize << 64;
 //~^ ERROR mismatched types
 //~| expected tuple, found `usize`
 const ARR: [i32; TUP.0] = [];
-//~^ ERROR evaluation of constant value failed
+//~^ constant
 
 fn main() {
 }

--- a/src/test/ui/consts/const-tup-index-span.stderr
+++ b/src/test/ui/consts/const-tup-index-span.stderr
@@ -11,13 +11,12 @@ help: use a trailing comma to create a tuple with one element
 LL | const TUP: (usize,) = (5usize << 64,);
    |                       +            ++
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/const-tup-index-span.rs:6:18
    |
 LL | const ARR: [i32; TUP.0] = [];
-   |                  ^^^ referenced constant has errors
+   |                  ^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0080, E0308.
-For more information about an error, try `rustc --explain E0080`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/consts/extra-const-ub/detect-extra-ub.rs
+++ b/src/test/ui/consts/extra-const-ub/detect-extra-ub.rs
@@ -29,7 +29,7 @@ const UNALIGNED_PTR: () = unsafe {
 };
 
 const UNALIGNED_READ: () = {
-    INNER; //[with_flag]~ERROR evaluation of constant value failed
+    INNER; //[with_flag]~ constant
     // There is an error here but its span is in the standard library so we cannot match it...
     // so we have this in a *nested* const, such that the *outer* const fails to use it.
     const INNER: () = unsafe {

--- a/src/test/ui/consts/extra-const-ub/detect-extra-ub.with_flag.stderr
+++ b/src/test/ui/consts/extra-const-ub/detect-extra-ub.with_flag.stderr
@@ -47,12 +47,12 @@ LL |         unsafe { read(self) }
 LL |         ptr.read();
    |         ---------- inside `INNER` at $DIR/detect-extra-ub.rs:38:9
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/detect-extra-ub.rs:32:5
    |
 LL |     INNER;
-   |     ^^^^^ referenced constant has errors
+   |     ^^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/invalid-union.32bit.stderr
+++ b/src/test/ui/consts/invalid-union.32bit.stderr
@@ -9,12 +9,24 @@ LL | fn main() {
                ╾─alloc7──╼                                     │ ╾──╼
            }
 
-error[E0080]: erroneous constant used
-  --> $DIR/invalid-union.rs:42:25
+note: erroneous constant used
+  --> $DIR/invalid-union.rs:43:25
    |
 LL |     let _: &'static _ = &C;
-   |                         ^^ referenced constant has errors
+   |                         ^^
 
-error: aborting due to 2 previous errors
+note: erroneous constant used
+  --> $DIR/invalid-union.rs:43:25
+   |
+LL |     let _: &'static _ = &C;
+   |                         ^^
+
+note: erroneous constant used
+  --> $DIR/invalid-union.rs:43:25
+   |
+LL |     let _: &'static _ = &C;
+   |                         ^^
+
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/invalid-union.64bit.stderr
+++ b/src/test/ui/consts/invalid-union.64bit.stderr
@@ -9,12 +9,24 @@ LL | fn main() {
                ╾───────alloc7────────╼                         │ ╾──────╼
            }
 
-error[E0080]: erroneous constant used
-  --> $DIR/invalid-union.rs:42:25
+note: erroneous constant used
+  --> $DIR/invalid-union.rs:43:25
    |
 LL |     let _: &'static _ = &C;
-   |                         ^^ referenced constant has errors
+   |                         ^^
 
-error: aborting due to 2 previous errors
+note: erroneous constant used
+  --> $DIR/invalid-union.rs:43:25
+   |
+LL |     let _: &'static _ = &C;
+   |                         ^^
+
+note: erroneous constant used
+  --> $DIR/invalid-union.rs:43:25
+   |
+LL |     let _: &'static _ = &C;
+   |                         ^^
+
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/invalid-union.rs
+++ b/src/test/ui/consts/invalid-union.rs
@@ -39,5 +39,6 @@ const C: S = {
 };
 
 fn main() { //~ ERROR it is undefined behavior to use this value
-    let _: &'static _ = &C; //~ ERROR erroneous constant used
+    // FIXME the span here is wrong, sould be pointing at the line below, not above.
+    let _: &'static _ = &C;
 }

--- a/src/test/ui/consts/issue-36163.stderr
+++ b/src/test/ui/consts/issue-36163.stderr
@@ -5,10 +5,10 @@ LL |     B = A,
    |         ^
    |
 note: ...which requires const-evaluating + checking `A`...
-  --> $DIR/issue-36163.rs:1:1
+  --> $DIR/issue-36163.rs:1:18
    |
 LL | const A: isize = Foo::B as isize;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^^^^
    = note: ...which again requires const-evaluating + checking `Foo::B::{constant#0}`, completing the cycle
 note: cycle used when simplifying constant for the type system `Foo::B::{constant#0}`
   --> $DIR/issue-36163.rs:4:9

--- a/src/test/ui/consts/issue-54954.rs
+++ b/src/test/ui/consts/issue-54954.rs
@@ -9,8 +9,8 @@ trait Tt {
 }
 
 fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
-  //~^ ERROR evaluation of constant value failed
-  //~| ERROR evaluation of constant value failed
+  //~^ constant
+  //~| constant
     z
 }
 

--- a/src/test/ui/consts/issue-54954.stderr
+++ b/src/test/ui/consts/issue-54954.stderr
@@ -16,19 +16,19 @@ LL | |         core::mem::size_of::<T>()
 LL | |     }
    | |_____- `Tt::const_val` defined here
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/issue-54954.rs:11:15
    |
 LL | fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
-   |               ^^^^^^^ referenced constant has errors
+   |               ^^^^^^^
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/issue-54954.rs:11:34
    |
 LL | fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
-   |                                  ^^^^^^^ referenced constant has errors
+   |                                  ^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0080, E0379, E0790.
-For more information about an error, try `rustc --explain E0080`.
+Some errors have detailed explanations: E0379, E0790.
+For more information about an error, try `rustc --explain E0379`.

--- a/src/test/ui/consts/issue-56164.rs
+++ b/src/test/ui/consts/issue-56164.rs
@@ -1,6 +1,5 @@
 const fn foo() { (||{})() }
 //~^ ERROR cannot call non-const closure
-//~| ERROR erroneous constant used
 
 const fn bad(input: fn()) {
     input()

--- a/src/test/ui/consts/issue-56164.stderr
+++ b/src/test/ui/consts/issue-56164.stderr
@@ -8,18 +8,23 @@ LL | const fn foo() { (||{})() }
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: function pointer calls are not allowed in constant functions
-  --> $DIR/issue-56164.rs:6:5
+  --> $DIR/issue-56164.rs:5:5
    |
 LL |     input()
    |     ^^^^^^^
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/issue-56164.rs:1:18
    |
 LL | const fn foo() { (||{})() }
-   |                  ^^^^^^ referenced constant has errors
+   |                  ^^^^^^
 
-error: aborting due to 3 previous errors
+note: erroneous constant used
+  --> $DIR/issue-56164.rs:1:18
+   |
+LL | const fn foo() { (||{})() }
+   |                  ^^^^^^
 
-Some errors have detailed explanations: E0015, E0080.
-For more information about an error, try `rustc --explain E0015`.
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/consts/issue-66693.rs
+++ b/src/test/ui/consts/issue-66693.rs
@@ -10,7 +10,6 @@ static _FOO: () = panic!(true);
 const fn _foo() {
     panic!(&1);
     //~^ ERROR: argument to `panic!()` in a const context must have type `&str`
-    //~| ERROR: erroneous constant used
 }
 
 // ensure that conforming panics don't cause an error

--- a/src/test/ui/consts/issue-66693.stderr
+++ b/src/test/ui/consts/issue-66693.stderr
@@ -22,12 +22,17 @@ LL |     panic!(&1);
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/issue-66693.rs:11:12
    |
 LL |     panic!(&1);
-   |            ^^ referenced constant has errors
+   |            ^^
 
-error: aborting due to 4 previous errors
+note: erroneous constant used
+  --> $DIR/issue-66693.rs:11:12
+   |
+LL |     panic!(&1);
+   |            ^^
 
-For more information about this error, try `rustc --explain E0080`.
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/consts/miri_unleashed/assoc_const.rs
+++ b/src/test/ui/consts/miri_unleashed/assoc_const.rs
@@ -26,5 +26,5 @@ fn main() {
     // this is fine, but would have been forbidden by the static checks on `F`
     let x = <() as Bar<u32, ()>>::F;
     // this test only causes errors due to the line below, so post-monomorphization
-    let y = <String as Bar<Vec<u32>, String>>::F; //~ ERROR erroneous constant
+    let y = <String as Bar<Vec<u32>, String>>::F; //~ constant
 }

--- a/src/test/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/assoc_const.stderr
@@ -13,11 +13,23 @@ LL | pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
 LL |     const F: u32 = (U::X, 42).1;
    |                               - inside `<String as Bar<Vec<u32>, String>>::F` at $DIR/assoc_const.rs:12:31
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/assoc_const.rs:29:13
    |
 LL |     let y = <String as Bar<Vec<u32>, String>>::F;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant used
+  --> $DIR/assoc_const.rs:29:13
+   |
+LL |     let y = <String as Bar<Vec<u32>, String>>::F;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant used
+  --> $DIR/assoc_const.rs:29:13
+   |
+LL |     let y = <String as Bar<Vec<u32>, String>>::F;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: skipping const checks
    |
@@ -27,6 +39,6 @@ help: skipping check that does not even have a feature gate
 LL |     const F: u32 = (U::X, 42).1;
    |                    ^^^^^^^^^^
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/assoc_const_2.rs
+++ b/src/test/ui/consts/miri_unleashed/assoc_const_2.rs
@@ -24,5 +24,5 @@ impl Bar<String> for String {}
 fn main() {
     let x = <() as Bar<()>>::F;
     // this test only causes errors due to the line below, so post-monomorphization
-    let y = <String as Bar<String>>::F; //~ ERROR erroneous constant
+    let y = <String as Bar<String>>::F; //~ constant
 }

--- a/src/test/ui/consts/miri_unleashed/assoc_const_2.stderr
+++ b/src/test/ui/consts/miri_unleashed/assoc_const_2.stderr
@@ -4,12 +4,24 @@ error[E0080]: evaluation of `<std::string::String as Bar<std::string::String>>::
 LL |     const F: u32 = 100 / U::X;
    |                    ^^^^^^^^^^ attempt to divide `100_u32` by zero
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/assoc_const_2.rs:27:13
    |
 LL |     let y = <String as Bar<String>>::F;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+note: erroneous constant used
+  --> $DIR/assoc_const_2.rs:27:13
+   |
+LL |     let y = <String as Bar<String>>::F;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant used
+  --> $DIR/assoc_const_2.rs:27:13
+   |
+LL |     let y = <String as Bar<String>>::F;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/uninhabited-const-issue-61744.rs
+++ b/src/test/ui/consts/uninhabited-const-issue-61744.rs
@@ -15,5 +15,5 @@ trait Const {
 impl<T> Const for T {}
 
 pub fn main() -> () {
-    dbg!(i32::CONSTANT); //~ ERROR erroneous constant used
+    dbg!(i32::CONSTANT); //~ constant
 }

--- a/src/test/ui/consts/uninhabited-const-issue-61744.stderr
+++ b/src/test/ui/consts/uninhabited-const-issue-61744.stderr
@@ -140,12 +140,24 @@ LL |     fake_type()
 LL |     const CONSTANT: i32 = unsafe { fake_type() };
    |                                    ----------- inside `<i32 as Const>::CONSTANT` at $DIR/uninhabited-const-issue-61744.rs:12:36
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/uninhabited-const-issue-61744.rs:18:10
    |
 LL |     dbg!(i32::CONSTANT);
-   |          ^^^^^^^^^^^^^ referenced constant has errors
+   |          ^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+note: erroneous constant used
+  --> $DIR/uninhabited-const-issue-61744.rs:18:10
+   |
+LL |     dbg!(i32::CONSTANT);
+   |          ^^^^^^^^^^^^^
+
+note: erroneous constant used
+  --> $DIR/uninhabited-const-issue-61744.rs:18:10
+   |
+LL |     dbg!(i32::CONSTANT);
+   |          ^^^^^^^^^^^^^
+
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/issues/issue-17252.stderr
+++ b/src/test/ui/issues/issue-17252.stderr
@@ -1,8 +1,8 @@
 error[E0391]: cycle detected when const-evaluating + checking `FOO`
-  --> $DIR/issue-17252.rs:1:1
+  --> $DIR/issue-17252.rs:1:20
    |
 LL | const FOO: usize = FOO;
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^
    |
    = note: ...which immediately requires const-evaluating + checking `FOO` again
 note: cycle used when const-evaluating + checking `main::{constant#0}`

--- a/src/test/ui/issues/issue-23302-3.stderr
+++ b/src/test/ui/issues/issue-23302-3.stderr
@@ -1,14 +1,14 @@
 error[E0391]: cycle detected when const-evaluating + checking `A`
-  --> $DIR/issue-23302-3.rs:1:1
+  --> $DIR/issue-23302-3.rs:1:16
    |
 LL | const A: i32 = B;
-   | ^^^^^^^^^^^^^^^^^
+   |                ^
    |
 note: ...which requires const-evaluating + checking `B`...
-  --> $DIR/issue-23302-3.rs:3:1
+  --> $DIR/issue-23302-3.rs:3:16
    |
 LL | const B: i32 = A;
-   | ^^^^^^^^^^^^^^^^^
+   |                ^
    = note: ...which again requires const-evaluating + checking `A`, completing the cycle
 note: cycle used when simplifying constant for the type system `A`
   --> $DIR/issue-23302-3.rs:1:1

--- a/src/test/ui/issues/issue-41394.rs
+++ b/src/test/ui/issues/issue-41394.rs
@@ -5,7 +5,7 @@ enum Foo {
 
 enum Bar {
     A = Foo::A as isize
-    //~^ ERROR evaluation of constant value failed
+    //~^ const
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-41394.stderr
+++ b/src/test/ui/issues/issue-41394.stderr
@@ -6,13 +6,12 @@ LL |     A = "" + 1
    |         |
    |         &str
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/issue-41394.rs:7:9
    |
 LL |     A = Foo::A as isize
-   |         ^^^^^^^^^^^^^^^ referenced constant has errors
+   |         ^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0080, E0369.
-For more information about an error, try `rustc --explain E0080`.
+For more information about this error, try `rustc --explain E0369`.

--- a/src/test/ui/issues/issue-69602-type-err-during-codegen-ice.rs
+++ b/src/test/ui/issues/issue-69602-type-err-during-codegen-ice.rs
@@ -19,5 +19,5 @@ impl TraitB for B { //~ ERROR not all trait items implemented, missing: `MyA`
 
 fn main() {
     let _ = [0; B::VALUE];
-    //~^ ERROR evaluation of constant value failed
+    //~^ constant
 }

--- a/src/test/ui/issues/issue-69602-type-err-during-codegen-ice.stderr
+++ b/src/test/ui/issues/issue-69602-type-err-during-codegen-ice.stderr
@@ -13,13 +13,13 @@ LL |     type MyA: TraitA;
 LL | impl TraitB for B {
    | ^^^^^^^^^^^^^^^^^ missing `MyA` in implementation
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/issue-69602-type-err-during-codegen-ice.rs:21:17
    |
 LL |     let _ = [0; B::VALUE];
-   |                 ^^^^^^^^ referenced constant has errors
+   |                 ^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0046, E0080, E0437.
+Some errors have detailed explanations: E0046, E0437.
 For more information about an error, try `rustc --explain E0046`.

--- a/src/test/ui/limits/issue-55878.stderr
+++ b/src/test/ui/limits/issue-55878.stderr
@@ -9,14 +9,30 @@ LL |     intrinsics::size_of::<T>()
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    |                          ---------------------------------------------- inside `main` at $DIR/issue-55878.rs:7:26
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/issue-55878.rs:7:26
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+note: erroneous constant used
+  --> $DIR/issue-55878.rs:7:26
+   |
+LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant used
+  --> $DIR/issue-55878.rs:7:26
+   |
+LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/resolve/issue-50599.rs
+++ b/src/test/ui/resolve/issue-50599.rs
@@ -2,5 +2,5 @@ fn main() {
     const N: u32 = 1_000;
     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize; //~ ERROR cannot find value
     let mut digits = [0u32; M];
-    //~^ ERROR evaluation of constant value failed
+    //~^ constant
 }

--- a/src/test/ui/resolve/issue-50599.stderr
+++ b/src/test/ui/resolve/issue-50599.stderr
@@ -16,13 +16,12 @@ LL -     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize;
 LL +     const M: usize = (f64::from(N) * LOG10_2) as usize;
    |
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/issue-50599.rs:4:29
    |
 LL |     let mut digits = [0u32; M];
-   |                             ^ referenced constant has errors
+   |                             ^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0080, E0425.
-For more information about an error, try `rustc --explain E0080`.
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/type/type-dependent-def-issue-49241.rs
+++ b/src/test/ui/type/type-dependent-def-issue-49241.rs
@@ -2,5 +2,5 @@ fn main() {
     let v = vec![0];
     const l: usize = v.count(); //~ ERROR attempt to use a non-constant value in a constant
     let s: [u32; l] = v.into_iter().collect();
-    //~^ERROR evaluation of constant value failed
+    //~^ constant
 }

--- a/src/test/ui/type/type-dependent-def-issue-49241.stderr
+++ b/src/test/ui/type/type-dependent-def-issue-49241.stderr
@@ -6,13 +6,12 @@ LL |     const l: usize = v.count();
    |     |
    |     help: consider using `let` instead of `const`: `let l`
 
-error[E0080]: evaluation of constant value failed
+note: erroneous constant used
   --> $DIR/type-dependent-def-issue-49241.rs:4:18
    |
 LL |     let s: [u32; l] = v.into_iter().collect();
-   |                  ^ referenced constant has errors
+   |                  ^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0080, E0435.
-For more information about an error, try `rustc --explain E0080`.
+For more information about this error, try `rustc --explain E0435`.

--- a/src/tools/clippy/tests/ui/indexing_slicing_index.stderr
+++ b/src/tools/clippy/tests/ui/indexing_slicing_index.stderr
@@ -4,11 +4,11 @@ error[E0080]: evaluation of `main::{constant#3}` failed
 LL |     const { &ARR[idx4()] }; // Ok, let rustc handle const contexts.
    |              ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4
 
-error[E0080]: erroneous constant used
+note: erroneous constant used
   --> $DIR/indexing_slicing_index.rs:31:5
    |
 LL |     const { &ARR[idx4()] }; // Ok, let rustc handle const contexts.
-   |     ^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: indexing may panic
   --> $DIR/indexing_slicing_index.rs:22:5
@@ -65,6 +65,6 @@ error[E0080]: evaluation of constant value failed
 LL | const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
    |                        ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4
 
-error: aborting due to 9 previous errors
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/tools/miri/src/concurrency/thread.rs
+++ b/src/tools/miri/src/concurrency/thread.rs
@@ -712,7 +712,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             if tcx.is_foreign_item(def_id) {
                 throw_unsup_format!("foreign thread-local statics are not supported");
             }
-            let allocation = tcx.eval_static_initializer(def_id)?;
+            // We don't give a span -- statics don't need that, they cannot be generic or associated.
+            let allocation = this.ctfe_query(None, |tcx| tcx.eval_static_initializer(def_id))?;
             let mut allocation = allocation.inner().clone();
             // This allocation will be deallocated when the thread dies, so it is not in read-only memory.
             allocation.mutability = Mutability::Mut;

--- a/src/tools/miri/src/diagnostics.rs
+++ b/src/tools/miri/src/diagnostics.rs
@@ -146,7 +146,9 @@ fn prune_stacktrace<'tcx>(
     }
 }
 
-/// Emit a custom diagnostic without going through the miri-engine machinery
+/// Emit a custom diagnostic without going through the miri-engine machinery.
+///
+/// Returns `Some` if this was regular program termination with a given exit code, `None` otherwise.
 pub fn report_error<'tcx, 'mir>(
     ecx: &InterpCx<'mir, 'tcx, MiriMachine<'mir, 'tcx>>,
     e: InterpErrorInfo<'tcx>,
@@ -155,106 +157,102 @@ pub fn report_error<'tcx, 'mir>(
 
     let mut msg = vec![];
 
-    let (title, helps) = match &e.kind() {
-        MachineStop(info) => {
-            let info = info.downcast_ref::<TerminationInfo>().expect("invalid MachineStop payload");
-            use TerminationInfo::*;
-            let title = match info {
-                Exit(code) => return Some(*code),
-                Abort(_) => Some("abnormal termination"),
-                UnsupportedInIsolation(_) | Int2PtrWithStrictProvenance =>
-                    Some("unsupported operation"),
-                StackedBorrowsUb { .. } => Some("Undefined Behavior"),
-                Deadlock => Some("deadlock"),
-                MultipleSymbolDefinitions { .. } | SymbolShimClashing { .. } => None,
-            };
-            #[rustfmt::skip]
-            let helps = match info {
-                UnsupportedInIsolation(_) =>
-                    vec![
-                        (None, format!("pass the flag `-Zmiri-disable-isolation` to disable isolation;")),
-                        (None, format!("or pass `-Zmiri-isolation-error=warn` to configure Miri to return an error code from isolated operations (if supported for that operation) and continue with a warning")),
-                    ],
-                StackedBorrowsUb { help, history, .. } => {
-                    let url = "https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md";
-                    msg.extend(help.clone());
-                    let mut helps = vec![
-                        (None, format!("this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental")),
-                        (None, format!("see {url} for further information")),
-                    ];
-                    if let Some(TagHistory {created, invalidated, protected}) = history.clone() {
-                        helps.push((Some(created.1), created.0));
-                        if let Some((msg, span)) = invalidated {
-                            helps.push((Some(span), msg));
-                        }
-                        if let Some((protector_msg, protector_span)) = protected {
-                            helps.push((Some(protector_span), protector_msg));
-                        }
+    let (title, helps) = if let MachineStop(info) = e.kind() {
+        let info = info.downcast_ref::<TerminationInfo>().expect("invalid MachineStop payload");
+        use TerminationInfo::*;
+        let title = match info {
+            Exit(code) => return Some(*code),
+            Abort(_) => Some("abnormal termination"),
+            UnsupportedInIsolation(_) | Int2PtrWithStrictProvenance =>
+                Some("unsupported operation"),
+            StackedBorrowsUb { .. } => Some("Undefined Behavior"),
+            Deadlock => Some("deadlock"),
+            MultipleSymbolDefinitions { .. } | SymbolShimClashing { .. } => None,
+        };
+        #[rustfmt::skip]
+        let helps = match info {
+            UnsupportedInIsolation(_) =>
+                vec![
+                    (None, format!("pass the flag `-Zmiri-disable-isolation` to disable isolation;")),
+                    (None, format!("or pass `-Zmiri-isolation-error=warn` to configure Miri to return an error code from isolated operations (if supported for that operation) and continue with a warning")),
+                ],
+            StackedBorrowsUb { help, history, .. } => {
+                let url = "https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md";
+                msg.extend(help.clone());
+                let mut helps = vec![
+                    (None, format!("this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental")),
+                    (None, format!("see {url} for further information")),
+                ];
+                if let Some(TagHistory {created, invalidated, protected}) = history.clone() {
+                    helps.push((Some(created.1), created.0));
+                    if let Some((msg, span)) = invalidated {
+                        helps.push((Some(span), msg));
                     }
-                    helps
+                    if let Some((protector_msg, protector_span)) = protected {
+                        helps.push((Some(protector_span), protector_msg));
+                    }
                 }
-                MultipleSymbolDefinitions { first, first_crate, second, second_crate, .. } =>
-                    vec![
-                        (Some(*first), format!("it's first defined here, in crate `{first_crate}`")),
-                        (Some(*second), format!("then it's defined here again, in crate `{second_crate}`")),
-                    ],
-                SymbolShimClashing { link_name, span } =>
-                    vec![(Some(*span), format!("the `{link_name}` symbol is defined here"))],
-                Int2PtrWithStrictProvenance =>
-                    vec![(None, format!("use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead"))],
-                _ => vec![],
-            };
-            (title, helps)
-        }
-        _ => {
-            #[rustfmt::skip]
-            let title = match e.kind() {
-                Unsupported(_) =>
-                    "unsupported operation",
-                UndefinedBehavior(_) =>
-                    "Undefined Behavior",
-                ResourceExhaustion(_) =>
-                    "resource exhaustion",
-                InvalidProgram(
-                    InvalidProgramInfo::AlreadyReported(_) |
-                    InvalidProgramInfo::Layout(..) |
-                    InvalidProgramInfo::ReferencedConstant
-                ) =>
-                    "post-monomorphization error",
-                kind =>
-                    bug!("This error should be impossible in Miri: {kind:?}"),
-            };
-            #[rustfmt::skip]
-            let helps = match e.kind() {
-                Unsupported(
-                    UnsupportedOpInfo::ThreadLocalStatic(_) |
-                    UnsupportedOpInfo::ReadExternStatic(_) |
-                    UnsupportedOpInfo::PartialPointerOverwrite(_) |
-                    UnsupportedOpInfo::PartialPointerCopy(_) |
-                    UnsupportedOpInfo::ReadPointerAsBytes
-                ) =>
-                    panic!("Error should never be raised by Miri: {kind:?}", kind = e.kind()),
-                Unsupported(
-                    UnsupportedOpInfo::Unsupported(_)
-                ) =>
-                    vec![(None, format!("this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support"))],
-                UndefinedBehavior(UndefinedBehaviorInfo::AlignmentCheckFailed { .. })
-                    if ecx.machine.check_alignment == AlignmentCheck::Symbolic
-                =>
-                    vec![
-                        (None, format!("this usually indicates that your program performed an invalid operation and caused Undefined Behavior")),
-                        (None, format!("but due to `-Zmiri-symbolic-alignment-check`, alignment errors can also be false positives")),
-                    ],
-                UndefinedBehavior(_) =>
-                    vec![
-                        (None, format!("this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior")),
-                        (None, format!("see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information")),
-                    ],
-                InvalidProgram(_) | ResourceExhaustion(_) | MachineStop(_) =>
-                    vec![],
-            };
-            (Some(title), helps)
-        }
+                helps
+            }
+            MultipleSymbolDefinitions { first, first_crate, second, second_crate, .. } =>
+                vec![
+                    (Some(*first), format!("it's first defined here, in crate `{first_crate}`")),
+                    (Some(*second), format!("then it's defined here again, in crate `{second_crate}`")),
+                ],
+            SymbolShimClashing { link_name, span } =>
+                vec![(Some(*span), format!("the `{link_name}` symbol is defined here"))],
+            Int2PtrWithStrictProvenance =>
+                vec![(None, format!("use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead"))],
+            _ => vec![],
+        };
+        (title, helps)
+    } else {
+        #[rustfmt::skip]
+        let title = match e.kind() {
+            UndefinedBehavior(_) =>
+                "Undefined Behavior",
+            ResourceExhaustion(_) =>
+                "resource exhaustion",
+            Unsupported(
+                // We list only the ones that can actually happen.
+                UnsupportedOpInfo::Unsupported(_)
+            ) =>
+                "unsupported operation",
+            InvalidProgram(
+                // We list only the ones that can actually happen.
+                InvalidProgramInfo::AlreadyReported(_) |
+                InvalidProgramInfo::Layout(..)
+            ) =>
+                "post-monomorphization error",
+            kind =>
+                bug!("This error should be impossible in Miri: {kind:?}"),
+        };
+        #[rustfmt::skip]
+        let helps = match e.kind() {
+            Unsupported(_) =>
+                vec![(None, format!("this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support"))],
+            UndefinedBehavior(UndefinedBehaviorInfo::AlignmentCheckFailed { .. })
+                if ecx.machine.check_alignment == AlignmentCheck::Symbolic
+            =>
+                vec![
+                    (None, format!("this usually indicates that your program performed an invalid operation and caused Undefined Behavior")),
+                    (None, format!("but due to `-Zmiri-symbolic-alignment-check`, alignment errors can also be false positives")),
+                ],
+            UndefinedBehavior(_) =>
+                vec![
+                    (None, format!("this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior")),
+                    (None, format!("see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information")),
+                ],
+            InvalidProgram(
+                InvalidProgramInfo::AlreadyReported(rustc_errors::ErrorGuaranteed { .. })
+            ) => {
+                // This got already reported. No point in reporting it again.
+                return None;
+            }
+            _ =>
+                vec![],
+        };
+        (Some(title), helps)
     };
 
     let stacktrace = ecx.generate_stacktrace();

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -117,7 +117,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         let this = self.eval_context_ref();
         let instance = this.resolve_path(path);
         let cid = GlobalId { instance, promoted: None };
-        let const_val = this.eval_to_allocation(cid)?;
+        // We don't give a span -- this isn't actually used directly by the program anyway.
+        let const_val = this.eval_global(cid, None)?;
         this.read_scalar(&const_val.into())
     }
 

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -46,6 +46,7 @@ extern crate rustc_ast;
 extern crate rustc_middle;
 extern crate rustc_const_eval;
 extern crate rustc_data_structures;
+extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_index;
 extern crate rustc_session;

--- a/src/tools/miri/tests/fail/erroneous_const.rs
+++ b/src/tools/miri/tests/fail/erroneous_const.rs
@@ -11,7 +11,7 @@ impl<T> PrintName<T> {
 
 fn no_codegen<T>() {
     if false {
-        let _ = PrintName::<T>::VOID; //~ERROR: post-monomorphization error
+        let _ = PrintName::<T>::VOID; //~NOTE: constant
     }
 }
 fn main() {

--- a/src/tools/miri/tests/fail/erroneous_const.stderr
+++ b/src/tools/miri/tests/fail/erroneous_const.stderr
@@ -6,21 +6,12 @@ LL |     const VOID: ! = panic!();
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: post-monomorphization error: referenced constant has errors
+note: erroneous constant used
   --> $DIR/erroneous_const.rs:LL:CC
    |
 LL |         let _ = PrintName::<T>::VOID;
-   |                 ^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
-   |
-   = note: inside `no_codegen::<i32>` at $DIR/erroneous_const.rs:LL:CC
-note: inside `main` at $DIR/erroneous_const.rs:LL:CC
-  --> $DIR/erroneous_const.rs:LL:CC
-   |
-LL |     no_codegen::<i32>();
-   |     ^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^
 
-note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
It looks like most of the time, this error raised from const_prop_lint is just redundant -- it duplicates the error reported when evaluating the const-eval query. This lets us make `ConstEvalErr` private to the const_eval module which I think is a good step.

The Miri change mostly replaces a `match` by `if let`, and dedupes the "this error is impossible in Miri" checks.

r? @oli-obk 
Fixes https://github.com/rust-lang/rust/issues/75461