### PR TITLE
Readd the matches_macro diag item

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -893,6 +893,7 @@ symbols! {
         masked,
         match_beginning_vert,
         match_default_bindings,
+        matches_macro,
         maxnumf32,
         maxnumf64,
         may_dangle,

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -338,6 +338,7 @@ pub macro debug_assert_matches($($arg:tt)*) {
 /// ```
 #[macro_export]
 #[stable(feature = "matches_macro", since = "1.42.0")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "matches_macro")]
 macro_rules! matches {
     ($expression:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {
         match $expression {


### PR DESCRIPTION
This is now used by Clippy

r? @compiler-errors

This was removed in #104383. But in the meantime Clippy now makes use of it https://github.com/rust-lang/rust-clippy/blob/dac600e32fce89cb4b05ae6edb0c47982b99eb48/clippy_lints/src/manual_is_ascii_check.rs#L153

--- 

This is blocking the Clippy sync. (kinda. I could work around it, but I don't want to play ping-pong with this change.)