### PR TITLE
Restore control flow on error in EUV

### DIFF
--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -2184,7 +2184,7 @@ fn determine_place_ancestry_relation<'tcx>(
     place_a: &Place<'tcx>,
     place_b: &Place<'tcx>,
 ) -> PlaceAncestryRelation {
-    // If Place A and Place B, don't start off from the same root variable, they are divergent.
+    // If Place A and Place B don't start off from the same root variable, they are divergent.
     if place_a.base != place_b.base {
         return PlaceAncestryRelation::Divergent;
     }

--- a/src/test/ui/inference/issue-104649.rs
+++ b/src/test/ui/inference/issue-104649.rs
@@ -1,0 +1,32 @@
+type Result<T, E = Error> = ::std::result::Result<T, E>;
+struct Error;
+
+trait ForEach {
+    type Input;
+    fn for_each<F, U>(self, f: F)
+    where
+        F: FnOnce(Self::Input) -> U;
+}
+
+impl<T> ForEach for A<T> {
+    type Input = T;
+    fn for_each<F, U>(self, f: F)
+    where
+        F: FnOnce(Self::Input) -> U,
+    {
+        todo!()
+    }
+}
+
+struct A<T>(T);
+
+fn main() {
+    let a = A(Result::Ok(Result::Ok(()))); //~ ERROR type annotations needed
+    a.for_each(|a: Result<_>| {
+        let f = || match a {
+            Ok(Ok(a)) => {}
+            Ok(Err(a)) => {}
+            Err(a) => {}
+        };
+    });
+}

--- a/src/test/ui/inference/issue-104649.stderr
+++ b/src/test/ui/inference/issue-104649.stderr
@@ -1,0 +1,14 @@
+error[E0282]: type annotations needed for `A<std::result::Result<std::result::Result<(), E>, Error>>`
+  --> $DIR/issue-104649.rs:24:9
+   |
+LL |     let a = A(Result::Ok(Result::Ok(())));
+   |         ^
+   |
+help: consider giving `a` an explicit type, where the type for type parameter `E` is specified
+   |
+LL |     let a: A<std::result::Result<std::result::Result<(), E>, Error>> = A(Result::Ok(Result::Ok(())));
+   |          +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
cc @Nilstrieb 

Fix #104649

Since #98574 refactored a piece of scrutinee memory categorization out as a subroutine, there is a subtle change in handling match arms especially when the categorization process faults and bails. In the correct case, it is not supposed to continue to process the arms any more. This PR restores the original control flow in EUV.

I promise to add a compile-fail test to demonstrate that this indeed fixes the issue after coming back from a nap.