### PR TITLE
Add missing intra-doc link

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -510,8 +510,9 @@ impl File {
     /// # Errors
     ///
     /// This function will return an error if the file is not opened for writing.
-    /// Also, std::io::ErrorKind::InvalidInput will be returned if the desired
-    /// length would cause an overflow due to the implementation specifics.
+    /// Also, [`std::io::ErrorKind::InvalidInput`](crate::io::ErrorKind::InvalidInput)
+    /// will be returned if the desired length would cause an overflow due to
+    /// the implementation specifics.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Trivial change. This makes the plain text into inline code and makes it a link.

@rustbot label +A-docs