### PR TITLE
Run patchelf also on rust-analyzer-proc-macro-srv.

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -441,6 +441,7 @@ class RustBuild(object):
 
             self.fix_bin_or_dylib("{}/bin/rustc".format(bin_root))
             self.fix_bin_or_dylib("{}/bin/rustdoc".format(bin_root))
+            self.fix_bin_or_dylib("{}/libexec/rust-analyzer-proc-macro-srv".format(bin_root))
             lib_dir = "{}/lib".format(bin_root)
             for lib in os.listdir(lib_dir):
                 if lib.endswith(".so"):

--- a/src/bootstrap/download.rs
+++ b/src/bootstrap/download.rs
@@ -360,6 +360,7 @@ impl Config {
 
             self.fix_bin_or_dylib(&bin_root.join("bin").join("rustc"));
             self.fix_bin_or_dylib(&bin_root.join("bin").join("rustdoc"));
+            self.fix_bin_or_dylib(&bin_root.join("libexec").join("rust-analyzer-proc-macro-srv"));
             let lib_dir = bin_root.join("lib");
             for lib in t!(fs::read_dir(&lib_dir), lib_dir.display().to_string()) {
                 let lib = t!(lib);


### PR DESCRIPTION
On NixOS, `rust-analyzer-proc-macro-srv` needs to be `patchelf`ed just like all the other libs and binaries.

With this fix, I am able to use the language server configuration recommended in [the guide](https://rustc-dev-guide.rust-lang.org/building/suggested.html#configuring-rust-analyzer-for-rustc).