### PR TITLE
Revert "Update CI to use Android NDK r25b"

### DIFF
--- a/src/bootstrap/cc_detect.rs
+++ b/src/bootstrap/cc_detect.rs
@@ -47,8 +47,6 @@ fn cc2ar(cc: &Path, target: TargetSelection) -> Option<PathBuf> {
         Some(PathBuf::from("ar"))
     } else if target.contains("vxworks") {
         Some(PathBuf::from("wr-ar"))
-    } else if target.contains("android") {
-        Some(cc.parent().unwrap().join(PathBuf::from("llvm-ar")))
     } else {
         let parent = cc.parent().unwrap();
         let file = cc.file_name().unwrap().to_str().unwrap();
@@ -221,22 +219,12 @@ fn set_compiler(
 }
 
 pub(crate) fn ndk_compiler(compiler: Language, triple: &str, ndk: &Path) -> PathBuf {
-    let mut triple_iter = triple.split("-");
-    let triple_translated = if let Some(arch) = triple_iter.next() {
-        let arch_new = match arch {
-            "arm" | "armv7" | "armv7neon" | "thumbv7" | "thumbv7neon" => "armv7a",
-            other => other,
-        };
-        std::iter::once(arch_new).chain(triple_iter).collect::<Vec<&str>>().join("-")
-    } else {
-        triple.to_string()
-    };
-
-    // API 19 is the earliest API level supported by NDK r25b but AArch64 and x86_64 support
-    // begins at API level 21.
-    let api_level =
-        if triple.contains("aarch64") || triple.contains("x86_64") { "21" } else { "19" };
-    let compiler = format!("{}{}-{}", triple_translated, api_level, compiler.clang());
+    let triple_translated = triple
+        .replace("armv7neon", "arm")
+        .replace("armv7", "arm")
+        .replace("thumbv7neon", "arm")
+        .replace("thumbv7", "arm");
+    let compiler = format!("{}-{}", triple_translated, compiler.clang());
     ndk.join("bin").join(compiler)
 }
 

--- a/src/ci/docker/host-x86_64/arm-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/arm-android/Dockerfile
@@ -6,7 +6,7 @@ RUN sh /scripts/android-base-apt-get.sh
 
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
-    download_ndk android-ndk-r25b-linux.zip
+    download_and_make_toolchain android-ndk-r15c-linux-x86_64.zip arm 14
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
@@ -30,7 +30,7 @@ ENV PATH=$PATH:/android/sdk/platform-tools
 
 ENV TARGETS=arm-linux-androideabi
 
-ENV RUST_CONFIGURE_ARGS --arm-linux-androideabi-ndk=/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/
+ENV RUST_CONFIGURE_ARGS --arm-linux-androideabi-ndk=/android/ndk/arm-14
 
 ENV SCRIPT python3 ../x.py --stage 2 test --host='' --target $TARGETS
 

--- a/src/ci/docker/host-x86_64/dist-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-android/Dockerfile
@@ -6,7 +6,14 @@ RUN sh /scripts/android-base-apt-get.sh
 # ndk
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
-    download_ndk android-ndk-r25b-linux.zip
+    download_ndk android-ndk-r15c-linux-x86_64.zip && \
+    make_standalone_toolchain arm 14 && \
+    make_standalone_toolchain x86 14 && \
+    make_standalone_toolchain arm 21 && \
+    make_standalone_toolchain x86 21 && \
+    make_standalone_toolchain arm64 21 && \
+    make_standalone_toolchain x86_64 21 && \
+    remove_ndk
 
 # env
 ENV TARGETS=arm-linux-androideabi
@@ -19,12 +26,12 @@ ENV TARGETS=$TARGETS,x86_64-linux-android
 ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
       --enable-profiler \
-      --arm-linux-androideabi-ndk=/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/ \
-      --armv7-linux-androideabi-ndk=/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/ \
-      --thumbv7neon-linux-androideabi-ndk=/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/ \
-      --i686-linux-android-ndk=/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/ \
-      --aarch64-linux-android-ndk=/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/ \
-      --x86_64-linux-android-ndk=/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/ \
+      --arm-linux-androideabi-ndk=/android/ndk/arm-14 \
+      --armv7-linux-androideabi-ndk=/android/ndk/arm-14 \
+      --thumbv7neon-linux-androideabi-ndk=/android/ndk/arm-14 \
+      --i686-linux-android-ndk=/android/ndk/x86-14 \
+      --aarch64-linux-android-ndk=/android/ndk/arm64-21 \
+      --x86_64-linux-android-ndk=/android/ndk/x86_64-21 \
       --disable-docs
 
 ENV SCRIPT python3 ../x.py dist --host='' --target $TARGETS

--- a/src/ci/docker/scripts/android-ndk.sh
+++ b/src/ci/docker/scripts/android-ndk.sh
@@ -4,10 +4,28 @@ set -ex
 URL=https://dl.google.com/android/repository
 
 download_ndk() {
-    mkdir /android/
-    cd /android
+    mkdir -p /android/ndk
+    cd /android/ndk
     curl -fO $URL/$1
     unzip -q $1
     rm $1
     mv android-ndk-* ndk
+}
+
+make_standalone_toolchain() {
+    # See https://developer.android.com/ndk/guides/standalone_toolchain.htm
+    python3 /android/ndk/ndk/build/tools/make_standalone_toolchain.py \
+        --install-dir /android/ndk/$1-$2 \
+        --arch $1 \
+        --api $2
+}
+
+remove_ndk() {
+    rm -rf /android/ndk/ndk
+}
+
+download_and_make_toolchain() {
+    download_ndk $1 && \
+    make_standalone_toolchain $2 $3 && \
+    remove_ndk
 }


### PR DESCRIPTION
This reverts commit bf7f1ca316a249cf99d722d79a0db12fef687142 (pull request #102332).

The relevant discussion can be found in #103673, where it was agreed that more time is needed to warn the community of the upcoming breakage.

This PR is for the `master` branch, where a conflict was recently introduced due to 6d8160261ff3aee3b6eaacc37ac96cafff530980. The conflict is in `cc_detect.rs`, where the code that corrects the target triple was moved to a new function called `ndk_compiler()`. This puts the old logic in the `ndk_compiler` function, and assumes that it works properly in the other location where that code is being called. I would appreciate review from @pietroalbini to understand how we can test that the reverted logic is also suitable for the additional use case (seems to be related to setting `cc` and `cxx`). I've confirmed already that with these changes I can compile for `armv7-linux-androideabi`, `aarch64-linux-android`, `i686-linux-android`, and `x86_64-linux-android` using `x.py`.

A separate revert for the `beta` branch will be required, since the original change has already made it to beta. The beta revert is available at https://github.com/alex-pinkus/rust/commit/3fa0d94674fbe37090ebe44ac1f06e2233f3121e, but I'm not sure of the process for staging that PR.