### PR TITLE
`rustc_ast_{passes,pretty}`: remove `ref` patterns

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -209,7 +209,7 @@ impl<'a> AstValidator<'a> {
 
     // Mirrors `visit::walk_ty`, but tracks relevant state.
     fn walk_ty(&mut self, t: &'a Ty) {
-        match t.kind {
+        match &t.kind {
             TyKind::ImplTrait(..) => {
                 self.with_impl_trait(Some(t.span), |this| visit::walk_ty(this, t))
             }
@@ -217,7 +217,7 @@ impl<'a> AstValidator<'a> {
                 .with_banned_tilde_const(DisallowTildeConstContext::TraitObject, |this| {
                     visit::walk_ty(this, t)
                 }),
-            TyKind::Path(ref qself, ref path) => {
+            TyKind::Path(qself, path) => {
                 // We allow these:
                 //  - `Option<impl Trait>`
                 //  - `option::Option<impl Trait>`
@@ -231,7 +231,7 @@ impl<'a> AstValidator<'a> {
                 // (for cases like `<impl Trait>::Foo>`)
                 // but we allow `impl Trait` in `GenericArgs`
                 // iff there are no more PathSegments.
-                if let Some(ref qself) = *qself {
+                if let Some(qself) = qself {
                     // `impl Trait` in `qself` is always illegal
                     self.with_banned_impl_trait(|this| this.visit_ty(&qself.ty));
                 }
@@ -738,8 +738,8 @@ impl<'a> AstValidator<'a> {
     }
 
     fn visit_ty_common(&mut self, ty: &'a Ty) {
-        match ty.kind {
-            TyKind::BareFn(ref bfty) => {
+        match &ty.kind {
+            TyKind::BareFn(bfty) => {
                 self.check_fn_decl(&bfty.decl, SelfSemantic::No);
                 Self::check_decl_no_pat(&bfty.decl, |span, _, _| {
                     struct_span_err!(
@@ -756,10 +756,10 @@ impl<'a> AstValidator<'a> {
                     self.maybe_lint_missing_abi(sig_span, ty.id);
                 }
             }
-            TyKind::TraitObject(ref bounds, ..) => {
+            TyKind::TraitObject(bounds, ..) => {
                 let mut any_lifetime_bounds = false;
                 for bound in bounds {
-                    if let GenericBound::Outlives(ref lifetime) = *bound {
+                    if let GenericBound::Outlives(lifetime) = bound {
                         if any_lifetime_bounds {
                             struct_span_err!(
                                 self.session,
@@ -774,7 +774,7 @@ impl<'a> AstValidator<'a> {
                     }
                 }
             }
-            TyKind::ImplTrait(_, ref bounds) => {
+            TyKind::ImplTrait(_, bounds) => {
                 if self.is_impl_trait_banned {
                     struct_span_err!(
                         self.session,
@@ -842,8 +842,8 @@ fn validate_generic_param_order(
         let (kind, bounds, span) = (&param.kind, &param.bounds, ident.span);
         let (ord_kind, ident) = match &param.kind {
             GenericParamKind::Lifetime => (ParamKindOrd::Lifetime, ident.to_string()),
-            GenericParamKind::Type { default: _ } => (ParamKindOrd::TypeOrConst, ident.to_string()),
-            GenericParamKind::Const { ref ty, kw_span: _, default: _ } => {
+            GenericParamKind::Type { .. } => (ParamKindOrd::TypeOrConst, ident.to_string()),
+            GenericParamKind::Const { ty, .. } => {
                 let ty = pprust::ty_to_string(ty);
                 (ParamKindOrd::TypeOrConst, format!("const {}: {}", ident, ty))
             }
@@ -948,8 +948,8 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 }
                 ExprKind::Paren(local_expr) => {
                     fn has_let_expr(expr: &Expr) -> bool {
-                        match expr.kind {
-                            ExprKind::Binary(_, ref lhs, ref rhs) => has_let_expr(lhs) || has_let_expr(rhs),
+                        match &expr.kind {
+                            ExprKind::Binary(_, lhs, rhs) => has_let_expr(lhs) || has_let_expr(rhs),
                             ExprKind::Let(..) => true,
                             _ => false,
                         }
@@ -1005,18 +1005,18 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             self.check_nomangle_item_asciionly(item.ident, item.span);
         }
 
-        match item.kind {
+        match &item.kind {
             ItemKind::Impl(box Impl {
                 unsafety,
                 polarity,
                 defaultness: _,
                 constness,
-                ref generics,
-                of_trait: Some(ref t),
-                ref self_ty,
-                ref items,
+                generics,
+                of_trait: Some(t),
+                self_ty,
+                items,
             }) => {
-                self.with_in_trait_impl(true, Some(constness), |this| {
+                self.with_in_trait_impl(true, Some(*constness), |this| {
                     this.invalid_visibility(&item.vis, None);
                     if let TyKind::Err = self_ty.kind {
                         this.err_handler()
@@ -1027,7 +1027,8 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                             .help("use `auto trait Trait {}` instead")
                             .emit();
                     }
-                    if let (Unsafe::Yes(span), ImplPolarity::Negative(sp)) = (unsafety, polarity) {
+                    if let (&Unsafe::Yes(span), &ImplPolarity::Negative(sp)) = (unsafety, polarity)
+                    {
                         struct_span_err!(
                             this.session,
                             sp.to(t.path.span),
@@ -1061,7 +1062,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 constness,
                 generics: _,
                 of_trait: None,
-                ref self_ty,
+                self_ty,
                 items: _,
             }) => {
                 let error = |annotation_span, annotation| {
@@ -1078,25 +1079,25 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     &item.vis,
                     Some(InvalidVisibilityNote::IndividualImplItems),
                 );
-                if let Unsafe::Yes(span) = unsafety {
+                if let &Unsafe::Yes(span) = unsafety {
                     error(span, "unsafe").code(error_code!(E0197)).emit();
                 }
-                if let ImplPolarity::Negative(span) = polarity {
+                if let &ImplPolarity::Negative(span) = polarity {
                     error(span, "negative").emit();
                 }
-                if let Defaultness::Default(def_span) = defaultness {
+                if let &Defaultness::Default(def_span) = defaultness {
                     error(def_span, "`default`")
                         .note("only trait implementations may be annotated with `default`")
                         .emit();
                 }
-                if let Const::Yes(span) = constness {
+                if let &Const::Yes(span) = constness {
                     error(span, "`const`")
                         .note("only trait implementations may be annotated with `const`")
                         .emit();
                 }
             }
-            ItemKind::Fn(box Fn { defaultness, ref sig, ref generics, ref body }) => {
-                self.check_defaultness(item.span, defaultness);
+            ItemKind::Fn(box Fn { defaultness, sig, generics, body }) => {
+                self.check_defaultness(item.span, *defaultness);
 
                 if body.is_none() {
                     self.session.emit_err(FnWithoutBody {
@@ -1132,7 +1133,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     &item.vis,
                     Some(InvalidVisibilityNote::IndividualForeignItems),
                 );
-                if let Unsafe::Yes(span) = unsafety {
+                if let &Unsafe::Yes(span) = unsafety {
                     self.err_handler().span_err(span, "extern block cannot be declared unsafe");
                 }
                 if abi.is_none() {
@@ -1142,7 +1143,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 self.extern_mod = old_item;
                 return; // Avoid visiting again.
             }
-            ItemKind::Enum(ref def, _) => {
+            ItemKind::Enum(def, _) => {
                 for variant in &def.variants {
                     self.invalid_visibility(&variant.vis, None);
                     for field in variant.data.fields() {
@@ -1150,8 +1151,8 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     }
                 }
             }
-            ItemKind::Trait(box Trait { is_auto, ref generics, ref bounds, ref items, .. }) => {
-                if is_auto == IsAuto::Yes {
+            ItemKind::Trait(box Trait { is_auto, generics, bounds, items, .. }) => {
+                if *is_auto == IsAuto::Yes {
                     // Auto traits cannot have generics, super traits nor contain items.
                     self.deny_generic_params(generics, item.ident.span);
                     self.deny_super_traits(bounds, item.ident.span);
@@ -1171,8 +1172,8 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 walk_list!(self, visit_attribute, &item.attrs);
                 return; // Avoid visiting again
             }
-            ItemKind::Mod(unsafety, ref mod_kind) => {
-                if let Unsafe::Yes(span) = unsafety {
+            ItemKind::Mod(unsafety, mod_kind) => {
+                if let &Unsafe::Yes(span) = unsafety {
                     self.err_handler().span_err(span, "module cannot be declared unsafe");
                 }
                 // Ensure that `path` attributes on modules are recorded as used (cf. issue #35584).
@@ -1182,13 +1183,13 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     self.check_mod_file_item_asciionly(item.ident);
                 }
             }
-            ItemKind::Union(ref vdata, ..) => {
+            ItemKind::Union(vdata, ..) => {
                 if vdata.fields().is_empty() {
                     self.err_handler().span_err(item.span, "unions cannot have zero fields");
                 }
             }
             ItemKind::Const(def, .., None) => {
-                self.check_defaultness(item.span, def);
+                self.check_defaultness(item.span, *def);
                 self.session.emit_err(ConstWithoutBody {
                     span: item.span,
                     replace_span: self.ending_semi_or_hi(item.span),
@@ -1200,14 +1201,8 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     replace_span: self.ending_semi_or_hi(item.span),
                 });
             }
-            ItemKind::TyAlias(box TyAlias {
-                defaultness,
-                where_clauses,
-                ref bounds,
-                ref ty,
-                ..
-            }) => {
-                self.check_defaultness(item.span, defaultness);
+            ItemKind::TyAlias(box TyAlias { defaultness, where_clauses, bounds, ty, .. }) => {
+                self.check_defaultness(item.span, *defaultness);
                 if ty.is_none() {
                     self.session.emit_err(TyAliasWithoutBody {
                         span: item.span,
@@ -1266,8 +1261,8 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
 
     // Mirrors `visit::walk_generic_args`, but tracks relevant state.
     fn visit_generic_args(&mut self, generic_args: &'a GenericArgs) {
-        match *generic_args {
-            GenericArgs::AngleBracketed(ref data) => {
+        match generic_args {
+            GenericArgs::AngleBracketed(data) => {
                 self.check_generic_args_before_constraints(data);
 
                 for arg in &data.args {
@@ -1283,7 +1278,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     }
                 }
             }
-            GenericArgs::Parenthesized(ref data) => {
+            GenericArgs::Parenthesized(data) => {
                 walk_list!(self, visit_ty, &data.inputs);
                 if let FnRetTy::Ty(ty) = &data.output {
                     // `-> Foo` syntax is essentially an associated type binding,
@@ -1319,7 +1314,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
         validate_generic_param_order(self.err_handler(), &generics.params, generics.span);
 
         for predicate in &generics.where_clause.predicates {
-            if let WherePredicate::EqPredicate(ref predicate) = *predicate {
+            if let WherePredicate::EqPredicate(predicate) = predicate {
                 deny_equality_constraints(self, predicate, generics);
             }
         }
@@ -1368,7 +1363,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
     }
 
     fn visit_param_bound(&mut self, bound: &'a GenericBound, ctxt: BoundKind) {
-        if let GenericBound::Trait(ref poly, modify) = *bound {
+        if let GenericBound::Trait(poly, modify) = bound {
             match (ctxt, modify) {
                 (BoundKind::SuperTraits, TraitBoundModifier::Maybe) => {
                     let mut err = self
@@ -1573,8 +1568,8 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             self.check_item_named(item.ident, "const");
         }
 
-        match item.kind {
-            AssocItemKind::Type(box TyAlias { ref generics, ref bounds, ref ty, .. })
+        match &item.kind {
+            AssocItemKind::Type(box TyAlias { generics, bounds, ty, .. })
                 if ctxt == AssocCtxt::Trait =>
             {
                 self.visit_vis(&item.vis);
@@ -1586,7 +1581,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 });
                 walk_list!(self, visit_ty, ty);
             }
-            AssocItemKind::Fn(box Fn { ref sig, ref generics, ref body, .. })
+            AssocItemKind::Fn(box Fn { sig, generics, body, .. })
                 if self.in_const_trait_impl
                     || ctxt == AssocCtxt::Trait
                     || matches!(sig.header.constness, Const::Yes(_)) =>

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -198,8 +198,8 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     }
 
     fn visit_item(&mut self, i: &'a ast::Item) {
-        match i.kind {
-            ast::ItemKind::ForeignMod(ref foreign_module) => {
+        match &i.kind {
+            ast::ItemKind::ForeignMod(foreign_module) => {
                 if let Some(abi) = foreign_module.abi {
                     self.check_abi(abi, ast::Const::No);
                 }
@@ -233,8 +233,8 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 }
             }
 
-            ast::ItemKind::Impl(box ast::Impl { polarity, defaultness, ref of_trait, .. }) => {
-                if let ast::ImplPolarity::Negative(span) = polarity {
+            ast::ItemKind::Impl(box ast::Impl { polarity, defaultness, of_trait, .. }) => {
+                if let &ast::ImplPolarity::Negative(span) = polarity {
                     gate_feature_post!(
                         &self,
                         negative_impls,
@@ -267,7 +267,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 gate_feature_post!(&self, decl_macro, i.span, msg);
             }
 
-            ast::ItemKind::TyAlias(box ast::TyAlias { ty: Some(ref ty), .. }) => {
+            ast::ItemKind::TyAlias(box ast::TyAlias { ty: Some(ty), .. }) => {
                 self.check_impl_trait(&ty)
             }
 
@@ -302,8 +302,8 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     }
 
     fn visit_ty(&mut self, ty: &'a ast::Ty) {
-        match ty.kind {
-            ast::TyKind::BareFn(ref bare_fn_ty) => {
+        match &ty.kind {
+            ast::TyKind::BareFn(bare_fn_ty) => {
                 // Function pointers cannot be `const`
                 self.check_extern(bare_fn_ty.ext, ast::Const::No);
             }
@@ -319,7 +319,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     }
 
     fn visit_fn_ret_ty(&mut self, ret_ty: &'a ast::FnRetTy) {
-        if let ast::FnRetTy::Ty(ref output_ty) = *ret_ty {
+        if let ast::FnRetTy::Ty(output_ty) = ret_ty {
             if let ast::TyKind::Never = output_ty.kind {
                 // Do nothing.
             } else {
@@ -455,9 +455,9 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     }
 
     fn visit_assoc_item(&mut self, i: &'a ast::AssocItem, ctxt: AssocCtxt) {
-        let is_fn = match i.kind {
+        let is_fn = match &i.kind {
             ast::AssocItemKind::Fn(_) => true,
-            ast::AssocItemKind::Type(box ast::TyAlias { ref ty, .. }) => {
+            ast::AssocItemKind::Type(box ast::TyAlias { ty, .. }) => {
                 if let (Some(_), AssocCtxt::Trait) = (ty, ctxt) {
                     gate_feature_post!(
                         &self,

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -11,7 +11,7 @@ use rustc_ast::tokenstream::{TokenStream, TokenTree};
 use rustc_ast::util::classify;
 use rustc_ast::util::comments::{gather_comments, Comment, CommentStyle};
 use rustc_ast::util::parser;
-use rustc_ast::{self as ast, AttrArgs, AttrArgsEq, BlockCheckMode, Mutability, PatKind};
+use rustc_ast::{self as ast, AttrArgs, AttrArgsEq, BlockCheckMode, PatKind};
 use rustc_ast::{attr, BindingAnnotation, ByRef, DelimArgs, RangeEnd, RangeSyntax, Term};
 use rustc_ast::{GenericArg, GenericBound, SelfKind, TraitBoundModifier};
 use rustc_ast::{InlineAsmOperand, InlineAsmRegOrRegClass};
@@ -64,6 +64,7 @@ impl<'a> Comments<'a> {
         Comments { sm, comments, current: 0 }
     }
 
+    // This shouldn't probably clone lmao
     pub fn next(&self) -> Option<Comment> {
         self.comments.get(self.current).cloned()
     }
@@ -268,10 +269,10 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
 
     fn maybe_print_comment(&mut self, pos: BytePos) -> bool {
         let mut has_comment = false;
-        while let Some(ref cmnt) = self.next_comment() {
+        while let Some(cmnt) = self.next_comment() {
             if cmnt.pos < pos {
                 has_comment = true;
-                self.print_comment(cmnt);
+                self.print_comment(&cmnt);
             } else {
                 break;
             }
@@ -366,8 +367,8 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
         if self.next_comment().is_none() {
             self.hardbreak();
         }
-        while let Some(ref cmnt) = self.next_comment() {
-            self.print_comment(cmnt)
+        while let Some(cmnt) = self.next_comment() {
+            self.print_comment(&cmnt)
         }
     }
 
@@ -446,8 +447,8 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
             self.hardbreak_if_not_bol();
         }
         self.maybe_print_comment(attr.span.lo());
-        match attr.kind {
-            ast::AttrKind::Normal(ref normal) => {
+        match &attr.kind {
+            ast::AttrKind::Normal(normal) => {
                 match attr.style {
                     ast::AttrStyle::Inner => self.word("#!["),
                     ast::AttrStyle::Outer => self.word("#["),
@@ -456,7 +457,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
                 self.word("]");
             }
             ast::AttrKind::DocComment(comment_kind, data) => {
-                self.word(doc_comment_to_string(comment_kind, attr.style, data));
+                self.word(doc_comment_to_string(*comment_kind, attr.style, *data));
                 self.hardbreak()
             }
         }
@@ -497,22 +498,22 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
 
     fn print_meta_list_item(&mut self, item: &ast::NestedMetaItem) {
         match item {
-            ast::NestedMetaItem::MetaItem(ref mi) => self.print_meta_item(mi),
-            ast::NestedMetaItem::Lit(ref lit) => self.print_meta_item_lit(lit),
+            ast::NestedMetaItem::MetaItem(mi) => self.print_meta_item(mi),
+            ast::NestedMetaItem::Lit(lit) => self.print_meta_item_lit(lit),
         }
     }
 
     fn print_meta_item(&mut self, item: &ast::MetaItem) {
         self.ibox(INDENT_UNIT);
-        match item.kind {
+        match &item.kind {
             ast::MetaItemKind::Word => self.print_path(&item.path, false, 0),
-            ast::MetaItemKind::NameValue(ref value) => {
+            ast::MetaItemKind::NameValue(value) => {
                 self.print_path(&item.path, false, 0);
                 self.space();
                 self.word_space("=");
                 self.print_meta_item_lit(value);
             }
-            ast::MetaItemKind::List(ref items) => {
+            ast::MetaItemKind::List(items) => {
                 self.print_path(&item.path, false, 0);
                 self.popen();
                 self.commasep(Consistent, &items, |s, i| s.print_meta_list_item(i));
@@ -657,7 +658,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
     fn print_path_segment(&mut self, segment: &ast::PathSegment, colons_before_params: bool) {
         if segment.ident.name != kw::PathRoot {
             self.print_ident(segment.ident);
-            if let Some(ref args) = segment.args {
+            if let Some(args) = &segment.args {
                 self.print_generic_args(args, colons_before_params);
             }
         }
@@ -712,19 +713,19 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
     }
 
     fn nonterminal_to_string(&self, nt: &Nonterminal) -> String {
-        match *nt {
-            token::NtExpr(ref e) => self.expr_to_string(e),
-            token::NtMeta(ref e) => self.attr_item_to_string(e),
-            token::NtTy(ref e) => self.ty_to_string(e),
-            token::NtPath(ref e) => self.path_to_string(e),
-            token::NtItem(ref e) => self.item_to_string(e),
-            token::NtBlock(ref e) => self.block_to_string(e),
-            token::NtStmt(ref e) => self.stmt_to_string(e),
-            token::NtPat(ref e) => self.pat_to_string(e),
-            token::NtIdent(e, is_raw) => IdentPrinter::for_ast_ident(e, is_raw).to_string(),
+        match nt {
+            token::NtExpr(e) => self.expr_to_string(e),
+            token::NtMeta(e) => self.attr_item_to_string(e),
+            token::NtTy(e) => self.ty_to_string(e),
+            token::NtPath(e) => self.path_to_string(e),
+            token::NtItem(e) => self.item_to_string(e),
+            token::NtBlock(e) => self.block_to_string(e),
+            token::NtStmt(e) => self.stmt_to_string(e),
+            token::NtPat(e) => self.pat_to_string(e),
+            token::NtIdent(e, is_raw) => IdentPrinter::for_ast_ident(*e, *is_raw).to_string(),
             token::NtLifetime(e) => e.to_string(),
-            token::NtLiteral(ref e) => self.expr_to_string(e),
-            token::NtVis(ref e) => self.vis_to_string(e),
+            token::NtLiteral(e) => self.expr_to_string(e),
+            token::NtVis(e) => self.vis_to_string(e),
         }
     }
 
@@ -917,8 +918,8 @@ impl<'a> PrintState<'a> for State<'a> {
             self.word("::")
         }
 
-        match *args {
-            ast::GenericArgs::AngleBracketed(ref data) => {
+        match args {
+            ast::GenericArgs::AngleBracketed(data) => {
                 self.word("<");
                 self.commasep(Inconsistent, &data.args, |s, arg| match arg {
                     ast::AngleBracketedArg::Arg(a) => s.print_generic_arg(a),
@@ -927,7 +928,7 @@ impl<'a> PrintState<'a> for State<'a> {
                 self.word(">")
             }
 
-            ast::GenericArgs::Parenthesized(ref data) => {
+            ast::GenericArgs::Parenthesized(data) => {
                 self.word("(");
                 self.commasep(Inconsistent, &data.inputs, |s, ty| s.print_type(ty));
                 self.word(")");
@@ -1011,17 +1012,17 @@ impl<'a> State<'a> {
     pub fn print_type(&mut self, ty: &ast::Ty) {
         self.maybe_print_comment(ty.span.lo());
         self.ibox(0);
-        match ty.kind {
-            ast::TyKind::Slice(ref ty) => {
+        match &ty.kind {
+            ast::TyKind::Slice(ty) => {
                 self.word("[");
                 self.print_type(ty);
                 self.word("]");
             }
-            ast::TyKind::Ptr(ref mt) => {
+            ast::TyKind::Ptr(mt) => {
                 self.word("*");
                 self.print_mt(mt, true);
             }
-            ast::TyKind::Rptr(ref lifetime, ref mt) => {
+            ast::TyKind::Rptr(lifetime, mt) => {
                 self.word("&");
                 self.print_opt_lifetime(lifetime);
                 self.print_mt(mt, false);
@@ -1029,7 +1030,7 @@ impl<'a> State<'a> {
             ast::TyKind::Never => {
                 self.word("!");
             }
-            ast::TyKind::Tup(ref elts) => {
+            ast::TyKind::Tup(elts) => {
                 self.popen();
                 self.commasep(Inconsistent, &elts, |s, ty| s.print_type(ty));
                 if elts.len() == 1 {
@@ -1037,36 +1038,36 @@ impl<'a> State<'a> {
                 }
                 self.pclose();
             }
-            ast::TyKind::Paren(ref typ) => {
+            ast::TyKind::Paren(typ) => {
                 self.popen();
                 self.print_type(typ);
                 self.pclose();
             }
-            ast::TyKind::BareFn(ref f) => {
+            ast::TyKind::BareFn(f) => {
                 self.print_ty_fn(f.ext, f.unsafety, &f.decl, None, &f.generic_params);
             }
-            ast::TyKind::Path(None, ref path) => {
+            ast::TyKind::Path(None, path) => {
                 self.print_path(path, false, 0);
             }
-            ast::TyKind::Path(Some(ref qself), ref path) => self.print_qpath(path, qself, false),
-            ast::TyKind::TraitObject(ref bounds, syntax) => {
-                if syntax == ast::TraitObjectSyntax::Dyn {
+            ast::TyKind::Path(Some(qself), path) => self.print_qpath(path, qself, false),
+            ast::TyKind::TraitObject(bounds, syntax) => {
+                if *syntax == ast::TraitObjectSyntax::Dyn {
                     self.word_nbsp("dyn");
                 }
                 self.print_type_bounds(bounds);
             }
-            ast::TyKind::ImplTrait(_, ref bounds) => {
+            ast::TyKind::ImplTrait(_, bounds) => {
                 self.word_nbsp("impl");
                 self.print_type_bounds(bounds);
             }
-            ast::TyKind::Array(ref ty, ref length) => {
+            ast::TyKind::Array(ty, length) => {
                 self.word("[");
                 self.print_type(ty);
                 self.word("; ");
                 self.print_expr(&length.value);
                 self.word("]");
             }
-            ast::TyKind::Typeof(ref e) => {
+            ast::TyKind::Typeof(e) => {
                 self.word("typeof(");
                 self.print_expr(&e.value);
                 self.word(")");
@@ -1082,7 +1083,7 @@ impl<'a> State<'a> {
             ast::TyKind::ImplicitSelf => {
                 self.word("Self");
             }
-            ast::TyKind::MacCall(ref m) => {
+            ast::TyKind::MacCall(m) => {
                 self.print_mac(m);
             }
             ast::TyKind::CVarArgs => {
@@ -1111,8 +1112,8 @@ impl<'a> State<'a> {
 
     pub(crate) fn print_stmt(&mut self, st: &ast::Stmt) {
         self.maybe_print_comment(st.span.lo());
-        match st.kind {
-            ast::StmtKind::Local(ref loc) => {
+        match &st.kind {
+            ast::StmtKind::Local(loc) => {
                 self.print_outer_attributes(&loc.attrs);
                 self.space_if_not_bol();
                 self.ibox(INDENT_UNIT);
@@ -1135,15 +1136,15 @@ impl<'a> State<'a> {
                 self.word(";");
                 self.end(); // `let` ibox
             }
-            ast::StmtKind::Item(ref item) => self.print_item(item),
-            ast::StmtKind::Expr(ref expr) => {
+            ast::StmtKind::Item(item) => self.print_item(item),
+            ast::StmtKind::Expr(expr) => {
                 self.space_if_not_bol();
                 self.print_expr_outer_attr_style(expr, false);
                 if classify::expr_requires_semi_to_be_stmt(expr) {
                     self.word(";");
                 }
             }
-            ast::StmtKind::Semi(ref expr) => {
+            ast::StmtKind::Semi(expr) => {
                 self.space_if_not_bol();
                 self.print_expr_outer_attr_style(expr, false);
                 self.word(";");
@@ -1152,7 +1153,7 @@ impl<'a> State<'a> {
                 self.space_if_not_bol();
                 self.word(";");
             }
-            ast::StmtKind::MacCall(ref mac) => {
+            ast::StmtKind::MacCall(mac) => {
                 self.space_if_not_bol();
                 self.print_outer_attributes(&mac.attrs);
                 self.print_mac(&mac.mac);
@@ -1193,8 +1194,8 @@ impl<'a> State<'a> {
         let has_attrs = self.print_inner_attributes(attrs);
 
         for (i, st) in blk.stmts.iter().enumerate() {
-            match st.kind {
-                ast::StmtKind::Expr(ref expr) if i == blk.stmts.len() - 1 => {
+            match &st.kind {
+                ast::StmtKind::Expr(expr) if i == blk.stmts.len() - 1 => {
                     self.maybe_print_comment(st.span.lo());
                     self.space_if_not_bol();
                     self.print_expr_outer_attr_style(expr, false);
@@ -1362,7 +1363,7 @@ impl<'a> State<'a> {
 
     pub(crate) fn print_local_decl(&mut self, loc: &ast::Local) {
         self.print_pat(&loc.pat);
-        if let Some(ref ty) = loc.ty {
+        if let Some(ty) = &loc.ty {
             self.word_space(":");
             self.print_type(ty);
         }
@@ -1386,7 +1387,7 @@ impl<'a> State<'a> {
         for item_segment in &path.segments[qself.position..] {
             self.word("::");
             self.print_ident(item_segment.ident);
-            if let Some(ref args) = item_segment.args {
+            if let Some(args) = &item_segment.args {
                 self.print_generic_args(args, colons_before_params)
             }
         }
@@ -1397,23 +1398,23 @@ impl<'a> State<'a> {
         self.ann.pre(self, AnnNode::Pat(pat));
         /* Pat isn't normalized, but the beauty of it
         is that it doesn't matter */
-        match pat.kind {
+        match &pat.kind {
             PatKind::Wild => self.word("_"),
-            PatKind::Ident(BindingAnnotation(by_ref, mutbl), ident, ref sub) => {
-                if by_ref == ByRef::Yes {
+            PatKind::Ident(BindingAnnotation(by_ref, mutbl), ident, sub) => {
+                if *by_ref == ByRef::Yes {
                     self.word_nbsp("ref");
                 }
-                if mutbl == Mutability::Mut {
+                if mutbl.is_mut() {
                     self.word_nbsp("mut");
                 }
-                self.print_ident(ident);
-                if let Some(ref p) = *sub {
+                self.print_ident(*ident);
+                if let Some(p) = sub {
                     self.space();
                     self.word_space("@");
                     self.print_pat(p);
                 }
             }
-            PatKind::TupleStruct(ref qself, ref path, ref elts) => {
+            PatKind::TupleStruct(qself, path, elts) => {
                 if let Some(qself) = qself {
                     self.print_qpath(path, qself, true);
                 } else {
@@ -1423,16 +1424,16 @@ impl<'a> State<'a> {
                 self.commasep(Inconsistent, &elts, |s, p| s.print_pat(p));
                 self.pclose();
             }
-            PatKind::Or(ref pats) => {
+            PatKind::Or(pats) => {
                 self.strsep("|", true, Inconsistent, &pats, |s, p| s.print_pat(p));
             }
-            PatKind::Path(None, ref path) => {
+            PatKind::Path(None, path) => {
                 self.print_path(path, true, 0);
             }
-            PatKind::Path(Some(ref qself), ref path) => {
+            PatKind::Path(Some(qself), path) => {
                 self.print_qpath(path, qself, false);
             }
-            PatKind::Struct(ref qself, ref path, ref fields, etc) => {
+            PatKind::Struct(qself, path, fields, etc) => {
                 if let Some(qself) = qself {
                     self.print_qpath(path, qself, true);
                 } else {
@@ -1458,7 +1459,7 @@ impl<'a> State<'a> {
                     },
                     |f| f.pat.span,
                 );
-                if etc {
+                if *etc {
                     if !fields.is_empty() {
                         self.word_space(",");
                     }
@@ -1469,7 +1470,7 @@ impl<'a> State<'a> {
                 }
                 self.word("}");
             }
-            PatKind::Tuple(ref elts) => {
+            PatKind::Tuple(elts) => {
                 self.popen();
                 self.commasep(Inconsistent, &elts, |s, p| s.print_pat(p));
                 if elts.len() == 1 {
@@ -1477,13 +1478,13 @@ impl<'a> State<'a> {
                 }
                 self.pclose();
             }
-            PatKind::Box(ref inner) => {
+            PatKind::Box(inner) => {
                 self.word("box ");
                 self.print_pat(inner);
             }
-            PatKind::Ref(ref inner, mutbl) => {
+            PatKind::Ref(inner, mutbl) => {
                 self.word("&");
-                if mutbl == Mutability::Mut {
+                if mutbl.is_mut() {
                     self.word("mut ");
                 }
                 if let PatKind::Ident(ast::BindingAnnotation::MUT, ..) = inner.kind {
@@ -1494,12 +1495,12 @@ impl<'a> State<'a> {
                     self.print_pat(inner);
                 }
             }
-            PatKind::Lit(ref e) => self.print_expr(&**e),
-            PatKind::Range(ref begin, ref end, Spanned { node: ref end_kind, .. }) => {
+            PatKind::Lit(e) => self.print_expr(&**e),
+            PatKind::Range(begin, end, Spanned { node: end_kind, .. }) => {
                 if let Some(e) = begin {
                     self.print_expr(e);
                 }
-                match *end_kind {
+                match end_kind {
                     RangeEnd::Included(RangeSyntax::DotDotDot) => self.word("..."),
                     RangeEnd::Included(RangeSyntax::DotDotEq) => self.word("..="),
                     RangeEnd::Excluded => self.word(".."),
@@ -1508,36 +1509,36 @@ impl<'a> State<'a> {
                     self.print_expr(e);
                 }
             }
-            PatKind::Slice(ref elts) => {
+            PatKind::Slice(elts) => {
                 self.word("[");
                 self.commasep(Inconsistent, &elts, |s, p| s.print_pat(p));
                 self.word("]");
             }
             PatKind::Rest => self.word(".."),
-            PatKind::Paren(ref inner) => {
+            PatKind::Paren(inner) => {
                 self.popen();
                 self.print_pat(inner);
                 self.pclose();
             }
-            PatKind::MacCall(ref m) => self.print_mac(m),
+            PatKind::MacCall(m) => self.print_mac(m),
         }
         self.ann.post(self, AnnNode::Pat(pat))
     }
 
     fn print_explicit_self(&mut self, explicit_self: &ast::ExplicitSelf) {
-        match explicit_self.node {
+        match &explicit_self.node {
             SelfKind::Value(m) => {
-                self.print_mutability(m, false);
+                self.print_mutability(*m, false);
                 self.word("self")
             }
-            SelfKind::Region(ref lt, m) => {
+            SelfKind::Region(lt, m) => {
                 self.word("&");
                 self.print_opt_lifetime(lt);
-                self.print_mutability(m, false);
+                self.print_mutability(*m, false);
                 self.word("self")
             }
-            SelfKind::Explicit(ref typ, m) => {
-                self.print_mutability(m, false);
+            SelfKind::Explicit(typ, m) => {
+                self.print_mutability(*m, false);
                 self.word("self");
                 self.word_space(":");
                 self.print_type(typ)
@@ -1599,7 +1600,7 @@ impl<'a> State<'a> {
         self.commasep(Inconsistent, &generic_params, |s, param| {
             s.print_outer_attributes_inline(&param.attrs);
 
-            match param.kind {
+            match &param.kind {
                 ast::GenericParamKind::Lifetime => {
                     let lt = ast::Lifetime { id: param.id, ident: param.ident };
                     s.print_lifetime(lt);
@@ -1608,19 +1609,19 @@ impl<'a> State<'a> {
                         s.print_lifetime_bounds(&param.bounds)
                     }
                 }
-                ast::GenericParamKind::Type { ref default } => {
+                ast::GenericParamKind::Type { default } => {
                     s.print_ident(param.ident);
                     if !param.bounds.is_empty() {
                         s.word_nbsp(":");
                         s.print_type_bounds(&param.bounds);
                     }
-                    if let Some(ref default) = default {
+                    if let Some(default) = default {
                         s.space();
                         s.word_space("=");
                         s.print_type(default)
                     }
                 }
-                ast::GenericParamKind::Const { ref ty, kw_span: _, ref default } => {
+                ast::GenericParamKind::Const { ty, default, .. } => {
                     s.word_space("const");
                     s.print_ident(param.ident);
                     s.space();
@@ -1630,7 +1631,7 @@ impl<'a> State<'a> {
                         s.word_nbsp(":");
                         s.print_type_bounds(&param.bounds);
                     }
-                    if let Some(ref default) = default {
+                    if let Some(default) = default {
                         s.space();
                         s.word_space("=");
                         s.print_expr(&default.value);

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -64,7 +64,7 @@ impl<'a> Comments<'a> {
         Comments { sm, comments, current: 0 }
     }
 
-    // This shouldn't probably clone lmao
+    // FIXME: This shouldn't probably clone lmao
     pub fn next(&self) -> Option<Comment> {
         self.comments.get(self.current).cloned()
     }

--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -8,9 +8,9 @@ use rustc_ast::{self as ast, BlockCheckMode};
 impl<'a> State<'a> {
     fn print_else(&mut self, els: Option<&ast::Expr>) {
         if let Some(_else) = els {
-            match _else.kind {
+            match &_else.kind {
                 // Another `else if` block.
-                ast::ExprKind::If(ref i, ref then, ref e) => {
+                ast::ExprKind::If(i, then, e) => {
                     self.cbox(INDENT_UNIT - 1);
                     self.ibox(0);
                     self.word(" else if ");
@@ -20,7 +20,7 @@ impl<'a> State<'a> {
                     self.print_else(e.as_deref())
                 }
                 // Final `else` block.
-                ast::ExprKind::Block(ref b, _) => {
+                ast::ExprKind::Block(b, _) => {
                     self.cbox(INDENT_UNIT - 1);
                     self.ibox(0);
                     self.word(" else ");
@@ -202,7 +202,7 @@ impl<'a> State<'a> {
         self.print_expr_maybe_paren(receiver, parser::PREC_POSTFIX);
         self.word(".");
         self.print_ident(segment.ident);
-        if let Some(ref args) = segment.args {
+        if let Some(args) = &segment.args {
             self.print_generic_args(args, true);
         }
         self.print_call_post(base_args)
@@ -284,73 +284,66 @@ impl<'a> State<'a> {
 
         self.ibox(INDENT_UNIT);
         self.ann.pre(self, AnnNode::Expr(expr));
-        match expr.kind {
-            ast::ExprKind::Box(ref expr) => {
+        match &expr.kind {
+            ast::ExprKind::Box(expr) => {
                 self.word_space("box");
                 self.print_expr_maybe_paren(expr, parser::PREC_PREFIX);
             }
-            ast::ExprKind::Array(ref exprs) => {
+            ast::ExprKind::Array(exprs) => {
                 self.print_expr_vec(exprs);
             }
-            ast::ExprKind::ConstBlock(ref anon_const) => {
+            ast::ExprKind::ConstBlock(anon_const) => {
                 self.print_expr_anon_const(anon_const, attrs);
             }
-            ast::ExprKind::Repeat(ref element, ref count) => {
+            ast::ExprKind::Repeat(element, count) => {
                 self.print_expr_repeat(element, count);
             }
-            ast::ExprKind::Struct(ref se) => {
+            ast::ExprKind::Struct(se) => {
                 self.print_expr_struct(&se.qself, &se.path, &se.fields, &se.rest);
             }
-            ast::ExprKind::Tup(ref exprs) => {
+            ast::ExprKind::Tup(exprs) => {
                 self.print_expr_tup(exprs);
             }
-            ast::ExprKind::Call(ref func, ref args) => {
+            ast::ExprKind::Call(func, args) => {
                 self.print_expr_call(func, &args);
             }
-            ast::ExprKind::MethodCall(box ast::MethodCall {
-                ref seg,
-                ref receiver,
-                ref args,
-                ..
-            }) => {
+            ast::ExprKind::MethodCall(box ast::MethodCall { seg, receiver, args, .. }) => {
                 self.print_expr_method_call(seg, &receiver, &args);
             }
-            ast::ExprKind::Binary(op, ref lhs, ref rhs) => {
-                self.print_expr_binary(op, lhs, rhs);
+            ast::ExprKind::Binary(op, lhs, rhs) => {
+                self.print_expr_binary(*op, lhs, rhs);
             }
-            ast::ExprKind::Unary(op, ref expr) => {
-                self.print_expr_unary(op, expr);
+            ast::ExprKind::Unary(op, expr) => {
+                self.print_expr_unary(*op, expr);
             }
-            ast::ExprKind::AddrOf(k, m, ref expr) => {
-                self.print_expr_addr_of(k, m, expr);
+            ast::ExprKind::AddrOf(k, m, expr) => {
+                self.print_expr_addr_of(*k, *m, expr);
             }
             ast::ExprKind::Lit(token_lit) => {
-                self.print_token_literal(token_lit, expr.span);
+                self.print_token_literal(*token_lit, expr.span);
             }
-            ast::ExprKind::IncludedBytes(ref bytes) => {
+            ast::ExprKind::IncludedBytes(bytes) => {
                 let lit = ast::LitKind::ByteStr(bytes.clone()).to_token_lit();
                 self.print_token_literal(lit, expr.span)
             }
-            ast::ExprKind::Cast(ref expr, ref ty) => {
+            ast::ExprKind::Cast(expr, ty) => {
                 let prec = AssocOp::As.precedence() as i8;
                 self.print_expr_maybe_paren(expr, prec);
                 self.space();
                 self.word_space("as");
                 self.print_type(ty);
             }
-            ast::ExprKind::Type(ref expr, ref ty) => {
+            ast::ExprKind::Type(expr, ty) => {
                 let prec = AssocOp::Colon.precedence() as i8;
                 self.print_expr_maybe_paren(expr, prec);
                 self.word_space(":");
                 self.print_type(ty);
             }
-            ast::ExprKind::Let(ref pat, ref scrutinee, _) => {
+            ast::ExprKind::Let(pat, scrutinee, _) => {
                 self.print_let(pat, scrutinee);
             }
-            ast::ExprKind::If(ref test, ref blk, ref elseopt) => {
-                self.print_if(test, blk, elseopt.as_deref())
-            }
-            ast::ExprKind::While(ref test, ref blk, opt_label) => {
+            ast::ExprKind::If(test, blk, elseopt) => self.print_if(test, blk, elseopt.as_deref()),
+            ast::ExprKind::While(test, blk, opt_label) => {
                 if let Some(label) = opt_label {
                     self.print_ident(label.ident);
                     self.word_space(":");
@@ -362,7 +355,7 @@ impl<'a> State<'a> {
                 self.space();
                 self.print_block_with_attrs(blk, attrs);
             }
-            ast::ExprKind::ForLoop(ref pat, ref iter, ref blk, opt_label) => {
+            ast::ExprKind::ForLoop(pat, iter, blk, opt_label) => {
                 if let Some(label) = opt_label {
                     self.print_ident(label.ident);
                     self.word_space(":");
@@ -377,7 +370,7 @@ impl<'a> State<'a> {
                 self.space();
                 self.print_block_with_attrs(blk, attrs);
             }
-            ast::ExprKind::Loop(ref blk, opt_label, _) => {
+            ast::ExprKind::Loop(blk, opt_label, _) => {
                 if let Some(label) = opt_label {
                     self.print_ident(label.ident);
                     self.word_space(":");
@@ -387,7 +380,7 @@ impl<'a> State<'a> {
                 self.word_nbsp("loop");
                 self.print_block_with_attrs(blk, attrs);
             }
-            ast::ExprKind::Match(ref expr, ref arms) => {
+            ast::ExprKind::Match(expr, arms) => {
                 self.cbox(0);
                 self.ibox(0);
                 self.word_nbsp("match");
@@ -402,18 +395,18 @@ impl<'a> State<'a> {
                 self.bclose(expr.span, empty);
             }
             ast::ExprKind::Closure(box ast::Closure {
-                ref binder,
+                binder,
                 capture_clause,
                 asyncness,
                 movability,
-                ref fn_decl,
-                ref body,
+                fn_decl,
+                body,
                 fn_decl_span: _,
             }) => {
                 self.print_closure_binder(binder);
-                self.print_movability(movability);
-                self.print_asyncness(asyncness);
-                self.print_capture_clause(capture_clause);
+                self.print_movability(*movability);
+                self.print_asyncness(*asyncness);
+                self.print_capture_clause(*capture_clause);
 
                 self.print_fn_params_and_ret(fn_decl, true);
                 self.space();
@@ -425,7 +418,7 @@ impl<'a> State<'a> {
                 // empty box to satisfy the close.
                 self.ibox(0);
             }
-            ast::ExprKind::Block(ref blk, opt_label) => {
+            ast::ExprKind::Block(blk, opt_label) => {
                 if let Some(label) = opt_label {
                     self.print_ident(label.ident);
                     self.word_space(":");
@@ -436,26 +429,26 @@ impl<'a> State<'a> {
                 self.ibox(0);
                 self.print_block_with_attrs(blk, attrs);
             }
-            ast::ExprKind::Async(capture_clause, _, ref blk) => {
+            ast::ExprKind::Async(capture_clause, _, blk) => {
                 self.word_nbsp("async");
-                self.print_capture_clause(capture_clause);
+                self.print_capture_clause(*capture_clause);
                 // cbox/ibox in analogy to the `ExprKind::Block` arm above
                 self.cbox(0);
                 self.ibox(0);
                 self.print_block_with_attrs(blk, attrs);
             }
-            ast::ExprKind::Await(ref expr) => {
+            ast::ExprKind::Await(expr) => {
                 self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
                 self.word(".await");
             }
-            ast::ExprKind::Assign(ref lhs, ref rhs, _) => {
+            ast::ExprKind::Assign(lhs, rhs, _) => {
                 let prec = AssocOp::Assign.precedence() as i8;
                 self.print_expr_maybe_paren(lhs, prec + 1);
                 self.space();
                 self.word_space("=");
                 self.print_expr_maybe_paren(rhs, prec);
             }
-            ast::ExprKind::AssignOp(op, ref lhs, ref rhs) => {
+            ast::ExprKind::AssignOp(op, lhs, rhs) => {
                 let prec = AssocOp::Assign.precedence() as i8;
                 self.print_expr_maybe_paren(lhs, prec + 1);
                 self.space();
@@ -463,45 +456,44 @@ impl<'a> State<'a> {
                 self.word_space("=");
                 self.print_expr_maybe_paren(rhs, prec);
             }
-            ast::ExprKind::Field(ref expr, ident) => {
+            ast::ExprKind::Field(expr, ident) => {
                 self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
                 self.word(".");
-                self.print_ident(ident);
+                self.print_ident(*ident);
             }
-            ast::ExprKind::Index(ref expr, ref index) => {
+            ast::ExprKind::Index(expr, index) => {
                 self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
                 self.word("[");
                 self.print_expr(index);
                 self.word("]");
             }
-            ast::ExprKind::Range(ref start, ref end, limits) => {
+            ast::ExprKind::Range(start, end, limits) => {
                 // Special case for `Range`.  `AssocOp` claims that `Range` has higher precedence
                 // than `Assign`, but `x .. x = x` gives a parse error instead of `x .. (x = x)`.
                 // Here we use a fake precedence value so that any child with lower precedence than
                 // a "normal" binop gets parenthesized.  (`LOr` is the lowest-precedence binop.)
                 let fake_prec = AssocOp::LOr.precedence() as i8;
-                if let Some(ref e) = *start {
+                if let Some(e) = start {
                     self.print_expr_maybe_paren(e, fake_prec);
                 }
-                if limits == ast::RangeLimits::HalfOpen {
-                    self.word("..");
-                } else {
-                    self.word("..=");
+                match limits {
+                    ast::RangeLimits::HalfOpen => self.word(".."),
+                    ast::RangeLimits::Closed => self.word("..="),
                 }
-                if let Some(ref e) = *end {
+                if let Some(e) = end {
                     self.print_expr_maybe_paren(e, fake_prec);
                 }
             }
             ast::ExprKind::Underscore => self.word("_"),
-            ast::ExprKind::Path(None, ref path) => self.print_path(path, true, 0),
-            ast::ExprKind::Path(Some(ref qself), ref path) => self.print_qpath(path, qself, true),
-            ast::ExprKind::Break(opt_label, ref opt_expr) => {
+            ast::ExprKind::Path(None, path) => self.print_path(path, true, 0),
+            ast::ExprKind::Path(Some(qself), path) => self.print_qpath(path, qself, true),
+            ast::ExprKind::Break(opt_label, opt_expr) => {
                 self.word("break");
                 if let Some(label) = opt_label {
                     self.space();
                     self.print_ident(label.ident);
                 }
-                if let Some(ref expr) = *opt_expr {
+                if let Some(expr) = opt_expr {
                     self.space();
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                 }
@@ -513,45 +505,45 @@ impl<'a> State<'a> {
                     self.print_ident(label.ident);
                 }
             }
-            ast::ExprKind::Ret(ref result) => {
+            ast::ExprKind::Ret(result) => {
                 self.word("return");
-                if let Some(ref expr) = *result {
+                if let Some(expr) = result {
                     self.word(" ");
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                 }
             }
-            ast::ExprKind::Yeet(ref result) => {
+            ast::ExprKind::Yeet(result) => {
                 self.word("do");
                 self.word(" ");
                 self.word("yeet");
-                if let Some(ref expr) = *result {
+                if let Some(expr) = result {
                     self.word(" ");
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                 }
             }
-            ast::ExprKind::InlineAsm(ref a) => {
+            ast::ExprKind::InlineAsm(a) => {
                 self.word("asm!");
                 self.print_inline_asm(a);
             }
-            ast::ExprKind::MacCall(ref m) => self.print_mac(m),
-            ast::ExprKind::Paren(ref e) => {
+            ast::ExprKind::MacCall(m) => self.print_mac(m),
+            ast::ExprKind::Paren(e) => {
                 self.popen();
                 self.print_expr(e);
                 self.pclose();
             }
-            ast::ExprKind::Yield(ref e) => {
+            ast::ExprKind::Yield(e) => {
                 self.word("yield");
 
-                if let Some(ref expr) = *e {
+                if let Some(expr) = e {
                     self.space();
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                 }
             }
-            ast::ExprKind::Try(ref e) => {
+            ast::ExprKind::Try(e) => {
                 self.print_expr_maybe_paren(e, parser::PREC_POSTFIX);
                 self.word("?")
             }
-            ast::ExprKind::TryBlock(ref blk) => {
+            ast::ExprKind::TryBlock(blk) => {
                 self.cbox(0);
                 self.ibox(0);
                 self.word_nbsp("try");
@@ -578,15 +570,15 @@ impl<'a> State<'a> {
         self.print_outer_attributes(&arm.attrs);
         self.print_pat(&arm.pat);
         self.space();
-        if let Some(ref e) = arm.guard {
+        if let Some(e) = &arm.guard {
             self.word_space("if");
             self.print_expr(e);
             self.space();
         }
         self.word_space("=>");
 
-        match arm.body.kind {
-            ast::ExprKind::Block(ref blk, opt_label) => {
+        match &arm.body.kind {
+            ast::ExprKind::Block(blk, opt_label) => {
                 if let Some(label) = opt_label {
                     self.print_ident(label.ident);
                     self.word_space(":");


### PR DESCRIPTION
r? @compiler-errors 
Previous PR: https://github.com/rust-lang/rust/pull/104721