### PR TITLE
jsondoclint: Accept trait alias is places where trait expected.

### DIFF
--- a/src/test/rustdoc-json/traits/trait_alias.rs
+++ b/src/test/rustdoc-json/traits/trait_alias.rs
@@ -1,0 +1,30 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/104923>
+// ignore-tidy-linelength
+
+#![feature(trait_alias)]
+
+// @set Orig = "$.index[*][?(@.name == 'Orig')].id"
+// @is "$.index[*][?(@.name == 'Orig')].kind" '"trait"'
+pub trait Orig<T> {}
+
+// @set Alias = "$.index[*][?(@.name == 'Alias')].id"
+// @is "$.index[*][?(@.name == 'Alias')].kind" '"trait_alias"'
+// @is "$.index[*][?(@.name == 'Alias')].inner.generics" '{"params": [], "where_predicates": []}'
+// @count "$.index[*][?(@.name == 'Alias')].inner.params[*]" 1
+// @is "$.index[*][?(@.name == 'Alias')].inner.params[0].trait_bound.trait.id" $Orig
+// @is "$.index[*][?(@.name == 'Alias')].inner.params[0].trait_bound.trait.args.angle_bracketed.args[0].type.inner" '"i32"'
+pub trait Alias = Orig<i32>;
+
+pub struct Struct;
+
+impl Orig<i32> for Struct {}
+
+// @is "$.index[*][?(@.name=='takes_alias')].inner.decl.inputs[0][1].kind" '"impl_trait"'
+// @is "$.index[*][?(@.name=='takes_alias')].inner.decl.inputs[0][1].inner[0].trait_bound.trait.id" $Alias
+// @is "$.index[*][?(@.name=='takes_alias')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $Alias
+pub fn takes_alias(_: impl Alias) {}
+// FIXME: Should the trait be mentioned in both the decl and generics?
+
+fn main() {
+    takes_alias(Struct);
+}

--- a/src/tools/jsondoclint/src/item_kind.rs
+++ b/src/tools/jsondoclint/src/item_kind.rs
@@ -111,8 +111,8 @@ impl Kind {
     pub fn is_variant(self) -> bool {
         matches!(self, Kind::Variant)
     }
-    pub fn is_trait(self) -> bool {
-        matches!(self, Kind::Trait)
+    pub fn is_trait_or_alias(self) -> bool {
+        matches!(self, Kind::Trait | Kind::TraitAlias)
     }
     pub fn is_type(self) -> bool {
         matches!(self, Kind::Struct | Kind::Enum | Kind::Union | Kind::Typedef)

--- a/src/tools/jsondoclint/src/validator.rs
+++ b/src/tools/jsondoclint/src/validator.rs
@@ -266,7 +266,7 @@ impl<'a> Validator<'a> {
 
     fn check_path(&mut self, x: &'a Path, kind: PathKind) {
         match kind {
-            PathKind::Trait => self.add_trait_id(&x.id),
+            PathKind::Trait => self.add_trait_or_alias_id(&x.id),
             PathKind::Type => self.add_type_id(&x.id),
         }
         if let Some(args) = &x.args {
@@ -391,8 +391,8 @@ impl<'a> Validator<'a> {
         self.add_id_checked(id, Kind::is_variant, "Variant");
     }
 
-    fn add_trait_id(&mut self, id: &'a Id) {
-        self.add_id_checked(id, Kind::is_trait, "Trait");
+    fn add_trait_or_alias_id(&mut self, id: &'a Id) {
+        self.add_id_checked(id, Kind::is_trait_or_alias, "Trait (or TraitAlias)");
     }
 
     fn add_type_id(&mut self, id: &'a Id) {


### PR DESCRIPTION
More work to make `jsondoclint` work for `core.json`

Closes #104923

r? @GuillaumeGomez 

@rustbot modify labels: +A-testsuite