### PR TITLE
rustdoc: use `code-header` class to format enum variants

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -19,8 +19,8 @@ use super::{
     collect_paths_for_type, document, ensure_trailing_slash, get_filtered_impls_for_reference,
     item_ty_to_section, notable_traits_button, notable_traits_json, render_all_impls,
     render_assoc_item, render_assoc_items, render_attributes_in_code, render_attributes_in_pre,
-    render_impl, render_rightside, render_stability_since_raw, AssocItemLink, Context,
-    ImplRenderingParameters,
+    render_impl, render_rightside, render_stability_since_raw,
+    render_stability_since_raw_with_extra, AssocItemLink, Context, ImplRenderingParameters,
 };
 use crate::clean;
 use crate::config::ModuleSorting;
@@ -1267,30 +1267,30 @@ fn item_enum(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, e: &clean::
             document_non_exhaustive_header(it)
         );
         document_non_exhaustive(w, it);
+        write!(w, "<div class=\"variants\">");
         for variant in e.variants() {
             let id = cx.derive_id(format!("{}.{}", ItemType::Variant, variant.name.unwrap()));
             write!(
                 w,
-                "<h3 id=\"{id}\" class=\"variant small-section-header\">\
-                    <a href=\"#{id}\" class=\"anchor field\"></a>\
-                    <code>{name}",
+                "<section id=\"{id}\" class=\"variant\">\
+                    <a href=\"#{id}\" class=\"anchor\"></a>",
                 id = id,
-                name = variant.name.unwrap()
             );
-            if let clean::VariantItem(clean::Variant::Tuple(ref s)) = *variant.kind {
-                w.write_str("(");
-                print_tuple_struct_fields(w, cx, s);
-                w.write_str(")");
-            }
-            w.write_str("</code>");
-            render_stability_since_raw(
+            render_stability_since_raw_with_extra(
                 w,
                 variant.stable_since(tcx),
                 variant.const_stability(tcx),
                 it.stable_since(tcx),
                 it.const_stable_since(tcx),
+                " rightside",
             );
-            w.write_str("</h3>");
+            write!(w, "<h3 class=\"code-header\">{name}", name = variant.name.unwrap());
+            if let clean::VariantItem(clean::Variant::Tuple(ref s)) = *variant.kind {
+                w.write_str("(");
+                print_tuple_struct_fields(w, cx, s);
+                w.write_str(")");
+            }
+            w.write_str("</h3></section>");
 
             use crate::clean::Variant;
 
@@ -1324,7 +1324,7 @@ fn item_enum(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, e: &clean::
                             write!(
                                 w,
                                 "<div class=\"sub-variant-field\">\
-                                 <span id=\"{id}\" class=\"variant small-section-header\">\
+                                 <span id=\"{id}\" class=\"small-section-header\">\
                                      <a href=\"#{id}\" class=\"anchor field\"></a>\
                                      <code>{f}:&nbsp;{t}</code>\
                                  </span>",
@@ -1343,6 +1343,7 @@ fn item_enum(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, e: &clean::
 
             document(w, cx, variant, Some(it), HeadingOffset::H4);
         }
+        write!(w, "</div>");
     }
     let def_id = it.item_id.expect_def_id();
     render_assoc_items(w, cx, it, def_id, AssocItemRender::All);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -709,8 +709,6 @@ a {
 }
 
 .small-section-header {
-	display: flex;
-	justify-content: space-between;
 	position: relative;
 }
 
@@ -718,7 +716,7 @@ a {
 	display: initial;
 }
 
-.impl:hover > .anchor, .trait-impl:hover > .anchor {
+.impl:hover > .anchor, .trait-impl:hover > .anchor, .variant:hover > .anchor {
 	display: inline-block;
 	position: absolute;
 }
@@ -1233,12 +1231,6 @@ a.test-arrow:hover {
 
 .out-of-band > span.since {
 	font-size: 1.25rem;
-}
-
-h3.variant {
-	font-weight: 600;
-	font-size: 1.125rem;
-	margin-bottom: 10px;
 }
 
 .sub-variant h4 {
@@ -1909,6 +1901,7 @@ in storage.js
 	}
 }
 
+.variant,
 .implementors-toggle > summary,
 .impl,
 #implementors-list > .docblock,
@@ -1920,6 +1913,7 @@ in storage.js
 	margin-bottom: 0.75em;
 }
 
+.variants > .docblock,
 .impl-items > .rustdoc-toggle[open]:not(:last-child),
 .methods > .rustdoc-toggle[open]:not(:last-child),
 .implementors-toggle[open]:not(:last-child) {

--- a/src/test/rustdoc-gui/enum-variants.goml
+++ b/src/test/rustdoc-gui/enum-variants.goml
@@ -1,0 +1,5 @@
+// Verifies that there is non-zero margin on variants and their docblocks.
+goto: "file://" + |DOC_PATH| + "/test_docs/enum.WhoLetTheDogOut.html"
+
+assert-css: (".variants > .variant", {"margin": "0px 0px 12px"})
+assert-css: (".variants > .docblock", {"margin": "0px 0px 32px 24px"})

--- a/src/test/rustdoc/issue-88600.rs
+++ b/src/test/rustdoc/issue-88600.rs
@@ -8,22 +8,22 @@ pub struct S;
 
 // @has issue_88600/enum.FooEnum.html
 pub enum FooEnum {
-    // @has - '//*[@id="variant.HiddenTupleItem"]//code' 'HiddenTupleItem(_)'
+    // @has - '//*[@id="variant.HiddenTupleItem"]//h3' 'HiddenTupleItem(_)'
     // @count - '//*[@id="variant.HiddenTupleItem.field.0"]' 0
     HiddenTupleItem(#[doc(hidden)] H),
-    // @has - '//*[@id="variant.MultipleHidden"]//code' 'MultipleHidden(_, _)'
+    // @has - '//*[@id="variant.MultipleHidden"]//h3' 'MultipleHidden(_, _)'
     // @count - '//*[@id="variant.MultipleHidden.field.0"]' 0
     // @count - '//*[@id="variant.MultipleHidden.field.1"]' 0
     MultipleHidden(#[doc(hidden)] H, #[doc(hidden)] H),
-    // @has - '//*[@id="variant.MixedHiddenFirst"]//code' 'MixedHiddenFirst(_, S)'
+    // @has - '//*[@id="variant.MixedHiddenFirst"]//h3' 'MixedHiddenFirst(_, S)'
     // @count - '//*[@id="variant.MixedHiddenFirst.field.0"]' 0
     // @has - '//*[@id="variant.MixedHiddenFirst.field.1"]' '1: S'
     MixedHiddenFirst(#[doc(hidden)] H, /** dox */ S),
-    // @has - '//*[@id="variant.MixedHiddenLast"]//code' 'MixedHiddenLast(S, _)'
+    // @has - '//*[@id="variant.MixedHiddenLast"]//h3' 'MixedHiddenLast(S, _)'
     // @has - '//*[@id="variant.MixedHiddenLast.field.0"]' '0: S'
     // @count - '//*[@id="variant.MixedHiddenLast.field.1"]' 0
     MixedHiddenLast(/** dox */ S, #[doc(hidden)] H),
-    // @has - '//*[@id="variant.HiddenStruct"]//code' 'HiddenStruct'
+    // @has - '//*[@id="variant.HiddenStruct"]//h3' 'HiddenStruct'
     // @count - '//*[@id="variant.HiddenStruct.field.h"]' 0
     // @has - '//*[@id="variant.HiddenStruct.field.s"]' 's: S'
     HiddenStruct {


### PR DESCRIPTION
The font size and weights should be exactly the same after this PR, but the spacing is changed to be the same as methods.

Preview: http://notriddle.com/notriddle-rustdoc-demos/variant/test_dingus_enum/enum.TestEnum.html