### PR TITLE
rustdoc: remove no-op CSS `.scrape-help { background: transparent }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1984,7 +1984,6 @@ in storage.js
 	font-size: 12px;
 	position: relative;
 	bottom: 1px;
-	background: transparent;
 	border-width: 1px;
 	border-style: solid;
 	border-radius: 50px;


### PR DESCRIPTION
It's a link. This is the default CSS for it.