### PR TITLE
[perf] Put a span into `TyCtxt`

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1017,6 +1017,7 @@ pub struct FreeRegionInfo {
 #[rustc_pass_by_value]
 pub struct TyCtxt<'tcx> {
     gcx: &'tcx GlobalCtxt<'tcx>,
+    pub span: Span,
 }
 
 impl<'tcx> Deref for TyCtxt<'tcx> {
@@ -1830,6 +1831,7 @@ pub mod tls {
     use crate::ty::query;
     use rustc_data_structures::sync::{self, Lock};
     use rustc_errors::Diagnostic;
+    use rustc_span::DUMMY_SP;
     use std::mem;
     use thin_vec::ThinVec;
 
@@ -1867,7 +1869,7 @@ pub mod tls {
 
     impl<'a, 'tcx> ImplicitCtxt<'a, 'tcx> {
         pub fn new(gcx: &'tcx GlobalCtxt<'tcx>) -> Self {
-            let tcx = TyCtxt { gcx };
+            let tcx = TyCtxt { gcx, span: DUMMY_SP };
             ImplicitCtxt {
                 tcx,
                 query: None,

--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -94,7 +94,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Returns a transparent wrapper for `TyCtxt` which uses
     /// `span` as the location of queries performed through it.
     #[inline(always)]
-    pub fn at(self, span: Span) -> TyCtxtAt<'tcx> {
+    pub fn at(mut self, span: Span) -> TyCtxtAt<'tcx> {
         self.span = span;
         TyCtxtAt { tcx: self }
     }

--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -68,7 +68,6 @@ use rustc_query_system::query::*;
 #[derive(Copy, Clone)]
 pub struct TyCtxtAt<'tcx> {
     pub tcx: TyCtxt<'tcx>,
-    pub span: Span,
 }
 
 impl<'tcx> Deref for TyCtxtAt<'tcx> {
@@ -96,7 +95,8 @@ impl<'tcx> TyCtxt<'tcx> {
     /// `span` as the location of queries performed through it.
     #[inline(always)]
     pub fn at(self, span: Span) -> TyCtxtAt<'tcx> {
-        TyCtxtAt { tcx: self, span }
+        self.span = span;
+        TyCtxtAt { tcx: self }
     }
 
     pub fn try_mark_green(self, dep_node: &dep_graph::DepNode) -> bool {


### PR DESCRIPTION
Getting rid of `TyCtxtAt` would be quite nice, but putting a `Span` into `TyCtxt` might regress perf - this PR checks that.

r? @ghost