### PR TITLE
Convert Operand::Move to Operand::Copy

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -74,6 +74,7 @@ mod instcombine;
 mod lower_intrinsics;
 mod lower_slice_len;
 mod match_branches;
+mod move_to_copy;
 mod multiple_return_terminators;
 mod normalize_array_len;
 mod nrvo;
@@ -557,6 +558,7 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             &normalize_array_len::NormalizeArrayLen, // has to run after `slice::len` lowering
             &unreachable_prop::UnreachablePropagation,
             &uninhabited_enum_branching::UninhabitedEnumBranching,
+            &move_to_copy::MoveToCopy,
             &o1(simplify::SimplifyCfg::new("after-uninhabited-enum-branching")),
             &inline::Inline,
             &remove_storage_markers::RemoveStorageMarkers,

--- a/compiler/rustc_mir_transform/src/move_to_copy.rs
+++ b/compiler/rustc_mir_transform/src/move_to_copy.rs
@@ -1,0 +1,97 @@
+use crate::MirPass;
+use rustc_middle::mir::visit::MutVisitor;
+use rustc_middle::mir::*;
+use rustc_middle::ty::{FnDef, TyCtxt};
+
+/// Within-block replacement empowers ConstProp, DataflowConstProp, and DestProp. (based on looking
+/// at the tests)
+///
+/// SwitchInt replacement causes some basic blocks which only contain a goto to be deleted. (based
+/// on looking at core and alloc)
+/// It also makes EarlyOtherwiseBranch much more effective, but that pass is currently marked as
+/// unsound so this effect is not useful yet.
+///
+/// At time of writing, Assert replacement has no effect. Most likely we don't often need the
+/// asserted predicate for anything else, and aren't smart enough to optimize into a form that
+/// could use it anyway.
+///
+/// Enabling this pass for Call arguments breaks the moved-from local reuse optimization that
+/// Inline does, so without DestinationPropagation, modifying call arguments is just a regression.
+/// Except for calls to intrinsics, because those cannot be inlined.
+pub struct MoveToCopy;
+
+impl<'tcx> MirPass<'tcx> for MoveToCopy {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        let mut visitor = MoveToCopyVisitor { tcx };
+        let mut call_visitor = MoveToCopyCallVisitor { tcx, local_decls: &body.local_decls };
+        for (block, block_data) in body.basic_blocks.as_mut().iter_enumerated_mut() {
+            for (statement_index, statement) in block_data.statements.iter_mut().enumerate() {
+                visitor.visit_statement(statement, Location { block, statement_index });
+            }
+            let Some(terminator) = &mut block_data.terminator else {
+                continue;
+            };
+            match &terminator.kind {
+                TerminatorKind::SwitchInt { .. } | TerminatorKind::Assert { .. } => {
+                    visitor.visit_terminator(
+                        terminator,
+                        Location { block, statement_index: block_data.statements.len() },
+                    );
+                }
+                TerminatorKind::Call { func, .. } => {
+                    let func_ty = func.ty(call_visitor.local_decls, tcx);
+                    let is_intrinsic = if let FnDef(def_id, _) = *func_ty.kind() {
+                        tcx.is_intrinsic(def_id)
+                    } else {
+                        false
+                    };
+                    if is_intrinsic || tcx.sess.mir_opt_level() >= 3 {
+                        call_visitor.visit_terminator(
+                            terminator,
+                            Location { block, statement_index: block_data.statements.len() },
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+struct MoveToCopyCallVisitor<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    local_decls: &'a LocalDecls<'tcx>,
+}
+
+impl<'a, 'tcx> MutVisitor<'tcx> for MoveToCopyCallVisitor<'a, 'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
+    fn visit_operand(&mut self, operand: &mut Operand<'tcx>, location: Location) {
+        if let Operand::Move(place) = operand {
+            let ty = place.ty(self.local_decls, self.tcx).ty;
+            if ty.is_numeric() || ty.is_bool() || ty.is_char() {
+                *operand = Operand::Copy(*place);
+            }
+        }
+        self.super_operand(operand, location);
+    }
+}
+
+struct MoveToCopyVisitor<'tcx> {
+    tcx: TyCtxt<'tcx>,
+}
+
+impl<'tcx> MutVisitor<'tcx> for MoveToCopyVisitor<'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
+    fn visit_operand(&mut self, operand: &mut Operand<'tcx>, location: Location) {
+        if let Operand::Move(place) = operand {
+            *operand = Operand::Copy(*place);
+        }
+        self.super_operand(operand, location);
+    }
+}

--- a/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
@@ -8,11 +8,11 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/76803_regression.rs:+1:11: +1:12
-          switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/76803_regression.rs:+1:5: +1:12
+          switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/76803_regression.rs:+1:5: +1:12
       }
   
       bb1: {
-          _0 = move _1;                    // scope 0 at $DIR/76803_regression.rs:+3:14: +3:15
+          _0 = _1;                         // scope 0 at $DIR/76803_regression.rs:+3:14: +3:15
           goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:+3:14: +3:15
       }
   

--- a/src/test/mir-opt/bool_compare.opt1.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt1.InstCombine.diff
@@ -11,10 +11,10 @@
           StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
           StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:+1:8: +1:9
--         _2 = Ne(move _3, const true);    // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
-+         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
+-         _2 = Ne(_3, const true);         // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
++         _2 = Not(_3);                    // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
           StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
-          switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
+          switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
       }
   
       bb1: {

--- a/src/test/mir-opt/bool_compare.opt2.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt2.InstCombine.diff
@@ -11,10 +11,10 @@
           StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
           StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
           _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
--         _2 = Ne(const true, move _3);    // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
-+         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
+-         _2 = Ne(const true, _3);         // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
++         _2 = Not(_3);                    // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
           StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
-          switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
+          switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
       }
   
       bb1: {

--- a/src/test/mir-opt/bool_compare.opt3.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt3.InstCombine.diff
@@ -11,10 +11,10 @@
           StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
           StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:+1:8: +1:9
--         _2 = Eq(move _3, const false);   // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
-+         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
+-         _2 = Eq(_3, const false);        // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
++         _2 = Not(_3);                    // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
           StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
-          switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
+          switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
       }
   
       bb1: {

--- a/src/test/mir-opt/bool_compare.opt4.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt4.InstCombine.diff
@@ -11,10 +11,10 @@
           StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
           StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
           _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
--         _2 = Eq(const false, move _3);   // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
-+         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
+-         _2 = Eq(const false, _3);        // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
++         _2 = Not(_3);                    // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
           StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
-          switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
+          switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
       }
   
       bb1: {

--- a/src/test/mir-opt/combine_array_len.norm2.InstCombine.diff
+++ b/src/test/mir-opt/combine_array_len.norm2.InstCombine.diff
@@ -32,7 +32,7 @@
 -         _4 = Len(_1);                    // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
 +         _4 = const 2_usize;              // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
           _5 = Lt(_3, _4);                 // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
-          assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
+          assert(_5, "index out of bounds: the length is {} but the index is {}", _4, _3) -> bb1; // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
       }
   
       bb1: {
@@ -44,7 +44,7 @@
 -         _8 = Len(_1);                    // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
 +         _8 = const 2_usize;              // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
           _9 = Lt(_7, _8);                 // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
-          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
+          assert(_9, "index out of bounds: the length is {} but the index is {}", _8, _7) -> bb2; // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
       }
   
       bb2: {
@@ -55,7 +55,7 @@
           _11 = _2;                        // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:6
           StorageLive(_12);                // scope 2 at $DIR/combine_array_len.rs:+3:7: +3:8
           _12 = _2;                        // scope 2 at $DIR/combine_array_len.rs:+3:7: +3:8
-          _10 = Mul(move _11, move _12);   // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:8
+          _10 = Mul(_11, _12);             // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:8
           StorageDead(_12);                // scope 2 at $DIR/combine_array_len.rs:+3:7: +3:8
           StorageDead(_11);                // scope 2 at $DIR/combine_array_len.rs:+3:7: +3:8
           StorageLive(_13);                // scope 2 at $DIR/combine_array_len.rs:+3:11: +3:14
@@ -63,10 +63,10 @@
           _14 = _6;                        // scope 2 at $DIR/combine_array_len.rs:+3:11: +3:12
           StorageLive(_15);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
           _15 = _6;                        // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
-          _13 = Mul(move _14, move _15);   // scope 2 at $DIR/combine_array_len.rs:+3:11: +3:14
+          _13 = Mul(_14, _15);             // scope 2 at $DIR/combine_array_len.rs:+3:11: +3:14
           StorageDead(_15);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
           StorageDead(_14);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
-          _0 = Add(move _10, move _13);    // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:14
+          _0 = Add(_10, _13);              // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:14
           StorageDead(_13);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
           StorageDead(_10);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
           StorageDead(_6);                 // scope 1 at $DIR/combine_array_len.rs:+4:1: +4:2

--- a/src/test/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstCombine.diff
+++ b/src/test/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstCombine.diff
@@ -62,9 +62,9 @@
       bb3: {
           StorageDead(_9);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:10:15: 10:16
           Deinit(_0);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
-          (_0.0: T) = move _2;             // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
-          (_0.1: u64) = move _5;           // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
-          (_0.2: [f32; 3]) = move _8;      // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
+          (_0.0: T) = _2;                  // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
+          (_0.1: u64) = _5;                // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
+          (_0.2: [f32; 3]) = _8;           // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
           StorageDead(_8);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15
           StorageDead(_5);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15
           StorageDead(_2);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15

--- a/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
@@ -11,9 +11,9 @@
       bb0: {
 -         StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -         _3 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:+1:17: +1:20
--         switchInt(move _3) -> [1: bb2, 2: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         switchInt(_3) -> [1: bb2, 2: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         _2 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:+1:17: +1:20
-+         switchInt(move _2) -> [1: bb2, 2: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
++         switchInt(_2) -> [1: bb2, 2: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
       bb1: {
@@ -29,7 +29,7 @@
 -     }
 - 
 -     bb3: {
--         switchInt(move _2) -> [0: bb5, otherwise: bb4]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         switchInt(_2) -> [0: bb5, otherwise: bb4]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
 -     bb4: {

--- a/src/test/mir-opt/const_goto_storage.match_nested_if.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto_storage.match_nested_if.ConstGoto.diff
@@ -23,10 +23,10 @@
 -         StorageLive(_5);                 // scope 0 at $DIR/const_goto_storage.rs:+2:21: +2:52
 -         StorageLive(_6);                 // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
 -         _6 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
--         switchInt(move _6) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
+-         switchInt(_6) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
 +         StorageLive(_2);                 // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
 +         _2 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
-+         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
++         switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
       }
   
       bb1: {
@@ -41,7 +41,7 @@
 - 
 -     bb3: {
 -         StorageDead(_6);                 // scope 0 at $DIR/const_goto_storage.rs:+2:51: +2:52
--         switchInt(move _5) -> [0: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto_storage.rs:+2:21: +2:52
+-         switchInt(_5) -> [0: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto_storage.rs:+2:21: +2:52
 -     }
 - 
 -     bb4: {
@@ -56,7 +56,7 @@
 - 
 -     bb6: {
 -         StorageDead(_5);                 // scope 0 at $DIR/const_goto_storage.rs:+2:75: +2:76
--         switchInt(move _4) -> [0: bb8, otherwise: bb7]; // scope 0 at $DIR/const_goto_storage.rs:+2:18: +2:76
+-         switchInt(_4) -> [0: bb8, otherwise: bb7]; // scope 0 at $DIR/const_goto_storage.rs:+2:18: +2:76
 -     }
 - 
 -     bb7: {
@@ -70,7 +70,7 @@
 -     }
 - 
 -     bb9: {
--         switchInt(move _3) -> [0: bb11, otherwise: bb10]; // scope 0 at $DIR/const_goto_storage.rs:+2:15: +6:10
+-         switchInt(_3) -> [0: bb11, otherwise: bb10]; // scope 0 at $DIR/const_goto_storage.rs:+2:15: +6:10
 -     }
 - 
 -     bb10: {

--- a/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
@@ -19,7 +19,7 @@
           (_3.1: i32) = const 1_i32;       // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
           (_3.2: i32) = const 2_i32;       // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
 -         _2 = (_3.1: i32);                // scope 0 at $DIR/aggregate.rs:+1:13: +1:24
--         _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/aggregate.rs:+1:13: +1:28
+-         _1 = Add(_2, const 0_i32);       // scope 0 at $DIR/aggregate.rs:+1:13: +1:28
 +         _2 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:+1:13: +1:24
 +         _1 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:+1:13: +1:28
           StorageDead(_2);                 // scope 0 at $DIR/aggregate.rs:+1:27: +1:28

--- a/src/test/mir-opt/const_prop/array_index.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/array_index.main.ConstProp.32bit.diff
@@ -20,10 +20,10 @@
           _3 = const 2_usize;              // scope 0 at $DIR/array_index.rs:+1:31: +1:32
 -         _4 = Len(_2);                    // scope 0 at $DIR/array_index.rs:+1:18: +1:33
 -         _5 = Lt(_3, _4);                 // scope 0 at $DIR/array_index.rs:+1:18: +1:33
--         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/array_index.rs:+1:18: +1:33
+-         assert(_5, "index out of bounds: the length is {} but the index is {}", _4, _3) -> bb1; // scope 0 at $DIR/array_index.rs:+1:18: +1:33
 +         _4 = const 4_usize;              // scope 0 at $DIR/array_index.rs:+1:18: +1:33
 +         _5 = const true;                 // scope 0 at $DIR/array_index.rs:+1:18: +1:33
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/array_index.rs:+1:18: +1:33
++         assert(const true, "index out of bounds: the length is {} but the index is {}", _4, _3) -> bb1; // scope 0 at $DIR/array_index.rs:+1:18: +1:33
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/array_index.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/array_index.main.ConstProp.64bit.diff
@@ -20,10 +20,10 @@
           _3 = const 2_usize;              // scope 0 at $DIR/array_index.rs:+1:31: +1:32
 -         _4 = Len(_2);                    // scope 0 at $DIR/array_index.rs:+1:18: +1:33
 -         _5 = Lt(_3, _4);                 // scope 0 at $DIR/array_index.rs:+1:18: +1:33
--         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/array_index.rs:+1:18: +1:33
+-         assert(_5, "index out of bounds: the length is {} but the index is {}", _4, _3) -> bb1; // scope 0 at $DIR/array_index.rs:+1:18: +1:33
 +         _4 = const 4_usize;              // scope 0 at $DIR/array_index.rs:+1:18: +1:33
 +         _5 = const true;                 // scope 0 at $DIR/array_index.rs:+1:18: +1:33
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/array_index.rs:+1:18: +1:33
++         assert(const true, "index out of bounds: the length is {} but the index is {}", _4, _3) -> bb1; // scope 0 at $DIR/array_index.rs:+1:18: +1:33
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.diff
@@ -26,14 +26,14 @@
 -         _4 = Eq(_3, const 0_i32);        // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
 +         _3 = const 0_i32;                // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:18: +2:19
 +         _4 = const true;                 // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
-          assert(!move _4, "attempt to divide `{}` by zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
+          assert(!_4, "attempt to divide `{}` by zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
       }
   
       bb1: {
 -         _5 = Eq(_3, const -1_i32);       // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
 -         _6 = Eq(const 1_i32, const i32::MIN); // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
--         _7 = BitAnd(move _5, move _6);   // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
--         assert(!move _7, "attempt to compute `{} / {}`, which would overflow", const 1_i32, _3) -> bb2; // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
+-         _7 = BitAnd(_5, _6);             // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
+-         assert(!_7, "attempt to compute `{} / {}`, which would overflow", const 1_i32, _3) -> bb2; // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
 +         _5 = const false;                // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
 +         _6 = const false;                // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
 +         _7 = const false;                // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
@@ -41,7 +41,7 @@
       }
   
       bb2: {
-          _2 = Div(const 1_i32, move _3);  // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
+          _2 = Div(const 1_i32, _3);       // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
           StorageDead(_3);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:18: +2:19
           _0 = const ();                   // scope 0 at $DIR/bad_op_div_by_zero.rs:+0:11: +3:2
           StorageDead(_2);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:+3:1: +3:2

--- a/src/test/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
@@ -24,7 +24,7 @@
           StorageLive(_3);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:18: +2:19
 -         _3 = _1;                         // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:18: +2:19
 -         _4 = Eq(_3, const 0_i32);        // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
--         assert(!move _4, "attempt to calculate the remainder of `{}` with a divisor of zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
+-         assert(!_4, "attempt to calculate the remainder of `{}` with a divisor of zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
 +         _3 = const 0_i32;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:18: +2:19
 +         _4 = const true;                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
 +         assert(!const true, "attempt to calculate the remainder of `{}` with a divisor of zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
@@ -33,8 +33,8 @@
       bb1: {
 -         _5 = Eq(_3, const -1_i32);       // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
 -         _6 = Eq(const 1_i32, const i32::MIN); // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
--         _7 = BitAnd(move _5, move _6);   // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
--         assert(!move _7, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, _3) -> bb2; // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
+-         _7 = BitAnd(_5, _6);             // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
+-         assert(!_7, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, _3) -> bb2; // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
 +         _5 = const false;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
 +         _6 = const false;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
 +         _7 = const false;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
@@ -42,7 +42,7 @@
       }
   
       bb2: {
--         _2 = Rem(const 1_i32, move _3);  // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
+-         _2 = Rem(const 1_i32, _3);       // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
 +         _2 = Rem(const 1_i32, const 0_i32); // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
           StorageDead(_3);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:18: +2:19
           nop;                             // scope 0 at $DIR/bad_op_mod_by_zero.rs:+0:11: +3:2

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
@@ -31,7 +31,7 @@
                                            // + literal: Const { ty: &[i32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
           _3 = _9;                         // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           _2 = &raw const (*_3);           // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
-          _1 = move _2 as *const [i32] (Pointer(Unsize)); // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          _1 = _2 as *const [i32] (Pointer(Unsize)); // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           StorageDead(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:34: +1:35
           StorageDead(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:35: +1:36
           StorageLive(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
@@ -39,9 +39,9 @@
           _6 = const 3_usize;              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
           _7 = Len((*_1));                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
 -         _8 = Lt(_6, _7);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+-         assert(_8, "index out of bounds: the length is {} but the index is {}", _7, _6) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
 +         _8 = Lt(const 3_usize, _7);      // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
-+         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
++         assert(_8, "index out of bounds: the length is {} but the index is {}", _7, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
@@ -31,7 +31,7 @@
                                            // + literal: Const { ty: &[i32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
           _3 = _9;                         // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           _2 = &raw const (*_3);           // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
-          _1 = move _2 as *const [i32] (Pointer(Unsize)); // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          _1 = _2 as *const [i32] (Pointer(Unsize)); // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           StorageDead(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:34: +1:35
           StorageDead(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:35: +1:36
           StorageLive(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
@@ -39,9 +39,9 @@
           _6 = const 3_usize;              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
           _7 = Len((*_1));                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
 -         _8 = Lt(_6, _7);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+-         assert(_8, "index out of bounds: the length is {} but the index is {}", _7, _6) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
 +         _8 = Lt(const 3_usize, _7);      // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
-+         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
++         assert(_8, "index out of bounds: the length is {} but the index is {}", _7, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/boolean_identities.test.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boolean_identities.test.ConstProp.diff
@@ -14,16 +14,16 @@
           StorageLive(_3);                 // scope 0 at $DIR/boolean_identities.rs:+1:5: +1:15
           StorageLive(_4);                 // scope 0 at $DIR/boolean_identities.rs:+1:6: +1:7
           _4 = _2;                         // scope 0 at $DIR/boolean_identities.rs:+1:6: +1:7
--         _3 = BitOr(move _4, const true); // scope 0 at $DIR/boolean_identities.rs:+1:5: +1:15
+-         _3 = BitOr(_4, const true);      // scope 0 at $DIR/boolean_identities.rs:+1:5: +1:15
 +         _3 = const true;                 // scope 0 at $DIR/boolean_identities.rs:+1:5: +1:15
           StorageDead(_4);                 // scope 0 at $DIR/boolean_identities.rs:+1:14: +1:15
           StorageLive(_5);                 // scope 0 at $DIR/boolean_identities.rs:+1:18: +1:29
           StorageLive(_6);                 // scope 0 at $DIR/boolean_identities.rs:+1:19: +1:20
           _6 = _1;                         // scope 0 at $DIR/boolean_identities.rs:+1:19: +1:20
--         _5 = BitAnd(move _6, const false); // scope 0 at $DIR/boolean_identities.rs:+1:18: +1:29
+-         _5 = BitAnd(_6, const false);    // scope 0 at $DIR/boolean_identities.rs:+1:18: +1:29
 +         _5 = const false;                // scope 0 at $DIR/boolean_identities.rs:+1:18: +1:29
           StorageDead(_6);                 // scope 0 at $DIR/boolean_identities.rs:+1:28: +1:29
--         _0 = BitAnd(move _3, move _5);   // scope 0 at $DIR/boolean_identities.rs:+1:5: +1:29
+-         _0 = BitAnd(_3, _5);             // scope 0 at $DIR/boolean_identities.rs:+1:5: +1:29
 +         _0 = const false;                // scope 0 at $DIR/boolean_identities.rs:+1:5: +1:29
           StorageDead(_5);                 // scope 0 at $DIR/boolean_identities.rs:+1:28: +1:29
           StorageDead(_3);                 // scope 0 at $DIR/boolean_identities.rs:+1:28: +1:29

--- a/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
@@ -34,14 +34,14 @@
   
       bb1: {
           StorageLive(_7);                 // scope 0 at $DIR/boxes.rs:+1:14: +1:22
-          _7 = ShallowInitBox(move _6, i32); // scope 0 at $DIR/boxes.rs:+1:14: +1:22
+          _7 = ShallowInitBox(_6, i32);    // scope 0 at $DIR/boxes.rs:+1:14: +1:22
           _8 = (((_7.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: *const i32); // scope 0 at $DIR/boxes.rs:+1:19: +1:21
           (*_8) = const 42_i32;            // scope 0 at $DIR/boxes.rs:+1:19: +1:21
-          _3 = move _7;                    // scope 0 at $DIR/boxes.rs:+1:14: +1:22
+          _3 = _7;                         // scope 0 at $DIR/boxes.rs:+1:14: +1:22
           StorageDead(_7);                 // scope 0 at $DIR/boxes.rs:+1:21: +1:22
           _9 = (((_3.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: *const i32); // scope 0 at $DIR/boxes.rs:+1:13: +1:22
           _2 = (*_9);                      // scope 0 at $DIR/boxes.rs:+1:13: +1:22
-          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/boxes.rs:+1:13: +1:26
+          _1 = Add(_2, const 0_i32);       // scope 0 at $DIR/boxes.rs:+1:13: +1:26
           StorageDead(_2);                 // scope 0 at $DIR/boxes.rs:+1:25: +1:26
           drop(_3) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/boxes.rs:+1:26: +1:27
       }

--- a/src/test/mir-opt/const_prop/checked_add.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/checked_add.main.ConstProp.diff
@@ -12,13 +12,13 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/checked_add.rs:+1:9: +1:10
 -         _2 = CheckedAdd(const 1_u32, const 1_u32); // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
--         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
+-         assert(!(_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
 +         _2 = const (2_u32, false);       // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
       }
   
       bb1: {
--         _1 = move (_2.0: u32);           // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
+-         _1 = (_2.0: u32);                // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
 +         _1 = const 2_u32;                // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
           _0 = const ();                   // scope 0 at $DIR/checked_add.rs:+0:11: +2:2
           StorageDead(_1);                 // scope 0 at $DIR/checked_add.rs:+2:1: +2:2

--- a/src/test/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
@@ -21,7 +21,7 @@
                                            // + span: $DIR/const_prop_fails_gracefully.rs:8:13: 8:16
                                            // + literal: Const { ty: &i32, val: Unevaluated(FOO, [], None) }
           _2 = &raw const (*_3);           // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:16
-          _1 = move _2 as usize (PointerExposeAddress); // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:39
+          _1 = _2 as usize (PointerExposeAddress); // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:39
           StorageDead(_2);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:38: +2:39
           StorageDead(_3);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:39: +2:40
           StorageLive(_4);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:+3:5: +3:12

--- a/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
@@ -9,7 +9,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/control_flow_simplification.rs:+1:8: +1:21
           _1 = const _;                    // scope 0 at $DIR/control_flow_simplification.rs:+1:8: +1:21
--         switchInt(move _1) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/control_flow_simplification.rs:+1:8: +1:21
+-         switchInt(_1) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/control_flow_simplification.rs:+1:8: +1:21
 +         switchInt(const false) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/control_flow_simplification.rs:+1:8: +1:21
       }
   

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
@@ -21,7 +21,7 @@
           ((_3 as Some).0: bool) = const true; // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
           discriminant(_3) = 1;            // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
 -         _4 = discriminant(_3);           // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
--         switchInt(move _4) -> [1: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
+-         switchInt(_4) -> [1: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
 +         _4 = const 1_isize;              // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
 +         switchInt(const 1_isize) -> [1: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
       }
@@ -41,7 +41,7 @@
       }
   
       bb4: {
-          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/discriminant.rs:+1:13: +1:68
+          _1 = Add(_2, const 0_i32);       // scope 0 at $DIR/discriminant.rs:+1:13: +1:68
           StorageDead(_2);                 // scope 0 at $DIR/discriminant.rs:+1:67: +1:68
           StorageDead(_3);                 // scope 0 at $DIR/discriminant.rs:+1:68: +1:69
           _0 = const ();                   // scope 0 at $DIR/discriminant.rs:+0:11: +2:2

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
@@ -21,7 +21,7 @@
           ((_3 as Some).0: bool) = const true; // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
           discriminant(_3) = 1;            // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
 -         _4 = discriminant(_3);           // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
--         switchInt(move _4) -> [1: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
+-         switchInt(_4) -> [1: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
 +         _4 = const 1_isize;              // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
 +         switchInt(const 1_isize) -> [1: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
       }
@@ -41,7 +41,7 @@
       }
   
       bb4: {
-          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/discriminant.rs:+1:13: +1:68
+          _1 = Add(_2, const 0_i32);       // scope 0 at $DIR/discriminant.rs:+1:13: +1:68
           StorageDead(_2);                 // scope 0 at $DIR/discriminant.rs:+1:67: +1:68
           StorageDead(_3);                 // scope 0 at $DIR/discriminant.rs:+1:68: +1:69
           _0 = const ();                   // scope 0 at $DIR/discriminant.rs:+0:11: +2:2

--- a/src/test/mir-opt/const_prop/indirect.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/indirect.main.ConstProp.diff
@@ -15,14 +15,14 @@
           StorageLive(_2);                 // scope 0 at $DIR/indirect.rs:+1:13: +1:25
 -         _2 = const 2_u32 as u8 (IntToInt); // scope 0 at $DIR/indirect.rs:+1:13: +1:25
 -         _3 = CheckedAdd(_2, const 1_u8); // scope 0 at $DIR/indirect.rs:+1:13: +1:29
--         assert(!move (_3.1: bool), "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:+1:13: +1:29
+-         assert(!(_3.1: bool), "attempt to compute `{} + {}`, which would overflow", _2, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:+1:13: +1:29
 +         _2 = const 2_u8;                 // scope 0 at $DIR/indirect.rs:+1:13: +1:25
 +         _3 = const (3_u8, false);        // scope 0 at $DIR/indirect.rs:+1:13: +1:29
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:+1:13: +1:29
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", _2, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:+1:13: +1:29
       }
   
       bb1: {
--         _1 = move (_3.0: u8);            // scope 0 at $DIR/indirect.rs:+1:13: +1:29
+-         _1 = (_3.0: u8);                 // scope 0 at $DIR/indirect.rs:+1:13: +1:29
 +         _1 = const 3_u8;                 // scope 0 at $DIR/indirect.rs:+1:13: +1:29
           StorageDead(_2);                 // scope 0 at $DIR/indirect.rs:+1:28: +1:29
           _0 = const ();                   // scope 0 at $DIR/indirect.rs:+0:11: +2:2

--- a/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
@@ -45,7 +45,7 @@
           Deinit(_5);                      // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
           (_5.0: u32) = const 4_u32;       // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
 -         _4 = (_5.1: E);                  // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:57
--         _3 = [move _4];                  // scope 1 at $DIR/invalid_constant.rs:+13:24: +13:60
+-         _3 = [_4];                       // scope 1 at $DIR/invalid_constant.rs:+13:24: +13:60
 +         _4 = const Scalar(0x00000004): E; // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:57
 +                                          // mir::Constant
 +                                          // + span: $DIR/invalid_constant.rs:28:34: 28:57

--- a/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
@@ -15,7 +15,7 @@
           (_3.0: u8) = const 1_u8;         // scope 0 at $DIR/issue_67019.rs:+1:11: +1:17
           (_3.1: u8) = const 2_u8;         // scope 0 at $DIR/issue_67019.rs:+1:11: +1:17
           Deinit(_2);                      // scope 0 at $DIR/issue_67019.rs:+1:10: +1:19
--         (_2.0: (u8, u8)) = move _3;      // scope 0 at $DIR/issue_67019.rs:+1:10: +1:19
+-         (_2.0: (u8, u8)) = _3;           // scope 0 at $DIR/issue_67019.rs:+1:10: +1:19
 +         (_2.0: (u8, u8)) = const (1_u8, 2_u8); // scope 0 at $DIR/issue_67019.rs:+1:10: +1:19
           StorageDead(_3);                 // scope 0 at $DIR/issue_67019.rs:+1:18: +1:19
           _1 = test(move _2) -> bb1;       // scope 0 at $DIR/issue_67019.rs:+1:5: +1:20

--- a/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.diff
@@ -20,7 +20,7 @@
           _3 = const 2_usize;              // scope 0 at $DIR/large_array_index.rs:+2:30: +2:31
           _4 = const 5000_usize;           // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
 -         _5 = Lt(_3, _4);                 // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
--         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
+-         assert(_5, "index out of bounds: the length is {} but the index is {}", _4, _3) -> bb1; // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
 +         _5 = const true;                 // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 5000_usize, const 2_usize) -> bb1; // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
       }

--- a/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.diff
@@ -20,7 +20,7 @@
           _3 = const 2_usize;              // scope 0 at $DIR/large_array_index.rs:+2:30: +2:31
           _4 = const 5000_usize;           // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
 -         _5 = Lt(_3, _4);                 // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
--         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
+-         assert(_5, "index out of bounds: the length is {} but the index is {}", _4, _3) -> bb1; // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
 +         _5 = const true;                 // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 5000_usize, const 2_usize) -> bb1; // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
       }

--- a/src/test/mir-opt/const_prop/mult_by_zero.test.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mult_by_zero.test.ConstProp.diff
@@ -9,7 +9,7 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/mult_by_zero.rs:+1:3: +1:4
           _2 = _1;                         // scope 0 at $DIR/mult_by_zero.rs:+1:3: +1:4
--         _0 = Mul(move _2, const 0_i32);  // scope 0 at $DIR/mult_by_zero.rs:+1:3: +1:8
+-         _0 = Mul(_2, const 0_i32);       // scope 0 at $DIR/mult_by_zero.rs:+1:3: +1:8
 +         _0 = const 0_i32;                // scope 0 at $DIR/mult_by_zero.rs:+1:3: +1:8
           StorageDead(_2);                 // scope 0 at $DIR/mult_by_zero.rs:+1:7: +1:8
           return;                          // scope 0 at $DIR/mult_by_zero.rs:+2:2: +2:2

--- a/src/test/mir-opt/const_prop/mutable_variable_no_prop.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_no_prop.main.ConstProp.diff
@@ -28,7 +28,7 @@
                                            // + span: $DIR/mutable_variable_no_prop.rs:10:13: 10:19
                                            // + literal: Const { ty: *mut u32, val: Value(Scalar(alloc1)) }
           _3 = (*_4);                      // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
-          _1 = move _3;                    // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:9: +3:19
+          _1 = _3;                         // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:9: +3:19
           StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:18: +3:19
           StorageDead(_4);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:19: +3:20
           nop;                             // scope 2 at $DIR/mutable_variable_no_prop.rs:+2:5: +4:6

--- a/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
@@ -40,7 +40,7 @@
           _7 = const 2_i32;                // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:29: +2:35
           StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
           _3 = _1;                         // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
-          _7 = move _3;                    // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:5: +3:12
+          _7 = _3;                         // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:5: +3:12
           StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
           StorageLive(_4);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+4:9: +4:10
           _4 = _7;                         // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+4:13: +4:16

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
@@ -27,13 +27,13 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
 -         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
--         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+-         assert(!(_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
 +         _2 = const (4_i32, false);       // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
       }
   
       bb1: {
--         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+-         _1 = (_2.0: i32);                // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
 +         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
           StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
           StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
@@ -42,7 +42,7 @@
           _5 = const 3_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:+2:32: +2:33
           _6 = const 6_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
 -         _7 = Lt(_5, _6);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
--         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+-         assert(_7, "index out of bounds: the length is {} but the index is {}", _6, _5) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
 +         _7 = const true;                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 6_usize, const 3_usize) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
       }

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
@@ -27,13 +27,13 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
 -         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
--         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+-         assert(!(_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
 +         _2 = const (4_i32, false);       // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
       }
   
       bb1: {
--         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+-         _1 = (_2.0: i32);                // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
 +         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
           StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
           StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
@@ -42,7 +42,7 @@
           _5 = const 3_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:+2:32: +2:33
           _6 = const 6_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
 -         _7 = Lt(_5, _6);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
--         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+-         assert(_7, "index out of bounds: the length is {} but the index is {}", _6, _5) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
 +         _7 = const true;                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 6_usize, const 3_usize) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
       }

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ScalarReplacementOfAggregates.32bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ScalarReplacementOfAggregates.32bit.diff
@@ -27,11 +27,11 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
           _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
-          assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+          assert(!(_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
       }
   
       bb1: {
-          _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+          _1 = (_2.0: i32);                // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
           StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
           StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
           _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32]; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
@@ -39,7 +39,7 @@
           _5 = const 3_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:+2:32: +2:33
           _6 = Len(_4);                    // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
           _7 = Lt(_5, _6);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
-          assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+          assert(_7, "index out of bounds: the length is {} but the index is {}", _6, _5) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
       }
   
       bb2: {

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.diff
@@ -27,11 +27,11 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
           _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
-          assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+          assert(!(_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
       }
   
       bb1: {
-          _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+          _1 = (_2.0: i32);                // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
           StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
           StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
           _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32]; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
@@ -39,7 +39,7 @@
           _5 = const 3_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:+2:32: +2:33
           _6 = Len(_4);                    // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
           _7 = Lt(_5, _6);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
-          assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+          assert(_7, "index out of bounds: the length is {} but the index is {}", _6, _5) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
       }
   
       bb2: {

--- a/src/test/mir-opt/const_prop/read_immutable_static.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/read_immutable_static.main.ConstProp.diff
@@ -29,7 +29,7 @@
                                            // + span: $DIR/read_immutable_static.rs:8:19: 8:22
                                            // + literal: Const { ty: &u8, val: Value(Scalar(alloc1)) }
 -         _4 = (*_5);                      // scope 0 at $DIR/read_immutable_static.rs:+1:19: +1:22
--         _1 = Add(move _2, move _4);      // scope 0 at $DIR/read_immutable_static.rs:+1:13: +1:22
+-         _1 = Add(_2, _4);                // scope 0 at $DIR/read_immutable_static.rs:+1:13: +1:22
 +         _4 = const 2_u8;                 // scope 0 at $DIR/read_immutable_static.rs:+1:19: +1:22
 +         _1 = const 4_u8;                 // scope 0 at $DIR/read_immutable_static.rs:+1:13: +1:22
           StorageDead(_4);                 // scope 0 at $DIR/read_immutable_static.rs:+1:21: +1:22

--- a/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
@@ -17,9 +17,9 @@
                                            // mir::Constant
                                            // + span: $DIR/reify_fn_ptr.rs:4:13: 4:17
                                            // + literal: Const { ty: fn() {main}, val: Value(<ZST>) }
-          _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
+          _2 = _3 as usize (PointerExposeAddress); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
           StorageDead(_3);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:25: +1:26
-          _1 = move _2 as *const fn() (PointerFromExposedAddress); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:41
+          _1 = _2 as *const fn() (PointerFromExposedAddress); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:41
           StorageDead(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:40: +1:41
           StorageDead(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:41: +1:42
           nop;                             // scope 0 at $DIR/reify_fn_ptr.rs:+0:11: +2:2

--- a/src/test/mir-opt/const_prop/repeat.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/repeat.main.ConstProp.32bit.diff
@@ -22,14 +22,14 @@
           _4 = const 2_usize;              // scope 0 at $DIR/repeat.rs:+1:26: +1:27
           _5 = const 8_usize;              // scope 0 at $DIR/repeat.rs:+1:18: +1:28
 -         _6 = Lt(_4, _5);                 // scope 0 at $DIR/repeat.rs:+1:18: +1:28
--         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> bb1; // scope 0 at $DIR/repeat.rs:+1:18: +1:28
+-         assert(_6, "index out of bounds: the length is {} but the index is {}", _5, _4) -> bb1; // scope 0 at $DIR/repeat.rs:+1:18: +1:28
 +         _6 = const true;                 // scope 0 at $DIR/repeat.rs:+1:18: +1:28
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 8_usize, const 2_usize) -> bb1; // scope 0 at $DIR/repeat.rs:+1:18: +1:28
       }
   
       bb1: {
 -         _2 = _3[_4];                     // scope 0 at $DIR/repeat.rs:+1:18: +1:28
--         _1 = Add(move _2, const 0_u32);  // scope 0 at $DIR/repeat.rs:+1:18: +1:32
+-         _1 = Add(_2, const 0_u32);       // scope 0 at $DIR/repeat.rs:+1:18: +1:32
 +         _2 = const 42_u32;               // scope 0 at $DIR/repeat.rs:+1:18: +1:28
 +         _1 = const 42_u32;               // scope 0 at $DIR/repeat.rs:+1:18: +1:32
           StorageDead(_2);                 // scope 0 at $DIR/repeat.rs:+1:31: +1:32

--- a/src/test/mir-opt/const_prop/repeat.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/repeat.main.ConstProp.64bit.diff
@@ -22,14 +22,14 @@
           _4 = const 2_usize;              // scope 0 at $DIR/repeat.rs:+1:26: +1:27
           _5 = const 8_usize;              // scope 0 at $DIR/repeat.rs:+1:18: +1:28
 -         _6 = Lt(_4, _5);                 // scope 0 at $DIR/repeat.rs:+1:18: +1:28
--         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> bb1; // scope 0 at $DIR/repeat.rs:+1:18: +1:28
+-         assert(_6, "index out of bounds: the length is {} but the index is {}", _5, _4) -> bb1; // scope 0 at $DIR/repeat.rs:+1:18: +1:28
 +         _6 = const true;                 // scope 0 at $DIR/repeat.rs:+1:18: +1:28
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 8_usize, const 2_usize) -> bb1; // scope 0 at $DIR/repeat.rs:+1:18: +1:28
       }
   
       bb1: {
 -         _2 = _3[_4];                     // scope 0 at $DIR/repeat.rs:+1:18: +1:28
--         _1 = Add(move _2, const 0_u32);  // scope 0 at $DIR/repeat.rs:+1:18: +1:32
+-         _1 = Add(_2, const 0_u32);       // scope 0 at $DIR/repeat.rs:+1:18: +1:32
 +         _2 = const 42_u32;               // scope 0 at $DIR/repeat.rs:+1:18: +1:28
 +         _1 = const 42_u32;               // scope 0 at $DIR/repeat.rs:+1:18: +1:32
           StorageDead(_2);                 // scope 0 at $DIR/repeat.rs:+1:31: +1:32

--- a/src/test/mir-opt/const_prop/return_place.add.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/return_place.add.ConstProp.diff
@@ -7,13 +7,13 @@
   
       bb0: {
 -         _1 = CheckedAdd(const 2_u32, const 2_u32); // scope 0 at $DIR/return_place.rs:+1:5: +1:10
--         assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:+1:5: +1:10
+-         assert(!(_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:+1:5: +1:10
 +         _1 = const (4_u32, false);       // scope 0 at $DIR/return_place.rs:+1:5: +1:10
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:+1:5: +1:10
       }
   
       bb1: {
--         _0 = move (_1.0: u32);           // scope 0 at $DIR/return_place.rs:+1:5: +1:10
+-         _0 = (_1.0: u32);                // scope 0 at $DIR/return_place.rs:+1:5: +1:10
 +         _0 = const 4_u32;                // scope 0 at $DIR/return_place.rs:+1:5: +1:10
           return;                          // scope 0 at $DIR/return_place.rs:+2:2: +2:2
       }

--- a/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
@@ -16,7 +16,7 @@
           StorageLive(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
           StorageLive(_3);                 // scope 1 at $DIR/scalar_literal_propagation.rs:+2:13: +2:14
 -         _3 = _1;                         // scope 1 at $DIR/scalar_literal_propagation.rs:+2:13: +2:14
--         _2 = consume(move _3) -> bb1;    // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
+-         _2 = consume(_3) -> bb1;         // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
 +         _3 = const 1_u32;                // scope 1 at $DIR/scalar_literal_propagation.rs:+2:13: +2:14
 +         _2 = consume(const 1_u32) -> bb1; // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
                                            // mir::Constant

--- a/src/test/mir-opt/const_prop/slice_len.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/slice_len.main.ConstProp.32bit.diff
@@ -27,14 +27,14 @@
           _3 = _4;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           StorageLive(_10);                // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           _10 = _3;                        // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
-          _2 = move _3 as &[u32] (Pointer(Unsize)); // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          _2 = _3 as &[u32] (Pointer(Unsize)); // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           StorageDead(_3);                 // scope 0 at $DIR/slice_len.rs:+1:18: +1:19
           StorageLive(_6);                 // scope 0 at $DIR/slice_len.rs:+1:31: +1:32
           _6 = const 1_usize;              // scope 0 at $DIR/slice_len.rs:+1:31: +1:32
           _7 = const 3_usize;              // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
           StorageDead(_10);                // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
 -         _8 = Lt(_6, _7);                 // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+-         assert(_8, "index out of bounds: the length is {} but the index is {}", _7, _6) -> bb1; // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
 +         _8 = const true;                 // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 1_usize) -> bb1; // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
       }

--- a/src/test/mir-opt/const_prop/slice_len.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/slice_len.main.ConstProp.64bit.diff
@@ -27,14 +27,14 @@
           _3 = _4;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           StorageLive(_10);                // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           _10 = _3;                        // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
-          _2 = move _3 as &[u32] (Pointer(Unsize)); // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          _2 = _3 as &[u32] (Pointer(Unsize)); // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           StorageDead(_3);                 // scope 0 at $DIR/slice_len.rs:+1:18: +1:19
           StorageLive(_6);                 // scope 0 at $DIR/slice_len.rs:+1:31: +1:32
           _6 = const 1_usize;              // scope 0 at $DIR/slice_len.rs:+1:31: +1:32
           _7 = const 3_usize;              // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
           StorageDead(_10);                // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
 -         _8 = Lt(_6, _7);                 // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+-         assert(_8, "index out of bounds: the length is {} but the index is {}", _7, _6) -> bb1; // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
 +         _8 = const true;                 // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 1_usize) -> bb1; // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
       }

--- a/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
@@ -31,7 +31,7 @@
           StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:9: +5:10
           StorageLive(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:20
           _5 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:+5:15: +5:18
-          _4 = Eq(move _5, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:25
+          _4 = Eq(_5, const 5_i32);        // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:25
           StorageDead(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:24: +5:25
           nop;                             // scope 0 at $DIR/const_prop_miscompile.rs:+0:10: +6:2
           StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+6:1: +6:2

--- a/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
@@ -25,7 +25,7 @@
           StorageLive(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:+3:9: +3:10
           StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+3:13: +3:20
           _4 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:+3:15: +3:18
-          _3 = Eq(move _4, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:+3:13: +3:25
+          _3 = Eq(_4, const 5_i32);        // scope 1 at $DIR/const_prop_miscompile.rs:+3:13: +3:25
           StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+3:24: +3:25
           nop;                             // scope 0 at $DIR/const_prop_miscompile.rs:+0:10: +4:2
           StorageDead(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:+4:1: +4:2

--- a/src/test/mir-opt/coverage_graphviz.main.InstrumentCoverage.0.dot
+++ b/src/test/mir-opt/coverage_graphviz.main.InstrumentCoverage.0.dot
@@ -7,7 +7,7 @@ digraph Cov_0_3 {
     bcb1__Cov_0_3 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">bcb1</td></tr><tr><td align="left" balign="left">Expression(bcb0 + bcb3) at 10:5-11:17<br align="left"/>    11:12-11:17: @2.Call: _2 = bar() -&gt; [return: bb3, unwind: bb6]</td></tr><tr><td align="left" balign="left">bb1: FalseUnwind<br align="left"/>bb2: Call</td></tr><tr><td align="left" balign="left">bb3: SwitchInt</td></tr></table>>];
     bcb0__Cov_0_3 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">bcb0</td></tr><tr><td align="left" balign="left"></td></tr><tr><td align="left" balign="left">Counter(bcb0) at 9:1-9:11<br align="left"/>    </td></tr><tr><td align="left" balign="left">bb0: Goto</td></tr></table>>];
     bcb3__Cov_0_3 -> bcb1__Cov_0_3 [label=<>];
-    bcb1__Cov_0_3 -> bcb3__Cov_0_3 [label=<0>];
+    bcb1__Cov_0_3 -> bcb3__Cov_0_3 [label=<false>];
     bcb1__Cov_0_3 -> bcb2__Cov_0_3 [label=<otherwise>];
     bcb0__Cov_0_3 -> bcb1__Cov_0_3 [label=<>];
 }

--- a/src/test/mir-opt/dataflow-const-prop/cast.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/cast.main.DataflowConstProp.diff
@@ -21,11 +21,11 @@
           StorageLive(_3);                 // scope 1 at $DIR/cast.rs:+2:13: +2:20
           StorageLive(_4);                 // scope 1 at $DIR/cast.rs:+2:13: +2:14
 -         _4 = _1;                         // scope 1 at $DIR/cast.rs:+2:13: +2:14
--         _3 = move _4 as u8 (IntToInt);   // scope 1 at $DIR/cast.rs:+2:13: +2:20
+-         _3 = _4 as u8 (IntToInt);        // scope 1 at $DIR/cast.rs:+2:13: +2:20
 +         _4 = const 257_i32;              // scope 1 at $DIR/cast.rs:+2:13: +2:14
 +         _3 = const 1_u8;                 // scope 1 at $DIR/cast.rs:+2:13: +2:20
           StorageDead(_4);                 // scope 1 at $DIR/cast.rs:+2:19: +2:20
--         _2 = Add(move _3, const 1_u8);   // scope 1 at $DIR/cast.rs:+2:13: +2:24
+-         _2 = Add(_3, const 1_u8);        // scope 1 at $DIR/cast.rs:+2:13: +2:24
 +         _2 = const 2_u8;                 // scope 1 at $DIR/cast.rs:+2:13: +2:24
           StorageDead(_3);                 // scope 1 at $DIR/cast.rs:+2:23: +2:24
           _0 = const ();                   // scope 0 at $DIR/cast.rs:+0:11: +3:2

--- a/src/test/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.diff
@@ -41,14 +41,14 @@
           StorageLive(_5);                 // scope 2 at $DIR/checked.rs:+3:17: +3:18
 -         _5 = _2;                         // scope 2 at $DIR/checked.rs:+3:17: +3:18
 -         _6 = CheckedAdd(_4, _5);         // scope 2 at $DIR/checked.rs:+3:13: +3:18
--         assert(!move (_6.1: bool), "attempt to compute `{} + {}`, which would overflow", move _4, move _5) -> bb1; // scope 2 at $DIR/checked.rs:+3:13: +3:18
+-         assert(!(_6.1: bool), "attempt to compute `{} + {}`, which would overflow", _4, _5) -> bb1; // scope 2 at $DIR/checked.rs:+3:13: +3:18
 +         _5 = const 2_i32;                // scope 2 at $DIR/checked.rs:+3:17: +3:18
 +         _6 = CheckedAdd(const 1_i32, const 2_i32); // scope 2 at $DIR/checked.rs:+3:13: +3:18
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_i32, const 2_i32) -> bb1; // scope 2 at $DIR/checked.rs:+3:13: +3:18
       }
   
       bb1: {
--         _3 = move (_6.0: i32);           // scope 2 at $DIR/checked.rs:+3:13: +3:18
+-         _3 = (_6.0: i32);                // scope 2 at $DIR/checked.rs:+3:13: +3:18
 +         _3 = const 3_i32;                // scope 2 at $DIR/checked.rs:+3:13: +3:18
           StorageDead(_5);                 // scope 2 at $DIR/checked.rs:+3:17: +3:18
           StorageDead(_4);                 // scope 2 at $DIR/checked.rs:+3:17: +3:18
@@ -58,14 +58,14 @@
           StorageLive(_9);                 // scope 4 at $DIR/checked.rs:+6:13: +6:14
 -         _9 = _7;                         // scope 4 at $DIR/checked.rs:+6:13: +6:14
 -         _10 = CheckedAdd(_9, const 1_i32); // scope 4 at $DIR/checked.rs:+6:13: +6:18
--         assert(!move (_10.1: bool), "attempt to compute `{} + {}`, which would overflow", move _9, const 1_i32) -> bb2; // scope 4 at $DIR/checked.rs:+6:13: +6:18
+-         assert(!(_10.1: bool), "attempt to compute `{} + {}`, which would overflow", _9, const 1_i32) -> bb2; // scope 4 at $DIR/checked.rs:+6:13: +6:18
 +         _9 = const i32::MAX;             // scope 4 at $DIR/checked.rs:+6:13: +6:14
 +         _10 = CheckedAdd(const i32::MAX, const 1_i32); // scope 4 at $DIR/checked.rs:+6:13: +6:18
-+         assert(!move (_10.1: bool), "attempt to compute `{} + {}`, which would overflow", const i32::MAX, const 1_i32) -> bb2; // scope 4 at $DIR/checked.rs:+6:13: +6:18
++         assert(!(_10.1: bool), "attempt to compute `{} + {}`, which would overflow", const i32::MAX, const 1_i32) -> bb2; // scope 4 at $DIR/checked.rs:+6:13: +6:18
       }
   
       bb2: {
--         _8 = move (_10.0: i32);          // scope 4 at $DIR/checked.rs:+6:13: +6:18
+-         _8 = (_10.0: i32);               // scope 4 at $DIR/checked.rs:+6:13: +6:18
 +         _8 = const i32::MIN;             // scope 4 at $DIR/checked.rs:+6:13: +6:18
           StorageDead(_9);                 // scope 4 at $DIR/checked.rs:+6:17: +6:18
           _0 = const ();                   // scope 0 at $DIR/checked.rs:+0:11: +7:2

--- a/src/test/mir-opt/dataflow-const-prop/enum.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/enum.main.DataflowConstProp.diff
@@ -28,7 +28,7 @@
           discriminant(_1) = 0;            // scope 0 at $DIR/enum.rs:+1:13: +1:21
           StorageLive(_2);                 // scope 1 at $DIR/enum.rs:+2:9: +2:10
           _3 = discriminant(_1);           // scope 1 at $DIR/enum.rs:+2:19: +2:20
-          switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 1 at $DIR/enum.rs:+2:13: +2:20
+          switchInt(_3) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 1 at $DIR/enum.rs:+2:13: +2:20
       }
   
       bb1: {

--- a/src/test/mir-opt/dataflow-const-prop/if.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/if.main.DataflowConstProp.diff
@@ -38,11 +38,11 @@
           StorageLive(_3);                 // scope 1 at $DIR/if.rs:+2:16: +2:22
           StorageLive(_4);                 // scope 1 at $DIR/if.rs:+2:16: +2:17
 -         _4 = _1;                         // scope 1 at $DIR/if.rs:+2:16: +2:17
--         _3 = Eq(move _4, const 1_i32);   // scope 1 at $DIR/if.rs:+2:16: +2:22
+-         _3 = Eq(_4, const 1_i32);        // scope 1 at $DIR/if.rs:+2:16: +2:22
 +         _4 = const 1_i32;                // scope 1 at $DIR/if.rs:+2:16: +2:17
 +         _3 = const true;                 // scope 1 at $DIR/if.rs:+2:16: +2:22
           StorageDead(_4);                 // scope 1 at $DIR/if.rs:+2:21: +2:22
--         switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/if.rs:+2:16: +2:22
+-         switchInt(_3) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/if.rs:+2:16: +2:22
 +         switchInt(const true) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/if.rs:+2:16: +2:22
       }
   
@@ -61,7 +61,7 @@
           StorageLive(_5);                 // scope 2 at $DIR/if.rs:+3:9: +3:10
           StorageLive(_6);                 // scope 2 at $DIR/if.rs:+3:13: +3:14
 -         _6 = _2;                         // scope 2 at $DIR/if.rs:+3:13: +3:14
--         _5 = Add(move _6, const 1_i32);  // scope 2 at $DIR/if.rs:+3:13: +3:18
+-         _5 = Add(_6, const 1_i32);       // scope 2 at $DIR/if.rs:+3:13: +3:18
 +         _6 = const 2_i32;                // scope 2 at $DIR/if.rs:+3:13: +3:14
 +         _5 = const 3_i32;                // scope 2 at $DIR/if.rs:+3:13: +3:18
           StorageDead(_6);                 // scope 2 at $DIR/if.rs:+3:17: +3:18
@@ -69,11 +69,11 @@
           StorageLive(_8);                 // scope 3 at $DIR/if.rs:+5:16: +5:22
           StorageLive(_9);                 // scope 3 at $DIR/if.rs:+5:16: +5:17
 -         _9 = _1;                         // scope 3 at $DIR/if.rs:+5:16: +5:17
--         _8 = Eq(move _9, const 1_i32);   // scope 3 at $DIR/if.rs:+5:16: +5:22
+-         _8 = Eq(_9, const 1_i32);        // scope 3 at $DIR/if.rs:+5:16: +5:22
 +         _9 = const 1_i32;                // scope 3 at $DIR/if.rs:+5:16: +5:17
 +         _8 = const true;                 // scope 3 at $DIR/if.rs:+5:16: +5:22
           StorageDead(_9);                 // scope 3 at $DIR/if.rs:+5:21: +5:22
--         switchInt(move _8) -> [0: bb5, otherwise: bb4]; // scope 3 at $DIR/if.rs:+5:16: +5:22
+-         switchInt(_8) -> [0: bb5, otherwise: bb4]; // scope 3 at $DIR/if.rs:+5:16: +5:22
 +         switchInt(const true) -> [0: bb5, otherwise: bb4]; // scope 3 at $DIR/if.rs:+5:16: +5:22
       }
   
@@ -86,7 +86,7 @@
       bb5: {
           StorageLive(_10);                // scope 3 at $DIR/if.rs:+5:36: +5:37
           _10 = _1;                        // scope 3 at $DIR/if.rs:+5:36: +5:37
-          _7 = Add(move _10, const 1_i32); // scope 3 at $DIR/if.rs:+5:36: +5:41
+          _7 = Add(_10, const 1_i32);      // scope 3 at $DIR/if.rs:+5:36: +5:41
           StorageDead(_10);                // scope 3 at $DIR/if.rs:+5:40: +5:41
           goto -> bb6;                     // scope 3 at $DIR/if.rs:+5:13: +5:43
       }
@@ -96,7 +96,7 @@
           StorageLive(_11);                // scope 4 at $DIR/if.rs:+6:9: +6:10
           StorageLive(_12);                // scope 4 at $DIR/if.rs:+6:13: +6:14
 -         _12 = _7;                        // scope 4 at $DIR/if.rs:+6:13: +6:14
--         _11 = Add(move _12, const 1_i32); // scope 4 at $DIR/if.rs:+6:13: +6:18
+-         _11 = Add(_12, const 1_i32);     // scope 4 at $DIR/if.rs:+6:13: +6:18
 +         _12 = const 1_i32;               // scope 4 at $DIR/if.rs:+6:13: +6:14
 +         _11 = const 2_i32;               // scope 4 at $DIR/if.rs:+6:13: +6:18
           StorageDead(_12);                // scope 4 at $DIR/if.rs:+6:17: +6:18

--- a/src/test/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.diff
@@ -27,11 +27,11 @@
           StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           _5 = const 1_u8;                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           _6 = CheckedAdd(const u8::MAX, const 1_u8); // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-          assert(!move (_6.1: bool), "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> bb1; // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
+          assert(!(_6.1: bool), "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> bb1; // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
       }
   
       bb1: {
--         _1 = move (_6.0: u8);            // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
+-         _1 = (_6.0: u8);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
 +         _1 = const 0_u8;                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL

--- a/src/test/mir-opt/dataflow-const-prop/issue_81605.f.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/issue_81605.f.DataflowConstProp.diff
@@ -10,7 +10,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/issue_81605.rs:+1:9: +1:33
           StorageLive(_2);                 // scope 0 at $DIR/issue_81605.rs:+1:12: +1:16
           _2 = const true;                 // scope 0 at $DIR/issue_81605.rs:+1:12: +1:16
--         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/issue_81605.rs:+1:12: +1:16
+-         switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/issue_81605.rs:+1:12: +1:16
 +         switchInt(const true) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/issue_81605.rs:+1:12: +1:16
       }
   
@@ -26,7 +26,7 @@
   
       bb3: {
           StorageDead(_2);                 // scope 0 at $DIR/issue_81605.rs:+1:32: +1:33
--         _0 = Add(const 1_usize, move _1); // scope 0 at $DIR/issue_81605.rs:+1:5: +1:33
+-         _0 = Add(const 1_usize, _1);     // scope 0 at $DIR/issue_81605.rs:+1:5: +1:33
 +         _0 = const 2_usize;              // scope 0 at $DIR/issue_81605.rs:+1:5: +1:33
           StorageDead(_1);                 // scope 0 at $DIR/issue_81605.rs:+1:32: +1:33
           return;                          // scope 0 at $DIR/issue_81605.rs:+2:2: +2:2

--- a/src/test/mir-opt/dataflow-const-prop/repr_transparent.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/repr_transparent.main.DataflowConstProp.diff
@@ -26,13 +26,13 @@
 +         _4 = const 0_i32;                // scope 1 at $DIR/repr_transparent.rs:+2:17: +2:20
           StorageLive(_5);                 // scope 1 at $DIR/repr_transparent.rs:+2:23: +2:26
 -         _5 = (_1.0: i32);                // scope 1 at $DIR/repr_transparent.rs:+2:23: +2:26
--         _3 = Add(move _4, move _5);      // scope 1 at $DIR/repr_transparent.rs:+2:17: +2:26
+-         _3 = Add(_4, _5);                // scope 1 at $DIR/repr_transparent.rs:+2:17: +2:26
 +         _5 = const 0_i32;                // scope 1 at $DIR/repr_transparent.rs:+2:23: +2:26
 +         _3 = const 0_i32;                // scope 1 at $DIR/repr_transparent.rs:+2:17: +2:26
           StorageDead(_5);                 // scope 1 at $DIR/repr_transparent.rs:+2:25: +2:26
           StorageDead(_4);                 // scope 1 at $DIR/repr_transparent.rs:+2:25: +2:26
           Deinit(_2);                      // scope 1 at $DIR/repr_transparent.rs:+2:13: +2:27
--         (_2.0: i32) = move _3;           // scope 1 at $DIR/repr_transparent.rs:+2:13: +2:27
+-         (_2.0: i32) = _3;                // scope 1 at $DIR/repr_transparent.rs:+2:13: +2:27
 +         (_2.0: i32) = const 0_i32;       // scope 1 at $DIR/repr_transparent.rs:+2:13: +2:27
           StorageDead(_3);                 // scope 1 at $DIR/repr_transparent.rs:+2:26: +2:27
           _0 = const ();                   // scope 0 at $DIR/repr_transparent.rs:+0:11: +3:2

--- a/src/test/mir-opt/dataflow-const-prop/self_assign.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/self_assign.main.DataflowConstProp.diff
@@ -21,21 +21,21 @@
           _1 = const 0_i32;                // scope 0 at $DIR/self_assign.rs:+1:17: +1:18
           StorageLive(_2);                 // scope 1 at $DIR/self_assign.rs:+2:9: +2:10
           _2 = _1;                         // scope 1 at $DIR/self_assign.rs:+2:9: +2:10
-          _1 = Add(move _2, const 1_i32);  // scope 1 at $DIR/self_assign.rs:+2:5: +2:14
+          _1 = Add(_2, const 1_i32);       // scope 1 at $DIR/self_assign.rs:+2:5: +2:14
           StorageDead(_2);                 // scope 1 at $DIR/self_assign.rs:+2:13: +2:14
           StorageLive(_3);                 // scope 1 at $DIR/self_assign.rs:+3:9: +3:10
           _3 = _1;                         // scope 1 at $DIR/self_assign.rs:+3:9: +3:10
-          _1 = move _3;                    // scope 1 at $DIR/self_assign.rs:+3:5: +3:10
+          _1 = _3;                         // scope 1 at $DIR/self_assign.rs:+3:5: +3:10
           StorageDead(_3);                 // scope 1 at $DIR/self_assign.rs:+3:9: +3:10
           StorageLive(_4);                 // scope 1 at $DIR/self_assign.rs:+5:9: +5:14
           _4 = &_1;                        // scope 1 at $DIR/self_assign.rs:+5:17: +5:19
           StorageLive(_5);                 // scope 2 at $DIR/self_assign.rs:+6:9: +6:10
           _5 = _4;                         // scope 2 at $DIR/self_assign.rs:+6:9: +6:10
-          _4 = move _5;                    // scope 2 at $DIR/self_assign.rs:+6:5: +6:10
+          _4 = _5;                         // scope 2 at $DIR/self_assign.rs:+6:5: +6:10
           StorageDead(_5);                 // scope 2 at $DIR/self_assign.rs:+6:9: +6:10
           StorageLive(_6);                 // scope 2 at $DIR/self_assign.rs:+7:9: +7:11
           _6 = (*_4);                      // scope 2 at $DIR/self_assign.rs:+7:9: +7:11
-          _1 = move _6;                    // scope 2 at $DIR/self_assign.rs:+7:5: +7:11
+          _1 = _6;                         // scope 2 at $DIR/self_assign.rs:+7:5: +7:11
           StorageDead(_6);                 // scope 2 at $DIR/self_assign.rs:+7:10: +7:11
           _0 = const ();                   // scope 0 at $DIR/self_assign.rs:+0:11: +8:2
           StorageDead(_4);                 // scope 1 at $DIR/self_assign.rs:+8:1: +8:2

--- a/src/test/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.diff
@@ -26,7 +26,7 @@
           StorageLive(_2);                 // scope 1 at $DIR/struct.rs:+2:9: +2:10
           StorageLive(_3);                 // scope 1 at $DIR/struct.rs:+2:13: +2:16
 -         _3 = (_1.0: i32);                // scope 1 at $DIR/struct.rs:+2:13: +2:16
--         _2 = Add(move _3, const 2_i32);  // scope 1 at $DIR/struct.rs:+2:13: +2:20
+-         _2 = Add(_3, const 2_i32);       // scope 1 at $DIR/struct.rs:+2:13: +2:20
 +         _3 = const 1_i32;                // scope 1 at $DIR/struct.rs:+2:13: +2:16
 +         _2 = const 3_i32;                // scope 1 at $DIR/struct.rs:+2:13: +2:20
           StorageDead(_3);                 // scope 1 at $DIR/struct.rs:+2:19: +2:20
@@ -37,7 +37,7 @@
 +         _5 = const 3_i32;                // scope 2 at $DIR/struct.rs:+4:13: +4:14
           StorageLive(_6);                 // scope 2 at $DIR/struct.rs:+4:17: +4:20
 -         _6 = (_1.0: i32);                // scope 2 at $DIR/struct.rs:+4:17: +4:20
--         _4 = Add(move _5, move _6);      // scope 2 at $DIR/struct.rs:+4:13: +4:20
+-         _4 = Add(_5, _6);                // scope 2 at $DIR/struct.rs:+4:13: +4:20
 +         _6 = const 3_i32;                // scope 2 at $DIR/struct.rs:+4:17: +4:20
 +         _4 = const 6_i32;                // scope 2 at $DIR/struct.rs:+4:13: +4:20
           StorageDead(_6);                 // scope 2 at $DIR/struct.rs:+4:19: +4:20

--- a/src/test/mir-opt/dataflow-const-prop/terminator.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/terminator.main.DataflowConstProp.diff
@@ -18,7 +18,7 @@
           StorageLive(_3);                 // scope 1 at $DIR/terminator.rs:+3:9: +3:14
           StorageLive(_4);                 // scope 1 at $DIR/terminator.rs:+3:9: +3:10
 -         _4 = _1;                         // scope 1 at $DIR/terminator.rs:+3:9: +3:10
--         _3 = Add(move _4, const 1_i32);  // scope 1 at $DIR/terminator.rs:+3:9: +3:14
+-         _3 = Add(_4, const 1_i32);       // scope 1 at $DIR/terminator.rs:+3:9: +3:14
 +         _4 = const 1_i32;                // scope 1 at $DIR/terminator.rs:+3:9: +3:10
 +         _3 = const 2_i32;                // scope 1 at $DIR/terminator.rs:+3:9: +3:14
           StorageDead(_4);                 // scope 1 at $DIR/terminator.rs:+3:13: +3:14

--- a/src/test/mir-opt/dataflow-const-prop/tuple.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/tuple.main.DataflowConstProp.diff
@@ -35,12 +35,12 @@
 +         _4 = const 1_i32;                // scope 1 at $DIR/tuple.rs:+2:13: +2:16
           StorageLive(_5);                 // scope 1 at $DIR/tuple.rs:+2:19: +2:22
 -         _5 = (_1.1: i32);                // scope 1 at $DIR/tuple.rs:+2:19: +2:22
--         _3 = Add(move _4, move _5);      // scope 1 at $DIR/tuple.rs:+2:13: +2:22
+-         _3 = Add(_4, _5);                // scope 1 at $DIR/tuple.rs:+2:13: +2:22
 +         _5 = const 2_i32;                // scope 1 at $DIR/tuple.rs:+2:19: +2:22
 +         _3 = const 3_i32;                // scope 1 at $DIR/tuple.rs:+2:13: +2:22
           StorageDead(_5);                 // scope 1 at $DIR/tuple.rs:+2:21: +2:22
           StorageDead(_4);                 // scope 1 at $DIR/tuple.rs:+2:21: +2:22
--         _2 = Add(move _3, const 3_i32);  // scope 1 at $DIR/tuple.rs:+2:13: +2:26
+-         _2 = Add(_3, const 3_i32);       // scope 1 at $DIR/tuple.rs:+2:13: +2:26
 +         _2 = const 6_i32;                // scope 1 at $DIR/tuple.rs:+2:13: +2:26
           StorageDead(_3);                 // scope 1 at $DIR/tuple.rs:+2:25: +2:26
           Deinit(_1);                      // scope 2 at $DIR/tuple.rs:+3:5: +3:15
@@ -53,14 +53,14 @@
 +         _8 = const 2_i32;                // scope 2 at $DIR/tuple.rs:+4:13: +4:16
           StorageLive(_9);                 // scope 2 at $DIR/tuple.rs:+4:19: +4:22
 -         _9 = (_1.1: i32);                // scope 2 at $DIR/tuple.rs:+4:19: +4:22
--         _7 = Add(move _8, move _9);      // scope 2 at $DIR/tuple.rs:+4:13: +4:22
+-         _7 = Add(_8, _9);                // scope 2 at $DIR/tuple.rs:+4:13: +4:22
 +         _9 = const 3_i32;                // scope 2 at $DIR/tuple.rs:+4:19: +4:22
 +         _7 = const 5_i32;                // scope 2 at $DIR/tuple.rs:+4:13: +4:22
           StorageDead(_9);                 // scope 2 at $DIR/tuple.rs:+4:21: +4:22
           StorageDead(_8);                 // scope 2 at $DIR/tuple.rs:+4:21: +4:22
           StorageLive(_10);                // scope 2 at $DIR/tuple.rs:+4:25: +4:26
 -         _10 = _2;                        // scope 2 at $DIR/tuple.rs:+4:25: +4:26
--         _6 = Add(move _7, move _10);     // scope 2 at $DIR/tuple.rs:+4:13: +4:26
+-         _6 = Add(_7, _10);               // scope 2 at $DIR/tuple.rs:+4:13: +4:26
 +         _10 = const 6_i32;               // scope 2 at $DIR/tuple.rs:+4:25: +4:26
 +         _6 = const 11_i32;               // scope 2 at $DIR/tuple.rs:+4:13: +4:26
           StorageDead(_10);                // scope 2 at $DIR/tuple.rs:+4:25: +4:26

--- a/src/test/mir-opt/dead-store-elimination/cycle.cycle.DeadStoreElimination.diff
+++ b/src/test/mir-opt/dead-store-elimination/cycle.cycle.DeadStoreElimination.diff
@@ -37,8 +37,8 @@
       }
   
       bb2: {
--         switchInt(move _5) -> [0: bb4, otherwise: bb3]; // scope 0 at $DIR/cycle.rs:+3:11: +3:17
-+         switchInt(move _4) -> [0: bb4, otherwise: bb3]; // scope 0 at $DIR/cycle.rs:+3:11: +3:17
+-         switchInt(_5) -> [0: bb4, otherwise: bb3]; // scope 0 at $DIR/cycle.rs:+3:11: +3:17
++         switchInt(_4) -> [0: bb4, otherwise: bb3]; // scope 0 at $DIR/cycle.rs:+3:11: +3:17
       }
   
       bb3: {
@@ -46,15 +46,15 @@
 -         _6 = _3;                         // scope 0 at $DIR/cycle.rs:+4:20: +4:21
 -         StorageLive(_7);                 // scope 1 at $DIR/cycle.rs:+5:13: +5:14
 -         _7 = _2;                         // scope 1 at $DIR/cycle.rs:+5:13: +5:14
--         _3 = move _7;                    // scope 1 at $DIR/cycle.rs:+5:9: +5:14
+-         _3 = _7;                         // scope 1 at $DIR/cycle.rs:+5:9: +5:14
 -         StorageDead(_7);                 // scope 1 at $DIR/cycle.rs:+5:13: +5:14
 -         StorageLive(_8);                 // scope 1 at $DIR/cycle.rs:+6:13: +6:14
 -         _8 = _1;                         // scope 1 at $DIR/cycle.rs:+6:13: +6:14
--         _2 = move _8;                    // scope 1 at $DIR/cycle.rs:+6:9: +6:14
+-         _2 = _8;                         // scope 1 at $DIR/cycle.rs:+6:9: +6:14
 -         StorageDead(_8);                 // scope 1 at $DIR/cycle.rs:+6:13: +6:14
 -         StorageLive(_9);                 // scope 1 at $DIR/cycle.rs:+7:13: +7:17
 -         _9 = _6;                         // scope 1 at $DIR/cycle.rs:+7:13: +7:17
--         _1 = move _9;                    // scope 1 at $DIR/cycle.rs:+7:9: +7:17
+-         _1 = _9;                         // scope 1 at $DIR/cycle.rs:+7:9: +7:17
 -         StorageDead(_9);                 // scope 1 at $DIR/cycle.rs:+7:16: +7:17
 -         _4 = const ();                   // scope 0 at $DIR/cycle.rs:+3:18: +8:6
 -         StorageDead(_6);                 // scope 0 at $DIR/cycle.rs:+8:5: +8:6

--- a/src/test/mir-opt/dead-store-elimination/provenance_soundness.pointer_to_int.DeadStoreElimination.diff
+++ b/src/test/mir-opt/dead-store-elimination/provenance_soundness.pointer_to_int.DeadStoreElimination.diff
@@ -19,12 +19,12 @@
           StorageLive(_2);                 // scope 0 at $DIR/provenance_soundness.rs:+1:9: +1:11
           StorageLive(_3);                 // scope 0 at $DIR/provenance_soundness.rs:+1:14: +1:15
           _3 = _1;                         // scope 0 at $DIR/provenance_soundness.rs:+1:14: +1:15
-          _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/provenance_soundness.rs:+1:14: +1:24
+          _2 = _3 as usize (PointerExposeAddress); // scope 0 at $DIR/provenance_soundness.rs:+1:14: +1:24
           StorageDead(_3);                 // scope 0 at $DIR/provenance_soundness.rs:+1:23: +1:24
           StorageLive(_4);                 // scope 1 at $DIR/provenance_soundness.rs:+2:9: +2:11
           StorageLive(_5);                 // scope 1 at $DIR/provenance_soundness.rs:+2:14: +2:15
           _5 = _1;                         // scope 1 at $DIR/provenance_soundness.rs:+2:14: +2:15
-          _4 = move _5 as isize (PointerExposeAddress); // scope 1 at $DIR/provenance_soundness.rs:+2:14: +2:24
+          _4 = _5 as isize (PointerExposeAddress); // scope 1 at $DIR/provenance_soundness.rs:+2:14: +2:24
           StorageDead(_5);                 // scope 1 at $DIR/provenance_soundness.rs:+2:23: +2:24
           _0 = const ();                   // scope 0 at $DIR/provenance_soundness.rs:+0:32: +3:2
           StorageDead(_4);                 // scope 1 at $DIR/provenance_soundness.rs:+3:1: +3:2

--- a/src/test/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
+++ b/src/test/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
@@ -27,8 +27,8 @@
           StorageDead(_3);                 // scope 0 at $DIR/deduplicate_blocks.rs:+1:22: +1:23
           _7 = Len((*_2));                 // scope 0 at $DIR/deduplicate_blocks.rs:+2:9: +2:37
           _8 = const 4_usize;              // scope 0 at $DIR/deduplicate_blocks.rs:+2:9: +2:37
-          _9 = Ge(move _7, move _8);       // scope 0 at $DIR/deduplicate_blocks.rs:+2:9: +2:37
-          switchInt(move _9) -> [0: bb6, otherwise: bb2]; // scope 0 at $DIR/deduplicate_blocks.rs:+2:9: +2:37
+          _9 = Ge(_7, _8);                 // scope 0 at $DIR/deduplicate_blocks.rs:+2:9: +2:37
+          switchInt(_9) -> [0: bb6, otherwise: bb2]; // scope 0 at $DIR/deduplicate_blocks.rs:+2:9: +2:37
       }
   
       bb2: {
@@ -51,8 +51,8 @@
       bb6: {
           _4 = Len((*_2));                 // scope 0 at $DIR/deduplicate_blocks.rs:+3:9: +3:31
           _5 = const 3_usize;              // scope 0 at $DIR/deduplicate_blocks.rs:+3:9: +3:31
-          _6 = Ge(move _4, move _5);       // scope 0 at $DIR/deduplicate_blocks.rs:+3:9: +3:31
-          switchInt(move _6) -> [0: bb10, otherwise: bb7]; // scope 0 at $DIR/deduplicate_blocks.rs:+3:9: +3:31
+          _6 = Ge(_4, _5);                 // scope 0 at $DIR/deduplicate_blocks.rs:+3:9: +3:31
+          switchInt(_6) -> [0: bb10, otherwise: bb7]; // scope 0 at $DIR/deduplicate_blocks.rs:+3:9: +3:31
       }
   
       bb7: {

--- a/src/test/mir-opt/deref-patterns/string.foo.PreCodegen.after.mir
+++ b/src/test/mir-opt/deref-patterns/string.foo.PreCodegen.after.mir
@@ -17,13 +17,13 @@ fn foo(_1: Option<String>) -> i32 {
         _7 = const false;                // scope 0 at $DIR/string.rs:+1:11: +1:12
         _7 = const true;                 // scope 0 at $DIR/string.rs:+1:11: +1:12
         _5 = discriminant(_1);           // scope 0 at $DIR/string.rs:+1:11: +1:12
-        switchInt(move _5) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/string.rs:+1:5: +1:12
+        switchInt(_5) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/string.rs:+1:5: +1:12
     }
 
     bb1: {
         StorageLive(_6);                 // scope 0 at $DIR/string.rs:+3:9: +3:10
         _7 = const false;                // scope 0 at $DIR/string.rs:+3:9: +3:10
-        _6 = move _1;                    // scope 0 at $DIR/string.rs:+3:9: +3:10
+        _6 = _1;                         // scope 0 at $DIR/string.rs:+3:9: +3:10
         _0 = const 4321_i32;             // scope 1 at $DIR/string.rs:+3:14: +3:18
         drop(_6) -> bb6;                 // scope 0 at $DIR/string.rs:+3:17: +3:18
     }
@@ -47,7 +47,7 @@ fn foo(_1: Option<String>) -> i32 {
     }
 
     bb4: {
-        switchInt(move _4) -> [0: bb1, otherwise: bb5]; // scope 0 at $DIR/string.rs:+2:14: +2:17
+        switchInt(_4) -> [0: bb1, otherwise: bb5]; // scope 0 at $DIR/string.rs:+2:14: +2:17
     }
 
     bb5: {

--- a/src/test/mir-opt/dest-prop/branch.foo.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/branch.foo.DestinationPropagation.diff
@@ -37,7 +37,7 @@
       }
   
       bb2: {
-          switchInt(move _3) -> [0: bb4, otherwise: bb3]; // scope 1 at $DIR/branch.rs:+3:16: +3:22
+          switchInt(_3) -> [0: bb4, otherwise: bb3]; // scope 1 at $DIR/branch.rs:+3:16: +3:22
       }
   
       bb3: {

--- a/src/test/mir-opt/dest-prop/copy_propagation_arg.baz.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/copy_propagation_arg.baz.DestinationPropagation.diff
@@ -9,7 +9,7 @@
       bb0: {
 -         StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:10
 -         _2 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:10
--         _1 = move _2;                    // scope 0 at $DIR/copy_propagation_arg.rs:+2:5: +2:10
+-         _1 = _2;                         // scope 0 at $DIR/copy_propagation_arg.rs:+2:5: +2:10
 -         StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:10
 +         nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:10
 +         nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:10

--- a/src/test/mir-opt/dest-prop/copy_propagation_arg.foo.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/copy_propagation_arg.foo.DestinationPropagation.diff
@@ -21,7 +21,7 @@
   
       bb1: {
           StorageDead(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:+2:16: +2:17
--         _1 = move _2;                    // scope 0 at $DIR/copy_propagation_arg.rs:+2:5: +2:17
+-         _1 = _2;                         // scope 0 at $DIR/copy_propagation_arg.rs:+2:5: +2:17
 -         StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:+2:16: +2:17
 +         nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+2:5: +2:17
 +         nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+2:16: +2:17

--- a/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
@@ -39,7 +39,7 @@
 -         _3 = _2;                         // scope 2 at $DIR/cycle.rs:+3:13: +3:14
 -         StorageLive(_4);                 // scope 3 at $DIR/cycle.rs:+4:9: +4:10
 -         _4 = _3;                         // scope 3 at $DIR/cycle.rs:+4:9: +4:10
--         _1 = move _4;                    // scope 3 at $DIR/cycle.rs:+4:5: +4:10
+-         _1 = _4;                         // scope 3 at $DIR/cycle.rs:+4:5: +4:10
 -         StorageDead(_4);                 // scope 3 at $DIR/cycle.rs:+4:9: +4:10
 +         nop;                             // scope 1 at $DIR/cycle.rs:+2:9: +2:10
 +         nop;                             // scope 1 at $DIR/cycle.rs:+2:13: +2:14

--- a/src/test/mir-opt/dest-prop/dead_stores_79191.f.DestinationPropagation.after.mir
+++ b/src/test/mir-opt/dest-prop/dead_stores_79191.f.DestinationPropagation.after.mir
@@ -16,7 +16,7 @@ fn f(_1: usize) -> usize {
         _1 = const 5_usize;              // scope 1 at $DIR/dead_stores_79191.rs:+2:5: +2:10
         nop;                             // scope 1 at $DIR/dead_stores_79191.rs:+3:9: +3:10
         nop;                             // scope 1 at $DIR/dead_stores_79191.rs:+3:9: +3:10
-        _1 = move _3;                    // scope 1 at $DIR/dead_stores_79191.rs:+3:5: +3:10
+        _1 = _3;                         // scope 1 at $DIR/dead_stores_79191.rs:+3:5: +3:10
         nop;                             // scope 1 at $DIR/dead_stores_79191.rs:+3:9: +3:10
         nop;                             // scope 1 at $DIR/dead_stores_79191.rs:+4:8: +4:9
         nop;                             // scope 1 at $DIR/dead_stores_79191.rs:+4:8: +4:9

--- a/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
@@ -5,7 +5,7 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/union.rs:+0:11: +0:11
       let _1: main::Un;                    // in scope 0 at $DIR/union.rs:+5:9: +5:11
       let mut _2: u32;                     // in scope 0 at $DIR/union.rs:+5:23: +5:28
-      let mut _3: u32;                     // in scope 0 at $DIR/union.rs:+7:10: +7:26
+      let mut _3: u32;                     // in scope 0 at $DIR/union.rs:+7:5: +7:27
       scope 1 {
           debug un => _1;                  // in scope 1 at $DIR/union.rs:+5:9: +5:11
           scope 2 {
@@ -28,9 +28,10 @@
           nop;                             // scope 0 at $DIR/union.rs:+5:14: +5:30
           nop;                             // scope 0 at $DIR/union.rs:+5:14: +5:30
           StorageDead(_2);                 // scope 0 at $DIR/union.rs:+5:29: +5:30
-          StorageLive(_3);                 // scope 1 at $DIR/union.rs:+7:10: +7:26
           nop;                             // scope 2 at $DIR/union.rs:+7:19: +7:24
-          StorageDead(_3);                 // scope 1 at $DIR/union.rs:+7:26: +7:27
+          StorageLive(_3);                 // scope 1 at $DIR/union.rs:+7:5: +7:27
+          nop;                             // scope 1 at $DIR/union.rs:+7:5: +7:27
+          StorageDead(_3);                 // scope 1 at $DIR/union.rs:+7:5: +7:27
           StorageDead(_1);                 // scope 0 at $DIR/union.rs:+8:1: +8:2
           return;                          // scope 0 at $DIR/union.rs:+8:2: +8:2
       }

--- a/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
@@ -12,8 +12,6 @@
       let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+2:10: +2:17
       let _8: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
       let _9: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
-+     let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+     let mut _11: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       scope 1 {
           debug a => _8;                   // in scope 1 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
           debug b => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
@@ -26,33 +24,25 @@
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
           Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
-          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.0: std::option::Option<u32>) = _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.1: std::option::Option<u32>) = _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
           _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
--         switchInt(move _7) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         _10 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         _11 = Ne(_7, move _10);          // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         switchInt(move _11) -> [0: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
+          switchInt(_7) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   
       bb1: {
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
--         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
-+         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
+          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
       }
   
       bb2: {
--         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
--         switchInt(move _6) -> [1: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
--     }
-- 
--     bb3: {
+          _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          switchInt(_6) -> [1: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
+      }
+  
+      bb3: {
           StorageLive(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
           _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
@@ -60,19 +50,12 @@
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
           StorageDead(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
--         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
-+         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
+          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
       }
   
--     bb4: {
-+     bb3: {
+      bb4: {
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:+5:1: +5:2
           return;                          // scope 0 at $DIR/early_otherwise_branch.rs:+5:2: +5:2
-+     }
-+ 
-+     bb4: {
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         switchInt(_7) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
@@ -13,8 +13,6 @@
       let mut _8: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+2:10: +2:17
       let _9: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
       let _10: u32;                        // in scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
-+     let mut _11: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+     let mut _12: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       scope 1 {
           debug a => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
           debug b => _10;                  // in scope 1 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
@@ -27,39 +25,30 @@
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
           Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
-          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.0: std::option::Option<u32>) = _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.1: std::option::Option<u32>) = _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
           _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
--         switchInt(move _8) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         _11 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         _12 = Ne(_8, move _11);          // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         switchInt(move _12) -> [0: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
+          switchInt(_8) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   
       bb1: {
--         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
--         switchInt(move _6) -> [0: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
--     }
-- 
--     bb2: {
-+         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:+4:14: +4:15
-          _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:+4:14: +4:15
--         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:+4:14: +4:15
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+4:14: +4:15
+          _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          switchInt(_6) -> [0: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   
--     bb3: {
--         _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
--         switchInt(move _7) -> [1: bb4, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
--     }
-- 
--     bb4: {
-+     bb2: {
+      bb2: {
+          _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:+4:14: +4:15
+          goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:+4:14: +4:15
+      }
+  
+      bb3: {
+          _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          switchInt(_7) -> [1: bb4, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
+      }
+  
+      bb4: {
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
           _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
           StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
@@ -67,26 +56,17 @@
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
           StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
--         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
+          goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
       }
   
--     bb5: {
-+     bb3: {
+      bb5: {
           _0 = const 0_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:+3:25: +3:26
--         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:25: +3:26
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:25: +3:26
+          goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:25: +3:26
       }
   
--     bb6: {
-+     bb4: {
+      bb6: {
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:+6:1: +6:2
           return;                          // scope 0 at $DIR/early_otherwise_branch.rs:+6:2: +6:2
-+     }
-+ 
-+     bb5: {
-+         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         switchInt(_8) -> [0: bb3, 1: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
@@ -12,8 +12,6 @@
       let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+2:10: +2:17
       let _8: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
       let _9: bool;                        // in scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
-+     let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+     let mut _11: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       scope 1 {
           debug a => _8;                   // in scope 1 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
           debug b => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
@@ -26,33 +24,25 @@
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
           Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
-          (_3.1: std::option::Option<bool>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.0: std::option::Option<u32>) = _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.1: std::option::Option<bool>) = _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
           _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
--         switchInt(move _7) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         _10 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         _11 = Ne(_7, move _10);          // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         switchInt(move _11) -> [0: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
+          switchInt(_7) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   
       bb1: {
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
--         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
-+         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
+          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
       }
   
       bb2: {
--         _6 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
--         switchInt(move _6) -> [1: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
--     }
-- 
--     bb3: {
+          _6 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          switchInt(_6) -> [1: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
+      }
+  
+      bb3: {
           StorageLive(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
           _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
@@ -60,19 +50,12 @@
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
           StorageDead(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
--         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
-+         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
+          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
       }
   
--     bb4: {
-+     bb3: {
+      bb4: {
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:+5:1: +5:2
           return;                          // scope 0 at $DIR/early_otherwise_branch.rs:+5:2: +5:2
-+     }
-+ 
-+     bb4: {
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         switchInt(_7) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
@@ -16,10 +16,6 @@
       let _11: u32;                        // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:15: +2:16
       let _12: u32;                        // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:24: +2:25
       let _13: u32;                        // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:33: +2:34
-+     let mut _14: isize;                  // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
-+     let mut _15: bool;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
-+     let mut _16: isize;                  // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
-+     let mut _17: bool;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
       scope 1 {
           debug a => _11;                  // in scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:15: +2:16
           debug b => _12;                  // in scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:24: +2:25
@@ -35,43 +31,32 @@
           StorageLive(_7);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:18: +1:19
           _7 = _3;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:18: +1:19
           Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
-          (_4.0: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
-          (_4.1: std::option::Option<u32>) = move _6; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
-          (_4.2: std::option::Option<u32>) = move _7; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          (_4.0: std::option::Option<u32>) = _5; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          (_4.1: std::option::Option<u32>) = _6; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          (_4.2: std::option::Option<u32>) = _7; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
           StorageDead(_7);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:19: +1:20
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:19: +1:20
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:19: +1:20
           _10 = discriminant((_4.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
--         switchInt(move _10) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
-+         StorageLive(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
-+         _14 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
-+         StorageLive(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
-+         _15 = Ne(_10, move _14);         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
-+         StorageDead(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
-+         switchInt(move _15) -> [0: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
+          switchInt(_10) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
       }
   
       bb1: {
-+         StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+3:14: +3:15
-+         StorageDead(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+3:14: +3:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+3:14: +3:15
--         goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+3:14: +3:15
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+3:14: +3:15
+          goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+3:14: +3:15
       }
   
       bb2: {
--         _9 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
--         switchInt(move _9) -> [1: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
--     }
-- 
--     bb3: {
-          _8 = discriminant((_4.2: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
--         switchInt(move _8) -> [1: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
-+         switchInt(move _8) -> [1: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
+          _9 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          switchInt(_9) -> [1: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
       }
   
--     bb4: {
-+     bb3: {
+      bb3: {
+          _8 = discriminant((_4.2: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          switchInt(_8) -> [1: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
+      }
+  
+      bb4: {
           StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:15: +2:16
           _11 = (((_4.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:15: +2:16
           StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:24: +2:25
@@ -82,19 +67,12 @@
           StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
           StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
           StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
--         goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
+          goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
       }
   
--     bb5: {
-+     bb4: {
+      bb5: {
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+5:1: +5:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+5:2: +5:2
-+     }
-+ 
-+     bb5: {
-+         StorageDead(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
-+         switchInt(_10) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -74,26 +74,26 @@
           StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:18: +5:23
           _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:18: +5:23
           Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
-          (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
-          (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          (_4.0: &ViewportPercentageLength) = _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          (_4.1: &ViewportPercentageLength) = _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:23: +5:24
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:23: +5:24
           _34 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           _11 = discriminant((*_34));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
-          switchInt(move _11) -> [0: bb1, 1: bb3, 2: bb4, 3: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(_11) -> [0: bb1, 1: bb3, 2: bb4, 3: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb1: {
           _35 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           _7 = discriminant((*_35));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
-          switchInt(move _7) -> [0: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(_7) -> [0: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb2: {
           StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:25: +10:27
           Deinit(_33);                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:25: +10:27
           Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
-          ((_0 as Err).0: ()) = move _33;  // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
+          ((_0 as Err).0: ()) = _33;       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
           discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
           StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:27: +10:28
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+11:6: +11:7
@@ -104,19 +104,19 @@
       bb3: {
           _36 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           _8 = discriminant((*_36));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
-          switchInt(move _8) -> [1: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(_8) -> [1: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb4: {
           _37 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           _9 = discriminant((*_37));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
-          switchInt(move _9) -> [2: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(_9) -> [2: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb5: {
           _38 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           _10 = discriminant((*_38));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
-          switchInt(move _10) -> [3: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(_10) -> [3: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb6: {
@@ -131,11 +131,11 @@
           _15 = _12;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:41
           StorageLive(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:44: +6:49
           _16 = _13;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:44: +6:49
-          _14 = Add(move _15, move _16);   // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
+          _14 = Add(_15, _16);             // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
           StorageDead(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:48: +6:49
           StorageDead(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:48: +6:49
           Deinit(_3);                      // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
-          ((_3 as Vw).0: f32) = move _14;  // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
+          ((_3 as Vw).0: f32) = _14;       // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
           discriminant(_3) = 0;            // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
           StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
           StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
@@ -155,11 +155,11 @@
           _20 = _17;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:41
           StorageLive(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:44: +7:49
           _21 = _18;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:44: +7:49
-          _19 = Add(move _20, move _21);   // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
+          _19 = Add(_20, _21);             // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
           StorageDead(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:48: +7:49
           StorageDead(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:48: +7:49
           Deinit(_3);                      // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
-          ((_3 as Vh).0: f32) = move _19;  // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
+          ((_3 as Vh).0: f32) = _19;       // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
           discriminant(_3) = 1;            // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
           StorageDead(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
           StorageDead(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
@@ -179,11 +179,11 @@
           _25 = _22;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:47
           StorageLive(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:50: +8:55
           _26 = _23;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:50: +8:55
-          _24 = Add(move _25, move _26);   // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
+          _24 = Add(_25, _26);             // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
           StorageDead(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:54: +8:55
           StorageDead(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:54: +8:55
           Deinit(_3);                      // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
-          ((_3 as Vmin).0: f32) = move _24; // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
+          ((_3 as Vmin).0: f32) = _24;     // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
           discriminant(_3) = 2;            // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
           StorageDead(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
           StorageDead(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
@@ -203,11 +203,11 @@
           _30 = _27;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:47
           StorageLive(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:50: +9:55
           _31 = _28;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:50: +9:55
-          _29 = Add(move _30, move _31);   // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
+          _29 = Add(_30, _31);             // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
           StorageDead(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:54: +9:55
           StorageDead(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:54: +9:55
           Deinit(_3);                      // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
-          ((_3 as Vmax).0: f32) = move _29; // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
+          ((_3 as Vmax).0: f32) = _29;     // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
           discriminant(_3) = 3;            // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
           StorageDead(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
           StorageDead(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
@@ -217,7 +217,7 @@
   
       bb10: {
           Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
-          ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
+          ((_0 as Ok).0: ViewportPercentageLength) = _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
           discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+11:6: +11:7
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:1: +12:2

--- a/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
@@ -33,17 +33,17 @@
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:15: +1:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:15: +1:16
           Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
-          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          (_3.0: std::option::Option<u32>) = _4; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          (_3.1: std::option::Option<u32>) = _5; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:16: +1:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:16: +1:17
           _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
-          switchInt(move _8) -> [0: bb1, 1: bb4, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:5: +1:17
+          switchInt(_8) -> [0: bb1, 1: bb4, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:5: +1:17
       }
   
       bb1: {
           _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
-          switchInt(move _6) -> [0: bb2, 1: bb7, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:5: +1:17
+          switchInt(_6) -> [0: bb2, 1: bb7, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:5: +1:17
       }
   
       bb2: {
@@ -57,7 +57,7 @@
   
       bb4: {
           _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
-          switchInt(move _7) -> [0: bb6, 1: bb5, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:5: +1:17
+          switchInt(_7) -> [0: bb6, 1: bb5, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:5: +1:17
       }
   
       bb5: {

--- a/src/test/mir-opt/early_otherwise_branch_soundness.no_deref_ptr.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_soundness.no_deref_ptr.EarlyOtherwiseBranch.diff
@@ -14,7 +14,7 @@
   
       bb0: {
           _3 = discriminant(_1);           // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:11: +1:12
-          switchInt(move _3) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:5: +1:12
+          switchInt(_3) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:5: +1:12
       }
   
       bb1: {
@@ -24,7 +24,7 @@
   
       bb2: {
           _4 = discriminant((*_2));        // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+3:26: +3:28
-          switchInt(move _4) -> [1: bb4, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+3:20: +3:28
+          switchInt(_4) -> [1: bb4, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+3:20: +3:28
       }
   
       bb3: {

--- a/src/test/mir-opt/early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
@@ -12,13 +12,13 @@
   
       bb0: {
           _3 = discriminant((*_1));        // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
-          switchInt(move _3) -> [1: bb1, otherwise: bb3]; // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
+          switchInt(_3) -> [1: bb1, otherwise: bb3]; // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
       }
   
       bb1: {
           _4 = deref_copy (((*_1) as Some).0: &E<'_>); // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
           _2 = discriminant((*_4));        // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
-          switchInt(move _2) -> [1: bb2, otherwise: bb3]; // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
+          switchInt(_2) -> [1: bb2, otherwise: bb3]; // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
       }
   
       bb2: {

--- a/src/test/mir-opt/equal_true.opt.InstCombine.diff
+++ b/src/test/mir-opt/equal_true.opt.InstCombine.diff
@@ -11,10 +11,10 @@
           StorageLive(_2);                 // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
           StorageLive(_3);                 // scope 0 at $DIR/equal_true.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/equal_true.rs:+1:8: +1:9
--         _2 = Eq(move _3, const true);    // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
-+         _2 = move _3;                    // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
+-         _2 = Eq(_3, const true);         // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
++         _2 = _3;                         // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
           StorageDead(_3);                 // scope 0 at $DIR/equal_true.rs:+1:16: +1:17
-          switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
+          switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
       }
   
       bb1: {

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -75,7 +75,7 @@
       bb5: {
           StorageDead(_8);                 // scope 3 at $DIR/funky_arms.rs:+13:44: +13:45
           _9 = discriminant(_7);           // scope 3 at $DIR/funky_arms.rs:+13:12: +13:27
-          switchInt(move _9) -> [1: bb6, otherwise: bb8]; // scope 3 at $DIR/funky_arms.rs:+13:12: +13:27
+          switchInt(_9) -> [1: bb6, otherwise: bb8]; // scope 3 at $DIR/funky_arms.rs:+13:12: +13:27
       }
   
       bb6: {
@@ -91,13 +91,13 @@
           StorageLive(_15);                // scope 3 at $DIR/funky_arms.rs:+15:59: +15:75
           StorageLive(_16);                // scope 3 at $DIR/funky_arms.rs:+15:59: +15:68
           _16 = _10;                       // scope 3 at $DIR/funky_arms.rs:+15:59: +15:68
-          _15 = move _16 as u32 (IntToInt); // scope 3 at $DIR/funky_arms.rs:+15:59: +15:75
+          _15 = _16 as u32 (IntToInt);     // scope 3 at $DIR/funky_arms.rs:+15:59: +15:75
           StorageDead(_16);                // scope 3 at $DIR/funky_arms.rs:+15:74: +15:75
-          _14 = Add(move _15, const 1_u32); // scope 3 at $DIR/funky_arms.rs:+15:59: +15:79
+          _14 = Add(_15, const 1_u32);     // scope 3 at $DIR/funky_arms.rs:+15:59: +15:79
           StorageDead(_15);                // scope 3 at $DIR/funky_arms.rs:+15:78: +15:79
           StorageLive(_17);                // scope 3 at $DIR/funky_arms.rs:+15:81: +15:86
           _17 = _3;                        // scope 3 at $DIR/funky_arms.rs:+15:81: +15:86
-          _0 = float_to_exponential_common_exact::<T>(move _11, move _12, move _13, move _14, move _17) -> bb7; // scope 3 at $DIR/funky_arms.rs:+15:9: +15:87
+          _0 = float_to_exponential_common_exact::<T>(move _11, move _12, move _13, _14, _17) -> bb7; // scope 3 at $DIR/funky_arms.rs:+15:9: +15:87
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:26:9: 26:42
                                            // + literal: Const { ty: for<'a, 'b, 'c> fn(&'a mut Formatter<'b>, &'c T, Sign, u32, bool) -> Result<(), std::fmt::Error> {float_to_exponential_common_exact::<T>}, val: Value(<ZST>) }
@@ -122,7 +122,7 @@
           _20 = _6;                        // scope 2 at $DIR/funky_arms.rs:+17:56: +17:60
           StorageLive(_21);                // scope 2 at $DIR/funky_arms.rs:+17:62: +17:67
           _21 = _3;                        // scope 2 at $DIR/funky_arms.rs:+17:62: +17:67
-          _0 = float_to_exponential_common_shortest::<T>(move _18, move _19, move _20, move _21) -> bb9; // scope 2 at $DIR/funky_arms.rs:+17:9: +17:68
+          _0 = float_to_exponential_common_shortest::<T>(move _18, move _19, move _20, _21) -> bb9; // scope 2 at $DIR/funky_arms.rs:+17:9: +17:68
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:28:9: 28:45
                                            // + literal: Const { ty: for<'a, 'b, 'c> fn(&'a mut Formatter<'b>, &'c T, Sign, bool) -> Result<(), std::fmt::Error> {float_to_exponential_common_shortest::<T>}, val: Value(<ZST>) }

--- a/src/test/mir-opt/if_condition_int.dont_opt_bool.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_opt_bool.SimplifyComparisonIntegral.diff
@@ -9,7 +9,7 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _2 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
-          switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
+          switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
       }
   
       bb1: {

--- a/src/test/mir-opt/if_condition_int.dont_opt_floats.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_opt_floats.SimplifyComparisonIntegral.diff
@@ -11,9 +11,9 @@
           StorageLive(_2);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:18
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
-          _2 = Eq(move _3, const -42f32);  // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:18
+          _2 = Eq(_3, const -42f32);       // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:18
           StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:17: +1:18
-          switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:18
+          switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:18
       }
   
       bb1: {

--- a/src/test/mir-opt/if_condition_int.dont_remove_comparison.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_remove_comparison.SimplifyComparisonIntegral.diff
@@ -18,10 +18,9 @@
           StorageLive(_2);                 // scope 0 at $DIR/if_condition_int.rs:+1:9: +1:10
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:13: +1:14
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:13: +1:14
--         _2 = Eq(move _3, const 17_i8);   // scope 0 at $DIR/if_condition_int.rs:+1:13: +1:20
+          _2 = Eq(_3, const 17_i8);        // scope 0 at $DIR/if_condition_int.rs:+1:13: +1:20
 -         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:19: +1:20
 -         switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/if_condition_int.rs:+2:5: +2:12
-+         _2 = Eq(_3, const 17_i8);        // scope 0 at $DIR/if_condition_int.rs:+1:13: +1:20
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:19: +1:20
 +         switchInt(move _3) -> [17: bb1, otherwise: bb2]; // scope 1 at $DIR/if_condition_int.rs:+2:5: +2:12
       }
@@ -31,9 +30,9 @@
           StorageLive(_6);                 // scope 1 at $DIR/if_condition_int.rs:+4:23: +4:31
           StorageLive(_7);                 // scope 1 at $DIR/if_condition_int.rs:+4:23: +4:24
           _7 = _2;                         // scope 1 at $DIR/if_condition_int.rs:+4:23: +4:24
-          _6 = move _7 as i32 (IntToInt);  // scope 1 at $DIR/if_condition_int.rs:+4:23: +4:31
+          _6 = _7 as i32 (IntToInt);       // scope 1 at $DIR/if_condition_int.rs:+4:23: +4:31
           StorageDead(_7);                 // scope 1 at $DIR/if_condition_int.rs:+4:30: +4:31
-          _0 = Add(const 100_i32, move _6); // scope 1 at $DIR/if_condition_int.rs:+4:17: +4:31
+          _0 = Add(const 100_i32, _6);     // scope 1 at $DIR/if_condition_int.rs:+4:17: +4:31
           StorageDead(_6);                 // scope 1 at $DIR/if_condition_int.rs:+4:30: +4:31
           goto -> bb3;                     // scope 1 at $DIR/if_condition_int.rs:+4:30: +4:31
       }
@@ -43,9 +42,9 @@
           StorageLive(_4);                 // scope 1 at $DIR/if_condition_int.rs:+3:23: +3:31
           StorageLive(_5);                 // scope 1 at $DIR/if_condition_int.rs:+3:23: +3:24
           _5 = _2;                         // scope 1 at $DIR/if_condition_int.rs:+3:23: +3:24
-          _4 = move _5 as i32 (IntToInt);  // scope 1 at $DIR/if_condition_int.rs:+3:23: +3:31
+          _4 = _5 as i32 (IntToInt);       // scope 1 at $DIR/if_condition_int.rs:+3:23: +3:31
           StorageDead(_5);                 // scope 1 at $DIR/if_condition_int.rs:+3:30: +3:31
-          _0 = Add(const 10_i32, move _4); // scope 1 at $DIR/if_condition_int.rs:+3:18: +3:31
+          _0 = Add(const 10_i32, _4);      // scope 1 at $DIR/if_condition_int.rs:+3:18: +3:31
           StorageDead(_4);                 // scope 1 at $DIR/if_condition_int.rs:+3:30: +3:31
           goto -> bb3;                     // scope 1 at $DIR/if_condition_int.rs:+3:30: +3:31
       }

--- a/src/test/mir-opt/if_condition_int.opt_char.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_char.SimplifyComparisonIntegral.diff
@@ -11,10 +11,9 @@
           StorageLive(_2);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
--         _2 = Eq(move _3, const 'x');     // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
+          _2 = Eq(_3, const 'x');          // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
 -         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:15: +1:16
--         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
-+         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
+-         switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:15: +1:16
 +         switchInt(move _3) -> [120: bb1, otherwise: bb2]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
       }

--- a/src/test/mir-opt/if_condition_int.opt_i8.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_i8.SimplifyComparisonIntegral.diff
@@ -11,10 +11,9 @@
           StorageLive(_2);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
--         _2 = Eq(move _3, const 42_i8);   // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
+          _2 = Eq(_3, const 42_i8);        // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
 -         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
--         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
-+         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
+-         switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
 +         switchInt(move _3) -> [42: bb1, otherwise: bb2]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
       }

--- a/src/test/mir-opt/if_condition_int.opt_multiple_ifs.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_multiple_ifs.SimplifyComparisonIntegral.diff
@@ -13,10 +13,9 @@
           StorageLive(_2);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
--         _2 = Eq(move _3, const 42_u32);  // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
+          _2 = Eq(_3, const 42_u32);       // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
 -         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
--         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
-+         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
+-         switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
 +         switchInt(move _3) -> [42: bb1, otherwise: bb2]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
       }
@@ -32,10 +31,9 @@
           StorageLive(_4);                 // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
           StorageLive(_5);                 // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:16
           _5 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:16
--         _4 = Ne(move _5, const 21_u32);  // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
+          _4 = Ne(_5, const 21_u32);       // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
 -         StorageDead(_5);                 // scope 0 at $DIR/if_condition_int.rs:+3:21: +3:22
--         switchInt(move _4) -> [0: bb4, otherwise: bb3]; // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
-+         nop;                             // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
+-         switchInt(_4) -> [0: bb4, otherwise: bb3]; // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+3:21: +3:22
 +         switchInt(move _5) -> [21: bb4, otherwise: bb3]; // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
       }

--- a/src/test/mir-opt/if_condition_int.opt_negative.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_negative.SimplifyComparisonIntegral.diff
@@ -11,10 +11,9 @@
           StorageLive(_2);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
--         _2 = Eq(move _3, const -42_i32); // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
+          _2 = Eq(_3, const -42_i32);      // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
 -         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:15: +1:16
--         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
-+         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
+-         switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:15: +1:16
 +         switchInt(move _3) -> [4294967254: bb1, otherwise: bb2]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
       }

--- a/src/test/mir-opt/if_condition_int.opt_u32.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_u32.SimplifyComparisonIntegral.diff
@@ -11,10 +11,9 @@
           StorageLive(_2);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
--         _2 = Eq(move _3, const 42_u32);  // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
+          _2 = Eq(_3, const 42_u32);       // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
 -         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
--         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
-+         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
+-         switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
 +         switchInt(move _3) -> [42: bb1, otherwise: bb2]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
       }

--- a/src/test/mir-opt/inline/dyn_trait.get_query.Inline.diff
+++ b/src/test/mir-opt/inline/dyn_trait.get_query.Inline.diff
@@ -35,7 +35,7 @@
           _4 = &(*_2);                     // scope 1 at $DIR/dyn_trait.rs:+2:23: +2:24
 -         _0 = try_execute_query::<<Q as Query>::C>(move _4) -> bb2; // scope 1 at $DIR/dyn_trait.rs:+2:5: +2:25
 +         StorageLive(_5);                 // scope 2 at $DIR/dyn_trait.rs:27:14: 27:15
-+         _5 = move _4 as &dyn Cache<V = <Q as Query>::V> (Pointer(Unsize)); // scope 2 at $DIR/dyn_trait.rs:27:14: 27:15
++         _5 = _4 as &dyn Cache<V = <Q as Query>::V> (Pointer(Unsize)); // scope 2 at $DIR/dyn_trait.rs:27:14: 27:15
 +         _0 = <dyn Cache<V = <Q as Query>::V> as Cache>::store_nocache(move _5) -> bb2; // scope 3 at $DIR/dyn_trait.rs:21:5: 21:22
                                            // mir::Constant
 -                                          // + span: $DIR/dyn_trait.rs:34:5: 34:22

--- a/src/test/mir-opt/inline/dyn_trait.try_execute_query.Inline.diff
+++ b/src/test/mir-opt/inline/dyn_trait.try_execute_query.Inline.diff
@@ -14,7 +14,7 @@
           StorageLive(_2);                 // scope 0 at $DIR/dyn_trait.rs:+1:14: +1:15
           StorageLive(_3);                 // scope 0 at $DIR/dyn_trait.rs:+1:14: +1:15
           _3 = &(*_1);                     // scope 0 at $DIR/dyn_trait.rs:+1:14: +1:15
-          _2 = move _3 as &dyn Cache<V = <C as Cache>::V> (Pointer(Unsize)); // scope 0 at $DIR/dyn_trait.rs:+1:14: +1:15
+          _2 = _3 as &dyn Cache<V = <C as Cache>::V> (Pointer(Unsize)); // scope 0 at $DIR/dyn_trait.rs:+1:14: +1:15
           StorageDead(_3);                 // scope 0 at $DIR/dyn_trait.rs:+1:14: +1:15
 -         _0 = mk_cycle::<<C as Cache>::V>(move _2) -> bb1; // scope 0 at $DIR/dyn_trait.rs:+1:5: +1:16
 +         _0 = <dyn Cache<V = <C as Cache>::V> as Cache>::store_nocache(move _2) -> bb1; // scope 1 at $DIR/dyn_trait.rs:21:5: 21:22

--- a/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
@@ -26,7 +26,7 @@ fn bar() -> bool {
         _3 = const 1_i32;                // scope 1 at $DIR/inline_any_operand.rs:+2:5: +2:13
         StorageLive(_4);                 // scope 1 at $DIR/inline_any_operand.rs:+2:5: +2:13
         _4 = const -1_i32;               // scope 1 at $DIR/inline_any_operand.rs:+2:5: +2:13
-        _0 = Eq(move _3, move _4);       // scope 2 at $DIR/inline_any_operand.rs:17:5: 17:11
+        _0 = Eq(_3, _4);                 // scope 2 at $DIR/inline_any_operand.rs:17:5: 17:11
         StorageDead(_4);                 // scope 1 at $DIR/inline_any_operand.rs:+2:5: +2:13
         StorageDead(_3);                 // scope 1 at $DIR/inline_any_operand.rs:+2:5: +2:13
         StorageDead(_2);                 // scope 1 at $DIR/inline_any_operand.rs:+2:12: +2:13

--- a/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
@@ -30,8 +30,8 @@ fn foo(_1: T, _2: i32) -> i32 {
         StorageLive(_7);                 // scope 1 at $DIR/inline_closure.rs:+2:10: +2:11
         _7 = _2;                         // scope 1 at $DIR/inline_closure.rs:+2:10: +2:11
         Deinit(_5);                      // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
-        (_5.0: i32) = move _6;           // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
-        (_5.1: i32) = move _7;           // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
+        (_5.0: i32) = _6;                // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
+        (_5.1: i32) = _7;                // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
         StorageLive(_8);                 // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
         _8 = move (_5.0: i32);           // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
         StorageLive(_9);                 // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12

--- a/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
@@ -33,8 +33,8 @@ fn foo(_1: T, _2: &i32) -> i32 {
         StorageLive(_7);                 // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:10: +5:11
         _7 = &(*_2);                     // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:10: +5:11
         Deinit(_5);                      // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
-        (_5.0: &i32) = move _6;          // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
-        (_5.1: &i32) = move _7;          // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
+        (_5.0: &i32) = _6;               // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
+        (_5.1: &i32) = _7;               // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
         StorageLive(_8);                 // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
         _8 = move (_5.0: &i32);          // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
         StorageLive(_9);                 // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12

--- a/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
@@ -31,8 +31,8 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         StorageLive(_5);                 // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
         _5 = &_1;                        // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
         Deinit(_3);                      // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
-        (_3.0: &i32) = move _4;          // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
-        (_3.1: &T) = move _5;            // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
+        (_3.0: &i32) = _4;               // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
+        (_3.1: &T) = _5;                 // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
         StorageDead(_5);                 // scope 0 at $DIR/inline_closure_captures.rs:+1:16: +1:17
         StorageDead(_4);                 // scope 0 at $DIR/inline_closure_captures.rs:+1:16: +1:17
         StorageLive(_6);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:6
@@ -41,7 +41,7 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         StorageLive(_8);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:7: +2:8
         _8 = _2;                         // scope 1 at $DIR/inline_closure_captures.rs:+2:7: +2:8
         Deinit(_7);                      // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
-        (_7.0: i32) = move _8;           // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
+        (_7.0: i32) = _8;                // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
         StorageLive(_9);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
         _9 = move (_7.0: i32);           // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
         StorageLive(_10);                // scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
@@ -51,8 +51,8 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         _13 = deref_copy ((*_6).1: &T);  // scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
         _11 = (*_13);                    // scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
         Deinit(_0);                      // scope 2 at $DIR/inline_closure_captures.rs:+1:18: +1:24
-        (_0.0: i32) = move _10;          // scope 2 at $DIR/inline_closure_captures.rs:+1:18: +1:24
-        (_0.1: T) = move _11;            // scope 2 at $DIR/inline_closure_captures.rs:+1:18: +1:24
+        (_0.0: i32) = _10;               // scope 2 at $DIR/inline_closure_captures.rs:+1:18: +1:24
+        (_0.1: T) = _11;                 // scope 2 at $DIR/inline_closure_captures.rs:+1:18: +1:24
         StorageDead(_11);                // scope 2 at $DIR/inline_closure_captures.rs:+1:23: +1:24
         StorageDead(_10);                // scope 2 at $DIR/inline_closure_captures.rs:+1:23: +1:24
         StorageDead(_9);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9

--- a/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
@@ -17,15 +17,15 @@
           StorageLive(_2);                 // scope 0 at $DIR/inline_diverging.rs:+1:8: +1:13
           StorageLive(_3);                 // scope 0 at $DIR/inline_diverging.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/inline_diverging.rs:+1:8: +1:9
-          _2 = Gt(move _3, const 0_i32);   // scope 0 at $DIR/inline_diverging.rs:+1:8: +1:13
+          _2 = Gt(_3, const 0_i32);        // scope 0 at $DIR/inline_diverging.rs:+1:8: +1:13
           StorageDead(_3);                 // scope 0 at $DIR/inline_diverging.rs:+1:12: +1:13
-          switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/inline_diverging.rs:+1:8: +1:13
+          switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/inline_diverging.rs:+1:8: +1:13
       }
   
       bb1: {
           StorageLive(_4);                 // scope 0 at $DIR/inline_diverging.rs:+2:9: +2:10
           _4 = _1;                         // scope 0 at $DIR/inline_diverging.rs:+2:9: +2:10
-          _0 = move _4 as u32 (IntToInt);  // scope 0 at $DIR/inline_diverging.rs:+2:9: +2:17
+          _0 = _4 as u32 (IntToInt);       // scope 0 at $DIR/inline_diverging.rs:+2:9: +2:17
           StorageDead(_4);                 // scope 0 at $DIR/inline_diverging.rs:+2:16: +2:17
           StorageDead(_2);                 // scope 0 at $DIR/inline_diverging.rs:+5:5: +5:6
           return;                          // scope 0 at $DIR/inline_diverging.rs:+6:2: +6:2

--- a/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
@@ -60,10 +60,10 @@
 +         StorageDead(_7);                 // scope 2 at $DIR/inline_diverging.rs:28:15: 28:16
 +         StorageDead(_6);                 // scope 2 at $DIR/inline_diverging.rs:28:15: 28:16
 +         StorageLive(_8);                 // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
-+         _8 = move _3;                    // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
++         _8 = _3;                         // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
 +         Deinit(_1);                      // scope 3 at $DIR/inline_diverging.rs:29:5: 29:11
-+         (_1.0: !) = move _8;             // scope 3 at $DIR/inline_diverging.rs:29:5: 29:11
-+         (_1.1: !) = move _9;             // scope 3 at $DIR/inline_diverging.rs:29:5: 29:11
++         (_1.0: !) = _8;                  // scope 3 at $DIR/inline_diverging.rs:29:5: 29:11
++         (_1.1: !) = _9;                  // scope 3 at $DIR/inline_diverging.rs:29:5: 29:11
 +         StorageDead(_8);                 // scope 3 at $DIR/inline_diverging.rs:29:10: 29:11
 +         StorageDead(_3);                 // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2
 +         drop(_2) -> bb3;                 // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2

--- a/src/test/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_generator.main.Inline.diff
@@ -56,11 +56,11 @@
 - 
 -     bb2: {
 +         StorageLive(_5);                 // scope 4 at $SRC_DIR/core/src/pin.rs:LL:COL
-+         _5 = move _3;                    // scope 4 at $SRC_DIR/core/src/pin.rs:LL:COL
++         _5 = _3;                         // scope 4 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         StorageLive(_6);                 // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
-+         _6 = move _5;                    // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
++         _6 = _5;                         // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         Deinit(_2);                      // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
-+         (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]) = move _6; // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
++         (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]) = _6; // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         StorageDead(_6);                 // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         StorageDead(_5);                 // scope 4 at $SRC_DIR/core/src/pin.rs:LL:COL
           StorageDead(_3);                 // scope 0 at $DIR/inline_generator.rs:+1:31: +1:32
@@ -72,7 +72,7 @@
 +         _7 = const false;                // scope 0 at $DIR/inline_generator.rs:+1:14: +1:46
 +         _10 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
 +         _9 = discriminant((*_10));       // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
-+         switchInt(move _9) -> [0: bb3, 1: bb8, 3: bb7, otherwise: bb9]; // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
++         switchInt(_9) -> [0: bb3, 1: bb8, 3: bb7, otherwise: bb9]; // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
       }
   
 -     bb3: {
@@ -92,7 +92,7 @@
 + 
 +     bb3: {
 +         StorageLive(_8);                 // scope 6 at $DIR/inline_generator.rs:15:17: 15:39
-+         switchInt(move _7) -> [0: bb5, otherwise: bb4]; // scope 6 at $DIR/inline_generator.rs:15:20: 15:21
++         switchInt(_7) -> [0: bb5, otherwise: bb4]; // scope 6 at $DIR/inline_generator.rs:15:20: 15:21
 +     }
 + 
 +     bb4: {
@@ -107,7 +107,7 @@
 + 
 +     bb6: {
 +         Deinit(_1);                      // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
-+         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
++         ((_1 as Yielded).0: i32) = _8;   // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
 +         discriminant(_1) = 0;            // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
 +         _11 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
 +         discriminant((*_11)) = 3;        // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
@@ -118,7 +118,7 @@
 +         StorageLive(_8);                 // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
 +         StorageDead(_8);                 // scope 6 at $DIR/inline_generator.rs:15:38: 15:39
 +         Deinit(_1);                      // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
-+         ((_1 as Complete).0: bool) = move _7; // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
++         ((_1 as Complete).0: bool) = _7; // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
 +         discriminant(_1) = 1;            // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
 +         _12 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
 +         discriminant((*_12)) = 1;        // scope 6 at $DIR/inline_generator.rs:15:41: 15:41

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.diff
@@ -24,7 +24,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:9: +1:11
           _2 = SizeOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline_into_box_place.rs:+1:29: +1:43
           _3 = AlignOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline_into_box_place.rs:+1:29: +1:43
-          _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/inline_into_box_place.rs:+1:29: +1:43
+          _4 = alloc::alloc::exchange_malloc(_2, _3) -> bb1; // scope 2 at $DIR/inline_into_box_place.rs:+1:29: +1:43
                                            // mir::Constant
                                            // + span: $DIR/inline_into_box_place.rs:8:29: 8:43
                                            // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
@@ -32,7 +32,7 @@
   
       bb1: {
           StorageLive(_5);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
-          _5 = ShallowInitBox(move _4, std::vec::Vec<u32>); // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
+          _5 = ShallowInitBox(_4, std::vec::Vec<u32>); // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
           _7 = (((_5.0: std::ptr::Unique<std::vec::Vec<u32>>).0: std::ptr::NonNull<std::vec::Vec<u32>>).0: *const std::vec::Vec<u32>); // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
 -         (*_7) = Vec::<u32>::new() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
 +         StorageLive(_8);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
@@ -50,11 +50,11 @@
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Unevaluated(alloc::raw_vec::RawVec::<T>::NEW, [u32], None) }
 +         Deinit((*_8));                   // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-+         ((*_8).0: alloc::raw_vec::RawVec<u32>) = move _9; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
++         ((*_8).0: alloc::raw_vec::RawVec<u32>) = _9; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         ((*_8).1: usize) = const 0_usize; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         StorageDead(_9);                 // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         StorageDead(_8);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
-          _1 = move _5;                    // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
+          _1 = _5;                         // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
           StorageDead(_5);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:42: +1:43
           _0 = const ();                   // scope 0 at $DIR/inline_into_box_place.rs:+0:11: +2:2
 -         drop(_1) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/inline_into_box_place.rs:+2:1: +2:2

--- a/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -54,7 +54,7 @@ fn bar() -> bool {
         _11 = (*_3);                     // scope 2 at $DIR/inline_retag.rs:17:5: 17:7
         StorageLive(_12);                // scope 2 at $DIR/inline_retag.rs:17:11: 17:13
         _12 = (*_6);                     // scope 2 at $DIR/inline_retag.rs:17:11: 17:13
-        _0 = Eq(move _11, move _12);     // scope 2 at $DIR/inline_retag.rs:17:5: 17:13
+        _0 = Eq(_11, _12);               // scope 2 at $DIR/inline_retag.rs:17:5: 17:13
         StorageDead(_12);                // scope 2 at $DIR/inline_retag.rs:17:12: 17:13
         StorageDead(_11);                // scope 2 at $DIR/inline_retag.rs:17:12: 17:13
         StorageDead(_6);                 // scope 1 at $DIR/inline_retag.rs:+2:14: +2:15

--- a/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
@@ -13,7 +13,7 @@ fn test2(_1: &dyn X) -> bool {
         StorageLive(_2);                 // scope 0 at $DIR/inline_trait_method_2.rs:+1:10: +1:11
         StorageLive(_3);                 // scope 0 at $DIR/inline_trait_method_2.rs:+1:10: +1:11
         _3 = &(*_1);                     // scope 0 at $DIR/inline_trait_method_2.rs:+1:10: +1:11
-        _2 = move _3 as &dyn X (Pointer(Unsize)); // scope 0 at $DIR/inline_trait_method_2.rs:+1:10: +1:11
+        _2 = _3 as &dyn X (Pointer(Unsize)); // scope 0 at $DIR/inline_trait_method_2.rs:+1:10: +1:11
         StorageDead(_3);                 // scope 0 at $DIR/inline_trait_method_2.rs:+1:10: +1:11
         _0 = <dyn X as X>::y(move _2) -> bb1; // scope 1 at $DIR/inline_trait_method_2.rs:10:5: 10:10
                                          // mir::Constant

--- a/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
@@ -27,7 +27,7 @@ fn main() -> () {
         StorageLive(_4);                 // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:7: +2:9
         Deinit(_4);                      // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:7: +2:9
         Deinit(_3);                      // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
-        (_3.0: ()) = move _4;            // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
+        (_3.0: ()) = _4;                 // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
         StorageLive(_5);                 // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
         _5 = move (_3.0: ());            // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
         StorageLive(_6);                 // scope 2 at $DIR/issue_76997_inline_scopes_parenting.rs:+1:23: +1:24

--- a/src/test/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
+++ b/src/test/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
@@ -26,7 +26,7 @@
       }
   
       bb3: {
-          switchInt(move _2) -> [0: bb5, otherwise: bb4]; // scope 0 at /the/src/instrument_coverage.rs:+2:12: +2:17
+          switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at /the/src/instrument_coverage.rs:+2:12: +2:17
       }
   
       bb4: {

--- a/src/test/mir-opt/issue_101973.inner.ConstProp.diff
+++ b/src/test/mir-opt/issue_101973.inner.ConstProp.diff
@@ -14,20 +14,23 @@
       let mut _9: u32;                     // in scope 0 at $DIR/issue_101973.rs:+1:33: +1:39
       let mut _10: (u32, bool);            // in scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
       let mut _11: (u32, bool);            // in scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
+      let mut _12: u32;                    // in scope 0 at $DIR/issue_101973.rs:+1:5: +1:17
+      let mut _16: u32;                    // in scope 0 at $DIR/issue_101973.rs:+1:5: +1:58
+      let mut _17: u32;                    // in scope 0 at $DIR/issue_101973.rs:+1:5: +1:58
       scope 1 (inlined imm8) {             // at $DIR/issue_101973.rs:14:5: 14:17
-          debug x => _5;                   // in scope 1 at $DIR/issue_101973.rs:5:13: 5:14
-          let mut _12: u32;                // in scope 1 at $DIR/issue_101973.rs:7:12: 7:27
-          let mut _13: u32;                // in scope 1 at $DIR/issue_101973.rs:7:12: 7:20
-          let mut _14: (u32, bool);        // in scope 1 at $DIR/issue_101973.rs:7:12: 7:20
+          debug x => _12;                  // in scope 1 at $DIR/issue_101973.rs:5:13: 5:14
+          let mut _13: u32;                // in scope 1 at $DIR/issue_101973.rs:7:12: 7:27
+          let mut _14: u32;                // in scope 1 at $DIR/issue_101973.rs:7:12: 7:20
+          let mut _15: (u32, bool);        // in scope 1 at $DIR/issue_101973.rs:7:12: 7:20
           scope 2 {
               debug out => _4;             // in scope 2 at $DIR/issue_101973.rs:6:9: 6:16
           }
       }
       scope 3 (inlined core::num::<impl u32>::rotate_right) { // at $DIR/issue_101973.rs:14:5: 14:58
-          debug self => _4;                // in scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-          debug n => _6;                   // in scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-          let mut _15: u32;                // in scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-          let mut _16: u32;                // in scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          debug self => _16;               // in scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          debug n => _17;                  // in scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          let mut _18: u32;                // in scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          let mut _19: u32;                // in scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
       }
   
       bb0: {
@@ -36,40 +39,47 @@
           StorageLive(_4);                 // scope 0 at $DIR/issue_101973.rs:+1:5: +1:17
           StorageLive(_5);                 // scope 0 at $DIR/issue_101973.rs:+1:10: +1:16
           _5 = _1;                         // scope 0 at $DIR/issue_101973.rs:+1:10: +1:16
-          StorageLive(_12);                // scope 2 at $DIR/issue_101973.rs:7:12: 7:27
-          StorageLive(_13);                // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
-          _14 = CheckedShr(_5, const 0_i32); // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
-          assert(!move (_14.1: bool), "attempt to shift right by `{}`, which would overflow", const 0_i32) -> bb3; // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
+          StorageLive(_12);                // scope 0 at $DIR/issue_101973.rs:+1:5: +1:17
+          _12 = _5;                        // scope 0 at $DIR/issue_101973.rs:+1:5: +1:17
+          StorageLive(_13);                // scope 2 at $DIR/issue_101973.rs:7:12: 7:27
+          StorageLive(_14);                // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
+          _15 = CheckedShr(_12, const 0_i32); // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
+          assert(!(_15.1: bool), "attempt to shift right by `{}`, which would overflow", const 0_i32) -> bb3; // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
       }
   
       bb1: {
-          _8 = move (_10.0: u32);          // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
+          _8 = (_10.0: u32);               // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
           StorageDead(_9);                 // scope 0 at $DIR/issue_101973.rs:+1:44: +1:45
-          _7 = BitAnd(move _8, const 15_u32); // scope 0 at $DIR/issue_101973.rs:+1:31: +1:52
+          _7 = BitAnd(_8, const 15_u32);   // scope 0 at $DIR/issue_101973.rs:+1:31: +1:52
           StorageDead(_8);                 // scope 0 at $DIR/issue_101973.rs:+1:51: +1:52
           _11 = CheckedShl(_7, const 1_i32); // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
-          assert(!move (_11.1: bool), "attempt to shift left by `{}`, which would overflow", const 1_i32) -> bb2; // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
+          assert(!(_11.1: bool), "attempt to shift left by `{}`, which would overflow", const 1_i32) -> bb2; // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
       }
   
       bb2: {
-          _6 = move (_11.0: u32);          // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
+          _6 = (_11.0: u32);               // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
           StorageDead(_7);                 // scope 0 at $DIR/issue_101973.rs:+1:56: +1:57
-          StorageLive(_15);                // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-          _15 = _4;                        // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-          StorageLive(_16);                // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-          _16 = _6;                        // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-          _3 = rotate_right::<u32>(move _15, move _16) -> bb4; // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          StorageLive(_16);                // scope 0 at $DIR/issue_101973.rs:+1:5: +1:58
+          _16 = _4;                        // scope 0 at $DIR/issue_101973.rs:+1:5: +1:58
+          StorageLive(_17);                // scope 0 at $DIR/issue_101973.rs:+1:5: +1:58
+          _17 = _6;                        // scope 0 at $DIR/issue_101973.rs:+1:5: +1:58
+          StorageLive(_18);                // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          _18 = _16;                       // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          StorageLive(_19);                // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          _19 = _17;                       // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          _3 = rotate_right::<u32>(move _18, move _19) -> bb4; // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
                                            // + literal: Const { ty: extern "rust-intrinsic" fn(u32, u32) -> u32 {rotate_right::<u32>}, val: Value(<ZST>) }
       }
   
       bb3: {
-          _13 = move (_14.0: u32);         // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
-          _12 = BitAnd(move _13, const 255_u32); // scope 2 at $DIR/issue_101973.rs:7:12: 7:27
+          _14 = (_15.0: u32);              // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
+          _13 = BitAnd(_14, const 255_u32); // scope 2 at $DIR/issue_101973.rs:7:12: 7:27
+          StorageDead(_14);                // scope 2 at $DIR/issue_101973.rs:7:26: 7:27
+          _4 = BitOr(const 0_u32, _13);    // scope 2 at $DIR/issue_101973.rs:7:5: 7:27
           StorageDead(_13);                // scope 2 at $DIR/issue_101973.rs:7:26: 7:27
-          _4 = BitOr(const 0_u32, move _12); // scope 2 at $DIR/issue_101973.rs:7:5: 7:27
-          StorageDead(_12);                // scope 2 at $DIR/issue_101973.rs:7:26: 7:27
+          StorageDead(_12);                // scope 0 at $DIR/issue_101973.rs:+1:5: +1:17
           StorageDead(_5);                 // scope 0 at $DIR/issue_101973.rs:+1:16: +1:17
           StorageLive(_6);                 // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
           StorageLive(_7);                 // scope 0 at $DIR/issue_101973.rs:+1:31: +1:52
@@ -77,17 +87,19 @@
           StorageLive(_9);                 // scope 0 at $DIR/issue_101973.rs:+1:33: +1:39
           _9 = _1;                         // scope 0 at $DIR/issue_101973.rs:+1:33: +1:39
           _10 = CheckedShr(_9, const 8_i32); // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
-          assert(!move (_10.1: bool), "attempt to shift right by `{}`, which would overflow", const 8_i32) -> bb1; // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
+          assert(!(_10.1: bool), "attempt to shift right by `{}`, which would overflow", const 8_i32) -> bb1; // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
       }
   
       bb4: {
-          StorageDead(_16);                // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-          StorageDead(_15);                // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          StorageDead(_19);                // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          StorageDead(_18);                // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          StorageDead(_17);                // scope 0 at $DIR/issue_101973.rs:+1:5: +1:58
+          StorageDead(_16);                // scope 0 at $DIR/issue_101973.rs:+1:5: +1:58
           StorageDead(_6);                 // scope 0 at $DIR/issue_101973.rs:+1:57: +1:58
           StorageDead(_4);                 // scope 0 at $DIR/issue_101973.rs:+1:57: +1:58
-          _2 = move _3 as i32 (IntToInt);  // scope 0 at $DIR/issue_101973.rs:+1:5: +1:65
+          _2 = _3 as i32 (IntToInt);       // scope 0 at $DIR/issue_101973.rs:+1:5: +1:65
           StorageDead(_3);                 // scope 0 at $DIR/issue_101973.rs:+1:64: +1:65
-          _0 = move _2 as i64 (IntToInt);  // scope 0 at $DIR/issue_101973.rs:+1:5: +1:72
+          _0 = _2 as i64 (IntToInt);       // scope 0 at $DIR/issue_101973.rs:+1:5: +1:72
           StorageDead(_2);                 // scope 0 at $DIR/issue_101973.rs:+1:71: +1:72
           return;                          // scope 0 at $DIR/issue_101973.rs:+2:2: +2:2
       }

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff
@@ -81,7 +81,7 @@
           StorageLive(_7);                 // scope 1 at $DIR/issue_73223.rs:+6:22: +6:27
           _7 = _1;                         // scope 1 at $DIR/issue_73223.rs:+6:22: +6:27
           Deinit(_6);                      // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
-          ((_6 as Some).0: i32) = move _7; // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
+          ((_6 as Some).0: i32) = _7;      // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
           discriminant(_6) = 1;            // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
           StorageDead(_7);                 // scope 1 at $DIR/issue_73223.rs:+6:27: +6:28
           StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -97,8 +97,8 @@
           _11 = _28;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           Deinit(_29);                     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           Deinit(_30);                     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _29 = move _10;                  // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _30 = move _11;                  // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _29 = _10;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _30 = _11;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -111,12 +111,12 @@
           _17 = (*_13);                    // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _18 = const 1_i32;               // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _16 = Eq(move _17, const 1_i32); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _16 = Eq(_17, const 1_i32);      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_17);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _15 = Not(move _16);             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _15 = Not(_16);                  // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_16);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          switchInt(move _15) -> [0: bb5, otherwise: bb4]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          switchInt(_15) -> [0: bb5, otherwise: bb4]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
       bb4: {

--- a/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -46,7 +46,7 @@
           _7 = _1;                         // scope 0 at $DIR/issue_76432.rs:+1:24: +1:25
           StorageLive(_8);                 // scope 0 at $DIR/issue_76432.rs:+1:27: +1:28
           _8 = _1;                         // scope 0 at $DIR/issue_76432.rs:+1:27: +1:28
-          _5 = [move _6, move _7, move _8]; // scope 0 at $DIR/issue_76432.rs:+1:20: +1:29
+          _5 = [_6, _7, _8];               // scope 0 at $DIR/issue_76432.rs:+1:20: +1:29
           StorageDead(_8);                 // scope 0 at $DIR/issue_76432.rs:+1:28: +1:29
           StorageDead(_7);                 // scope 0 at $DIR/issue_76432.rs:+1:28: +1:29
           StorageDead(_6);                 // scope 0 at $DIR/issue_76432.rs:+1:28: +1:29
@@ -54,7 +54,7 @@
           _3 = _4;                         // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
           StorageLive(_23);                // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
           _23 = _3;                        // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
-          _2 = move _3 as &[T] (Pointer(Unsize)); // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
+          _2 = _3 as &[T] (Pointer(Unsize)); // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
           StorageDead(_3);                 // scope 0 at $DIR/issue_76432.rs:+1:28: +1:29
           StorageDead(_4);                 // scope 0 at $DIR/issue_76432.rs:+1:29: +1:30
           StorageLive(_9);                 // scope 1 at $DIR/issue_76432.rs:+2:5: +5:6
@@ -95,7 +95,7 @@
           StorageLive(_21);                // scope 2 at $DIR/issue_76432.rs:+3:70: +3:84
           _21 = &raw const (*_15);         // scope 2 at $DIR/issue_76432.rs:+3:70: +3:72
           _20 = _21;                       // scope 2 at $DIR/issue_76432.rs:+3:70: +3:84
-          _9 = [move _16, move _18, move _20]; // scope 2 at $DIR/issue_76432.rs:+3:37: +3:85
+          _9 = [_16, _18, _20];            // scope 2 at $DIR/issue_76432.rs:+3:37: +3:85
           StorageDead(_21);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
           StorageDead(_20);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
           StorageDead(_19);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85

--- a/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -7,7 +7,7 @@ fn num_to_digit(_1: char) -> u32 {
     let mut _3: u32;                     // in scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
     let mut _9: isize;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 (inlined char::methods::<impl char>::is_digit) { // at $DIR/issue_59352.rs:14:8: 14:23
-        debug self => _1;                // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        debug self => _6;                // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         debug radix => _3;               // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         let mut _4: &std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         let _5: std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
@@ -26,11 +26,10 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb0: {
+        _6 = _1;                         // scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
         StorageLive(_3);                 // scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
         StorageLive(_4);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        _6 = _1;                         // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         _5 = char::methods::<impl char>::to_digit(move _6, const 8_u32) -> bb5; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/char/methods.rs:LL:COL
@@ -39,7 +38,7 @@ fn num_to_digit(_1: char) -> u32 {
 
     bb1: {
         StorageLive(_2);                 // scope 0 at $DIR/issue_59352.rs:+2:26: +2:41
-        _2 = char::methods::<impl char>::to_digit(move _1, const 8_u32) -> bb2; // scope 0 at $DIR/issue_59352.rs:+2:26: +2:41
+        _2 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> bb2; // scope 0 at $DIR/issue_59352.rs:+2:26: +2:41
                                          // mir::Constant
                                          // + span: $DIR/issue_59352.rs:14:30: 14:38
                                          // + literal: Const { ty: fn(char, u32) -> Option<u32> {char::methods::<impl char>::to_digit}, val: Value(<ZST>) }
@@ -47,7 +46,7 @@ fn num_to_digit(_1: char) -> u32 {
 
     bb2: {
         _7 = discriminant(_2);           // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        switchInt(move _7) -> [0: bb6, 1: bb8, otherwise: bb7]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(_7) -> [0: bb6, 1: bb8, otherwise: bb7]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
     bb3: {
@@ -61,7 +60,6 @@ fn num_to_digit(_1: char) -> u32 {
 
     bb5: {
         _4 = &_5;                        // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         _9 = discriminant((*_4));        // scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
         StorageDead(_4);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
@@ -85,7 +83,7 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb8: {
-        _0 = move ((_2 as Some).0: u32); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        _0 = ((_2 as Some).0: u32);      // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         StorageDead(_2);                 // scope 0 at $DIR/issue_59352.rs:+2:49: +2:50
         goto -> bb4;                     // scope 0 at $DIR/issue_59352.rs:+2:5: +2:63
     }

--- a/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
@@ -47,7 +47,7 @@
           StorageLive(_5);                 // scope 3 at $DIR/issue_75439.rs:+5:14: +5:38
           StorageLive(_6);                 // scope 4 at $DIR/issue_75439.rs:+5:33: +5:35
           _6 = _4;                         // scope 4 at $DIR/issue_75439.rs:+5:33: +5:35
-          _5 = transmute::<u32, [u8; 4]>(move _6) -> bb7; // scope 4 at $DIR/issue_75439.rs:+5:23: +5:36
+          _5 = transmute::<u32, [u8; 4]>(_6) -> bb7; // scope 4 at $DIR/issue_75439.rs:+5:23: +5:36
                                            // mir::Constant
                                            // + span: $DIR/issue_75439.rs:10:23: 10:32
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(u32) -> [u8; 4] {transmute::<u32, [u8; 4]>}, val: Value(<ZST>) }
@@ -68,7 +68,7 @@
       bb7: {
           StorageDead(_6);                 // scope 4 at $DIR/issue_75439.rs:+5:35: +5:36
           Deinit(_0);                      // scope 3 at $DIR/issue_75439.rs:+5:9: +5:39
-          ((_0 as Some).0: [u8; 4]) = move _5; // scope 3 at $DIR/issue_75439.rs:+5:9: +5:39
+          ((_0 as Some).0: [u8; 4]) = _5;  // scope 3 at $DIR/issue_75439.rs:+5:9: +5:39
           discriminant(_0) = 1;            // scope 3 at $DIR/issue_75439.rs:+5:9: +5:39
           StorageDead(_5);                 // scope 3 at $DIR/issue_75439.rs:+5:38: +5:39
           StorageDead(_4);                 // scope 1 at $DIR/issue_75439.rs:+6:5: +6:6

--- a/src/test/mir-opt/lower_array_len_e2e.array_bound.PreCodegen.after.mir
+++ b/src/test/mir-opt/lower_array_len_e2e.array_bound.PreCodegen.after.mir
@@ -5,27 +5,23 @@ fn array_bound(_1: usize, _2: &[u8; N]) -> u8 {
     debug slice => _2;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+0:50: +0:55
     let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len_e2e.rs:+0:70: +0:72
     let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
-    let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:13
-    let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
-    let mut _6: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-    let mut _7: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+    let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
+    let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+    let mut _6: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
 
     bb0: {
         StorageLive(_3);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
-        StorageLive(_4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:13
-        _4 = _1;                         // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:13
-        StorageLive(_5);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
-        _5 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
-        _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
-        StorageDead(_5);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:26: +1:27
+        StorageLive(_4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
+        _4 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
+        _3 = Lt(_1, _4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:26: +1:27
-        switchInt(move _3) -> [0: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
+        switchInt(_3) -> [0: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
     }
 
     bb1: {
-        _6 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-        _7 = Lt(_1, _6);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-        assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _1) -> bb2; // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+        _5 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+        _6 = Lt(_1, _5);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+        assert(_6, "index out of bounds: the length is {} but the index is {}", _5, _1) -> bb2; // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
     }
 
     bb2: {

--- a/src/test/mir-opt/lower_array_len_e2e.array_bound_mut.PreCodegen.after.mir
+++ b/src/test/mir-opt/lower_array_len_e2e.array_bound_mut.PreCodegen.after.mir
@@ -5,30 +5,26 @@ fn array_bound_mut(_1: usize, _2: &mut [u8; N]) -> u8 {
     debug slice => _2;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+0:54: +0:59
     let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len_e2e.rs:+0:78: +0:80
     let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
-    let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:13
-    let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
-    let mut _6: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-    let mut _7: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-    let _8: usize;                       // in scope 0 at $DIR/lower_array_len_e2e.rs:+4:15: +4:16
-    let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
-    let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
+    let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
+    let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+    let mut _6: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+    let _7: usize;                       // in scope 0 at $DIR/lower_array_len_e2e.rs:+4:15: +4:16
+    let mut _8: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
+    let mut _9: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
 
     bb0: {
         StorageLive(_3);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
-        StorageLive(_4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:13
-        _4 = _1;                         // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:13
-        StorageLive(_5);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
-        _5 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
-        _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
-        StorageDead(_5);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:26: +1:27
+        StorageLive(_4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
+        _4 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
+        _3 = Lt(_1, _4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:26: +1:27
-        switchInt(move _3) -> [0: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
+        switchInt(_3) -> [0: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
     }
 
     bb1: {
-        _6 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-        _7 = Lt(_1, _6);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-        assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _1) -> bb2; // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+        _5 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+        _6 = Lt(_1, _5);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+        assert(_6, "index out of bounds: the length is {} but the index is {}", _5, _1) -> bb2; // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
     }
 
     bb2: {
@@ -37,16 +33,16 @@ fn array_bound_mut(_1: usize, _2: &mut [u8; N]) -> u8 {
     }
 
     bb3: {
-        StorageLive(_8);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+4:15: +4:16
-        _8 = const 0_usize;              // scope 0 at $DIR/lower_array_len_e2e.rs:+4:15: +4:16
-        _9 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
-        _10 = Lt(const 0_usize, _9);     // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
-        assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, const 0_usize) -> bb4; // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
+        StorageLive(_7);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+4:15: +4:16
+        _7 = const 0_usize;              // scope 0 at $DIR/lower_array_len_e2e.rs:+4:15: +4:16
+        _8 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
+        _9 = Lt(const 0_usize, _8);      // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
+        assert(_9, "index out of bounds: the length is {} but the index is {}", _8, const 0_usize) -> bb4; // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
     }
 
     bb4: {
-        (*_2)[_8] = const 42_u8;         // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:22
-        StorageDead(_8);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+4:22: +4:23
+        (*_2)[_7] = const 42_u8;         // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:22
+        StorageDead(_7);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+4:22: +4:23
         _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len_e2e.rs:+6:9: +6:11
         goto -> bb5;                     // scope 0 at $DIR/lower_array_len_e2e.rs:+1:5: +7:6
     }

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.diff
@@ -70,10 +70,10 @@
           StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:+23:15: +23:16
           _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:+23:15: +23:16
           Deinit(_0);                      // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
-          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
-          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
-          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
-          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.0: bool) = _7;               // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.1: bool) = _8;               // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.2: bool) = _9;               // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.3: bool) = _10;              // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
           StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17
           StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17
           StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.diff
@@ -11,12 +11,12 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _3 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:+1:17: +1:20
--         switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         switchInt(_3) -> [0: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         StorageLive(_4);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         _4 = move _3;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
++         _4 = _3;                         // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         _2 = Eq(_4, const 0_isize);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         StorageDead(_4);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
++         switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
       bb1: {
@@ -30,7 +30,7 @@
 -     }
 - 
 -     bb3: {
--         switchInt(move _2) -> [0: bb5, otherwise: bb4]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         switchInt(_2) -> [0: bb5, otherwise: bb4]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
 -     bb4: {

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.diff
@@ -26,7 +26,7 @@
           StorageLive(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
           StorageLive(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
           _6 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
--         switchInt(move _6) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
+-         switchInt(_6) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
 -     }
 - 
 -     bb1: {
@@ -41,11 +41,11 @@
 - 
 -     bb3: {
 +         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
-+         _7 = move _6;                    // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
++         _7 = _6;                         // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
 +         _5 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:+2:45: +2:50
 +         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
           StorageDead(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:51: +2:52
--         switchInt(move _5) -> [0: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
+-         switchInt(_5) -> [0: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
 -     }
 - 
 -     bb4: {
@@ -60,11 +60,11 @@
 - 
 -     bb6: {
 +         StorageLive(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
-+         _8 = move _5;                    // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
++         _8 = _5;                         // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
 +         _4 = Ne(_8, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:+2:69: +2:74
 +         StorageDead(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
           StorageDead(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:75: +2:76
--         switchInt(move _4) -> [0: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
+-         switchInt(_4) -> [0: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
 -     }
 - 
 -     bb7: {
@@ -78,16 +78,16 @@
 -     }
 - 
 -     bb9: {
--         switchInt(move _3) -> [0: bb11, otherwise: bb10]; // scope 0 at $DIR/matches_reduce_branches.rs:+2:15: +6:10
+-         switchInt(_3) -> [0: bb11, otherwise: bb10]; // scope 0 at $DIR/matches_reduce_branches.rs:+2:15: +6:10
 -     }
 - 
 -     bb10: {
 +         StorageLive(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
-+         _9 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
++         _9 = _4;                         // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
 +         _3 = Ne(_9, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:+5:13: +5:18
 +         StorageDead(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
 +         StorageLive(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:+2:15: +6:10
-+         _10 = move _3;                   // scope 0 at $DIR/matches_reduce_branches.rs:+2:15: +6:10
++         _10 = _3;                        // scope 0 at $DIR/matches_reduce_branches.rs:+2:15: +6:10
           StorageDead(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:+6:9: +6:10
           StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:+6:9: +6:10
 -         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:+8:13: +8:17

--- a/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
-          switchInt(move _2) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
+          switchInt(_2) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
       }
   
       bb1: {

--- a/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
-          switchInt(move _2) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
+          switchInt(_2) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
       }
   
       bb1: {

--- a/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
+++ b/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
@@ -11,10 +11,10 @@
           StorageLive(_2);                 // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
           StorageLive(_3);                 // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:9
--         _2 = Ne(move _3, const false);   // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
-+         _2 = move _3;                    // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
+-         _2 = Ne(_3, const false);        // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
++         _2 = _3;                         // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
           StorageDead(_3);                 // scope 0 at $DIR/not_equal_false.rs:+1:17: +1:18
-          switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
+          switchInt(_2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
       }
   
       bb1: {

--- a/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
+++ b/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
@@ -43,7 +43,7 @@
       bb1: {
 -         StorageDead(_3);                 // scope 1 at $DIR/remove_storage_markers.rs:+2:18: +2:19
 -         StorageLive(_4);                 // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
-          _4 = move _2;                    // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          _4 = _2;                         // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
           goto -> bb2;                     // scope 2 at $DIR/remove_storage_markers.rs:+2:5: +4:6
       }
   
@@ -63,7 +63,7 @@
       bb3: {
 -         StorageDead(_8);                 // scope 2 at $DIR/remove_storage_markers.rs:+2:18: +2:19
           _10 = discriminant(_7);          // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
-          switchInt(move _10) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          switchInt(_10) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
       }
   
       bb4: {
@@ -71,7 +71,7 @@
           _12 = ((_7 as Some).0: i32);     // scope 2 at $DIR/remove_storage_markers.rs:+2:9: +2:10
 -         StorageLive(_13);                // scope 3 at $DIR/remove_storage_markers.rs:+3:16: +3:17
           _13 = _12;                       // scope 3 at $DIR/remove_storage_markers.rs:+3:16: +3:17
-          _1 = Add(_1, move _13);          // scope 3 at $DIR/remove_storage_markers.rs:+3:9: +3:17
+          _1 = Add(_1, _13);               // scope 3 at $DIR/remove_storage_markers.rs:+3:9: +3:17
 -         StorageDead(_13);                // scope 3 at $DIR/remove_storage_markers.rs:+3:16: +3:17
           _6 = const ();                   // scope 3 at $DIR/remove_storage_markers.rs:+2:20: +4:6
 -         StorageDead(_12);                // scope 2 at $DIR/remove_storage_markers.rs:+4:5: +4:6

--- a/src/test/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
@@ -13,7 +13,7 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
-          _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
+          _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
           drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   

--- a/src/test/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
@@ -13,7 +13,7 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
-          _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
+          _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
           drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   

--- a/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
@@ -6,18 +6,22 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:+0:17: +0:17
       let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
       let mut _3: bool;                    // in scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
+      let mut _4: bool;                    // in scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
       scope 1 (inlined std::mem::drop::<bool>) { // at $DIR/remove_unneeded_drops.rs:4:5: 4:12
-          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          debug _x => _4;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
           _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
--         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          StorageLive(_4);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+          _4 = _3;                         // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+-         drop(_4) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
 -     }
 - 
 -     bb1: {
+          StorageDead(_4);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
           StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:11: +1:12
           StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
 -         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+0:17: +2:2

--- a/src/test/mir-opt/remove_zsts.get_union.RemoveZsts.diff
+++ b/src/test/mir-opt/remove_zsts.get_union.RemoveZsts.diff
@@ -10,7 +10,7 @@
 -         Deinit(_1);                      // scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
 +         nop;                             // scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
           Deinit(_0);                      // scope 0 at $DIR/remove_zsts.rs:+1:5: +1:18
--         (_0.0: ()) = move _1;            // scope 0 at $DIR/remove_zsts.rs:+1:5: +1:18
+-         (_0.0: ()) = _1;                 // scope 0 at $DIR/remove_zsts.rs:+1:5: +1:18
 +         nop;                             // scope 0 at $DIR/remove_zsts.rs:+1:5: +1:18
           StorageDead(_1);                 // scope 0 at $DIR/remove_zsts.rs:+1:17: +1:18
           return;                          // scope 0 at $DIR/remove_zsts.rs:+2:2: +2:2

--- a/src/test/mir-opt/remove_zsts_dont_touch_unions.get_union.RemoveZsts.after.mir
+++ b/src/test/mir-opt/remove_zsts_dont_touch_unions.get_union.RemoveZsts.after.mir
@@ -1,0 +1,15 @@
+// MIR for `get_union` after RemoveZsts
+
+fn get_union() -> Foo {
+    let mut _0: Foo;                     // return place in scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+0:19: +0:22
+    let mut _1: ();                      // in scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:14: +1:16
+
+    bb0: {
+        StorageLive(_1);                 // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:14: +1:16
+        nop;                             // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:14: +1:16
+        Deinit(_0);                      // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:5: +1:18
+        nop;                             // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:5: +1:18
+        StorageDead(_1);                 // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:17: +1:18
+        return;                          // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+2:2: +2:2
+    }
+}

--- a/src/test/mir-opt/remove_zsts_dont_touch_unions.rs
+++ b/src/test/mir-opt/remove_zsts_dont_touch_unions.rs
@@ -1,0 +1,19 @@
+// unit-test: RemoveZsts
+
+// Ensure RemoveZsts doesn't remove ZST assignments to union fields,
+// which causes problems in Miri.
+
+union Foo {
+    x: (),
+    y: u64,
+}
+
+// EMIT_MIR remove_zsts_dont_touch_unions.get_union.RemoveZsts.after.mir
+fn get_union() -> Foo {
+    Foo { x: () }
+}
+
+
+fn main() {
+    get_union();
+}

--- a/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -53,14 +53,14 @@
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
           _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
           _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
--         switchInt(move _10) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-+         switchInt(move _10) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+-         switchInt(_10) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
++         switchInt(_10) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb1: {
 -         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
 -         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
--         switchInt(move _5) -> [0: bb2, 1: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+-         switchInt(_5) -> [0: bb2, 1: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
 -     }
 - 
 -     bb2: {
@@ -69,7 +69,7 @@
           _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:+1:8: +1:10
           StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
           Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
-          ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
+          ((_0 as Ok).0: i32) = _2;        // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
           discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+1:10: +1:11
           StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:+2:1: +2:2
@@ -88,10 +88,10 @@
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
           _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
           StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-          _16 = move ((_8 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+          _16 = ((_8 as Err).0: i32);      // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          _18 = move _16;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          _18 = _16;                       // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
 -         _17 = <i32 as From<i32>>::from(move _18) -> bb8; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
 +         _17 = <i32 as From<i32>>::from(move _18) -> bb7; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
                                            // mir::Constant
@@ -102,23 +102,23 @@
 -     bb5: {
 +     bb4: {
           StorageLive(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          _13 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _13 = ((_4 as Err).0: i32);      // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          _15 = move _13;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          _15 = _13;                       // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           Deinit(_14);                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_14 as Err).0: i32) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_14 as Err).0: i32) = _15;     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_14) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           Deinit(_3);                      // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 -         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 +         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
 +         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-+         switchInt(move _5) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
++         switchInt(_5) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   
 -     bb6: {
@@ -129,25 +129,25 @@
 -     bb7: {
 +     bb6: {
           StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _11 = ((_4 as Ok).0: i32);       // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          _12 = move _11;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          _12 = _11;                       // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           Deinit(_3);                      // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_3 as Continue).0: i32) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Continue).0: i32) = _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 -         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 +         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
 +         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-+         switchInt(move _5) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
++         switchInt(_5) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   
 -     bb8: {
 +     bb7: {
           StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           Deinit(_0);                      // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_0 as Err).0: i32) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_0 as Err).0: i32) = _17;      // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL

--- a/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
@@ -30,7 +30,7 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
           _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:+6:15: +6:16
-          switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+6:9: +6:16
+          switchInt(_3) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+6:9: +6:16
       }
   
       bb1: {
@@ -39,13 +39,13 @@
           StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:+8:42: +8:43
           _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:+8:42: +8:43
           Deinit(_2);                      // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
-          ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
+          ((_2 as Break).0: usize) = _7;   // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
           discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
           StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:+8:43: +8:44
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
 -         goto -> bb4;                     // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
 +         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
-+         switchInt(move _8) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
++         switchInt(_8) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
       bb2: {
@@ -58,7 +58,7 @@
           StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
           _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
           Deinit(_2);                      // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
-          ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
+          ((_2 as Continue).0: i32) = _5;  // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
           discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
           StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:45: +7:46
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:45: +7:46
@@ -67,8 +67,8 @@
 - 
 -     bb4: {
           _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
--         switchInt(move _8) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
-+         switchInt(move _8) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
+-         switchInt(_8) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
++         switchInt(_8) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
 -     bb5: {
@@ -94,7 +94,7 @@
           StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
           _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
           Deinit(_0);                      // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
-          ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
+          ((_0 as Some).0: i32) = _10;     // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
           discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
           StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:43: +11:44
           StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44

--- a/src/test/mir-opt/simplify_locals.c.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.c.SimplifyLocals.diff
@@ -21,7 +21,7 @@
 -         StorageLive(_4);                 // scope 1 at $DIR/simplify_locals.rs:+3:20: +3:26
 -         _4 = &_1;                        // scope 1 at $DIR/simplify_locals.rs:+3:20: +3:26
 -         _3 = &(*_4);                     // scope 1 at $DIR/simplify_locals.rs:+3:20: +3:26
--         _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 1 at $DIR/simplify_locals.rs:+3:20: +3:26
+-         _2 = _3 as &[u8] (Pointer(Unsize)); // scope 1 at $DIR/simplify_locals.rs:+3:20: +3:26
 -         StorageDead(_3);                 // scope 1 at $DIR/simplify_locals.rs:+3:25: +3:26
 -         StorageDead(_4);                 // scope 1 at $DIR/simplify_locals.rs:+3:26: +3:27
 -         StorageDead(_2);                 // scope 1 at $DIR/simplify_locals.rs:+3:26: +3:27

--- a/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
@@ -17,9 +17,9 @@
 -         discriminant(_3) = 0;            // scope 0 at $DIR/simplify_locals.rs:+2:11: +2:15
 -         Deinit(_2);                      // scope 0 at $DIR/simplify_locals.rs:+2:6: +2:16
 -         (_2.0: i32) = const 10_i32;      // scope 0 at $DIR/simplify_locals.rs:+2:6: +2:16
--         (_2.1: E) = move _3;             // scope 0 at $DIR/simplify_locals.rs:+2:6: +2:16
+-         (_2.1: E) = _3;                  // scope 0 at $DIR/simplify_locals.rs:+2:6: +2:16
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify_locals.rs:+2:15: +2:16
--         (_2.1: E) = move _1;             // scope 0 at $DIR/simplify_locals.rs:+2:5: +2:26
+-         (_2.1: E) = _1;                  // scope 0 at $DIR/simplify_locals.rs:+2:5: +2:26
 -         StorageDead(_1);                 // scope 0 at $DIR/simplify_locals.rs:+2:25: +2:26
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify_locals.rs:+2:26: +2:27
           _0 = const ();                   // scope 0 at $DIR/simplify_locals.rs:+0:9: +3:2

--- a/src/test/mir-opt/simplify_locals.expose_addr.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.expose_addr.SimplifyLocals.diff
@@ -11,7 +11,7 @@
           StorageLive(_2);                 // scope 0 at $DIR/simplify_locals.rs:+2:5: +2:15
           StorageLive(_3);                 // scope 0 at $DIR/simplify_locals.rs:+2:5: +2:6
           _3 = _1;                         // scope 0 at $DIR/simplify_locals.rs:+2:5: +2:6
-          _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/simplify_locals.rs:+2:5: +2:15
+          _2 = _3 as usize (PointerExposeAddress); // scope 0 at $DIR/simplify_locals.rs:+2:5: +2:15
           StorageDead(_3);                 // scope 0 at $DIR/simplify_locals.rs:+2:14: +2:15
           StorageDead(_2);                 // scope 0 at $DIR/simplify_locals.rs:+2:15: +2:16
           _0 = const ();                   // scope 0 at $DIR/simplify_locals.rs:+0:33: +3:2

--- a/src/test/mir-opt/simplify_locals.t4.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.t4.SimplifyLocals.diff
@@ -13,7 +13,7 @@
           StorageLive(_2);                 // scope 1 at $DIR/simplify_locals.rs:+2:14: +2:15
           _2 = &/*tls*/ mut X;             // scope 1 at $DIR/simplify_locals.rs:+2:14: +2:15
           _1 = (*_2);                      // scope 1 at $DIR/simplify_locals.rs:+2:14: +2:15
-          _0 = Add(move _1, const 1_u32);  // scope 1 at $DIR/simplify_locals.rs:+2:14: +2:19
+          _0 = Add(_1, const 1_u32);       // scope 1 at $DIR/simplify_locals.rs:+2:14: +2:19
           StorageDead(_1);                 // scope 1 at $DIR/simplify_locals.rs:+2:18: +2:19
           StorageDead(_2);                 // scope 0 at $DIR/simplify_locals.rs:+3:1: +3:2
           return;                          // scope 0 at $DIR/simplify_locals.rs:+3:2: +3:2

--- a/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
@@ -24,17 +24,17 @@
           Deinit(_3);                      // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:51: +1:68
           discriminant(_3) = 0;            // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:51: +1:68
           Deinit(_1);                      // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:30: +1:69
-          (_1.0: std::option::Option<u8>) = move _2; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:30: +1:69
-          (_1.1: std::option::Option<T>) = move _3; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:30: +1:69
+          (_1.0: std::option::Option<u8>) = _2; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:30: +1:69
+          (_1.1: std::option::Option<T>) = _3; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:30: +1:69
           StorageDead(_3);                 // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:68: +1:69
           StorageDead(_2);                 // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:68: +1:69
           _5 = discriminant((_1.0: std::option::Option<u8>)); // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:12: +1:27
-          switchInt(move _5) -> [1: bb1, otherwise: bb3]; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:12: +1:27
+          switchInt(_5) -> [1: bb1, otherwise: bb3]; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:12: +1:27
       }
   
       bb1: {
           _4 = discriminant((_1.1: std::option::Option<T>)); // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:12: +1:27
-          switchInt(move _4) -> [0: bb2, otherwise: bb3]; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:12: +1:27
+          switchInt(_4) -> [0: bb2, otherwise: bb3]; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:12: +1:27
       }
   
       bb2: {
@@ -43,7 +43,7 @@
 -         StorageLive(_7);                 // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+2:12: +2:20
 -         StorageLive(_8);                 // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+2:12: +2:13
 -         _8 = _6;                         // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+2:12: +2:13
--         _7 = Gt(move _8, const 42_u8);   // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+2:12: +2:20
+-         _7 = Gt(_8, const 42_u8);        // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+2:12: +2:20
 -         StorageDead(_8);                 // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+2:19: +2:20
 -         StorageDead(_7);                 // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+4:9: +4:10
           StorageDead(_6);                 // scope 0 at $DIR/simplify_locals_fixedpoint.rs:+5:5: +5:6

--- a/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
@@ -32,8 +32,8 @@
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:25: +1:27
 -         Deinit(_3);                      // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:25: +1:27
 -         Deinit(_1);                      // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:20: +1:28
--         (_1.0: ()) = move _2;            // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:20: +1:28
--         (_1.1: ()) = move _3;            // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:20: +1:28
+-         (_1.0: ()) = _2;                 // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:20: +1:28
+-         (_1.1: ()) = _3;                 // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:20: +1:28
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:27: +1:28
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:27: +1:28
 -         StorageDead(_1);                 // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:28: +1:29
@@ -44,8 +44,8 @@
 -         StorageLive(_7);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:18: +2:20
 -         Deinit(_7);                      // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:18: +2:20
 -         Deinit(_5);                      // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
--         (_5.0: ()) = move _6;            // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
--         (_5.1: ()) = move _7;            // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
+-         (_5.0: ()) = _6;                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
+-         (_5.1: ()) = _7;                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
 -         StorageDead(_7);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:20: +2:21
 -         StorageDead(_6);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:20: +2:21
 -         _4 = use_zst(move _5) -> bb1;    // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:5: +2:22
@@ -56,8 +56,8 @@
 +         StorageLive(_4);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:18: +2:20
 +         Deinit(_4);                      // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:18: +2:20
 +         Deinit(_2);                      // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
-+         (_2.0: ()) = move _3;            // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
-+         (_2.1: ()) = move _4;            // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
++         (_2.0: ()) = _3;                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
++         (_2.1: ()) = _4;                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
 +         StorageDead(_4);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:20: +2:21
 +         StorageDead(_3);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:20: +2:21
 +         _1 = use_zst(move _2) -> bb1;    // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:5: +2:22
@@ -76,7 +76,7 @@
 -         Deinit(_11);                     // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:28
 -         (_11.0: u8) = const 40_u8;       // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:28
 -         _10 = (_11.0: u8);               // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:30
--         _9 = Add(move _10, const 2_u8);  // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:34
+-         _9 = Add(_10, const 2_u8);       // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:34
 -         StorageDead(_10);                // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:33: +4:34
 -         _8 = use_u8(move _9) -> bb2;     // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:5: +4:35
 +         StorageDead(_2);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:21: +2:22
@@ -88,7 +88,7 @@
 +         Deinit(_8);                      // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:28
 +         (_8.0: u8) = const 40_u8;        // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:28
 +         _7 = (_8.0: u8);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:30
-+         _6 = Add(move _7, const 2_u8);   // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:34
++         _6 = Add(_7, const 2_u8);        // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:34
 +         StorageDead(_7);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:33: +4:34
 +         _5 = use_u8(move _6) -> bb2;     // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:5: +4:35
                                            // mir::Constant

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.diff
@@ -18,16 +18,16 @@
 -         _5 = const false;                // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+1:11: +1:12
 -         _5 = const true;                 // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+1:11: +1:12
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+1:11: +1:12
-          switchInt(move _2) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+1:5: +1:12
+          switchInt(_2) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+1:5: +1:12
       }
   
       bb1: {
           StorageLive(_3);                 // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:14: +3:15
-          _3 = move ((_1 as Some).0: std::boxed::Box<()>); // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:14: +3:15
+          _3 = ((_1 as Some).0: std::boxed::Box<()>); // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:14: +3:15
           StorageLive(_4);                 // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:25: +3:26
-          _4 = move _3;                    // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:25: +3:26
+          _4 = _3;                         // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:25: +3:26
           Deinit(_0);                      // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:20: +3:27
-          ((_0 as Some).0: std::boxed::Box<()>) = move _4; // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:20: +3:27
+          ((_0 as Some).0: std::boxed::Box<()>) = _4; // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:20: +3:27
           discriminant(_0) = 1;            // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:20: +3:27
           StorageDead(_4);                 // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:26: +3:27
           StorageDead(_3);                 // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:26: +3:27

--- a/src/test/mir-opt/sroa.dropping.ScalarReplacementOfAggregates.diff
+++ b/src/test/mir-opt/sroa.dropping.ScalarReplacementOfAggregates.diff
@@ -22,13 +22,13 @@
           Deinit(_5);                      // scope 0 at $DIR/sroa.rs:+1:23: +1:29
           (_5.0: usize) = const 2_usize;   // scope 0 at $DIR/sroa.rs:+1:23: +1:29
           Deinit(_2);                      // scope 0 at $DIR/sroa.rs:+1:5: +1:30
-          (_2.0: Tag) = move _3;           // scope 0 at $DIR/sroa.rs:+1:5: +1:30
-          (_2.1: Tag) = move _4;           // scope 0 at $DIR/sroa.rs:+1:5: +1:30
-          (_2.2: Tag) = move _5;           // scope 0 at $DIR/sroa.rs:+1:5: +1:30
+          (_2.0: Tag) = _3;                // scope 0 at $DIR/sroa.rs:+1:5: +1:30
+          (_2.1: Tag) = _4;                // scope 0 at $DIR/sroa.rs:+1:5: +1:30
+          (_2.2: Tag) = _5;                // scope 0 at $DIR/sroa.rs:+1:5: +1:30
           StorageDead(_5);                 // scope 0 at $DIR/sroa.rs:+1:29: +1:30
           StorageDead(_4);                 // scope 0 at $DIR/sroa.rs:+1:29: +1:30
           StorageDead(_3);                 // scope 0 at $DIR/sroa.rs:+1:29: +1:30
-          _1 = move (_2.1: Tag);           // scope 0 at $DIR/sroa.rs:+1:5: +1:32
+          _1 = (_2.1: Tag);                // scope 0 at $DIR/sroa.rs:+1:5: +1:32
           drop(_1) -> bb1;                 // scope 0 at $DIR/sroa.rs:+1:32: +1:33
       }
   

--- a/src/test/mir-opt/sroa.enums.ScalarReplacementOfAggregates.diff
+++ b/src/test/mir-opt/sroa.enums.ScalarReplacementOfAggregates.diff
@@ -17,11 +17,11 @@
           StorageLive(_3);                 // scope 1 at $DIR/sroa.rs:+1:27: +1:28
           _3 = _1;                         // scope 1 at $DIR/sroa.rs:+1:27: +1:28
           Deinit(_2);                      // scope 1 at $DIR/sroa.rs:+1:22: +1:29
-          ((_2 as Some).0: usize) = move _3; // scope 1 at $DIR/sroa.rs:+1:22: +1:29
+          ((_2 as Some).0: usize) = _3;    // scope 1 at $DIR/sroa.rs:+1:22: +1:29
           discriminant(_2) = 1;            // scope 1 at $DIR/sroa.rs:+1:22: +1:29
           StorageDead(_3);                 // scope 1 at $DIR/sroa.rs:+1:28: +1:29
           _4 = discriminant(_2);           // scope 1 at $DIR/sroa.rs:+1:12: +1:19
-          switchInt(move _4) -> [1: bb1, otherwise: bb2]; // scope 1 at $DIR/sroa.rs:+1:12: +1:19
+          switchInt(_4) -> [1: bb1, otherwise: bb2]; // scope 1 at $DIR/sroa.rs:+1:12: +1:19
       }
   
       bb1: {

--- a/src/test/mir-opt/sroa.escaping.ScalarReplacementOfAggregates.diff
+++ b/src/test/mir-opt/sroa.escaping.ScalarReplacementOfAggregates.diff
@@ -25,7 +25,7 @@
           Deinit(_4);                      // scope 0 at $DIR/sroa.rs:+2:8: +2:39
           (_4.0: u32) = const 1_u32;       // scope 0 at $DIR/sroa.rs:+2:8: +2:39
           (_4.1: u32) = const 2_u32;       // scope 0 at $DIR/sroa.rs:+2:8: +2:39
-          (_4.2: u32) = move _5;           // scope 0 at $DIR/sroa.rs:+2:8: +2:39
+          (_4.2: u32) = _5;                // scope 0 at $DIR/sroa.rs:+2:8: +2:39
           StorageDead(_5);                 // scope 0 at $DIR/sroa.rs:+2:38: +2:39
           _3 = &(_4.0: u32);               // scope 0 at $DIR/sroa.rs:+2:7: +2:41
           _2 = &raw const (*_3);           // scope 0 at $DIR/sroa.rs:+2:7: +2:41

--- a/src/test/mir-opt/sroa.flat.ScalarReplacementOfAggregates.diff
+++ b/src/test/mir-opt/sroa.flat.ScalarReplacementOfAggregates.diff
@@ -43,20 +43,20 @@
           discriminant(_7) = 1;            // scope 0 at $DIR/sroa.rs:+1:60: +1:68
 -         Deinit(_5);                      // scope 0 at $DIR/sroa.rs:+1:30: +1:70
 -         (_5.0: u8) = const 5_u8;         // scope 0 at $DIR/sroa.rs:+1:30: +1:70
--         (_5.1: ()) = move _6;            // scope 0 at $DIR/sroa.rs:+1:30: +1:70
+-         (_5.1: ()) = _6;                 // scope 0 at $DIR/sroa.rs:+1:30: +1:70
 -         (_5.2: &str) = const "a";        // scope 0 at $DIR/sroa.rs:+1:30: +1:70
 +         Deinit(_8);                      // scope 0 at $DIR/sroa.rs:+1:30: +1:70
 +         Deinit(_9);                      // scope 0 at $DIR/sroa.rs:+1:30: +1:70
 +         Deinit(_10);                     // scope 0 at $DIR/sroa.rs:+1:30: +1:70
 +         Deinit(_11);                     // scope 0 at $DIR/sroa.rs:+1:30: +1:70
 +         _8 = const 5_u8;                 // scope 0 at $DIR/sroa.rs:+1:30: +1:70
-+         _9 = move _6;                    // scope 0 at $DIR/sroa.rs:+1:30: +1:70
++         _9 = _6;                         // scope 0 at $DIR/sroa.rs:+1:30: +1:70
 +         _10 = const "a";                 // scope 0 at $DIR/sroa.rs:+1:30: +1:70
                                            // mir::Constant
                                            // + span: $DIR/sroa.rs:57:52: 57:55
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
--         (_5.3: std::option::Option<isize>) = move _7; // scope 0 at $DIR/sroa.rs:+1:30: +1:70
-+         _11 = move _7;                   // scope 0 at $DIR/sroa.rs:+1:30: +1:70
+-         (_5.3: std::option::Option<isize>) = _7; // scope 0 at $DIR/sroa.rs:+1:30: +1:70
++         _11 = _7;                        // scope 0 at $DIR/sroa.rs:+1:30: +1:70
           StorageDead(_7);                 // scope 0 at $DIR/sroa.rs:+1:69: +1:70
           StorageDead(_6);                 // scope 0 at $DIR/sroa.rs:+1:69: +1:70
           StorageLive(_1);                 // scope 0 at $DIR/sroa.rs:+1:15: +1:16

--- a/src/test/mir-opt/sroa.structs.ScalarReplacementOfAggregates.diff
+++ b/src/test/mir-opt/sroa.structs.ScalarReplacementOfAggregates.diff
@@ -17,11 +17,11 @@
           _3 = _1;                         // scope 0 at $DIR/sroa.rs:+6:18: +6:19
 -         Deinit(_2);                      // scope 0 at $DIR/sroa.rs:+6:5: +6:21
 -         (_2.0: usize) = const 0_usize;   // scope 0 at $DIR/sroa.rs:+6:5: +6:21
--         (_2.1: f32) = move _3;           // scope 0 at $DIR/sroa.rs:+6:5: +6:21
+-         (_2.1: f32) = _3;                // scope 0 at $DIR/sroa.rs:+6:5: +6:21
 +         Deinit(_4);                      // scope 0 at $DIR/sroa.rs:+6:5: +6:21
 +         Deinit(_5);                      // scope 0 at $DIR/sroa.rs:+6:5: +6:21
 +         _4 = const 0_usize;              // scope 0 at $DIR/sroa.rs:+6:5: +6:21
-+         _5 = move _3;                    // scope 0 at $DIR/sroa.rs:+6:5: +6:21
++         _5 = _3;                         // scope 0 at $DIR/sroa.rs:+6:5: +6:21
           StorageDead(_3);                 // scope 0 at $DIR/sroa.rs:+6:20: +6:21
 -         _0 = (_2.1: f32);                // scope 0 at $DIR/sroa.rs:+6:5: +6:23
 -         StorageDead(_2);                 // scope 0 at $DIR/sroa.rs:+7:1: +7:2

--- a/src/test/mir-opt/sroa.unions.ScalarReplacementOfAggregates.diff
+++ b/src/test/mir-opt/sroa.unions.ScalarReplacementOfAggregates.diff
@@ -14,7 +14,7 @@
           StorageLive(_3);                 // scope 1 at $DIR/sroa.rs:+5:24: +5:25
           _3 = _1;                         // scope 1 at $DIR/sroa.rs:+5:24: +5:25
           Deinit(_2);                      // scope 1 at $DIR/sroa.rs:+5:14: +5:27
-          (_2.0: f32) = move _3;           // scope 1 at $DIR/sroa.rs:+5:14: +5:27
+          (_2.0: f32) = _3;                // scope 1 at $DIR/sroa.rs:+5:14: +5:27
           StorageDead(_3);                 // scope 1 at $DIR/sroa.rs:+5:26: +5:27
           _0 = (_2.1: u32);                // scope 1 at $DIR/sroa.rs:+5:14: +5:29
           StorageDead(_2);                 // scope 0 at $DIR/sroa.rs:+6:1: +6:2

--- a/src/test/mir-opt/try_identity_e2e.new.PreCodegen.after.mir
+++ b/src/test/mir-opt/try_identity_e2e.new.PreCodegen.after.mir
@@ -26,31 +26,31 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/try_identity_e2e.rs:+2:15: +7:10
         _3 = discriminant(_1);           // scope 0 at $DIR/try_identity_e2e.rs:+3:19: +3:20
-        switchInt(move _3) -> [0: bb2, 1: bb1, otherwise: bb4]; // scope 0 at $DIR/try_identity_e2e.rs:+3:13: +3:20
+        switchInt(_3) -> [0: bb2, 1: bb1, otherwise: bb4]; // scope 0 at $DIR/try_identity_e2e.rs:+3:13: +3:20
     }
 
     bb1: {
-        _5 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity_e2e.rs:+5:21: +5:22
+        _5 = ((_1 as Err).0: E);         // scope 0 at $DIR/try_identity_e2e.rs:+5:21: +5:22
         Deinit(_2);                      // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
-        ((_2 as Break).0: E) = move _5;  // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
+        ((_2 as Break).0: E) = _5;       // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
         discriminant(_2) = 1;            // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
         _6 = discriminant(_2);           // scope 0 at $DIR/try_identity_e2e.rs:+2:15: +7:10
-        switchInt(move _6) -> [0: bb5, 1: bb3, otherwise: bb4]; // scope 0 at $DIR/try_identity_e2e.rs:+2:9: +7:10
+        switchInt(_6) -> [0: bb5, 1: bb3, otherwise: bb4]; // scope 0 at $DIR/try_identity_e2e.rs:+2:9: +7:10
     }
 
     bb2: {
-        _4 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity_e2e.rs:+4:20: +4:21
+        _4 = ((_1 as Ok).0: T);          // scope 0 at $DIR/try_identity_e2e.rs:+4:20: +4:21
         Deinit(_2);                      // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
-        ((_2 as Continue).0: T) = move _4; // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
+        ((_2 as Continue).0: T) = _4;    // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
         discriminant(_2) = 0;            // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
         _6 = discriminant(_2);           // scope 0 at $DIR/try_identity_e2e.rs:+2:15: +7:10
-        switchInt(move _6) -> [0: bb5, 1: bb3, otherwise: bb4]; // scope 0 at $DIR/try_identity_e2e.rs:+2:9: +7:10
+        switchInt(_6) -> [0: bb5, 1: bb3, otherwise: bb4]; // scope 0 at $DIR/try_identity_e2e.rs:+2:9: +7:10
     }
 
     bb3: {
-        _8 = move ((_2 as Break).0: E);  // scope 0 at $DIR/try_identity_e2e.rs:+9:32: +9:33
+        _8 = ((_2 as Break).0: E);       // scope 0 at $DIR/try_identity_e2e.rs:+9:32: +9:33
         Deinit(_0);                      // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
-        ((_0 as Err).0: E) = move _8;    // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
+        ((_0 as Err).0: E) = _8;         // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
         discriminant(_0) = 1;            // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
         StorageDead(_2);                 // scope 0 at $DIR/try_identity_e2e.rs:+12:1: +12:2
         return;                          // scope 0 at $DIR/try_identity_e2e.rs:+12:1: +12:2
@@ -61,9 +61,9 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb5: {
-        _7 = move ((_2 as Continue).0: T); // scope 0 at $DIR/try_identity_e2e.rs:+8:35: +8:36
+        _7 = ((_2 as Continue).0: T);    // scope 0 at $DIR/try_identity_e2e.rs:+8:35: +8:36
         Deinit(_0);                      // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +11:6
-        ((_0 as Ok).0: T) = move _7;     // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +11:6
+        ((_0 as Ok).0: T) = _7;          // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +11:6
         discriminant(_0) = 0;            // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +11:6
         StorageDead(_2);                 // scope 0 at $DIR/try_identity_e2e.rs:+12:1: +12:2
         return;                          // scope 0 at $DIR/try_identity_e2e.rs:+12:1: +12:2

--- a/src/test/mir-opt/try_identity_e2e.old.PreCodegen.after.mir
+++ b/src/test/mir-opt/try_identity_e2e.old.PreCodegen.after.mir
@@ -15,13 +15,13 @@ fn old(_1: Result<T, E>) -> Result<T, E> {
 
     bb0: {
         _2 = discriminant(_1);           // scope 0 at $DIR/try_identity_e2e.rs:+2:15: +2:16
-        switchInt(move _2) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/try_identity_e2e.rs:+2:9: +2:16
+        switchInt(_2) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/try_identity_e2e.rs:+2:9: +2:16
     }
 
     bb1: {
-        _4 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity_e2e.rs:+4:17: +4:18
+        _4 = ((_1 as Err).0: E);         // scope 0 at $DIR/try_identity_e2e.rs:+4:17: +4:18
         Deinit(_0);                      // scope 2 at $DIR/try_identity_e2e.rs:+4:30: +4:36
-        ((_0 as Err).0: E) = move _4;    // scope 2 at $DIR/try_identity_e2e.rs:+4:30: +4:36
+        ((_0 as Err).0: E) = _4;         // scope 2 at $DIR/try_identity_e2e.rs:+4:30: +4:36
         discriminant(_0) = 1;            // scope 2 at $DIR/try_identity_e2e.rs:+4:30: +4:36
         return;                          // scope 0 at $DIR/try_identity_e2e.rs:+7:1: +7:2
     }
@@ -31,9 +31,9 @@ fn old(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb3: {
-        _3 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity_e2e.rs:+3:16: +3:17
+        _3 = ((_1 as Ok).0: T);          // scope 0 at $DIR/try_identity_e2e.rs:+3:16: +3:17
         Deinit(_0);                      // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +6:6
-        ((_0 as Ok).0: T) = move _3;     // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +6:6
+        ((_0 as Ok).0: T) = _3;          // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +6:6
         discriminant(_0) = 0;            // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +6:6
         return;                          // scope 0 at $DIR/try_identity_e2e.rs:+7:1: +7:2
     }

--- a/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -18,7 +18,7 @@ fn main() -> () {
         Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
         discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
         _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
-        switchInt(move _3) -> [2: bb1, otherwise: bb2]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +1:19
+        switchInt(_3) -> [2: bb1, otherwise: bb2]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +1:19
     }
 
     bb1: {
@@ -36,7 +36,7 @@ fn main() -> () {
         Deinit(_7);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
         discriminant(_7) = 0;            // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
         _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
-        switchInt(move _8) -> [4: bb5, 5: bb3, otherwise: bb4]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +7:19
+        switchInt(_8) -> [4: bb5, 5: bb3, otherwise: bb4]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +7:19
     }
 
     bb2: {

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -26,13 +26,13 @@ fn main() -> () {
         discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
         Deinit(_1);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
         (_1.0: u32) = const 51_u32;      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
-        (_1.1: Test1) = move _2;         // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
+        (_1.1: Test1) = _2;              // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
         StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:47: +1:48
         StorageLive(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +8:6
         StorageLive(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
         _4 = &(_1.1: Test1);             // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
         _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
-        switchInt(move _5) -> [2: bb3, 3: bb1, otherwise: bb2]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
+        switchInt(_5) -> [2: bb3, 3: bb1, otherwise: bb2]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
     }
 
     bb1: {
@@ -66,7 +66,7 @@ fn main() -> () {
         StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
         StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +15:6
         _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
-        switchInt(move _10) -> [2: bb7, 3: bb5, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
+        switchInt(_10) -> [2: bb7, 3: bb5, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
     }
 
     bb5: {

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.diff
@@ -24,7 +24,7 @@
           Deinit(_3);                      // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
           discriminant(_3) = 0;            // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
 -         _4 = discriminant(_3);           // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
--         switchInt(move _4) -> [1: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
+-         switchInt(_4) -> [1: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
 +         _4 = const 0_isize;              // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
 +         switchInt(const 0_isize) -> [1: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
       }

--- a/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
@@ -4,9 +4,7 @@ fn while_loop(_1: bool) -> () {
     debug c => _1;                       // in scope 0 at $DIR/while_storage.rs:+0:15: +0:16
     let mut _0: ();                      // return place in scope 0 at $DIR/while_storage.rs:+0:24: +0:24
     let mut _2: bool;                    // in scope 0 at $DIR/while_storage.rs:+1:11: +1:22
-    let mut _3: bool;                    // in scope 0 at $DIR/while_storage.rs:+1:20: +1:21
-    let mut _4: bool;                    // in scope 0 at $DIR/while_storage.rs:+2:12: +2:23
-    let mut _5: bool;                    // in scope 0 at $DIR/while_storage.rs:+2:21: +2:22
+    let mut _3: bool;                    // in scope 0 at $DIR/while_storage.rs:+2:12: +2:23
 
     bb0: {
         goto -> bb1;                     // scope 0 at $DIR/while_storage.rs:+1:5: +5:6
@@ -14,41 +12,35 @@ fn while_loop(_1: bool) -> () {
 
     bb1: {
         StorageLive(_2);                 // scope 0 at $DIR/while_storage.rs:+1:11: +1:22
-        StorageLive(_3);                 // scope 0 at $DIR/while_storage.rs:+1:20: +1:21
-        _3 = _1;                         // scope 0 at $DIR/while_storage.rs:+1:20: +1:21
-        _2 = get_bool(move _3) -> bb2;   // scope 0 at $DIR/while_storage.rs:+1:11: +1:22
+        _2 = get_bool(_1) -> bb2;        // scope 0 at $DIR/while_storage.rs:+1:11: +1:22
                                          // mir::Constant
                                          // + span: $DIR/while_storage.rs:10:11: 10:19
                                          // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_3);                 // scope 0 at $DIR/while_storage.rs:+1:21: +1:22
-        switchInt(move _2) -> [0: bb7, otherwise: bb3]; // scope 0 at $DIR/while_storage.rs:+1:11: +1:22
+        switchInt(_2) -> [0: bb7, otherwise: bb3]; // scope 0 at $DIR/while_storage.rs:+1:11: +1:22
     }
 
     bb3: {
-        StorageLive(_4);                 // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
-        StorageLive(_5);                 // scope 0 at $DIR/while_storage.rs:+2:21: +2:22
-        _5 = _1;                         // scope 0 at $DIR/while_storage.rs:+2:21: +2:22
-        _4 = get_bool(move _5) -> bb4;   // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
+        StorageLive(_3);                 // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
+        _3 = get_bool(_1) -> bb4;        // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
                                          // mir::Constant
                                          // + span: $DIR/while_storage.rs:11:12: 11:20
                                          // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(<ZST>) }
     }
 
     bb4: {
-        StorageDead(_5);                 // scope 0 at $DIR/while_storage.rs:+2:22: +2:23
-        switchInt(move _4) -> [0: bb6, otherwise: bb5]; // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
+        switchInt(_3) -> [0: bb6, otherwise: bb5]; // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
     }
 
     bb5: {
-        StorageDead(_4);                 // scope 0 at $DIR/while_storage.rs:+4:9: +4:10
+        StorageDead(_3);                 // scope 0 at $DIR/while_storage.rs:+4:9: +4:10
         goto -> bb8;                     // scope 0 at no-location
     }
 
     bb6: {
-        StorageDead(_4);                 // scope 0 at $DIR/while_storage.rs:+4:9: +4:10
+        StorageDead(_3);                 // scope 0 at $DIR/while_storage.rs:+4:9: +4:10
         StorageDead(_2);                 // scope 0 at $DIR/while_storage.rs:+5:5: +5:6
         goto -> bb1;                     // scope 0 at $DIR/while_storage.rs:+1:5: +5:6
     }


### PR DESCRIPTION
Looks like this fires ~72,000 times on the standard library. Neat.

Note: The unleashed version fires ~165,000 times.

cc @JakobDegen 