### PR TITLE
Check for occupied niches

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -561,6 +561,11 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
                     found: eval_to_int(found)?,
                 }
             }
+            OccupiedNiche { ref found, ref start, ref end } => OccupiedNiche {
+                found: eval_to_int(found)?,
+                start: eval_to_int(start)?,
+                end: eval_to_int(end)?,
+            },
         };
         Err(ConstEvalErrKind::AssertFailure(err).into())
     }

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -234,6 +234,7 @@ language_item_table! {
     ConstPanicFmt,           sym::const_panic_fmt,     const_panic_fmt,            Target::Fn,             GenericRequirement::None;
     PanicBoundsCheck,        sym::panic_bounds_check,  panic_bounds_check_fn,      Target::Fn,             GenericRequirement::Exact(0);
     PanicMisalignedPointerDereference,        sym::panic_misaligned_pointer_dereference,  panic_misaligned_pointer_dereference_fn,      Target::Fn,             GenericRequirement::Exact(0);
+    PanicOccupiedNiche,      sym::panic_occupied_niche, panic_occupied_niche_fn,   Target::Fn,             GenericRequirement::Exact(1);
     PanicInfo,               sym::panic_info,          panic_info,                 Target::Struct,         GenericRequirement::None;
     PanicLocation,           sym::panic_location,      panic_location,             Target::Struct,         GenericRequirement::None;
     PanicImpl,               sym::panic_impl,          panic_impl,                 Target::Fn,             GenericRequirement::None;

--- a/compiler/rustc_middle/messages.ftl
+++ b/compiler/rustc_middle/messages.ftl
@@ -17,6 +17,9 @@ middle_assert_gen_resume_after_panic = `gen` fn or block cannot be further itera
 middle_assert_misaligned_ptr_deref =
     misaligned pointer dereference: address must be a multiple of {$required} but is {$found}
 
+middle_assert_occupied_niche =
+    occupied niche: {$found} must be in {$start}..={$end}
+
 middle_assert_op_overflow =
     attempt to compute `{$left} {$op} {$right}`, which would overflow
 

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -886,6 +886,7 @@ pub enum AssertKind<O> {
     ResumedAfterReturn(CoroutineKind),
     ResumedAfterPanic(CoroutineKind),
     MisalignedPointerDereference { required: O, found: O },
+    OccupiedNiche { found: O, start: O, end: O },
 }
 
 #[derive(Clone, Debug, PartialEq, TyEncodable, TyDecodable, Hash, HashStable)]

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -157,7 +157,7 @@ impl<O> AssertKind<O> {
                 "`gen fn` should just keep returning `None` after panicking"
             }
 
-            BoundsCheck { .. } | MisalignedPointerDereference { .. } => {
+            BoundsCheck { .. } | MisalignedPointerDereference { .. } | OccupiedNiche { .. } => {
                 bug!("Unexpected AssertKind")
             }
         }
@@ -220,6 +220,13 @@ impl<O> AssertKind<O> {
                     "\"misaligned pointer dereference: address must be a multiple of {{}} but is {{}}\", {required:?}, {found:?}"
                 )
             }
+            OccupiedNiche { found, start, end } => {
+                write!(
+                    f,
+                    "\"occupied niche: {{}} must be in {{}}..={{}}\", {:?}, {:?}, {:?}",
+                    found, start, end
+                )
+            }
             _ => write!(f, "\"{}\"", self.description()),
         }
     }
@@ -254,8 +261,8 @@ impl<O> AssertKind<O> {
             ResumedAfterPanic(CoroutineKind::Coroutine) => {
                 middle_assert_coroutine_resume_after_panic
             }
-
             MisalignedPointerDereference { .. } => middle_assert_misaligned_ptr_deref,
+            OccupiedNiche { .. } => middle_assert_occupied_niche,
         }
     }
 
@@ -291,6 +298,11 @@ impl<O> AssertKind<O> {
             MisalignedPointerDereference { required, found } => {
                 add!("required", format!("{required:#?}"));
                 add!("found", format!("{found:#?}"));
+            }
+            OccupiedNiche { found, start, end } => {
+                add!("found", format!("{found:?}"));
+                add!("start", format!("{start:?}"));
+                add!("end", format!("{end:?}"));
             }
         }
     }

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -625,6 +625,11 @@ macro_rules! make_mir_visitor {
                         self.visit_operand(required, location);
                         self.visit_operand(found, location);
                     }
+                    OccupiedNiche { found, start, end } => {
+                        self.visit_operand(found, location);
+                        self.visit_operand(start, location);
+                        self.visit_operand(end, location);
+                    }
                 }
             }
 

