### PR TITLE
Enable profiler in dist-riscv64-linux

### DIFF
--- a/src/ci/docker/host-x86_64/dist-riscv64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-riscv64-linux/Dockerfile
@@ -27,5 +27,5 @@ ENV CC_riscv64gc_unknown_linux_gnu=riscv64-unknown-linux-gnu-gcc \
 
 ENV HOSTS=riscv64gc-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
+ENV RUST_CONFIGURE_ARGS --enable-extended --enable-profiler --disable-docs
 ENV SCRIPT python3 ../x.py dist --target $HOSTS --host $HOSTS


### PR DESCRIPTION
Build the profiler runtime to allow using -C profile-generate and -C instrument-coverage on riscv64-linux.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>