### PR TITLE
Make inline const block `ExprWithBlock`

### DIFF
--- a/compiler/rustc_ast/src/util/classify.rs
+++ b/compiler/rustc_ast/src/util/classify.rs
@@ -21,6 +21,7 @@ pub fn expr_requires_semi_to_be_stmt(e: &ast::Expr) -> bool {
             | ast::ExprKind::Loop(..)
             | ast::ExprKind::ForLoop(..)
             | ast::ExprKind::TryBlock(..)
+            | ast::ExprKind::ConstBlock(..)
     )
 }
 

--- a/src/test/ui/inline-const/expr-with-block-err.rs
+++ b/src/test/ui/inline-const/expr-with-block-err.rs
@@ -1,0 +1,6 @@
+#![feature(inline_const)]
+
+fn main() {
+    const { 2 } - const { 1 };
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/inline-const/expr-with-block-err.stderr
+++ b/src/test/ui/inline-const/expr-with-block-err.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/expr-with-block-err.rs:4:13
+   |
+LL |     const { 2 } - const { 1 };
+   |             ^ expected `()`, found integer
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/inline-const/expr-with-block.rs
+++ b/src/test/ui/inline-const/expr-with-block.rs
@@ -1,0 +1,10 @@
+// check-pass
+#![feature(inline_const)]
+fn main() {
+    match true {
+        true => const {}
+        false => ()
+    }
+    const {}
+    ()
+}


### PR DESCRIPTION
Fix https://github.com/rust-lang/rust/pull/104087#issuecomment-1324190817

@rustbot label: +T-lang +F-inline_const