### PR TITLE
Make `List::empty` const

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1578,8 +1578,7 @@ pub struct PlaceRef<'tcx> {
 impl<'tcx> !PartialOrd for PlaceRef<'tcx> {}
 
 impl<'tcx> Place<'tcx> {
-    // FIXME change this to a const fn by also making List::empty a const fn.
-    pub fn return_place() -> Place<'tcx> {
+    pub const fn return_place() -> Place<'tcx> {
         Place { local: RETURN_PLACE, projection: List::empty() }
     }
 

--- a/compiler/rustc_middle/src/ty/list.rs
+++ b/compiler/rustc_middle/src/ty/list.rs
@@ -46,7 +46,7 @@ extern "C" {
 impl<T> List<T> {
     /// Returns a reference to the (unique, static) empty list.
     #[inline(always)]
-    pub fn empty<'a>() -> &'a List<T> {
+    pub const fn empty<'a>() -> &'a List<T> {
         #[repr(align(64))]
         struct MaxAlign;
 
@@ -58,8 +58,8 @@ impl<T> List<T> {
         // The empty slice is static and contains a single `0` usize (for the
         // length) that is 64-byte aligned, thus featuring the necessary
         // trailing padding for elements with up to 64-byte alignment.
-        static EMPTY_SLICE: InOrder<usize, MaxAlign> = InOrder(0, MaxAlign);
-        unsafe { &*(&EMPTY_SLICE as *const _ as *const List<T>) }
+        const EMPTY_SLICE: &'static InOrder<usize, MaxAlign> = &InOrder(0, MaxAlign);
+        unsafe { &*(EMPTY_SLICE as *const _ as *const List<T>) }
     }
 
     pub fn len(&self) -> usize {

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1214,7 +1214,7 @@ impl<'tcx> FnSig<'tcx> {
 
     // Creates a minimal `FnSig` to be used when encountering a `TyKind::Error` in a fallible
     // method.
-    fn fake() -> FnSig<'tcx> {
+    const fn fake() -> FnSig<'tcx> {
         FnSig {
             inputs_and_output: List::empty(),
             c_variadic: false,

--- a/compiler/rustc_mir_dataflow/src/framework/tests.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/tests.rs
@@ -5,7 +5,6 @@ use std::marker::PhantomData;
 use rustc_index::bit_set::BitSet;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::{self, BasicBlock, Location};
-use rustc_middle::ty;
 use rustc_span::DUMMY_SP;
 
 use super::*;
@@ -28,7 +27,7 @@ fn mock_body<'tcx>() -> mir::Body<'tcx> {
         })
     };
 
-    let dummy_place = mir::Place { local: mir::RETURN_PLACE, projection: ty::List::empty() };
+    let dummy_place = mir::Place::return_place();
 
     block(4, mir::TerminatorKind::Return);
     block(1, mir::TerminatorKind::Return);

--- a/compiler/rustc_mir_transform/src/coverage/tests.rs
+++ b/compiler/rustc_mir_transform/src/coverage/tests.rs
@@ -37,7 +37,7 @@ use rustc_data_structures::graph::WithSuccessors;
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_middle::mir::coverage::CoverageKind;
 use rustc_middle::mir::*;
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::{Ty, TyCtxt};
 use rustc_span::{self, BytePos, Pos, Span, DUMMY_SP};
 
 // All `TEMP_BLOCK` targets should be replaced before calling `to_body() -> mir::Body`.
@@ -54,7 +54,7 @@ impl<'tcx> MockBlocks<'tcx> {
     fn new() -> Self {
         Self {
             blocks: IndexVec::new(),
-            dummy_place: Place { local: RETURN_PLACE, projection: ty::List::empty() },
+            dummy_place: Place::return_place(),
             next_local: 0,
             bool_ty: TyCtxt::BOOL_TY_FOR_UNIT_TESTING,
         }


### PR DESCRIPTION
I don't see anything that this really allows (esp. given that the compiler isn't allowed to replace runtime calls with const calls), but it's one fixme less :>