### PR TITLE
avoid rustc_llvm rebuilds when LD_LIBRARY_PATH changes

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -46,11 +46,12 @@ fn detect_llvm_link() -> (&'static str, &'static str) {
 // perfect -- we might actually want to see something from Cargo's added library paths -- but
 // for now it works.
 fn restore_library_path() {
-    let key = tracked_env_var_os("REAL_LIBRARY_PATH_VAR").expect("REAL_LIBRARY_PATH_VAR");
-    if let Some(env) = tracked_env_var_os("REAL_LIBRARY_PATH") {
-        env::set_var(&key, &env);
-    } else {
-        env::remove_var(&key);
+    if let Some(key) = tracked_env_var_os("REAL_LIBRARY_PATH_VAR") {
+        if let Some(env) = tracked_env_var_os("REAL_LIBRARY_PATH") {
+            env::set_var(&key, &env);
+        } else {
+            env::remove_var(&key);
+        }
     }
 }
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1361,9 +1361,11 @@ impl<'a> Builder<'a> {
 
         // See comment in rustc_llvm/build.rs for why this is necessary, largely llvm-config
         // needs to not accidentally link to libLLVM in stage0/lib.
-        cargo.env("REAL_LIBRARY_PATH_VAR", &util::dylib_path_var());
-        if let Some(e) = env::var_os(util::dylib_path_var()) {
-            cargo.env("REAL_LIBRARY_PATH", e);
+        if !self.config.llvm_from_ci {
+            cargo.env("REAL_LIBRARY_PATH_VAR", &util::dylib_path_var());
+            if let Some(e) = env::var_os(util::dylib_path_var()) {
+                cargo.env("REAL_LIBRARY_PATH", e);
+            }
         }
 
         // Found with `rg "init_env_logger\("`. If anyone uses `init_env_logger`


### PR DESCRIPTION
Currently the fairly slow rustc_llvm build script gets rerun every time LD_LIBRARY_PATH changes. So if one has an IDE setup where LD_LIBRARY_PATH inside the IDE differs from the one on the host, rebuilds happen all the time.

With LLVM being downloaded from CI, this REAL_LIBRARY_PATH stuff does not seem needed any more, at least not on my system. But I also don't really understand what happens here. Does a patch like this make sense?

r? @jyn514  @Mark-Simulacrum 
Cc @bjorn3 