### PR TITLE
codegen-llvm: never combine DSOLocal and DllImport

### DIFF
--- a/src/test/codegen/auxiliary/extern_decl.rs
+++ b/src/test/codegen/auxiliary/extern_decl.rs
@@ -1,0 +1,11 @@
+// Auxiliary crate that exports a function and static. Both always
+// evaluate to `71`. We force mutability on the static to prevent
+// it from being inlined as constant.
+
+#![crate_type = "lib"]
+
+#[no_mangle]
+pub fn extern_fn() -> u8 { unsafe { extern_static } }
+
+#[no_mangle]
+pub static mut extern_static: u8 = 71;

--- a/src/test/codegen/static-relocation-model-msvc.rs
+++ b/src/test/codegen/static-relocation-model-msvc.rs
@@ -1,0 +1,26 @@
+// Verify linkage of external symbols in the static relocation model on MSVC.
+//
+// compile-flags: -O -C relocation-model=static
+// aux-build: extern_decl.rs
+// only-x86_64-pc-windows-msvc
+
+#![crate_type = "rlib"]
+
+extern crate extern_decl;
+
+// The `extern_decl` definitions are imported from a statically linked rust
+// crate, thus they are expected to be marked `dso_local` without `dllimport`.
+//
+// The `access_extern()` symbol is from this compilation unit, thus we expect
+// it to be marked `dso_local` as well, given the static relocation model.
+//
+// CHECK: @extern_static = external dso_local local_unnamed_addr global i8
+// CHECK: define dso_local i8 @access_extern() {{.*}}
+// CHECK: declare dso_local i8 @extern_fn() {{.*}}
+
+#[no_mangle]
+pub fn access_extern() -> u8 {
+    unsafe {
+        extern_decl::extern_fn() + extern_decl::extern_static
+    }
+}


### PR DESCRIPTION
Prevent DllImport from being attached to DSOLocal definitions in the LLVM IR. The combination makes no sense, since definitions local to the compilation unit will never be imported from external objects.

Additionally, LLVM will refuse the IR if it encounters the combination (introduced in [1]):

```
  if (GV.hasDLLImportStorageClass())
    Assert(!GV.isDSOLocal(),
           "GlobalValue with DLLImport Storage is dso_local!", &GV);
```

Right now, codegen-llvm will only apply DllImport to constants and rely on call-stubs for functions. Hence, we simply extend the codegen of constants to skip DllImport for any local definitions.

This was discovered when switching the EFI targets to the static relocation model [2]. With this fixed, we can start another attempt at this.

[1] https://smlnj-gitlab.cs.uchicago.edu/manticore/llvm/commit/509132b368efed10bbdad825403f45e9cf1d6e38
[2] https://github.com/rust-lang/rust/issues/101656