### PR TITLE
Ensure required submodules at the same time as updating existing submodules

### DIFF
--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -143,7 +143,7 @@ pub enum Subcommand {
         args: Vec<String>,
     },
     Setup {
-        profile: Profile,
+        profile: Option<Profile>,
     },
 }
 
@@ -628,14 +628,15 @@ Arguments:
                         |path| format!("{} is not a valid UTF8 string", path.to_string_lossy())
                     ));
 
-                    profile_string.parse().unwrap_or_else(|err| {
+                    let profile = profile_string.parse().unwrap_or_else(|err| {
                         eprintln!("error: {}", err);
                         eprintln!("help: the available profiles are:");
                         eprint!("{}", Profile::all_for_help("- "));
                         crate::detail_exit(1);
-                    })
+                    });
+                    Some(profile)
                 } else {
-                    t!(crate::setup::interactive_path())
+                    None
                 };
                 Subcommand::Setup { profile }
             }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -579,6 +579,8 @@ impl Build {
             for s in rust_submodules {
                 build.update_submodule(Path::new(s));
             }
+            // Now, update all existing submodules.
+            build.update_existing_submodules();
 
             build.verbose("learning about cargo");
             metadata::build(&mut build);
@@ -660,7 +662,7 @@ impl Build {
 
     /// If any submodule has been initialized already, sync it unconditionally.
     /// This avoids contributors checking in a submodule change by accident.
-    pub fn maybe_update_submodules(&self) {
+    pub fn update_existing_submodules(&self) {
         // Avoid running git when there isn't a git checkout.
         if !self.config.submodules(&self.rust_info()) {
             return;
@@ -688,8 +690,6 @@ impl Build {
         unsafe {
             job::setup(self);
         }
-
-        self.maybe_update_submodules();
 
         if let Subcommand::Format { check, paths } = &self.config.cmd {
             return format::format(&builder::Builder::new(&self), *check, &paths);

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -81,8 +81,9 @@ impl fmt::Display for Profile {
     }
 }
 
-pub fn setup(config: &Config, profile: Profile) {
+pub fn setup(config: &Config, profile: Option<Profile>) {
     let path = &config.config.clone().unwrap_or(PathBuf::from("config.toml"));
+    let profile = profile.unwrap_or_else(|| t!(interactive_path()));
 
     if path.exists() {
         eprintln!(


### PR DESCRIPTION
In practice, this would always happen at the same time, but putting them next to each other makes that more obvious and ensures it doesn't change in the future. It also avoids the difference affecting `cargo metadata` somehow.

This is based on https://github.com/rust-lang/rust/pull/104952 for convenience to avoid merge conflicts, but doesn't depend on that PR.