### PR TITLE
try_normalize_after_erasing_regions: promote an assertion to always run

### DIFF
--- a/compiler/rustc_traits/src/normalize_erasing_regions.rs
+++ b/compiler/rustc_traits/src/normalize_erasing_regions.rs
@@ -34,7 +34,9 @@ fn try_normalize_after_erasing_regions<'tcx, T: TypeFoldable<'tcx> + PartialEq +
             // We don't care about the `obligations`; they are
             // always only region relations, and we are about to
             // erase those anyway:
-            debug_assert_eq!(
+            // This has been seen to fail in RL, so making it a non-debug assertion to better catch
+            // those cases.
+            assert_eq!(
                 normalized_obligations.iter().find(|p| not_outlives_predicate(p.predicate)),
                 None,
             );


### PR DESCRIPTION
In https://github.com/rust-lang/miri/issues/2433 this assertion has been seen to trigger, so it might be worth actually checking this? Regressing debug assertions are very easy to miss until much later, and then they become quite hard to debug.