### PR TITLE
Fix --extern library finding errors

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/metadata.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/metadata.ftl
@@ -275,7 +275,7 @@ metadata_crate_location_unknown_type =
     extern location for {$crate_name} is of an unknown type: {$path}
 
 metadata_lib_filename_form =
-    file name should be lib*.rlib or {$dll_prefix}*.{$dll_suffix}
+    file name should be lib*.rlib or {$dll_prefix}*{$dll_suffix}
 
 metadata_multiple_import_name_type =
     multiple `import_name_type` arguments in a single `#[link]` attribute

--- a/compiler/rustc_error_messages/locales/en-US/metadata.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/metadata.ftl
@@ -275,7 +275,7 @@ metadata_crate_location_unknown_type =
     extern location for {$crate_name} is of an unknown type: {$path}
 
 metadata_lib_filename_form =
-    file name should be lib*.rlib or {dll_prefix}*.{dll_suffix}
+    file name should be lib*.rlib or {$dll_prefix}*.{$dll_suffix}
 
 metadata_multiple_import_name_type =
     multiple `import_name_type` arguments in a single `#[link]` attribute

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -692,6 +692,7 @@ pub struct CrateLocationUnknownType<'a> {
     #[primary_span]
     pub span: Span,
     pub path: &'a Path,
+    pub crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -1026,7 +1026,6 @@ impl CrateError {
                     None => String::new(),
                     Some(r) => format!(" which `{}` depends on", r.name),
                 };
-                // FIXME: There are no tests for CrateLocationUnknownType or LibFilenameForm
                 if !locator.crate_rejections.via_filename.is_empty() {
                     let mismatches = locator.crate_rejections.via_filename.iter();
                     for CrateMismatch { path, .. } in mismatches {

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -1024,7 +1024,7 @@ impl CrateError {
                 if !locator.crate_rejections.via_filename.is_empty() {
                     let mismatches = locator.crate_rejections.via_filename.iter();
                     for CrateMismatch { path, .. } in mismatches {
-                        sess.emit_err(CrateLocationUnknownType { span, path: &path });
+                        sess.emit_err(CrateLocationUnknownType { span, path: &path, crate_name });
                         sess.emit_err(LibFilenameForm {
                             span,
                             dll_prefix: &locator.dll_prefix,

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -707,6 +707,12 @@ impl<'a> CrateLocator<'a> {
                     loc.original().clone(),
                 ));
             }
+            if !loc.original().is_file() {
+                return Err(CrateError::ExternLocationNotFile(
+                    self.crate_name,
+                    loc.original().clone(),
+                ));
+            }
             let Some(file) = loc.original().file_name().and_then(|s| s.to_str()) else {
                 return Err(CrateError::ExternLocationNotFile(
                     self.crate_name,

--- a/src/test/ui/errors/issue-104621-extern-bad-file.rs
+++ b/src/test/ui/errors/issue-104621-extern-bad-file.rs
@@ -1,0 +1,8 @@
+// compile-flags: --extern foo={{src-base}}/errors/issue-104621-extern-bad-file.rs
+// only-linux
+
+extern crate foo;
+//~^ ERROR extern location for foo is of an unknown type
+//~| ERROR file name should be lib*.rlib or lib*.so
+//~| ERROR can't find crate for `foo` [E0463]
+fn main() {}

--- a/src/test/ui/errors/issue-104621-extern-bad-file.stderr
+++ b/src/test/ui/errors/issue-104621-extern-bad-file.stderr
@@ -1,0 +1,21 @@
+error: extern location for foo is of an unknown type: $DIR/issue-104621-extern-bad-file.rs
+  --> $DIR/issue-104621-extern-bad-file.rs:4:1
+   |
+LL | extern crate foo;
+   | ^^^^^^^^^^^^^^^^^
+
+error: file name should be lib*.rlib or lib*.so
+  --> $DIR/issue-104621-extern-bad-file.rs:4:1
+   |
+LL | extern crate foo;
+   | ^^^^^^^^^^^^^^^^^
+
+error[E0463]: can't find crate for `foo`
+  --> $DIR/issue-104621-extern-bad-file.rs:4:1
+   |
+LL | extern crate foo;
+   | ^^^^^^^^^^^^^^^^^ can't find crate
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0463`.

--- a/src/test/ui/errors/issue-104621-extern-not-file.rs
+++ b/src/test/ui/errors/issue-104621-extern-not-file.rs
@@ -1,0 +1,4 @@
+// compile-flags: --extern foo=.
+
+extern crate foo; //~ ERROR extern location for foo is not a file: .
+fn main() {}

--- a/src/test/ui/errors/issue-104621-extern-not-file.stderr
+++ b/src/test/ui/errors/issue-104621-extern-not-file.stderr
@@ -1,0 +1,8 @@
+error: extern location for foo is not a file: .
+  --> $DIR/issue-104621-extern-not-file.rs:3:1
+   |
+LL | extern crate foo;
+   | ^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
- `crate_name` is not specified/passed to `metadata_crate_location_unknown_type`
https://github.com/rust-lang/rust/blob/c493bae0d8efd75723460ce5c371f726efa93f15/compiler/rustc_error_messages/locales/en-US/metadata.ftl#L274-L275
- `metadata_lib_filename_form` is missing `$`
- Add additional check to ensure that library is file

Testing
1. Create file `a.rs`
```rust
extern crate t;
fn main() {}
```
1. Create empty file `x`
1. Create empty directory `y`
1. Run
```sh
$ rustc -o a a.rs --extern t=x
$ rustc -o a a.rs --extern t=y
```
Both currently panic with stable. 