### PR TITLE
[perf] test making v0 mangling the default

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1186,7 +1186,7 @@ options! {
         "how to handle split-debuginfo, a platform-specific option"),
     strip: Strip = (Strip::None, parse_strip, [UNTRACKED],
         "tell the linker which information to strip (`none` (default), `debuginfo` or `symbols`)"),
-    symbol_mangling_version: Option<SymbolManglingVersion> = (None,
+    symbol_mangling_version: Option<SymbolManglingVersion> = (Some(SymbolManglingVersion::V0),
         parse_symbol_mangling_version, [TRACKED],
         "which mangling version to use for symbol names ('legacy' (default) or 'v0')"),
     target_cpu: Option<String> = (None, parse_opt_string, [TRACKED],


### PR DESCRIPTION
We saw a case where deep recursive types had huge symbols in the legacy mangling scheme and killed LLVM. Using v0 fixed it, so let's see what the perf impact is if we made that the default: I'd think we'd still see some perf regressions, but let's make sure.

(makes me realize `dyn*` doesn't yet support v0 mangling apparently, so CI should see test failures & ICEs)

r? @ghost