### PR TITLE
str::replace preallocate

### DIFF
--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -269,7 +269,7 @@ impl str {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn replace<'a, P: Pattern<'a>>(&'a self, from: P, to: &str) -> String {
-        let mut result = String::new();
+        let mut result = String::with_capacity(32);
         let mut last_end = 0;
         for (start, part) in self.match_indices(from) {
             result.push_str(unsafe { self.get_unchecked(last_end..start) });


### PR DESCRIPTION
I thought it was odd that `replace` didn't try to reserve space for the result. My first instinct was to reserve `self.len()`, but `replacen` reserves 32, and I think it's a good default.