### PR TITLE
rustdoc: clean up sidebar link CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -480,15 +480,11 @@ ul.block, .block li {
 	list-style: none;
 }
 
-.block a,
-.sidebar h2 a,
-.sidebar h3 a {
+.sidebar-elems a,
+.sidebar > h2 a {
 	display: block;
-	padding: 0.25rem;
+	padding: 0.25rem; /* 4px */
 	margin-left: -0.25rem;
-
-	text-overflow: ellipsis;
-	overflow: hidden;
 }
 
 .sidebar h2 {
@@ -522,6 +518,8 @@ ul.block, .block li {
 
 .sidebar-elems .block li a {
 	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
 }
 
 .mobile-topbar {


### PR DESCRIPTION
Group `text-overflow: ellipses` along with `white-space: nowrap`. It makes no sense to try to apply it to links with `overflow-wrap: anywhere`, because it can't actually make ellipses when that's turned on.

Simplify the selector for the 25rem left padding on sidebar links, to match up with the style for the container left padding that makes room for it.