### PR TITLE
notify lcnr on changes to `ObligationCtxt`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -334,6 +334,13 @@ cc = ["@rust-lang/wg-mir-opt"]
 message = "Some changes occurred in const_evaluatable.rs"
 cc = ["@lcnr"]
 
+[mentions."compiler/rustc_trait_selection/src/traits/engine.rs"]
+message = """
+Some changes occurred in engine.rs, potentially modifying the public API \
+of `ObligationCtxt`.
+"""
+cc = ["@lcnr"]
+
 [mentions."compiler/rustc_error_codes/src/error_codes.rs"]
 message = "Some changes occurred in diagnostic error codes"
 cc = ["@GuillaumeGomez"]


### PR DESCRIPTION
Right now the `ObligationCtxt` has an API which should prevent leaking any important details of the trait solver. This allows us to freely use it without having to worry about causing issues for the [trait solver rewrite](https://github.com/orgs/rust-lang/projects/26/views/1).

I would like to keep it this way ^^
