### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -73,6 +73,8 @@ Björn Steinbrink <bsteinbr@gmail.com> <B.Steinbrink@gmx.de>
 blake2-ppc <ulrik.sverdrup@gmail.com> <blake2-ppc>
 boolean_coercion <booleancoercion@gmail.com>
 Boris Egorov <jightuse@gmail.com> <egorov@linux.com>
+bors <bors@rust-lang.org> bors[bot] <26634292+bors[bot]@users.noreply.github.com>
+bors <bors@rust-lang.org> bors[bot] <bors[bot]@users.noreply.github.com>
 Braden Nelson <moonheart08@users.noreply.github.com>
 Brandon Sanderson <singingboyo@gmail.com> Brandon Sanderson <singingboyo@hotmail.com>
 Brett Cannon <brett@python.org> Brett Cannon <brettcannon@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -141,6 +141,10 @@ David Ross <daboross@daboross.net>
 David Wood <david@davidtw.co> <david.wood@huawei.com>
 Deadbeef <ent3rm4n@gmail.com>
 Deadbeef <ent3rm4n@gmail.com> <fee1-dead-beef@protonmail.com>
+dependabot[bot] <dependabot[bot]@users.noreply.github.com> <27856297+dependabot-preview[bot]@users.noreply.github.com>
+dependabot[bot] <dependabot[bot]@users.noreply.github.com> <49699333+dependabot[bot]@users.noreply.github.com>
+dependabot[bot] <dependabot[bot]@users.noreply.github.com> <dependabot-preview[bot]@users.noreply.github.com>
+dependabot[bot] <dependabot[bot]@users.noreply.github.com> <support@dependabot.com>
 Derek Chiang <derekchiang93@gmail.com> Derek Chiang (Enchi Jiang) <derekchiang93@gmail.com>
 DeveloperC <DeveloperC@protonmail.com>
 Devin Ragotzy <devin.ragotzy@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -396,6 +396,8 @@ Nathaniel Herman <nherman@post.harvard.edu> Nathaniel Herman <nherman@college.ha
 Neil Pankey <npankey@gmail.com> <neil@wire.im>
 Ngo Iok Ui (Wu Yu Wei) <wusyong9104@gmail.com>
 Nicholas Baron <nicholas.baron.ten@gmail.com>
+Nicholas Nethercote <n.nethercote@gmail.com> <nnethercote@apple.com>
+Nicholas Nethercote <n.nethercote@gmail.com> <nnethercote@mozilla.com>
 Nick Platt <platt.nicholas@gmail.com>
 Niclas Schwarzlose <15schnic@gmail.com>
 Nicolas Abram <abramlujan@gmail.com>

--- a/compiler/rustc_builtin_macros/src/concat_bytes.rs
+++ b/compiler/rustc_builtin_macros/src/concat_bytes.rs
@@ -2,6 +2,7 @@ use rustc_ast as ast;
 use rustc_ast::{ptr::P, tokenstream::TokenStream};
 use rustc_errors::Applicability;
 use rustc_expand::base::{self, DummyResult};
+use rustc_session::errors::report_lit_error;
 use rustc_span::Span;
 
 /// Emits errors for literal expressions that are invalid inside and outside of an array.
