### PR TITLE
Change multiline span ASCII art visual order

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2282,7 +2282,7 @@ impl FileWithAnnotatedLines {
         }
 
         // Find overlapping multiline annotations, put them at different depths
-        multiline_annotations.sort_by_key(|&(_, ref ml)| (ml.line_start, ml.line_end));
+        multiline_annotations.sort_by_key(|&(_, ref ml)| (ml.line_start, usize::MAX - ml.line_end));
         for (_, ann) in multiline_annotations.clone() {
             for (_, a) in multiline_annotations.iter_mut() {
                 // Move all other multiline annotations overlapping with this one

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2300,8 +2300,14 @@ impl FileWithAnnotatedLines {
         }
 
         let mut max_depth = 0; // max overlapping multiline spans
-        for (file, ann) in multiline_annotations {
+        for (_, ann) in &multiline_annotations {
             max_depth = max(max_depth, ann.depth);
+        }
+        // Change order of multispan depth to minimize the number of overlaps in the ASCII art.
+        for (_, a) in multiline_annotations.iter_mut() {
+            a.depth = max_depth - a.depth + 1;
+        }
+        for (file, ann) in multiline_annotations {
             let mut end_ann = ann.as_end();
             if !ann.overlaps_exactly {
                 // avoid output like

--- a/compiler/rustc_expand/src/tests.rs
+++ b/compiler/rustc_expand/src/tests.rs
@@ -272,13 +272,13 @@ error: foo
  --> test.rs:3:3
   |
 3 |      X0 Y0
-  |  ____^__-
-  | | ___|
+  |   ___^__-
+  |  |___|
   | ||
 4 | ||   X1 Y1
 5 | ||   X2 Y2
   | ||____^__- `Y` is a good letter too
-  |  |____|
+  | |_____|
   |       `X` is a good letter
 
 "#,
@@ -311,12 +311,12 @@ error: foo
  --> test.rs:3:3
   |
 3 |      X0 Y0
-  |  ____^__-
-  | | ___|
+  |   ___^__-
+  |  |___|
   | ||
 4 | ||   Y1 X1
   | ||____-__^ `X` is a good letter
-  | |_____|
+  |  |____|
   |       `Y` is a good letter too
 
 "#,
@@ -351,13 +351,13 @@ error: foo
  --> test.rs:3:6
   |
 3 |      X0 Y0 Z0
-  |   ______^
-4 |  |   X1 Y1 Z1
-  |  |_________-
+  |  _______^
+4 | |    X1 Y1 Z1
+  | | _________-
 5 | ||   X2 Y2 Z2
   | ||____^ `X` is a good letter
-6 | |    X3 Y3 Z3
-  | |_____- `Y` is a good letter too
+6 |  |   X3 Y3 Z3
+  |  |____- `Y` is a good letter too
 
 "#,
     );
@@ -395,15 +395,15 @@ error: foo
  --> test.rs:3:3
   |
 3 |       X0 Y0 Z0
-  |  _____^__-__-
-  | | ____|__|
-  | || ___|
+  |    ___^__-__-
+  |   |___|__|
+  |  ||___|
   | |||
 4 | |||   X1 Y1 Z1
 5 | |||   X2 Y2 Z2
   | |||____^__-__- `Z` label
-  |  ||____|__|
-  |   |____|  `Y` is a good letter too
+  | ||_____|__|
+  | |______|  `Y` is a good letter too
   |        `X` is a good letter
 
 "#,
@@ -487,17 +487,17 @@ error: foo
  --> test.rs:3:6
   |
 3 |      X0 Y0 Z0
-  |   ______^
-4 |  |   X1 Y1 Z1
-  |  |____^_-
+  |  _______^
+4 | |    X1 Y1 Z1
+  | | ____^_-
   | ||____|
-  | |     `X` is a good letter
-5 | |    X2 Y2 Z2
-  | |____-______- `Y` is a good letter too
-  |  ____|
-  | |
-6 | |    X3 Y3 Z3
-  | |________- `Z`
+  |  |    `X` is a good letter
+5 |  |   X2 Y2 Z2
+  |  |___-______- `Y` is a good letter too
+  |   ___|
+  |  |
+6 |  |   X3 Y3 Z3
+  |  |_______- `Z`
 
 "#,
     );
@@ -570,14 +570,14 @@ error: foo
  --> test.rs:3:6
   |
 3 |      X0 Y0 Z0
-  |   ______^
-4 |  |   X1 Y1 Z1
-  |  |____^____-
+  |  _______^
+4 | |    X1 Y1 Z1
+  | | ____^____-
   | ||____|
-  | |     `X` is a good letter
-5 | |    X2 Y2 Z2
-6 | |    X3 Y3 Z3
-  | |___________- `Y` is a good letter too
+  |  |    `X` is a good letter
+5 |  |   X2 Y2 Z2
+6 |  |   X3 Y3 Z3
+  |  |__________- `Y` is a good letter too
 
 "#,
     );
@@ -941,18 +941,18 @@ error: foo
   --> test.rs:3:6
    |
 3  |      X0 Y0 Z0
-   |   ______^
-4  |  |   X1 Y1 Z1
-   |  |____^____-
+   |  _______^
+4  | |    X1 Y1 Z1
+   | | ____^____-
    | ||____|
-   | |     `X` is a good letter
-5  | |  1
-6  | |  2
-7  | |  3
-...  |
-15 | |    X2 Y2 Z2
-16 | |    X3 Y3 Z3
-   | |___________- `Y` is a good letter too
+   |  |    `X` is a good letter
+5  |  | 1
+6  |  | 2
+7  |  | 3
+...   |
+15 |  |   X2 Y2 Z2
+16 |  |   X3 Y3 Z3
+   |  |__________- `Y` is a good letter too
 
 "#,
     );
@@ -996,21 +996,21 @@ error: foo
   --> test.rs:3:6
    |
 3  |      X0 Y0 Z0
-   |   ______^
-4  |  | 1
-5  |  | 2
-6  |  | 3
-7  |  |   X1 Y1 Z1
-   |  |_________-
+   |  _______^
+4  | |  1
+5  | |  2
+6  | |  3
+7  | |    X1 Y1 Z1
+   | | _________-
 8  | || 4
 9  | || 5
 10 | || 6
 11 | ||   X2 Y2 Z2
    | ||__________- `Z` is a good letter too
-...   |
-15 |  | 10
-16 |  |   X3 Y3 Z3
-   |  |_______^ `Y` is a good letter
+...  |
+15 | |  10
+16 | |    X3 Y3 Z3
+   | |________^ `Y` is a good letter
 
 "#,
     );

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.stderr
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.stderr
@@ -10,10 +10,10 @@ LL |    fn oom(
 LL | ||     info: &Layout,
 LL | || ) -> ()
    | ||_______- arguments to this function are incorrect
