### PR TITLE
Add a note about implicit temporaries on &mut (fn or const)

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1925,7 +1925,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
         if let Some((item_name, value_desc)) = implicit_temporary {
             err.note(format!(
-                "mutably borrowing a {} implicitly copies the {} to a temporary",
+                "mutably borrowing a {} copies the {} to a temporary",
                 item_name, value_desc
             ));
         }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -900,6 +900,8 @@ pub enum LocalInfo<'tcx> {
     StaticRef { def_id: DefId, is_thread_local: bool },
     /// A temporary created that references the const with the given `DefId`
     ConstRef { def_id: DefId },
+    /// A temporary created that references a function
+    FnDefRef,
     /// A temporary created during the creation of an aggregate
     /// (e.g. a temporary for `foo` in `MyStruct { my_field: foo }`)
     AggregateTemp,

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -432,8 +432,8 @@ pub enum ExprKind<'tcx> {
         lit: ty::ScalarInt,
         user_ty: UserTy<'tcx>,
     },
-    /// A literal of a ZST type.
-    ZstLiteral {
+    /// Named functions, associated functions, and constructors (including `Self(...)`)
+    NamedFn {
         user_ty: UserTy<'tcx>,
     },
     /// Associated constants and named constants

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -136,7 +136,7 @@ pub fn walk_expr<'a, 'tcx: 'a, V: Visitor<'a, 'tcx>>(visitor: &mut V, expr: &Exp
         }) => {}
         Literal { lit: _, neg: _ } => {}
         NonHirLiteral { lit: _, user_ty: _ } => {}
-        ZstLiteral { user_ty: _ } => {}
+        NamedFn { user_ty: _ } => {}
         NamedConst { def_id: _, substs: _, user_ty: _ } => {}
         ConstParam { param: _, def_id: _ } => {}
         StaticRef { alloc_id: _, ty: _, def_id: _ } => {}

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -153,7 +153,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
             ExprKind::Literal { .. }
             | ExprKind::NamedConst { .. }
             | ExprKind::NonHirLiteral { .. }
