### PR TITLE
Fix test/ui/issues/issue-30490.rs

### DIFF
--- a/src/test/ui/issues/issue-30490.rs
+++ b/src/test/ui/issues/issue-30490.rs
@@ -10,7 +10,7 @@
 // This test checks to avoid that regression.
 
 #![cfg_attr(unix, feature(rustc_private))]
-#![cfg_attr(windows, allow(unused_imports))]
+#![cfg_attr(not(unix), allow(unused_imports))]
 
 #[cfg(unix)]
 extern crate libc;


### PR DESCRIPTION
Since the empty main is used for `not(unix)`, all the targets that will use this empty main will also need `allow(unused_imports)`.

Originally part of https://github.com/rust-lang/rust/pull/100316

Signed-off-by: Ayush Singh <ayushsingh1325@gmail.com>