### PR TITLE
Use normal iterators instead of the internal `vec::ExtendWith`

### DIFF
--- a/library/alloc/src/vec/spec_from_elem.rs
+++ b/library/alloc/src/vec/spec_from_elem.rs
@@ -1,9 +1,10 @@
+use core::iter;
 use core::ptr;
 
 use crate::alloc::Allocator;
 use crate::raw_vec::RawVec;
 
-use super::{ExtendElement, IsZero, Vec};
+use super::{IsZero, Vec};
 
 // Specialization trait used for Vec::from_elem
 pub(super) trait SpecFromElem: Sized {
@@ -13,7 +14,7 @@ pub(super) trait SpecFromElem: Sized {
 impl<T: Clone> SpecFromElem for T {
     default fn from_elem<A: Allocator>(elem: Self, n: usize, alloc: A) -> Vec<Self, A> {
         let mut v = Vec::with_capacity_in(n, alloc);
-        v.extend_with(n, ExtendElement(elem));
+        v.extend(iter::repeat_n(elem, n));
         v
     }
 }
@@ -25,7 +26,7 @@ impl<T: Clone + IsZero> SpecFromElem for T {
             return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: n };
         }
         let mut v = Vec::with_capacity_in(n, alloc);
-        v.extend_with(n, ExtendElement(elem));
+        v.extend(iter::repeat_n(elem, n));
         v
     }
 }

--- a/src/test/codegen/vec-calloc.rs
+++ b/src/test/codegen/vec-calloc.rs
@@ -6,6 +6,7 @@
 #![crate_type = "lib"]
 
 // CHECK-LABEL: @vec_zero_bytes
+// CHECK-SAME: i64 %n
 #[no_mangle]
 pub fn vec_zero_bytes(n: usize) -> Vec<u8> {
     // CHECK-NOT: call {{.*}}alloc::vec::from_elem
@@ -13,7 +14,7 @@ pub fn vec_zero_bytes(n: usize) -> Vec<u8> {
     // CHECK-NOT: call {{.*}}__rust_alloc(
     // CHECK-NOT: call {{.*}}llvm.memset
 
-    // CHECK: call {{.*}}__rust_alloc_zeroed(
+    // CHECK: call {{.*}}__rust_alloc_zeroed(i64 %n
 
     // CHECK-NOT: call {{.*}}alloc::vec::from_elem
     // CHECK-NOT: call {{.*}}reserve
@@ -22,17 +23,19 @@ pub fn vec_zero_bytes(n: usize) -> Vec<u8> {
 
     // CHECK: ret void
     vec![0; n]
-}
 
+}
 // CHECK-LABEL: @vec_one_bytes
+// CHECK-SAME: i64 %n
 #[no_mangle]
 pub fn vec_one_bytes(n: usize) -> Vec<u8> {
     // CHECK-NOT: call {{.*}}alloc::vec::from_elem
     // CHECK-NOT: call {{.*}}reserve
     // CHECK-NOT: call {{.*}}__rust_alloc_zeroed(
 
-    // CHECK: call {{.*}}__rust_alloc(
+    // CHECK: call {{.*}}__rust_alloc(i64 %n
     // CHECK: call {{.*}}llvm.memset
+    // CHECK-SAME: i8 1, i64 %n
 
     // CHECK-NOT: call {{.*}}alloc::vec::from_elem
     // CHECK-NOT: call {{.*}}reserve
@@ -43,13 +46,20 @@ pub fn vec_one_bytes(n: usize) -> Vec<u8> {
 }
 
 // CHECK-LABEL: @vec_zero_scalar
+// CHECK-SAME: i64 %n
 #[no_mangle]
 pub fn vec_zero_scalar(n: usize) -> Vec<i32> {
     // CHECK-NOT: call {{.*}}alloc::vec::from_elem
     // CHECK-NOT: call {{.*}}reserve
     // CHECK-NOT: call {{.*}}__rust_alloc(
 
-    // CHECK: call {{.*}}__rust_alloc_zeroed(
+    // CHECK: %[[BYTES:.+]] = shl i64 %n, 2
+
+    // CHECK-NOT: call {{.*}}alloc::vec::from_elem
+    // CHECK-NOT: call {{.*}}reserve
+    // CHECK-NOT: call {{.*}}__rust_alloc(
+
+    // CHECK: call {{.*}}__rust_alloc_zeroed(i64 %[[BYTES]]
 
     // CHECK-NOT: call {{.*}}alloc::vec::from_elem
     // CHECK-NOT: call {{.*}}reserve
@@ -60,13 +70,20 @@ pub fn vec_zero_scalar(n: usize) -> Vec<i32> {
 }
 
 // CHECK-LABEL: @vec_one_scalar
+// CHECK-SAME: i64 %n
 #[no_mangle]
 pub fn vec_one_scalar(n: usize) -> Vec<i32> {
     // CHECK-NOT: call {{.*}}alloc::vec::from_elem
     // CHECK-NOT: call {{.*}}reserve
     // CHECK-NOT: call {{.*}}__rust_alloc_zeroed(
 
-    // CHECK: call {{.*}}__rust_alloc(
+    // CHECK: %[[BYTES:.+]] = shl i64 %n, 2
+
+    // CHECK-NOT: call {{.*}}alloc::vec::from_elem
+    // CHECK-NOT: call {{.*}}reserve
+    // CHECK-NOT: call {{.*}}__rust_alloc_zeroed(
+
+    // CHECK: call {{.*}}__rust_alloc(i64 %[[BYTES]]
 
     // CHECK-NOT: call {{.*}}alloc::vec::from_elem
     // CHECK-NOT: call {{.*}}reserve


### PR DESCRIPTION
Repeating is `TrustedLen`, so we don't need another copy of [the `TrustedLen` specialization for `extend`](https://github.com/rust-lang/rust/blob/c5d82ed7a4ad94a538bb87e5016e7d5ce0bd434b/library/alloc/src/vec/spec_extend.rs#L27).

All the codegen tests are passing (and I made one stricter to help be sure), so let's see if perf is also happy with it.

(This is a simpler version of https://github.com/rust-lang/rust/pull/104596, which tried to do too many things at once.)

r? @ghost

~~Built atop https://github.com/rust-lang/rust/pull/104435; will leave draft until I can rebase atop that.~~