### PR TITLE
Create parent directory if missing when copying shared assets

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -407,6 +407,10 @@ impl Step for SharedAssets {
                 .replace("VERSION", &builder.rust_release())
                 .replace("SHORT_HASH", builder.rust_info().sha_short().unwrap_or(""))
                 .replace("STAMP", builder.rust_info().sha().unwrap_or(""));
+
+            if let Some(parent) = version_info.parent() {
+                t!(std::fs::create_dir_all(parent));
+            }
             t!(fs::write(&version_info, &info));
         }
 


### PR DESCRIPTION
Not sure exactly why, but there are cases when running `./x dist` fails because the documentation directory is missing when copying the shared assets. This PR ensures we create the parent directory if missing when copying the shared assets.