### PR TITLE
rustdoc: remove no-op CSS `.main-header { justify-content }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -159,7 +159,6 @@ h1.fqn {
 .main-heading {
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: space-between;
 	padding-bottom: 6px;
 	margin-bottom: 15px;
 }

--- a/src/test/rustdoc-gui/type-declation-overflow.goml
+++ b/src/test/rustdoc-gui/type-declation-overflow.goml
@@ -41,3 +41,20 @@ goto: "file://" + |DOC_PATH| + "/lib2/too_long/struct.SuperIncrediblyLongLongLon
 store-property: (scrollWidth, ".mobile-topbar h2", "scrollWidth")
 assert-property: (".mobile-topbar h2", {"clientWidth": |scrollWidth|})
 assert-css: (".mobile-topbar h2", {"overflow-x": "hidden"})
+
+// Check wrapping for top main-heading h1 and out-of-band.
+// On desktop, they wrap when too big.
+size: (1100, 800)
+goto: "file://" + |DOC_PATH| + "/lib2/too_long/struct.SuperIncrediblyLongLongLongLongLongLongLongGigaGigaGigaMegaLongLongLongStructName.html"
+compare-elements-position-false: (".main-heading h1", ".main-heading .out-of-band", ("y"))
+goto: "file://" + |DOC_PATH| + "/lib2/index.html"
+compare-elements-position: (".main-heading h1", ".main-heading .out-of-band", ("y"))
+// make sure there is a gap between them
+compare-elements-position-near-false: (".main-heading h1", ".main-heading .out-of-band", {"x": 550})
+
+// On mobile, they always wrap.
+size: (600, 600)
+goto: "file://" + |DOC_PATH| + "/lib2/too_long/struct.SuperIncrediblyLongLongLongLongLongLongLongGigaGigaGigaMegaLongLongLongStructName.html"
+compare-elements-position-false: (".main-heading h1", ".main-heading .out-of-band", ("y"))
+goto: "file://" + |DOC_PATH| + "/lib2/index.html"
+compare-elements-position-false: (".main-heading h1", ".main-heading .out-of-band", ("y"))


### PR DESCRIPTION
This rule was added in 152e8889052adaaa6c12652486292be34059713c to push the out-of-band content to the right while allowing it to line wrap when it got too big. The idea was that the justification rule would fill the space between the `<h1>` element and the `<div class="out-of-band">` element.

A later commit, 3cb03cb34247383ffb67a017ae70134741e8c4da, flattened the in-band element into the `<h1>`, copying the `flex-grow` rule. This means the `<h1>` element now grows to fill the space, so there's no need to justify-content any more.

This commit also adds a test case for this.