### PR TITLE
Avoid Invalid code suggested when encountering unsatisfied trait bounds in derive macro code

### DIFF
--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -355,6 +355,12 @@ pub fn suggest_constraining_type_params<'a>(
         ));
     }
 
+    // FIXME: remove the suggestions that are from derive, as the span is not correct
+    suggestions = suggestions
+        .into_iter()
+        .filter(|(span, _, _)| !span.in_derive_expansion())
+        .collect::<Vec<_>>();
+
     if suggestions.len() == 1 {
         let (span, suggestion, msg) = suggestions.pop().unwrap();
 

--- a/src/test/ui/proc-macro/auxiliary/issue-104884.rs
+++ b/src/test/ui/proc-macro/auxiliary/issue-104884.rs
@@ -1,0 +1,23 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(AddImpl)]
+
+pub fn derive(input: TokenStream) -> TokenStream {
+    "use std::cmp::Ordering;
+
+    impl<T> Ord for PriorityQueue<T> {
+        fn cmp(&self, other: &Self) -> Ordering {
+            self.0.cmp(&self.height)
+        }
+    }
+    "
+    .parse()
+    .unwrap()
+}

--- a/src/test/ui/proc-macro/issue-104884-trait-impl-sugg-err.rs
+++ b/src/test/ui/proc-macro/issue-104884-trait-impl-sugg-err.rs
@@ -1,0 +1,20 @@
+// aux-build:issue-104884.rs
+
+use std::collections::BinaryHeap;
+
+#[macro_use]
+extern crate issue_104884;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct PriorityQueueEntry<T> {
+    value: T,
+}
+
+#[derive(PartialOrd, AddImpl)]
+//~^ ERROR can't compare `PriorityQueue<T>` with `PriorityQueue<T>`
+//~| ERROR the trait bound `PriorityQueue<T>: Eq` is not satisfied
+//~| ERROR can't compare `T` with `T`
+
+struct PriorityQueue<T>(BinaryHeap<PriorityQueueEntry<T>>);
+
+fn main() {}

--- a/src/test/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
+++ b/src/test/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
@@ -1,0 +1,48 @@
+error[E0277]: can't compare `PriorityQueue<T>` with `PriorityQueue<T>`
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:10
+   |
+LL | #[derive(PartialOrd, AddImpl)]
+   |          ^^^^^^^^^^ no implementation for `PriorityQueue<T> == PriorityQueue<T>`
+   |
+   = help: the trait `PartialEq` is not implemented for `PriorityQueue<T>`
+note: required by a bound in `PartialOrd`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL | pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
+   |                                           ^^^^^^^^^^^^^^ required by this bound in `PartialOrd`
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `PriorityQueue<T>: Eq` is not satisfied
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:22
+   |
+LL | #[derive(PartialOrd, AddImpl)]
+   |                      ^^^^^^^ the trait `Eq` is not implemented for `PriorityQueue<T>`
+   |
+note: required by a bound in `Ord`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL | pub trait Ord: Eq + PartialOrd<Self> {
+   |                ^^ required by this bound in `Ord`
+   = note: this error originates in the derive macro `AddImpl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: can't compare `T` with `T`
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:22
+   |
+LL | #[derive(PartialOrd, AddImpl)]
+   |                      ^^^^^^^ no implementation for `T < T` and `T > T`
+   |
+note: required for `PriorityQueue<T>` to implement `PartialOrd`
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:10
+   |
+LL | #[derive(PartialOrd, AddImpl)]
+   |          ^^^^^^^^^^
+note: required by a bound in `Ord`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL | pub trait Ord: Eq + PartialOrd<Self> {
+   |                     ^^^^^^^^^^^^^^^^ required by this bound in `Ord`
+   = note: this error originates in the derive macro `AddImpl` which comes from the expansion of the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #104884