--- a/compiler/rustc_mir_transform/src/check_niches.rs
+++ b/compiler/rustc_mir_transform/src/check_niches.rs
@@ -1,0 +1,484 @@
+use crate::MirPass;
+use rustc_hir::def::DefKind;
+use rustc_hir::lang_items::LangItem;
+use rustc_hir::Unsafety;
+use rustc_index::IndexVec;
+use rustc_middle::mir::interpret::{Pointer, Scalar};
+use rustc_middle::mir::visit::NonMutatingUseContext;
+use rustc_middle::mir::visit::PlaceContext;
+use rustc_middle::mir::visit::Visitor;
+use rustc_middle::mir::*;
+use rustc_middle::ty::print::with_no_trimmed_paths;
+use rustc_middle::ty::{ParamEnv, Ty, TyCtxt, TypeAndMut};
+use rustc_session::Session;
+use rustc_target::abi::{Integer, Niche, Primitive, Size};
+
+pub struct CheckNiches;
+
+impl<'tcx> MirPass<'tcx> for CheckNiches {
+    fn is_enabled(&self, sess: &Session) -> bool {
+        sess.opts.debug_assertions
+    }
+
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        // This pass emits new panics. If for whatever reason we do not have a panic
+        // implementation, running this pass may cause otherwise-valid code to not compile.
+        if tcx.lang_items().get(LangItem::PanicImpl).is_none() {
+            return;
+        }
+
+        let def_id = body.source.def_id();
+        if tcx.type_of(def_id).instantiate_identity().is_coroutine() {
+            return;
+        }
+
+        // This pass will in general insert an enormous amount of checks, so we need some way to
+        // trim them down a bit.
+        // Our tactic here is to only emit checks if we are compiling an `unsafe fn` or a function
+        // that contains an unsafe block. Yes this means that we can fail to check some operations.
+        // If you have a better strategy that doesn't impose 2x compile time overhead, please
+        // share.
+        let is_safe_code =
+            tcx.unsafety_check_result(def_id.expect_local()).used_unsafe_blocks.is_empty();
+        let is_unsafe_fn = match tcx.def_kind(def_id) {
+            DefKind::Closure => false,
+            _ => tcx.fn_sig(def_id).skip_binder().unsafety() == Unsafety::Unsafe,
+        };
+        if is_safe_code && !is_unsafe_fn {
+            return;
+        }
+
+        with_no_trimmed_paths!(debug!("Inserting niche checks for {:?}", body.source));
+
+        let basic_blocks = &body.basic_blocks;
+        let param_env = tcx.param_env_reveal_all_normalized(def_id);
+
+        // This pass inserts new blocks. Each insertion changes the Location for all
+        // statements/blocks after. Iterating or visiting the MIR in order would require updating
+        // our current location after every insertion. By iterating backwards, we dodge this issue:
+        // The only Locations that an insertion changes have already been handled.
+        for block in (0..basic_blocks.len()).rev() {
+            let block = block.into();
+            let basic_blocks = &body.basic_blocks;
+            for statement_index in (0..basic_blocks[block].statements.len()).rev() {
+                let location = Location { block, statement_index };
+                let statement = &body.basic_blocks[block].statements[statement_index];
+                let source_info = statement.source_info;
+
+                let mut finder = NicheFinder { tcx, param_env, body, places: Vec::new() };
+                finder.visit_statement(statement, location);
+                let places = finder.places;
+
+                let mut checker = NicheChecker { tcx, local_decls: &mut body.local_decls };
+                for (place, niche) in places {
+                    let basic_blocks = body.basic_blocks.as_mut();
+                    let (block_data, new_block) = split_block(basic_blocks, location);
+                    checker.insert_niche_check(block_data, new_block, place, niche, source_info);
+                }
+            }
+        }
+    }
+}
+
+struct NicheFinder<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    param_env: ParamEnv<'tcx>,
+    body: &'a Body<'tcx>,
+    places: Vec<(Place<'tcx>, NicheKind)>,
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for NicheFinder<'a, 'tcx> {
+    fn visit_rvalue(&mut self, rvalue: &Rvalue<'tcx>, location: Location) {
+        if let Rvalue::Cast(CastKind::Transmute, op, ty) = rvalue {
+            if let Some(niche) = self.get_niche(*ty) && let Some(place) = op.place() {
+                with_no_trimmed_paths!(debug!(
+                    "Found place {place:?}: {ty:?} with niche {niche:?} due to Transmute: {:?}",
+                    self.body.stmt_at(location)
+                ));
+                self.places.push((place, niche));
+            }
+        } else {
+            self.super_rvalue(rvalue, location);
+        }
+    }
+
+    fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, location: Location) {
+        match context {
+            PlaceContext::NonMutatingUse(
+                NonMutatingUseContext::Copy | NonMutatingUseContext::Move,
+            ) => {}
+            _ => {
+                return;
+            }
+        }
+
+        let ty = place.ty(self.body, self.tcx).ty;
+        // bool is actually an i1 to LLVM which means a bool local can never be invalid.
+        if ty == self.tcx.types.bool && place.projection.is_empty() {
+            return;
+        }
+        let Some(niche) = self.get_niche(ty) else {
+            return;
+        };
+
+        with_no_trimmed_paths!(debug!(
+            "Found place {place:?}: {ty:?} with niche {niche:?} due to {:?}",
+            self.body.stmt_at(location)
+        ));
+        self.places.push((*place, niche));
+    }
+}
+
+impl<'a, 'tcx> NicheFinder<'a, 'tcx> {
+    fn get_niche(&self, ty: Ty<'tcx>) -> Option<NicheKind> {
+        // If we can't get the layout of this, just skip the check.
+        let Ok(layout) = self.tcx.layout_of(self.param_env.and(ty)) else {
+            return None;
+        };
+
+        let niche = layout.largest_niche?;
+
+        if niche.size(self.tcx) == layout.size {
+            Some(NicheKind::Full(niche))
+        } else {
+            Some(NicheKind::Partial(niche, layout.size))
+        }
+    }
+}
+
+struct NicheChecker<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    local_decls: &'a mut IndexVec<Local, LocalDecl<'tcx>>,
+}
+
+impl<'a, 'tcx> NicheChecker<'a, 'tcx> {
+    fn insert_niche_check(
+        &mut self,
+        block_data: &mut BasicBlockData<'tcx>,
+        new_block: BasicBlock,
+        place: Place<'tcx>,
+        niche: NicheKind,
+        source_info: SourceInfo,
+    ) {
+        let mut value_in_niche = self
+            .local_decls
+            .push(LocalDecl::with_source_info(niche.niche().ty(self.tcx), source_info))
+            .into();
+
+        match niche {
+            NicheKind::Full(niche) => {
+                // The niche occupies the entire source Operand, so we can just transmute
+                // directly to the niche primitive.
+                let rvalue =
+                    Rvalue::Cast(CastKind::Transmute, Operand::Copy(place), niche.ty(self.tcx));
+                block_data.statements.push(Statement {
+                    source_info,
+                    kind: StatementKind::Assign(Box::new((value_in_niche, rvalue))),
+                });
+            }
+            NicheKind::Partial(niche, size) => {
+                if niche.offset == Size::ZERO {
+                    // FIXME: Delete value_in_niche, we don't need it on this path
+                    self.local_decls.pop();
+
+                    // Take the address of the place
+                    let full_ptr = self
+                        .local_decls
+                        .push(LocalDecl::with_source_info(
+                            Ty::new_ptr(
+                                self.tcx,
+                                TypeAndMut {
+                                    ty: place.ty(self.local_decls, self.tcx).ty,
+                                    mutbl: Mutability::Not,
+                                },
+                            ),
+                            source_info,
+                        ))
+                        .into();
+                    let rvalue = Rvalue::AddressOf(Mutability::Not, place);
+                    block_data.statements.push(Statement {
+                        source_info,
+                        kind: StatementKind::Assign(Box::new((full_ptr, rvalue))),
+                    });
+
+                    // Cast to a pointer to the niche type
+                    let niche_ptr_ty = Ty::new_ptr(
+                        self.tcx,
+                        TypeAndMut { ty: niche.ty(self.tcx), mutbl: Mutability::Not },
+                    );
+                    let niche_ptr = self
+                        .local_decls
+                        .push(LocalDecl::with_source_info(niche_ptr_ty, source_info))
+                        .into();
+                    let rvalue =
+                        Rvalue::Cast(CastKind::PtrToPtr, Operand::Copy(full_ptr), niche_ptr_ty);
+                    block_data.statements.push(Statement {
+                        source_info,
+                        kind: StatementKind::Assign(Box::new((niche_ptr, rvalue))),
+                    });
+
+                    // Set value_in_niche to a projection of our pointer
+                    value_in_niche = niche_ptr.project_deeper(&[ProjectionElem::Deref], self.tcx);
+                } else {
+                    let mu = Ty::new_maybe_uninit(self.tcx, niche.ty(self.tcx));
+
+                    // Transmute the niche-containing type to a [MaybeUninit; N]
+                    let array_len = size.bytes() / niche.size(self.tcx).bytes();
+                    let mu_array_ty = Ty::new_array(self.tcx, mu, array_len);
+                    let mu_array = self
+                        .local_decls
+                        .push(LocalDecl::with_source_info(mu_array_ty, source_info))
+                        .into();
+                    let rvalue =
+                        Rvalue::Cast(CastKind::Transmute, Operand::Copy(place), mu_array_ty);
+                    block_data.statements.push(Statement {
+                        source_info,
+                        kind: StatementKind::Assign(Box::new((mu_array, rvalue))),
+                    });
+
+                    // Convert the niche byte offset into an array index
+                    assert_eq!(niche.offset.bytes() % niche.size(self.tcx).bytes(), 0);
+                    let offset = niche.offset.bytes() / niche.size(self.tcx).bytes();
+
+                    let niche_as_mu = mu_array.project_deeper(
+                        &[ProjectionElem::ConstantIndex {
+                            offset,
+                            min_length: array_len,
+                            from_end: false,
+                        }],
+                        self.tcx,
+                    );
+
+                    // Transmute the MaybeUninit<T> to the niche primitive
+                    let rvalue = Rvalue::Cast(
+                        CastKind::Transmute,
+                        Operand::Copy(niche_as_mu),
+                        niche.ty(self.tcx),
+                    );
+                    block_data.statements.push(Statement {
+                        source_info,
+                        kind: StatementKind::Assign(Box::new((value_in_niche, rvalue))),
+                    });
+                }
+            }
+        }
+
+        let is_in_range = self
+            .local_decls
+            .push(LocalDecl::with_source_info(self.tcx.types.bool, source_info))
+            .into();
+
+        NicheCheckBuilder {
+            tcx: self.tcx,
+            local_decls: self.local_decls,
+            block_data,
+            new_block,
+            niche: niche.niche(),
+            value_in_niche,
+            is_in_range,
+            source_info,
+        }
+        .insert_niche_check();
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum NicheKind {
+    Full(Niche),
+    // We need the full Size of the type in order to do the transmute-to-MU approach
+    Partial(Niche, Size),
+}
+
+impl NicheKind {
+    fn niche(self) -> Niche {
+        use NicheKind::*;
+        match self {
+            Full(niche) => niche,
+            Partial(niche, _size) => niche,
+        }
+    }
+}
+
+fn split_block<'a, 'tcx>(
+    basic_blocks: &'a mut IndexVec<BasicBlock, BasicBlockData<'tcx>>,
+    location: Location,
+) -> (&'a mut BasicBlockData<'tcx>, BasicBlock) {
+    let block_data = &mut basic_blocks[location.block];
+
+    // Drain every statement after this one and move the current terminator to a new basic block
+    let new_block = BasicBlockData {
+        statements: block_data.statements.drain(location.statement_index..).collect(),
+        terminator: block_data.terminator.take(),
+        is_cleanup: block_data.is_cleanup,
+    };
+
+    let new_block = basic_blocks.push(new_block);
+    let block_data = &mut basic_blocks[location.block];
+
+    (block_data, new_block)
+}
+
+struct NicheCheckBuilder<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    block_data: &'a mut BasicBlockData<'tcx>,
+    local_decls: &'a mut IndexVec<Local, LocalDecl<'tcx>>,
+    new_block: BasicBlock,
+    niche: Niche,
+    value_in_niche: Place<'tcx>,
+    is_in_range: Place<'tcx>,
+    source_info: SourceInfo,
+}
+
+impl<'a, 'tcx> NicheCheckBuilder<'a, 'tcx> {
+    fn insert_niche_check(&mut self) {
+        let niche = self.niche;
+
+        let size = niche.size(self.tcx);
+
+        if niche.valid_range.start == 0 {
+            // The niche starts at 0, so we can just check if it is Le the end
+            self.check_end_only();
+        } else if niche.valid_range.end == (u128::MAX >> (128 - size.bits())) {
+            // The niche ends at the max, so we can just check if it is Ge the start
+            self.check_start_only();
+        } else {
+            self.general_case();
+        }
+
+        let start = self.niche_const(niche.valid_range.start);
+        let end = self.niche_const(niche.valid_range.end);
+
+        self.block_data.terminator = Some(Terminator {
+            source_info: self.source_info,
+            kind: TerminatorKind::Assert {
+                cond: Operand::Copy(self.is_in_range),
+                expected: true,
+                target: self.new_block,
+                msg: Box::new(AssertKind::OccupiedNiche {
+                    found: Operand::Copy(self.value_in_niche),
+                    start,
+                    end,
+                }),
+                // This calls panic_occupied_niche, which is #[rustc_nounwind].
+                // We never want to insert an unwind into unsafe code, because unwinding could
+                // make a failing UB check turn into much worse UB when we start unwinding.
+                unwind: UnwindAction::Unreachable,
+            },
+        });
+    }
+
+    fn niche_const(&self, val: u128) -> Operand<'tcx> {
+        let niche_ty = self.niche.ty(self.tcx);
+        if niche_ty.is_any_ptr() {
+            Operand::Constant(Box::new(ConstOperand {
+                span: self.source_info.span,
+                user_ty: None,
+                const_: Const::Val(
+                    ConstValue::Scalar(Scalar::from_maybe_pointer(
+                        Pointer::from_addr_invalid(val as u64),
+                        &self.tcx,
+                    )),
+                    niche_ty,
+                ),
+            }))
+        } else {
+            Operand::Constant(Box::new(ConstOperand {
+                span: self.source_info.span,
+                user_ty: None,
+                const_: Const::Val(
+                    ConstValue::Scalar(Scalar::from_uint(val, self.niche.size(self.tcx))),
+                    niche_ty,
+                ),
+            }))
+        }
+    }
+
+    fn add_assignment(&mut self, place: Place<'tcx>, rvalue: Rvalue<'tcx>) {
+        self.block_data.statements.push(Statement {
+            source_info: self.source_info,
+            kind: StatementKind::Assign(Box::new((place, rvalue))),
+        });
+    }
+
+    fn check_start_only(&mut self) {
+        let rvalue = if self.niche.valid_range.start == 1 {
+            let bound = self.niche_const(0);
+            Rvalue::BinaryOp(BinOp::Ne, Box::new((Operand::Copy(self.value_in_niche), bound)))
+        } else {
+            let bound = self.niche_const(self.niche.valid_range.start);
+            Rvalue::BinaryOp(BinOp::Ge, Box::new((Operand::Copy(self.value_in_niche), bound)))
+        };
+        self.add_assignment(self.is_in_range, rvalue);
+    }
+
+    fn check_end_only(&mut self) {
+        let end = self.niche_const(self.niche.valid_range.end);
+
+        let rvalue =
+            Rvalue::BinaryOp(BinOp::Le, Box::new((Operand::Copy(self.value_in_niche), end)));
+        self.add_assignment(self.is_in_range, rvalue);
+    }
+
+    fn general_case(&mut self) {
+        let mut max = self.niche.valid_range.end.wrapping_sub(self.niche.valid_range.start);
+        let size = self.niche.size(self.tcx);
+        if size.bits() < 128 {
+            let mask = (1 << size.bits()) - 1;
+            max &= mask;
+        }
+
+        let start = self.niche_const(self.niche.valid_range.start);
+        let max_adjusted_allowed_value = self.niche_const(max);
+
+        let biased = self
+            .local_decls
+            .push(LocalDecl::with_source_info(self.niche.ty(self.tcx), self.source_info))
+            .into();
+        let rvalue =
+            Rvalue::BinaryOp(BinOp::Sub, Box::new((Operand::Copy(self.value_in_niche), start)));
+        self.add_assignment(biased, rvalue);
+
+        let rvalue = Rvalue::BinaryOp(
+            BinOp::Le,
+            Box::new((Operand::Copy(biased), max_adjusted_allowed_value)),
+        );
+        self.add_assignment(self.is_in_range, rvalue);
+    }
+}
+
+trait NicheExt {
+    fn ty<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Ty<'tcx>;
+    fn size<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Size;
+}
+
+impl NicheExt for Niche {
+    fn ty<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
+        let types = &tcx.types;
+        match self.value {
+            Primitive::Int(Integer::I8, _) => types.u8,
+            Primitive::Int(Integer::I16, _) => types.u16,
+            Primitive::Int(Integer::I32, _) => types.u32,
+            Primitive::Int(Integer::I64, _) => types.u64,
+            Primitive::Int(Integer::I128, _) => types.u128,
+            Primitive::Pointer(_) => {
+                Ty::new_ptr(tcx, TypeAndMut { ty: types.unit, mutbl: Mutability::Not })
+            }
+            Primitive::F32 => types.u32,
+            Primitive::F64 => types.u64,
+        }
+    }
+
+    fn size<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Size {
+        let bits = match self.value {
+            Primitive::Int(Integer::I8, _) => 8,
+            Primitive::Int(Integer::I16, _) => 16,
+            Primitive::Int(Integer::I32, _) => 32,
+            Primitive::Int(Integer::I64, _) => 64,
+            Primitive::Int(Integer::I128, _) => 128,
+            Primitive::Pointer(_) => tcx.sess.target.pointer_width as usize,
+            Primitive::F32 => 32,
+            Primitive::F64 => 64,
+        };
+        Size::from_bits(bits)
+    }
+}

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -52,6 +52,7 @@ mod add_call_guards;
 mod add_moves_for_packed_drops;
 mod add_retag;
 mod check_const_item_mutation;
