### PR TITLE
rustdoc: remove unused JS IIFE from main.js

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -47,10 +47,8 @@ function blurHandler(event, parentElem, hideCallback) {
     }
 }
 
-(function() {
-    window.rootPath = getVar("root-path");
-    window.currentCrate = getVar("current-crate");
-}());
+window.rootPath = getVar("root-path");
+window.currentCrate = getVar("current-crate");
 
 function setMobileTopbar() {
     // FIXME: It would be nicer to generate this text content directly in HTML,


### PR DESCRIPTION
This [IIFE] made sense when it was added in f0683f98fa114cc4f9e795031f44be3eebb65790 and there was a local variable scoped to it, but now it only sets two globals, so it does nothing.

[IIFE]: https://developer.mozilla.org/en-US/docs/Glossary/IIFE "immediately invoked function expression"