### PR TITLE
various cleanups to try to reduce the use of spans inside method resolution

### DIFF
--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -504,7 +504,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // method lookup.
             let Ok(pick) = self
             .probe_for_name(
-                call_expr.span,
                 Mode::MethodCall,
                 segment.ident,
                 IsSuggestion(true),

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -209,7 +209,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     call_expr,
                     ProbeScope::TraitsInScope,
                 ) {
-                    Ok(ref new_pick) if new_pick.self_ty != pick.self_ty => {
+                    Ok(ref new_pick) if pick.differs_from(new_pick) => {
                         needs_mut = true;
                     }
                     _ => {}
@@ -220,7 +220,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let mut candidates =
                 match self.lookup_probe(segment.ident, self_ty, call_expr, ProbeScope::AllTraits) {
                     // If we find a different result the caller probably forgot to import a trait.
-                    Ok(ref new_pick) if new_pick.self_ty != pick.self_ty => {
+                    Ok(ref new_pick) if pick.differs_from(new_pick) => {
                         vec![new_pick.item.container_id(self.tcx)]
                     }
                     Err(Ambiguity(ref sources)) => sources

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -202,7 +202,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     call_expr,
                     ProbeScope::TraitsInScope,
                 ) {
-                    Ok(ref new_pick) if *new_pick != pick => {
+                    Ok(ref new_pick) if new_pick.self_ty != pick.self_ty => {
                         needs_mut = true;
                     }
                     _ => {}
@@ -213,7 +213,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let mut candidates =
                 match self.lookup_probe(segment.ident, self_ty, call_expr, ProbeScope::AllTraits) {
                     // If we find a different result the caller probably forgot to import a trait.
-                    Ok(ref new_pick) if *new_pick != pick => {
+                    Ok(ref new_pick) if new_pick.self_ty != pick.self_ty => {
                         vec![new_pick.item.container_id(self.tcx)]
                     }
                     Err(Ambiguity(ref sources)) => sources

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -93,10 +93,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         call_expr_id: hir::HirId,
         allow_private: bool,
     ) -> bool {
-        let mode = probe::Mode::MethodCall;
         match self.probe_for_name(
             method_name.span,
-            mode,
+            probe::Mode::MethodCall,
             method_name,
             IsSuggestion(false),
             self_ty,
@@ -253,11 +252,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         call_expr: &'tcx hir::Expr<'tcx>,
         scope: ProbeScope,
     ) -> probe::PickResult<'tcx> {
-        let mode = probe::Mode::MethodCall;
-        let self_ty = self.resolve_vars_if_possible(self_ty);
         self.probe_for_name(
             span,
-            mode,
+            probe::Mode::MethodCall,
             method_name,
             IsSuggestion(false),
             self_ty,

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -128,7 +128,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 method_name.span,
                 probe::Mode::MethodCall,
                 method_name,
-                IsSuggestion(false),
+                IsSuggestion(true),
                 self_ty,
                 call_expr.hir_id,
                 ProbeScope::TraitsInScope,

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -102,7 +102,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ProbeScope::TraitsInScope,
         ) {
             Ok(pick) => {
-                pick.emit_unstable_name_collision_hint(self.tcx, method_name.span, call_expr_id);
+                pick.maybe_emit_unstable_name_collision_hint(
+                    self.tcx,
+                    method_name.span,
+                    call_expr_id,
+                );
                 true
             }
             Err(NoMatch(..)) => false,
@@ -256,7 +260,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             call_expr.hir_id,
             scope,
         )?;
-        pick.emit_unstable_name_collision_hint(self.tcx, method_name.span, call_expr.hir_id);
+        pick.maybe_emit_unstable_name_collision_hint(self.tcx, method_name.span, call_expr.hir_id);
         Ok(pick)
     }
 
@@ -589,7 +593,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ProbeScope::TraitsInScope,
         )?;
 
-        pick.emit_unstable_name_collision_hint(self.tcx, span, expr_id);
+        pick.maybe_emit_unstable_name_collision_hint(self.tcx, span, expr_id);
 
         self.lint_fully_qualified_call_from_2018(
             span,

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -193,7 +193,7 @@ impl AutorefOrPtrAdjustment {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 pub struct Pick<'tcx> {
     pub item: ty::AssocItem,
     pub kind: PickKind<'tcx>,

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -298,7 +298,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     #[instrument(level = "debug", skip(self))]
     pub fn probe_for_name(
         &self,
-        span: Span,
         mode: Mode,
         item_name: Ident,
         is_suggestion: IsSuggestion,
@@ -307,7 +306,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         scope: ProbeScope,
     ) -> PickResult<'tcx> {
         self.probe_op(
-            span,
+            item_name.span,
             mode,
             Some(item_name),
             None,

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1331,7 +1331,8 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
 }
 
 impl<'tcx> Pick<'tcx> {
-    pub fn emit_unstable_name_collision_hint(
+    /// In case there were unstable name collisions, emit them as a lint.
+    pub fn maybe_emit_unstable_name_collision_hint(
         &self,
         tcx: TyCtxt<'tcx>,
         span: Span,


### PR DESCRIPTION
definitely review commit by commit.