### PR TITLE
Always validate MIR after runtime lowering

### DIFF
--- a/compiler/rustc_mir_transform/src/pass_manager.rs
+++ b/compiler/rustc_mir_transform/src/pass_manager.rs
@@ -4,7 +4,7 @@ use rustc_middle::mir::{self, Body, MirPhase, RuntimePhase};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 
-use crate::{validate, MirPass};
+use crate::{validate_body, MirPass};
 
 /// Just like `MirPass`, except it cannot mutate `Body`.
 pub trait MirLint<'tcx> {
@@ -154,10 +154,6 @@ fn run_passes_inner<'tcx>(
 
         body.pass_count = 1;
     }
-}
-
-pub fn validate_body<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>, when: String) {
-    validate::Validator { when, mir_phase: body.phase }.run_pass(tcx, body);
 }
 
 pub fn dump_mir_for_pass<'tcx>(


### PR DESCRIPTION
There are often issues with locals not having storage after drop elaboration. These issues turn into ICEs in release when we keep storage markers, but don't happen in debug mode as storage markers get removed before the MIR validation run. To also make them ICE in debug, run a MIR validation pass right after runtime MIR has been built where storage markers are still around.

Alternative to #104740