### PR TITLE
Probe + better error messsage for `need_migrate_deref_output_trait_object`

### DIFF
--- a/src/test/ui/traits/trait-upcasting/migrate-lint-deny.rs
+++ b/src/test/ui/traits/trait-upcasting/migrate-lint-deny.rs
@@ -18,7 +18,7 @@ fn take_a(_: &dyn A) {}
 
 fn whoops(b: &dyn B) {
     take_a(b)
-    //~^ ERROR `dyn B` implements `Deref` with supertrait `(dyn A + 'static)` as output
+    //~^ ERROR `dyn B` implements `Deref` with supertrait `A` as output
     //~^^ WARN this was previously accepted by the compiler but is being phased out;
 }
 

--- a/src/test/ui/traits/trait-upcasting/migrate-lint-deny.stderr
+++ b/src/test/ui/traits/trait-upcasting/migrate-lint-deny.stderr
@@ -1,4 +1,4 @@
-error: `dyn B` implements `Deref` with supertrait `(dyn A + 'static)` as output
+error: `dyn B` implements `Deref` with supertrait `A` as output
   --> $DIR/migrate-lint-deny.rs:20:12
    |
 LL |     take_a(b)


### PR DESCRIPTION
1. Use `InferCtxt::probe` in `need_migrate_deref_output_trait_object` -- that normalization *could* technically do type inference as a side-effect, and this is a lint, so it should have no side-effects.
2. Return the trait-ref so we format the error message correctly. See the UI test change -- `(dyn A + 'static)` is not a trait.