### PR TITLE
rustdoc: clean up sidebar width CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -387,8 +387,7 @@ img {
 
 .sidebar {
 	font-size: 0.875rem;
-	width: 200px;
-	min-width: 200px;
+	flex: 0 0 200px;
 	overflow-y: scroll;
 	position: sticky;
 	height: 100vh;
@@ -397,12 +396,7 @@ img {
 }
 
 .rustdoc.source .sidebar {
-	width: 50px;
-	min-width: 0px;
-	max-width: 300px;
-	flex-grow: 0;
-	flex-shrink: 0;
-	flex-basis: auto;
+	flex-basis: 50px;
 	border-right: 1px solid;
 	overflow-x: hidden;
 	/* The sidebar is by default hidden  */
@@ -423,7 +417,7 @@ img {
 
 .source-sidebar-expanded .source .sidebar {
 	overflow-y: auto;
-	width: 300px;
+	flex-basis: 300px;
 }
 
 .source-sidebar-expanded .source .sidebar > *:not(#sidebar-toggle) {
@@ -1702,6 +1696,7 @@ in storage.js
 		z-index: 11;
 		/* Reduce height slightly to account for mobile topbar. */
 		height: calc(100vh - 45px);
+		width: 200px;
 	}
 
 	/* The source view uses a different design for the sidebar toggle, and doesn't have a topbar,


### PR DESCRIPTION
This commit takes advantage of the ability to set [flex-basis] to a specific length instead of setting it to `auto` and changing min-/max-width, and setting flex-grow/-shrink both to 0.

This PR should not cause any visual changes.

preview: https://notriddle.com/notriddle-rustdoc-demos/flex-basis-sidebar-width/std/index.html

[flex-basis]: https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis
