### PR TITLE
Add an explanatory note when suggesting to use `impl Trait` instead of a type parameter

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -878,7 +878,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             format!("impl {}", all_bounds_str),
             Applicability::MaybeIncorrect,
         );
-        err.span_note(fn_return.span(), "generic type variables are chosen by the caller");
+        err.note("generic type variables are chosen by the caller");
     }
 
     pub(in super::super) fn suggest_missing_break_or_return_expr(

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -878,6 +878,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             format!("impl {}", all_bounds_str),
             Applicability::MaybeIncorrect,
         );
+        err.span_note(fn_return.span(), "generic type variables are chosen by the caller");
     }
 
     pub(in super::super) fn suggest_missing_break_or_return_expr(

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -878,7 +878,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             format!("impl {}", all_bounds_str),
             Applicability::MaybeIncorrect,
         );
-        err.note("generic type variables are chosen by the caller");
+        err.note("the caller chooses the value of a type parameter");
     }
 
     pub(in super::super) fn suggest_missing_break_or_return_expr(


### PR DESCRIPTION
Add a note to E308 explaining that generic type variables are chosen by the caller rather than the implementer, when suggesting to use `impl Trait` instead of a generic type variable. 
```rust
error[E0308]: mismatched types
 --> src/lib.rs:3:5
  |
2 | fn foo<T: Clone>() -> T {
  |        -              -
  |        |              |
  |        |              expected `T` because of return type
  |        |              help: consider using an impl return type: `impl Clone`
  |        this type parameter
3 |     "hello"
  |     ^^^^^^^ expected type parameter `T`, found `&str`
  |
  = note: expected type parameter `T`
                  found reference `&'static str`
  = note: the caller chooses the value of a type parameter
```

r? rust-lang/diagnostics