### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -211,6 +211,102 @@ pub enum TargetDataLayoutErrors<'a> {
 }
 
 impl TargetDataLayout {
+    /// Parse data layout from an [llvm data layout string](https://llvm.org/docs/LangRef.html#data-layout)
+    ///
+    /// This function doesn't fill `c_enum_min_size` and it will always be `I32` since it can not be
+    /// determined from llvm string.
+    pub fn parse_from_llvm_datalayout_string<'a>(
+        input: &'a str,
+    ) -> Result<TargetDataLayout, TargetDataLayoutErrors<'a>> {
+        // Parse an address space index from a string.
+        let parse_address_space = |s: &'a str, cause: &'a str| {
+            s.parse::<u32>().map(AddressSpace).map_err(|err| {
+                TargetDataLayoutErrors::InvalidAddressSpace { addr_space: s, cause, err }
+            })
+        };
+
+        // Parse a bit count from a string.
+        let parse_bits = |s: &'a str, kind: &'a str, cause: &'a str| {
+            s.parse::<u64>().map_err(|err| TargetDataLayoutErrors::InvalidBits {
+                kind,
+                bit: s,
+                cause,
+                err,
+            })
+        };
+
+        // Parse a size string.
+        let size = |s: &'a str, cause: &'a str| parse_bits(s, "size", cause).map(Size::from_bits);
+
+        // Parse an alignment string.
+        let align = |s: &[&'a str], cause: &'a str| {
+            if s.is_empty() {
+                return Err(TargetDataLayoutErrors::MissingAlignment { cause });
+            }
+            let align_from_bits = |bits| {
+                Align::from_bits(bits)
+                    .map_err(|err| TargetDataLayoutErrors::InvalidAlignment { cause, err })
+            };
+            let abi = parse_bits(s[0], "alignment", cause)?;
+            let pref = s.get(1).map_or(Ok(abi), |pref| parse_bits(pref, "alignment", cause))?;
+            Ok(AbiAndPrefAlign { abi: align_from_bits(abi)?, pref: align_from_bits(pref)? })
+        };
+
+        let mut dl = TargetDataLayout::default();
+        let mut i128_align_src = 64;
+        for spec in input.split('-') {
+            let spec_parts = spec.split(':').collect::<Vec<_>>();
+
+            match &*spec_parts {
+                ["e"] => dl.endian = Endian::Little,
+                ["E"] => dl.endian = Endian::Big,
+                [p] if p.starts_with('P') => {
+                    dl.instruction_address_space = parse_address_space(&p[1..], "P")?
+                }
+                ["a", ref a @ ..] => dl.aggregate_align = align(a, "a")?,
+                ["f32", ref a @ ..] => dl.f32_align = align(a, "f32")?,
+                ["f64", ref a @ ..] => dl.f64_align = align(a, "f64")?,
+                [p @ "p", s, ref a @ ..] | [p @ "p0", s, ref a @ ..] => {
+                    dl.pointer_size = size(s, p)?;
+                    dl.pointer_align = align(a, p)?;
+                }
+                [s, ref a @ ..] if s.starts_with('i') => {
+                    let Ok(bits) = s[1..].parse::<u64>() else {
+                        size(&s[1..], "i")?; // For the user error.
+                        continue;
+                    };
+                    let a = align(a, s)?;
+                    match bits {
+                        1 => dl.i1_align = a,
+                        8 => dl.i8_align = a,
+                        16 => dl.i16_align = a,
+                        32 => dl.i32_align = a,
+                        64 => dl.i64_align = a,
+                        _ => {}
+                    }
+                    if bits >= i128_align_src && bits <= 128 {
+                        // Default alignment for i128 is decided by taking the alignment of
+                        // largest-sized i{64..=128}.
+                        i128_align_src = bits;
+                        dl.i128_align = a;
+                    }
+                }
+                [s, ref a @ ..] if s.starts_with('v') => {
+                    let v_size = size(&s[1..], "v")?;
+                    let a = align(a, s)?;
+                    if let Some(v) = dl.vector_align.iter_mut().find(|v| v.0 == v_size) {
+                        v.1 = a;
+                        continue;
+                    }
+                    // No existing entry, add a new one.
+                    dl.vector_align.push((v_size, a));
+                }
+                _ => {} // Ignore everything else.
+            }
+        }
+        Ok(dl)
+    }
+
     /// Returns exclusive upper bound on object size.
     ///
     /// The theoretical maximum object size is defined as the maximum positive `isize` value.