-LL |  | {
-LL |  |     loop {}
-LL |  | }
-   |  |_^ expected `&Layout`, found struct `Layout`
+LL | |  {
+LL | |      loop {}
+LL | |  }
+   | |__^ expected `&Layout`, found struct `Layout`
    |
 note: function defined here
   --> $DIR/alloc-error-handler-bad-signature-1.rs:10:4
@@ -36,10 +36,10 @@ LL |    fn oom(
 LL | ||     info: &Layout,
 LL | || ) -> ()
    | ||_______^ expected `!`, found `()`
-LL |  | {
-LL |  |     loop {}
-LL |  | }
-   |  |_- expected `!` because of return type
+LL | |  {
+LL | |      loop {}
+LL | |  }
+   | |__- expected `!` because of return type
    |
    = note:   expected type `!`
            found unit type `()`

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.stderr
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.stderr
@@ -4,16 +4,16 @@ error[E0308]: mismatched types
 LL |    #[alloc_error_handler]
    |    ---------------------- in this procedural macro expansion
 LL |    fn oom(
-   |   _^
-   |  |_|
+   |  __^
+   | | _|
    | ||
 LL | ||     info: &Layout,
 LL | || ) -> ()
    | ||_______- arguments to this function are incorrect
-LL | |  {
-LL | |      loop {}
-LL | |  }
-   | |__^ expected `&Layout`, found struct `Layout`
+LL |  | {
+LL |  |     loop {}
+LL |  | }
+   |  |_^ expected `&Layout`, found struct `Layout`
    |
 note: function defined here
   --> $DIR/alloc-error-handler-bad-signature-1.rs:10:4
@@ -30,16 +30,16 @@ error[E0308]: mismatched types
 LL |    #[alloc_error_handler]
    |    ---------------------- in this procedural macro expansion
 LL |    fn oom(
-   |   _^
-   |  |_|
+   |  __^
+   | | _|
    | ||
 LL | ||     info: &Layout,
 LL | || ) -> ()
    | ||_______^ expected `!`, found `()`
-LL | |  {
-LL | |      loop {}
-LL | |  }
-   | |__- expected `!` because of return type
+LL |  | {
+LL |  |     loop {}
+LL |  | }
+   |  |_- expected `!` because of return type
    |
    = note:   expected type `!`
            found unit type `()`

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.stderr
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.stderr
@@ -4,17 +4,17 @@ error[E0308]: mismatched types
 LL |    #[alloc_error_handler]
    |    ---------------------- in this procedural macro expansion
 LL |    fn oom(
-   |   _^
-   |  |_|
+   |  __^
+   | | _|
    | ||
 LL | ||     info: Layout,
 LL | || ) {
    | || -
    | ||_|
-   | |  arguments to this function are incorrect
-LL | |      loop {}
-LL | |  }
-   | |__^ expected struct `Layout`, found struct `core::alloc::Layout`
+   |  | arguments to this function are incorrect
+LL |  |     loop {}
+LL |  | }
+   |  |_^ expected struct `Layout`, found struct `core::alloc::Layout`
    |
    = note: struct `core::alloc::Layout` and struct `Layout` have similar names, but are actually distinct types
 note: struct `core::alloc::Layout` is defined in crate `core`
