### PR TITLE
Add a test case for async dyn* traits

### DIFF
--- a/src/test/ui/dyn-star/dyn-async-trait.rs
+++ b/src/test/ui/dyn-star/dyn-async-trait.rs
@@ -1,0 +1,36 @@
+// check-pass
+// edition: 2021
+
+// This test case is meant to demonstrate how close we can get to async
+// functions in dyn traits with the current level of dyn* support.
+
+#![feature(dyn_star)]
+#![allow(incomplete_features)]
+
+use std::future::Future;
+
+trait DynAsyncCounter {
+    fn increment<'a>(&'a mut self) -> dyn* Future<Output = usize> + 'a;
+}
+
+struct MyCounter {
+    count: usize,
+}
+
+impl DynAsyncCounter for MyCounter {
+    fn increment<'a>(&'a mut self) -> dyn* Future<Output = usize> + 'a {
+        Box::pin(async {
+            self.count += 1;
+            self.count
+        }) as dyn* Future<Output = _> // FIXME(dyn-star): coercion doesn't work here yet
+    }
+}
+
+async fn do_counter(counter: &mut dyn DynAsyncCounter) -> usize {
+    counter.increment().await
+}
+
+fn main() {
+    let mut counter = MyCounter { count: 0 };
+    let _ = do_counter(&mut counter);
+}

--- a/src/test/ui/dyn-star/dyn-async-trait.rs
+++ b/src/test/ui/dyn-star/dyn-async-trait.rs
@@ -22,7 +22,7 @@ impl DynAsyncCounter for MyCounter {
         Box::pin(async {
             self.count += 1;
             self.count
-        }) as dyn* Future<Output = _> // FIXME(dyn-star): coercion doesn't work here yet
+        })
     }
 }
 


### PR DESCRIPTION
This adds a test case that approximates async functions in dyn traits using `dyn*`. The purpose is to have an example of where we are with `dyn*` and the goal of using it for dyn traits.

Issue #102425

r? @compiler-errors 