### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "glob",
  "hex 0.4.2",
  "home",
+ "http-auth",
  "humantime 2.0.1",
  "ignore",
  "im-rc",
@@ -349,11 +350,11 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "cargo-credential-1password"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cargo-credential",
  "serde",
@@ -362,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-macos-keychain"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cargo-credential",
  "security-framework",
@@ -370,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-wincred"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cargo-credential",
  "winapi",
@@ -1690,6 +1691,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b40b39d66c28829a0cf4d09f7e139ff8201f7500a5083732848ed3b4b4d850"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]


### PR DESCRIPTION
3 commits in 16b097879b6f117c8ae698aab054c87f26ff325e..eb5d35917b2395194593c9ca70c3778f60c1573b
2022-11-14 23:28:16 +0000 to 2022-11-17 22:08:43 +0000
- Fix several tests that are waiting 60 seconds for publishing to time out (rust-lang/cargo#11388)
- Implement RFC 3139: alternative registry authentication support (rust-lang/cargo#10592)
- Fix cargo install --index when used with registry.default (rust-lang/cargo#11302)

r? @ghost