### PR TITLE
Add example of numeric float literal without decimal point for `FromStr`

### DIFF
--- a/library/core/src/num/dec2flt/mod.rs
+++ b/library/core/src/num/dec2flt/mod.rs
@@ -110,8 +110,8 @@ macro_rules! from_str_float_impl {
             /// * '-3.14'
             /// * '2.5E10', or equivalently, '2.5e10'
             /// * '2.5E-10'
-            /// * '5.'
-            /// * '.5', or, equivalently, '0.5'
+            /// * '5.', or equivalently, '5'
+            /// * '.5', or equivalently, '0.5'
             /// * 'inf', '-inf', '+infinity', 'NaN'
             ///
             /// Note that alphabetical characters are not case-sensitive.


### PR DESCRIPTION
Reading the docs, it seemed to me that a numeric float literal had to have a decimal point. This is not the case, so I figured I'd contribute to the docs to help clarify that for future readers.

This behavior is already guaranteed by the EBNF grammar so there's no new stability guarantee.
