### PR TITLE
Check `dyn*` return type correctly

### DIFF
--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -100,7 +100,7 @@ pub(super) fn check_fn<'a, 'tcx>(
 
     inherited.typeck_results.borrow_mut().liberated_fn_sigs_mut().insert(fn_id, fn_sig);
 
-    if let ty::Dynamic(..) = declared_ret_ty.kind() {
+    if let ty::Dynamic(_, _, ty::Dyn) = declared_ret_ty.kind() {
         // FIXME: We need to verify that the return type is `Sized` after the return expression has
         // been evaluated so that we have types available for all the nodes being returned, but that
         // requires the coerced evaluated type to be stored. Moving `check_return_expr` before this

--- a/src/test/ui/dyn-star/return.rs
+++ b/src/test/ui/dyn-star/return.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+#![feature(dyn_star)]
+//~^ WARN the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+
+fn _foo() -> dyn* Unpin {
+    4usize
+}
+
+fn main() {}

--- a/src/test/ui/dyn-star/return.stderr
+++ b/src/test/ui/dyn-star/return.stderr
@@ -1,0 +1,11 @@
+warning: the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/return.rs:3:12
+   |
+LL | #![feature(dyn_star)]
+   |            ^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
In `check_fn`, if the declared return type is `dyn Trait`, then we check the return type separately to produce better diagnostics, because this is never valid -- however, when `dyn*` was introduced, this check was never adjusted to only account for *unsized* `dyn Trait` and not *sized* `dyn* Trait`.

Fixes #104501