### PR TITLE
Fix up a Fluent message

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/infer.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/infer.ftl
@@ -126,10 +126,10 @@ infer_data_lifetime_flow = ...but data with one lifetime flows into the other he
 infer_declared_multiple = this type is declared with multiple lifetimes...
 infer_types_declared_different = these two types are declared with different lifetimes...
 infer_data_flows = ...but data{$label_var1_exists ->
-    [true] -> {" "}from `{$label_var1}`
+    [true] {" "}from `{$label_var1}`
     *[false] -> {""}
 } flows{$label_var2_exists ->
-    [true] -> {" "}into `{$label_var2}`
+    [true] {" "}into `{$label_var2}`
     *[false] -> {""}
 } here
 

--- a/src/test/ui/implied-bounds/hrlt-implied-trait-bounds-guard.rs
+++ b/src/test/ui/implied-bounds/hrlt-implied-trait-bounds-guard.rs
@@ -31,6 +31,16 @@ fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) -> &'out T {
     sadness.cast()
 }
 
+fn badboi2<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) {
+    //~^ ERROR lifetime mismatch
+    let _: &'out T = sadness.cast();
+}
+
+fn badboi3<'in_, 'out, T>(a: Foo<'in_, 'out, (&'in_ T, &'out T)>, sadness: &'in_ T) {
+    //~^ ERROR lifetime mismatch
+    let _: &'out T = sadness.cast();
+}
+
 fn bad<'short, T>(value: &'short T) -> &'static T {
     let x: for<'in_, 'out> fn(Foo<'in_, 'out, T>, &'in_ T) -> &'out T = badboi;
     let x: for<'out> fn(Foo<'short, 'out, T>, &'short T) -> &'out T = x;

--- a/src/test/ui/implied-bounds/hrlt-implied-trait-bounds-guard.stderr
+++ b/src/test/ui/implied-bounds/hrlt-implied-trait-bounds-guard.stderr
@@ -7,6 +7,24 @@ LL | fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) -> &'out 
    |                             this parameter and the return type are declared with different lifetimes...
    |                             ...but data from `x` is returned here
 
-error: aborting due to previous error
+error[E0623]: lifetime mismatch
+  --> $DIR/hrlt-implied-trait-bounds-guard.rs:34:30
+   |
+LL | fn badboi2<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) {
+   |                              ^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              this type is declared with multiple lifetimes...
+   |                              ...but data with one lifetime flows into the other here
+
+error[E0623]: lifetime mismatch
+  --> $DIR/hrlt-implied-trait-bounds-guard.rs:39:30
+   |
+LL | fn badboi3<'in_, 'out, T>(a: Foo<'in_, 'out, (&'in_ T, &'out T)>, sadness: &'in_ T) {
+   |                              ^^^^^^^^^^^^^^^^^-------^^-------^^
+   |                              |                |
+   |                              |                these two types are declared with different lifetimes...
+   |                              ...but data from `a` flows into `a` here
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0623`.


### PR DESCRIPTION
Fix up a Fluent message which contained arrows `->` after [selectors](https://projectfluent.org/fluent/guide/selectors.html). The original author probably thought that they were required as part of the selector syntax but in reality they were interpreted as literal text and actually showed up in the emitted diagnostic.

This wasn't caught during the diagnostic migration since the branch constructing the diagnostic in question (`rustc_infer::errors::LifetimeMismatchLabels::Normal`) was not exercised by the UI test suite. I've added two more test cases to do so (one testing `LifetimeMismatchLabels::Normal` where `hir_equal == true` and one where `hir_equal == false`).

Diff visualizing the `->` bug (`master` vs `fix-up-a-fluent-message`):

```diff
 error[E0623]: lifetime mismatch
   --> src/test/ui/implied-bounds/hrlt-implied-trait-bounds-guard.rs:39:30
    |
 39 | fn badboi3<'in_, 'out, T>(a: Foo<'in_, 'out, (&'in_ T, &'out T)>, sadness: &'in_ T) {
    |                              ^^^^^^^^^^^^^^^^^-------^^-------^^
    |                              |                |
    |                              |                these two types are declared with different lifetimes...
-   |                              ...but data->  from `a` flows->  into `a` here
+   |                              ...but data from `a` flows into `a` here
```