### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_ast/src/util/classify.rs
+++ b/compiler/rustc_ast/src/util/classify.rs
@@ -21,6 +21,7 @@ pub fn expr_requires_semi_to_be_stmt(e: &ast::Expr) -> bool {
             | ast::ExprKind::Loop(..)
             | ast::ExprKind::ForLoop(..)
             | ast::ExprKind::TryBlock(..)
+            | ast::ExprKind::ConstBlock(..)
     )
 }
 

--- a/compiler/rustc_target/src/spec/aarch64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/aarch64_apple_darwin.rs
@@ -1,4 +1,4 @@
-use super::apple_base::{macos_link_env_remove, macos_llvm_target, opts, Arch};
+use super::apple_base::{macos_llvm_target, opts, Arch};
 use crate::spec::{FramePointer, SanitizerSet, Target, TargetOptions};
 
 pub fn target() -> Target {
@@ -9,8 +9,6 @@ pub fn target() -> Target {
 
     // FIXME: The leak sanitizer currently fails the tests, see #88132.
     base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::THREAD;
-
-    base.link_env_remove.to_mut().extend(macos_link_env_remove());
 
     Target {
         // Clang automatically chooses a more specific target based on

--- a/compiler/rustc_target/src/spec/apple/tests.rs
+++ b/compiler/rustc_target/src/spec/apple/tests.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    aarch64_apple_ios_sim, aarch64_apple_watchos_sim, x86_64_apple_ios, x86_64_apple_tvos,
-    x86_64_apple_watchos_sim,
+    aarch64_apple_darwin, aarch64_apple_ios_sim, aarch64_apple_watchos_sim, i686_apple_darwin,
+    x86_64_apple_darwin, x86_64_apple_ios, x86_64_apple_tvos, x86_64_apple_watchos_sim,
 };
 
 #[test]
@@ -16,5 +16,20 @@ fn simulator_targets_set_abi() {
 
     for target in all_sim_targets {
         assert_eq!(target.abi, "sim")
+    }
+}
+
+#[test]
+fn macos_link_environment_unmodified() {
+    let all_macos_targets = [
+        aarch64_apple_darwin::target(),
+        i686_apple_darwin::target(),
+        x86_64_apple_darwin::target(),
+    ];
+
+    for target in all_macos_targets {
+        // macOS targets should only remove information for cross-compiling, but never
+        // for the host.
+        assert_eq!(target.link_env_remove, crate::spec::cvs!["IPHONEOS_DEPLOYMENT_TARGET"]);
     }
 }

--- a/compiler/rustc_target/src/spec/i686_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/i686_apple_darwin.rs
@@ -1,4 +1,4 @@
-use super::apple_base::{macos_link_env_remove, macos_llvm_target, opts, Arch};
+use super::apple_base::{macos_llvm_target, opts, Arch};
 use crate::spec::{Cc, FramePointer, LinkerFlavor, Lld, StackProbeType, Target, TargetOptions};
 
 pub fn target() -> Target {
@@ -7,7 +7,6 @@ pub fn target() -> Target {
     let mut base = opts("macos", arch);
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Darwin(Cc::Yes, Lld::No), &["-m32"]);
-    base.link_env_remove.to_mut().extend(macos_link_env_remove());
     base.stack_probes = StackProbeType::X86;
     base.frame_pointer = FramePointer::Always;
 

--- a/compiler/rustc_target/src/spec/x86_64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_darwin.rs
@@ -1,4 +1,4 @@
-use super::apple_base::{macos_link_env_remove, macos_llvm_target, opts, Arch};
+use super::apple_base::{macos_llvm_target, opts, Arch};
 use crate::spec::{Cc, FramePointer, LinkerFlavor, Lld, SanitizerSet};
 use crate::spec::{StackProbeType, Target, TargetOptions};
 
@@ -8,7 +8,6 @@ pub fn target() -> Target {
     base.max_atomic_width = Some(128); // core2 supports cmpxchg16b
     base.frame_pointer = FramePointer::Always;
     base.add_pre_link_args(LinkerFlavor::Darwin(Cc::Yes, Lld::No), &["-m64"]);
-    base.link_env_remove.to_mut().extend(macos_link_env_remove());
     base.stack_probes = StackProbeType::X86;
     base.supported_sanitizers =
         SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::LEAK | SanitizerSet::THREAD;

--- a/src/test/run-make/macos-deployment-target/Makefile
+++ b/src/test/run-make/macos-deployment-target/Makefile
@@ -1,0 +1,21 @@
+# only-macos
+#
+# Check that a set deployment target actually makes it to the linker.
+# This is important since its a compatibility hazard. The linker will
+# generate load commands differently based on what minimum OS it can assume.
+
+include ../../run-make-fulldeps/tools.mk
+
+ifeq ($(strip $(shell uname -m)),arm64)
+	GREP_PATTERN = "minos 11.0"
+else
+ 	GREP_PATTERN = "version 10.9"
+endif
+
+OUT_FILE=$(TMPDIR)/with_deployment_target.dylib
+all:
+	env MACOSX_DEPLOYMENT_TARGET=10.9 $(RUSTC) with_deployment_target.rs -o $(OUT_FILE)
+# XXX: The check is for either the x86_64 minimum OR the aarch64 minimum (M1 starts at macOS 11).
+# They also use different load commands, so we let that change with each too. The aarch64 check
+# isn't as robust as the x86 one, but testing both seems unneeded.
+	vtool -show-build $(OUT_FILE) | $(CGREP) -e $(GREP_PATTERN)

--- a/src/test/run-make/macos-deployment-target/with_deployment_target.rs
+++ b/src/test/run-make/macos-deployment-target/with_deployment_target.rs
@@ -1,0 +1,4 @@
+#![crate_type = "cdylib"]
+
+#[allow(dead_code)]
+fn something_and_nothing() {}

--- a/src/test/ui/inline-const/expr-with-block-err.rs
+++ b/src/test/ui/inline-const/expr-with-block-err.rs
@@ -1,0 +1,6 @@
+#![feature(inline_const)]
+
+fn main() {
+    const { 2 } - const { 1 };
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/inline-const/expr-with-block-err.stderr
+++ b/src/test/ui/inline-const/expr-with-block-err.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/expr-with-block-err.rs:4:13
+   |
+LL |     const { 2 } - const { 1 };
+   |             ^ expected `()`, found integer
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/inline-const/expr-with-block.rs
+++ b/src/test/ui/inline-const/expr-with-block.rs
@@ -1,0 +1,10 @@
+// check-pass
+#![feature(inline_const)]
+fn main() {
+    match true {
+        true => const {}
+        false => ()
+    }
+    const {}
+    ()
+}

--- a/src/test/ui/rfc-2632-const-trait-impl/issue-79450.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/issue-79450.rs
@@ -1,0 +1,20 @@
+#![feature(const_fmt_arguments_new)]
+#![feature(const_trait_impl)]
+
+#[const_trait]
+trait Tr {
+    fn req(&self);
+
+    fn prov(&self) {
+        println!("lul"); //~ ERROR: cannot call non-const fn `_print` in constant functions
+        self.req();
+    }
+}
+
+struct S;
+
+impl const Tr for S {
+    fn req(&self) {}
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/issue-79450.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/issue-79450.stderr
@@ -1,0 +1,12 @@
+error[E0015]: cannot call non-const fn `_print` in constant functions
+  --> $DIR/issue-79450.rs:9:9
+   |
+LL |         println!("lul");
+   |         ^^^^^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/suggestions/dont-suggest-ufcs-for-const.stderr
+++ b/src/test/ui/suggestions/dont-suggest-ufcs-for-const.stderr
@@ -2,13 +2,7 @@ error[E0599]: no method named `MAX` found for type `u32` in the current scope
   --> $DIR/dont-suggest-ufcs-for-const.rs:2:11
    |
 LL |     1_u32.MAX();
-   |     ------^^^--
-   |     |     |
-   |     |     this is an associated function, not a method
-   |     help: use associated function syntax instead: `u32::MAX()`
-   |
-   = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
-   = note: the candidate is defined in an impl for the type `u32`
+   |           ^^^ method not found in `u32`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #104856 (Don't suggest associated function call for associated const.)
 - #105123 (Fix passing MACOSX_DEPLOYMENT_TARGET to the linker)
 - #105142 (Make inline const block `ExprWithBlock`)
 - #105237 (Add regression test for #79450)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=104856,105123,105142,105237)
<!-- homu-ignore:end -->