### PR TITLE
Do not record unresolved const vars in generator interior

### DIFF
--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -98,8 +98,8 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
                 expr, scope, ty, self.expr_count, yield_data.span
             );
 
-            if let Some((unresolved_type, unresolved_type_span)) =
-                self.fcx.unresolved_type_vars(&ty)
+            if let Some((unresolved_term, unresolved_type_span)) =
+                self.fcx.first_unresolved_const_or_ty_var(&ty)
             {
                 // If unresolved type isn't a ty_var then unresolved_type_span is None
                 let span = self
@@ -108,13 +108,13 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
 
                 // If we encounter an int/float variable, then inference fallback didn't
                 // finish due to some other error. Don't emit spurious additional errors.
-                if let ty::Infer(ty::InferTy::IntVar(_) | ty::InferTy::FloatVar(_)) =
-                    unresolved_type.kind()
+                if let Some(unresolved_ty) = unresolved_term.ty()
+                    && let ty::Infer(ty::InferTy::IntVar(_) | ty::InferTy::FloatVar(_)) = unresolved_ty.kind()
                 {
                     self.fcx
                         .tcx
                         .sess
-                        .delay_span_bug(span, &format!("Encountered var {:?}", unresolved_type));
+                        .delay_span_bug(span, &format!("Encountered var {:?}", unresolved_term));
                 } else {
                     let note = format!(
                         "the type is part of the {} because of this {}",
@@ -122,7 +122,7 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
                     );
 
                     self.fcx
-                        .need_type_info_err_in_generator(self.kind, span, unresolved_type)
+                        .need_type_info_err_in_generator(self.kind, span, unresolved_term)
                         .span_note(yield_data.span, &*note)
                         .emit();
                 }
@@ -162,7 +162,7 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
                 expr.map(|e| e.span)
             );
             if let Some((unresolved_type, unresolved_type_span)) =
