### PR TITLE
Fix ICE from #105101

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/default.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/default.rs
@@ -146,7 +146,7 @@ fn extract_default_variant<'a>(
                 let suggestion = default_variants
                     .iter()
                     .filter_map(|v| {
-                        if v.ident == variant.ident {
+                        if v.span == variant.span {
                             None
                         } else {
                             Some((cx.sess.find_by_name(&v.attrs, kw::Default)?.span, String::new()))

--- a/src/test/ui/deriving/issue-105101.rs
+++ b/src/test/ui/deriving/issue-105101.rs
@@ -1,0 +1,9 @@
+// compile-flags: --crate-type=lib
+
+#[derive(Default)] //~ ERROR multiple declared defaults
+enum E {
+    #[default]
+    A,
+    #[default]
+    A, //~ ERROR defined multiple times
+}

--- a/src/test/ui/deriving/issue-105101.stderr
+++ b/src/test/ui/deriving/issue-105101.stderr
@@ -1,0 +1,29 @@
+error: multiple declared defaults
+  --> $DIR/issue-105101.rs:3:10
+   |
+LL | #[derive(Default)]
+   |          ^^^^^^^
+...
+LL |     A,
+   |     - first default
+LL |     #[default]
+LL |     A,
+   |     - additional default
+   |
+   = note: only one variant can be default
+   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0428]: the name `A` is defined multiple times
+  --> $DIR/issue-105101.rs:8:5
+   |
+LL |     A,
+   |     - previous definition of the type `A` here
+LL |     #[default]
+LL |     A,
+   |     ^ `A` redefined here
+   |
+   = note: `A` must be defined only once in the type namespace of this enum
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0428`.


### PR DESCRIPTION
Fixes #105101

Rather than comparing idents, compare spans, which should be unique to each variant.