+mod check_niches;
 mod check_packed_ref;
 pub mod check_unsafety;
 mod remove_place_mention;
@@ -321,6 +322,7 @@ fn mir_promoted(
     tcx: TyCtxt<'_>,
     def: LocalDefId,
 ) -> (&Steal<Body<'_>>, &Steal<IndexVec<Promoted, Body<'_>>>) {
+    tcx.ensure_with_value().unsafety_check_result(def);
     // Ensure that we compute the `mir_const_qualif` for constants at
     // this point, before we steal the mir-const result.
     // Also this means promotion can rely on all const checks having been done.
@@ -567,6 +569,7 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         body,
         &[
             &check_alignment::CheckAlignment,
+            &check_niches::CheckNiches,
             &lower_slice_len::LowerSliceLenCalls, // has to be done before inlining, otherwise actual call will be almost always inlined. Also simple, so can just do first
             &inline::Inline,
             // Substitutions during inlining may introduce switch on enums with uninhabited branches.

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -812,6 +812,13 @@ impl<'tcx> Stable<'tcx> for mir::AssertMessage<'tcx> {
                     found: found.stable(tables),
                 }
             }
+            AssertKind::OccupiedNiche { found, start, end } => {
+                stable_mir::mir::AssertMessage::OccupiedNiche {
+                    found: found.stable(tables),
+                    start: start.stable(tables),
+                    end: end.stable(tables),
+                }
+            }
         }
     }
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1157,6 +1157,7 @@ symbols! {
         panic_location,
         panic_misaligned_pointer_dereference,
         panic_nounwind,
+        panic_occupied_niche,
         panic_runtime,
         panic_str,
         panic_unwind,

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -149,6 +149,7 @@ pub enum AssertMessage {
     ResumedAfterReturn(CoroutineKind),
     ResumedAfterPanic(CoroutineKind),
     MisalignedPointerDereference { required: Operand, found: Operand },
+    OccupiedNiche { found: Operand, start: Operand, end: Operand },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/compiler/stable_mir/src/mir/visit.rs
+++ b/compiler/stable_mir/src/mir/visit.rs
@@ -372,6 +372,11 @@ pub trait MirVisitor {
                 self.visit_operand(required, location);
                 self.visit_operand(found, location);
             }
+            AssertMessage::OccupiedNiche { found, start, end } => {
+                self.visit_operand(found, location);
+                self.visit_operand(start, location);
+                self.visit_operand(end, location);
+            }
         }
     }
 }

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -139,5 +139,5 @@ pub const MIRI_DEFAULT_ARGS: &[&str] = &[
     "-Zmir-emit-retag",
     "-Zmir-keep-place-mention",
     "-Zmir-opt-level=0",
-    "-Zmir-enable-passes=-CheckAlignment",
+    "-Zmir-enable-passes=-CheckAlignment,-CheckNiches",
 ];

