### PR TITLE
Fix non clickable source link

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -183,8 +183,6 @@ h4.code-header {
 	font-weight: 600;
 	margin: 0;
 	padding: 0;
-	/* position notable traits in mobile mode within the header */
-	position: relative;
 }
 
 #crate-search,

--- a/src/test/rustdoc-gui/src-font-size.goml
+++ b/src/test/rustdoc-gui/src-font-size.goml
@@ -9,3 +9,8 @@ assert-css: (".impl.has-srclink .code-header", {"font-size": "18px", "font-weigh
 // Check the impl items.
 assert-css: (".impl-items .has-srclink .srclink", {"font-size": "16px", "font-weight": 400}, ALL)
 assert-css: (".impl-items .has-srclink .code-header", {"font-size": "16px", "font-weight": 600}, ALL)
+
+// Check that we can click on source link
+store-document-property: (url, "URL")
+click: ".impl-items .has-srclink .srclink"
+assert-document-property-false: {"URL": |url|}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/104313.

It was also fixed in https://github.com/rust-lang/rust/pull/104177. If https://github.com/rust-lang/rust/pull/104177 is merged first, I'll simply remove the first commit to keep the test.

r? @notriddle 