### PR TITLE
rustdoc: add comment to confusing CSS `main { min-width: 0 }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -314,7 +314,7 @@ main {
 	position: relative;
 	flex-grow: 1;
 	padding: 10px 15px 40px 45px;
-	min-width: 0;
+	min-width: 0; /* avoid growing beyond the size limit */
 }
 
 .source main {


### PR DESCRIPTION
This CSS was added in cad0fce2053d52b7ba04c458f4c124c8b5c6141e, but the reason why it was necessary was unclear. This comment makes it clear.