--- a/tests/codegen/array-equality.rs
+++ b/tests/codegen/array-equality.rs
@@ -1,5 +1,6 @@
 // compile-flags: -O -Z merge-functions=disabled
 // only-x86_64
+// ignore-debug: array comparison sometimes transmutes references, so we have niche checks in std
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/debug-vtable.rs
+++ b/tests/codegen/debug-vtable.rs
@@ -6,7 +6,7 @@
 // legacy mangling scheme rustc version and generic parameters are both hashed into a single part
 // of the name, thus randomizing item order with respect to rustc version.
 
-// compile-flags: -Cdebuginfo=2 -Copt-level=0 -Csymbol-mangling-version=v0
+// compile-flags: -Cdebuginfo=2 -Copt-level=0 -Csymbol-mangling-version=v0 -Zmir-enable-passes=-CheckNiches
 // ignore-tidy-linelength
 
 // Make sure that vtables don't have the unnamed_addr attribute when debuginfo is enabled.

--- a/tests/codegen/intrinsics/transmute-niched.rs
+++ b/tests/codegen/intrinsics/transmute-niched.rs
@@ -1,6 +1,6 @@
 // revisions: OPT DBG
 // [OPT] compile-flags: -C opt-level=3 -C no-prepopulate-passes
-// [DBG] compile-flags: -C opt-level=0 -C no-prepopulate-passes
+// [DBG] compile-flags: -C opt-level=0 -C no-prepopulate-passes -Zmir-enable-passes=-CheckNiches
 // only-64bit (so I don't need to worry about usize)
 
 #![crate_type = "lib"]

