### PR TITLE
Add sentence when rustdoc search is running

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -302,12 +302,14 @@ function loadCss(cssUrl) {
 
             const params = searchState.getQueryStringParams();
             if (params.search !== undefined) {
-                const search = searchState.outputElement();
-                search.innerHTML = "<h3 class=\"search-loading\">" +
-                    searchState.loadingText + "</h3>";
-                searchState.showResults(search);
+                searchState.setLoadingSearch();
                 loadSearch();
             }
+        },
+        setLoadingSearch: () => {
+            const search = searchState.outputElement();
+            search.innerHTML = "<h3 class=\"search-loading\">" + searchState.loadingText + "</h3>";
+            searchState.showResults(search);
         },
     };
 

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1766,12 +1766,12 @@ function initSearch(rawSearchIndex) {
      * @param {boolean} [forced]
      */
     function search(e, forced) {
-        const params = searchState.getQueryStringParams();
-        const query = parseQuery(searchState.input.value.trim());
-
         if (e) {
             e.preventDefault();
         }
+
+        const query = parseQuery(searchState.input.value.trim());
+        let filterCrates = getFilterCrates();
 
         if (!forced && query.userQuery === currentResults) {
             if (query.userQuery.length > 0) {
@@ -1780,7 +1780,9 @@ function initSearch(rawSearchIndex) {
             return;
         }
 
-        let filterCrates = getFilterCrates();
+        searchState.setLoadingSearch();
+
+        const params = searchState.getQueryStringParams();
 
         // In case we have no information about the saved crate and there is a URL query parameter,
         // we override it with the URL query parameter.


### PR DESCRIPTION
This is a small improvement, mostly relevant on big search indexes. As soon as the search starts, it'll display:

![image](https://user-images.githubusercontent.com/3050060/204336014-4660634a-09a0-4d5e-a772-d7e1e810dddf.png)

cc @jsha 
r? @notriddle 