### PR TITLE
rustdoc: remove unused JS IIFE from main.js

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -723,12 +723,9 @@ function loadCss(cssUrl) {
         });
     };
 
-    (function() {
-        // To avoid checking on "rustdoc-line-numbers" value on every loop...
-        if (getSettingValue("line-numbers") === "true") {
-            window.rustdoc_add_line_numbers_to_examples();
-        }
-    }());
+    if (getSettingValue("line-numbers") === "true") {
+        window.rustdoc_add_line_numbers_to_examples();
+    }
 
     let oldSidebarScrollPosition = null;
 


### PR DESCRIPTION
This [IIFE] made sense when it was added in deaf5e200e79a75ac57d3f0952f6758a38168e52 and there was a local variable scoped to it, but now it calls a function, but declares nothing.

[IIFE]: https://developer.mozilla.org/en-US/docs/Glossary/IIFE "immediately invoked function expression"