### PR TITLE
Optimize format_args placeholders without options: Display::simple_fmt

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -996,6 +996,7 @@ symbols! {
         new_lower_hex,
         new_octal,
         new_pointer,
+        new_simple_display,
         new_unchecked,
         new_upper_exp,
         new_upper_hex,

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -145,6 +145,7 @@
 #![feature(receiver_trait)]
 #![feature(saturating_int_impl)]
 #![feature(set_ptr_value)]
+#![feature(simple_fmt)]
 #![feature(sized_type_properties)]
 #![feature(slice_from_ptr_range)]
 #![feature(slice_group_by)]

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2261,6 +2261,10 @@ impl fmt::Display for String {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
+    #[inline]
+    fn simple_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&**self)
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/tools/miri/tests/fail/panic/double_panic.stderr
+++ b/src/tools/miri/tests/fail/panic/double_panic.stderr
@@ -12,57 +12,59 @@ stack backtrace:
  at RUSTLIB/std/src/sys_common/backtrace.rs:LL:CC
    4: <std::sys_common::backtrace::_print::DisplayBacktrace as std::fmt::Display>::fmt
  at RUSTLIB/std/src/sys_common/backtrace.rs:LL:CC
-   5: std::fmt::write
+   5: <std::sys_common::backtrace::_print::DisplayBacktrace as std::fmt::Display>::simple_fmt
  at RUSTLIB/core/src/fmt/mod.rs:LL:CC
-   6: <std::sys::PLATFORM::stdio::Stderr as std::io::Write>::write_fmt
+   6: std::fmt::write
+ at RUSTLIB/core/src/fmt/mod.rs:LL:CC
+   7: <std::sys::PLATFORM::stdio::Stderr as std::io::Write>::write_fmt
  at RUSTLIB/std/src/io/mod.rs:LL:CC
-   7: std::sys_common::backtrace::_print
+   8: std::sys_common::backtrace::_print
  at RUSTLIB/std/src/sys_common/backtrace.rs:LL:CC
-   8: std::sys_common::backtrace::print
+   9: std::sys_common::backtrace::print
  at RUSTLIB/std/src/sys_common/backtrace.rs:LL:CC
-   9: std::panicking::default_hook::{closure#1}
+  10: std::panicking::default_hook::{closure#1}
  at RUSTLIB/std/src/panicking.rs:LL:CC
-  10: std::panicking::default_hook
+  11: std::panicking::default_hook
  at RUSTLIB/std/src/panicking.rs:LL:CC
-  11: std::panicking::rust_panic_with_hook
+  12: std::panicking::rust_panic_with_hook
  at RUSTLIB/std/src/panicking.rs:LL:CC
-  12: std::rt::begin_panic::{closure#0}
+  13: std::rt::begin_panic::{closure#0}
  at RUSTLIB/std/src/panicking.rs:LL:CC
-  13: std::sys_common::backtrace::__rust_end_short_backtrace
+  14: std::sys_common::backtrace::__rust_end_short_backtrace
  at RUSTLIB/std/src/sys_common/backtrace.rs:LL:CC
-  14: std::rt::begin_panic
+  15: std::rt::begin_panic
  at RUSTLIB/std/src/panicking.rs:LL:CC
-  15: <Foo as std::ops::Drop>::drop
+  16: <Foo as std::ops::Drop>::drop
  at $DIR/double_panic.rs:LL:CC
-  16: std::ptr::drop_in_place - shim(Some(Foo))
+  17: std::ptr::drop_in_place - shim(Some(Foo))
  at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-  17: main
+  18: main
  at $DIR/double_panic.rs:LL:CC
-  18: <fn() as std::ops::FnOnce<()>>::call_once - shim(fn())
+  19: <fn() as std::ops::FnOnce<()>>::call_once - shim(fn())
  at RUSTLIB/core/src/ops/function.rs:LL:CC
-  19: std::sys_common::backtrace::__rust_begin_short_backtrace
+  20: std::sys_common::backtrace::__rust_begin_short_backtrace
  at RUSTLIB/std/src/sys_common/backtrace.rs:LL:CC
-  20: std::rt::lang_start::{closure#0}
+  21: std::rt::lang_start::{closure#0}
  at RUSTLIB/std/src/rt.rs:LL:CC
-  21: std::ops::function::impls::call_once
+  22: std::ops::function::impls::call_once
  at RUSTLIB/core/src/ops/function.rs:LL:CC
-  22: std::panicking::r#try::do_call
+  23: std::panicking::r#try::do_call
  at RUSTLIB/std/src/panicking.rs:LL:CC
-  23: std::panicking::r#try
+  24: std::panicking::r#try
  at RUSTLIB/std/src/panicking.rs:LL:CC
-  24: std::panic::catch_unwind
+  25: std::panic::catch_unwind
  at RUSTLIB/std/src/panic.rs:LL:CC
-  25: std::rt::lang_start_internal::{closure#2}
+  26: std::rt::lang_start_internal::{closure#2}
  at RUSTLIB/std/src/rt.rs:LL:CC
-  26: std::panicking::r#try::do_call
+  27: std::panicking::r#try::do_call
  at RUSTLIB/std/src/panicking.rs:LL:CC
-  27: std::panicking::r#try
+  28: std::panicking::r#try
  at RUSTLIB/std/src/panicking.rs:LL:CC
-  28: std::panic::catch_unwind
+  29: std::panic::catch_unwind
  at RUSTLIB/std/src/panic.rs:LL:CC
-  29: std::rt::lang_start_internal
+  30: std::rt::lang_start_internal
  at RUSTLIB/std/src/rt.rs:LL:CC
-  30: std::rt::lang_start
+  31: std::rt::lang_start
  at RUSTLIB/std/src/rt.rs:LL:CC
 thread panicked while panicking. aborting.
 error: abnormal termination: the program aborted execution

--- a/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
@@ -113,11 +113,11 @@
           StorageLive(_22);                // scope 4 at $DIR/lifetimes.rs:+10:20: +10:23
           _22 = &_8;                       // scope 4 at $DIR/lifetimes.rs:+10:20: +10:23
           _21 = &(*_22);                   // scope 4 at $DIR/lifetimes.rs:+10:20: +10:23
-          _20 = core::fmt::ArgumentV1::<'_>::new_display::<Box<dyn std::fmt::Display>>(move _21) -> [return: bb3, unwind unreachable]; // scope 4 at $DIR/lifetimes.rs:+10:20: +10:23
+          _20 = core::fmt::ArgumentV1::<'_>::new_simple_display::<Box<dyn std::fmt::Display>>(move _21) -> [return: bb3, unwind unreachable]; // scope 4 at $DIR/lifetimes.rs:+10:20: +10:23
                                            // mir::Constant
                                            // + span: $DIR/lifetimes.rs:27:20: 27:23
                                            // + user_ty: UserType(4)
-                                           // + literal: Const { ty: for<'b> fn(&'b Box<dyn std::fmt::Display>) -> core::fmt::ArgumentV1<'b> {core::fmt::ArgumentV1::<'_>::new_display::<Box<dyn std::fmt::Display>>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: fn(&Box<dyn std::fmt::Display>) -> core::fmt::ArgumentV1<'_> {core::fmt::ArgumentV1::<'_>::new_simple_display::<Box<dyn std::fmt::Display>>}, val: Value(<ZST>) }
       }
   
       bb3: {
@@ -127,11 +127,11 @@
           StorageLive(_25);                // scope 4 at $DIR/lifetimes.rs:+10:24: +10:27
           _25 = &_6;                       // scope 4 at $DIR/lifetimes.rs:+10:24: +10:27
           _24 = &(*_25);                   // scope 4 at $DIR/lifetimes.rs:+10:24: +10:27
-          _23 = core::fmt::ArgumentV1::<'_>::new_display::<u32>(move _24) -> [return: bb4, unwind unreachable]; // scope 4 at $DIR/lifetimes.rs:+10:24: +10:27
+          _23 = core::fmt::ArgumentV1::<'_>::new_simple_display::<u32>(move _24) -> [return: bb4, unwind unreachable]; // scope 4 at $DIR/lifetimes.rs:+10:24: +10:27
                                            // mir::Constant
                                            // + span: $DIR/lifetimes.rs:27:24: 27:27
                                            // + user_ty: UserType(5)
-                                           // + literal: Const { ty: for<'b> fn(&'b u32) -> core::fmt::ArgumentV1<'b> {core::fmt::ArgumentV1::<'_>::new_display::<u32>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: fn(&u32) -> core::fmt::ArgumentV1<'_> {core::fmt::ArgumentV1::<'_>::new_simple_display::<u32>}, val: Value(<ZST>) }
       }
   
       bb4: {

--- a/tests/ui/unpretty/flattened-format-args.stdout
+++ b/tests/ui/unpretty/flattened-format-args.stdout
@@ -11,6 +11,6 @@ fn main() {
         {
                 ::std::io::_print(<#[lang = "format_arguments"]>::new_v1(&["a 123 b ",
                                     " xyz\n"],
-                        &[<#[lang = "format_argument"]>::new_display(&x)]));
+                        &[<#[lang = "format_argument"]>::new_simple_display(&x)]));
             };
     }


### PR DESCRIPTION
This is part of #99012

`format_args!("{}", "hello")` pulls in the entire `Display for str` implementation, which includes the code necessary to support formatting options like padding (e.g. `"{:50^}"`, etc.), which is quite unnecessary for the basic case of formatting with no options (`"{}"`).

This adds a new method to the format trait: `Display::simple_fmt`. It is implemented by forwarding to the regular `Display::fmt` method, but is overridden in the `Display` impl of `String` and `str` to just call `write_str` directly, avoiding pulling in any code related to padding.