### PR TITLE
rustbuild: Don't build doc::SharedAssets when building JSON docs.

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -458,7 +458,9 @@ impl Step for Std {
 
         t!(fs::create_dir_all(&out));
 
-        builder.ensure(SharedAssets { target: self.target });
+        if self.format == DocumentationFormat::HTML {
+            builder.ensure(SharedAssets { target: self.target });
+        }
 
         let index_page = builder.src.join("src/doc/index.md").into_os_string();
         let mut extra_args = match self.format {


### PR DESCRIPTION
Previously, running `./x doc library/core/ --json` on a plain build would panic bootstrap.

```
$ ./x doc library/core/ --json
Building rustbuild
    Blocking waiting for file lock on package cache
   Compiling bootstrap v0.0.0 (/home/nixon/dev/rust/rust/src/bootstrap)
    Finished dev [unoptimized] target(s) in 4.47s
thread 'main' panicked at 'fs::write(&version_info, &info) failed with No such file or directory (os error 2) ("/home/nixon/dev/rust/rust/build/x86_64-unknown-linux-gnu/doc/version_info.html")', doc.rs:410:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Build completed unsuccessfully in 0:00:04
```

Becuase the `SharedAssets` step assumes that the HTML out dir has been created. This isn't true for JSON.

The fix is to not build shared assets when doing a JSON doc build, as it doesn't need them.

r? @jyn514 

@rustbot modify labels: +A-rustdoc-json
