### PR TITLE
Attempt to improve codegen for arrays of repeated enums

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -12,8 +12,6 @@ use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::ty::Ty;
 use rustc_target::abi::{Abi, Align, Size};
 
-use std::fmt;
-
 /// The representation of a Rust value. The enum variant is in fact
 /// uniquely determined by the value's type, but is kept as a
 /// safety check.
@@ -38,19 +36,13 @@ pub enum OperandValue<V> {
 /// to avoid nasty edge cases. In particular, using `Builder::store`
 /// directly is sure to cause problems -- use `OperandRef::store`
 /// instead.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct OperandRef<'tcx, V> {
     // The value.
     pub val: OperandValue<V>,
 
     // The layout of value, based on its Rust type.
     pub layout: TyAndLayout<'tcx>,
-}
-
-impl<V: CodegenObject> fmt::Debug for OperandRef<'_, V> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "OperandRef({:?} @ {:?})", self.val, self.layout)
-    }
 }
 
 impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {

--- a/src/test/codegen/enum-repeat.rs
+++ b/src/test/codegen/enum-repeat.rs
@@ -1,0 +1,19 @@
+// compile-flags: -O
+
+#![crate_type = "lib"]
+
+// CHECK-LABEL: @none_repeat
+#[no_mangle]
+pub fn none_repeat() -> [Option<u8>; 64] {
+    // CHECK: store <128 x i8>
+    // CHECK-NEXT: ret void
+    [None; 64]
+}
+
+// CHECK-LABEL: @some_repeat
+#[no_mangle]
+pub fn some_repeat() -> [Option<u8>; 64] {
+    // CHECK: store <128 x i8>
+    // CHECK-NEXT: ret void
+    [Some(0); 64]
+}


### PR DESCRIPTION
Fixes #101685

For enums where the tag and value are the same type, we can get better codegen for `[Enum; N]` by emitting a vector store instruction.

1024 as a limit was picked randomly and is probably too low - I'm unsure how to construct a vector of alternating elements without it being O(n)