### PR TITLE
Run Windows-only tests only on Windows

### DIFF
--- a/src/test/codegen/dllimports/main.rs
+++ b/src/test/codegen/dllimports/main.rs
@@ -1,5 +1,6 @@
 // This test is for *-windows-msvc only.
 // only-windows
+// ignore-gnu
 
 // aux-build:dummy.rs
 // aux-build:wrapper.rs

--- a/src/test/codegen/dllimports/main.rs
+++ b/src/test/codegen/dllimports/main.rs
@@ -1,17 +1,5 @@
 // This test is for *-windows-msvc only.
-// ignore-android
-// ignore-dragonfly
-// ignore-emscripten
-// ignore-freebsd
-// ignore-gnu
-// ignore-haiku
-// ignore-ios
-// ignore-linux
-// ignore-macos
-// ignore-netbsd
-// ignore-openbsd
-// ignore-solaris
-// ignore-sgx no dynamic linking
+// only-windows
 
 // aux-build:dummy.rs
 // aux-build:wrapper.rs

--- a/src/test/codegen/panic-abort-windows.rs
+++ b/src/test/codegen/panic-abort-windows.rs
@@ -1,4 +1,4 @@
-// This test is for *-windows-msvc only.
+// This test is for *-windows only.
 // only-windows
 
 // compile-flags: -C no-prepopulate-passes -C panic=abort -O

--- a/src/test/codegen/panic-abort-windows.rs
+++ b/src/test/codegen/panic-abort-windows.rs
@@ -1,16 +1,5 @@
 // This test is for *-windows-msvc only.
-// ignore-android
-// ignore-dragonfly
-// ignore-emscripten
-// ignore-freebsd
-// ignore-haiku
-// ignore-ios
-// ignore-linux
-// ignore-macos
-// ignore-netbsd
-// ignore-openbsd
-// ignore-solaris
-// ignore-sgx
+// only-windows
 
 // compile-flags: -C no-prepopulate-passes -C panic=abort -O
 


### PR DESCRIPTION
This removes the need to maintain an ignore-list of all other OSs.

See https://github.com/rust-lang/rust/pull/102305 for a similar change.