### PR TITLE
Implement int_from_ascii_radix

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -62,6 +62,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::from_str_radix(\"A\", 16), Ok(10));")]
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
+        #[track_caller]
         pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
             from_ascii_radix(src.as_bytes(), radix)
         }
@@ -89,6 +90,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::from_ascii_radix(b\"+100\", 2), Ok(4));")]
         /// ```
         #[unstable(feature = "int_from_ascii_radix", issue = "none")]
+        #[track_caller]
         pub fn from_ascii_radix(src: &[u8], radix: u32) -> Result<Self, ParseIntError> {
             from_ascii_radix(src, radix)
         }

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -63,7 +63,34 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
-            from_str_radix(src, radix)
+            from_ascii_radix(src.as_bytes(), radix)
+        }
+
+        /// Parses an integer in a given base from a slice of bytes.
+        ///
+        /// The bytes are interpreted as ASCII characters. Accepts an optional
+        /// `+` or `-` sign followed by digits. Leading and trailing whitespace
+        /// are rejected.
+        /// Digits are a subset of these characters, depending on `radix`:
+        ///
+        /// * `0-9`
+        /// * `a-z`
+        /// * `A-Z`
+        ///
+        /// # Panics
+        ///
+        /// This function panics if `radix` is not in the range from 2 to 36.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_from_ascii_radix)]
+        ///
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::from_ascii_radix(b\"+100\", 2), Ok(4));")]
+        /// ```
+        #[unstable(feature = "int_from_ascii_radix", issue = "none")]
+        pub fn from_ascii_radix(src: &[u8], radix: u32) -> Result<Self, ParseIntError> {
+            from_ascii_radix(src, radix)
         }
 
         /// Returns the number of ones in the binary representation of `self`.

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -4,7 +4,7 @@ use crate::fmt;
 use crate::ops::{BitOr, BitOrAssign, Div, Rem};
 use crate::str::FromStr;
 
-use super::from_str_radix;
+use super::from_ascii_radix;
 use super::{IntErrorKind, ParseIntError};
 use crate::intrinsics;
 
@@ -182,7 +182,7 @@ macro_rules! from_str_radix_nzint_impl {
         impl FromStr for $t {
             type Err = ParseIntError;
             fn from_str(src: &str) -> Result<Self, Self::Err> {
-                Self::new(from_str_radix(src, 10)?)
+                Self::new(from_ascii_radix(src.as_bytes(), 10)?)
                     .ok_or(ParseIntError {
                         kind: IntErrorKind::Zero
                     })

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -63,6 +63,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::from_str_radix(\"A\", 16), Ok(10));")]
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
+        #[track_caller]
         pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
             from_ascii_radix(src.as_bytes(), radix)
         }
@@ -90,6 +91,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::from_ascii_radix(b\"+100\", 2), Ok(4));")]
         /// ```
         #[unstable(feature = "int_from_ascii_radix", issue = "none")]
+        #[track_caller]
         pub fn from_ascii_radix(src: &[u8], radix: u32) -> Result<Self, ParseIntError> {
             from_ascii_radix(src, radix)
         }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -64,7 +64,34 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
-            from_str_radix(src, radix)
+            from_ascii_radix(src.as_bytes(), radix)
+        }
+
+        /// Parses an integer in a given base from a slice of bytes.
+        ///
+        /// The bytes are interpreted as ASCII characters. Accepts an
+        /// optional `+` sign followed by digits. Leading and trailing
+        /// whitespace are rejected.
+        /// Digits are a subset of these characters, depending on `radix`:
+        ///
+        /// * `0-9`
+        /// * `a-z`
+        /// * `A-Z`
+        ///
+        /// # Panics
+        ///
+        /// This function panics if `radix` is not in the range from 2 to 36.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_from_ascii_radix)]
+        ///
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::from_ascii_radix(b\"+100\", 2), Ok(4));")]
+        /// ```
+        #[unstable(feature = "int_from_ascii_radix", issue = "none")]
+        pub fn from_ascii_radix(src: &[u8], radix: u32) -> Result<Self, ParseIntError> {
+            from_ascii_radix(src, radix)
         }
 
         /// Returns the number of ones in the binary representation of `self`.


### PR DESCRIPTION
Motivation here is to allow parsing integers without UTF-8 validation. Useful when strings are UTF-8 by only convention, and even some binary protocols. Similar to #101035.

Behaves exactly like `from_str_radix`, which already works with raw bytes internally.
