### PR TITLE
rustdoc: Resolve doc links in external traits having local impls

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1932,6 +1932,11 @@ impl<'a> Resolver<'a> {
         }
     }
 
+    /// For rustdoc.
+    pub fn get_partial_res(&self, node_id: NodeId) -> Option<PartialRes> {
+        self.partial_res_map.get(&node_id).copied()
+    }
+
     /// Retrieves the span of the given `DefId` if `DefId` is in the local crate.
     #[inline]
     pub fn opt_span(&self, def_id: DefId) -> Option<Span> {

--- a/src/test/rustdoc/intra-doc/issue-104145.rs
+++ b/src/test/rustdoc/intra-doc/issue-104145.rs
@@ -1,0 +1,14 @@
+// Doc links in `Trait`'s methods are resolved because it has a local impl.
+
+// aux-build:issue-103463-aux.rs
+
+extern crate issue_103463_aux;
+use issue_103463_aux::Trait;
+
+pub struct LocalType;
+
+impl Trait for LocalType {
+    fn method() {}
+}
+
+fn main() {}


### PR DESCRIPTION
For external impls it was done in https://github.com/rust-lang/rust/pull/103192 right away, but the local impl case was forgotten.

Fixes https://github.com/rust-lang/rust/issues/104145.