### PR TITLE
Make more `Result` methods `const`

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -128,6 +128,7 @@
 #![feature(const_ops)]
 #![feature(const_option)]
 #![feature(const_option_ext)]
+#![feature(const_result)]
 #![feature(const_pin)]
 #![feature(const_ptr_sub_ptr)]
 #![feature(const_replace)]


### PR DESCRIPTION
Tracking issue: #82814

Constified methods: Result::{map, map_or, map_or_else, map_err, as_deref, as_deref_mut, unwrap_or_default, and_then, or_else, unwrap_or_else, unwrap_unchecked, unwrap_err_unchecked, copied, cloned}