### PR TITLE
bootstrap: Include line numbers in debuginfo by default for library/compiler profile

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1650,6 +1650,8 @@ impl<'a> Builder<'a> {
             }
         };
         cargo.env(profile_var("DEBUG"), debuginfo_level.to_string());
+        // Regardless of the config setting, don't build debuginfo for build scripts.
+        cargo.env(profile_var("BUILD_OVERRIDE_DEBUG"), "0");
         if !self.config.dry_run() && self.cc.borrow()[&target].args().iter().any(|arg| arg == "-gz")
         {
             rustflags.arg("-Clink-arg=-gz");

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -69,21 +69,25 @@ impl<'de> Deserialize<'de> for DebuginfoLevel {
         use serde::de::Error;
 
         Ok(match Deserialize::deserialize(deserializer)? {
-            StringOrInt::String("none") | StringOrInt::Int(0) => DebuginfoLevel::None,
-            StringOrInt::String("line-tables-only") => DebuginfoLevel::LineTablesOnly,
-            StringOrInt::String("limited") | StringOrInt::Int(1) => DebuginfoLevel::Limited,
-            StringOrInt::String("full") | StringOrInt::Int(2) => DebuginfoLevel::Full,
+            StringOrInt::Int(0) => DebuginfoLevel::None,
+            StringOrInt::Int(1) => DebuginfoLevel::Limited,
+            StringOrInt::Int(2) => DebuginfoLevel::Full,
             StringOrInt::Int(n) => {
                 let other = serde::de::Unexpected::Signed(n);
                 return Err(D::Error::invalid_value(other, &"expected 0, 1, or 2"));
             }
-            StringOrInt::String(s) => {
-                let other = serde::de::Unexpected::Str(s);
-                return Err(D::Error::invalid_value(
-                    other,
-                    &"expected none, line-tables-only, limited, or full",
-                ));
-            }
+            StringOrInt::String(s) => match s.as_str() {
+                "none" => DebuginfoLevel::None,
+                "line-tables-only" => DebuginfoLevel::LineTablesOnly,
+                "limited" => DebuginfoLevel::Limited,
+                "full" => DebuginfoLevel::Full,
+                _ => {
+                    return Err(D::Error::invalid_value(
+                        serde::de::Unexpected::Str(&s),
+                        &"expected none, line-tables-only, limited, or full",
+                    ));
+                }
+            },
         })
     }
 }
@@ -877,8 +881,8 @@ impl Default for StringOrBool {
 
 #[derive(Deserialize)]
 #[serde(untagged)]
-enum StringOrInt<'a> {
-    String(&'a str),
+enum StringOrInt {
+    String(String),
     Int(i64),
 }
 

--- a/src/bootstrap/defaults/config.codegen.toml
+++ b/src/bootstrap/defaults/config.codegen.toml
@@ -23,3 +23,5 @@ incremental = true
 backtrace-on-ice = true
 # Make the compiler and standard library faster to build, at the expense of a ~20% runtime slowdown.
 lto = "off"
+# Include line numbers in backtraces.
+debuginfo-level-rustc = "line-tables-only"

--- a/src/bootstrap/defaults/config.compiler.toml
+++ b/src/bootstrap/defaults/config.compiler.toml
@@ -14,6 +14,8 @@ incremental = true
 backtrace-on-ice = true
 # Make the compiler and standard library faster to build, at the expense of a ~20% runtime slowdown.
 lto = "off"
+# Include line numbers in backtraces.
+debuginfo-level-rustc = "line-tables-only"
 
 [llvm]
 # Will download LLVM from CI if available on your platform.

--- a/src/bootstrap/defaults/config.library.toml
+++ b/src/bootstrap/defaults/config.library.toml
@@ -10,6 +10,8 @@ bench-stage = 0
 incremental = true
 # Make the compiler and standard library faster to build, at the expense of a ~20% runtime slowdown.
 lto = "off"
+# Include line numbers in backtraces.
+debuginfo-level-std = "line-tables-only"
 
 [llvm]
 # Will download LLVM from CI if available on your platform.

--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -12,6 +12,8 @@ incremental = true
 # Using these defaults will download the stage2 compiler (see `download-rustc`
 # setting) and the stage2 toolchain should therefore be used for these defaults.
 download-rustc = "if-unchanged"
+# Include line numbers in backtraces.
+debuginfo-level-tools = "line-tables-only"
 
 [build]
 # Document with the in-tree rustdoc by default, since `download-rustc` makes it quick to compile.


### PR DESCRIPTION
This only includes debuginfo for the relevant component, so for library and tool developers the compile time impact should be negligible. For compiler authors I think the improved backtraces are worth the slight compile time hit (roughly 10% slower).

- Set the default to LineTablesOnly. This isn't enough debuginfo to run perf, but it's enough to
get full backtraces.
- Don't build debuginfo for build scripts and proc macros. This lowers the total disk space for stage0-rustc from 5.4 to 5.3 GB, or by 120 MB.
- Fix a bug in deserialization where string values would never be deserialized

  For reasons I don't quite understand, using `&str` unconditionally failed:
    ```
    thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { inner: Error { inner: TomlError { message: "data did not match any variant of untagged enum StringOrInt", original: None, keys: [], span: None } } }', src/main.rs:15:49
    ```