### PR TITLE
lint: do not warn unused parens around higher-ranked function pointers

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1002,6 +1002,7 @@ impl EarlyLintPass for UnusedParens {
         if let ast::TyKind::Paren(r) = &ty.kind {
             match &r.kind {
                 ast::TyKind::TraitObject(..) => {}
+                ast::TyKind::BareFn(b) if b.generic_params.len() > 0 => {}
                 ast::TyKind::ImplTrait(_, bounds) if bounds.len() > 1 => {}
                 ast::TyKind::Array(_, len) => {
                     self.check_unused_delims_expr(

--- a/src/test/ui/lint/unused/issue-104397.rs
+++ b/src/test/ui/lint/unused/issue-104397.rs
@@ -1,0 +1,18 @@
+// check-pass
+
+#![warn(unused)]
+#![deny(warnings)]
+
+struct Inv<'a>(&'a mut &'a ());
+
+trait Trait {}
+impl Trait for for<'a> fn(Inv<'a>) {}
+
+fn with_bound()
+where
+    (for<'a> fn(Inv<'a>)): Trait,
+{}
+
+fn main() {
+    with_bound();
+}


### PR DESCRIPTION
Fixes #104397