### PR TITLE
Bump the const eval step limit

### DIFF
--- a/compiler/rustc_middle/src/middle/limits.rs
+++ b/compiler/rustc_middle/src/middle/limits.rs
@@ -38,7 +38,7 @@ pub fn provide(providers: &mut ty::query::Providers) {
             tcx.hir().krate_attrs(),
             tcx.sess,
             sym::const_eval_limit,
-            1_000_000,
+            2_000_000,
         ),
     }
 }

--- a/src/test/ui/consts/const-eval/infinite_loop.rs
+++ b/src/test/ui/consts/const-eval/infinite_loop.rs
@@ -4,8 +4,8 @@ fn main() {
     let _ = [(); {
         let mut n = 113383; // #20 in https://oeis.org/A006884
         while n != 0 {
-            n = if n % 2 == 0 { n/2 } else { 3*n + 1 };
             //~^ ERROR evaluation of constant value failed
+            n = if n % 2 == 0 { n/2 } else { 3*n + 1 };
         }
         n
     }];

--- a/src/test/ui/consts/const-eval/infinite_loop.stderr
+++ b/src/test/ui/consts/const-eval/infinite_loop.stderr
@@ -1,8 +1,8 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/infinite_loop.rs:7:20
+  --> $DIR/infinite_loop.rs:6:15
    |
-LL |             n = if n % 2 == 0 { n/2 } else { 3*n + 1 };
-   |                    ^^^^^^^^^^ exceeded interpreter step limit (see `#[const_eval_limit]`)
+LL |         while n != 0 {
+   |               ^^^^^^ exceeded interpreter step limit (see `#[const_eval_limit]`)
 
 error: aborting due to previous error
 


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/103814

https://github.com/rust-lang/rust/pull/103877 has too much of an impact to beta backport. So let's just increase the limit, avoiding the immediate breakage.

r? @pnkfelix 