--- a/compiler/rustc_builtin_macros/src/deriving/default.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/default.rs
@@ -146,7 +146,7 @@ fn extract_default_variant<'a>(
                 let suggestion = default_variants
                     .iter()
                     .filter_map(|v| {
-                        if v.ident == variant.ident {
+                        if v.span == variant.span {
                             None
                         } else {
                             Some((cx.sess.find_by_name(&v.attrs, kw::Default)?.span, String::new()))

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -16,6 +16,7 @@ use rustc_errors::{
 use rustc_lint_defs::builtin::PROC_MACRO_BACK_COMPAT;
 use rustc_lint_defs::{BufferedEarlyLint, BuiltinLintDiagnostics};
 use rustc_parse::{self, parser, MACRO_ARGUMENTS};
+use rustc_session::errors::report_lit_error;
 use rustc_session::{parse::ParseSess, Limit, Session};
 use rustc_span::def_id::{CrateNum, DefId, LocalDefId};
 use rustc_span::edition::Edition;
@@ -1245,7 +1246,10 @@ pub fn expr_to_spanned_string<'a>(
                 Some((err, true))
             }
             Ok(ast::LitKind::Err) => None,
-            Err(_) => None,
+            Err(err) => {
+                report_lit_error(&cx.sess.parse_sess, err, token_lit, expr.span);
+                None
+            }
             _ => Some((cx.struct_span_err(expr.span, err_msg), false)),
         },
         ast::ExprKind::Err => None,

--- a/compiler/rustc_mir_build/src/build/custom/mod.rs
+++ b/compiler/rustc_mir_build/src/build/custom/mod.rs
@@ -74,7 +74,7 @@ pub(super) fn build_custom_mir<'tcx>(
     let mut pctxt = ParseCtxt {
         tcx,
         thir,
-        source_info: SourceInfo { span, scope: OUTERMOST_SOURCE_SCOPE },
+        source_scope: OUTERMOST_SOURCE_SCOPE,
         body: &mut body,
         local_map: FxHashMap::default(),
         block_map: FxHashMap::default(),
@@ -128,7 +128,7 @@ fn parse_attribute(attr: &Attribute) -> MirPhase {
 struct ParseCtxt<'tcx, 'body> {
     tcx: TyCtxt<'tcx>,
     thir: &'body Thir<'tcx>,
-    source_info: SourceInfo,
+    source_scope: SourceScope,
 
     body: &'body mut Body<'tcx>,
     local_map: FxHashMap<LocalVarId, Local>,

--- a/compiler/rustc_mir_build/src/build/custom/parse.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse.rs
@@ -233,15 +233,23 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
         let mut data = BasicBlockData::new(None);
         for stmt_id in &*block.stmts {
             let stmt = self.statement_as_expr(*stmt_id)?;
+            let span = self.thir[stmt].span;
             let statement = self.parse_statement(stmt)?;
-            data.statements.push(Statement { source_info: self.source_info, kind: statement });
+            data.statements.push(Statement {
+                source_info: SourceInfo { span, scope: self.source_scope },
+                kind: statement,
+            });
         }
 
         let Some(trailing) = block.expr else {
             return Err(self.expr_error(expr_id, "terminator"))
         };
+        let span = self.thir[trailing].span;
         let terminator = self.parse_terminator(trailing)?;
-        data.terminator = Some(Terminator { source_info: self.source_info, kind: terminator });
+        data.terminator = Some(Terminator {
+            source_info: SourceInfo { span, scope: self.source_scope },
+            kind: terminator,
+        });
 
         Ok(data)
     }

--- a/compiler/rustc_mir_build/src/build/custom/parse.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse.rs
@@ -23,6 +23,7 @@ macro_rules! parse_by_kind {
     (
         $self:ident,
         $expr_id:expr,
+        $expr_name:pat,
         $expected:literal,
         $(
             @call($name:literal, $args:ident) => $call_expr:expr,
@@ -33,6 +34,8 @@ macro_rules! parse_by_kind {
     ) => {{
         let expr_id = $self.preparse($expr_id);
         let expr = &$self.thir[expr_id];
+        debug!("Trying to parse {:?} as {}", expr.kind, $expected);
+        let $expr_name = expr;
         match &expr.kind {
             $(
                 ExprKind::Call { ty, fun: _, args: $args, .. } if {
@@ -137,10 +140,10 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
     /// This allows us to easily parse the basic blocks declarations, local declarations, and
     /// basic block definitions in order.
     pub fn parse_body(&mut self, expr_id: ExprId) -> PResult<()> {
-        let body = parse_by_kind!(self, expr_id, "whole body",
+        let body = parse_by_kind!(self, expr_id, _, "whole body",
             ExprKind::Block { block } => self.thir[*block].expr.unwrap(),
         );
-        let (block_decls, rest) = parse_by_kind!(self, body, "body with block decls",
+        let (block_decls, rest) = parse_by_kind!(self, body, _, "body with block decls",
             ExprKind::Block { block } => {
                 let block = &self.thir[*block];
                 (&block.stmts, block.expr.unwrap())
@@ -148,7 +151,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
         );
         self.parse_block_decls(block_decls.iter().copied())?;
 
-        let (local_decls, rest) = parse_by_kind!(self, rest, "body with local decls",
+        let (local_decls, rest) = parse_by_kind!(self, rest, _, "body with local decls",
             ExprKind::Block { block } => {
                 let block = &self.thir[*block];
                 (&block.stmts, block.expr.unwrap())
@@ -156,7 +159,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
         );
         self.parse_local_decls(local_decls.iter().copied())?;
 
-        let block_defs = parse_by_kind!(self, rest, "body with block defs",
+        let block_defs = parse_by_kind!(self, rest, _, "body with block defs",
             ExprKind::Block { block } => &self.thir[*block].stmts,
         );
         for (i, block_def) in block_defs.iter().enumerate() {
@@ -223,7 +226,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
     }
 
     fn parse_block_def(&self, expr_id: ExprId) -> PResult<BasicBlockData<'tcx>> {
-        let block = parse_by_kind!(self, expr_id, "basic block",
+        let block = parse_by_kind!(self, expr_id, _, "basic block",
             ExprKind::Block { block } => &self.thir[*block],
         );
 

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -4,7 +4,7 @@ use super::{parse_by_kind, PResult, ParseCtxt};
 
 impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
     pub fn parse_statement(&self, expr_id: ExprId) -> PResult<StatementKind<'tcx>> {
-        parse_by_kind!(self, expr_id, "statement",
+        parse_by_kind!(self, expr_id, _, "statement",
             @call("mir_retag", args) => {
                 Ok(StatementKind::Retag(RetagKind::Default, Box::new(self.parse_place(args[0])?)))
             },
@@ -20,7 +20,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
     }
 
     pub fn parse_terminator(&self, expr_id: ExprId) -> PResult<TerminatorKind<'tcx>> {
-        parse_by_kind!(self, expr_id, "terminator",
+        parse_by_kind!(self, expr_id, _, "terminator",
             @call("mir_return", _args) => {
                 Ok(TerminatorKind::Return)
             },
@@ -31,7 +31,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
     }
 
     fn parse_rvalue(&self, expr_id: ExprId) -> PResult<Rvalue<'tcx>> {
-        parse_by_kind!(self, expr_id, "rvalue",
+        parse_by_kind!(self, expr_id, _, "rvalue",
             ExprKind::Borrow { borrow_kind, arg } => Ok(
                 Rvalue::Ref(self.tcx.lifetimes.re_erased, *borrow_kind, self.parse_place(*arg)?)
             ),
@@ -43,14 +43,24 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
     }
 
     fn parse_operand(&self, expr_id: ExprId) -> PResult<Operand<'tcx>> {
-        parse_by_kind!(self, expr_id, "operand",
+        parse_by_kind!(self, expr_id, expr, "operand",
             @call("mir_move", args) => self.parse_place(args[0]).map(Operand::Move),
+            ExprKind::Literal { .. }
+            | ExprKind::NamedConst { .. }
+            | ExprKind::NonHirLiteral { .. }
+            | ExprKind::ZstLiteral { .. }
+            | ExprKind::ConstParam { .. }
+            | ExprKind::ConstBlock { .. } => {
+                Ok(Operand::Constant(Box::new(
+                    crate::build::expr::as_constant::as_constant_inner(expr, |_| None, self.tcx)
+                )))
+            },
             _ => self.parse_place(expr_id).map(Operand::Copy),
         )
     }
 
     fn parse_place(&self, expr_id: ExprId) -> PResult<Place<'tcx>> {
-        parse_by_kind!(self, expr_id, "place",
+        parse_by_kind!(self, expr_id, _, "place",
             ExprKind::Deref { arg } => Ok(
                 self.parse_place(*arg)?.project_deeper(&[PlaceElem::Deref], self.tcx)
             ),
@@ -59,13 +69,13 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
     }
 
     fn parse_local(&self, expr_id: ExprId) -> PResult<Local> {
-        parse_by_kind!(self, expr_id, "local",
+        parse_by_kind!(self, expr_id, _, "local",
             ExprKind::VarRef { id } => Ok(self.local_map[id]),
         )
     }
 
     fn parse_block(&self, expr_id: ExprId) -> PResult<BasicBlock> {
-        parse_by_kind!(self, expr_id, "basic block",
+        parse_by_kind!(self, expr_id, _, "basic block",
             ExprKind::VarRef { id } => Ok(self.block_map[id]),
         )
     }

--- a/compiler/rustc_mir_build/src/build/expr/as_constant.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_constant.rs
@@ -8,7 +8,9 @@ use rustc_middle::mir::interpret::{
 };
 use rustc_middle::mir::*;
 use rustc_middle::thir::*;
-use rustc_middle::ty::{self, CanonicalUserTypeAnnotation, TyCtxt};
+use rustc_middle::ty::{
+    self, CanonicalUserType, CanonicalUserTypeAnnotation, TyCtxt, UserTypeAnnotationIndex,
+};
 use rustc_span::DUMMY_SP;
 use rustc_target::abi::Size;
 
@@ -19,84 +21,87 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let this = self;
         let tcx = this.tcx;
         let Expr { ty, temp_lifetime: _, span, ref kind } = *expr;
-        match *kind {
+        match kind {
             ExprKind::Scope { region_scope: _, lint_level: _, value } => {
-                this.as_constant(&this.thir[value])
+                this.as_constant(&this.thir[*value])
             }
-            ExprKind::Literal { lit, neg } => {
-                let literal =
-                    match lit_to_mir_constant(tcx, LitToConstInput { lit: &lit.node, ty, neg }) {
-                        Ok(c) => c,
-                        Err(LitToConstError::Reported(guar)) => {
-                            ConstantKind::Ty(tcx.const_error_with_guaranteed(ty, guar))
-                        }
-                        Err(LitToConstError::TypeError) => {
-                            bug!("encountered type error in `lit_to_mir_constant")
-                        }
-                    };
-
-                Constant { span, user_ty: None, literal }
-            }
-            ExprKind::NonHirLiteral { lit, ref user_ty } => {
-                let user_ty = user_ty.as_ref().map(|user_ty| {
-                    this.canonical_user_type_annotations.push(CanonicalUserTypeAnnotation {
+            _ => as_constant_inner(
+                expr,
+                |user_ty| {
+                    Some(this.canonical_user_type_annotations.push(CanonicalUserTypeAnnotation {
                         span,
                         user_ty: user_ty.clone(),
                         inferred_ty: ty,
-                    })
-                });
-                let literal = ConstantKind::Val(ConstValue::Scalar(Scalar::Int(lit)), ty);
-
-                Constant { span, user_ty: user_ty, literal }
-            }
-            ExprKind::ZstLiteral { ref user_ty } => {
-                let user_ty = user_ty.as_ref().map(|user_ty| {
-                    this.canonical_user_type_annotations.push(CanonicalUserTypeAnnotation {
-                        span,
-                        user_ty: user_ty.clone(),
-                        inferred_ty: ty,
-                    })
-                });
-                let literal = ConstantKind::Val(ConstValue::ZeroSized, ty);
-
-                Constant { span, user_ty: user_ty, literal }
-            }
-            ExprKind::NamedConst { def_id, substs, ref user_ty } => {
-                let user_ty = user_ty.as_ref().map(|user_ty| {
-                    this.canonical_user_type_annotations.push(CanonicalUserTypeAnnotation {
-                        span,
-                        user_ty: user_ty.clone(),
-                        inferred_ty: ty,
-                    })
-                });
-
-                let uneval =
-                    mir::UnevaluatedConst::new(ty::WithOptConstParam::unknown(def_id), substs);
-                let literal = ConstantKind::Unevaluated(uneval, ty);
-
-                Constant { user_ty, span, literal }
-            }
-            ExprKind::ConstParam { param, def_id: _ } => {
-                let const_param = tcx.mk_const(param, expr.ty);
-                let literal = ConstantKind::Ty(const_param);
-
-                Constant { user_ty: None, span, literal }
-            }
-            ExprKind::ConstBlock { did: def_id, substs } => {
-                let uneval =
-                    mir::UnevaluatedConst::new(ty::WithOptConstParam::unknown(def_id), substs);
-                let literal = ConstantKind::Unevaluated(uneval, ty);
-
-                Constant { user_ty: None, span, literal }
-            }
-            ExprKind::StaticRef { alloc_id, ty, .. } => {
-                let const_val = ConstValue::Scalar(Scalar::from_pointer(alloc_id.into(), &tcx));
-                let literal = ConstantKind::Val(const_val, ty);
-
-                Constant { span, user_ty: None, literal }
-            }
-            _ => span_bug!(span, "expression is not a valid constant {:?}", kind),
+                    }))
+                },
+                tcx,
+            ),
         }
+    }
+}
+
+pub fn as_constant_inner<'tcx>(
+    expr: &Expr<'tcx>,
+    push_cuta: impl FnMut(&Box<CanonicalUserType<'tcx>>) -> Option<UserTypeAnnotationIndex>,
+    tcx: TyCtxt<'tcx>,
+) -> Constant<'tcx> {
+    let Expr { ty, temp_lifetime: _, span, ref kind } = *expr;
+    match *kind {
+        ExprKind::Literal { lit, neg } => {
+            let literal =
+                match lit_to_mir_constant(tcx, LitToConstInput { lit: &lit.node, ty, neg }) {
+                    Ok(c) => c,
+                    Err(LitToConstError::Reported(guar)) => {
+                        ConstantKind::Ty(tcx.const_error_with_guaranteed(ty, guar))
+                    }
+                    Err(LitToConstError::TypeError) => {
+                        bug!("encountered type error in `lit_to_mir_constant")
+                    }
+                };
+
+            Constant { span, user_ty: None, literal }
+        }
+        ExprKind::NonHirLiteral { lit, ref user_ty } => {
+            let user_ty = user_ty.as_ref().map(push_cuta).flatten();
+
+            let literal = ConstantKind::Val(ConstValue::Scalar(Scalar::Int(lit)), ty);
+
+            Constant { span, user_ty: user_ty, literal }
+        }
+        ExprKind::ZstLiteral { ref user_ty } => {
+            let user_ty = user_ty.as_ref().map(push_cuta).flatten();
+
+            let literal = ConstantKind::Val(ConstValue::ZeroSized, ty);
+
+            Constant { span, user_ty: user_ty, literal }
+        }
+        ExprKind::NamedConst { def_id, substs, ref user_ty } => {
+            let user_ty = user_ty.as_ref().map(push_cuta).flatten();
+
+            let uneval = mir::UnevaluatedConst::new(ty::WithOptConstParam::unknown(def_id), substs);
+            let literal = ConstantKind::Unevaluated(uneval, ty);
+
+            Constant { user_ty, span, literal }
+        }
+        ExprKind::ConstParam { param, def_id: _ } => {
+            let const_param = tcx.mk_const(ty::ConstKind::Param(param), expr.ty);
+            let literal = ConstantKind::Ty(const_param);
+
+            Constant { user_ty: None, span, literal }
+        }
+        ExprKind::ConstBlock { did: def_id, substs } => {
+            let uneval = mir::UnevaluatedConst::new(ty::WithOptConstParam::unknown(def_id), substs);
+            let literal = ConstantKind::Unevaluated(uneval, ty);
+
+            Constant { user_ty: None, span, literal }
+        }
+        ExprKind::StaticRef { alloc_id, ty, .. } => {
+            let const_val = ConstValue::Scalar(Scalar::from_pointer(alloc_id.into(), &tcx));
+            let literal = ConstantKind::Val(const_val, ty);
+
+            Constant { span, user_ty: None, literal }
+        }
+        _ => span_bug!(span, "expression is not a valid constant {:?}", kind),
     }
 }
 

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -492,7 +492,7 @@ fn construct_fn<'tcx>(
             arguments,
             return_ty,
             return_ty_span,
-            span,
+            span_with_body,
             custom_mir_attr,
         );
     }

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -197,12 +197,12 @@ pub enum UnleashedFeatureHelp {
 
 #[derive(Diagnostic)]
 #[diag(session_invalid_literal_suffix)]
-pub(crate) struct InvalidLiteralSuffix {
+pub(crate) struct InvalidLiteralSuffix<'a> {
     #[primary_span]
     #[label]
     pub span: Span,
     // FIXME(#100717)
-    pub kind: String,
+    pub kind: &'a str,
     pub suffix: Symbol,
 }
 
@@ -311,11 +311,7 @@ pub fn report_lit_error(sess: &ParseSess, err: LitError, lit: token::Lit, span: 
         LitError::LexerError => {}
         LitError::InvalidSuffix => {
             if let Some(suffix) = suffix {
-                sess.emit_err(InvalidLiteralSuffix {
-                    span,
-                    kind: format!("{}", kind.descr()),
-                    suffix,
-                });
+                sess.emit_err(InvalidLiteralSuffix { span, kind: kind.descr(), suffix });
             }
         }
         LitError::InvalidIntSuffix => {

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -35,10 +35,7 @@
 //! to the list specified by the target, rather than replace.
 
 use crate::abi::call::Conv;
-use crate::abi::{
-    AbiAndPrefAlign, AddressSpace, Align, Endian, Integer, Size, TargetDataLayout,
-    TargetDataLayoutErrors,
-};
+use crate::abi::{Endian, Integer, Size, TargetDataLayout, TargetDataLayoutErrors};
 use crate::json::{Json, ToJson};
 use crate::spec::abi::{lookup as lookup_abi, Abi};
 use crate::spec::crt_objects::{CrtObjects, LinkSelfContainedDefault};
@@ -1322,92 +1319,7 @@ pub struct Target {
 
 impl Target {
     pub fn parse_data_layout<'a>(&'a self) -> Result<TargetDataLayout, TargetDataLayoutErrors<'a>> {
-        // Parse an address space index from a string.
-        let parse_address_space = |s: &'a str, cause: &'a str| {
-            s.parse::<u32>().map(AddressSpace).map_err(|err| {
-                TargetDataLayoutErrors::InvalidAddressSpace { addr_space: s, cause, err }
-            })
-        };
-
-        // Parse a bit count from a string.
-        let parse_bits = |s: &'a str, kind: &'a str, cause: &'a str| {
-            s.parse::<u64>().map_err(|err| TargetDataLayoutErrors::InvalidBits {
-                kind,
-                bit: s,
-                cause,
-                err,
-            })
-        };
-
-        // Parse a size string.
-        let size = |s: &'a str, cause: &'a str| parse_bits(s, "size", cause).map(Size::from_bits);
-
-        // Parse an alignment string.
-        let align = |s: &[&'a str], cause: &'a str| {
-            if s.is_empty() {
-                return Err(TargetDataLayoutErrors::MissingAlignment { cause });
-            }
-            let align_from_bits = |bits| {
-                Align::from_bits(bits)
-                    .map_err(|err| TargetDataLayoutErrors::InvalidAlignment { cause, err })
-            };
-            let abi = parse_bits(s[0], "alignment", cause)?;
-            let pref = s.get(1).map_or(Ok(abi), |pref| parse_bits(pref, "alignment", cause))?;
-            Ok(AbiAndPrefAlign { abi: align_from_bits(abi)?, pref: align_from_bits(pref)? })
-        };
-
-        let mut dl = TargetDataLayout::default();
-        let mut i128_align_src = 64;
-        for spec in self.data_layout.split('-') {
-            let spec_parts = spec.split(':').collect::<Vec<_>>();
-
-            match &*spec_parts {
-                ["e"] => dl.endian = Endian::Little,
-                ["E"] => dl.endian = Endian::Big,
-                [p] if p.starts_with('P') => {
-                    dl.instruction_address_space = parse_address_space(&p[1..], "P")?
-                }
-                ["a", ref a @ ..] => dl.aggregate_align = align(a, "a")?,
-                ["f32", ref a @ ..] => dl.f32_align = align(a, "f32")?,
-                ["f64", ref a @ ..] => dl.f64_align = align(a, "f64")?,
-                [p @ "p", s, ref a @ ..] | [p @ "p0", s, ref a @ ..] => {
-                    dl.pointer_size = size(s, p)?;
-                    dl.pointer_align = align(a, p)?;
-                }
-                [s, ref a @ ..] if s.starts_with('i') => {
-                    let Ok(bits) = s[1..].parse::<u64>() else {
-                        size(&s[1..], "i")?; // For the user error.
-                        continue;
-                    };
-                    let a = align(a, s)?;
-                    match bits {
-                        1 => dl.i1_align = a,
-                        8 => dl.i8_align = a,
-                        16 => dl.i16_align = a,
-                        32 => dl.i32_align = a,
-                        64 => dl.i64_align = a,
-                        _ => {}
-                    }
-                    if bits >= i128_align_src && bits <= 128 {
-                        // Default alignment for i128 is decided by taking the alignment of
-                        // largest-sized i{64..=128}.
-                        i128_align_src = bits;
-                        dl.i128_align = a;
-                    }
-                }
-                [s, ref a @ ..] if s.starts_with('v') => {
-                    let v_size = size(&s[1..], "v")?;
-                    let a = align(a, s)?;
-                    if let Some(v) = dl.vector_align.iter_mut().find(|v| v.0 == v_size) {
-                        v.1 = a;
-                        continue;
-                    }
-                    // No existing entry, add a new one.
-                    dl.vector_align.push((v_size, a));
-                }
-                _ => {} // Ignore everything else.
-            }
-        }
+        let mut dl = TargetDataLayout::parse_from_llvm_datalayout_string(&self.data_layout)?;
 
         // Perform consistency checks against the Target information.
         if dl.endian != self.endian {

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -151,6 +151,13 @@ pub macro __internal_extract_let {
         let $var $(: $ty)?;
         ::core::intrinsics::mir::__internal_extract_let!($($rest)*);
     },
+    // Due to #86730, we have to handle const blocks separately
+    (
+        let $var:ident $(: $ty:ty)? = const $block:block; $($rest:tt)*
+    ) => {
+        let $var $(: $ty)?;
+        ::core::intrinsics::mir::__internal_extract_let!($($rest)*);
+    },
     // Otherwise, output nothing
     (
         $stmt:stmt; $($rest:tt)*
@@ -212,6 +219,28 @@ pub macro __internal_remove_let {
             {
                 $($already_parsed)*
                 $var = $expr;
+            }
+            {
+                $($rest)*
+            }
+        }
+    )},
+    // Due to #86730 , we have to handle const blocks separately
+    (
+        {
+            {
+                $($already_parsed:tt)*
+            }
+            {
+                let $var:ident $(: $ty:ty)? = const $block:block;
+                $($rest:tt)*
+            }
+        }
+    ) => { ::core::intrinsics::mir::__internal_remove_let!(
+        {
+            {
+                $($already_parsed)*
+                $var = const $block;
             }
             {
                 $($rest)*

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -80,6 +80,8 @@ define!("mir_goto", fn Goto(destination: BasicBlock) -> BasicBlock);
 define!("mir_retag", fn Retag<T>(place: T));
 define!("mir_retag_raw", fn RetagRaw<T>(place: T));
 define!("mir_move", fn Move<T>(place: T) -> T);
+define!("mir_static", fn Static<T>(s: T) -> &'static T);
+define!("mir_static_mut", fn StaticMut<T>(s: T) -> *mut T);
 
 /// Convenience macro for generating custom MIR.
 ///

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -896,7 +896,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
-	display: block;
 }
 
 .search-results a:hover,

--- a/src/test/codegen/dllimports/main.rs
+++ b/src/test/codegen/dllimports/main.rs
@@ -1,17 +1,5 @@
 // This test is for *-windows-msvc only.
-// ignore-android
-// ignore-dragonfly
-// ignore-emscripten
-// ignore-freebsd
-// ignore-gnu
-// ignore-haiku
-// ignore-ios
-// ignore-linux
-// ignore-macos
-// ignore-netbsd
-// ignore-openbsd
-// ignore-solaris
-// ignore-sgx no dynamic linking
+// only-windows
 
 // aux-build:dummy.rs
 // aux-build:wrapper.rs

--- a/src/test/codegen/panic-abort-windows.rs
+++ b/src/test/codegen/panic-abort-windows.rs
@@ -1,16 +1,5 @@
 // This test is for *-windows-msvc only.
-// ignore-android
-// ignore-dragonfly
-// ignore-emscripten
-// ignore-freebsd
-// ignore-haiku
-// ignore-ios
-// ignore-linux
-// ignore-macos
-// ignore-netbsd
-// ignore-openbsd
-// ignore-solaris
-// ignore-sgx
+// only-windows
 
 // compile-flags: -C no-prepopulate-passes -C panic=abort -O
 

--- a/src/test/mir-opt/building/custom/arbitrary_let.arbitrary_let.built.after.mir
+++ b/src/test/mir-opt/building/custom/arbitrary_let.arbitrary_let.built.after.mir
@@ -1,0 +1,22 @@
+// MIR for `arbitrary_let` after built
+
+fn arbitrary_let(_1: i32) -> i32 {
+    let mut _0: i32;                     // return place in scope 0 at $DIR/arbitrary_let.rs:+0:29: +0:32
+    let mut _2: i32;                     // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+    let mut _3: i32;                     // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+
+    bb0: {
+        _2 = _1;                         // scope 0 at $DIR/arbitrary_let.rs:+0:1: +0:32
+        goto -> bb2;                     // scope 0 at $DIR/arbitrary_let.rs:+0:1: +0:32
+    }
+
+    bb1: {
+        _0 = _3;                         // scope 0 at $DIR/arbitrary_let.rs:+0:1: +0:32
+        return;                          // scope 0 at $DIR/arbitrary_let.rs:+0:1: +0:32
+    }
+
+    bb2: {
+        _3 = _2;                         // scope 0 at $DIR/arbitrary_let.rs:+0:1: +0:32
+        goto -> bb1;                     // scope 0 at $DIR/arbitrary_let.rs:+0:1: +0:32
+    }
+}

--- a/src/test/mir-opt/building/custom/arbitrary_let.arbitrary_let.built.after.mir
+++ b/src/test/mir-opt/building/custom/arbitrary_let.arbitrary_let.built.after.mir
@@ -6,17 +6,17 @@ fn arbitrary_let(_1: i32) -> i32 {
     let mut _3: i32;                     // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
 
     bb0: {
-        _2 = _1;                         // scope 0 at $DIR/arbitrary_let.rs:+0:1: +0:32
-        goto -> bb2;                     // scope 0 at $DIR/arbitrary_let.rs:+0:1: +0:32
+        _2 = _1;                         // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+        goto -> bb2;                     // scope 0 at $DIR/arbitrary_let.rs:+4:13: +4:25
     }
 
     bb1: {
-        _0 = _3;                         // scope 0 at $DIR/arbitrary_let.rs:+0:1: +0:32
-        return;                          // scope 0 at $DIR/arbitrary_let.rs:+0:1: +0:32
+        _0 = _3;                         // scope 0 at $DIR/arbitrary_let.rs:+7:13: +7:20
+        return;                          // scope 0 at $DIR/arbitrary_let.rs:+8:13: +8:21
     }
 
     bb2: {
-        _3 = _2;                         // scope 0 at $DIR/arbitrary_let.rs:+0:1: +0:32
-        goto -> bb1;                     // scope 0 at $DIR/arbitrary_let.rs:+0:1: +0:32
+        _3 = _2;                         // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+        goto -> bb1;                     // scope 0 at $DIR/arbitrary_let.rs:+12:13: +12:24
     }
 }

--- a/src/test/mir-opt/building/custom/arbitrary_let.rs
+++ b/src/test/mir-opt/building/custom/arbitrary_let.rs
@@ -1,0 +1,28 @@
+#![feature(custom_mir, core_intrinsics)]
+
+extern crate core;
+use core::intrinsics::mir::*;
+use core::ptr::{addr_of, addr_of_mut};
+
+// EMIT_MIR arbitrary_let.arbitrary_let.built.after.mir
+#[custom_mir(dialect = "built")]
+fn arbitrary_let(x: i32) -> i32 {
+    mir!(
+        {
+            let y = x;
+            Goto(second)
+        }
+        third = {
+            RET = z;
+            Return()
+        }
+        second = {
+            let z = y;
+            Goto(third)
+        }
+    )
+}
+
+fn main() {
+    assert_eq!(arbitrary_let(5), 5);
+}

--- a/src/test/mir-opt/building/custom/consts.consts.built.after.mir
+++ b/src/test/mir-opt/building/custom/consts.consts.built.after.mir
@@ -1,0 +1,22 @@
+// MIR for `consts` after built
+
+fn consts() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/consts.rs:10:27: 10:27
+    let mut _1: u8;                      // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+    let mut _2: i8;                      // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+    let mut _3: u32;                     // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+    let mut _4: i32;                     // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+    let mut _5: fn() {consts::<10>};     // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+
+    bb0: {
+        _1 = const 5_u8;                 // scope 0 at $DIR/consts.rs:+0:1: +0:26
+        _2 = const _;                    // scope 0 at $DIR/consts.rs:+0:1: +0:26
+        _3 = const C;                    // scope 0 at $DIR/consts.rs:+0:1: +0:26
+        _4 = const _;                    // scope 0 at $DIR/consts.rs:+0:1: +0:26
+        _5 = consts::<10>;               // scope 0 at $DIR/consts.rs:+0:1: +0:26
+                                         // mir::Constant
+                                         // + span: $DIR/consts.rs:16:18: 16:30
+                                         // + literal: Const { ty: fn() {consts::<10>}, val: Value(<ZST>) }
+        return;                          // scope 0 at $DIR/consts.rs:+0:1: +0:26
+    }
+}

--- a/src/test/mir-opt/building/custom/consts.consts.built.after.mir
+++ b/src/test/mir-opt/building/custom/consts.consts.built.after.mir
@@ -1,7 +1,7 @@
 // MIR for `consts` after built
 
 fn consts() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/consts.rs:10:27: 10:27
+    let mut _0: ();                      // return place in scope 0 at $DIR/consts.rs:+0:27: +0:27
     let mut _1: u8;                      // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
     let mut _2: i8;                      // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
     let mut _3: u32;                     // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
@@ -9,14 +9,14 @@ fn consts() -> () {
     let mut _5: fn() {consts::<10>};     // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
 
     bb0: {
-        _1 = const 5_u8;                 // scope 0 at $DIR/consts.rs:+0:1: +0:26
-        _2 = const _;                    // scope 0 at $DIR/consts.rs:+0:1: +0:26
-        _3 = const C;                    // scope 0 at $DIR/consts.rs:+0:1: +0:26
-        _4 = const _;                    // scope 0 at $DIR/consts.rs:+0:1: +0:26
-        _5 = consts::<10>;               // scope 0 at $DIR/consts.rs:+0:1: +0:26
+        _1 = const 5_u8;                 // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+        _2 = const _;                    // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+        _3 = const C;                    // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+        _4 = const _;                    // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+        _5 = consts::<10>;               // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
                                          // mir::Constant
                                          // + span: $DIR/consts.rs:16:18: 16:30
                                          // + literal: Const { ty: fn() {consts::<10>}, val: Value(<ZST>) }
-        return;                          // scope 0 at $DIR/consts.rs:+0:1: +0:26
+        return;                          // scope 0 at $DIR/consts.rs:+7:9: +7:17
     }
 }

--- a/src/test/mir-opt/building/custom/consts.rs
+++ b/src/test/mir-opt/building/custom/consts.rs
@@ -1,0 +1,23 @@
+#![feature(custom_mir, core_intrinsics, inline_const)]
+
+extern crate core;
+use core::intrinsics::mir::*;
+
+const D: i32 = 5;
+
+// EMIT_MIR consts.consts.built.after.mir
+#[custom_mir(dialect = "built")]
+fn consts<const C: u32>() {
+    mir!({
+        let _a = 5_u8;
+        let _b = const { 5_i8 };
+        let _c = C;
+        let _d = D;
+        let _e = consts::<10>;
+        Return()
+    })
+}
+
+fn main() {
+    consts::<5>();
+}

--- a/src/test/mir-opt/building/custom/consts.rs
+++ b/src/test/mir-opt/building/custom/consts.rs
@@ -18,6 +18,19 @@ fn consts<const C: u32>() {
     })
 }
 
+static S: i32 = 5;
+static mut T: i32 = 10;
+// EMIT_MIR consts.statics.built.after.mir
+#[custom_mir(dialect = "built")]
+fn statics() {
+    mir!({
+        let _a: &i32 = Static(S);
+        let _b: *mut i32 = StaticMut(T);
+        Return()
+    })
+}
+
 fn main() {
     consts::<5>();
+    statics();
 }

--- a/src/test/mir-opt/building/custom/consts.statics.built.after.mir
+++ b/src/test/mir-opt/building/custom/consts.statics.built.after.mir
@@ -1,0 +1,27 @@
+// MIR for `statics` after built
+
+fn statics() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/consts.rs:25:14: 25:14
+    let mut _1: &i32;                    // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+    let mut _2: *mut i32;                // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+
+    bb0: {
+        _1 = const {alloc1: &i32};       // scope 0 at $DIR/consts.rs:+0:1: +0:13
+                                         // mir::Constant
+                                         // + span: $DIR/consts.rs:27:31: 27:32
+                                         // + literal: Const { ty: &i32, val: Value(Scalar(alloc1)) }
+        _2 = const {alloc2: *mut i32};   // scope 0 at $DIR/consts.rs:+0:1: +0:13
+                                         // mir::Constant
+                                         // + span: $DIR/consts.rs:28:38: 28:39
+                                         // + literal: Const { ty: *mut i32, val: Value(Scalar(alloc2)) }
+        return;                          // scope 0 at $DIR/consts.rs:+0:1: +0:13
+    }
+}
+
+alloc2 (static: T, size: 4, align: 4) {
+    0a 00 00 00                                     │ ....
+}
+
+alloc1 (static: S, size: 4, align: 4) {
+    05 00 00 00                                     │ ....
+}

--- a/src/test/mir-opt/building/custom/consts.statics.built.after.mir
+++ b/src/test/mir-opt/building/custom/consts.statics.built.after.mir
@@ -1,20 +1,20 @@
 // MIR for `statics` after built
 
 fn statics() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/consts.rs:25:14: 25:14
+    let mut _0: ();                      // return place in scope 0 at $DIR/consts.rs:+0:14: +0:14
     let mut _1: &i32;                    // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
     let mut _2: *mut i32;                // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
 
     bb0: {
-        _1 = const {alloc1: &i32};       // scope 0 at $DIR/consts.rs:+0:1: +0:13
+        _1 = const {alloc1: &i32};       // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
                                          // mir::Constant
                                          // + span: $DIR/consts.rs:27:31: 27:32
                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc1)) }
-        _2 = const {alloc2: *mut i32};   // scope 0 at $DIR/consts.rs:+0:1: +0:13
+        _2 = const {alloc2: *mut i32};   // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
                                          // mir::Constant
                                          // + span: $DIR/consts.rs:28:38: 28:39
                                          // + literal: Const { ty: *mut i32, val: Value(Scalar(alloc2)) }
-        return;                          // scope 0 at $DIR/consts.rs:+0:1: +0:13
+        return;                          // scope 0 at $DIR/consts.rs:+4:9: +4:17
     }
 }
 

--- a/src/test/mir-opt/building/custom/references.immut_ref.built.after.mir
+++ b/src/test/mir-opt/building/custom/references.immut_ref.built.after.mir
@@ -5,10 +5,10 @@ fn immut_ref(_1: &i32) -> &i32 {
     let mut _2: *const i32;              // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
 
     bb0: {
-        _2 = &raw const (*_1);           // scope 0 at $DIR/references.rs:+0:1: +0:34
-        Retag([raw] _2);                 // scope 0 at $DIR/references.rs:+0:1: +0:34
-        _0 = &(*_2);                     // scope 0 at $DIR/references.rs:+0:1: +0:34
-        Retag(_0);                       // scope 0 at $DIR/references.rs:+0:1: +0:34
-        return;                          // scope 0 at $DIR/references.rs:+0:1: +0:34
+        _2 = &raw const (*_1);           // scope 0 at $DIR/references.rs:+5:13: +5:29
+        Retag([raw] _2);                 // scope 0 at $DIR/references.rs:+6:13: +6:24
+        _0 = &(*_2);                     // scope 0 at $DIR/references.rs:+7:13: +7:23
+        Retag(_0);                       // scope 0 at $DIR/references.rs:+8:13: +8:23
+        return;                          // scope 0 at $DIR/references.rs:+9:13: +9:21
     }
 }

--- a/src/test/mir-opt/building/custom/references.mut_ref.built.after.mir
+++ b/src/test/mir-opt/building/custom/references.mut_ref.built.after.mir
@@ -5,10 +5,10 @@ fn mut_ref(_1: &mut i32) -> &mut i32 {
     let mut _2: *mut i32;                // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
 
     bb0: {
-        _2 = &raw mut (*_1);             // scope 0 at $DIR/references.rs:+0:1: +0:40
-        Retag([raw] _2);                 // scope 0 at $DIR/references.rs:+0:1: +0:40
-        _0 = &mut (*_2);                 // scope 0 at $DIR/references.rs:+0:1: +0:40
-        Retag(_0);                       // scope 0 at $DIR/references.rs:+0:1: +0:40
-        return;                          // scope 0 at $DIR/references.rs:+0:1: +0:40
+        _2 = &raw mut (*_1);             // scope 0 at $DIR/references.rs:+5:13: +5:33
+        Retag([raw] _2);                 // scope 0 at $DIR/references.rs:+6:13: +6:24
+        _0 = &mut (*_2);                 // scope 0 at $DIR/references.rs:+7:13: +7:26
+        Retag(_0);                       // scope 0 at $DIR/references.rs:+8:13: +8:23
+        return;                          // scope 0 at $DIR/references.rs:+9:13: +9:21
     }
 }

--- a/src/test/mir-opt/building/custom/simple_assign.simple.built.after.mir
+++ b/src/test/mir-opt/building/custom/simple_assign.simple.built.after.mir
@@ -6,13 +6,13 @@ fn simple(_1: i32) -> i32 {
     let mut _3: i32;                     // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
 
     bb0: {
-        _2 = _1;                         // scope 0 at $DIR/simple_assign.rs:+0:1: +0:29
-        goto -> bb1;                     // scope 0 at $DIR/simple_assign.rs:+0:1: +0:29
+        _2 = _1;                         // scope 0 at $DIR/simple_assign.rs:+6:13: +6:22
+        goto -> bb1;                     // scope 0 at $DIR/simple_assign.rs:+7:13: +7:23
     }
 
     bb1: {
-        _3 = move _2;                    // scope 0 at $DIR/simple_assign.rs:+0:1: +0:29
-        _0 = _3;                         // scope 0 at $DIR/simple_assign.rs:+0:1: +0:29
-        return;                          // scope 0 at $DIR/simple_assign.rs:+0:1: +0:29
+        _3 = move _2;                    // scope 0 at $DIR/simple_assign.rs:+11:13: +11:32
+        _0 = _3;                         // scope 0 at $DIR/simple_assign.rs:+12:13: +12:24
+        return;                          // scope 0 at $DIR/simple_assign.rs:+13:13: +13:21
     }
 }

--- a/src/test/mir-opt/building/custom/simple_assign.simple_ref.built.after.mir
+++ b/src/test/mir-opt/building/custom/simple_assign.simple_ref.built.after.mir
@@ -4,7 +4,7 @@ fn simple_ref(_1: &mut i32) -> &mut i32 {
     let mut _0: &mut i32;                // return place in scope 0 at $DIR/simple_assign.rs:+0:35: +0:43
 
     bb0: {
-        _0 = move _1;                    // scope 0 at $DIR/simple_assign.rs:+0:1: +0:43
-        return;                          // scope 0 at $DIR/simple_assign.rs:+0:1: +0:43
+        _0 = move _1;                    // scope 0 at $DIR/simple_assign.rs:+2:9: +2:22
+        return;                          // scope 0 at $DIR/simple_assign.rs:+3:9: +3:17
     }
 }

--- a/src/test/ui/deriving/issue-105101.rs
+++ b/src/test/ui/deriving/issue-105101.rs
@@ -1,0 +1,9 @@
+// compile-flags: --crate-type=lib
+
+#[derive(Default)] //~ ERROR multiple declared defaults
+enum E {
+    #[default]
+    A,
+    #[default]
+    A, //~ ERROR defined multiple times
+}

--- a/src/test/ui/deriving/issue-105101.stderr
+++ b/src/test/ui/deriving/issue-105101.stderr
@@ -1,0 +1,29 @@
+error: multiple declared defaults
+  --> $DIR/issue-105101.rs:3:10
+   |
+LL | #[derive(Default)]
+   |          ^^^^^^^
+...
+LL |     A,
+   |     - first default
+LL |     #[default]
+LL |     A,
+   |     - additional default
+   |
+   = note: only one variant can be default
+   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0428]: the name `A` is defined multiple times
+  --> $DIR/issue-105101.rs:8:5
+   |
+LL |     A,
+   |     - previous definition of the type `A` here
+LL |     #[default]
+LL |     A,
+   |     ^ `A` redefined here
+   |
+   = note: `A` must be defined only once in the type namespace of this enum
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0428`.

--- a/src/test/ui/macros/issue-105011.rs
+++ b/src/test/ui/macros/issue-105011.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!(""y); //~ ERROR suffixes on string literals are invalid
+}

--- a/src/test/ui/macros/issue-105011.stderr
+++ b/src/test/ui/macros/issue-105011.stderr
@@ -1,0 +1,8 @@
+error: suffixes on string literals are invalid
+  --> $DIR/issue-105011.rs:2:14
+   |
+LL |     println!(""y);
+   |              ^^^ invalid suffix `y`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #104975 (`#![custom_mir]`: Various improvements)
 - #105003 (Run Windows-only tests only on Windows)
 - #105078 (Fix `expr_to_spanned_string` ICE)
 - #105087 (Extract llvm datalayout parsing out of spec module)
 - #105088 (rustdoc: remove redundant CSS `div.desc { display: block }`)
 - #105106 (Fix ICE from #105101)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=104975,105003,105078,105087,105088,105106)
<!-- homu-ignore:end -->