### PR TITLE
Specify language of code comment to generate document

### DIFF
--- a/compiler/rustc_lint/src/let_underscore.rs
+++ b/compiler/rustc_lint/src/let_underscore.rs
@@ -11,7 +11,8 @@ declare_lint! {
     /// scope.
     ///
     /// ### Example
-    /// ```
+    ///
+    /// ```rust
     /// struct SomeStruct;
     /// impl Drop for SomeStruct {
     ///     fn drop(&mut self) {


### PR DESCRIPTION
Fix `let_underscore_drop` comment
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#example-7