### PR TITLE
[llvm-wrapper] adapt for LLVM API change

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -627,7 +627,11 @@ LLVMRustOptimize(
   bool DebugPassManager = false;
 
   PassInstrumentationCallbacks PIC;
+#if LLVM_VERSION_LT(16, 0)
   StandardInstrumentations SI(DebugPassManager);
+#else
+  StandardInstrumentations SI(TheModule->getContext(), DebugPassManager);
+#endif
   SI.registerCallbacks(PIC);
 
   if (LlvmSelfProfiler){


### PR DESCRIPTION
Adapt for the LLVM API changes from https://github.com/llvm/llvm-project/commit/721f975d3518403502f770ce11f3f02509b30c5b.

Found via our experimental rust + llvm @ HEAD bot: https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/15203#0184ae73-5169-4b9b-92f4-d4e6e9b86ad9/194-531