### PR TITLE
layout_of: `T: Thin` implies `sizeof(&T) == sizeof(usize)`

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -670,13 +670,24 @@ where
                         });
                     }
 
-                    match tcx.struct_tail_erasing_lifetimes(pointee, cx.param_env()).kind() {
-                        ty::Slice(_) | ty::Str => TyMaybeWithLayout::Ty(tcx.types.usize),
-                        ty::Dynamic(_, _, ty::Dyn) => {
-                            TyMaybeWithLayout::Ty(tcx.mk_imm_ref(
+                    let metadata = if let Some(metadata_def_id) = tcx.lang_items().metadata_type() {
+                        let metadata = tcx.normalize_erasing_regions(
+                            cx.param_env(),
+                            tcx.mk_projection(metadata_def_id, [pointee]),
+                        );
+
+                        // Map `Metadata = DynMetadata<dyn Trait>` back to a vtable, since it
+                        // offers better information than `std::ptr::metadata::VTable`,
+                        // and we rely on this layout information to trigger a panic in
+                        // `std::mem::uninitialized::<&dyn Trait>()`, for example.
+                        if let ty::Adt(def, substs) = metadata.kind()
+                            && Some(def.did()) == tcx.lang_items().dyn_metadata()
+                            && substs.type_at(0).is_trait()
+                        {
+                            tcx.mk_imm_ref(
                                 tcx.lifetimes.re_static,
                                 tcx.mk_array(tcx.types.usize, 3),
-                            ))
+                            )
                             /* FIXME: use actual fn pointers
                             Warning: naively computing the number of entries in the
                             vtable by counting the methods on the trait + methods on
@@ -690,9 +701,36 @@ where
                                 tcx.mk_array(Option<fn()>),
                             ])
                             */
+                        } else {
+                            metadata
                         }
-                        _ => bug!("TyAndLayout::field({:?}): not applicable", this),
-                    }
+                    } else {
+                        match tcx.struct_tail_erasing_lifetimes(pointee, cx.param_env()).kind() {
+                            ty::Slice(_) | ty::Str => tcx.types.usize,
+                            ty::Dynamic(_, _, ty::Dyn) => {
+                                tcx.mk_imm_ref(
+                                    tcx.lifetimes.re_static,
+                                    tcx.mk_array(tcx.types.usize, 3),
+                                )
+                                /* FIXME: use actual fn pointers
+                                Warning: naively computing the number of entries in the
+                                vtable by counting the methods on the trait + methods on
+                                all parent traits does not work, because some methods can
+                                be not object safe and thus excluded from the vtable.
+                                Increase this counter if you tried to implement this but
+                                failed to do it without duplicating a lot of code from
+                                other places in the compiler: 2
+                                tcx.mk_tup(&[
+                                    tcx.mk_array(tcx.types.usize, 3),
+                                    tcx.mk_array(Option<fn()>),
+                                ])
+                                */
+                            }
+                            _ => bug!("TyAndLayout::field({:?}): not applicable", this),
+                        }
+                    };
+
+                    TyMaybeWithLayout::Ty(metadata)
                 }
 
                 // Arrays and slices.

--- a/src/test/ui/layout/thin-meta-implies-thin-ptr.rs
+++ b/src/test/ui/layout/thin-meta-implies-thin-ptr.rs
@@ -1,0 +1,11 @@
+// check-pass
+
+#![feature(ptr_metadata)]
+
+use std::ptr::Thin;
+
+fn main() {}
+
+fn foo<T: ?Sized + Thin>(t: *const T) -> *const () {
+    unsafe { std::mem::transmute(t) }
+}


### PR DESCRIPTION
Use the `<T as Pointee>::Metadata` associated type to calculate the layout of a pointee's metadata, instead of hard-coding rules about certain types.

Maybe this approach is overkill -- we could instead hard-code this approach as a fallback, with the matching on `Slice`/`Dynamic`/etc. happening first

Fixes this issue here https://github.com/rust-lang/rust/pull/104338#issuecomment-1312595844 .. But is also useful with transmutes, for example, given the UI test I added below.