### PR TITLE
Add failing test for projections used as const generic

### DIFF
--- a/src/test/ui/const-generics/projection-as-arg-const.rs
+++ b/src/test/ui/const-generics/projection-as-arg-const.rs
@@ -1,0 +1,20 @@
+// This is currently not possible to use projections as const generics.
+// More information about this available here:
+// https://github.com/rust-lang/rust/pull/104443#discussion_r1029375633
+
+pub trait Identity {
+    type Identity;
+}
+
+impl<T> Identity for T {
+    type Identity = Self;
+}
+
+pub fn foo<const X: <i32 as Identity>::Identity>() {
+//~^ ERROR
+    assert!(X == 12);
+}
+
+fn main() {
+    foo::<12>();
+}

--- a/src/test/ui/const-generics/projection-as-arg-const.stderr
+++ b/src/test/ui/const-generics/projection-as-arg-const.stderr
@@ -1,0 +1,11 @@
+error: `<i32 as Identity>::Identity` is forbidden as the type of a const generic parameter
+  --> $DIR/projection-as-arg-const.rs:13:21
+   |
+LL | pub fn foo<const X: <i32 as Identity>::Identity>() {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: more complex types are supported with `#![feature(adt_const_params)]`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Based on the experiment done in https://github.com/rust-lang/rust/pull/104443, we realized it's currently not possible to support projections in const generics. More information about it in https://github.com/rust-lang/rust/pull/104443#discussion_r1029375633.

This PR adds the UI test in any case so we can gather data in order to work towards adding `TyAlias` into the ABI in the future.

r? @oli-obk 