### PR TITLE
update ntapi dep to remove future-incompat warning

### DIFF
--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
 dependencies = [
  "winapi",
 ]
@@ -607,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.24.2"
+version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2809487b962344ca55d9aea565f9ffbcb6929780802217acc82561f6746770"
+checksum = "c375d5fd899e32847b8566e10598d6e9f1d9b55ec6de3cdf9e7da4bdc51371bc"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -54,7 +54,7 @@ xz2 = "0.1"
 walkdir = "2"
 
 # Dependencies needed by the build-metrics feature
-sysinfo = { version = "0.24.1", optional = true }
+sysinfo = { version = "0.26.0", optional = true }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/src/bootstrap/metrics.rs
+++ b/src/bootstrap/metrics.rs
@@ -97,7 +97,7 @@ impl BuildMetrics {
             cpu_threads_count: system.cpus().len(),
             cpu_model: system.cpus()[0].brand().into(),
 
-            memory_total_bytes: system.total_memory() * 1024,
+            memory_total_bytes: system.total_memory(),
         };
         let steps = std::mem::take(&mut state.finished_steps);
 


### PR DESCRIPTION
This fixes warning https://github.com/rust-lang-ci/rust/actions/runs/3477235400/jobs/5813202075#step:25:217
`warning: the following packages contain code that will be rejected by a future version of Rust: ntapi v0.3.7`

by upgrading `sysinfo` version (https://github.com/GuillaumeGomez/sysinfo/blob/master/CHANGELOG.md#0267)

There was some breaking changes in `sysinfo`:
* 0.25.0 (System::refresh_cpu behaviour changed: it only computes CPU usage and doesn't retrieve CPU frequency.) not affected?
* 0.26.0 (Switch memory unit from kilobytes to bytes) fixed.