### PR TITLE
Don't use periods in target names

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1244,8 +1244,8 @@ supported_targets! {
 
     ("mips64-openwrt-linux-musl", mips64_openwrt_linux_musl),
 
-    ("aarch64-unknown-nto-qnx7.1.0", aarch64_unknown_nto_qnx_710),
-    ("x86_64-pc-nto-qnx7.1.0", x86_64_pc_nto_qnx710),
+    ("aarch64-unknown-nto-qnx710", aarch64_unknown_nto_qnx_710),
+    ("x86_64-pc-nto-qnx710", x86_64_pc_nto_qnx710),
 }
 
 /// Cow-Vec-Str: Cow<'static, [Cow<'static, str>]>

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -214,7 +214,7 @@ target | std | host | notes
 [`aarch64-kmc-solid_asp3`](platform-support/kmc-solid.md) | ✓ |  | ARM64 SOLID with TOPPERS/ASP3
 [`aarch64-nintendo-switch-freestanding`](platform-support/aarch64-nintendo-switch-freestanding.md) | * |  | ARM64 Nintendo Switch, Horizon
 [`aarch64-pc-windows-gnullvm`](platform-support/pc-windows-gnullvm.md) | ✓ | ✓ |
-[`aarch64-unknown-nto-qnx7.1.0`](platform-support/nto-qnx.md) | ? |  | ARM64 QNX Neutrino 7.1 RTOS |
+[`aarch64-unknown-nto-qnx710`](platform-support/nto-qnx.md) | ? |  | ARM64 QNX Neutrino 7.1 RTOS |
 `aarch64-unknown-freebsd` | ✓ | ✓ | ARM64 FreeBSD
 `aarch64-unknown-hermit` | ✓ |  | ARM64 HermitCore
 `aarch64-unknown-linux-gnu_ilp32` | ✓ | ✓ | ARM64 Linux (ILP32 ABI)
@@ -304,7 +304,7 @@ target | std | host | notes
 `x86_64-apple-ios-macabi` | ✓ |  | Apple Catalyst on x86_64
 `x86_64-apple-tvos` | * | | x86 64-bit tvOS
 [`x86_64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ | | x86 64-bit Apple WatchOS simulator
-[`x86_64-pc-nto-qnx7.1.0`](platform-support/nto-qnx.md) | ? |  | x86 64-bit QNX Neutrino 7.1 RTOS |
+[`x86_64-pc-nto-qnx710`](platform-support/nto-qnx.md) | ? |  | x86 64-bit QNX Neutrino 7.1 RTOS |
 [`x86_64-pc-windows-gnullvm`](platform-support/pc-windows-gnullvm.md) | ✓ | ✓ |
 `x86_64-pc-windows-msvc` | * |  | 64-bit Windows XP support
 `x86_64-sun-solaris` | ? |  | Deprecated target for 64-bit Solaris 10/11, illumos

--- a/src/doc/rustc/src/platform-support/nto-qnx.md
+++ b/src/doc/rustc/src/platform-support/nto-qnx.md
@@ -93,15 +93,15 @@ Run the following:
 
 ```bash
 env \
-    CC_aarch64-unknown-nto-qnx7.1.0="qcc" \
-    CFLAGS_aarch64-unknown-nto-qnx7.1.0="-Vgcc_ntoaarch64le_cxx" \
-    CXX_aarch64-unknown-nto-qnx7.1.0="qcc" \
-    AR_aarch64_unknown_nto_qnx7.1.0="ntoaarch64-ar" \
-    CC_x86_64-pc-nto-qnx7.1.0="qcc" \
-    CFLAGS_x86_64-pc-nto-qnx7.1.0="-Vgcc_ntox86_64_cxx" \
-    CXX_x86_64-pc-nto-qnx7.1.0="qcc" \
-    AR_x86_64_pc_nto_qnx7.1.0="ntox86_64-ar" \
-        ./x.py build --target aarch64-unknown-nto-qnx7.1.0 --target x86_64-pc-nto-qnx7.1.0 --target x86_64-unknown-linux-gnu rustc library/core library/alloc/
+    CC_aarch64-unknown-nto-qnx710="qcc" \
+    CFLAGS_aarch64-unknown-nto-qnx710="-Vgcc_ntoaarch64le_cxx" \
+    CXX_aarch64-unknown-nto-qnx710="qcc" \
+    AR_aarch64_unknown_nto_qnx710="ntoaarch64-ar" \
+    CC_x86_64-pc-nto-qnx710="qcc" \
+    CFLAGS_x86_64-pc-nto-qnx710="-Vgcc_ntox86_64_cxx" \
+    CXX_x86_64-pc-nto-qnx710="qcc" \
+    AR_x86_64_pc_nto_qnx710="ntox86_64-ar" \
+        ./x.py build --target aarch64-unknown-nto-qnx710 --target x86_64-pc-nto-qnx710 --target x86_64-unknown-linux-gnu rustc library/core library/alloc/
 ```
 
 ## Building Rust programs

--- a/src/doc/rustc/src/target-tier-policy.md
+++ b/src/doc/rustc/src/target-tier-policy.md
@@ -158,6 +158,8 @@ approved by the appropriate team for that shared code before acceptance.
     the name of the target makes people extremely likely to form incorrect
     beliefs about what it targets, the name should be changed or augmented to
     disambiguate it.
+  - If possible, use only letters, numbers, dashes and underscores for the name.
+    Periods (`.`) are known to cause issues in Cargo.
 - Tier 3 targets may have unusual requirements to build or use, but must not
   create legal issues or impose onerous legal terms for the Rust project or for
   Rust developers or users.

--- a/src/tools/tier-check/src/main.rs
+++ b/src/tools/tier-check/src/main.rs
@@ -44,7 +44,23 @@ fn main() {
             target, filename, src
         );
     }
-    if !missing.is_empty() || !extra.is_empty() {
+    // Check target names for unwanted characters like `.` that can cause problems e.g. in Cargo.
+    // See also Tier 3 target policy.
+    // If desired, target names can ignore this check.
+    let ignore_target_names =
+        vec!["thumbv8m.base-none-eabi", "thumbv8m.main-none-eabi", "thumbv8m.main-none-eabihf"];
+    let mut invalid_target_name_found = false;
+    for target in &target_list {
+        if !ignore_target_names.contains(target)
+            && !target.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            invalid_target_name_found = true;
+            eprintln!(
+                "error: Target name `{target}` contains other characters than ASCII alphanumeric (a-z, A-Z, 0-9), dash (-) or underscore (_)."
+            );
+        }
+    }
+    if !missing.is_empty() || !extra.is_empty() || invalid_target_name_found {
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
Using a period in the target name can cause issues in e.g. cargo, see also https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Running.20tests.20on.20remote.20target