### PR TITLE
Properly deal with function pointer `Fn` candidates with escaping bound vars

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -2055,6 +2055,7 @@ fn confirm_callable_candidate<'cx, 'tcx>(
         obligation.predicate.self_ty(),
         fn_sig,
         flag,
+        false,
     )
     .map_bound(|(trait_ref, ret_type)| ty::ProjectionPredicate {
         projection_ty: ty::ProjectionTy {

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2322,6 +2322,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             self_ty,
             closure_sig,
             util::TupleArgumentsFlag::No,
+            false,
         )
         .map_bound(|(trait_ref, _)| trait_ref)
     }

--- a/src/test/ui/higher-rank-trait-bounds/fn-ptr-with-escaping-bound-vars.rs
+++ b/src/test/ui/higher-rank-trait-bounds/fn-ptr-with-escaping-bound-vars.rs
@@ -1,0 +1,18 @@
+// check-pass
+
+fn main() {
+    foo();
+    foo2();
+}
+
+fn foo()
+where
+    for<'a> for<'b> fn(&'a (), &'b ()): Fn(&'a (), &'static ()),
+{
+}
+
+fn foo2()
+where
+    for<'a> fn(&'a ()): Fn(&'a ()),
+{
+}


### PR DESCRIPTION
Function pointers in where clauses can reference both bound regions from their own binder, and from the binder of the where clause predicate that they're the Self type of.

The UI test demonstrates that we need to be able to deal with _both_ of these cases for `Fn` trait bounds, sometimes at the same time. 

This PR introduces a function called `flatten_binders` which takes a `Binder<Binder<T>>` and flattens it into a `Binder<T>`, concatenating the variables list and adjusting the de Bruijn indices accordingly. If we see a function pointer's signature that captures bound vars from the where-clause, flatten those bound variables so that we can subtype signatures properly in `confirm_poly_trait_refs`.

cc @lcnr @jackh726 who know more about binders and higher-ranked subtyping than I do.
r? types

------

I'm *pretty* sure this approach is (at least mostly) correct, but maybe it's overkill. The `where` clauses in the UI test I added are certainly a bit contrived, but perhaps they could show up in the wild... I recall seeing an ICE that looked like this, but I can't find it anymore.

We could alternatively deal with this in a forwards-compatible way by just erroring out if we see escaping bound vars in the fn ptr type... I mostly want to make sure that this code no longer ICEs:

```rust
fn foo2()
where
    for<'a> fn(&'a ()): Fn(&'a ()),
{
}
```