### PR TITLE
Allow non-org members to label `requires-debug-assertions`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -15,7 +15,7 @@ allow-unauthenticated = [
     "llvm-main",
     "needs-fcp",
     "relnotes",
-    "requires-nightly",
+    "requires-*",
     "regression-*",
     "perf-*",
     "AsyncAwait-OnDeck",


### PR DESCRIPTION
`jruderman` tried to add this in #104916, for example. I think I've seen this happen before as well.