### PR TITLE
add instructions on how to use bench along stable rust

### DIFF
--- a/src/doc/unstable-book/src/library-features/test.md
+++ b/src/doc/unstable-book/src/library-features/test.md
@@ -106,14 +106,14 @@ mod tests {
         assert_eq!(4, add_two(2));
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(feature = "bench")]
     #[bench]
     fn bench_add_two(b: &mut test::Bencher) {
         b.iter(|| add_two(2));
     }
 }
 ```
-And now to invoke the bechmark, we can use `cargo +nightly bench --features nightly`.
+And now to invoke the bechmark, we can use `cargo +nightly bench --features bench`.
 
 ## Gotcha: optimizations
 

--- a/src/doc/unstable-book/src/library-features/test.md
+++ b/src/doc/unstable-book/src/library-features/test.md
@@ -77,7 +77,7 @@ Advice on writing benchmarks:
 
 ## Using cargo bench along stable rust
 
-To improve user experience when using `cargo bench` in a porject built with stable rust,
+To improve user experience when using `cargo bench` in a project built with stable rust,
 you can gate all the benchmarking under a seperate feature that you shoulld only call it
 with nightly. In this example we add a new feature to `Cargo.toml` called `bench`.
 

--- a/src/doc/unstable-book/src/library-features/test.md
+++ b/src/doc/unstable-book/src/library-features/test.md
@@ -75,6 +75,46 @@ Advice on writing benchmarks:
 * Make the code in the `iter` loop do something simple, to assist in pinpointing
   performance improvements (or regressions)
 
+## Using cargo bench along stable rust
+
+To improve user experience when using `cargo bench` in a porject built with stable rust,
+you can gate all the benchmarking under a seperate feature that you shoulld only call it
+with nightly. In this example we add a new feature to `Cargo.toml` called `bench`.
+
+```toml
+[features]
+bench = []
+```
+and update our `lib.rs`:
+
+```rs
+#![cfg_attr(feature = "bench", feature(test))]
+
+pub fn add_two(a: i32) -> i32 {
+    a + 2
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "bench")]
+    extern crate test;
+
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        assert_eq!(4, add_two(2));
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn bench_add_two(b: &mut test::Bencher) {
+        b.iter(|| add_two(2));
+    }
+}
+```
+And now to invoke the bechmark, we can use `cargo +nightly bench --features nightly`.
+
 ## Gotcha: optimizations
 
 There's another tricky part to writing benchmarks: benchmarks compiled with

--- a/src/doc/unstable-book/src/library-features/test.md
+++ b/src/doc/unstable-book/src/library-features/test.md
@@ -78,7 +78,7 @@ Advice on writing benchmarks:
 ## Using cargo bench along stable rust
 
 To improve user experience when using `cargo bench` in a project built with stable rust,
-you can gate all the benchmarking under a seperate feature that you shoulld only call it
+you can gate all the benchmarking under a seperate feature that you should only call it
 with nightly. In this example we add a new feature to `Cargo.toml` called `bench`.
 
 ```toml


### PR DESCRIPTION
I personally found this useful, so I thought maybe its interesting to add it here.

criterion can't bench binary crates or do inline bench-marking, so cargo bench still have its own use-cases.

Using cargo-bench in a project built with rust stable is not that obvious, so this PR add an example of how to do it.