### PR TITLE
Fix documentation of asymptotic complexity for rustc_data_structures::SortedMap

### DIFF
--- a/compiler/rustc_data_structures/src/sorted_map.rs
+++ b/compiler/rustc_data_structures/src/sorted_map.rs
@@ -10,8 +10,8 @@ mod index_map;
 pub use index_map::SortedIndexMultiMap;
 
 /// `SortedMap` is a data structure with similar characteristics as BTreeMap but
-/// slightly different trade-offs: lookup, insertion, and removal are *O*(log(*n*))
-/// and elements can be iterated in order cheaply.
+/// slightly different trade-offs: lookup is *O*(log(*n*)), insertion and removal
+/// are *O*(*n*) but elements can be iterated in order cheaply.
 ///
 /// `SortedMap` can be faster than a `BTreeMap` for small sizes (<50) since it
 /// stores data in a more compact way. It also supports accessing contiguous


### PR DESCRIPTION
https://users.rust-lang.org/t/is-the-document-in-sortedmap-in-rustc-data-structures-sorted-map-correct/84939

SortedMap have `O(n)` insertions and removal rather than `O(log(n))`