### PR TITLE
rustdoc: remove no-op CSS `#crate-search-div { display: inline-block }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -803,7 +803,6 @@ table,
 	align-items: baseline;
 }
 #crate-search-div {
-	display: inline-block;
 	/* ensures that 100% in properties of #crate-search-div:after
 	are relative to the size of this div */
 	position: relative;


### PR DESCRIPTION
`#crate-search-div` is nested directly below `.search-results-title`, which has `display: inline-flex`. This makes the crate-search-div a [flex item], which makes its display property irrelevant, because flex items have their display [blockified] in any case.

[flex item]: https://developer.mozilla.org/en-US/docs/Glossary/Flex_Item
[blockified]: https://www.w3.org/TR/css-flexbox-1/#flex-items