### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "curl",


### PR DESCRIPTION
5 commits in a3dfea71ca0c888a88111086898aa833c291d497..16b097879b6f117c8ae698aab054c87f26ff325e 2022-11-11 03:50:47 +0000 to 2022-11-14 23:28:16 +0000
- improve error message for cargo add/remove (rust-lang/cargo#11375)
- Bump crate versions of `cargo-util` and `crates-io` (rust-lang/cargo#11369)
- doc(changelog): suggestions of cargo fix are nightly only (rust-lang/cargo#11373)
- Add warning when PATH env separator is in project path (rust-lang/cargo#11318)
- Fix git2 safe-directory disable (rust-lang/cargo#11366)

r? @ghost