### PR TITLE
[watchos] Dynamic linking is not allowed for watchos targets

### DIFF
--- a/compiler/rustc_target/src/spec/arm64_32_apple_watchos.rs
+++ b/compiler/rustc_target/src/spec/arm64_32_apple_watchos.rs
@@ -12,6 +12,8 @@ pub fn target() -> Target {
             features: "+neon,+fp-armv8,+apple-a7".into(),
             max_atomic_width: Some(128),
             forces_embed_bitcode: true,
+            dynamic_linking: false,
+            position_independent_executables: true,
             // These arguments are not actually invoked - they just have
             // to look right to pass App Store validation.
             bitcode_llvm_cmdline: "-triple\0\

--- a/compiler/rustc_target/src/spec/armv7k_apple_watchos.rs
+++ b/compiler/rustc_target/src/spec/armv7k_apple_watchos.rs
@@ -12,6 +12,8 @@ pub fn target() -> Target {
             features: "+v7,+vfp4,+neon".into(),
             max_atomic_width: Some(64),
             forces_embed_bitcode: true,
+            dynamic_linking: false,
+            position_independent_executables: true,
             // These arguments are not actually invoked - they just have
             // to look right to pass App Store validation.
             bitcode_llvm_cmdline: "-triple\0\


### PR DESCRIPTION
Dynamic linking of all apple targets was (re-) enabled in PR #100636. However, dynamic linking is not allowed on WatchOS so this broke the build of standard library for WatchOS. 

This change disables dynamic linking for WatchOS non-simulator targets.