### PR TITLE
Properly synthesize `FnSig` value during cycle

### DIFF
--- a/src/test/ui/query-system/fn-sig-cycle-arity.rs
+++ b/src/test/ui/query-system/fn-sig-cycle-arity.rs
@@ -1,0 +1,8 @@
+trait Dancer {
+    fn dance(&self) -> _ {
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+        self.dance()
+    }
+}
+
+fn main() {}

--- a/src/test/ui/query-system/fn-sig-cycle-arity.stderr
+++ b/src/test/ui/query-system/fn-sig-cycle-arity.stderr
@@ -1,0 +1,9 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/fn-sig-cycle-arity.rs:2:24
+   |
+LL |     fn dance(&self) -> _ {
+   |                        ^ not allowed in type signatures
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
Get the arity correct when creating a `FnSig` type during `tcx.fn_sig` cycle recovery

Fixes #105152