### PR TITLE
rustdoc: remove pointless CSS `.rightside { padding-right: 2px }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1051,7 +1051,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 
 .rightside {
 	padding-left: 12px;
-	padding-right: 2px;
 	float: right;
 }
 


### PR DESCRIPTION
This CSS was added in 34bd2b845b3acd84c5a9bddae3ff8081c19ec5e9, as `.since { padding-right: 2px }`, to prevent it from uncomfortably touching the srclink, which were separate floated elements. It was carried forward with 962c0a4ee59e3c1a2413e785694c9433ffd0a9e1 to the new `.rightside`, but its role was replaced with adding " &bull; " between them. All it does now is pushes the element 2px away from the page's right margin.

Removing this rule changes the page layout, but you have to look for it to notice it.