### PR TITLE
rustdoc: remove no-op CSS `.popover::before / a.test-arrow { display: inline-block }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -932,7 +932,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	right: var(--popover-arrow-offset);
 	border: solid var(--border-color);
 	border-width: 1px 1px 0 0;
-	display: inline-block;
 	padding: 4px;
 	transform: rotate(-45deg);
 	top: -5px;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1199,7 +1199,6 @@ pre.rust .doccomment {
 }
 
 a.test-arrow {
-	display: inline-block;
 	visibility: hidden;
 	position: absolute;
 	padding: 5px 10px 5px 10px;


### PR DESCRIPTION
Since this box is absolutely positioned, its display type is [blockified] anyway. We just need to make sure it isn't `display: none`.

[blockified]: https://www.w3.org/TR/css-display-3/#transformations