### PR TITLE
Streamline deriving on packed structs.

### DIFF
--- a/src/test/ui/deriving/deriving-all-codegen.stdout
+++ b/src/test/ui/deriving/deriving-all-codegen.stdout
@@ -463,16 +463,14 @@ struct PackedNonCopy(u8);
 impl ::core::clone::Clone for PackedNonCopy {
     #[inline]
     fn clone(&self) -> PackedNonCopy {
-        let Self(ref __self_0_0) = *self;
-        PackedNonCopy(::core::clone::Clone::clone(__self_0_0))
+        PackedNonCopy(::core::clone::Clone::clone(&self.0))
     }
 }
 #[automatically_derived]
 impl ::core::fmt::Debug for PackedNonCopy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        let Self(ref __self_0_0) = *self;
         ::core::fmt::Formatter::debug_tuple_field1_finish(f, "PackedNonCopy",
-            &__self_0_0)
+            &&self.0)
     }
 }
 #[automatically_derived]
@@ -485,8 +483,7 @@ impl ::core::default::Default for PackedNonCopy {
 #[automatically_derived]
 impl ::core::hash::Hash for PackedNonCopy {
     fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
-        let Self(ref __self_0_0) = *self;
-        ::core::hash::Hash::hash(__self_0_0, state)
+        ::core::hash::Hash::hash(&self.0, state)
     }
 }
 #[automatically_derived]
@@ -494,11 +491,7 @@ impl ::core::marker::StructuralPartialEq for PackedNonCopy { }
 #[automatically_derived]
 impl ::core::cmp::PartialEq for PackedNonCopy {
     #[inline]
-    fn eq(&self, other: &PackedNonCopy) -> bool {
-        let Self(ref __self_0_0) = *self;
-        let Self(ref __self_1_0) = *other;
-        *__self_0_0 == *__self_1_0
-    }
+    fn eq(&self, other: &PackedNonCopy) -> bool { self.0 == other.0 }
 }
 #[automatically_derived]
 impl ::core::marker::StructuralEq for PackedNonCopy { }
@@ -516,18 +509,14 @@ impl ::core::cmp::PartialOrd for PackedNonCopy {
     #[inline]
     fn partial_cmp(&self, other: &PackedNonCopy)
         -> ::core::option::Option<::core::cmp::Ordering> {
-        let Self(ref __self_0_0) = *self;
-        let Self(ref __self_1_0) = *other;
-        ::core::cmp::PartialOrd::partial_cmp(__self_0_0, __self_1_0)
+        ::core::cmp::PartialOrd::partial_cmp(&self.0, &other.0)
     }
 }
 #[automatically_derived]
 impl ::core::cmp::Ord for PackedNonCopy {
     #[inline]
     fn cmp(&self, other: &PackedNonCopy) -> ::core::cmp::Ordering {
-        let Self(ref __self_0_0) = *self;
-        let Self(ref __self_1_0) = *other;
-        ::core::cmp::Ord::cmp(__self_0_0, __self_1_0)
+        ::core::cmp::Ord::cmp(&self.0, &other.0)
     }
 }
 


### PR DESCRIPTION
The current approach to field accesses in derived code:
- Normal case: `&self.0`
- In a packed struct that derives `Copy`: `&{self.0}`
- In a packed struct that doesn't derive `Copy`: `let Self(ref x) = *self`

The `let` pattern used in the third case is equivalent to the simpler field access in the first case. This commit changes the third case to use a field access.

The commit also combines two boolean arguments (`is_packed` and `always_copy`) into a single field (`copy_fields`) earlier, to save passing both around.

r? @jackh726 