### PR TITLE
Add simple markdown formatting to `rustc --explain` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3675,6 +3675,7 @@ name = "rustc_errors"
 version = "0.0.0"
 dependencies = [
  "annotate-snippets",
+ "regex",
  "rustc_ast",
  "rustc_ast_pretty",
  "rustc_data_structures",

--- a/compiler/rustc_errors/Cargo.toml
+++ b/compiler/rustc_errors/Cargo.toml
@@ -23,6 +23,7 @@ annotate-snippets = "0.9"
 termize = "0.1.1"
 serde = { version = "1.0.125", features = [ "derive" ] }
 serde_json = "1.0.59"
+regex = "1.5"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = [ "handleapi", "synchapi", "winbase" ] }

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(adt_const_params)]
 #![feature(let_chains)]
 #![feature(never_type)]
+#![feature(once_cell)]
 #![feature(result_option_inspect)]
 #![feature(rustc_attrs)]
 #![allow(incomplete_features)]
@@ -56,6 +57,7 @@ mod diagnostic_impls;
 pub mod emitter;
 pub mod json;
 mod lock;
+pub mod markdown;
 pub mod registry;
 mod snippet;
 mod styled_buffer;

--- a/compiler/rustc_errors/src/markdown.rs
+++ b/compiler/rustc_errors/src/markdown.rs
@@ -1,0 +1,455 @@
+//! A very minimal markdown parser
+//!
+//! Use the entrypoint `create_ast(&str) -> MdTree` to generate the AST.
+#![warn(clippy::pedantic)]
+#![warn(clippy::nursery)]
+
+use regex::bytes::Regex;
+use std::cmp::min;
+use std::io::Error;
+use std::io::Write;
+use std::str::{self, from_utf8};
+use std::sync::LazyLock;
+use termcolor::{Buffer, BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
+
+const NEWLINE_CHARS: &[u8; 2] = b"\r\n";
+const PUNCT_CHARS: &[u8; 8] = br#".,"'\;:?"#;
+
+/// Representation of how to match various markdown types
+const PATTERNS: [MdPattern; 10] = [
+    MdPattern::new(Anchor::Any("<!--"), Anchor::Any("-->"), MdType::Comment),
+    MdPattern::new(Anchor::Sol("```"), Anchor::Sol("```"), MdType::CodeBlock),
+    MdPattern::new(Anchor::Sol("# "), Anchor::Eol(""), MdType::Heading1),
+    MdPattern::new(Anchor::Sol("## "), Anchor::Eol(""), MdType::Heading2),
+    MdPattern::new(Anchor::Sol("### "), Anchor::Eol(""), MdType::Heading3),
+    MdPattern::new(Anchor::Sol("#### "), Anchor::Eol(""), MdType::Heading4),
+    MdPattern::new(Anchor::LeadWs("`"), Anchor::TrailWs("`"), MdType::CodeInline),
+    MdPattern::new(Anchor::LeadWs("**"), Anchor::TrailWs("**"), MdType::Strong),
+    MdPattern::new(Anchor::LeadWs("_"), Anchor::TrailWs("_"), MdType::Emphasis),
+    MdPattern::new(Anchor::Sol("-"), Anchor::Eol(""), MdType::ListItem),
+    // MdPattern::new(Anchor::Any("\n\n"),Anchor::Any(""))
+    // strikethrough
+];
+
+/// This is an example for using doc comment attributes
+static RE_URL_NAMED: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+    r"(?P<pre_ws>^|\s|[[:punct:]])\[(?P<display>.+)\]\((?P<url>\S+)\)(?P<post_ws>$|\s|[[:punct:]])"
+).unwrap()
+});
+static RE_URL: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?P<pre_ws>^|\s|[[:punct:]])<(?P<url>\S+)>(?P<post_ws>$|\s|[[:punct:]])").unwrap()
+});
+
+/// An AST representation of a Markdown document
+#[derive(Debug, PartialEq, Clone)]
+pub enum MdTree<'a> {
+    /// Leaf types
+    Comment(&'a str),
+    CodeBlock(&'a str),
+    CodeInline(&'a str),
+    Strong(&'a str),
+    Emphasis(&'a str),
+    PlainText(&'a str),
+    /// Nexting types
+    Heading1(Vec<MdTree<'a>>),
+    Heading2(Vec<MdTree<'a>>),
+    Heading3(Vec<MdTree<'a>>),
+    Heading4(Vec<MdTree<'a>>),
+    ListItem(Vec<MdTree<'a>>),
+    /// Root node
+    Root(Vec<MdTree<'a>>),
+}
+
+impl<'a> MdTree<'a> {
+    /// Create a `MdTree` from a string and a specified type
+    fn from_type(s: &'a str, tag: MdType) -> Self {
+        match tag {
+            MdType::Comment => Self::Comment(s),
+            MdType::CodeBlock => Self::CodeBlock(s),
+            MdType::CodeInline => Self::CodeInline(s),
+            MdType::Strong => Self::Strong(s),
+            MdType::Emphasis => Self::Emphasis(s),
+            MdType::Heading1 => Self::Heading1(vec![MdTree::PlainText(s)]),
+            MdType::Heading2 => Self::Heading2(vec![MdTree::PlainText(s)]),
+            MdType::Heading3 => Self::Heading3(vec![MdTree::PlainText(s)]),
+            MdType::Heading4 => Self::Heading4(vec![MdTree::PlainText(s)]),
+            MdType::ListItem => Self::ListItem(vec![MdTree::PlainText(s)]),
+        }
+    }
+
+    /// Print to terminal output, resetting to the default style after each
+    fn term_print_vec(
+        v: &Vec<Self>,
+        buf: &mut Buffer,
+        default: Option<&ColorSpec>,
+        is_firstline: &mut bool,
+    ) -> Result<(), Error> {
+        match default {
+            Some(c) => buf.set_color(c)?,
+            None => buf.reset()?,
+        }
+
+        for item in v {
+            item.term_write_recurse(buf, is_firstline)?;
+            if let Some(c) = default {
+                buf.set_color(c)?;
+            }
+        }
+
+        buf.reset()?;
+        Ok(())
+    }
+
+    fn term_write_recurse(&self, buf: &mut Buffer, is_firstline: &mut bool) -> Result<(), Error> {
+        match self {
+            // Do nothing
+            MdTree::Comment(_) => (),
+            MdTree::CodeBlock(s) => {
+                buf.set_color(ColorSpec::new().set_dimmed(true))?;
+                write_if_not_first(buf, "\n", is_firstline)?;
+                // Account for "```rust\n..." starts of strings
+                if !s.starts_with('\n') {
+                    write!(buf, "{}\n", s.split('\n').nth(1).unwrap_or(s).trim())?;
+                } else {
+                    write!(buf, "{}\n", s.trim())?;
+                }
+            }
+            MdTree::CodeInline(s) => {
+                buf.set_color(ColorSpec::new().set_dimmed(true))?;
+                write!(buf, "{s}")?;
+            }
+            MdTree::Strong(s) => {
+                buf.set_color(ColorSpec::new().set_bold(true))?;
+                buf.write(&write_replace(s))?;
+            }
+            MdTree::Emphasis(s) => {
+                buf.set_color(ColorSpec::new().set_italic(true))?;
+                buf.write(&write_replace(s))?;
+            }
+            MdTree::Heading1(v) => {
+                write_if_not_first(buf, "\n", is_firstline)?;
+                Self::term_print_vec(
+                    v,
+                    buf,
+                    Some(
+                        ColorSpec::new()
+                            .set_fg(Some(Color::Cyan))
+                            .set_intense(true)
+                            .set_bold(true)
+                            .set_underline(true),
+                    ),
+                    is_firstline,
+                )?;
+            }
+            MdTree::Heading2(v) => {
+                write_if_not_first(buf, "\n", is_firstline)?;
+                Self::term_print_vec(
+                    v,
+                    buf,
+                    Some(
+                        ColorSpec::new()
+                            .set_fg(Some(Color::Cyan))
+                            .set_intense(true)
+                            .set_underline(true),
+                    ),
+                    is_firstline,
+                )?;
+            }
+            MdTree::Heading3(v) => {
+                Self::term_print_vec(
+                    v,
+                    buf,
+                    Some(
+                        ColorSpec::new()
+                            .set_fg(Some(Color::Cyan))
+                            .set_intense(true)
+                            .set_italic(true),
+                    ),
+                    is_firstline,
+                )?;
+            }
+            MdTree::Heading4(v) => {
+                Self::term_print_vec(
+                    v,
+                    buf,
+                    Some(
+                        ColorSpec::new()
+                            .set_fg(Some(Color::Cyan))
+                            .set_underline(true)
+                            .set_italic(true),
+                    ),
+                    is_firstline,
+                )?;
+            }
+            MdTree::ListItem(v) => {
+                write!(buf, "* ")?;
+                Self::term_print_vec(v, buf, None, is_firstline)?;
+            }
+            MdTree::Root(v) => Self::term_print_vec(v, buf, None, is_firstline)?,
+            MdTree::PlainText(s) => {
+                buf.write(&write_replace(s))?;
+            }
+        }
+
+        buf.reset()?;
+        Ok(())
+    }
+
+    pub fn write_termcolor_buf(&self, buf: &mut Buffer) {
+        let _ = self.term_write_recurse(buf, &mut true);
+    }
+}
+
+/// Grumble grumble workaround for not being able to `as` cast mixed field enums
+#[derive(Debug, PartialEq, Copy, Clone)]
+enum MdType {
+    Comment,
+    CodeBlock,
+    CodeInline,
+    Heading1,
+    Heading2,
+    Heading3,
+    Heading4,
+    Strong,
+    Emphasis,
+    ListItem,
+}
+
+/// A representation of the requirements to match a pattern
+#[derive(Debug, PartialEq, Clone)]
+enum Anchor {
+    /// Start of line
+    Sol(&'static str),
+    /// End of line
+    Eol(&'static str),
+    /// Preceded by whitespace
+    LeadWs(&'static str),
+    /// Precedes whitespace OR punctuation
+    TrailWs(&'static str),
+    /// Plain pattern matching
+    Any(&'static str),
+}
+
+impl Anchor {
+    /// Get any inner value
+    const fn unwrap(&self) -> &str {
+        match self {
+            Self::Sol(s) | Self::Eol(s) | Self::LeadWs(s) | Self::TrailWs(s) | Self::Any(s) => s,
+        }
+    }
+}
+
+/// Context used for pattern matching
+#[derive(Debug, PartialEq, Clone)]
+struct Context {
+    at_line_start: bool,
+    preceded_by_ws: bool,
+}
+
+/// A simple markdown type
+#[derive(Debug, PartialEq, Clone)]
+struct MdPattern {
+    start: Anchor,
+    end: Anchor,
+    tag: MdType,
+}
+
+/// Return matched data and leftover data
+#[derive(Debug, PartialEq, Clone)]
+struct MdResult<'a> {
+    matched: MdTree<'a>,
+    residual: &'a [u8],
+}
+
+impl MdPattern {
+    const fn new(start: Anchor, end: Anchor, tag: MdType) -> Self {
+        Self { start, end, tag }
+    }
+
+    /// Given a string like `match]residual`, return `match` and `residual` within `MdResult`
+    fn parse_end<'a>(&self, bytes: &'a [u8], ctx: &Context) -> MdResult<'a> {
+        let mut i = 0usize;
+        let mut at_line_start: bool; // whether this index is the start of a line
+        let mut next_at_line_start = ctx.at_line_start;
+        let anchor = &self.end;
+        let pat_end = anchor.unwrap().as_bytes();
+
+        while i < bytes.len() {
+            let working = &bytes[i..];
+            at_line_start = next_at_line_start;
+            next_at_line_start = NEWLINE_CHARS.contains(&working[0]);
+
+            if !working.starts_with(pat_end) {
+                i += 1;
+                continue;
+            }
+
+            // Our pattern matches. Just break if there is no remaining
+            // string
+            let residual = &working[pat_end.len()..];
+
+            let Some(next_byte) = residual.first()  else {
+                break
+            };
+
+            // Validate postconditions if we have a remaining string
+            let is_matched = match anchor {
+                Anchor::TrailWs(_) => {
+                    next_byte.is_ascii_whitespace() | PUNCT_CHARS.contains(next_byte)
+                }
+                Anchor::Eol(_) => NEWLINE_CHARS.contains(next_byte),
+                Anchor::Sol(_) => at_line_start,
+                Anchor::Any(_) => true,
+                Anchor::LeadWs(_) => panic!("unexpected end pattern"),
+            };
+
+            if is_matched {
+                break;
+            }
+            i += 1;
+        }
+
+        let matched = MdTree::from_type(from_utf8(&bytes[..i]).unwrap(), self.tag);
+        let residual = &bytes[min(bytes.len(), i + pat_end.len())..];
+
+        MdResult { matched, residual }
+    }
+
+    /// Given a string like `[match]residual`, return `MdTree(match)` and `residual`
+    ///
+    /// Return `None` if the string does not start with the correct pattern
+    fn parse_start<'a>(&self, bytes: &'a [u8], ctx: &Context) -> Option<MdResult<'a>> {
+        // Guard for strings that do not match
+        if !ctx.at_line_start && matches!(self.start, Anchor::Sol(_)) {
+            return None;
+        }
+        if !ctx.preceded_by_ws && matches!(self.start, Anchor::LeadWs(_)) {
+            return None;
+        }
+
+        // Return if we don't start with the pattern
+        let pat_start = self.start.unwrap().as_bytes();
+        if !bytes.starts_with(pat_start) {
+            return None;
+        }
+
+        // We have a match, parse to the closing delimiter
+        let residual = &bytes[pat_start.len()..];
+        Some(self.parse_end(residual, ctx))
+    }
+}
+
+/// Apply `recurse_tree` to each element in a vector
+fn recurse_vec<'a>(v: Vec<MdTree<'a>>) -> Vec<MdTree<'a>> {
+    v.into_iter().flat_map(recurse_tree).collect()
+}
+
+/// Given a `MdTree`, expand all children
+fn recurse_tree<'a>(tree: MdTree<'a>) -> Vec<MdTree<'a>> {
+    match tree {
+        // Leaf nodes; just add
+        MdTree::Comment(_)
+        | MdTree::CodeBlock(_)
+        | MdTree::CodeInline(_)
+        | MdTree::Strong(_)
+        | MdTree::Emphasis(_) => vec![tree],
+        // Leaf node with possible further expansion
+        MdTree::PlainText(s) => parse_str(s),
+        // Parent nodes; recurse these and add
+        MdTree::Heading1(v) => vec![MdTree::Heading1(recurse_vec(v))],
+        MdTree::Heading2(v) => vec![MdTree::Heading2(recurse_vec(v))],
+        MdTree::Heading3(v) => vec![MdTree::Heading3(recurse_vec(v))],
+        MdTree::Heading4(v) => vec![MdTree::Heading4(recurse_vec(v))],
+        MdTree::ListItem(v) => vec![MdTree::ListItem(recurse_vec(v))],
+        MdTree::Root(v) => vec![MdTree::Root(recurse_vec(v))],
+    }
+}
+
+/// Main parser function for a single string
+fn parse_str<'a>(s: &'a str) -> Vec<MdTree<'a>> {
+    let mut v: Vec<MdTree<'_>> = Vec::new();
+    let mut ctx = Context { at_line_start: true, preceded_by_ws: true };
+    let mut next_ctx = ctx.clone();
+    let mut working = s.as_bytes();
+    let mut i = 0;
+
+    while i < working.len() {
+        let test_slice = &working[i..];
+        let current_char = test_slice.first().unwrap();
+
+        ctx = next_ctx.clone();
+        next_ctx.at_line_start = NEWLINE_CHARS.contains(current_char);
+        next_ctx.preceded_by_ws = current_char.is_ascii_whitespace();
+
+        let found = PATTERNS.iter().find_map(|p| p.parse_start(&working[i..], &ctx));
+
+        let Some(res) = found else {
+            i += 1;
+            continue;
+        };
+
+        if i > 0 {
+            v.push(MdTree::PlainText(from_utf8(&working[..i]).unwrap()));
+        }
+        v.append(&mut recurse_tree(res.matched));
+        working = res.residual;
+        i = 0;
+    }
+
+    if i > 0 {
+        v.push(MdTree::PlainText(from_utf8(&working[..i]).unwrap()));
+    }
+
+    v
+}
+
+#[must_use]
+pub fn create_ast<'a>(s: &'a str) -> MdTree<'a> {
+    MdTree::Root(parse_str(s))
+}
+
+fn write_replace(s: &str) -> Vec<u8> {
+    const REPLACEMENTS: [(&str, &str); 7] = [
+        ("(c)", "©"),
+        ("(C)", "©"),
+        ("(r)", "®"),
+        ("(R)", "®"),
+        ("(tm)", "™"),
+        ("(TM)", "™"),
+        (":crab:", "🦀"),
+    ];
+
+    let mut ret = s.to_owned();
+    for (from, to) in REPLACEMENTS {
+        ret = ret.replace(from, to);
+    }
+
+    let tmp = RE_URL_NAMED.replace_all(
+        ret.as_bytes(),
+        b"${pre_ws}\x1b]8;;${url}\x1b\\${display}\x1b]8;;\x1b\\${post_ws}".as_slice(),
+    );
+    RE_URL
+        .replace_all(
+            &tmp,
+            b"${pre_ws}\x1b]8;;${url}\x1b\\${url}\x1b]8;;\x1b\\${post_ws}".as_slice(),
+        )
+        .to_vec()
+}
+
+/// Write something to the buf if some first indicator is false, then set the indicator false
+fn write_if_not_first(buf: &mut Buffer, s: &str, is_firstline: &mut bool) -> Result<(), Error> {
+    if *is_firstline {
+        *is_firstline = false;
+    } else {
+        write!(buf, "{s}")?;
+    }
+    Ok(())
+}
+
+pub fn create_stdout_bufwtr() -> BufferWriter {
+    BufferWriter::stdout(ColorChoice::Always)
+}
+
+#[cfg(test)]
+mod tests;

--- a/compiler/rustc_errors/src/markdown/tests.rs
+++ b/compiler/rustc_errors/src/markdown/tests.rs
@@ -149,7 +149,7 @@ fn expected_ast() -> MdTree<'static> {
         MdTree::PlainText("\n"),
         MdTree::Strong("more start of line"),
         MdTree::PlainText("\n\n"),
-        MdTree::CodeBlock("\ntry two of everything\n"),
+        MdTree::CodeBlock("rust\ntry two of everything\n"),
         MdTree::PlainText("\n"),
         MdTree::Comment("\n  another\n  comment "),
         MdTree::PlainText("\n"),

--- a/compiler/rustc_errors/src/markdown/tests.rs
+++ b/compiler/rustc_errors/src/markdown/tests.rs
@@ -1,0 +1,163 @@
+use super::*;
+
+#[test]
+fn test_comment() {
+    const TAG: MdType = MdType::Comment;
+    let pat = PATTERNS.iter().find(|p| p.tag == TAG).unwrap();
+    let ctx = Context { at_line_start: true, preceded_by_ws: true };
+
+    let input = b"none<!--none-->residual";
+    assert_eq!(
+        pat.parse_end(input, &ctx),
+        MdResult { matched: MdTree::Comment("none<!--none"), residual: b"residual" }
+    );
+    assert_eq!(pat.parse_start(input, &ctx), None);
+
+    let input = b"<!--comment\n-->residual";
+    let expected = MdResult { matched: MdTree::Comment("comment\n"), residual: b"residual" };
+    assert_eq!(pat.parse_start(input, &ctx), Some(expected));
+}
+
+#[test]
+fn test_code_block() {
+    const TAG: MdType = MdType::CodeBlock;
+    let pat = PATTERNS.iter().find(|p| p.tag == TAG).unwrap();
+    let ctx = Context { at_line_start: true, preceded_by_ws: true };
+
+    let input = b"none\n```\nblock\n```";
+    let end_expected =
+        MdResult { matched: MdTree::from_type("none\n", TAG), residual: b"\nblock\n```" };
+    assert_eq!(pat.parse_end(input, &ctx), end_expected);
+    assert_eq!(pat.parse_start(input, &ctx), None);
+
+    let input = b"```\nblock\nof\ncode\n```residual";
+    let expected =
+        MdResult { matched: MdTree::from_type("\nblock\nof\ncode\n", TAG), residual: b"residual" };
+    assert_eq!(pat.parse_start(input, &ctx), Some(expected));
+
+    let ctx = Context { at_line_start: false, preceded_by_ws: true };
+    assert_eq!(pat.parse_start(input, &ctx), None);
+}
+
+#[test]
+fn test_headings() {
+    const TAG: MdType = MdType::Heading1;
+    let pat = PATTERNS.iter().find(|p| p.tag == TAG).unwrap();
+    let ctx = Context { at_line_start: true, preceded_by_ws: true };
+
+    let input = b"content\nresidual";
+    let end_expected = MdResult {
+        // Only match if whitespace comes after
+        matched: MdTree::from_type("content", TAG),
+        residual: b"\nresidual",
+    };
+    assert_eq!(pat.parse_end(input, &ctx), end_expected);
+    assert_eq!(pat.parse_start(input, &ctx), None);
+
+    let input = b"# content\nresidual";
+    let expected = MdResult { matched: MdTree::from_type("content", TAG), residual: b"\nresidual" };
+    assert_eq!(pat.parse_start(input, &ctx), Some(expected));
+
+    let ctx = Context { at_line_start: false, preceded_by_ws: true };
+    assert_eq!(pat.parse_start(input, &ctx), None);
+}
+
+#[test]
+fn test_code_inline() {
+    const TAG: MdType = MdType::CodeInline;
+    let pat = PATTERNS.iter().find(|p| p.tag == TAG).unwrap();
+    let ctx = Context { at_line_start: false, preceded_by_ws: true };
+
+    let input = b"none `block` residual";
+    let end_expected = MdResult {
+        // Only match if whitespace comes after
+        matched: MdTree::from_type("none `block", TAG),
+        residual: b" residual",
+    };
+    assert_eq!(pat.parse_end(input, &ctx), end_expected);
+    assert_eq!(pat.parse_start(input, &ctx), None);
+
+    let input = b"`block` residual";
+    let expected = MdResult { matched: MdTree::from_type("block", TAG), residual: b" residual" };
+    assert_eq!(pat.parse_start(input, &ctx), Some(expected));
+
+    let ctx = Context { at_line_start: false, preceded_by_ws: false };
+    assert_eq!(pat.parse_start(input, &ctx), None);
+}
+
+const MD_INPUT: &str = r#"# Headding 1
+
+Some `inline code`
+
+```
+code block here;
+more code;
+```
+
+<!-- I should disappear -->
+Further `inline`, some **bold**, a bit of _italics
+wrapped across lines_.
+
+Let's end with a list:
+
+- Item 1 _italics_ example
+- Item 2 **bold**
+
+## Heading 2: Other things for `code`
+
+_start of line_
+**more start of line**
+
+```rust
+try two of everything
+```
+<!--
+  another
+  comment -->
+"#;
+
+fn expected_ast() -> MdTree<'static> {
+    MdTree::Root(vec![
+        MdTree::Heading1(vec![MdTree::PlainText("Headding 1")]),
+        MdTree::PlainText("\n\nSome "),
+        MdTree::CodeInline("inline code"),
+        MdTree::PlainText("\n\n"),
+        MdTree::CodeBlock("\ncode block here;\nmore code;\n"),
+        MdTree::PlainText("\n\n"),
+        MdTree::Comment(" I should disappear "),
+        MdTree::PlainText("\nFurther "),
+        MdTree::CodeInline("inline"),
+        MdTree::PlainText(", some "),
+        MdTree::Strong("bold"),
+        MdTree::PlainText(", a bit of "),
+        MdTree::Emphasis("italics\nwrapped across lines"),
+        MdTree::PlainText(".\n\nLet's end with a list:\n\n"),
+        MdTree::ListItem(vec![
+            MdTree::PlainText(" Item 1 "),
+            MdTree::Emphasis("italics"),
+            MdTree::PlainText(" example"),
+        ]),
+        MdTree::PlainText("\n"),
+        MdTree::ListItem(vec![MdTree::PlainText(" Item 2 "), MdTree::Strong("bold")]),
+        MdTree::PlainText("\n\n"),
+        MdTree::Heading2(vec![
+            MdTree::PlainText("Heading 2: Other things for "),
+            MdTree::CodeInline("code"),
+        ]),
+        MdTree::PlainText("\n\n"),
+        MdTree::Emphasis("start of line"),
+        MdTree::PlainText("\n"),
+        MdTree::Strong("more start of line"),
+        MdTree::PlainText("\n\n"),
+        MdTree::CodeBlock("\ntry two of everything\n"),
+        MdTree::PlainText("\n"),
+        MdTree::Comment("\n  another\n  comment "),
+        MdTree::PlainText("\n"),
+    ])
+}
+
+#[test]
+fn test_tree() {
+    let result = create_ast(MD_INPUT);
+    assert_eq!(result, expected_ast());
+}


### PR DESCRIPTION
The goal here is to provide some sort of super basic markdown formatting to `rustc --explain` output when available. This is a minimal alternative to #63128 without additiional dependencies.

There's a lot of tweaking to do but I'm creating this draft PR because I could use some guidance on things like:

- [x] What crate does this belong in? Currently it's in `rustc_driver` because that's where `handle_explain` is called, but it might make sense in `rustc_errors` which currently does some output formatting
- [ ] Should this tie in with `WritableDst` in `rustc_errors/src/emitter.rs`? It seems like this is used to indicate TTY-ness, but I can't find it in use anywhere
- [ ] What is the correct way to figure out if this is a TTY?

Currently, the output just displays raw markdown. This works of course, but it really doesn't look very elegant. (output is `rustc --explain E0038`)

<img width="583" alt="image" src="https://github.com/rust-lang/rust/assets/13724985/ea418117-47af-455b-83c0-6fc59276efee">

After this patch, sample output from the same file:

<img width="693" alt="image" src="https://github.com/rust-lang/rust/assets/13724985/12f7bf9b-a3fe-4104-b74b-c3e5227f3de9">
