### PR TITLE
Use clang for the UEFI targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.82"
+version = "0.1.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18cd7635fea7bb481ea543b392789844c1ad581299da70184c7175ce3af76603"
+checksum = "989b2c1ca6e90ad06fdc69d1d1862fa28d27a977be6d92ae2fa762cf61fe0b10"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "hex",
  "ignore",
  "libc",
+ "object",
  "once_cell",
  "opener",
  "pretty_assertions",
@@ -398,6 +399,15 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -42,6 +42,7 @@ getopts = "0.2.19"
 cc = "1.0.69"
 libc = "0.2"
 hex = "0.4"
+object = { version = "0.29.0", default-features = false, features = ["archive", "coff", "read_core", "unaligned"] }
 serde = { version = "1.0.8", features = ["derive"] }
 serde_json = "1.0.2"
 sha2 = "0.10"

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -61,6 +61,12 @@ ENV \
     AR_i686_unknown_freebsd=i686-unknown-freebsd12-ar \
     CC_i686_unknown_freebsd=i686-unknown-freebsd12-clang \
     CXX_i686_unknown_freebsd=i686-unknown-freebsd12-clang++ \
+    CC_aarch64_unknown_uefi=clang-11 \
+    CXX_aarch64_unknown_uefi=clang++-11 \
+    CC_i686_unknown_uefi=clang-11 \
+    CXX_i686_unknown_uefi=clang++-11 \
+    CC_x86_64_unknown_uefi=clang-11 \
+    CXX_x86_64_unknown_uefi=clang++-11 \
     CC=gcc-8 \
     CXX=g++-8
 

--- a/src/ci/docker/host-x86_64/test-various/Dockerfile
+++ b/src/ci/docker/host-x86_64/test-various/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  clang-11 \
   g++ \
   make \
   ninja-build \
@@ -67,7 +68,9 @@ ENV MUSL_TARGETS=x86_64-unknown-linux-musl \
 ENV MUSL_SCRIPT python3 /checkout/x.py --stage 2 test --host='' --target $MUSL_TARGETS
 
 COPY host-x86_64/test-various/uefi_qemu_test /uefi_qemu_test
-ENV UEFI_TARGETS=x86_64-unknown-uefi
+ENV UEFI_TARGETS=x86_64-unknown-uefi \
+    CC_x86_64_unknown_uefi=clang-11 \
+    CXX_x86_64_unknown_uefi=clang++-11
 ENV UEFI_SCRIPT python3 /checkout/x.py --stage 2 build --host='' --target $UEFI_TARGETS && \
   python3 -u /uefi_qemu_test/run.py
 


### PR DESCRIPTION
This fixes an issue where the C and asm sources built by compiler_builtins were being compiled as ELF objects instead of PE objects. This wasn't noticed before because it doesn't cause compiler_builtins or rustc to fail to build. You only see a failure when a program is built that references one of the symbols in an ELF object.

Compiling with clang fixes this because the cc crate converts the UEFI targets into Windows targets that clang understands, causing it to produce PE objects.

Also update compiler_builtins to 0.1.84 to pull in some necessary fixes for compiling the UEFI targets with clang.

Fixes https://github.com/rust-lang/rust/issues/104326
