### PR TITLE
Add x tool to triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -584,3 +584,4 @@ fallback = [
 "/src/tools/rustdoc-js" =                    ["rustdoc"]
 "/src/tools/rustdoc-themes" =                ["rustdoc"]
 "/src/tools/tidy" =                          ["bootstrap"]
+"/src/tools/x" =                             ["bootstrap"]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -182,6 +182,7 @@ trigger_files = [
     "x.ps1",
     "src/bootstrap",
     "src/tools/rust-installer",
+    "src/tools/x",
     "configure",
     "Cargo.toml",
     "Cargo.lock",


### PR DESCRIPTION
Assign the A-bootstrap label when a pr modifies the x tool.

Happened in #104350.