@@ -42,17 +42,17 @@ error[E0308]: mismatched types
 LL |    #[alloc_error_handler]
    |    ---------------------- in this procedural macro expansion
 LL |    fn oom(
-   |   _^
-   |  |_|
+   |  __^
+   | | _|
    | ||
 LL | ||     info: Layout,
 LL | || ) {
    | || ^
    | ||_|
-   | |  expected `!`, found `()`
-LL | |      loop {}
-LL | |  }
-   | |__- expected `!` because of return type
+   |  | expected `!`, found `()`
+LL |  |     loop {}
+LL |  | }
+   |  |_- expected `!` because of return type
    |
    = note:   expected type `!`
            found unit type `()`

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.stderr
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.stderr
@@ -9,12 +9,10 @@ LL |    fn oom(
    | ||
 LL | ||     info: Layout,
 LL | || ) {
-   | || -
-   | ||_|
-   |  | arguments to this function are incorrect
-LL |  |     loop {}
-LL |  | }
-   |  |_^ expected struct `Layout`, found struct `core::alloc::Layout`
+   | ||_- arguments to this function are incorrect
+LL | |      loop {}
+LL | |  }
+   | |__^ expected struct `Layout`, found struct `core::alloc::Layout`
    |
    = note: struct `core::alloc::Layout` and struct `Layout` have similar names, but are actually distinct types
 note: struct `core::alloc::Layout` is defined in crate `core`
@@ -47,12 +45,10 @@ LL |    fn oom(
    | ||
 LL | ||     info: Layout,
 LL | || ) {
-   | || ^
-   | ||_|
-   |  | expected `!`, found `()`
-LL |  |     loop {}
-LL |  | }
-   |  |_- expected `!` because of return type
+   | ||_^ expected `!`, found `()`
+LL | |      loop {}
+LL | |  }
+   | |__- expected `!` because of return type
    |
    = note:   expected type `!`
            found unit type `()`

--- a/src/test/ui/inference/deref-suggestion.stderr
+++ b/src/test/ui/inference/deref-suggestion.stderr
@@ -157,11 +157,11 @@ error[E0308]: `if` and `else` have incompatible types
   --> $DIR/deref-suggestion.rs:69:12
    |
 LL |        let val = if true {
-   |   _______________-
-LL |  |         *a
-   |  |         -- expected because of this
-LL |  |     } else if true {
-   |  |____________^
+   |  ________________-
+LL | |          *a
+   | |          -- expected because of this
+LL | |      } else if true {
+   | | ____________^
 LL | ||
 LL | ||         b
 LL | ||     } else {
@@ -169,7 +169,7 @@ LL | ||         &0
 LL | ||     };
    | ||     ^
    | ||_____|
-   | |______`if` and `else` have incompatible types
+   |  |_____`if` and `else` have incompatible types
    |        expected `i32`, found `&{integer}`
 
 error: aborting due to 13 previous errors

--- a/src/test/ui/issues/issue-13497-2.stderr
+++ b/src/test/ui/issues/issue-13497-2.stderr
@@ -2,12 +2,12 @@ error[E0515]: cannot return value referencing local variable `rawLines`
   --> $DIR/issue-13497-2.rs:3:5
    |
 LL |        rawLines
-   |   _____^
-   |  |_____|
+   |  ______^
+   | | _____|
    | ||
 LL | ||         .iter().map(|l| l.trim()).collect()
    | ||_______________-___________________________^ returns a value referencing data owned by the current function
-   | |________________|
+   |  |_______________|
    |                  `rawLines` is borrowed here
 
 error: aborting due to previous error

--- a/src/test/ui/lint/suggestions.stderr
+++ b/src/test/ui/lint/suggestions.stderr
@@ -41,12 +41,12 @@ warning: variable does not need to be mutable
   --> $DIR/suggestions.rs:54:13
    |
 LL |            let mut
-   |   _____________^
-   |  |_____________|
+   |  ______________^
+   | | _____________|
    | ||
 LL | ||             b = 1;
    | ||____________-^
-   |  |____________|
+   | |_____________|
    |               help: remove this `mut`
 
 error: const items should never be `#[no_mangle]`

--- a/src/test/ui/return/issue-86188-return-not-in-fn-body.stderr
+++ b/src/test/ui/return/issue-86188-return-not-in-fn-body.stderr
@@ -35,17 +35,17 @@ LL | |     }
 error[E0572]: return statement outside of function body
   --> $DIR/issue-86188-return-not-in-fn-body.rs:36:10
    |
