### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -530,6 +530,7 @@ Tomas Koutsky <tomas@stepnivlk.net>
 Torsten Weber <TorstenWeber12@gmail.com>
 Torsten Weber <TorstenWeber12@gmail.com> <torstenweber12@gmail.com>
 Trevor Spiteri <tspiteri@ieee.org> <trevor.spiteri@um.edu.mt>
+Tshepang Mbambo <tshepang@gmail.com>
 Ty Overby <ty@pre-alpha.com>
 Tyler Mandry <tmandry@gmail.com> <tmandry@google.com>
 Tyler Ruckinger <t.ruckinger@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -402,6 +402,8 @@ Nathaniel Herman <nherman@post.harvard.edu> Nathaniel Herman <nherman@college.ha
 Neil Pankey <npankey@gmail.com> <neil@wire.im>
 Ngo Iok Ui (Wu Yu Wei) <wusyong9104@gmail.com>
 Nicholas Baron <nicholas.baron.ten@gmail.com>
+Nicholas Bishop <nbishop@nbishop.net> <nicholasbishop@gmail.com>
+Nicholas Bishop <nbishop@nbishop.net> <nicholasbishop@google.com>
 Nicholas Nethercote <n.nethercote@gmail.com> <nnethercote@apple.com>
 Nicholas Nethercote <n.nethercote@gmail.com> <nnethercote@mozilla.com>
 Nick Platt <platt.nicholas@gmail.com>

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -355,6 +355,12 @@ pub fn suggest_constraining_type_params<'a>(
         ));
     }
 
