### PR TITLE
rustdoc: remove unused CSS `code { opacity: 1 }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1262,10 +1262,6 @@ h3.variant {
 	margin-left: 24px;
 }
 
-:target > code, :target > .code-header {
-	opacity: 1;
-}
-
 :target {
 	padding-right: 3px;
 	background-color: var(--target-background-color);


### PR DESCRIPTION
According to https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/CSS.20cleanup this style was added for declarations that no longer use opacity.