### PR TITLE
Simplify checking for `GeneratorKind::Async`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -514,12 +514,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             span: *span,
             ty_err: match output_ty.kind() {
                 ty::Closure(_, _) => FnMutReturnTypeErr::ReturnClosure { span: *span },
-                ty::Generator(def, ..)
-                    if matches!(
-                        self.infcx.tcx.generator_kind(def),
-                        Some(hir::GeneratorKind::Async(_))
-                    ) =>
-                {
+                ty::Generator(def, ..) if self.infcx.tcx.generator_is_async(*def) => {
                     FnMutReturnTypeErr::ReturnAsyncBlock { span: *span }
                 }
                 _ => FnMutReturnTypeErr::ReturnRef { span: *span },

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -322,10 +322,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
                 ty::Closure(..) => Some(MustUsePath::Closure(span)),
                 ty::Generator(def_id, ..) => {
                     // async fn should be treated as "implementor of `Future`"
-                    let must_use = if matches!(
-                        cx.tcx.generator_kind(def_id),
-                        Some(hir::GeneratorKind::Async(..))
-                    ) {
+                    let must_use = if cx.tcx.generator_is_async(def_id) {
                         let def_id = cx.tcx.lang_items().future_trait().unwrap();
                         is_def_must_use(cx, def_id, span)
                             .map(|inner| MustUsePath::Opaque(Box::new(inner)))

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1360,6 +1360,11 @@ impl<'tcx> TyCtxt<'tcx> {
         self.diagnostic_items(did.krate).name_to_id.get(&name) == Some(&did)
     }
 
+    /// Returns `true` if the node pointed to by `def_id` is a generator for an async construct.
+    pub fn generator_is_async(self, def_id: DefId) -> bool {
+        matches!(self.generator_kind(def_id), Some(hir::GeneratorKind::Async(_)))
+    }
+
     pub fn stability(self) -> &'tcx stability::Index {
         self.stability_index(())
     }

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -430,9 +430,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     ) {
         let self_ty = obligation.self_ty().skip_binder();
         if let ty::Generator(did, ..) = self_ty.kind() {
-            if let Some(rustc_hir::GeneratorKind::Async(_generator_kind)) =
-                self.tcx().generator_kind(did)
-            {
+            if self.tcx().generator_is_async(*did) {
                 debug!(?self_ty, ?obligation, "assemble_future_candidates",);
 
                 candidates.vec.push(FutureCandidate);


### PR DESCRIPTION
Adds a helper method around `generator_kind` that makes matching async constructs simpler.