### PR TITLE
rustdoc: fix broken tooltip CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1139,7 +1139,6 @@ pre.rust .doccomment {
 .example-wrap .tooltip {
 	position: absolute;
 	display: block;
-	cursor: pointer;
 	left: -25px;
 	top: 5px;
 }

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -64,7 +64,7 @@
 	--test-arrow-hover-background-color: #4e8bca;
 	--target-background-color: #fdffd3;
 	--target-border-color: #ad7c37;
-	--tooltip-background-color: #fdffd3;
+	--tooltip-background-color: #000;
 	--tooltip-color: #fff;
 	--kbd-color: #000;
 	--kbd-background: #fafbfc;

--- a/src/test/rustdoc-gui/codeblock-tooltip.goml
+++ b/src/test/rustdoc-gui/codeblock-tooltip.goml
@@ -146,7 +146,7 @@ call-function: ("check-colors", {
 })
 call-function: ("check-colors", {
     "theme": "light",
-    "background": "rgb(253, 255, 211)",
+    "background": "rgb(0, 0, 0)",
     "color": "rgb(255, 255, 255)",
     "border": "rgb(224, 224, 224)",
 })


### PR DESCRIPTION
text `#ffffff` on background `#fdffd3` fails the [WCAG color contrast checker], and seems like a mistake in https://github.com/rust-lang/rust/commit/16b55903ee16503e7026677c169727d1907704c2.

Making the cursor a pointer is misleading, since clicking it doesn't do anything.

[WCAG color contrast checker]: https://accessibleweb.com/color-contrast-checker/
