### PR TITLE
Special case repeating fieldless enum variants

### DIFF
--- a/compiler/rustc_borrowck/src/invalidation.rs
+++ b/compiler/rustc_borrowck/src/invalidation.rs
@@ -289,7 +289,7 @@ impl<'cx, 'tcx> InvalidationGenerator<'cx, 'tcx> {
             Rvalue::ThreadLocalRef(_) => {}
 
             Rvalue::Use(ref operand)
-            | Rvalue::Repeat(ref operand, _)
+            | Rvalue::Repeat(ref operand, _, _)
             | Rvalue::UnaryOp(_ /*un_op*/, ref operand)
             | Rvalue::Cast(_ /*cast_kind*/, ref operand, _ /*ty*/)
             | Rvalue::ShallowInitBox(ref operand, _ /*ty*/) => {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1233,7 +1233,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             Rvalue::ThreadLocalRef(_) => {}
 
             Rvalue::Use(ref operand)
-            | Rvalue::Repeat(ref operand, _)
+            | Rvalue::Repeat(ref operand, _, _)
             | Rvalue::UnaryOp(_ /*un_op*/, ref operand)
             | Rvalue::Cast(_ /*cast_kind*/, ref operand, _ /*ty*/)
             | Rvalue::ShallowInitBox(ref operand, _ /*ty*/) => {

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1854,7 +1854,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 self.check_aggregate_rvalue(&body, rvalue, ak, ops, location)
             }
 
-            Rvalue::Repeat(operand, len) => {
+            Rvalue::Repeat(operand, len, _) => {
                 self.check_operand(operand, location);
 
                 // If the length cannot be evaluated we must assume that the length can be larger

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(int_roundings)]
 #![feature(if_let_guard)]
 #![feature(never_type)]
+#![feature(let_chains)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]
 

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -207,7 +207,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 }
             }
 
-            Repeat(ref operand, _) => {
+            Repeat(ref operand, _, _) => {
                 let src = self.eval_operand(operand, None)?;
                 assert!(src.layout.is_sized());
                 let dest = self.force_allocation(&dest)?;

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -256,7 +256,7 @@ where
         Rvalue::CopyForDeref(place) => in_place::<Q, _>(cx, in_local, place.as_ref()),
 
         Rvalue::Use(operand)
-        | Rvalue::Repeat(operand, _)
+        | Rvalue::Repeat(operand, _, _)
         | Rvalue::UnaryOp(_, operand)
         | Rvalue::Cast(_, operand, _)
         | Rvalue::ShallowInitBox(operand, _) => in_operand::<Q, _>(cx, in_local, operand),

--- a/compiler/rustc_const_eval/src/transform/promote_consts.rs
+++ b/compiler/rustc_const_eval/src/transform/promote_consts.rs
@@ -487,7 +487,7 @@ impl<'tcx> Validator<'_, 'tcx> {
 
     fn validate_rvalue(&mut self, rvalue: &Rvalue<'tcx>) -> Result<(), Unpromotable> {
         match rvalue {
-            Rvalue::Use(operand) | Rvalue::Repeat(operand, _) => {
+            Rvalue::Use(operand) | Rvalue::Repeat(operand, _, _) => {
                 self.validate_operand(operand)?;
             }
             Rvalue::CopyForDeref(place) => {

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -591,7 +591,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                     }
                 }
             }
-            Rvalue::Repeat(_, _)
+            Rvalue::Repeat(_, _, _)
             | Rvalue::ThreadLocalRef(_)
             | Rvalue::AddressOf(_, _)
             | Rvalue::NullaryOp(_, _)

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1920,7 +1920,7 @@ impl<'tcx> Rvalue<'tcx> {
 
             Rvalue::Use(_)
             | Rvalue::CopyForDeref(_)
-            | Rvalue::Repeat(_, _)
+            | Rvalue::Repeat(_, _, _)
             | Rvalue::Ref(_, _, _)
             | Rvalue::ThreadLocalRef(_)
             | Rvalue::AddressOf(_, _)
@@ -1979,7 +1979,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
 
         match *self {
             Use(ref place) => write!(fmt, "{:?}", place),
-            Repeat(ref a, b) => {
+            Repeat(ref a, b, _) => {
                 write!(fmt, "[{:?}; ", a)?;
                 pretty_print_const(b, fmt, false)?;
                 write!(fmt, "]")

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -1004,10 +1004,13 @@ pub enum Rvalue<'tcx> {
     /// This is the cause of a bug in the case where the repetition count is zero because the value
     /// is not dropped, see [#74836].
     ///
+    /// The third param is true if the value we're repeating is an enum variant
+    /// with no fields so we can emit a memset.
+    ///
     /// Corresponds to source code like `[x; 32]`.
     ///
     /// [#74836]: https://github.com/rust-lang/rust/issues/74836
-    Repeat(Operand<'tcx>, ty::Const<'tcx>),
+    Repeat(Operand<'tcx>, ty::Const<'tcx>, bool),
 
     /// Creates a reference of the indicated kind to the place.
     ///

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -162,7 +162,7 @@ impl<'tcx> Rvalue<'tcx> {
     {
         match *self {
             Rvalue::Use(ref operand) => operand.ty(local_decls, tcx),
-            Rvalue::Repeat(ref operand, count) => {
+            Rvalue::Repeat(ref operand, count, _) => {
                 tcx.mk_ty(ty::Array(operand.ty(local_decls, tcx), count))
             }
             Rvalue::ThreadLocalRef(did) => {

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -627,7 +627,7 @@ macro_rules! make_mir_visitor {
                         self.visit_operand(operand, location);
                     }
 
-                    Rvalue::Repeat(value, _) => {
+                    Rvalue::Repeat(value, _, _) => {
                         self.visit_operand(value, location);
                     }
 

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -339,7 +339,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
         match *rvalue {
             Rvalue::ThreadLocalRef(_) => {} // not-a-move
             Rvalue::Use(ref operand)
-            | Rvalue::Repeat(ref operand, _)
+            | Rvalue::Repeat(ref operand, _, _)
             | Rvalue::Cast(_, ref operand, _)
             | Rvalue::ShallowInitBox(ref operand, _)
             | Rvalue::UnaryOp(_, ref operand) => self.gather_operand(operand),

--- a/compiler/rustc_mir_transform/src/separate_const_switch.rs
+++ b/compiler/rustc_mir_transform/src/separate_const_switch.rs
@@ -208,7 +208,7 @@ fn is_likely_const<'tcx>(mut tracked_place: Place<'tcx>, block: &BasicBlockData<
                         | Rvalue::UnaryOp(_, Operand::Constant(_)) => return true,
 
                         // These rvalues make things ambiguous
-                        Rvalue::Repeat(_, _)
+                        Rvalue::Repeat(_, _, _)
                         | Rvalue::ThreadLocalRef(_)
                         | Rvalue::Len(_)
                         | Rvalue::BinaryOp(_, _)
@@ -282,7 +282,7 @@ fn find_determining_place<'tcx>(
                     | Rvalue::UnaryOp(_, Operand::Copy(new) | Operand::Move(new))
                     | Rvalue::CopyForDeref(new)
                     | Rvalue::Cast(_, Operand::Move(new) | Operand::Copy(new), _)
-                    | Rvalue::Repeat(Operand::Move(new) | Operand::Copy(new), _)
+                    | Rvalue::Repeat(Operand::Move(new) | Operand::Copy(new), _, _)
                     | Rvalue::Discriminant(new)
                     => switch_place = new,
 
@@ -297,7 +297,7 @@ fn find_determining_place<'tcx>(
                     // The following rvalues definitely mean we cannot
                     // or should not apply this optimization
                     | Rvalue::Use(Operand::Constant(_))
-                    | Rvalue::Repeat(Operand::Constant(_), _)
+                    | Rvalue::Repeat(Operand::Constant(_), _, _)
                     | Rvalue::ThreadLocalRef(_)
                     | Rvalue::AddressOf(_, _)
                     | Rvalue::NullaryOp(_, _)

--- a/src/test/codegen/enum-repeat.rs
+++ b/src/test/codegen/enum-repeat.rs
@@ -1,0 +1,19 @@
+// compile-flags: -O
+
+#![crate_type = "lib"]
+
+// CHECK-LABEL: @none_repeat
+#[no_mangle]
+pub fn none_repeat() -> [Option<u8>; 64] {
+    // CHECK: call void @llvm.memset
+    // CHECK-NEXT: ret void
+    [None; 64]
+}
+
+// CHECK-LABEL: @some_repeat
+#[no_mangle]
+pub fn some_repeat() -> [Option<u8>; 64] {
+    // CHECK: call void @llvm.memset
+    // CHECK-NEXT: ret void
+    [Some(1); 64]
+}


### PR DESCRIPTION
Another approach to #104384

Add another field to `Rvalue::Repeat` specifying that the item being repeated is a fieldless enum variant so that it can be transformed to a memset.

r? @scottmcm 