### PR TITLE
linker: Preserve relative order of `-l` options, including dynamic libs

### DIFF
--- a/src/test/run-make-fulldeps/link-dedup/Makefile
+++ b/src/test/run-make-fulldeps/link-dedup/Makefile
@@ -6,7 +6,7 @@ all:
 	$(RUSTC) depa.rs
 	$(RUSTC) depb.rs
 	$(RUSTC) depc.rs
-	$(RUSTC) empty.rs --cfg bar 2>&1 | $(CGREP) '"-ltesta" "-ltestb" "-ltesta"'
+	$(RUSTC) empty.rs --cfg bar 2>&1 | $(CGREP) -e '"-ltesta".*"-ltestb".*"-ltesta"'
 	$(RUSTC) empty.rs 2>&1 | $(CGREP) '"-ltesta"'
 	$(RUSTC) empty.rs 2>&1 | $(CGREP) -v '"-ltestb"'
 	$(RUSTC) empty.rs 2>&1 | $(CGREP) -v '"-ltesta" "-ltesta" "-ltesta"'


### PR DESCRIPTION
Dynamic native libraries pulled through dependency crates are no longer linked last, they are now linked immediately after their corresponding crates, like other libraries.

The change is a part of RFC 2951 "Linking modifiers for native libraries" (https://github.com/rust-lang/rfcs/blob/master/text/2951-native-link-modifiers.md#relative-order-of--l-and--clink-args-options, https://github.com/rust-lang/rust/issues/99427).

Crater run with this change found some regressions, their analysis can be found in https://github.com/rust-lang/rust/pull/102832#issuecomment-1279772306.
There are 3 root regressions, in all cases crates depend on some native libraries, but do not declare that dependency.

This is a continuation of https://github.com/rust-lang/rust/pull/103311 and the second part of https://github.com/rust-lang/rust/pull/102832.
r? @bjorn3 

TODO:
- Add some test
- ~Create issues/PRs for the affected crates~ https://gitlab.com/taricorp/llvm-sys.rs/-/issues/41 https://github.com/blas-lapack-rs/lapacke-sys/issues/2 https://github.com/purpleprotocol/mimalloc_rust/issues/85