### PR TITLE
Be more careful about elaboration around trait aliases

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -1378,7 +1378,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
                 let bound_predicate = obligation.predicate.kind();
                 match bound_predicate.skip_binder() {
-                    ty::PredicateKind::Trait(pred) => {
+                    ty::PredicateKind::Trait(pred) if pred.self_ty() == dummy_self => {
                         let pred = bound_predicate.rebind(pred);
                         associated_types.entry(span).or_default().extend(
                             tcx.associated_items(pred.def_id())
@@ -1387,7 +1387,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                 .map(|item| item.def_id),
                         );
                     }
-                    ty::PredicateKind::Projection(pred) => {
+                    ty::PredicateKind::Projection(pred)
+                        if pred.projection_ty.self_ty() == dummy_self =>
+                    {
                         let pred = bound_predicate.rebind(pred);
                         // A `Self` within the original bound will be substituted with a
                         // `trait_object_dummy_self`, so check for that.
@@ -1510,7 +1512,11 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
         let existential_projections = bounds.projection_bounds.iter().map(|(bound, _)| {
             bound.map_bound(|mut b| {
-                assert_eq!(b.projection_ty.self_ty(), dummy_self);
+                assert_eq!(
+                    b.projection_ty.self_ty(),
+                    dummy_self,
+                    "projection doesn't have the dummy self as its `Self` type: {b:?}"
+                );
 
                 // Like for trait refs, verify that `dummy_self` did not leak inside default type
                 // parameters.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -640,7 +640,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     #[instrument(skip(self), level = "debug")]
-    fn self_type_matches_expected_vid(&self, self_ty: Ty<'tcx>, expected_vid: ty::TyVid) -> bool {
+    pub(in super::super) fn self_type_matches_expected_vid(
+        &self,
+        self_ty: Ty<'tcx>,
+        expected_vid: ty::TyVid,
+    ) -> bool {
         let self_ty = self.shallow_resolve(self_ty);
         debug!(?self_ty);
 

--- a/src/test/ui/closures/self-supertrait-bounds.rs
+++ b/src/test/ui/closures/self-supertrait-bounds.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+// Makes sure that we only consider `Self` supertrait predicates while
+// elaborating during closure signature deduction.
+
+#![feature(trait_alias)]
+
+trait Confusing<F> = Fn(i32) where F: Fn(u32);
+
+fn alias<T: Confusing<F>, F>(_: T, _: F) {}
+
+fn main() {
+    alias(|_| {}, |_| {});
+}

--- a/src/test/ui/lint/unused/trait-alias-supertrait.rs
+++ b/src/test/ui/lint/unused/trait-alias-supertrait.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+// Make sure that we only consider *Self* supertrait predicates
+// in the `unused_must_use` lint.
+
+#![feature(trait_alias)]
+#![deny(unused_must_use)]
+
+trait Foo<T> = Sized where T: Iterator;
+
+fn test<T: Iterator>() -> impl Foo<T> {}
+
+fn main() {
+    test::<std::iter::Once<()>>();
+}

--- a/src/test/ui/traits/alias/dont-elaborate-non-self.rs
+++ b/src/test/ui/traits/alias/dont-elaborate-non-self.rs
@@ -1,0 +1,10 @@
+#![feature(trait_alias)]
+
+use std::future::Future;
+
+trait F<Fut: Future<Output = usize>> = Fn() -> Fut;
+
+fn f<Fut>(a: dyn F<Fut>) {}
+//~^ ERROR the size for values of type `(dyn Fn() -> Fut + 'static)` cannot be known at compilation time
+
+fn main() {}

--- a/src/test/ui/traits/alias/dont-elaborate-non-self.stderr
+++ b/src/test/ui/traits/alias/dont-elaborate-non-self.stderr
@@ -1,0 +1,16 @@
+error[E0277]: the size for values of type `(dyn Fn() -> Fut + 'static)` cannot be known at compilation time
+  --> $DIR/dont-elaborate-non-self.rs:7:11
+   |
+LL | fn f<Fut>(a: dyn F<Fut>) {}
+   |           ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Fn() -> Fut + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn f<Fut>(a: &dyn F<Fut>) {}
+   |              +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/traits/trait-upcasting/alias-where-clause-isnt-supertrait.rs
+++ b/src/test/ui/traits/trait-upcasting/alias-where-clause-isnt-supertrait.rs
@@ -1,0 +1,33 @@
+#![feature(trait_upcasting)]
+#![feature(trait_alias)]
+
+// Although we *elaborate* `T: Alias` to `i32: B`, we should
+// not consider `B` to be a supertrait of the type.
+trait Alias = A where i32: B;
+
+trait A {}
+
+trait B {
+    fn test(&self);
+}
+
+trait C: Alias {}
+
+impl A for () {}
+
+impl C for () {}
+
+impl B for i32 {
+    fn test(&self) {
+        println!("hi {self}");
+    }
+}
+
+fn test(x: &dyn C) -> &dyn B {
+    x
+    //~^ ERROR mismatched types
+}
+
+fn main() {
+    let x: &dyn C = &();
+}

--- a/src/test/ui/traits/trait-upcasting/alias-where-clause-isnt-supertrait.stderr
+++ b/src/test/ui/traits/trait-upcasting/alias-where-clause-isnt-supertrait.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/alias-where-clause-isnt-supertrait.rs:27:5
+   |
+LL | fn test(x: &dyn C) -> &dyn B {
+   |                       ------ expected `&dyn B` because of return type
+LL |     x
+   |     ^ expected trait `B`, found trait `C`
+   |
+   = note: expected reference `&dyn B`
+              found reference `&dyn C`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes four separate (but similar) bugs that were found when it comes to trait aliases, for which the `traits::util::elaborate_*` methods can return predicates that have a different `Self` type than the one we started with.

Fixes #104719
Fixes #106238