### PR TITLE
make simple check of prinf function

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -282,6 +282,14 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                             "you may want to use a bool value instead",
                             format!("{}", item_typo),
                         ))
+                    // FIXME(vicnenzopalazzo): make the check smarter,
+                    // and maybe expand with levenshtein distance checks
+                    } else if item_str.as_str() == "printf" {
+                        Some((
+                            item_span,
+                            "you may have meant to use the `print` macro",
+                            "print!".to_owned(),
+                        ))
                     } else {
                         suggestion
                     };

--- a/src/test/ui/suggestions/seggest_print_over_printf.rs
+++ b/src/test/ui/suggestions/seggest_print_over_printf.rs
@@ -1,0 +1,9 @@
+// Suggest to a user to use the print macros
+// instead to use the printf.
+
+fn main() {
+    let x = 4;
+    printf("%d", x);
+    //~^ ERROR cannot find function `printf` in this scope
+    //~| HELP you may have meant to use the `print` macro
+}

--- a/src/test/ui/suggestions/seggest_print_over_printf.stderr
+++ b/src/test/ui/suggestions/seggest_print_over_printf.stderr
@@ -1,0 +1,14 @@
+error[E0425]: cannot find function `printf` in this scope
+  --> $DIR/seggest_print_over_printf.rs:6:5
+   |
+LL |     printf("%d", x);
+   |     ^^^^^^ not found in this scope
+   |
+help: you may have meant to use the `print` macro
+   |
+LL |     print!("%d", x);
+   |     ~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/92898

With this commit we start to make some simple
check when the name resolution fails, and
we generate some helper messages in case the
name is a C name like in the case of the `printf`
and suggest the correct rust method.

@rustbot r? @pnkfelix

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>