--- a/tests/codegen/sanitizer/cfi-emit-type-checks-attr-no-sanitize.rs
+++ b/tests/codegen/sanitizer/cfi-emit-type-checks-attr-no-sanitize.rs
@@ -1,7 +1,7 @@
 // Verifies that pointer type membership tests for indirect calls are omitted.
 //
 // needs-sanitizer-cfi
-// compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Copt-level=0
+// compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Copt-level=0 -Zmir-enable-passes=-CheckNiches
 
 #![crate_type="lib"]
 #![feature(no_sanitize)]

--- a/tests/codegen/sanitizer/cfi-emit-type-checks.rs
+++ b/tests/codegen/sanitizer/cfi-emit-type-checks.rs
@@ -1,7 +1,7 @@
 // Verifies that pointer type membership tests for indirect calls are emitted.
 //
 // needs-sanitizer-cfi
-// compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Copt-level=0
+// compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Copt-level=0 -Zmir-enable-passes=-CheckNiches
 
 #![crate_type="lib"]
 

--- a/tests/codegen/thread-local.rs
+++ b/tests/codegen/thread-local.rs
@@ -1,4 +1,5 @@
 // compile-flags: -O
+// ignore-debug: niche checks in std interfere with the codegen we are looking for
 // aux-build:thread_local_aux.rs
 // ignore-windows FIXME(#84933)
 // ignore-wasm globals are used instead of thread locals

