### PR TITLE
Rustdoc-Json: Add tests for linking to foreign variants.

### DIFF
--- a/src/test/rustdoc-json/enums/auxiliary/color.rs
+++ b/src/test/rustdoc-json/enums/auxiliary/color.rs
@@ -1,0 +1,5 @@
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}

--- a/src/test/rustdoc-json/enums/doc_link_to_foreign_variant.rs
+++ b/src/test/rustdoc-json/enums/doc_link_to_foreign_variant.rs
@@ -1,0 +1,11 @@
+// aux-build: color.rs
+
+//! The purpose of this test it to have a link to [a foreign variant](Red).
+
+extern crate color;
+use color::Color::Red;
+
+// @set red = "$.index[*][?(@.inner.is_crate == true)].links.Red"
+
+// @!has "$.index[*][?(@.name == 'Red')]"
+// @!has "$.index[*][?(@.name == 'Color')]"

--- a/src/test/rustdoc-json/enums/use_variant_foreign.rs
+++ b/src/test/rustdoc-json/enums/use_variant_foreign.rs
@@ -1,0 +1,9 @@
+// aux-build: color.rs
+
+extern crate color;
+
+// @is "$.index[*][?(@.inner.name == 'Red')].kind" '"import"'
+pub use color::Color::Red;
+
+// @!has "$.index[*][?(@.name == 'Red')]"
+// @!has "$.index[*][?(@.name == 'Color')]"


### PR DESCRIPTION
I initially taught these would be bugs, but it turn out they work perfectly, and the variant is added to paths.

Most of the work is done by jsondoclint checking all the ID's resolve (although this wont happen for links until #105015, which in turn is blocked on removing foreign traits), but we do check that neither the enum nor the variant is inlined, so it must be resolved correctly through paths.

r? @GuillaumeGomez 