### PR TITLE
Fix substraction with overflow in `wrong_number_of_generic_args.rs`

### DIFF
--- a/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
@@ -728,7 +728,8 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         && let Some(trait_path_segment) = path.segments.get(0) {
             let num_generic_args_supplied_to_trait = trait_path_segment.args().num_generic_params();
 
-            if num_assoc_fn_excess_args == num_trait_generics_except_self - num_generic_args_supplied_to_trait {
+            if num_generic_args_supplied_to_trait + num_assoc_fn_excess_args == num_trait_generics_except_self
+            {
                 if let Some(span) = self.gen_args.span_ext()
                 && let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
                     let sugg = vec![

--- a/src/test/ui/suggestions/issue-104287.rs
+++ b/src/test/ui/suggestions/issue-104287.rs
@@ -1,0 +1,9 @@
+// The purpose of this test is not to validate the output of the compiler.
+// Instead, it ensures the suggestion is generated without performing an arithmetic overflow.
+
+fn main() {
+    let x = not_found; //~ ERROR cannot find value `not_found` in this scope
+    simd_gt::<()>(x);
+    //~^ ERROR this associated function takes 0 generic arguments but 1 generic argument was supplied
+    //~| ERROR cannot find function `simd_gt` in this scope
+}

--- a/src/test/ui/suggestions/issue-104287.stderr
+++ b/src/test/ui/suggestions/issue-104287.stderr
@@ -1,0 +1,36 @@
+error[E0425]: cannot find value `not_found` in this scope
+  --> $DIR/issue-104287.rs:5:13
+   |
+LL |     let x = not_found;
+   |             ^^^^^^^^^ not found in this scope
+
+error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-104287.rs:6:5
+   |
+LL |     simd_gt::<()>(x);
+   |     ^^^^^^^------ help: remove these generics
+   |     |
+   |     expected 0 generic arguments
+   |
+note: associated function defined here, with 0 generic parameters
+  --> $SRC_DIR/core/src/../../portable-simd/crates/core_simd/src/ord.rs:LL:COL
+   |
+LL |     fn simd_gt(self, other: Self) -> Self::Mask;
+   |        ^^^^^^^
+
+error[E0425]: cannot find function `simd_gt` in this scope
+  --> $DIR/issue-104287.rs:6:5
+   |
+LL |     simd_gt::<()>(x);
+   |     ^^^^^^^ not found in this scope
+   |
+help: use the `.` operator to call the method `SimdPartialOrd::simd_gt` on `[type error]`
+   |
+LL -     simd_gt::<()>(x);
+LL +     x.simd_gt();
+   |
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0425.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
Fixes #104287

This issue happens in the `suggest_moving_args_from_assoc_fn_to_trait_for_qualified_path` function, which seems to run before the error checking facilities can catch an invalid use of generic arguments. Thus we get a subtraction with overflow because the code implicitly assumes that the source program makes sense (or is this assumption not true even if the program is correct?).