### PR TITLE
jsondoclint: Handle using enum variants and glob using enums.

### DIFF
--- a/src/test/rustdoc-json/enums/use_glob.rs
+++ b/src/test/rustdoc-json/enums/use_glob.rs
@@ -1,0 +1,18 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/104942>
+
+#![feature(no_core)]
+#![no_core]
+
+// @set Color = "$.index[*][?(@.name == 'Color')].id"
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+// @set use_Color = "$.index[*][?(@.kind == 'import')].id"
+// @is "$.index[*][?(@.kind == 'import')].inner.id" $Color
+// @is "$.index[*][?(@.kind == 'import')].inner.glob" true
+pub use Color::*;
+
+// @ismany "$.index[*][?(@.name == 'use_glob')].inner.items[*]" $Color $use_Color

--- a/src/test/rustdoc-json/enums/use_variant.rs
+++ b/src/test/rustdoc-json/enums/use_variant.rs
@@ -1,0 +1,15 @@
+#![feature(no_core)]
+#![no_core]
+
+// @set AlwaysNone = "$.index[*][?(@.name == 'AlwaysNone')].id"
+pub enum AlwaysNone {
+    // @set None = "$.index[*][?(@.name == 'None')].id"
+    None,
+}
+// @is "$.index[*][?(@.name == 'AlwaysNone')].inner.variants[*]" $None
+
+// @set use_None = "$.index[*][?(@.kind == 'import')].id"
+// @is "$.index[*][?(@.kind == 'import')].inner.id" $None
+pub use AlwaysNone::None;
+
+// @ismany "$.index[*][?(@.name == 'use_variant')].inner.items[*]" $AlwaysNone $use_None

--- a/src/tools/jsondoclint/src/item_kind.rs
+++ b/src/tools/jsondoclint/src/item_kind.rs
@@ -1,7 +1,7 @@
 use rustdoc_json_types::{Item, ItemEnum, ItemKind, ItemSummary};
 
 /// A univeral way to represent an [`ItemEnum`] or [`ItemKind`]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum Kind {
     Module,
     ExternCrate,
@@ -65,6 +65,22 @@ impl Kind {
 
             StructField => false, // Only in structs or variants
             Variant => false,     // Only in enums
+        }
+    }
+
+    pub fn can_appear_in_import(self) -> bool {
+        match self {
+            Kind::Variant => true,
+            Kind::Import => false,
+            other => other.can_appear_in_mod(),
+        }
+    }
+
+    pub fn can_appear_in_glob_import(self) -> bool {
+        match self {
+            Kind::Module => true,
+            Kind::Enum => true,
+            _ => false,
         }
     }
 

--- a/src/tools/jsondoclint/src/validator.rs
+++ b/src/tools/jsondoclint/src/validator.rs
@@ -103,9 +103,9 @@ impl<'a> Validator<'a> {
 
     fn check_import(&mut self, x: &'a Import) {
         if x.glob {
-            self.add_mod_id(x.id.as_ref().unwrap());
+            self.add_glob_import_item_id(x.id.as_ref().unwrap());
         } else if let Some(id) = &x.id {
-            self.add_mod_item_id(id);
+            self.add_import_item_id(id);
         }
     }
 
@@ -402,6 +402,15 @@ impl<'a> Validator<'a> {
     /// Add an Id that appeared in a trait
     fn add_trait_item_id(&mut self, id: &'a Id) {
         self.add_id_checked(id, Kind::can_appear_in_trait, "Trait inner item");
+    }
+
+    /// Add an Id that can be `use`d
+    fn add_import_item_id(&mut self, id: &'a Id) {
+        self.add_id_checked(id, Kind::can_appear_in_import, "Import inner item");
+    }
+
+    fn add_glob_import_item_id(&mut self, id: &'a Id) {
+        self.add_id_checked(id, Kind::can_appear_in_glob_import, "Glob import inner item");
     }
 
     /// Add an Id that appeared in a mod


### PR DESCRIPTION
More work on jsondoclint for `core.json`

Closes #104942

r? @GuillaumeGomez

@rustbot modify labels: +A-testsuite