### PR TITLE
Restore `use` suggestion for `dyn` method call requiring `Sized`

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -20,7 +20,7 @@ use rustc_hir::def_id::DefId;
 use rustc_infer::infer::{self, InferOk};
 use rustc_middle::traits::ObligationCause;
 use rustc_middle::ty::subst::{InternalSubsts, SubstsRef};
-use rustc_middle::ty::{self, DefIdTree, GenericParamDefKind, Ty, TypeVisitable};
+use rustc_middle::ty::{self, GenericParamDefKind, Ty, TypeVisitable};
 use rustc_span::symbol::Ident;
 use rustc_span::Span;
 use rustc_trait_selection::traits;
@@ -217,7 +217,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
 
             // We probe again, taking all traits into account (not only those in scope).
-            let mut candidates =
+            let candidates =
                 match self.lookup_probe(segment.ident, self_ty, call_expr, ProbeScope::AllTraits) {
                     // If we find a different result the caller probably forgot to import a trait.
                     Ok(ref new_pick) if pick.differs_from(new_pick) => {
@@ -236,7 +236,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         .collect(),
                     _ => Vec::new(),
                 };
-            candidates.retain(|candidate| *candidate != self.tcx.parent(result.callee.def_id));
 
             return Err(IllegalSizedBound(candidates, needs_mut, span));
         }

--- a/src/test/ui/issues/issue-35976.rs
+++ b/src/test/ui/issues/issue-35976.rs
@@ -1,5 +1,9 @@
+// revisions: imported unimported
+//[imported] check-pass
+
 mod private {
     pub trait Future {
+        //[unimported]~^^ HELP perhaps add a `use` for it
         fn wait(&self) where Self: Sized;
     }
 
@@ -8,13 +12,13 @@ mod private {
     }
 }
 
-//use private::Future;
+#[cfg(imported)]
+use private::Future;
 
 fn bar(arg: Box<dyn private::Future>) {
+    // Importing the trait means that we don't autoderef `Box<dyn Future>`
     arg.wait();
-    //~^ ERROR the `wait` method cannot be invoked on a trait object
+    //[unimported]~^ ERROR the `wait` method cannot be invoked on a trait object
 }
 
-fn main() {
-
-}
+fn main() {}

--- a/src/test/ui/issues/issue-35976.unimported.stderr
+++ b/src/test/ui/issues/issue-35976.unimported.stderr
@@ -1,11 +1,16 @@
 error: the `wait` method cannot be invoked on a trait object
-  --> $DIR/issue-35976.rs:14:9
+  --> $DIR/issue-35976.rs:20:9
    |
 LL |         fn wait(&self) where Self: Sized;
    |                                    ----- this has a `Sized` requirement
 ...
 LL |     arg.wait();
    |         ^^^^
+   |
+help: another candidate was found in the following trait, perhaps add a `use` for it:
+   |
+LL | use private::Future;
+   |
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Add the suggestion back that I accidentally removed in 88f2140d8736329610a4c0bd8000e164c9170537 because I didn't understand that suggestion was actually useful...

Fixes #105159