-                self.fcx.unresolved_type_vars(&ty)
+                self.fcx.first_unresolved_const_or_ty_var(&ty)
             {
                 debug!(
                     "remained unresolved_type = {:?}, unresolved_type_span: {:?}",

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -571,7 +571,7 @@ impl<'tcx> InferCtxt<'tcx> {
         &self,
         kind: hir::GeneratorKind,
         span: Span,
-        ty: Ty<'tcx>,
+        ty: ty::Term<'tcx>,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
         let ty = self.resolve_vars_if_possible(ty);
         let data = self.extract_inference_diagnostics_data(ty.into(), None);

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1421,16 +1421,15 @@ impl<'tcx> InferCtxt<'tcx> {
         value.fold_with(&mut r)
     }
 
-    /// Returns the first unresolved variable contained in `T`. In the
-    /// process of visiting `T`, this will resolve (where possible)
-    /// type variables in `T`, but it never constructs the final,
-    /// resolved type, so it's more efficient than
-    /// `resolve_vars_if_possible()`.
-    pub fn unresolved_type_vars<T>(&self, value: &T) -> Option<(Ty<'tcx>, Option<Span>)>
+    /// Returns the first unresolved type or const variable contained in `T`.
+    pub fn first_unresolved_const_or_ty_var<T>(
+        &self,
+        value: &T,
+    ) -> Option<(ty::Term<'tcx>, Option<Span>)>
     where
         T: TypeVisitable<'tcx>,
     {
-        value.visit_with(&mut resolve::UnresolvedTypeFinder::new(self)).break_value()
+        value.visit_with(&mut resolve::UnresolvedTypeOrConstFinder::new(self)).break_value()
     }
 
     pub fn probe_const_var(

--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -140,6 +140,15 @@ impl<'tcx> From<ty::Const<'tcx>> for GenericArg<'tcx> {
     }
 }
 
+impl<'tcx> From<ty::Term<'tcx>> for GenericArg<'tcx> {
+    fn from(value: ty::Term<'tcx>) -> Self {
+        match value.unpack() {
+            ty::TermKind::Ty(t) => t.into(),
+            ty::TermKind::Const(c) => c.into(),
+        }
+    }
+}
+
 impl<'tcx> GenericArg<'tcx> {
     #[inline]
     pub fn unpack(self) -> GenericArgKind<'tcx> {

--- a/src/test/ui/generator/unresolved-ct-var.rs
+++ b/src/test/ui/generator/unresolved-ct-var.rs
@@ -1,0 +1,14 @@
+// incremental
+// edition:2021
+
+fn main() {
+    let _ = async {
+        let s = std::array::from_fn(|_| ()).await;
+        //~^ ERROR `[(); _]` is not a future
+        //~| ERROR type inside `async` block must be known in this context
+        //~| ERROR type inside `async` block must be known in this context
+        //~| ERROR type inside `async` block must be known in this context
+        //~| ERROR type inside `async` block must be known in this context
+        //~| ERROR type inside `async` block must be known in this context
+    };
+}

--- a/src/test/ui/generator/unresolved-ct-var.stderr
+++ b/src/test/ui/generator/unresolved-ct-var.stderr
@@ -1,0 +1,78 @@
+error[E0277]: `[(); _]` is not a future
+  --> $DIR/unresolved-ct-var.rs:6:44
+   |
+LL |         let s = std::array::from_fn(|_| ()).await;
+   |                 ---------------------------^^^^^^
+   |                 |                          |
+   |                 |                          `[(); _]` is not a future
+   |                 |                          help: remove the `.await`
+   |                 this call returns `[(); _]`
+   |
+   = help: the trait `Future` is not implemented for `[(); _]`
+   = note: [(); _] must be a future or must implement `IntoFuture` to be awaited
+   = note: required for `[(); _]` to implement `IntoFuture`
+
+error[E0698]: type inside `async` block must be known in this context
+  --> $DIR/unresolved-ct-var.rs:6:17
+   |
+LL |         let s = std::array::from_fn(|_| ()).await;
+   |                 ^^^^^^^^^^^^^^^^^^^ cannot infer the value of const parameter `N` declared on the function `from_fn`
+   |
+note: the type is part of the `async` block because of this `await`
+  --> $DIR/unresolved-ct-var.rs:6:44
+   |
+LL |         let s = std::array::from_fn(|_| ()).await;
+   |                                            ^^^^^^
+
+error[E0698]: type inside `async` block must be known in this context
+  --> $DIR/unresolved-ct-var.rs:6:17
+   |
+LL |         let s = std::array::from_fn(|_| ()).await;
+   |                 ^^^^^^^^^^^^^^^^^^^ cannot infer the value of const parameter `N` declared on the function `from_fn`
+   |
+note: the type is part of the `async` block because of this `await`
+  --> $DIR/unresolved-ct-var.rs:6:44
+   |
+LL |         let s = std::array::from_fn(|_| ()).await;
+   |                                            ^^^^^^
+
+error[E0698]: type inside `async` block must be known in this context
+  --> $DIR/unresolved-ct-var.rs:6:17
+   |
+LL |         let s = std::array::from_fn(|_| ()).await;
+   |                 ^^^^^^^^^^^^^^^^^^^ cannot infer the value of const parameter `N` declared on the function `from_fn`
+   |
+note: the type is part of the `async` block because of this `await`
+  --> $DIR/unresolved-ct-var.rs:6:44
+   |
+LL |         let s = std::array::from_fn(|_| ()).await;
+   |                                            ^^^^^^
+
+error[E0698]: type inside `async` block must be known in this context
+  --> $DIR/unresolved-ct-var.rs:6:17
+   |
+LL |         let s = std::array::from_fn(|_| ()).await;
+   |                 ^^^^^^^^^^^^^^^^^^^ cannot infer the value of const parameter `N` declared on the function `from_fn`
+   |
+note: the type is part of the `async` block because of this `await`
+  --> $DIR/unresolved-ct-var.rs:6:44
+   |
+LL |         let s = std::array::from_fn(|_| ()).await;
+   |                                            ^^^^^^
+
+error[E0698]: type inside `async` block must be known in this context
+  --> $DIR/unresolved-ct-var.rs:6:17
+   |
+LL |         let s = std::array::from_fn(|_| ()).await;
+   |                 ^^^^^^^^^^^^^^^^^^^ cannot infer the value of const parameter `N` declared on the function `from_fn`
+   |
+note: the type is part of the `async` block because of this `await`
+  --> $DIR/unresolved-ct-var.rs:6:44
+   |
+LL |         let s = std::array::from_fn(|_| ()).await;
+   |                                            ^^^^^^
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0277, E0698.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Don't record types in the generator interior when we see unresolved const variables. 

We already do this for associated types -- this is important to avoid unresolved inference variables in the generator results during writeback, since the writeback results get stable hashed in incremental mode.

Fixes #104787