### PR TITLE
Avoid some `InferCtxt::build` calls

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/generics.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/generics.rs
@@ -11,7 +11,6 @@ use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::GenericArg;
-use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::ty::{
     self, subst, subst::SubstsRef, GenericParamDef, GenericParamDefKind, IsSuggestable, Ty, TyCtxt,
 };
@@ -83,9 +82,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 Res::Def(DefKind::TyParam, src_def_id) => {
                     if let Some(param_local_id) = param.def_id.as_local() {
                         let param_name = tcx.hir().ty_param_name(param_local_id);
-                        let infcx = tcx.infer_ctxt().build();
-                        let param_type =
-                            infcx.resolve_numeric_literals_with_default(tcx.type_of(param.def_id));
+                        let param_type = tcx.type_of(param.def_id);
                         if param_type.is_suggestable(tcx, false) {
                             err.span_suggestion(
                                 tcx.def_span(src_def_id),

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -10,7 +10,7 @@ use rustc_hir::{
     Expr, ExprKind, GenericBound, Node, Path, QPath, Stmt, StmtKind, TyKind, WherePredicate,
 };
 use rustc_hir_analysis::astconv::AstConv;
-use rustc_infer::infer::{self, TyCtxtInferExt};
+use rustc_infer::infer;
 use rustc_infer::traits::{self, StatementAsExpression};
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::{self, Binder, DefIdTree, IsSuggestable, ToPredicate, Ty};
@@ -921,19 +921,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let ty = <dyn AstConv<'_>>::ast_ty_to_ty(self, ty);
             let bound_vars = self.tcx.late_bound_vars(fn_id);
             let ty = self.tcx.erase_late_bound_regions(Binder::bind_with_vars(ty, bound_vars));
-            let ty = self.normalize(expr.span, ty);
             let ty = match self.tcx.asyncness(fn_id.owner) {
-                hir::IsAsync::Async => {
-                    let infcx = self.tcx.infer_ctxt().build();
-                    infcx.get_impl_future_output_ty(ty).unwrap_or_else(|| {
-                        span_bug!(
-                            fn_decl.output.span(),
-                            "failed to get output type of async function"
-                        )
-                    })
-                }
+                hir::IsAsync::Async => self.get_impl_future_output_ty(ty).unwrap_or_else(|| {
+                    span_bug!(fn_decl.output.span(), "failed to get output type of async function")
+                }),
                 hir::IsAsync::NotAsync => ty,
             };
+            let ty = self.normalize(expr.span, ty);
             if self.can_coerce(found, ty) {
                 err.multipart_suggestion(
                     "you might have meant to return this value",

--- a/src/test/ui/return/tail-expr-as-potential-return.rs
+++ b/src/test/ui/return/tail-expr-as-potential-return.rs
@@ -12,7 +12,6 @@
 // edition:2018
 
 fn main() {
-    let _ = foo(true);
 }
 
 fn foo(x: bool) -> Result<f64, i32> {
@@ -29,4 +28,20 @@ async fn bar(x: bool) -> Result<f64, i32> {
                 //| HELP you might have meant to return this value
     }
     Ok(42.0)
+}
+
+trait Identity {
+    type Out;
+}
+
+impl<T> Identity for T {
+    type Out = T;
+}
+
+async fn foo2() -> i32 {
+    if true {
+        1i32 //~ ERROR mismatched types
+            //| HELP you might have meant to return this value
+    }
+    0
 }

--- a/src/test/ui/return/tail-expr-as-potential-return.stderr
+++ b/src/test/ui/return/tail-expr-as-potential-return.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/tail-expr-as-potential-return.rs:28:9
+  --> $DIR/tail-expr-as-potential-return.rs:27:9
    |
 LL | /     if x {
 LL | |         Err(42)
@@ -16,7 +16,22 @@ LL |         return Err(42);
    |         ++++++        +
 
 error[E0308]: mismatched types
-  --> $DIR/tail-expr-as-potential-return.rs:20:9
+  --> $DIR/tail-expr-as-potential-return.rs:43:9
+   |
+LL | /     if true {
+LL | |         1i32
+   | |         ^^^^ expected `()`, found `i32`
+LL | |             //| HELP you might have meant to return this value
+LL | |     }
+   | |_____- expected this to be `()`
+   |
+help: you might have meant to return this value
+   |
+LL |         return 1i32;
+   |         ++++++     +
+
+error[E0308]: mismatched types
+  --> $DIR/tail-expr-as-potential-return.rs:19:9
    |
 LL | /     if x {
 LL | |         Err(42)
@@ -32,6 +47,6 @@ help: you might have meant to return this value
 LL |         return Err(42);
    |         ++++++        +
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Either because we're inside of an `InferCtxt` already, or because we're not in a place where we'd ever see inference vars.

r? types