### PR TITLE
Rename `Iterator::array_chunks` to `Iterator::chunks`

### DIFF
--- a/library/core/benches/iter.rs
+++ b/library/core/benches/iter.rs
@@ -419,7 +419,7 @@ fn bench_copied_chunks(b: &mut Bencher) {
     })
 }
 
-/// Exercises the TrustedRandomAccess specialization in ArrayChunks
+/// Exercises the TrustedRandomAccess specialization in Chunks
 #[bench]
 fn bench_trusted_random_access_chunks(b: &mut Bencher) {
     let v = vec![1u8; 1024];
@@ -429,7 +429,7 @@ fn bench_trusted_random_access_chunks(b: &mut Bencher) {
             .iter()
             // this shows that we're not relying on the slice::Iter specialization in Copied
             .map(|b| *b.borrow())
-            .array_chunks::<{ mem::size_of::<u64>() }>()
+            .chunks::<{ mem::size_of::<u64>() }>()
             .map(|ary| {
                 let d = u64::from_ne_bytes(ary);
                 Wrapping(d.rotate_left(7).wrapping_add(1))

--- a/library/core/src/iter/adapters/chunks.rs
+++ b/library/core/src/iter/adapters/chunks.rs
@@ -9,17 +9,17 @@ use crate::ops::{ControlFlow, NeverShortCircuit, Try};
 /// The chunks do not overlap. If `N` does not divide the length of the
 /// iterator, then the last up to `N-1` elements will be omitted.
 ///
-/// This `struct` is created by the [`array_chunks`][Iterator::array_chunks]
-/// method on [`Iterator`]. See its documentation for more.
+/// This `struct` is created by the [`chunks`][Iterator::chunks] method on
+/// [`Iterator`]. See its documentation for more.
 #[derive(Debug, Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
-pub struct ArrayChunks<I: Iterator, const N: usize> {
+pub struct Chunks<I: Iterator, const N: usize> {
     iter: I,
     remainder: Option<array::IntoIter<I::Item, N>>,
 }
 
-impl<I, const N: usize> ArrayChunks<I, N>
+impl<I, const N: usize> Chunks<I, N>
 where
     I: Iterator,
 {
@@ -40,7 +40,7 @@ where
 }
 
 #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
-impl<I, const N: usize> Iterator for ArrayChunks<I, N>
+impl<I, const N: usize> Iterator for Chunks<I, N>
 where
     I: Iterator,
 {
@@ -75,7 +75,7 @@ where
                 Ok(chunk) => acc = f(acc, chunk)?,
                 Err(remainder) => {
                     // Make sure to not override `self.remainder` with an empty array
-                    // when `next` is called after `ArrayChunks` exhaustion.
+                    // when `next` is called after `Chunks` exhaustion.
                     self.remainder.get_or_insert(remainder);
 
                     break try { acc };
@@ -94,7 +94,7 @@ where
 }
 
 #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
-impl<I, const N: usize> DoubleEndedIterator for ArrayChunks<I, N>
+impl<I, const N: usize> DoubleEndedIterator for Chunks<I, N>
 where
     I: DoubleEndedIterator + ExactSizeIterator,
 {
@@ -131,14 +131,14 @@ where
     impl_fold_via_try_fold! { rfold -> try_rfold }
 }
 
-impl<I, const N: usize> ArrayChunks<I, N>
+impl<I, const N: usize> Chunks<I, N>
 where
     I: DoubleEndedIterator + ExactSizeIterator,
 {
     /// Updates `self.remainder` such that `self.iter.len` is divisible by `N`.
     fn next_back_remainder(&mut self) {
         // Make sure to not override `self.remainder` with an empty array
-        // when `next_back` is called after `ArrayChunks` exhaustion.
+        // when `next_back` is called after `Chunks` exhaustion.
         if self.remainder.is_some() {
             return;
         }
@@ -159,10 +159,10 @@ where
 }
 
 #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
-impl<I, const N: usize> FusedIterator for ArrayChunks<I, N> where I: FusedIterator {}
+impl<I, const N: usize> FusedIterator for Chunks<I, N> where I: FusedIterator {}
 
 #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
-impl<I, const N: usize> ExactSizeIterator for ArrayChunks<I, N>
+impl<I, const N: usize> ExactSizeIterator for Chunks<I, N>
 where
     I: ExactSizeIterator,
 {
@@ -184,7 +184,7 @@ trait SpecFold: Iterator {
         F: FnMut(B, Self::Item) -> B;
 }
 
-impl<I, const N: usize> SpecFold for ArrayChunks<I, N>
+impl<I, const N: usize> SpecFold for Chunks<I, N>
 where
     I: Iterator,
 {
@@ -199,7 +199,7 @@ where
     }
 }
 
-impl<I, const N: usize> SpecFold for ArrayChunks<I, N>
+impl<I, const N: usize> SpecFold for Chunks<I, N>
 where
     I: Iterator + TrustedRandomAccessNoCoerce,
 {

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -1,9 +1,9 @@
 use crate::iter::{InPlaceIterable, Iterator};
 use crate::ops::{ChangeOutputType, ControlFlow, FromResidual, Residual, Try};
 
-mod array_chunks;
 mod by_ref_sized;
 mod chain;
+mod chunks;
 mod cloned;
 mod copied;
 mod cycle;
@@ -34,7 +34,7 @@ pub use self::{
 };
 
 #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
-pub use self::array_chunks::ArrayChunks;
+pub use self::chunks::Chunks;
 
 #[unstable(feature = "std_internals", issue = "none")]
 pub use self::by_ref_sized::ByRefSized;

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -423,10 +423,10 @@ pub use self::traits::{
 
 #[stable(feature = "iter_zip", since = "1.59.0")]
 pub use self::adapters::zip;
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
-pub use self::adapters::ArrayChunks;
 #[unstable(feature = "std_internals", issue = "none")]
 pub use self::adapters::ByRefSized;
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
+pub use self::adapters::Chunks;
 #[stable(feature = "iter_cloned", since = "1.1.0")]
 pub use self::adapters::Cloned;
 #[stable(feature = "iter_copied", since = "1.36.0")]

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -5,7 +5,7 @@ use crate::ops::{ChangeOutputType, ControlFlow, FromResidual, Residual, Try};
 use super::super::try_process;
 use super::super::ByRefSized;
 use super::super::TrustedRandomAccessNoCoerce;
-use super::super::{ArrayChunks, Chain, Cloned, Copied, Cycle, Enumerate, Filter, FilterMap, Fuse};
+use super::super::{Chain, Chunks, Cloned, Copied, Cycle, Enumerate, Filter, FilterMap, Fuse};
 use super::super::{FlatMap, Flatten};
 use super::super::{FromIterator, Intersperse, IntersperseWith, Product, Sum, Zip};
 use super::super::{
@@ -3311,7 +3311,7 @@ pub trait Iterator {
     ///
     /// The chunks do not overlap. If `N` does not divide the length of the
     /// iterator, then the last up to `N-1` elements will be omitted and can be
-    /// retrieved from the [`.into_remainder()`][ArrayChunks::into_remainder]
+    /// retrieved from the [`.into_remainder()`][Chunks::into_remainder]
     /// function of the iterator.
     ///
     /// # Panics
@@ -3325,7 +3325,7 @@ pub trait Iterator {
     /// ```
     /// #![feature(iter_array_chunks)]
     ///
-    /// let mut iter = "lorem".chars().array_chunks();
+    /// let mut iter = "lorem".chars().chunks();
     /// assert_eq!(iter.next(), Some(['l', 'o']));
     /// assert_eq!(iter.next(), Some(['r', 'e']));
     /// assert_eq!(iter.next(), None);
@@ -3337,17 +3337,17 @@ pub trait Iterator {
     ///
     /// let data = [1, 1, 2, -2, 6, 0, 3, 1];
     /// //          ^-----^  ^------^
-    /// for [x, y, z] in data.iter().array_chunks() {
+    /// for [x, y, z] in data.iter().chunks() {
     ///     assert_eq!(x + y + z, 4);
     /// }
     /// ```
     #[track_caller]
     #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
-    fn array_chunks<const N: usize>(self) -> ArrayChunks<Self, N>
+    fn chunks<const N: usize>(self) -> Chunks<Self, N>
     where
         Self: Sized,
     {
-        ArrayChunks::new(self)
+        Chunks::new(self)
     }
 
     /// Sums the elements of an iterator.

--- a/library/core/tests/iter/adapters/chunks.rs
+++ b/library/core/tests/iter/adapters/chunks.rs
@@ -4,17 +4,17 @@ use core::iter::{self, Iterator};
 use super::*;
 
 #[test]
-fn test_iterator_array_chunks_infer() {
+fn test_iterator_chunks_infer() {
     let xs = [1, 1, 2, -2, 6, 0, 3, 1];
-    for [a, b, c] in xs.iter().copied().array_chunks() {
+    for [a, b, c] in xs.iter().copied().chunks() {
         assert_eq!(a + b + c, 4);
     }
 }
 
 #[test]
-fn test_iterator_array_chunks_clone_and_drop() {
+fn test_iterator_chunks_clone_and_drop() {
     let count = Cell::new(0);
-    let mut it = (0..5).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let mut it = (0..5).map(|_| CountDrop::new(&count)).chunks::<3>();
     assert_eq!(it.by_ref().count(), 1);
     assert_eq!(count.get(), 3);
     let mut it2 = it.clone();
@@ -27,8 +27,8 @@ fn test_iterator_array_chunks_clone_and_drop() {
 }
 
 #[test]
-fn test_iterator_array_chunks_remainder() {
-    let mut it = (0..11).array_chunks::<4>();
+fn test_iterator_chunks_remainder() {
+    let mut it = (0..11).chunks::<4>();
     assert_eq!(it.next(), Some([0, 1, 2, 3]));
     assert_eq!(it.next(), Some([4, 5, 6, 7]));
     assert_eq!(it.next(), None);
@@ -36,53 +36,53 @@ fn test_iterator_array_chunks_remainder() {
 }
 
 #[test]
-fn test_iterator_array_chunks_size_hint() {
-    let it = (0..6).array_chunks::<1>();
+fn test_iterator_chunks_size_hint() {
+    let it = (0..6).chunks::<1>();
     assert_eq!(it.size_hint(), (6, Some(6)));
 
-    let it = (0..6).array_chunks::<3>();
+    let it = (0..6).chunks::<3>();
     assert_eq!(it.size_hint(), (2, Some(2)));
 
-    let it = (0..6).array_chunks::<5>();
+    let it = (0..6).chunks::<5>();
     assert_eq!(it.size_hint(), (1, Some(1)));
 
-    let it = (0..6).array_chunks::<7>();
+    let it = (0..6).chunks::<7>();
     assert_eq!(it.size_hint(), (0, Some(0)));
 
-    let it = (1..).array_chunks::<2>();
+    let it = (1..).chunks::<2>();
     assert_eq!(it.size_hint(), (usize::MAX / 2, None));
 
-    let it = (1..).filter(|x| x % 2 != 0).array_chunks::<2>();
+    let it = (1..).filter(|x| x % 2 != 0).chunks::<2>();
     assert_eq!(it.size_hint(), (0, None));
 }
 
 #[test]
-fn test_iterator_array_chunks_count() {
-    let it = (0..6).array_chunks::<1>();
+fn test_iterator_chunks_count() {
+    let it = (0..6).chunks::<1>();
     assert_eq!(it.count(), 6);
 
-    let it = (0..6).array_chunks::<3>();
+    let it = (0..6).chunks::<3>();
     assert_eq!(it.count(), 2);
 
-    let it = (0..6).array_chunks::<5>();
+    let it = (0..6).chunks::<5>();
     assert_eq!(it.count(), 1);
 
-    let it = (0..6).array_chunks::<7>();
+    let it = (0..6).chunks::<7>();
     assert_eq!(it.count(), 0);
 
-    let it = (0..6).filter(|x| x % 2 == 0).array_chunks::<2>();
+    let it = (0..6).filter(|x| x % 2 == 0).chunks::<2>();
     assert_eq!(it.count(), 1);
 
-    let it = iter::empty::<i32>().array_chunks::<2>();
+    let it = iter::empty::<i32>().chunks::<2>();
     assert_eq!(it.count(), 0);
 
-    let it = [(); usize::MAX].iter().array_chunks::<2>();
+    let it = [(); usize::MAX].iter().chunks::<2>();
     assert_eq!(it.count(), usize::MAX / 2);
 }
 
 #[test]
-fn test_iterator_array_chunks_next_and_next_back() {
-    let mut it = (0..11).array_chunks::<3>();
+fn test_iterator_chunks_next_and_next_back() {
+    let mut it = (0..11).chunks::<3>();
     assert_eq!(it.next(), Some([0, 1, 2]));
     assert_eq!(it.next_back(), Some([6, 7, 8]));
     assert_eq!(it.next(), Some([3, 4, 5]));
@@ -94,8 +94,8 @@ fn test_iterator_array_chunks_next_and_next_back() {
 }
 
 #[test]
-fn test_iterator_array_chunks_rev_remainder() {
-    let mut it = (0..11).array_chunks::<4>();
+fn test_iterator_chunks_rev_remainder() {
+    let mut it = (0..11).chunks::<4>();
     {
         let mut it = it.by_ref().rev();
         assert_eq!(it.next(), Some([4, 5, 6, 7]));
@@ -107,9 +107,9 @@ fn test_iterator_array_chunks_rev_remainder() {
 }
 
 #[test]
-fn test_iterator_array_chunks_try_fold() {
+fn test_iterator_chunks_try_fold() {
     let count = Cell::new(0);
-    let mut it = (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let mut it = (0..10).map(|_| CountDrop::new(&count)).chunks::<3>();
     let result: Result<_, ()> = it.by_ref().try_fold(0, |acc, _item| Ok(acc + 1));
     assert_eq!(result, Ok(3));
     assert_eq!(count.get(), 9);
@@ -117,7 +117,7 @@ fn test_iterator_array_chunks_try_fold() {
     assert_eq!(count.get(), 10);
 
     let count = Cell::new(0);
-    let mut it = (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let mut it = (0..10).map(|_| CountDrop::new(&count)).chunks::<3>();
     let result = it.by_ref().try_fold(0, |acc, _item| if acc < 2 { Ok(acc + 1) } else { Err(acc) });
     assert_eq!(result, Err(2));
     assert_eq!(count.get(), 9);
@@ -126,8 +126,8 @@ fn test_iterator_array_chunks_try_fold() {
 }
 
 #[test]
-fn test_iterator_array_chunks_fold() {
-    let result = (1..11).array_chunks::<3>().fold(0, |acc, [a, b, c]| {
+fn test_iterator_chunks_fold() {
+    let result = (1..11).chunks::<3>().fold(0, |acc, [a, b, c]| {
         assert_eq!(acc + 1, a);
         assert_eq!(acc + 2, b);
         assert_eq!(acc + 3, c);
@@ -137,16 +137,16 @@ fn test_iterator_array_chunks_fold() {
 
     let count = Cell::new(0);
     let result =
-        (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>().fold(0, |acc, _item| acc + 1);
+        (0..10).map(|_| CountDrop::new(&count)).chunks::<3>().fold(0, |acc, _item| acc + 1);
     assert_eq!(result, 3);
     // fold impls may or may not process the remainder
     assert!(count.get() <= 10 && count.get() >= 9);
 }
 
 #[test]
-fn test_iterator_array_chunks_try_rfold() {
+fn test_iterator_chunks_try_rfold() {
     let count = Cell::new(0);
-    let mut it = (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let mut it = (0..10).map(|_| CountDrop::new(&count)).chunks::<3>();
     let result: Result<_, ()> = it.try_rfold(0, |acc, _item| Ok(acc + 1));
     assert_eq!(result, Ok(3));
     assert_eq!(count.get(), 9);
@@ -154,7 +154,7 @@ fn test_iterator_array_chunks_try_rfold() {
     assert_eq!(count.get(), 10);
 
     let count = Cell::new(0);
-    let mut it = (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let mut it = (0..10).map(|_| CountDrop::new(&count)).chunks::<3>();
     let result = it.try_rfold(0, |acc, _item| if acc < 2 { Ok(acc + 1) } else { Err(acc) });
     assert_eq!(result, Err(2));
     assert_eq!(count.get(), 9);
@@ -163,8 +163,8 @@ fn test_iterator_array_chunks_try_rfold() {
 }
 
 #[test]
-fn test_iterator_array_chunks_rfold() {
-    let result = (1..11).array_chunks::<3>().rfold(0, |acc, [a, b, c]| {
+fn test_iterator_chunks_rfold() {
+    let result = (1..11).chunks::<3>().rfold(0, |acc, [a, b, c]| {
         assert_eq!(10 - (acc + 1), c);
         assert_eq!(10 - (acc + 2), b);
         assert_eq!(10 - (acc + 3), a);
@@ -174,7 +174,7 @@ fn test_iterator_array_chunks_rfold() {
 
     let count = Cell::new(0);
     let result =
-        (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>().rfold(0, |acc, _item| acc + 1);
+        (0..10).map(|_| CountDrop::new(&count)).chunks::<3>().rfold(0, |acc, _item| acc + 1);
     assert_eq!(result, 3);
     assert_eq!(count.get(), 10);
 }

--- a/library/core/tests/iter/adapters/mod.rs
+++ b/library/core/tests/iter/adapters/mod.rs
@@ -1,6 +1,6 @@
-mod array_chunks;
 mod by_ref_sized;
 mod chain;
+mod chunks;
 mod cloned;
 mod copied;
 mod cycle;

--- a/src/test/ui/impl-trait/example-calendar.rs
+++ b/src/test/ui/impl-trait/example-calendar.rs
@@ -676,7 +676,7 @@ fn test_paste_blocks() {
 
 /// Produces an iterator that yields `n` elements at a time.
 trait Chunks: Iterator + Sized {
-    fn chunks(self, n: usize) -> ChunksIter<Self> {
+    fn vec_chunks(self, n: usize) -> ChunksIter<Self> {
         assert!(n > 0);
         ChunksIter {
             it: self,
@@ -716,7 +716,7 @@ where It: Iterator {
 
 fn test_chunks() {
     let r = &[1, 2, 3, 4, 5, 6, 7];
-    let c = r.iter().cloned().chunks(3).collect::<Vec<_>>();
+    let c = r.iter().cloned().vec_chunks(3).collect::<Vec<_>>();
     assert_eq!(&*c, &[vec![1, 2, 3], vec![4, 5, 6], vec![7]]);
 }
 
@@ -731,7 +731,7 @@ fn format_year(year: i32, months_per_row: usize) -> String {
         .__(by_month).map(|(_, days)| days)
 
         // Group the months into horizontal rows.
-        .chunks(months_per_row)
+        .vec_chunks(months_per_row)
 
         // Format each row...
         .map(|r| r.into_iter()


### PR DESCRIPTION
The most logical way to yield chunks from an iterator is with arrays. Originally I named this to align with `slice::array_chunks` but I think `chunks` makes more sense for iterators and it aligns with the `next_chunk` method.

Related #100450