### PR TITLE
Clarify provenance of {Arc, Rc}::as_ptr pointer

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -845,6 +845,9 @@ impl<T: ?Sized> Rc<T> {
     /// The counts are not affected in any way and the `Rc` is not consumed. The pointer is valid
     /// for as long there are strong counts in the `Rc`.
     ///
+    /// Note that even though the returned pointer is a `*const T`, it is also valid for writes
+    /// so long as this `Rc` remains unique (i.e. strong count is 1 and weak count is 0).
+    ///
     /// # Examples
     ///
     /// ```

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -852,6 +852,9 @@ impl<T: ?Sized> Arc<T> {
     /// The counts are not affected in any way and the `Arc` is not consumed. The pointer is valid for
     /// as long as there are strong counts in the `Arc`.
     ///
+    /// Note that even though the returned pointer is a `*const T`, it is also valid for writes
+    /// so long as this `Arc` remains unique (i.e. strong count is 1 and weak count is 0).
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
Fixes #87862.
This spawned off of a discussion in the Rust discord server last year about whether the following code is valid:
```rs
use std::rc::Rc;

let foo = Rc::new(1u8);

unsafe {
  // *const u8 -> &mut u8
  let foo_ref = &mut *(Rc::as_ptr(&foo) as *mut u8);

  *foo_ref += 1;
};

assert_eq!(Rc::try_unwrap(foo), Ok(2));
```
That is, can you mutate the returned `*const T` from `Rc::as_ptr` (if the `Rc` is unique).

Looking at the function signature, one might think that mutating the `*const T` is illegal because it comes from `&Rc<T>` (effectively a `&T` -> `&mut T` transmute), however `Rc` does not directly store the `T`; instead it is stored in `RcBox` that the `Rc` always has a `*mut` to. This has always been an implementation detail up until now and one would rely on implementation details when writing to the returned pointer.

It is even noted in the function body of `Rc::as_ptr` that the provenance must be retained such that methods like `{Rc, Arc}::get_mut` could create a `&mut T` to the contained item using this function (if I understand correctly).
https://github.com/rust-lang/rust/blob/cd128880b13bc9f7a919567926e801c8a1487cdb/library/alloc/src/rc.rs#L860-L866

This PR documents/guarantees the ability to write to the pointer