-LL |  / fn main() {
-LL |  |
-LL |  |     [(); return || {
-   |  |__________^
+LL | /  fn main() {
+LL | |
+LL | |      [(); return || {
+   | | __________^
 LL | ||
 LL | ||
 LL | ||         let tx;
 LL | ||     }];
    | ||_____^ the return is part of this body...
-LL |  | }
-   |  |_- ...not the enclosing function body
+LL | |  }
+   | |__- ...not the enclosing function body
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/issue-99240-2.stderr
+++ b/src/test/ui/suggestions/issue-99240-2.stderr
@@ -5,12 +5,12 @@ LL |        Unit,
    |        ---- enum variant `Alias::Unit` defined here
 ...
 LL |        Alias::
-   |   _____^
-   |  |_____|
+   |  ______^
+   | | _____|
    | ||
 LL | ||     Unit();
    | ||________^_- call expression requires function
-   | |_________|
+   |  |________|
    | 
    |
 help: `Alias::Unit` is a unit enum variant, and does not take parentheses to be constructed

--- a/src/test/ui/suggestions/suggest-remove-refs-3.stderr
+++ b/src/test/ui/suggestions/suggest-remove-refs-3.stderr
@@ -2,14 +2,14 @@ error[E0277]: `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterat
   --> $DIR/suggest-remove-refs-3.rs:6:19
    |
 LL |        for (i, _) in & & &
-   |   ___________________^
-   |  |___________________|
+   |  ____________________^
+   | | ___________________|
    | ||
 LL | ||         & &v
    | ||___________- help: consider removing 5 leading `&`-references
-LL | |          .iter()
-LL | |          .enumerate() {
-   | |_____________________^ `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
+LL |  |         .iter()
+LL |  |         .enumerate() {
+   |  |____________________^ `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>`
    = note: required for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>` to implement `IntoIterator`

--- a/src/test/ui/suggestions/suggest-remove-refs-3.stderr
+++ b/src/test/ui/suggestions/suggest-remove-refs-3.stderr
@@ -7,9 +7,9 @@ LL |        for (i, _) in & & &
    | ||
 LL | ||         & &v
    | ||___________- help: consider removing 5 leading `&`-references
-LL |  |         .iter()
-LL |  |         .enumerate() {
-   |  |____________________^ `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
+LL | |          .iter()
+LL | |          .enumerate() {
+   | |_____________________^ `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>`
    = note: required for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>` to implement `IntoIterator`

--- a/src/tools/clippy/tests/ui/async_yields_async.stderr
+++ b/src/tools/clippy/tests/ui/async_yields_async.stderr
@@ -2,14 +2,14 @@ error: an async construct yields a type which is itself awaitable
   --> $DIR/async_yields_async.rs:39:9
    |
 LL |        let _h = async {
-   |   ____________________-
-LL |  |         async {
-   |  |_________^
+   |  _____________________-
+LL | |          async {
+   | | _________^
 LL | ||             3
 LL | ||         }
    | ||_________^ awaitable value not awaited
-LL |  |     };
-   |  |_____- outer async construct
+LL | |      };
+   | |______- outer async construct
    |
    = note: `-D clippy::async-yields-async` implied by `-D warnings`
 help: consider awaiting this value
@@ -36,14 +36,14 @@ error: an async construct yields a type which is itself awaitable
   --> $DIR/async_yields_async.rs:50:9
    |
 LL |        let _j = async || {
-   |   _______________________-
-LL |  |         async {
-   |  |_________^
+   |  ________________________-
+LL | |          async {
+   | | _________^
 LL | ||             3
 LL | ||         }
    | ||_________^ awaitable value not awaited
-LL |  |     };
-   |  |_____- outer async construct
+LL | |      };
+   | |______- outer async construct
    |
 help: consider awaiting this value
    |

--- a/src/tools/clippy/tests/ui/result_map_unit_fn_unfixable.stderr
+++ b/src/tools/clippy/tests/ui/result_map_unit_fn_unfixable.stderr
@@ -20,14 +20,14 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
   --> $DIR/result_map_unit_fn_unfixable.rs:29:5
    |
 LL |        x.field.map(|value| {
-   |   _____^
-   |  |_____|
+   |  ______^
+   | | _____|
    | ||
 LL | ||         do_nothing(value);
 LL | ||         do_nothing(value)
 LL | ||     });
    | ||______^- help: try this: `if let Ok(value) = x.field { ... }`
-   | |_______|
+   |  |______|
    | 
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`


### PR DESCRIPTION
Tweak the ASCII art for nested multiline spans so that we minimize line overlaps.

Partially addresses https://github.com/rust-lang/rust/issues/61017.