### PR TITLE
Implement current_exe for AIX

### DIFF
--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -497,12 +497,9 @@ pub fn current_exe() -> io::Result<PathBuf> {
     if let Some(p) = getenv(OsStr::from_bytes("PATH".as_bytes())) {
         for search_path in split_paths(&p) {
             let pb = search_path.join(&path);
-            if pb.is_file() && let Ok(metadata) = crate::fs::metadata(&pb) {
-                if metadata.permissions().mode() & 0o111 != 0 {
-                    return pb.canonicalize();
-                }
-            } else {
-                continue;
+            if pb.is_file() && let Ok(metadata) = crate::fs::metadata(&pb) &&
+               metadata.permissions().mode() & 0o111 != 0 {
+                return pb.canonicalize();
             }
         }
     }

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -471,7 +471,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
     if !path.is_absolute() { getcwd().map(|cwd| cwd.join(path)) } else { Ok(path) }
 }
 
-#[cfg(target_os) = "aix")]
+#[cfg(target_os = "aix")]
 pub fn current_exe() -> io::Result<PathBuf> {
     use crate::io::ErrorKind;
 

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -451,7 +451,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
     super::unsupported::unsupported()
 }
 
-#[cfg(target_os = "fuchsia", target_os = "aix")]
+#[cfg(any(target_os = "fuchsia", target_os = "aix"))]
 pub fn current_exe() -> io::Result<PathBuf> {
     use crate::io::ErrorKind;
 
@@ -469,7 +469,11 @@ pub fn current_exe() -> io::Result<PathBuf> {
 
     // Prepend the current working directory to the path if it's not absolute.
     if cfg!(target_os = "fuchsia") {
-        if !path.is_absolute() { getcwd().map(|cwd| cwd.join(path)) } else { Ok(path) }
+        if !path.is_absolute() {
+            return getcwd().map(|cwd| cwd.join(path));
+        } else {
+            return Ok(path);
+        }
     }
 
     if path.is_absolute() {


### PR DESCRIPTION
Added `current_exe` implementation for AIX. This implementation doesn't rely on system specific syscalls, I guess some other targets can also use it.