### PR TITLE
Fast-path some relations via strict equality

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/dropck.rs
+++ b/compiler/rustc_hir_analysis/src/check/dropck.rs
@@ -248,7 +248,8 @@ impl<'tcx> TypeRelation<'tcx> for SimpleEqRelation<'tcx> {
         self.param_env
     }
 
-    fn fast_equate_combine(&self) -> bool {
+    #[inline]
+    fn fast_equate(&self) -> bool {
         true
     }
 

--- a/compiler/rustc_hir_analysis/src/check/dropck.rs
+++ b/compiler/rustc_hir_analysis/src/check/dropck.rs
@@ -248,6 +248,10 @@ impl<'tcx> TypeRelation<'tcx> for SimpleEqRelation<'tcx> {
         self.param_env
     }
 
+    fn fast_equate_combine(&self) -> bool {
+        true
+    }
+
     fn tag(&self) -> &'static str {
         "dropck::SimpleEqRelation"
     }

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -525,7 +525,8 @@ impl<'tcx> TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
         self.param_env
     }
 
-    fn fast_equate_combine(&self) -> bool {
+    #[inline]
+    fn fast_equate(&self) -> bool {
         false
     }
 
@@ -806,7 +807,8 @@ impl<'tcx> TypeRelation<'tcx> for ConstInferUnifier<'_, 'tcx> {
         self.param_env
     }
 
-    fn fast_equate_combine(&self) -> bool {
+    #[inline]
+    fn fast_equate(&self) -> bool {
         false
     }
 

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -525,6 +525,10 @@ impl<'tcx> TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
         self.param_env
     }
 
+    fn fast_equate_combine(&self) -> bool {
+        false
+    }
+
     fn tag(&self) -> &'static str {
         "Generalizer"
     }
@@ -800,6 +804,10 @@ impl<'tcx> TypeRelation<'tcx> for ConstInferUnifier<'_, 'tcx> {
 
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.param_env
+    }
+
+    fn fast_equate_combine(&self) -> bool {
+        false
     }
 
     fn tag(&self) -> &'static str {

--- a/compiler/rustc_infer/src/infer/equate.rs
+++ b/compiler/rustc_infer/src/infer/equate.rs
@@ -32,7 +32,8 @@ impl<'tcx> TypeRelation<'tcx> for Equate<'_, '_, 'tcx> {
         self.fields.tcx()
     }
 
-    fn fast_equate_combine(&self) -> bool {
+    #[inline]
+    fn fast_equate(&self) -> bool {
         true
     }
 

--- a/compiler/rustc_infer/src/infer/equate.rs
+++ b/compiler/rustc_infer/src/infer/equate.rs
@@ -32,6 +32,10 @@ impl<'tcx> TypeRelation<'tcx> for Equate<'_, '_, 'tcx> {
         self.fields.tcx()
     }
 
+    fn fast_equate_combine(&self) -> bool {
+        true
+    }
+
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.fields.param_env
     }

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2945,6 +2945,10 @@ impl<'tcx> TypeRelation<'tcx> for SameTypeModuloInfer<'_, 'tcx> {
         "SameTypeModuloInfer"
     }
 
+    fn fast_equate_combine(&self) -> bool {
+        true
+    }
+
     fn a_is_expected(&self) -> bool {
         true
     }

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2945,7 +2945,8 @@ impl<'tcx> TypeRelation<'tcx> for SameTypeModuloInfer<'_, 'tcx> {
         "SameTypeModuloInfer"
     }
 
-    fn fast_equate_combine(&self) -> bool {
+    #[inline]
+    fn fast_equate(&self) -> bool {
         true
     }
 

--- a/compiler/rustc_infer/src/infer/glb.rs
+++ b/compiler/rustc_infer/src/infer/glb.rs
@@ -34,7 +34,8 @@ impl<'tcx> TypeRelation<'tcx> for Glb<'_, '_, 'tcx> {
         self.fields.tcx()
     }
 
-    fn fast_equate_combine(&self) -> bool {
+    #[inline]
+    fn fast_equate(&self) -> bool {
         true
     }
 

--- a/compiler/rustc_infer/src/infer/glb.rs
+++ b/compiler/rustc_infer/src/infer/glb.rs
@@ -34,6 +34,10 @@ impl<'tcx> TypeRelation<'tcx> for Glb<'_, '_, 'tcx> {
         self.fields.tcx()
     }
 
+    fn fast_equate_combine(&self) -> bool {
+        true
+    }
+
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.fields.param_env
     }

--- a/compiler/rustc_infer/src/infer/lub.rs
+++ b/compiler/rustc_infer/src/infer/lub.rs
@@ -34,7 +34,8 @@ impl<'tcx> TypeRelation<'tcx> for Lub<'_, '_, 'tcx> {
         self.fields.tcx()
     }
 
-    fn fast_equate_combine(&self) -> bool {
+    #[inline]
+    fn fast_equate(&self) -> bool {
         true
     }
 

--- a/compiler/rustc_infer/src/infer/lub.rs
+++ b/compiler/rustc_infer/src/infer/lub.rs
@@ -34,6 +34,10 @@ impl<'tcx> TypeRelation<'tcx> for Lub<'_, '_, 'tcx> {
         self.fields.tcx()
     }
 
+    fn fast_equate_combine(&self) -> bool {
+        true
+    }
+
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.fields.param_env
     }

--- a/compiler/rustc_infer/src/infer/nll_relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/nll_relate/mod.rs
@@ -535,6 +535,10 @@ where
         self.delegate.param_env()
     }
 
+    fn fast_equate_combine(&self) -> bool {
+        false
+    }
+
     fn tag(&self) -> &'static str {
         "nll::subtype"
     }
