### PR TITLE
rustdoc: remove no-op CSS `#help dt { display: block }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -949,7 +949,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 #help dt {
 	float: left;
 	clear: left;
-	display: block;
 	margin-right: 0.5rem;
 }
 #help span.top, #help span.bottom {


### PR DESCRIPTION
`display: block` is the [default UA style] for dt.

[default UA style]: https://html.spec.whatwg.org/multipage/rendering.html#lists