### PR TITLE
Fix missing minification for static files

### DIFF
--- a/src/librustdoc/html/static_files.rs
+++ b/src/librustdoc/html/static_files.rs
@@ -19,9 +19,13 @@ impl StaticFile {
     }
 
     pub(crate) fn minified(&self) -> Vec<u8> {
-        if self.filename.ends_with(".css") {
+        let extension = match self.filename.extension() {
+            Some(e) => e,
+            None => return self.bytes.to_owned(),
+        };
+        if extension == "css" {
             minifier::css::minify(str::from_utf8(self.bytes).unwrap()).unwrap().to_string().into()
-        } else if self.filename.ends_with(".js") {
+        } else if extension == "js" {
             minifier::js::minify(str::from_utf8(self.bytes).unwrap()).to_string().into()
         } else {
             self.bytes.to_owned()


### PR DESCRIPTION
It's a fix for https://github.com/rust-lang/rust/pull/101702.

The problem was that `Path::ends_with` doesn't do what we thought it does: it checks if the entire item is the last path part, no just if the "path string" ends with the given argument. So instead, I just used the `extension()` method to get the information we want.

cc @jsha 
r? @notriddle 

PS: Is it worth it to add a CI test to ensure that the minification was performed on JS and CSS files or not?