--- a/tests/codegen/transmute-scalar.rs
+++ b/tests/codegen/transmute-scalar.rs
@@ -1,4 +1,4 @@
-// compile-flags: -C opt-level=0 -C no-prepopulate-passes
+// compile-flags: -C opt-level=0 -C no-prepopulate-passes -Zmir-enable-passes=-CheckNiches
 
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/remove_storage_markers.rs
+++ b/tests/mir-opt/remove_storage_markers.rs
@@ -4,7 +4,7 @@
 
 // Checks that storage markers are removed at opt-level=0.
 //
-// compile-flags: -C opt-level=0 -Coverflow-checks=off
+// compile-flags: -C opt-level=0 -Cdebug-assertions=off
 
 // EMIT_MIR remove_storage_markers.main.RemoveStorageMarkers.diff
 fn main() {

--- a/tests/ui-fulldeps/stable-mir/crate-info.rs
+++ b/tests/ui-fulldeps/stable-mir/crate-info.rs
@@ -186,6 +186,7 @@ fn main() {
     let args = vec![
         "rustc".to_string(),
         "--crate-type=lib".to_string(),
+        "-Zmir-enable-passes=-CheckNiches".to_string(),
         "--crate-name".to_string(),
         CRATE_NAME.to_string(),
         path.to_string(),

--- a/tests/ui/lint/large_assignments/box_rc_arc_allowed.rs
+++ b/tests/ui/lint/large_assignments/box_rc_arc_allowed.rs
@@ -5,7 +5,7 @@
 // only-x86_64
 
 // edition:2018
-// compile-flags: -Zmir-opt-level=0
+// compile-flags: -Zmir-opt-level=0 -Zmir-enable-passes=-CheckNiches
 
 use std::{sync::Arc, rc::Rc};
 

--- a/tests/ui/mir/check_niches/invalid_enums.rs
+++ b/tests/ui/mir/check_niches/invalid_enums.rs
@@ -1,0 +1,23 @@
+// run-fail
+// ignore-wasm32-bare: No panic messages
+// compile-flags: -C debug-assertions -Zmir-opt-level=0
+
+#[repr(C)]
+struct Thing {
+    x: usize,
+    y: Contents,
+    z: usize,
+}
+
+#[repr(usize)]
+enum Contents {
+    A = 8usize,
+    B = 9usize,
+    C = 10usize,
+}
+
+fn main() {
+    unsafe {
+        let _thing = std::mem::transmute::<(usize, usize, usize), Thing>((0, 3, 0));
+    }
+}

--- a/tests/ui/mir/check_niches/invalid_nonnull_transmute.rs
+++ b/tests/ui/mir/check_niches/invalid_nonnull_transmute.rs
@@ -1,0 +1,10 @@
+// run-fail
+// ignore-wasm32-bare: No panic messages
+// compile-flags: -C debug-assertions -Zmir-opt-level=0
+// error-pattern: occupied niche: found 0x0 but must be in 0x1..=0xffffffff
+
+fn main() {
+    unsafe {
+        std::mem::transmute::<*const u8, std::ptr::NonNull<u8>>(std::ptr::null());
+    }
+}

--- a/tests/ui/mir/check_niches/invalid_nonzero_argument.rs
+++ b/tests/ui/mir/check_niches/invalid_nonzero_argument.rs
@@ -1,0 +1,14 @@
+// run-fail
+// ignore-wasm32-bare: No panic messages
+// compile-flags: -C debug-assertions -Zmir-opt-level=0
+// error-pattern: occupied niche: found 0 but must be in 1..=255
+
+fn main() {
+    let mut bad = std::num::NonZeroU8::new(1u8).unwrap();
+    unsafe {
+        std::ptr::write_bytes(&mut bad, 0u8, 1usize);
+    }
+    func(bad);
+}
+
+fn func<T>(_t: T) {}

--- a/tests/ui/mir/check_niches/valid_nonzero_argument.rs
+++ b/tests/ui/mir/check_niches/valid_nonzero_argument.rs
@@ -1,0 +1,13 @@
+// run-pass
+// compile-flags: -C debug-assertions -Zmir-opt-level=0
+
+fn main() {
+    for val in i8::MIN..=i8::MAX {
+        if val != 0 {
+            let x = std::num::NonZeroI8::new(val).unwrap();
+            if val != i8::MIN {
+                let _y = -x;
+            }
+        }
+    }
+}

--- a/tests/ui/numbers-arithmetic/saturating-float-casts-wasm.rs
+++ b/tests/ui/numbers-arithmetic/saturating-float-casts-wasm.rs
@@ -1,6 +1,6 @@
 // run-pass
 // only-wasm32
-// compile-flags: -Zmir-opt-level=0 -C target-feature=+nontrapping-fptoint
+// compile-flags: -Zmir-opt-level=0 -C target-feature=+nontrapping-fptoint -Zmir-enable-passes=-CheckNiches
 
 #![feature(test, stmt_expr_attributes)]
 #![deny(overflowing_literals)]

--- a/tests/ui/numbers-arithmetic/saturating-float-casts.rs
+++ b/tests/ui/numbers-arithmetic/saturating-float-casts.rs
@@ -1,5 +1,5 @@
 // run-pass
-// compile-flags:-Zmir-opt-level=0
+// compile-flags:-Zmir-opt-level=0 -Zmir-enable-passes=-CheckNiches
 
 #![feature(test, stmt_expr_attributes)]
 #![deny(overflowing_literals)]

--- a/tests/ui/print_type_sizes/niche-filling.rs
+++ b/tests/ui/print_type_sizes/niche-filling.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z print-type-sizes --crate-type=lib
+// compile-flags: -Z print-type-sizes --crate-type=lib -Zmir-enable-passes=-CheckNiches
 // build-pass
 // ignore-pass
 // ^-- needed because `--pass check` does not emit the output needed.

--- a/tests/ui/type-alias-enum-variants/self-in-enum-definition.rs
+++ b/tests/ui/type-alias-enum-variants/self-in-enum-definition.rs
@@ -1,3 +1,5 @@
+// compile-flags: -Cdebug-assertions=no
+
 #[repr(u8)]
 enum Alpha {
     V1 = 41,

--- a/tests/ui/type-alias-enum-variants/self-in-enum-definition.stderr
+++ b/tests/ui/type-alias-enum-variants/self-in-enum-definition.stderr
@@ -1,63 +1,53 @@
 error[E0391]: cycle detected when simplifying constant for the type system `Alpha::V3::{constant#0}`
-  --> $DIR/self-in-enum-definition.rs:5:10
+  --> $DIR/self-in-enum-definition.rs:7:10
    |
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^^^^^^^^^^^^^^
    |
 note: ...which requires simplifying constant for the type system `Alpha::V3::{constant#0}`...
-  --> $DIR/self-in-enum-definition.rs:5:10
+  --> $DIR/self-in-enum-definition.rs:7:10
    |
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `Alpha::V3::{constant#0}`...
-  --> $DIR/self-in-enum-definition.rs:5:10
+  --> $DIR/self-in-enum-definition.rs:7:10
    |
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires caching mir of `Alpha::V3::{constant#0}` for CTFE...
-  --> $DIR/self-in-enum-definition.rs:5:10
+  --> $DIR/self-in-enum-definition.rs:7:10
    |
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires elaborating drops for `Alpha::V3::{constant#0}`...
-  --> $DIR/self-in-enum-definition.rs:5:10
+  --> $DIR/self-in-enum-definition.rs:7:10
    |
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires borrow-checking `Alpha::V3::{constant#0}`...
-  --> $DIR/self-in-enum-definition.rs:5:10
+  --> $DIR/self-in-enum-definition.rs:7:10
    |
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires promoting constants in MIR for `Alpha::V3::{constant#0}`...
-  --> $DIR/self-in-enum-definition.rs:5:10
-   |
-LL |     V3 = Self::V1 {} as u8 + 2,
-   |          ^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires const checking `Alpha::V3::{constant#0}`...
-  --> $DIR/self-in-enum-definition.rs:5:10
-   |
-LL |     V3 = Self::V1 {} as u8 + 2,
-   |          ^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires preparing `Alpha::V3::{constant#0}` for borrow checking...
-  --> $DIR/self-in-enum-definition.rs:5:10
+  --> $DIR/self-in-enum-definition.rs:7:10
    |
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires unsafety-checking `Alpha::V3::{constant#0}`...
-  --> $DIR/self-in-enum-definition.rs:5:10
+  --> $DIR/self-in-enum-definition.rs:7:10
    |
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires building MIR for `Alpha::V3::{constant#0}`...
-  --> $DIR/self-in-enum-definition.rs:5:10
+  --> $DIR/self-in-enum-definition.rs:7:10
    |
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^^^^^^^^^^^^^^
    = note: ...which requires computing layout of `Alpha`...
    = note: ...which again requires simplifying constant for the type system `Alpha::V3::{constant#0}`, completing the cycle
 note: cycle used when collecting item types in top-level module
-  --> $DIR/self-in-enum-definition.rs:1:1
+  --> $DIR/self-in-enum-definition.rs:3:1
    |
 LL | / #[repr(u8)]
 LL | | enum Alpha {


### PR DESCRIPTION
Implementation of https://github.com/rust-lang/compiler-team/issues/624

Crater run has 62 crates that hit the check, 43 of those are published to crates.io. I see a lot of null function pointers and use of `mem::uninitialized` where the 0x1-filling collides with an enum niche.

But that is with full niche checks; checking transmute, plus any place where that we Copy, Move, or Inspect. Such checking is definitely too thorough to be on by default because it is 2x compile time overhead.

---

During implementation, this ran into https://github.com/llvm/llvm-project/issues/68381

r? @ghost