### PR TITLE
Rustdoc Json Tests: Don't assume that core::fmt::Debug will always have one item.

### DIFF
--- a/src/test/rustdoc-json/traits/uses_extern_trait.rs
+++ b/src/test/rustdoc-json/traits/uses_extern_trait.rs
@@ -3,5 +3,10 @@ pub fn drop_default<T: core::default::Default>(_x: T) {}
 
 // FIXME(adotinthevoid): Theses shouldn't be here
 // @has "$.index[*][?(@.name=='Debug')]"
-// @set Debug_fmt = "$.index[*][?(@.name=='Debug')].inner.items[*]"
+
+// Debug may have several items. All we depend on here the that `fmt` is first. See
+// https://github.com/rust-lang/rust/pull/104525#issuecomment-1331087852 for why we
+// can't use [*].
+
+// @set Debug_fmt = "$.index[*][?(@.name=='Debug')].inner.items[0]"
 // @has "$.index[*][?(@.name=='fmt')].id" $Debug_fmt


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/104525#issuecomment-1330837047 and https://github.com/rust-lang/rust/pull/104525#issuecomment-1331087852 for motivation.

This still assumes that `fmt` is the first method, but thats alot less brittle than assuming it will be the only method.

Sadly, we can't use a aux crate to insulate the tests from core changes, because core is special, so all we can do is try not to depend on things that may change.