### PR TITLE
rustdoc: remove no-op CSS `.popover { font-size: 1rem }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -920,7 +920,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 }
 
 .popover {
-	font-size: 1rem;
 	position: absolute;
 	right: 0;
 	z-index: 2;
@@ -928,7 +927,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	margin-top: 7px;
 	border-radius: 3px;
 	border: 1px solid var(--border-color);
-	font-size: 1rem;
 	--popover-arrow-offset: 11px;
 }
 

--- a/src/test/rustdoc-gui/help-page.goml
+++ b/src/test/rustdoc-gui/help-page.goml
@@ -3,6 +3,7 @@ goto: "file://" + |DOC_PATH| + "/help.html"
 size: (1000, 1000) // Try desktop size first.
 wait-for: "#help"
 assert-css: ("#help", {"display": "block"})
+assert-css: ("#help dd", {"font-size": "16px"})
 click: "#help-button > a"
 assert-css: ("#help", {"display": "block"})
 compare-elements-property: (".sub", "#help", ["offsetWidth"])
@@ -18,6 +19,7 @@ size: (1000, 1000) // Only supported on desktop.
 assert-false: "#help"
 click: "#help-button > a"
 assert-css: ("#help", {"display": "block"})
+assert-css: ("#help dd", {"font-size": "16px"})
 click: "#help-button > a"
 assert-css: ("#help", {"display": "none"})
 compare-elements-property-false: (".sub", "#help", ["offsetWidth"])


### PR DESCRIPTION
This rule was added in cc4f804829ae because the help popover inherited the font-size from the help button "?" icon.

It doesn't inherit this any more, because it was moved from being nested inside the link to sharing a wrapper DIV with it.