+    // FIXME: remove the suggestions that are from derive, as the span is not correct
+    suggestions = suggestions
+        .into_iter()
+        .filter(|(span, _, _)| !span.in_derive_expansion())
+        .collect::<Vec<_>>();
+
     if suggestions.len() == 1 {
         let (span, suggestion, msg) = suggestions.pop().unwrap();
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -647,9 +647,11 @@ impl Build {
         if !update(true).status().map_or(false, |status| status.success()) {
             self.run(&mut update(false));
         }
-
+        // 
+        self.run(Command::new("git").args(&["stash", "push"]).current_dir(&absolute_path));
         self.run(Command::new("git").args(&["reset", "-q", "--hard"]).current_dir(&absolute_path));
-        self.run(Command::new("git").args(&["clean", "-qdfx"]).current_dir(absolute_path));
+        self.run(Command::new("git").args(&["clean", "-qdfx"]).current_dir(&absolute_path));
+        self.run(Command::new("git").args(&["stash", "pop"]).current_dir(absolute_path))
     }
 
     /// If any submodule has been initialized already, sync it unconditionally.

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -647,7 +647,6 @@ impl Build {
         if !update(true).status().map_or(false, |status| status.success()) {
             self.run(&mut update(false));
         }
-        
         self.run(Command::new("git").args(&["stash", "push"]).current_dir(&absolute_path));
         self.run(Command::new("git").args(&["reset", "-q", "--hard"]).current_dir(&absolute_path));
         self.run(Command::new("git").args(&["clean", "-qdfx"]).current_dir(&absolute_path));

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -647,11 +647,11 @@ impl Build {
         if !update(true).status().map_or(false, |status| status.success()) {
             self.run(&mut update(false));
         }
-        // 
+        
         self.run(Command::new("git").args(&["stash", "push"]).current_dir(&absolute_path));
         self.run(Command::new("git").args(&["reset", "-q", "--hard"]).current_dir(&absolute_path));
         self.run(Command::new("git").args(&["clean", "-qdfx"]).current_dir(&absolute_path));
-        self.run(Command::new("git").args(&["stash", "pop"]).current_dir(absolute_path))
+        self.run(Command::new("git").args(&["stash", "pop"]).current_dir(absolute_path));
     }
 
     /// If any submodule has been initialized already, sync it unconditionally.

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -314,7 +314,7 @@ main {
 	position: relative;
 	flex-grow: 1;
 	padding: 10px 15px 40px 45px;
-	min-width: 0;
+	min-width: 0; /* avoid growing beyond the size limit */
 }
 
 .source main {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -480,15 +480,11 @@ ul.block, .block li {
 	list-style: none;
 }
 
-.block a,
-.sidebar h2 a,
-.sidebar h3 a {
+.sidebar-elems a,
+.sidebar > h2 a {
 	display: block;
-	padding: 0.25rem;
+	padding: 0.25rem; /* 4px */
 	margin-left: -0.25rem;
-
-	text-overflow: ellipsis;
-	overflow: hidden;
 }
 
 .sidebar h2 {
@@ -522,6 +518,8 @@ ul.block, .block li {
 
 .sidebar-elems .block li a {
 	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
 }
 
 .mobile-topbar {

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -618,6 +618,10 @@ pub struct FunctionPointer {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct FnDecl {
+    /// List of argument names and their type.
+    ///
+    /// Note that not all names will be valid identifiers, as some of
+    /// them may be patterns.
     pub inputs: Vec<(String, Type)>,
     pub output: Option<Type>,
     pub c_variadic: bool,

--- a/src/test/rustdoc-json/fns/pattern_arg.rs
+++ b/src/test/rustdoc-json/fns/pattern_arg.rs
@@ -1,0 +1,7 @@
+// @is "$.index[*][?(@.name=='fst')].inner.decl.inputs[0][0]" '"(x, _)"'
+pub fn fst<X, Y>((x, _): (X, Y)) -> X {
+    x
+}
+
+// @is "$.index[*][?(@.name=='drop_int')].inner.decl.inputs[0][0]" '"_"'
+pub fn drop_int(_: i32) {}

--- a/src/test/rustdoc-json/traits/uses_extern_trait.rs
+++ b/src/test/rustdoc-json/traits/uses_extern_trait.rs
@@ -3,5 +3,10 @@ pub fn drop_default<T: core::default::Default>(_x: T) {}
 
 // FIXME(adotinthevoid): Theses shouldn't be here
 // @has "$.index[*][?(@.name=='Debug')]"
-// @set Debug_fmt = "$.index[*][?(@.name=='Debug')].inner.items[*]"
+
+// Debug may have several items. All we depend on here the that `fmt` is first. See
+// https://github.com/rust-lang/rust/pull/104525#issuecomment-1331087852 for why we
+// can't use [*].
+
+// @set Debug_fmt = "$.index[*][?(@.name=='Debug')].inner.items[0]"
 // @has "$.index[*][?(@.name=='fmt')].id" $Debug_fmt

--- a/src/test/ui/proc-macro/auxiliary/issue-104884.rs
+++ b/src/test/ui/proc-macro/auxiliary/issue-104884.rs
@@ -1,0 +1,23 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(AddImpl)]
+
+pub fn derive(input: TokenStream) -> TokenStream {
+    "use std::cmp::Ordering;
+
+    impl<T> Ord for PriorityQueue<T> {
+        fn cmp(&self, other: &Self) -> Ordering {
+            self.0.cmp(&self.height)
+        }
+    }
+    "
+    .parse()
+    .unwrap()
+}

--- a/src/test/ui/proc-macro/issue-104884-trait-impl-sugg-err.rs
+++ b/src/test/ui/proc-macro/issue-104884-trait-impl-sugg-err.rs
@@ -1,0 +1,20 @@
+// aux-build:issue-104884.rs
+
+use std::collections::BinaryHeap;
+
+#[macro_use]
+extern crate issue_104884;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct PriorityQueueEntry<T> {
+    value: T,
+}
+
+#[derive(PartialOrd, AddImpl)]
+//~^ ERROR can't compare `PriorityQueue<T>` with `PriorityQueue<T>`
+//~| ERROR the trait bound `PriorityQueue<T>: Eq` is not satisfied
+//~| ERROR can't compare `T` with `T`
+
+struct PriorityQueue<T>(BinaryHeap<PriorityQueueEntry<T>>);
+
+fn main() {}

--- a/src/test/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
+++ b/src/test/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
@@ -1,0 +1,48 @@
+error[E0277]: can't compare `PriorityQueue<T>` with `PriorityQueue<T>`
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:10
+   |
+LL | #[derive(PartialOrd, AddImpl)]
+   |          ^^^^^^^^^^ no implementation for `PriorityQueue<T> == PriorityQueue<T>`
+   |
+   = help: the trait `PartialEq` is not implemented for `PriorityQueue<T>`
+note: required by a bound in `PartialOrd`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL | pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
+   |                                           ^^^^^^^^^^^^^^ required by this bound in `PartialOrd`
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `PriorityQueue<T>: Eq` is not satisfied
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:22
+   |
+LL | #[derive(PartialOrd, AddImpl)]
+   |                      ^^^^^^^ the trait `Eq` is not implemented for `PriorityQueue<T>`
+   |
+note: required by a bound in `Ord`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL | pub trait Ord: Eq + PartialOrd<Self> {
+   |                ^^ required by this bound in `Ord`
+   = note: this error originates in the derive macro `AddImpl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: can't compare `T` with `T`
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:22
+   |
+LL | #[derive(PartialOrd, AddImpl)]
+   |                      ^^^^^^^ no implementation for `T < T` and `T > T`
+   |
+note: required for `PriorityQueue<T>` to implement `PartialOrd`
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:10
+   |
+LL | #[derive(PartialOrd, AddImpl)]
+   |          ^^^^^^^^^^
+note: required by a bound in `Ord`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL | pub trait Ord: Eq + PartialOrd<Self> {
+   |                     ^^^^^^^^^^^^^^^^ required by this bound in `Ord`
+   = note: this error originates in the derive macro `AddImpl` which comes from the expansion of the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/traits/issue-104322.rs
+++ b/src/test/ui/traits/issue-104322.rs
@@ -1,0 +1,80 @@
+// build-pass
+//
+// Tests that overflows do not occur in certain situations
+// related to generic diesel code
+
+use mini_diesel::*;
+
+pub trait HandleDelete<K> {}
+
+pub fn handle_delete<D, R>()
+where
+    R: HasTable,
+    R::Table: HandleDelete<D> + 'static,
+{
+}
+
+impl<K, T> HandleDelete<K> for T
+where
+    T: Table + HasTable<Table = T> + 'static,
+    K: 'static,
+    &'static K: Identifiable<Table = T>,
+    T::PrimaryKey: EqAll<<&'static K as Identifiable>::Id>,
+    T::Query: FilterDsl<<T::PrimaryKey as EqAll<<&'static K as Identifiable>::Id>>::Output>,
+    Filter<T::Query, <T::PrimaryKey as EqAll<<&'static K as Identifiable>::Id>>::Output>:
+        IntoUpdateTarget<Table = T>,
+{
+}
+
+mod mini_diesel {
+    pub trait HasTable {
+        type Table: Table;
+    }
+
+    pub trait Identifiable: HasTable {
+        type Id;
+    }
+
+    pub trait EqAll<Rhs> {
+        type Output;
+    }
+
+    pub trait IntoUpdateTarget: HasTable {
+        type WhereClause;
+    }
+
+    pub trait Query {
+        type SqlType;
+    }
+
+    pub trait AsQuery {
+        type Query: Query;
+    }
+    impl<T: Query> AsQuery for T {
+        type Query = Self;
+    }
+
+    pub trait FilterDsl<Predicate> {
+        type Output;
+    }
+
+    impl<T, Predicate> FilterDsl<Predicate> for T
+    where
+        T: Table,
+        T::Query: FilterDsl<Predicate>,
+    {
+        type Output = Filter<T::Query, Predicate>;
+    }
+
+    pub trait QuerySource {
+        type FromClause;
+    }
+
+    pub trait Table: QuerySource + AsQuery + Sized {
+        type PrimaryKey;
+    }
+
+    pub type Filter<Source, Predicate> = <Source as FilterDsl<Predicate>>::Output;
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #103065 (rustdoc-json: Document and Test that args can be patterns.)
 - #104865 (Don't overwrite local changes when updating submodules)
 - #104895 (Avoid Invalid code suggested when encountering unsatisfied trait bounds in derive macro code)
 - #105063 (Rustdoc Json Tests: Don't assume that core::fmt::Debug will always have one item.)
 - #105064 (rustdoc: add comment to confusing CSS `main { min-width: 0 }`)
 - #105074 (Add Nicholas Bishop to `.mailmap`)
 - #105081 (Add a regression test for #104322)
 - #105086 (rustdoc: clean up sidebar link CSS)
 - #105091 (add Tshepang Mbambo to .mailmap)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=103065,104865,104895,105063,105064,105074,105081,105086,105091)
<!-- homu-ignore:end -->