### PR TITLE
Respect visibility & stability of inherent associated types

### DIFF
--- a/src/test/ui/associated-inherent-types/assoc-inherent-private.rs
+++ b/src/test/ui/associated-inherent-types/assoc-inherent-private.rs
@@ -1,0 +1,23 @@
+#![feature(inherent_associated_types)]
+#![allow(incomplete_features)]
+
+mod m {
+    pub struct T;
+    impl T {
+        type P = ();
+    }
+}
+type U = m::T::P; //~ ERROR associated type `P` is private
+
+mod n {
+    pub mod n {
+        pub struct T;
+        impl T {
+            pub(super) type P = bool;
+        }
+    }
+    type U = n::T::P;
+}
+type V = n::n::T::P; //~ ERROR associated type `P` is private
+
+fn main() {}

--- a/src/test/ui/associated-inherent-types/assoc-inherent-private.stderr
+++ b/src/test/ui/associated-inherent-types/assoc-inherent-private.stderr
@@ -1,0 +1,21 @@
+error[E0624]: associated type `P` is private
+  --> $DIR/assoc-inherent-private.rs:10:10
+   |
+LL |         type P = ();
+   |         ------ associated type defined here
+...
+LL | type U = m::T::P;
+   |          ^^^^^^^ private associated type
+
+error[E0624]: associated type `P` is private
+  --> $DIR/assoc-inherent-private.rs:21:10
+   |
+LL |             pub(super) type P = bool;
+   |             ----------------- associated type defined here
+...
+LL | type V = n::n::T::P;
+   |          ^^^^^^^^^^ private associated type
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0624`.

--- a/src/test/ui/associated-inherent-types/assoc-inherent-unstable.rs
+++ b/src/test/ui/associated-inherent-types/assoc-inherent-unstable.rs
@@ -1,0 +1,6 @@
+// aux-crate:aux=assoc-inherent-unstable.rs
+// edition: 2021
+
+type Data = aux::Owner::Data; //~ ERROR use of unstable library feature 'data'
+
+fn main() {}

--- a/src/test/ui/associated-inherent-types/assoc-inherent-unstable.stderr
+++ b/src/test/ui/associated-inherent-types/assoc-inherent-unstable.stderr
@@ -1,0 +1,11 @@
+error[E0658]: use of unstable library feature 'data'
+  --> $DIR/assoc-inherent-unstable.rs:4:13
+   |
+LL | type Data = aux::Owner::Data;
+   |             ^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(data)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/associated-inherent-types/auxiliary/assoc-inherent-unstable.rs
+++ b/src/test/ui/associated-inherent-types/auxiliary/assoc-inherent-unstable.rs
@@ -1,0 +1,11 @@
+#![feature(staged_api)]
+#![feature(inherent_associated_types)]
+#![stable(feature = "main", since = "1.0.0")]
+
+#[stable(feature = "main", since = "1.0.0")]
+pub struct Owner;
+
+impl Owner {
+    #[unstable(feature = "data", issue = "none")]
+    pub type Data = ();
+}

--- a/src/test/ui/traits/item-privacy.stderr
+++ b/src/test/ui/traits/item-privacy.stderr
@@ -162,9 +162,12 @@ error[E0223]: ambiguous associated type
 LL |     let _: S::C;
    |            ^^^^ help: use fully-qualified syntax: `<S as Trait>::C`
 
-error: associated type `A` is private
+error[E0624]: associated type `A` is private
   --> $DIR/item-privacy.rs:119:12
    |
+LL |         type A = u8;
+   |         ------ associated type defined here
+...
 LL |     let _: T::A;
    |            ^^^^ private associated type
 


### PR DESCRIPTION
As discussed in #103621, this probably won't be the final location of the code that resolves inherent associated types. Still, I think it's valuable to push correctness fixes for this feature (in regards to visibility and stability).

Let me know if I should write a translatable diagnostic instead and if I should move the tests to `privacy/` and `stability-attribute/` respectively.

Fixes #104243.
@rustbot label A-visibility F-inherent_associated_types
r? @cjgillot (since you reviewed #103621, feel free to reroll though)