@@ -68,7 +69,10 @@ fn invalid_type_err(
         Ok(ast::LitKind::Int(_, _)) => {
             cx.span_err(span, "numeric literal is not a `u8`");
         }
-        _ => unreachable!(),
+        Ok(ast::LitKind::ByteStr(_) | ast::LitKind::Byte(_)) => unreachable!(),
+        Err(err) => {
+            report_lit_error(&cx.sess.parse_sess, err, token_lit, span);
+        }
     }
 }
 

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -2184,7 +2184,7 @@ fn determine_place_ancestry_relation<'tcx>(
     place_a: &Place<'tcx>,
     place_b: &Place<'tcx>,
 ) -> PlaceAncestryRelation {
-    // If Place A and Place B, don't start off from the same root variable, they are divergent.
+    // If Place A and Place B don't start off from the same root variable, they are divergent.
     if place_a.base != place_b.base {
         return PlaceAncestryRelation::Divergent;
     }

--- a/library/std/src/sys/wasi/net.rs
+++ b/library/std/src/sys/wasi/net.rs
@@ -119,8 +119,14 @@ impl TcpStream {
         unsupported()
     }
 
-    pub fn shutdown(&self, _: Shutdown) -> io::Result<()> {
-        unsupported()
+    pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
+        let wasi_how = match how {
+            Shutdown::Read => wasi::SDFLAGS_RD,
+            Shutdown::Write => wasi::SDFLAGS_WR,
+            Shutdown::Both => wasi::SDFLAGS_RD | wasi::SDFLAGS_WR,
+        };
+
+        unsafe { wasi::sock_shutdown(self.socket().as_raw_fd() as _, wasi_how).map_err(err2io) }
     }
 
     pub fn duplicate(&self) -> io::Result<TcpStream> {

--- a/src/test/ui/inference/issue-104649.rs
+++ b/src/test/ui/inference/issue-104649.rs
@@ -1,0 +1,32 @@
+type Result<T, E = Error> = ::std::result::Result<T, E>;
+struct Error;
+
+trait ForEach {
+    type Input;
+    fn for_each<F, U>(self, f: F)
+    where
+        F: FnOnce(Self::Input) -> U;
+}
+
+impl<T> ForEach for A<T> {
+    type Input = T;
+    fn for_each<F, U>(self, f: F)
+    where
+        F: FnOnce(Self::Input) -> U,
+    {
+        todo!()
+    }
+}
+
+struct A<T>(T);
+
+fn main() {
+    let a = A(Result::Ok(Result::Ok(()))); //~ ERROR type annotations needed
+    a.for_each(|a: Result<_>| {
+        let f = || match a {
+            Ok(Ok(a)) => {}
+            Ok(Err(a)) => {}
+            Err(a) => {}
+        };
+    });
+}

--- a/src/test/ui/inference/issue-104649.stderr
+++ b/src/test/ui/inference/issue-104649.stderr
@@ -1,0 +1,14 @@
+error[E0282]: type annotations needed for `A<std::result::Result<std::result::Result<(), E>, Error>>`
+  --> $DIR/issue-104649.rs:24:9
+   |
+LL |     let a = A(Result::Ok(Result::Ok(())));
+   |         ^
+   |
+help: consider giving `a` an explicit type, where the type for type parameter `E` is specified
+   |
+LL |     let a: A<std::result::Result<std::result::Result<(), E>, Error>> = A(Result::Ok(Result::Ok(())));
+   |          +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/macros/issue-104769-concat_bytes-invalid-literal.rs
+++ b/src/test/ui/macros/issue-104769-concat_bytes-invalid-literal.rs
@@ -1,0 +1,8 @@
+#![feature(concat_bytes)]
+
+fn main() {
+    concat_bytes!(7Y);
+    //~^ ERROR invalid suffix `Y` for number literal
+    concat_bytes!(888888888888888888888888888888888888888);
+    //~^ ERROR integer literal is too large
+}

--- a/src/test/ui/macros/issue-104769-concat_bytes-invalid-literal.stderr
+++ b/src/test/ui/macros/issue-104769-concat_bytes-invalid-literal.stderr
@@ -1,0 +1,16 @@
+error: invalid suffix `Y` for number literal
+  --> $DIR/issue-104769-concat_bytes-invalid-literal.rs:4:19
+   |
+LL |     concat_bytes!(7Y);
+   |                   ^^ invalid suffix `Y`
+   |
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+
+error: integer literal is too large
+  --> $DIR/issue-104769-concat_bytes-invalid-literal.rs:6:19
+   |
+LL |     concat_bytes!(888888888888888888888888888888888888888);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #104697 (Restore control flow on error in EUV)
 - #104811 (feat: implement TcpStream shutdown for wasm32-wasi)
 - #105039 (Fix an ICE parsing a malformed literal in `concat_bytes!`.)
 - #105071 (Add Nicholas Nethercote to `.mailmap`.)
 - #105079 (Add bots to `.mailmap`)

Failed merges:

 - #105074 (Add Nicholas Bishop to `.mailmap`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=104697,104811,105039,105071,105079)
<!-- homu-ignore:end -->