@@ -899,6 +903,10 @@ where
 
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.delegate.param_env()
+    }
+
+    fn fast_equate_combine(&self) -> bool {
+        false
     }
 
     fn tag(&self) -> &'static str {

--- a/compiler/rustc_infer/src/infer/nll_relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/nll_relate/mod.rs
@@ -535,7 +535,8 @@ where
         self.delegate.param_env()
     }
 
-    fn fast_equate_combine(&self) -> bool {
+    #[inline]
+    fn fast_equate(&self) -> bool {
         false
     }
 
@@ -905,7 +906,8 @@ where
         self.delegate.param_env()
     }
 
-    fn fast_equate_combine(&self) -> bool {
+    #[inline]
+    fn fast_equate(&self) -> bool {
         false
     }
 

--- a/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
+++ b/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
@@ -142,7 +142,8 @@ impl<'tcx> TypeRelation<'tcx> for Match<'tcx> {
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.param_env
     }
-    fn fast_equate_combine(&self) -> bool {
+    #[inline]
+    fn fast_equate(&self) -> bool {
         false
     }
     fn a_is_expected(&self) -> bool {

--- a/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
+++ b/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
@@ -142,6 +142,9 @@ impl<'tcx> TypeRelation<'tcx> for Match<'tcx> {
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.param_env
     }
+    fn fast_equate_combine(&self) -> bool {
+        false
+    }
     fn a_is_expected(&self) -> bool {
         true
     } // irrelevant

--- a/compiler/rustc_infer/src/infer/sub.rs
+++ b/compiler/rustc_infer/src/infer/sub.rs
@@ -43,6 +43,10 @@ impl<'tcx> TypeRelation<'tcx> for Sub<'_, '_, 'tcx> {
         self.fields.param_env
     }
 
+    fn fast_equate_combine(&self) -> bool {
+        true
+    }
+
     fn a_is_expected(&self) -> bool {
         self.a_is_expected
     }

--- a/compiler/rustc_infer/src/infer/sub.rs
+++ b/compiler/rustc_infer/src/infer/sub.rs
@@ -43,7 +43,8 @@ impl<'tcx> TypeRelation<'tcx> for Sub<'_, '_, 'tcx> {
         self.fields.param_env
     }
 
-    fn fast_equate_combine(&self) -> bool {
+    #[inline]
+    fn fast_equate(&self) -> bool {
         true
     }
 

--- a/compiler/rustc_middle/src/ty/_match.rs
+++ b/compiler/rustc_middle/src/ty/_match.rs
@@ -39,7 +39,8 @@ impl<'tcx> TypeRelation<'tcx> for Match<'tcx> {
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.param_env
     }
-    fn fast_equate_combine(&self) -> bool {
+    #[inline]
+    fn fast_equate(&self) -> bool {
         false
     }
     fn a_is_expected(&self) -> bool {

--- a/compiler/rustc_middle/src/ty/_match.rs
+++ b/compiler/rustc_middle/src/ty/_match.rs
@@ -39,6 +39,9 @@ impl<'tcx> TypeRelation<'tcx> for Match<'tcx> {
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.param_env
     }
+    fn fast_equate_combine(&self) -> bool {
+        false
+    }
     fn a_is_expected(&self) -> bool {
         true
     } // irrelevant

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -29,7 +29,7 @@ pub trait TypeRelation<'tcx>: Sized {
     fn tag(&self) -> &'static str;
 
     /// Returns whether or not structural equality can be used to fast-path this relation
-    fn fast_equate_combine(&self) -> bool;
+    fn fast_equate(&self) -> bool;
 
     /// Returns `true` if the value `a` is the "expected" type in the
     /// relation. Just affects error messages.
@@ -143,7 +143,7 @@ pub fn relate_substs<'tcx, R: TypeRelation<'tcx>>(
     a_subst: SubstsRef<'tcx>,
     b_subst: SubstsRef<'tcx>,
 ) -> RelateResult<'tcx, SubstsRef<'tcx>> {
-    if relation.fast_equate_combine() && a_subst == b_subst {
+    if relation.fast_equate() && a_subst == b_subst {
         return Ok(a_subst);
     }
 
@@ -159,7 +159,7 @@ pub fn relate_substs_with_variances<'tcx, R: TypeRelation<'tcx>>(
     a_subst: SubstsRef<'tcx>,
     b_subst: SubstsRef<'tcx>,
 ) -> RelateResult<'tcx, SubstsRef<'tcx>> {
-    if relation.fast_equate_combine() && a_subst == b_subst {
+    if relation.fast_equate() && a_subst == b_subst {
         return Ok(a_subst);
     }
 
@@ -365,7 +365,7 @@ impl<'tcx> Relate<'tcx> for GeneratorWitness<'tcx> {
         a: GeneratorWitness<'tcx>,
         b: GeneratorWitness<'tcx>,
     ) -> RelateResult<'tcx, GeneratorWitness<'tcx>> {
-        if relation.fast_equate_combine() && a == b {
+        if relation.fast_equate() && a == b {
             return Ok(a);
         }
 
@@ -670,7 +670,7 @@ impl<'tcx> Relate<'tcx> for &'tcx ty::List<ty::Binder<'tcx, ty::ExistentialPredi
         a: Self,
         b: Self,
     ) -> RelateResult<'tcx, Self> {
-        if relation.fast_equate_combine() && a == b {
+        if relation.fast_equate() && a == b {
             return Ok(a);
         }
 


### PR DESCRIPTION
Some relations can take advantage of strict equality (that is, the `==` operator), which is far cheaper to check in some cases like substs and existential predicate lists. 

This also fixes #104583.

r? @ghost