### PR TITLE
Don't duplicate last cdb debuginfo test command

### DIFF
--- a/src/test/debuginfo/function-names.rs
+++ b/src/test/debuginfo/function-names.rs
@@ -76,9 +76,9 @@
 // Const generic parameter
 // cdb-command:x a!function_names::const_generic_fn*
 // cdb-check:[...] a!function_names::const_generic_fn_bool<false> (void)
-// cdb-check:[...] a!function_names::const_generic_fn_non_int<CONST$6348c650c7b26618> (void)
 // cdb-check:[...] a!function_names::const_generic_fn_unsigned_int<14> (void)
 // cdb-check:[...] a!function_names::const_generic_fn_signed_int<-7> (void)
+// cdb-check:[...] a!function_names::const_generic_fn_non_int<CONST$6348c650c7b26618> (void)
 
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -711,7 +711,7 @@ impl<'test> TestCx<'test> {
             script_str.push_str("\n");
         }
 
-        script_str.push_str("\nqq\n"); // Quit the debugger (including remote debugger, if any)
+        script_str.push_str("qq\n"); // Quit the debugger (including remote debugger, if any)
 
         // Write the script into a file
         debug!("script_str = {}", script_str);


### PR DESCRIPTION
cdb scripts interpret a blank line to mean "repeat the last command", similar to what happens when running the debugger from a console. The code for compiletest that constructs the debugger script was inserting a blank line between the last command and the "quit" command. This caused the last command to be executed twice. This can cause some confusion since the `-check` lines are expecting the output in a certain order. But printing the last command twice causes that order-assumption to fail, and that can cause confusion.

This fixes it by removing the blank line.

AFAICT, gdb and lldb scripts don't have the same behavior with blank lines (and the gdb code doesn't add any blank lines anyways).
