### PR TITLE
warn newer available version of the x tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5310,7 +5310,6 @@ dependencies = [
  "miropt-test-tools",
  "regex",
  "semver",
- "serde_json",
  "termcolor",
  "walkdir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4814,9 +4814,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -4833,9 +4833,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4853,9 +4853,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "indexmap",
  "itoa",
@@ -5133,9 +5133,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5310,6 +5310,7 @@ dependencies = [
  "miropt-test-tools",
  "regex",
  "semver",
+ "serde_json",
  "termcolor",
  "walkdir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4805,9 +4805,9 @@ checksum = "1ef965a420fe14fdac7dd018862966a4c14094f900e1650bbc71ddd7d580c8af"
 
 [[package]]
 name = "semver"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 dependencies = [
  "serde",
 ]
@@ -5309,6 +5309,7 @@ dependencies = [
  "lazy_static",
  "miropt-test-tools",
  "regex",
+ "semver",
  "termcolor",
  "walkdir",
 ]

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -934,7 +934,6 @@ def main():
     if len(sys.argv) > 1 and sys.argv[1] == 'help':
         sys.argv = [sys.argv[0], '-h'] + sys.argv[2:]
 
-    # help_triggered = ('-h' in sys.argv) or ('--help' in sys.argv) or (len(sys.argv) == 1)
     help_triggered = len(sys.argv) == 1 or any(x in ["-h", "--help", "--version"] for x in sys.argv)
     try:
         bootstrap(help_triggered)

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -934,8 +934,8 @@ def main():
     if len(sys.argv) > 1 and sys.argv[1] == 'help':
         sys.argv = [sys.argv[0], '-h'] + sys.argv[2:]
 
-    help_triggered = (
-        '-h' in sys.argv) or ('--help' in sys.argv) or (len(sys.argv) == 1)
+    # help_triggered = ('-h' in sys.argv) or ('--help' in sys.argv) or (len(sys.argv) == 1)
+    help_triggered = len(sys.argv) == 1 or any(x in ["-h", "--help", "--version"] for x in sys.argv)
     try:
         bootstrap(help_triggered)
         if not help_triggered:

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -11,6 +11,7 @@ miropt-test-tools = { path = "../miropt-test-tools" }
 lazy_static = "1"
 walkdir = "2"
 ignore = "0.4.18"
+semver = "1.0.14"
 termcolor = "1.1.3"
 
 [[bin]]

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -12,6 +12,7 @@ lazy_static = "1"
 walkdir = "2"
 ignore = "0.4.18"
 semver = "1.0.14"
+serde_json = "1.0.91"
 termcolor = "1.1.3"
 
 [[bin]]

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -12,7 +12,6 @@ lazy_static = "1"
 walkdir = "2"
 ignore = "0.4.18"
 semver = "1.0.14"
-serde_json = "1.0.91"
 termcolor = "1.1.3"
 
 [[bin]]

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -69,4 +69,4 @@ pub mod ui_tests;
 pub mod unit_tests;
 pub mod unstable_book;
 pub mod walk;
-pub mod x;
+pub mod x_version;

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -69,3 +69,4 @@ pub mod ui_tests;
 pub mod unit_tests;
 pub mod unstable_book;
 pub mod walk;
+pub mod x;

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -107,7 +107,7 @@ fn main() {
         check!(alphabetical, &compiler_path);
         check!(alphabetical, &library_path);
 
-        check!(x_version);
+        check!(x_version, &root_path, &cargo);
 
         let collected = {
             drain_handles(&mut handles);

--- a/src/tools/tidy/src/x.rs
+++ b/src/tools/tidy/src/x.rs
@@ -1,0 +1,19 @@
+use std::process::Command;
+
+pub fn check(_bad: &mut bool) {
+    let result = Command::new("x")
+        .arg("--version")
+        .output();
+    let output = match result {
+        Ok(output) => output,
+        Err(_e) => todo!(),
+    };
+
+    if output.status.success() {
+        let version = String::from_utf8_lossy(&output.stdout);
+        assert_eq!("0.1.0", version.trim_end());
+    }
+    // FIXME: throw some kind of tidy error when the version of x isn't
+    // greater than or equal to the version we'd expect.
+    //tidy_error!(bad, "Current version of x is {version} Consider updating to the newer version of x by running `cargo install --path src/tools/x`")
+}

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -4,7 +4,7 @@ use std::process::{Command, Stdio};
 
 pub fn check(bad: &mut bool) {
     let result = Command::new("x").arg("--wrapper-version").stdout(Stdio::piped()).spawn();
-    // This runs the command inside a temporarily directory.
+    // This runs the command inside a temporary directory.
     // This allows us to compare output of result to see if `--wrapper-version` is not a recognized argument to x.
     let temp_result = Command::new("x")
         .arg("--wrapper-version")

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -58,6 +58,7 @@ fn get_x_wrapper_version(root: &Path, cargo: &Path) -> Option<Version> {
     let mut cmd = cargo_metadata::MetadataCommand::new();
     cmd.cargo_path(cargo)
         .manifest_path(root.join("src/tools/x/Cargo.toml"))
+        .no_deps()
         .features(cargo_metadata::CargoOpt::AllFeatures);
     let mut metadata = t!(cmd.exec());
     metadata.packages.pop().map(|x| x.version)

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -3,14 +3,11 @@ use std::io::ErrorKind;
 use std::process::{Command, Stdio};
 
 pub fn check(bad: &mut bool) {
-    let result = Command::new("x")
-        .arg("--version")
-        .stdout(Stdio::piped())
-        .spawn();
+    let result = Command::new("x").arg("--version").stdout(Stdio::piped()).spawn();
     let child = match result {
         Ok(child) => child,
         Err(e) => match e.kind() {
-            ErrorKind::NotFound => return (),
+            ErrorKind::NotFound => return,
             _ => return tidy_error!(bad, "{}", e),
         },
     };
@@ -28,7 +25,10 @@ pub fn check(bad: &mut bool) {
             build: BuildMetadata::EMPTY,
         };
         if version < expected {
-            return tidy_error!(bad, "Current version of x is {version} Consider updating to the newer version of x by running `cargo install --path src/tools/x`");
+            return tidy_error!(
+                bad,
+                "Current version of x is {version} Consider updating to the newer version of x by running `cargo install --path src/tools/x`"
+            );
         }
     } else {
         return tidy_error!(bad, "{}", output.status);

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -1,17 +1,36 @@
-use std::process::Command;
+use semver::{BuildMetadata, Prerelease, Version};
+use std::io::ErrorKind;
+use std::process::{Command, Stdio};
 
-pub fn check(_bad: &mut bool) {
-    let result = Command::new("x").arg("--version").output();
-    let output = match result {
-        Ok(output) => output,
-        Err(_e) => todo!(),
+pub fn check(bad: &mut bool) {
+    let result = Command::new("x")
+        .arg("--version")
+        .stdout(Stdio::piped())
+        .spawn();
+    let child = match result {
+        Ok(child) => child,
+        Err(e) => match e.kind() {
+            ErrorKind::NotFound => return (),
+            _ => return tidy_error!(bad, "{}", e),
+        },
     };
+
+    let output = child.wait_with_output().unwrap();
 
     if output.status.success() {
         let version = String::from_utf8_lossy(&output.stdout);
-        assert_eq!("0.1.0", version.trim_end());
+        let version = Version::parse(version.trim_end()).unwrap();
+        let expected = Version {
+            major: 0,
+            minor: 1,
+            patch: 0,
+            pre: Prerelease::new("").unwrap(),
+            build: BuildMetadata::EMPTY,
+        };
+        if version < expected {
+            return tidy_error!(bad, "Current version of x is {version} Consider updating to the newer version of x by running `cargo install --path src/tools/x`");
+        }
+    } else {
+        return tidy_error!(bad, "{}", output.status);
     }
-    // FIXME: throw some kind of tidy error when the version of x isn't
-    // greater than or equal to the version we'd expect.
-    //tidy_error!(bad, "Current version of x is {version} Consider updating to the newer version of x by running `cargo install --path src/tools/x`")
 }

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -8,7 +8,7 @@ pub fn check(bad: &mut bool) {
         Ok(child) => child,
         Err(e) => match e.kind() {
             ErrorKind::NotFound => return,
-            _ => return tidy_error!(bad, "{}", e),
+            _ => return tidy_error!(bad, "failed to run `x`: {}", e),
         },
     };
 

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -4,15 +4,29 @@ use std::process::{Command, Stdio};
 
 pub fn check(bad: &mut bool) {
     let result = Command::new("x").arg("--wrapper-version").stdout(Stdio::piped()).spawn();
-    let child = match result {
-        Ok(child) => child,
-        Err(e) => match e.kind() {
+    // This runs the command inside a temporarily directory.
+    // This allows us to compare output of result to see if `--wrapper-version` is not a recognized argument to x.
+    let temp_result = Command::new("x").arg("--wrapper-version").current_dir(std::env::temp_dir()).stdout(Stdio::piped()).spawn();
+
+    let (child, temp_child) = match (result, temp_result) {
+        (Ok(child), Ok(temp_child)) => (child, temp_child),
+        // what would it mean if the temp cmd error'd?
+        (Ok(_child), Err(_e)) => todo!(),
+        (Err(e), _) => match e.kind() {
             ErrorKind::NotFound => return,
             _ => return tidy_error!(bad, "failed to run `x`: {}", e),
         },
     };
 
     let output = child.wait_with_output().unwrap();
+    let temp_output = temp_child.wait_with_output().unwrap();
+
+    if output != temp_output {
+        return tidy_error!(
+                bad,
+                "Current version of x does not support the `--wrapper-version` argument\nConsider updating to the newer version of x by running `cargo install --path src/tools/x`"
+            )
+    }
 
     if output.status.success() {
         let version = String::from_utf8_lossy(&output.stdout);

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -43,7 +43,7 @@ pub fn check(bad: &mut bool) {
         if version < expected {
             return tidy_error!(
                 bad,
-                "Current version of x is {version} Consider updating to the newer version of x by running `cargo install --path src/tools/x`"
+                "Current version of x is {version}, but the latest version is {expected}\nConsider updating to the newer version of x by running `cargo install --path src/tools/x`"
             );
         }
     } else {

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -31,6 +31,6 @@ pub fn check(bad: &mut bool) {
             );
         }
     } else {
-        return tidy_error!(bad, "{}", output.status);
+        return tidy_error!(bad, "failed to check version of `x`: {}", output.status);
     }
 }

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -3,7 +3,7 @@ use std::io::ErrorKind;
 use std::process::{Command, Stdio};
 
 pub fn check(bad: &mut bool) {
-    let result = Command::new("x").arg("--version").stdout(Stdio::piped()).spawn();
+    let result = Command::new("x").arg("--wrapper-version").stdout(Stdio::piped()).spawn();
     let child = match result {
         Ok(child) => child,
         Err(e) => match e.kind() {

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -1,9 +1,7 @@
 use std::process::Command;
 
 pub fn check(_bad: &mut bool) {
-    let result = Command::new("x")
-        .arg("--version")
-        .output();
+    let result = Command::new("x").arg("--version").output();
     let output = match result {
         Ok(output) => output,
         Err(_e) => todo!(),

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -14,9 +14,7 @@ pub fn check(bad: &mut bool) {
 
     let (child, temp_child) = match (result, temp_result) {
         (Ok(child), Ok(temp_child)) => (child, temp_child),
-        // what would it mean if the temp cmd error'd?
-        (Ok(_child), Err(_e)) => todo!(),
-        (Err(e), _) => match e.kind() {
+        (Err(e), _) | (_, Err(e)) => match e.kind() {
             ErrorKind::NotFound => return,
             _ => return tidy_error!(bad, "failed to run `x`: {}", e),
         },

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -6,7 +6,11 @@ pub fn check(bad: &mut bool) {
     let result = Command::new("x").arg("--wrapper-version").stdout(Stdio::piped()).spawn();
     // This runs the command inside a temporarily directory.
     // This allows us to compare output of result to see if `--wrapper-version` is not a recognized argument to x.
-    let temp_result = Command::new("x").arg("--wrapper-version").current_dir(std::env::temp_dir()).stdout(Stdio::piped()).spawn();
+    let temp_result = Command::new("x")
+        .arg("--wrapper-version")
+        .current_dir(std::env::temp_dir())
+        .stdout(Stdio::piped())
+        .spawn();
 
     let (child, temp_child) = match (result, temp_result) {
         (Ok(child), Ok(temp_child)) => (child, temp_child),
@@ -23,9 +27,9 @@ pub fn check(bad: &mut bool) {
 
     if output != temp_output {
         return tidy_error!(
-                bad,
-                "Current version of x does not support the `--wrapper-version` argument\nConsider updating to the newer version of x by running `cargo install --path src/tools/x`"
-            )
+            bad,
+            "Current version of x does not support the `--wrapper-version` argument\nConsider updating to the newer version of x by running `cargo install --path src/tools/x`"
+        );
     }
 
     if output.status.success() {

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -1,4 +1,5 @@
-use semver::{BuildMetadata, Prerelease, Version};
+use semver::Version;
+use serde_json::Value;
 use std::io::ErrorKind;
 use std::process::{Command, Stdio};
 
@@ -33,20 +34,47 @@ pub fn check(bad: &mut bool) {
     if output.status.success() {
         let version = String::from_utf8_lossy(&output.stdout);
         let version = Version::parse(version.trim_end()).unwrap();
-        let expected = Version {
-            major: 0,
-            minor: 1,
-            patch: 0,
-            pre: Prerelease::new("").unwrap(),
-            build: BuildMetadata::EMPTY,
-        };
-        if version < expected {
+
+        if let Some(expected) = get_x_wrapper_version() {
+            if version < expected {
+                return tidy_error!(
+                    bad,
+                    "Current version of x is {version}, but the latest version is {expected}\nConsider updating to the newer version of x by running `cargo install --path src/tools/x`"
+                );
+            }
+        } else {
             return tidy_error!(
                 bad,
-                "Current version of x is {version}, but the latest version is {expected}\nConsider updating to the newer version of x by running `cargo install --path src/tools/x`"
+                "Unable to parse the latest version of `x` at `src/tools/x/Cargo.toml`"
             );
         }
     } else {
         return tidy_error!(bad, "failed to check version of `x`: {}", output.status);
     }
+}
+
+// Parse latest version out of `x` Cargo.toml
+fn get_x_wrapper_version() -> Option<Version> {
+    let cmd = Command::new("cargo")
+        .arg("metadata")
+        .args(["--no-deps", "--format-version", "1", "--manifest-path", "src/tools/x/Cargo.toml"])
+        .stdout(Stdio::piped())
+        .spawn();
+
+    let child = match cmd {
+        Ok(child) => child,
+        Err(e) => {
+            println!("failed to get version of `x`: {}", e);
+            return None;
+        }
+    };
+
+    let cargo_output = child.wait_with_output().unwrap();
+    let cargo_output_str =
+        String::from_utf8(cargo_output.stdout).expect("Unable to parse `src/tools/x/Cargo.toml`");
+
+    let v: Value = serde_json::from_str(&cargo_output_str).unwrap();
+    let vesrion_str = &v["packages"][0]["version"].as_str()?;
+
+    Some(Version::parse(vesrion_str).unwrap())
 }

--- a/src/tools/x/src/main.rs
+++ b/src/tools/x/src/main.rs
@@ -53,7 +53,7 @@ fn exec_or_status(command: &mut Command) -> io::Result<ExitStatus> {
 
 fn main() {
     match env::args().skip(1).next().as_deref() {
-        Some("--version") => {
+        Some("--wrapper-version") => {
             let version = env!("CARGO_PKG_VERSION");
             println!("{}", version);
             return;

--- a/src/tools/x/src/main.rs
+++ b/src/tools/x/src/main.rs
@@ -52,6 +52,14 @@ fn exec_or_status(command: &mut Command) -> io::Result<ExitStatus> {
 }
 
 fn main() {
+    match env::args().skip(1).next().as_deref() {
+        Some("--version") => {
+            let version = env!("CARGO_PKG_VERSION");
+            println!("{}", version);
+            return;
+        }
+        _ => {}
+    }
     let current = match env::current_dir() {
         Ok(dir) => dir,
         Err(err) => {


### PR DESCRIPTION
This PR adds a check to `tidy` to assert that the installed version of `x` is equal to the version in `src/tools/x/Cargo.toml`. It adds a `--wrapper-version` argument to `x` to determine the version at runtime, .

It does not warn if `x` has not yet been installed, on the assumption that the user isn't interested in using it.