### PR TITLE
Don't codegen dead code

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1186,6 +1186,13 @@ struct RootCollector<'a, 'tcx> {
 
 impl<'v> RootCollector<'_, 'v> {
     fn process_item(&mut self, id: hir::ItemId) {
+        let def_id = id.owner_id.def_id;
+        let (live_symbols, _) = self.tcx.live_symbols_and_ignored_derived_traits(());
+        if !live_symbols.contains(&def_id) && !self.tcx.sess.link_dead_code() {
+            // This is dead code; ignore it.
+            return;
+        }
+
         match self.tcx.def_kind(id.owner_id) {
             DefKind::Enum | DefKind::Struct | DefKind::Union => {
                 let item = self.tcx.hir().item(id);

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -623,6 +623,11 @@ fn create_and_seed_worklist<'tcx>(
         check_foreign_item(tcx, &mut worklist, id);
     }
 
+    if let Some(static_) = tcx.proc_macro_decls_static(()) {
+        // We assume this is always used if present.
+        worklist.push(static_);
+    }
+
     (worklist, struct_constructors)
 }
 


### PR DESCRIPTION
This is the internal-facing portion of https://github.com/rust-lang/rust/pull/103356; it should not be user-visible in any way, since we already stripped dead code at the linker level.

Fixes https://github.com/rust-lang/rust/issues/104858.