### PR TITLE
Add `#![deny(unsafe_op_in_unsafe_fn)]` in liballoc tests

### DIFF
--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -48,6 +48,7 @@
 #![feature(once_cell)]
 #![feature(drain_keep_rest)]
 #![deny(fuzzy_provenance_casts)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -1089,7 +1089,8 @@ fn test_into_iter_drop_allocator() {
         }
 
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-            System.deallocate(ptr, layout)
+            // Safety: Invariants passed to caller.
+            unsafe { System.deallocate(ptr, layout) }
         }
     }
 


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/104647#discussion_r1027332930 it was mentioned that liballoc tests should probably have this enabled (we have it pretty much everywhere else in the stdlib), so I added it.

This will probably conflict with https://github.com/rust-lang/rust/pull/104647 so I'll rebase after that lands.