### PR TITLE
rustdoc: remove redundant font-color CSS on `.where`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -217,10 +217,7 @@ h1 a,
 .search-results a,
 .module-item .stab,
 .import-item .stab,
-.result-name .primitive > i, .result-name .keyword > i,
-.method .where,
-.fn .where,
-.where.fmt-newline {
+.result-name .primitive > i, .result-name .keyword > i {
 	color: var(--main-color);
 }
 


### PR DESCRIPTION
Before 7f6ce7dddd49f453da15bb4d586a5990985814d8, light-theme where clauses had color `#4E4C4C` while the main color was `#000`. One of that commit's simplifications made it so that everything used the same black.