### PR TITLE
rustdoc: remove redundant CSS `div.desc { display: block }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -896,7 +896,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
-	display: block;
 }
 
 .search-results a:hover,


### PR DESCRIPTION
DIV tags have block display by default. It is from when this rule used to target a SPAN tag, but became redundant in 4bd6748bb9b73c210558498070ae0b7ed8193ddf.