### PR TITLE
Add comment noting that the `Arc::clone` "not 100% water-proof" applies to `thread::scope` as well

### DIFF
--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -45,6 +45,8 @@ impl ScopeData {
     pub(super) fn increment_num_running_threads(&self) {
         // We check for 'overflow' with usize::MAX / 2, to make sure there's no
         // chance it overflows to 0, which would result in unsoundness.
+        // Like with the abort in Arc::clone, this relies on it being impractical for
+        // enough threads to concurrently increment the count to still cause an overflow.
         if self.num_running_threads.fetch_add(1, Ordering::Relaxed) > usize::MAX / 2 {
             // This can only reasonably happen by mem::forget()'ing many many ScopedJoinHandles.
             self.decrement_num_running_threads(false);


### PR DESCRIPTION
This is still a case that's practical to dismiss as impractical (it requires `isize::MAX` live threads each concurrently in the process of creating a new thread), but it seems prudent to at least acknowledge the potential hole.