### PR TITLE
Added type_info macro

### DIFF
--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1181,7 +1181,7 @@ pub const fn variant_count<T>() -> usize {
 /// This is useful for quickly obtaining parameters about a type during debugging.
 ///
 /// ```
-/// use playground::type_info;
+/// use std::type_info;
 ///
 /// // For usage with raw types, wrap the type in `<..>`
 /// let result = type_info!(<Option<String>>);
@@ -1197,7 +1197,7 @@ pub const fn variant_count<T>() -> usize {
 /// are the same as the `write!` macro
 ///
 /// ```
-/// use playground::type_info;
+/// use std:type_info;
 /// use std::io::Write;
 ///
 /// // in `no_std` a different type would be used; this is just an example


### PR DESCRIPTION
When developing, it can be handy to quickly find the size and alignment of a type, and/or the type of a variable if it may not be known. This macro seeks to add this helpful feature, which pairs well in scope with the `dbg!` macro. Usage is simple, as follows:

```rust
let result1 = type_info!(<Option<String>>); // creates a formatted `String`
let expected = "core::option::Option<alloc::string::String>: size 24, alignment 8";
assert_eq!(expected, result1);

let s = Option<String::new()>;
let result2 = type_info!(s);
assert_eq!(expected, result2);
```

I think this is probably suitable for FCP. There are a couple issues I will need help resolving if the team is open to moving forward:

- I believe the macro to be cleaner without the `<>` that is currently required for raw types (e.g. `type_info!(<Option<String>>)`). I have this for now because I can't get the macro to differentiate between an `expr` and a `ty` in its overload matching.
- I have had some issues getting the writer option to work with an identiifer and not a raw type.