### PR TITLE
Fix an ICE parsing a malformed literal in `concat_bytes!`.

### DIFF
--- a/compiler/rustc_builtin_macros/src/concat_bytes.rs
+++ b/compiler/rustc_builtin_macros/src/concat_bytes.rs
@@ -2,6 +2,7 @@ use rustc_ast as ast;
 use rustc_ast::{ptr::P, tokenstream::TokenStream};
 use rustc_errors::Applicability;
 use rustc_expand::base::{self, DummyResult};
+use rustc_session::errors::report_lit_error;
 use rustc_span::Span;
 
 /// Emits errors for literal expressions that are invalid inside and outside of an array.
@@ -68,7 +69,10 @@ fn invalid_type_err(
         Ok(ast::LitKind::Int(_, _)) => {
             cx.span_err(span, "numeric literal is not a `u8`");
         }
-        _ => unreachable!(),
+        Ok(ast::LitKind::ByteStr(_) | ast::LitKind::Byte(_)) => unreachable!(),
+        Err(err) => {
+            report_lit_error(&cx.sess.parse_sess, err, token_lit, span);
+        }
     }
 }
 

--- a/src/test/ui/macros/issue-104769-concat_bytes-invalid-literal.rs
+++ b/src/test/ui/macros/issue-104769-concat_bytes-invalid-literal.rs
@@ -1,0 +1,8 @@
+#![feature(concat_bytes)]
+
+fn main() {
+    concat_bytes!(7Y);
+    //~^ ERROR invalid suffix `Y` for number literal
+    concat_bytes!(888888888888888888888888888888888888888);
+    //~^ ERROR integer literal is too large
+}

--- a/src/test/ui/macros/issue-104769-concat_bytes-invalid-literal.stderr
+++ b/src/test/ui/macros/issue-104769-concat_bytes-invalid-literal.stderr
@@ -1,0 +1,16 @@
+error: invalid suffix `Y` for number literal
+  --> $DIR/issue-104769-concat_bytes-invalid-literal.rs:4:19
+   |
+LL |     concat_bytes!(7Y);
+   |                   ^^ invalid suffix `Y`
+   |
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+
+error: integer literal is too large
+  --> $DIR/issue-104769-concat_bytes-invalid-literal.rs:6:19
+   |
+LL |     concat_bytes!(888888888888888888888888888888888888888);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #104769.

r? @petrochenkov 