### PR TITLE
[DRAFT] jsondoclint: Check `links` field

### DIFF
--- a/src/tools/jsondoclint/src/validator.rs
+++ b/src/tools/jsondoclint/src/validator.rs
@@ -60,6 +60,8 @@ impl<'a> Validator<'a> {
 
     fn check_item(&mut self, id: &'a Id) {
         if let Some(item) = &self.krate.index.get(id) {
+            item.links.values().for_each(|id| self.add_any_id(id));
+
             match &item.inner {
                 ItemEnum::Import(x) => self.check_import(x),
                 ItemEnum::Union(x) => self.check_union(x),
@@ -376,6 +378,10 @@ impl<'a> Validator<'a> {
         }
     }
 
+    fn add_any_id(&mut self, id: &'a Id) {
+        self.add_id_checked(id, |_| true, "any kind of item");
+    }
+
     fn add_field_id(&mut self, id: &'a Id) {
         self.add_id_checked(id, Kind::is_struct_field, "StructField");
     }
@@ -446,3 +452,6 @@ fn set_remove<T: Hash + Eq + Clone>(set: &mut HashSet<T>) -> Option<T> {
         None
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/tools/jsondoclint/src/validator/tests.rs
+++ b/src/tools/jsondoclint/src/validator/tests.rs
@@ -1,0 +1,50 @@
+use std::collections::HashMap;
+
+use rustdoc_json_types::{Crate, Item, Visibility};
+
+use super::*;
+
+#[track_caller]
+fn check(krate: &Crate, errs: &[Error]) {
+    let mut validator = Validator::new(krate);
+    validator.check_crate();
+
+    assert_eq!(errs, &validator.errs[..]);
+}
+
+fn id(s: &str) -> Id {
+    Id(s.to_owned())
+}
+
+#[test]
+fn errors_on_missing_links() {
+    let k = Crate {
+        root: id("0"),
+        crate_version: None,
+        includes_private: false,
+        index: HashMap::from_iter([(
+            id("0"),
+            Item {
+                name: Some("root".to_owned()),
+                id: id(""),
+                crate_id: 0,
+                span: None,
+                visibility: Visibility::Public,
+                docs: None,
+                links: HashMap::from_iter([("Not Found".to_owned(), id("1"))]),
+                attrs: vec![],
+                deprecation: None,
+                inner: ItemEnum::Module(Module {
+                    is_crate: true,
+                    items: vec![],
+                    is_stripped: false,
+                }),
+            },
+        )]),
+        paths: HashMap::new(),
+        external_crates: HashMap::new(),
+        format_version: rustdoc_json_types::FORMAT_VERSION,
+    };
+
+    check(&k, &[Error { kind: ErrorKind::NotFound, id: id("1") }]);
+}


### PR DESCRIPTION
Note that this currently fails, due to #105025 ~~a newly discovered bug in rustdoc-json (will post soon, after I have a MCVE)~~

```
---- [rustdoc-json] src/test/rustdoc-json/fns/async_return.rs stdout ----

error: jsondoclint failed!
status: exit status: 1
command: "/home/nixon/dev/rust/rust/build/x86_64-unknown-linux-gnu/stage0-tools-bin/jsondoclint" "/home/nixon/dev/rust/rust/build/x86_64-unknown-linux-gnu/test/rustdoc-json/fns/async_return/async_return.json"
stdout: none
--- stderr -------------------------------
2:54321:199 not in index or paths, but refered to at '$.index["2:14227:1011"].links["Poll::Ready"]'
2:54324:186 not in index or paths, but refered to at '$.index["2:14227:1011"].links["`Poll::Pending`"]'
2:14562:2921 not in index or paths, but refered to at '$.index["2:14227:1011"].links["crate::task::Waker::wake"]'
Error: Errors validating json /home/nixon/dev/rust/rust/build/x86_64-unknown-linux-gnu/test/rustdoc-json/fns/async_return/async_return.json
------------------------------------------
```

r? @ghost

@rustbot modify labels: +A-testsuite


