### PR TITLE
Provide a better error and a suggestion for `Fn` traits with lifetime params

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2423,7 +2423,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses the parameter list of a function, including the `(` and `)` delimiters.
-    fn parse_fn_params(&mut self, req_name: ReqName) -> PResult<'a, Vec<Param>> {
+    pub(super) fn parse_fn_params(&mut self, req_name: ReqName) -> PResult<'a, Vec<Param>> {
         let mut first_param = true;
         // Parse the arguments, starting out with `self` being allowed...
         let (mut params, _) = self.parse_paren_comma_seq(|p| {

--- a/src/test/ui/higher-rank-trait-bounds/hrtb-malformed-lifetime-generics.rs
+++ b/src/test/ui/higher-rank-trait-bounds/hrtb-malformed-lifetime-generics.rs
@@ -1,0 +1,20 @@
+// Test that Fn-family traits with lifetime parameters shouldn't compile and
+// we suggest the usage of higher-rank trait bounds instead.
+
+fn fa(_: impl Fn<'a>(&'a str) -> bool) {}
+//~^ ERROR `Fn` traits cannot take lifetime parameters
+
+fn fb(_: impl FnMut<'a, 'b>(&'a str, &'b str) -> bool) {}
+//~^ ERROR `Fn` traits cannot take lifetime parameters
+
+fn fc(_: impl std::fmt::Display + FnOnce<'a>(&'a str) -> bool + std::fmt::Debug) {}
+//~^ ERROR `Fn` traits cannot take lifetime parameters
+
+use std::ops::Fn as AliasedFn;
+fn fd(_: impl AliasedFn<'a>(&'a str) -> bool) {}
+//~^ ERROR `Fn` traits cannot take lifetime parameters
+
+fn fe<F>(_: F) where F: Fn<'a>(&'a str) -> bool {}
+//~^ ERROR `Fn` traits cannot take lifetime parameters
+
+fn main() {}

--- a/src/test/ui/higher-rank-trait-bounds/hrtb-malformed-lifetime-generics.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/hrtb-malformed-lifetime-generics.stderr
@@ -1,0 +1,62 @@
+error: `Fn` traits cannot take lifetime parameters
+  --> $DIR/hrtb-malformed-lifetime-generics.rs:4:17
+   |
+LL | fn fa(_: impl Fn<'a>(&'a str) -> bool) {}
+   |                 ^^^^
+   |
+help: consider using a higher-ranked trait bound instead
+   |
+LL - fn fa(_: impl Fn<'a>(&'a str) -> bool) {}
+LL + fn fa(_: impl for<'a> Fn(&'a str) -> bool) {}
+   |
+
+error: `Fn` traits cannot take lifetime parameters
+  --> $DIR/hrtb-malformed-lifetime-generics.rs:7:20
+   |
+LL | fn fb(_: impl FnMut<'a, 'b>(&'a str, &'b str) -> bool) {}
+   |                    ^^^^^^^^
+   |
+help: consider using a higher-ranked trait bound instead
+   |
+LL - fn fb(_: impl FnMut<'a, 'b>(&'a str, &'b str) -> bool) {}
+LL + fn fb(_: impl for<'a, 'b> FnMut(&'a str, &'b str) -> bool) {}
+   |
+
+error: `Fn` traits cannot take lifetime parameters
+  --> $DIR/hrtb-malformed-lifetime-generics.rs:10:41
+   |
+LL | fn fc(_: impl std::fmt::Display + FnOnce<'a>(&'a str) -> bool + std::fmt::Debug) {}
+   |                                         ^^^^
+   |
+help: consider using a higher-ranked trait bound instead
+   |
+LL - fn fc(_: impl std::fmt::Display + FnOnce<'a>(&'a str) -> bool + std::fmt::Debug) {}
+LL + fn fc(_: impl std::fmt::Display + for<'a> FnOnce(&'a str) -> bool + std::fmt::Debug) {}
+   |
+
+error: `Fn` traits cannot take lifetime parameters
+  --> $DIR/hrtb-malformed-lifetime-generics.rs:14:24
+   |
+LL | fn fd(_: impl AliasedFn<'a>(&'a str) -> bool) {}
+   |                        ^^^^
+   |
+help: consider using a higher-ranked trait bound instead
+   |
+LL - fn fd(_: impl AliasedFn<'a>(&'a str) -> bool) {}
+LL + fn fd(_: impl for<'a> AliasedFn(&'a str) -> bool) {}
+   |
+
+error: `Fn` traits cannot take lifetime parameters
+  --> $DIR/hrtb-malformed-lifetime-generics.rs:17:27
+   |
+LL | fn fe<F>(_: F) where F: Fn<'a>(&'a str) -> bool {}
+   |                           ^^^^
+   |
+help: consider using a higher-ranked trait bound instead
+   |
+LL - fn fe<F>(_: F) where F: Fn<'a>(&'a str) -> bool {}
+LL + fn fe<F>(_: F) where F: for<'a> Fn(&'a str) -> bool {}
+   |
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
Given `Fn`-family traits with lifetime params in trait bounds like `fn f(_: impl Fn<'a>(&'a str) -> bool)`, we currently produce many unhelpful errors.

This PR allows these situations to suggest simply using Higher-Rank Trait Bounds like `for<'a> Fn(&'a str) -> bool`.

Fixes https://github.com/rust-lang/rust/issues/103490.