-            | ExprKind::ZstLiteral { .. }
+            | ExprKind::NamedFn { .. }
             | ExprKind::ConstParam { .. }
             | ExprKind::ConstBlock { .. } => {
                 Ok(Operand::Constant(Box::new(

--- a/compiler/rustc_mir_build/src/build/expr/as_constant.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_constant.rs
@@ -68,7 +68,7 @@ pub fn as_constant_inner<'tcx>(
 
             Constant { span, user_ty, literal }
         }
-        ExprKind::ZstLiteral { ref user_ty } => {
+        ExprKind::NamedFn { ref user_ty } => {
             let user_ty = user_ty.as_ref().map(push_cuta).flatten();
 
             let literal = ConstantKind::Val(ConstValue::ZeroSized, ty);

--- a/compiler/rustc_mir_build/src/build/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_place.rs
@@ -554,7 +554,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::Literal { .. }
             | ExprKind::NamedConst { .. }
             | ExprKind::NonHirLiteral { .. }
-            | ExprKind::ZstLiteral { .. }
+            | ExprKind::NamedFn { .. }
             | ExprKind::ConstParam { .. }
             | ExprKind::ConstBlock { .. }
             | ExprKind::StaticRef { .. }

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -459,7 +459,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Literal { .. }
             | ExprKind::NamedConst { .. }
             | ExprKind::NonHirLiteral { .. }
-            | ExprKind::ZstLiteral { .. }
+            | ExprKind::NamedFn { .. }
             | ExprKind::ConstParam { .. }
             | ExprKind::ConstBlock { .. }
             | ExprKind::StaticRef { .. } => {

--- a/compiler/rustc_mir_build/src/build/expr/as_temp.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_temp.rs
@@ -70,6 +70,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 ExprKind::NamedConst { def_id, .. } | ExprKind::ConstParam { def_id, .. } => {
                     local_decl.local_info = Some(Box::new(LocalInfo::ConstRef { def_id }));
                 }
+                ExprKind::NamedFn { .. } => {
+                    local_decl.local_info = Some(Box::new(LocalInfo::FnDefRef));
+                }
                 _ => {}
             }
             this.local_decls.push(local_decl)

--- a/compiler/rustc_mir_build/src/build/expr/category.rs
+++ b/compiler/rustc_mir_build/src/build/expr/category.rs
@@ -72,7 +72,7 @@ impl Category {
             ExprKind::ConstBlock { .. }
             | ExprKind::Literal { .. }
             | ExprKind::NonHirLiteral { .. }
-            | ExprKind::ZstLiteral { .. }
+            | ExprKind::NamedFn { .. }
             | ExprKind::ConstParam { .. }
             | ExprKind::StaticRef { .. }
             | ExprKind::NamedConst { .. } => Some(Category::Constant),

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -554,7 +554,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::Literal { .. }
             | ExprKind::NamedConst { .. }
             | ExprKind::NonHirLiteral { .. }
-            | ExprKind::ZstLiteral { .. }
+            | ExprKind::NamedFn { .. }
             | ExprKind::ConstParam { .. }
             | ExprKind::ThreadLocalRef(_)
             | ExprKind::StaticRef { .. } => {

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -295,7 +295,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
             | ExprKind::Literal { .. }
             | ExprKind::NamedConst { .. }
             | ExprKind::NonHirLiteral { .. }
-            | ExprKind::ZstLiteral { .. }
+            | ExprKind::NamedFn { .. }
             | ExprKind::ConstParam { .. }
             | ExprKind::ConstBlock { .. }
             | ExprKind::Deref { .. }

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -822,7 +822,7 @@ impl<'tcx> Cx<'tcx> {
                 )
             }
         };
-        Expr { temp_lifetime, ty, span, kind: ExprKind::ZstLiteral { user_ty } }
+        Expr { temp_lifetime, ty, span, kind: ExprKind::NamedFn { user_ty } }
     }
 
     fn convert_arm(&mut self, arm: &'tcx hir::Arm<'tcx>) -> ArmId {
@@ -851,7 +851,7 @@ impl<'tcx> Cx<'tcx> {
             | Res::Def(DefKind::Ctor(_, CtorKind::Fn), _)
             | Res::SelfCtor(_) => {
                 let user_ty = self.user_substs_applied_to_res(expr.hir_id, res);
-                ExprKind::ZstLiteral { user_ty }
+                ExprKind::NamedFn { user_ty }
             }
 
             Res::Def(DefKind::ConstParam, def_id) => {

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -127,7 +127,7 @@ fn recurse_build<'tcx>(
             let val = ty::ValTree::from_scalar_int(lit);
             tcx.mk_const(val, node.ty)
         }
-        &ExprKind::ZstLiteral { user_ty: _ } => {
+        &ExprKind::NamedFn { user_ty: _ } => {
             let val = ty::ValTree::zst();
             tcx.mk_const(val, node.ty)
         }

--- a/tests/ui/borrowck/return-borrow-mut-const.rs
+++ b/tests/ui/borrowck/return-borrow-mut-const.rs
@@ -1,0 +1,34 @@
+// See PR #104857 for details
+
+// don't want to tie this test to the lint, even though it's related
+#![allow(const_item_mutation)]
+
+fn main() {}
+
+const X: i32 = 42;
+
+fn borrow_const_immut() -> &'static i32 {
+    &X
+}
+
+fn borrow_const_immut_explicit_return() -> &'static i32 {
+    return &X;
+}
+
+fn borrow_const_immut_into_temp() -> &'static i32 {
+    let x_ref = &X;
+    x_ref
+}
+
+fn borrow_const_mut() -> &'static mut i32 {
+    return &mut X; //~ ERROR
+}
+
+fn borrow_const_mut_explicit_return() -> &'static mut i32 {
+    return &mut X; //~ ERROR
+}
+
+fn borrow_const_mut_into_temp() -> &'static mut i32 {
+    let x_ref = &mut X;
+    x_ref //~ ERROR
+}

--- a/tests/ui/borrowck/return-borrow-mut-const.stderr
+++ b/tests/ui/borrowck/return-borrow-mut-const.stderr
@@ -1,0 +1,35 @@
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/return-borrow-mut-const.rs:24:12
+   |
+LL |     return &mut X;
+   |            ^^^^^-
+   |            |    |
+   |            |    temporary value created here
+   |            returns a reference to data owned by the current function
+   |
+   = note: mutably borrowing a constant copies the value to a temporary
+
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/return-borrow-mut-const.rs:28:12
+   |
+LL |     return &mut X;
+   |            ^^^^^-
+   |            |    |
+   |            |    temporary value created here
+   |            returns a reference to data owned by the current function
+   |
+   = note: mutably borrowing a constant copies the value to a temporary
+
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/return-borrow-mut-const.rs:33:5
+   |
+LL |     let x_ref = &mut X;
+   |                      - temporary value created here
+LL |     x_ref
+   |     ^^^^^ returns a value referencing data owned by the current function
+   |
+   = note: mutably borrowing a constant copies the value to a temporary
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0515`.

--- a/tests/ui/borrowck/return-borrow-mut-fn.rs
+++ b/tests/ui/borrowck/return-borrow-mut-fn.rs
@@ -1,0 +1,31 @@
+// See PR #104857 for details
+
+fn main() {}
+
+fn do_nothing() {}
+
+fn borrow_fn_immut() -> &'static dyn Fn() {
+    &do_nothing
+}
+
+fn borrow_fn_immut_explicit_return() -> &'static dyn Fn() {
+    &do_nothing
+}
+
+fn borrow_fn_immut_into_temp() -> &'static dyn Fn() {
+    let f = &do_nothing;
+    f
+}
+
+fn borrow_fn_mut() -> &'static mut dyn FnMut() {
+    &mut do_nothing //~ ERROR
+}
+
+fn borrow_fn_mut_explicit_return() -> &'static mut dyn FnMut() {
+    &mut do_nothing //~ ERROR
+}
+
+fn borrow_fn_mut_into_temp() -> &'static mut dyn FnMut() {
+    let f = &mut do_nothing;
+    f //~ ERROR
+}

--- a/tests/ui/borrowck/return-borrow-mut-fn.stderr
+++ b/tests/ui/borrowck/return-borrow-mut-fn.stderr
@@ -1,0 +1,35 @@
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/return-borrow-mut-fn.rs:21:5
+   |
+LL |     &mut do_nothing
+   |     ^^^^^----------
+   |     |    |
+   |     |    temporary value created here
+   |     returns a reference to data owned by the current function
+   |
+   = note: mutably borrowing a function copies the function pointer to a temporary
+
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/return-borrow-mut-fn.rs:25:5
+   |
+LL |     &mut do_nothing
+   |     ^^^^^----------
+   |     |    |
+   |     |    temporary value created here
+   |     returns a reference to data owned by the current function
+   |
+   = note: mutably borrowing a function copies the function pointer to a temporary
+
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/return-borrow-mut-fn.rs:30:5
+   |
+LL |     let f = &mut do_nothing;
+   |                  ---------- temporary value created here
+LL |     f
+   |     ^ returns a value referencing data owned by the current function
+   |
+   = note: mutably borrowing a function copies the function pointer to a temporary
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0515`.


### PR DESCRIPTION
Ran into a confusing error message and thought I'd open a PR to improve it.

My confusion came about because something like
```rust
fn do_nothing() {}

fn return_fn() -> &'static dyn Fn() {
    &do_nothing
}
```
is valid, but
```rust
fn do_nothing() {}

fn return_fn_mut() -> &'static mut dyn FnMut() {
    &mut do_nothing
}
```
is not. The error message didn't help much:
```
error[E0515]: cannot return reference to temporary value
  --> $file:4:5
  |
4 |     &mut do_nothing
  |     ^^^^^----------
  |     |    |
  |     |    temporary value created here
  |     returns a reference to data owned by the current function
```
"why is it creating a temporary only for `&mut` and not `&`?"

A similar case is true of constants (although they have the `const_item_mutation` lint).

## Changes to error messages

This PR adds a note to the error message for borrowck failures when a constants or functions are mutably borrowed and a referenece to the temporary is returned (at least, that's what it _should_ do - I've only superficially tested it).

The note is:

* (for constants) "mutably borrowing a constant copies the value to a temporary"
* (for functions) "mutably borrowing a function copies the function pointer to a temporary"

The text of the notes can be improved; I just wanted to get something here for feedback :)

I'm also not sure that _just_ having it in a "note" is sufficient, but I don't know what the ideal error construction would be. Maybe changing the "temporary value created here" line?

## Other changes

* Added `mir::LocalInfo::FnDefRef` to accompany `ConstRef` - required for detecting this (otherwise `local_info = None`)
* Renamed `thir::ExprKind::ZstLiteral` to `NamedFn`, because it was only used for functions (and now it's used to set `local_info = FnDefRef``)
    * This maybe should be renamed, because it also includes `Self` constructors, which might not _really_ be considered "named" functions

r? rust-lang/diagnostics