### PR TITLE
[EXPERIMENT] Record an allowed byte range in pointer provenance for miri

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1293,7 +1293,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 // second borrowed place for the same union and an access to a different field.
                 for (place_base, elem) in first_borrowed_place.iter_projections().rev() {
                     match elem {
-                        ProjectionElem::Field(field, _) if union_ty(place_base).is_some() => {
+                        ProjectionElem::Field(field, _, _) if union_ty(place_base).is_some() => {
                             return Some((place_base, field));
                         }
                         _ => {}
@@ -1305,7 +1305,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 // With the place of a union and a field access into it, we traverse the second
                 // borrowed place and look for an access to a different field of the same union.
                 for (place_base, elem) in second_borrowed_place.iter_projections().rev() {
-                    if let ProjectionElem::Field(field, _) = elem {
+                    if let ProjectionElem::Field(field, _, _) = elem {
                         if let Some(union_ty) = union_ty(place_base) {
                             if field != target_field && place_base == target_base {
                                 return Some((

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -240,7 +240,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 ProjectionElem::Downcast(..) if opt.including_downcast => return None,
                 ProjectionElem::Downcast(..) => (),
                 ProjectionElem::OpaqueCast(..) => (),
-                ProjectionElem::Field(field, _ty) => {
+                ProjectionElem::Field(field, _, _) => {
                     // FIXME(project-rfc_2229#36): print capture precisely here.
                     if let Some(field) = self.is_upvar_field_projection(PlaceRef {
                         local,
@@ -321,7 +321,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 }
                 ProjectionElem::Downcast(..) => place.ty(self.body, self.infcx.tcx),
                 ProjectionElem::OpaqueCast(ty) => PlaceTy::from_ty(*ty),
-                ProjectionElem::Field(_, field_type) => PlaceTy::from_ty(*field_type),
+                ProjectionElem::Field(_, field_type, _) => PlaceTy::from_ty(*field_type),
             },
         };
         self.describe_field_from_ty(

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -59,7 +59,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
 
             PlaceRef {
                 local,
-                projection: [proj_base @ .., ProjectionElem::Field(upvar_index, _)],
+                projection: [proj_base @ .., ProjectionElem::Field(upvar_index, _, _)],
             } => {
                 debug_assert!(is_closure_or_generator(
                     Place::ty_from(local, proj_base, self.body, self.infcx.tcx).ty
@@ -222,7 +222,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     &[
                         ref proj_base @ ..,
                         ProjectionElem::Deref,
-                        ProjectionElem::Field(field, _),
+                        ProjectionElem::Field(field, _, _),
                         ProjectionElem::Deref,
                     ],
             } => {
@@ -349,7 +349,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             // Also suggest adding mut for upvars
             PlaceRef {
                 local,
-                projection: [proj_base @ .., ProjectionElem::Field(upvar_index, _)],
+                projection: [proj_base @ .., ProjectionElem::Field(upvar_index, _, _)],
             } => {
                 debug_assert!(is_closure_or_generator(
                     Place::ty_from(local, proj_base, self.body, self.infcx.tcx).ty

--- a/compiler/rustc_borrowck/src/path_utils.rs
+++ b/compiler/rustc_borrowck/src/path_utils.rs
@@ -158,7 +158,7 @@ pub(crate) fn is_upvar_field_projection<'tcx>(
     }
 
     match place_ref.last_projection() {
-        Some((place_base, ProjectionElem::Field(field, _ty))) => {
+        Some((place_base, ProjectionElem::Field(field, _, _))) => {
             let base_ty = place_base.ty(body, tcx).ty;
             if (base_ty.is_closure() || base_ty.is_generator())
                 && (!by_ref || upvars[field.index()].by_ref)

--- a/compiler/rustc_borrowck/src/places_conflict.rs
+++ b/compiler/rustc_borrowck/src/places_conflict.rs
@@ -325,7 +325,7 @@ fn place_projection_conflict<'tcx>(
             debug!("place_element_conflict: DISJOINT-OR-EQ-OPAQUE");
             Overlap::EqualOrDisjoint
         }
-        (ProjectionElem::Field(f1, _), ProjectionElem::Field(f2, _)) => {
+        (ProjectionElem::Field(f1, _, _), ProjectionElem::Field(f2, _, _)) => {
             if f1 == f2 {
                 // same field (e.g., `a.y` vs. `a.y`) - recur.
                 debug!("place_element_conflict: DISJOINT-OR-EQ-FIELD");

--- a/compiler/rustc_borrowck/src/prefixes.rs
+++ b/compiler/rustc_borrowck/src/prefixes.rs
@@ -76,7 +76,7 @@ impl<'cx, 'tcx> Iterator for Prefixes<'cx, 'tcx> {
                 }
                 Some((cursor_base, elem)) => {
                     match elem {
-                        ProjectionElem::Field(_ /*field*/, _ /*ty*/) => {
+                        ProjectionElem::Field(..) => {
                             // FIXME: add union handling
                             self.next = Some(cursor_base);
                             return Some(cursor);

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -715,7 +715,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
                     PlaceTy::from_ty(ty)
                 }
             },
-            ProjectionElem::Field(field, fty) => {
+            ProjectionElem::Field(field, fty, _) => {
                 let fty = self.sanitize_type(place, fty);
                 let fty = self.cx.normalize(fty, location);
                 match self.field_ty(place, base, field, location) {

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -854,7 +854,7 @@ pub(crate) fn codegen_place<'tcx>(
                 cplace = cplace.place_deref(fx);
             }
             PlaceElem::OpaqueCast(ty) => cplace = cplace.place_opaque_cast(fx, ty),
-            PlaceElem::Field(field, _ty) => {
+            PlaceElem::Field(field, _, _) => {
                 cplace = cplace.place_field(fx, field);
             }
             PlaceElem::Index(local) => {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1252,7 +1252,7 @@ fn generator_layout_and_saved_local_names<'tcx>(
                 mir::ProjectionElem::Deref,
                 // Field of a variant of the state.
                 mir::ProjectionElem::Downcast(_, variant),
-                mir::ProjectionElem::Field(field, _),
+                mir::ProjectionElem::Field(field, _, _),
             ] => {
                 let name = &mut generator_saved_local_names
                     [generator_layout.variant_fields[variant][field]];

--- a/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
@@ -273,7 +273,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         indirect_offsets.push(Size::ZERO);
                         place = bx.load_operand(place).deref(bx.cx());
                     }
-                    mir::ProjectionElem::Field(field, _) => {
+                    mir::ProjectionElem::Field(field, _, _) => {
                         let i = field.index();
                         let offset = indirect_offsets.last_mut().unwrap_or(&mut direct_offset);
                         *offset += place.layout.fields.offset(i);
@@ -439,7 +439,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
                         for elem in &fragment.projection {
                             match *elem {
-                                mir::ProjectionElem::Field(field, _) => {
+                                mir::ProjectionElem::Field(field, _, _) => {
                                     let i = field.index();
                                     fragment_start += fragment_layout.fields.offset(i);
                                     fragment_layout = fragment_layout.field(self.cx, i);

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -374,7 +374,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 // Moves out of scalar and scalar pair fields are trivial.
                 for elem in place_ref.projection.iter() {
                     match elem {
-                        mir::ProjectionElem::Field(ref f, _) => {
+                        mir::ProjectionElem::Field(ref f, _, _) => {
                             o = o.extract_field(bx, f.index());
                         }
                         mir::ProjectionElem::Index(_)

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -550,7 +550,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         for elem in place_ref.projection[base..].iter() {
             cg_base = match *elem {
                 mir::ProjectionElem::Deref => bx.load_operand(cg_base).deref(bx.cx()),
-                mir::ProjectionElem::Field(ref field, _) => {
+                mir::ProjectionElem::Field(ref field, _, _) => {
                     cg_base.project_field(bx, field.index())
                 }
                 mir::ProjectionElem::OpaqueCast(ty) => cg_base.project_type(bx, ty),

--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -122,7 +122,7 @@ pub(crate) fn try_destructure_mir_constant<'tcx>(
 
     let fields_iter = (0..field_count)
         .map(|i| {
-            let field_op = ecx.operand_field(&down, i, mir::ProjectionMode::Weak)?;
+            let field_op = ecx.operand_field(&down, i, mir::ProjectionMode::Strong)?;
             let val = op_to_const(&ecx, &field_op);
             Ok(mir::ConstantKind::Val(val, field_op.layout.ty))
         })

--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -122,7 +122,7 @@ pub(crate) fn try_destructure_mir_constant<'tcx>(
 
     let fields_iter = (0..field_count)
         .map(|i| {
-            let field_op = ecx.operand_field(&down, i)?;
+            let field_op = ecx.operand_field(&down, i, mir::ProjectionMode::Weak)?;
             let val = op_to_const(&ecx, &field_op);
             Ok(mir::ConstantKind::Val(val, field_op.layout.ty))
         })

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -6,6 +6,7 @@ use crate::interpret::{
     MemoryKind, PlaceTy, Scalar,
 };
 use crate::interpret::{MPlaceTy, Value};
+use rustc_middle::mir::ProjectionMode;
 use rustc_middle::ty::{self, ScalarInt, Ty, TyCtxt};
 use rustc_span::source_map::DUMMY_SP;
 use rustc_target::abi::{Align, VariantIdx};
@@ -27,7 +28,7 @@ fn branches<'tcx>(
 
     let mut fields = Vec::with_capacity(n);
     for i in 0..n {
-        let field = ecx.mplace_field(&place, i).unwrap();
+        let field = ecx.mplace_field(&place, i, ProjectionMode::Weak).unwrap();
         let valtree = const_to_valtree_inner(ecx, &field, num_nodes)?;
         fields.push(Some(valtree));
     }
@@ -436,7 +437,7 @@ fn valtree_into_mplace<'tcx>(
                             )
                             .unwrap()
                     }
-                    _ => ecx.mplace_field(&place_adjusted, i).unwrap(),
+                    _ => ecx.mplace_field(&place_adjusted, i, ProjectionMode::Weak).unwrap(),
                 };
 
                 debug!(?place_inner);

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -28,7 +28,7 @@ fn branches<'tcx>(
 
     let mut fields = Vec::with_capacity(n);
     for i in 0..n {
-        let field = ecx.mplace_field(&place, i, ProjectionMode::Weak).unwrap();
+        let field = ecx.mplace_field(&place, i, ProjectionMode::Strong).unwrap();
         let valtree = const_to_valtree_inner(ecx, &field, num_nodes)?;
         fields.push(Some(valtree));
     }
@@ -437,7 +437,7 @@ fn valtree_into_mplace<'tcx>(
                             )
                             .unwrap()
                     }
-                    _ => ecx.mplace_field(&place_adjusted, i, ProjectionMode::Weak).unwrap(),
+                    _ => ecx.mplace_field(&place_adjusted, i, ProjectionMode::Strong).unwrap(),
                 };
 
                 debug!(?place_inner);

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 use rustc_apfloat::ieee::{Double, Single};
 use rustc_apfloat::{Float, FloatConvert};
 use rustc_middle::mir::interpret::{InterpResult, PointerArithmetic, Scalar};
-use rustc_middle::mir::CastKind;
+use rustc_middle::mir::{CastKind, ProjectionMode};
 use rustc_middle::ty::adjustment::PointerCast;
 use rustc_middle::ty::layout::{IntegerExt, LayoutOf, TyAndLayout};
 use rustc_middle::ty::{self, FloatTy, Ty, TypeAndMut};
@@ -385,8 +385,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     if cast_ty_field.is_zst() {
                         continue;
                     }
-                    let src_field = self.operand_field(src, i)?;
-                    let dst_field = self.place_field(dest, i)?;
+                    let src_field = self.operand_field(src, i, ProjectionMode::Weak)?;
+                    let dst_field = self.place_field(dest, i, ProjectionMode::Weak)?;
                     if src_field.layout.ty == cast_ty_field.ty {
                         self.copy_op(&src_field, &dst_field, /*allow_transmute*/ false)?;
                     } else {

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -385,8 +385,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     if cast_ty_field.is_zst() {
                         continue;
                     }
-                    let src_field = self.operand_field(src, i, ProjectionMode::Weak)?;
-                    let dst_field = self.place_field(dest, i, ProjectionMode::Weak)?;
+                    let src_field = self.operand_field(src, i, ProjectionMode::Strong)?;
+                    let dst_field = self.place_field(dest, i, ProjectionMode::Strong)?;
                     if src_field.layout.ty == cast_ty_field.ty {
                         self.copy_op(&src_field, &dst_field, /*allow_transmute*/ false)?;
                     } else {

--- a/compiler/rustc_const_eval/src/interpret/intrinsics/caller_location.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/caller_location.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use rustc_ast::Mutability;
 use rustc_hir::lang_items::LangItem;
-use rustc_middle::mir::TerminatorKind;
+use rustc_middle::mir::{ProjectionMode, TerminatorKind};
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_span::{Span, Symbol};
 
@@ -102,12 +102,21 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let location = self.allocate(loc_layout, MemoryKind::CallerLocation).unwrap();
 
         // Initialize fields.
-        self.write_immediate(file.to_ref(self), &self.mplace_field(&location, 0).unwrap().into())
-            .expect("writing to memory we just allocated cannot fail");
-        self.write_scalar(line, &self.mplace_field(&location, 1).unwrap().into())
-            .expect("writing to memory we just allocated cannot fail");
-        self.write_scalar(col, &self.mplace_field(&location, 2).unwrap().into())
-            .expect("writing to memory we just allocated cannot fail");
+        self.write_immediate(
+            file.to_ref(self),
+            &self.mplace_field(&location, 0, ProjectionMode::Strong).unwrap().into(),
+        )
+        .expect("writing to memory we just allocated cannot fail");
+        self.write_scalar(
+            line,
+            &self.mplace_field(&location, 1, ProjectionMode::Strong).unwrap().into(),
+        )
+        .expect("writing to memory we just allocated cannot fail");
+        self.write_scalar(
+            col,
+            &self.mplace_field(&location, 2, ProjectionMode::Strong).unwrap().into(),
+        )
+        .expect("writing to memory we just allocated cannot fail");
 
         location
     }

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -333,6 +333,16 @@ pub trait Machine<'mir, 'tcx>: Sized {
         throw_unsup_format!("inline assembly is not supported")
     }
 
+    #[inline(always)]
+    fn ptr_check_range(
+        _ecx: &InterpCx<'mir, 'tcx, Self>,
+        _range: AllocRange,
+        (_alloc_id, _prov_extra): (AllocId, Self::ProvenanceExtra),
+        _msg: super::CheckInAllocMsg,
+    ) -> InterpResult<'tcx> {
+        Ok(())
+    }
+
     /// Hook for performing extra checks on a memory read access.
     ///
     /// Takes read-only access to the allocation so we can keep all the memory read

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -435,6 +435,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         msg,
                     })
                 }
+                M::ptr_check_range(self, alloc_range(offset, size), (alloc_id, prov), msg)?;
                 // Ensure we never consider the null pointer dereferenceable.
                 if M::Provenance::OFFSET_IS_ADDR {
                     assert_ne!(ptr.addr(), Size::ZERO);

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -698,7 +698,11 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let tag_layout = self.layout_of(tag_scalar_layout.primitive().to_int_ty(*self.tcx))?;
 
         // Read tag and sanity-check `tag_layout`.
-        let tag_val = self.read_immediate(&self.operand_field(op, tag_field)?)?;
+        let tag_val = self.read_immediate(&self.operand_field(
+            op,
+            tag_field,
+            mir::ProjectionMode::Strong,
+        )?)?;
         assert_eq!(tag_layout.size, tag_val.layout.size);
         assert_eq!(tag_layout.abi.is_signed(), tag_val.layout.abi.is_signed());
         trace!("tag value: {}", tag_val);

--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -45,9 +45,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // With randomized layout, `(int, bool)` might cease to be a `ScalarPair`, so we have to
             // do a component-wise write here. This code path is slower than the above because
             // `place_field` will have to `force_allocate` locals here.
-            let val_field = self.place_field(&dest, 0)?;
+            let val_field = self.place_field(&dest, 0, mir::ProjectionMode::Strong)?;
             self.write_scalar(val, &val_field)?;
-            let overflowed_field = self.place_field(&dest, 1)?;
+            let overflowed_field = self.place_field(&dest, 1, mir::ProjectionMode::Strong)?;
             self.write_scalar(Scalar::from_bool(overflowed), &overflowed_field)?;
         }
         Ok(())

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -820,7 +820,7 @@ where
                 let size = tag_layout.size(self);
                 let tag_val = size.truncate(discr_val);
 
-                let tag_dest = self.place_field(dest, tag_field)?;
+                let tag_dest = self.place_field(dest, tag_field, mir::ProjectionMode::Strong)?;
                 self.write_scalar(Scalar::from_uint(tag_val, size), &tag_dest)?;
             }
             abi::Variants::Multiple {
@@ -851,7 +851,8 @@ where
                         &niche_start_val,
                     )?;
                     // Write result.
-                    let niche_dest = self.place_field(dest, tag_field)?;
+                    let niche_dest =
+                        self.place_field(dest, tag_field, mir::ProjectionMode::Strong)?;
                     self.write_immediate(*tag_val, &niche_dest)?;
                 }
             }

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -249,6 +249,11 @@ impl<'tcx, Prov: Provenance> MPlaceTy<'tcx, Prov> {
             _ => bug!("vtable not supported on type {:?}", self.layout.ty),
         }
     }
+
+    /// Adjust the provenance of the main pointer (metadata is unaffected).
+    pub fn map_provenance(self, f: impl FnOnce(Option<Prov>) -> Option<Prov>) -> Self {
+        MPlaceTy { mplace: self.mplace.map_provenance(f), ..self }
+    }
 }
 
 // These are defined here because they produce a place.

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -216,6 +216,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     self.get_place_alloc_mut(&dest)?;
                 } else {
                     // Write the src to the first element.
+                    // We use a weak projection to use `first` as a base for pointer arithmetic.
                     let first = self.mplace_field(&dest, 0, mir::ProjectionMode::Weak)?;
                     self.copy_op(&src, &first.into(), /*allow_transmute*/ false)?;
 

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -199,7 +199,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
                 for (field_index, operand) in operands.iter().enumerate() {
                     let op = self.eval_operand(operand, None)?;
-                    let field_dest = self.place_field(&dest, field_index)?;
+                    let field_dest =
+                        self.place_field(&dest, field_index, mir::ProjectionMode::Strong)?;
                     self.copy_op(&op, &field_dest, /*allow_transmute*/ false)?;
                 }
             }
@@ -215,7 +216,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     self.get_place_alloc_mut(&dest)?;
                 } else {
                     // Write the src to the first element.
-                    let first = self.mplace_field(&dest, 0)?;
+                    let first = self.mplace_field(&dest, 0, mir::ProjectionMode::Weak)?;
                     self.copy_op(&src, &first.into(), /*allow_transmute*/ false)?;
 
                     // This is performance-sensitive code for big static/const arrays! So we

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -301,7 +301,7 @@ where
             ProjectionElem::Index(index) if in_local(index) => return true,
 
             ProjectionElem::Deref
-            | ProjectionElem::Field(_, _)
+            | ProjectionElem::Field(..)
             | ProjectionElem::OpaqueCast(_)
             | ProjectionElem::ConstantIndex { .. }
             | ProjectionElem::Subslice { .. }

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -218,7 +218,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                     )
                 }
             }
-            ProjectionElem::Field(f, ty) => {
+            ProjectionElem::Field(f, ty, _) => {
                 let parent = Place { local, projection: self.tcx.intern_place_elems(proj_base) };
                 let parent_ty = parent.ty(&self.body.local_decls, self.tcx);
                 let fail_out_of_bounds = |this: &Self, location| {

--- a/compiler/rustc_middle/src/mir/interpret/pointer.rs
+++ b/compiler/rustc_middle/src/mir/interpret/pointer.rs
@@ -1,7 +1,7 @@
 use super::{AllocId, InterpResult};
 
 use rustc_macros::HashStable;
-use rustc_target::abi::{HasDataLayout, Size};
+use rustc_target::abi::{HasDataLayout, Layout, Size};
 
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -140,6 +140,8 @@ pub trait Provenance: Copy + fmt::Debug {
 
     /// Defines the 'join' of provenance: what happens when doing a pointer load and different bytes have different provenance.
     fn join(left: Option<Self>, right: Option<Self>) -> Option<Self>;
+
+    fn restrict_to_range(self, ptr: Pointer<Option<Self>>, field_layout: Layout<'_>) -> Self;
 }
 
 impl Provenance for AllocId {
@@ -167,6 +169,10 @@ impl Provenance for AllocId {
 
     fn join(_left: Option<Self>, _right: Option<Self>) -> Option<Self> {
         panic!("merging provenance is not supported when `OFFSET_IS_ADDR` is false")
+    }
+
+    fn restrict_to_range(self, _: Pointer<Option<Self>>, _: Layout<'_>) -> Self {
+        self
     }
 }
 

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2715,7 +2715,7 @@ impl UserTypeProjection {
     }
 
     pub(crate) fn leaf(mut self, field: Field) -> Self {
-        self.projs.push(ProjectionElem::Field(field, (), ProjectionMode::Weak));
+        self.projs.push(ProjectionElem::Field(field, (), ProjectionMode::Strong));
         self
     }
 
@@ -2729,7 +2729,7 @@ impl UserTypeProjection {
             Some(adt_def.variant(variant_index).name),
             variant_index,
         ));
-        self.projs.push(ProjectionElem::Field(field, (), ProjectionMode::Weak));
+        self.projs.push(ProjectionElem::Field(field, (), ProjectionMode::Strong));
         self
     }
 }

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -108,7 +108,7 @@ impl<'tcx> PlaceTy<'tcx> {
             ProjectionElem::Downcast(_name, index) => {
                 PlaceTy { ty: self.ty, variant_index: Some(index) }
             }
-            ProjectionElem::Field(f, fty) => PlaceTy::from_ty(handle_field(&self, f, fty)),
+            ProjectionElem::Field(f, fty, _) => PlaceTy::from_ty(handle_field(&self, f, fty)),
             ProjectionElem::OpaqueCast(ty) => PlaceTy::from_ty(handle_opaque_cast(&self, ty)),
         };
         debug!("projection_ty self: {:?} elem: {:?} yields: {:?}", self, elem, answer);

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -1090,10 +1090,14 @@ macro_rules! visit_place_fns {
 
                     if new_local == local { None } else { Some(PlaceElem::Index(new_local)) }
                 }
-                PlaceElem::Field(field, ty) => {
+                PlaceElem::Field(field, ty, strength) => {
                     let mut new_ty = ty;
                     self.visit_ty(&mut new_ty, TyContext::Location(location));
-                    if ty != new_ty { Some(PlaceElem::Field(field, new_ty)) } else { None }
+                    if ty != new_ty {
+                        Some(PlaceElem::Field(field, new_ty, strength))
+                    } else {
+                        None
+                    }
                 }
                 PlaceElem::OpaqueCast(ty) => {
                     let mut new_ty = ty;
@@ -1169,7 +1173,7 @@ macro_rules! visit_place_fns {
             location: Location,
         ) {
             match elem {
-                ProjectionElem::OpaqueCast(ty) | ProjectionElem::Field(_, ty) => {
+                ProjectionElem::OpaqueCast(ty) | ProjectionElem::Field(_, ty, _) => {
                     self.visit_ty(ty, TyContext::Location(location));
                 }
                 ProjectionElem::Index(local) => {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -10,7 +10,8 @@ use crate::middle::resolve_lifetime;
 use crate::middle::stability;
 use crate::mir::interpret::{self, Allocation, ConstAllocation};
 use crate::mir::{
-    Body, BorrowCheckResult, Field, Local, Place, PlaceElem, ProjectionKind, Promoted,
+    Body, BorrowCheckResult, Field, Local, Place, PlaceElem, ProjectionKind, ProjectionMode,
+    Promoted,
 };
 use crate::thir::Thir;
 use crate::traits;
@@ -2720,7 +2721,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     pub fn mk_place_field(self, place: Place<'tcx>, f: Field, ty: Ty<'tcx>) -> Place<'tcx> {
-        self.mk_place_elem(place, PlaceElem::Field(f, ty))
+        self.mk_place_elem(place, PlaceElem::Field(f, ty, ProjectionMode::Weak))
     }
 
     pub fn mk_place_deref(self, place: Place<'tcx>) -> Place<'tcx> {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2721,7 +2721,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     pub fn mk_place_field(self, place: Place<'tcx>, f: Field, ty: Ty<'tcx>) -> Place<'tcx> {
-        self.mk_place_elem(place, PlaceElem::Field(f, ty, ProjectionMode::Weak))
+        self.mk_place_elem(place, PlaceElem::Field(f, ty, ProjectionMode::Strong))
     }
 
     pub fn mk_place_deref(self, place: Place<'tcx>) -> Place<'tcx> {

--- a/compiler/rustc_mir_build/src/build/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_place.rs
@@ -90,7 +90,7 @@ fn convert_to_hir_projections_and_truncate_for_capture<'tcx>(
     for mir_projection in mir_projections {
         let hir_projection = match mir_projection {
             ProjectionElem::Deref => HirProjectionKind::Deref,
-            ProjectionElem::Field(field, _) => {
+            ProjectionElem::Field(field, _, _) => {
                 let variant = variant.unwrap_or(VariantIdx::new(0));
                 HirProjectionKind::Field(field.index() as u32, variant)
             }
@@ -296,7 +296,7 @@ impl<'tcx> PlaceBuilder<'tcx> {
     }
 
     pub(crate) fn field(self, f: Field, ty: Ty<'tcx>) -> Self {
-        self.project(PlaceElem::Field(f, ty))
+        self.project(PlaceElem::Field(f, ty, ProjectionMode::Weak))
     }
 
     pub(crate) fn deref(self) -> Self {

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -665,12 +665,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 match enclosing_upvars_resolved.as_ref() {
                     PlaceRef {
                         local,
-                        projection: &[ProjectionElem::Field(upvar_index, _), ..],
+                        projection: &[ProjectionElem::Field(upvar_index, _, _), ..],
                     }
                     | PlaceRef {
                         local,
                         projection:
-                            &[ProjectionElem::Deref, ProjectionElem::Field(upvar_index, _), ..],
+                            &[ProjectionElem::Deref, ProjectionElem::Field(upvar_index, _, _), ..],
                     } => {
                         // Not in a closure
                         debug_assert!(

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -361,7 +361,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 let place = place_builder.clone_project(PlaceElem::Field(
                                     n,
                                     *ty,
-                                    ProjectionMode::Weak,
+                                    ProjectionMode::Strong,
                                 ));
                                 this.consume_by_copy_or_move(place.to_place(this))
                             }

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -358,7 +358,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         .map(|(n, ty)| match fields_map.get(&n) {
                             Some(v) => v.clone(),
                             None => {
-                                let place = place_builder.clone_project(PlaceElem::Field(n, *ty));
+                                let place = place_builder.clone_project(PlaceElem::Field(
+                                    n,
+                                    *ty,
+                                    ProjectionMode::Weak,
+                                ));
                                 this.consume_by_copy_or_move(place.to_place(this))
                             }
                         })

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -763,7 +763,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             let place = downcast_place.clone_project(PlaceElem::Field(
                 subpattern.field,
                 subpattern.pattern.ty,
-                ProjectionMode::Weak,
+                ProjectionMode::Strong,
             ));
             // e.g., `(x as Variant).0 @ P1`
             MatchPair::new(place, &subpattern.pattern, self)

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -760,8 +760,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let downcast_place = match_pair.place.downcast(adt_def, variant_index); // `(x as Variant)`
         let consequent_match_pairs = subpatterns.iter().map(|subpattern| {
             // e.g., `(x as Variant).0`
-            let place = downcast_place
-                .clone_project(PlaceElem::Field(subpattern.field, subpattern.pattern.ty));
+            let place = downcast_place.clone_project(PlaceElem::Field(
+                subpattern.field,
+                subpattern.pattern.ty,
+                ProjectionMode::Weak,
+            ));
             // e.g., `(x as Variant).0 @ P1`
             MatchPair::new(place, &subpattern.pattern, self)
         });

--- a/compiler/rustc_mir_build/src/build/matches/util.rs
+++ b/compiler/rustc_mir_build/src/build/matches/util.rs
@@ -21,7 +21,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let place = place.clone_project(PlaceElem::Field(
                     fieldpat.field,
                     fieldpat.pattern.ty,
-                    ProjectionMode::Weak,
+                    ProjectionMode::Strong,
                 ));
                 MatchPair::new(place, &fieldpat.pattern, self)
             })

--- a/compiler/rustc_mir_build/src/build/matches/util.rs
+++ b/compiler/rustc_mir_build/src/build/matches/util.rs
@@ -18,8 +18,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         subpatterns
             .iter()
             .map(|fieldpat| {
-                let place =
-                    place.clone_project(PlaceElem::Field(fieldpat.field, fieldpat.pattern.ty));
+                let place = place.clone_project(PlaceElem::Field(
+                    fieldpat.field,
+                    fieldpat.pattern.ty,
+                    ProjectionMode::Weak,
+                ));
                 MatchPair::new(place, &fieldpat.pattern, self)
             })
             .collect()

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -844,7 +844,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     let mutability = captured_place.mutability;
 
                     let mut projs = closure_env_projs.clone();
-                    projs.push(ProjectionElem::Field(Field::new(i), ty));
+                    projs.push(ProjectionElem::Field(Field::new(i), ty, ProjectionMode::Weak));
                     match capture {
                         ty::UpvarCapture::ByValue => {}
                         ty::UpvarCapture::ByRef(..) => {

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -844,7 +844,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     let mutability = captured_place.mutability;
 
                     let mut projs = closure_env_projs.clone();
-                    projs.push(ProjectionElem::Field(Field::new(i), ty, ProjectionMode::Weak));
+                    projs.push(ProjectionElem::Field(Field::new(i), ty, ProjectionMode::Strong));
                     match capture {
                         ty::UpvarCapture::ByValue => {}
                         ty::UpvarCapture::ByRef(..) => {

--- a/compiler/rustc_mir_dataflow/src/move_paths/abs_domain.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/abs_domain.rs
@@ -47,7 +47,7 @@ impl<'tcx> Lift for PlaceElem<'tcx> {
     fn lift(&self) -> Self::Abstract {
         match *self {
             ProjectionElem::Deref => ProjectionElem::Deref,
-            ProjectionElem::Field(f, ty) => ProjectionElem::Field(f, ty.lift()),
+            ProjectionElem::Field(f, ty, s) => ProjectionElem::Field(f, ty.lift(), s),
             ProjectionElem::OpaqueCast(ty) => ProjectionElem::OpaqueCast(ty.lift()),
             ProjectionElem::Index(ref i) => ProjectionElem::Index(i.lift()),
             ProjectionElem::Subslice { from, to, from_end } => {

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -534,7 +534,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
 
         // Check if we are assigning into a field of a union, if so, lookup the place
         // of the union so it is marked as initialized again.
-        if let Some((place_base, ProjectionElem::Field(_, _))) = place.last_projection() {
+        if let Some((place_base, ProjectionElem::Field(..))) = place.last_projection() {
             if place_base.ty(self.builder.body, self.builder.tcx).ty.is_union() {
                 place = place_base;
             }

--- a/compiler/rustc_mir_dataflow/src/value_analysis.rs
+++ b/compiler/rustc_mir_dataflow/src/value_analysis.rs
@@ -639,7 +639,7 @@ impl Map {
                 // Downcasts are currently not supported.
                 return;
             }
-            projection.push(PlaceElem::Field(field, ty, ProjectionMode::Weak));
+            projection.push(PlaceElem::Field(field, ty, ProjectionMode::Strong));
             self.register_with_filter_rec(tcx, local, projection, ty, filter);
             projection.pop();
         });

--- a/compiler/rustc_mir_dataflow/src/value_analysis.rs
+++ b/compiler/rustc_mir_dataflow/src/value_analysis.rs
@@ -639,7 +639,7 @@ impl Map {
                 // Downcasts are currently not supported.
                 return;
             }
-            projection.push(PlaceElem::Field(field, ty));
+            projection.push(PlaceElem::Field(field, ty, ProjectionMode::Weak));
             self.register_with_filter_rec(tcx, local, projection, ty, filter);
             projection.pop();
         });
@@ -782,7 +782,7 @@ impl<V, T> TryFrom<ProjectionElem<V, T>> for TrackElem {
 
     fn try_from(value: ProjectionElem<V, T>) -> Result<Self, Self::Error> {
         match value {
-            ProjectionElem::Field(field, _) => Ok(TrackElem::Field(field)),
+            ProjectionElem::Field(field, _, _) => Ok(TrackElem::Field(field)),
             _ => Err(()),
         }
     }

--- a/compiler/rustc_mir_transform/src/elaborate_box_derefs.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_box_derefs.rs
@@ -32,9 +32,9 @@ pub fn build_projection<'tcx>(
     ptr_ty: Ty<'tcx>,
 ) -> [PlaceElem<'tcx>; 3] {
     [
-        PlaceElem::Field(Field::new(0), unique_ty),
-        PlaceElem::Field(Field::new(0), nonnull_ty),
-        PlaceElem::Field(Field::new(0), ptr_ty),
+        PlaceElem::Field(Field::new(0), unique_ty, ProjectionMode::Strong),
+        PlaceElem::Field(Field::new(0), nonnull_ty, ProjectionMode::Strong),
+        PlaceElem::Field(Field::new(0), ptr_ty, ProjectionMode::Strong),
     ]
 }
 

--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -219,7 +219,7 @@ impl<'a, 'tcx> DropElaborator<'a, 'tcx> for Elaborator<'a, '_, 'tcx> {
 
     fn field_subpath(&self, path: Self::Path, field: Field) -> Option<Self::Path> {
         rustc_mir_dataflow::move_path_children_matching(self.ctxt.move_data(), path, |e| match e {
-            ProjectionElem::Field(idx, _) => idx == field,
+            ProjectionElem::Field(idx, _, _) => idx == field,
             _ => false,
         })
     }

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -162,6 +162,7 @@ impl<'tcx> MutVisitor<'tcx> for PinArgVisitor<'tcx> {
                     projection: self.tcx().intern_place_elems(&[ProjectionElem::Field(
                         Field::new(0),
                         self.ref_gen_ty,
+                        ProjectionMode::Weak,
                     )]),
                 },
                 self.tcx,
@@ -300,7 +301,7 @@ impl<'tcx> TransformVisitor<'tcx> {
         let self_place = Place::from(SELF_ARG);
         let base = self.tcx.mk_place_downcast_unnamed(self_place, variant_index);
         let mut projection = base.projection.to_vec();
-        projection.push(ProjectionElem::Field(Field::new(idx), ty));
+        projection.push(ProjectionElem::Field(Field::new(idx), ty, ProjectionMode::Weak));
 
         Place { local: base.local, projection: self.tcx.intern_place_elems(&projection) }
     }

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -162,7 +162,7 @@ impl<'tcx> MutVisitor<'tcx> for PinArgVisitor<'tcx> {
                     projection: self.tcx().intern_place_elems(&[ProjectionElem::Field(
                         Field::new(0),
                         self.ref_gen_ty,
-                        ProjectionMode::Weak,
+                        ProjectionMode::Strong,
                     )]),
                 },
                 self.tcx,
@@ -301,7 +301,7 @@ impl<'tcx> TransformVisitor<'tcx> {
         let self_place = Place::from(SELF_ARG);
         let base = self.tcx.mk_place_downcast_unnamed(self_place, variant_index);
         let mut projection = base.projection.to_vec();
-        projection.push(ProjectionElem::Field(Field::new(idx), ty, ProjectionMode::Weak));
+        projection.push(ProjectionElem::Field(Field::new(idx), ty, ProjectionMode::Strong));
 
         Place { local: base.local, projection: self.tcx.intern_place_elems(&projection) }
     }

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -853,7 +853,7 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
         context: PlaceContext,
         location: Location,
     ) {
-        if let ProjectionElem::Field(f, ty) = elem {
+        if let ProjectionElem::Field(f, ty, _) = elem {
             let parent = Place { local, projection: self.tcx.intern_place_elems(proj_base) };
             let parent_ty = parent.ty(&self.callee_body.local_decls, self.tcx);
             let check_equal = |this: &mut Self, f_ty| {

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -29,8 +29,8 @@ use rustc_index::vec::IndexVec;
 use rustc_middle::mir::visit::Visitor as _;
 use rustc_middle::mir::{
     traversal, AnalysisPhase, Body, ConstQualifs, Constant, LocalDecl, MirPass, MirPhase, Operand,
-    Place, ProjectionElem, Promoted, RuntimePhase, Rvalue, SourceInfo, Statement, StatementKind,
-    TerminatorKind,
+    Place, ProjectionElem, ProjectionMode, Promoted, RuntimePhase, Rvalue, SourceInfo, Statement,
+    StatementKind, TerminatorKind,
 };
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, TyCtxt, TypeVisitable};
@@ -189,7 +189,7 @@ fn remap_mir_for_const_eval_select<'tcx>(
                 let place_elems = place.projection;
                 let arguments = (0..num_args).map(|x| {
                     let mut place_elems = place_elems.to_vec();
-                    place_elems.push(ProjectionElem::Field(x.into(), fields[x]));
+                    place_elems.push(ProjectionElem::Field(x.into(), fields[x], ProjectionMode::Weak));
                     let projection = tcx.intern_place_elems(&place_elems);
                     let place = Place {
                         local: place.local,

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -189,7 +189,7 @@ fn remap_mir_for_const_eval_select<'tcx>(
                 let place_elems = place.projection;
                 let arguments = (0..num_args).map(|x| {
                     let mut place_elems = place_elems.to_vec();
-                    place_elems.push(ProjectionElem::Field(x.into(), fields[x], ProjectionMode::Weak));
+                    place_elems.push(ProjectionElem::Field(x.into(), fields[x], ProjectionMode::Strong));
                     let projection = tcx.intern_place_elems(&place_elems);
                     let place = Place {
                         local: place.local,

--- a/compiler/rustc_mir_transform/src/simplify_try.rs
+++ b/compiler/rustc_mir_transform/src/simplify_try.rs
@@ -539,7 +539,7 @@ fn match_variant_field_place<'tcx>(place: Place<'tcx>) -> Option<(Local, VarFiel
             projection:
                 &[
                     ProjectionElem::Downcast(_, var_idx),
-                    ProjectionElem::Field(field, ty, ProjectionMode::Weak),
+                    ProjectionElem::Field(field, ty, ProjectionMode::Strong),
                 ],
         } => Some((local, VarField { field, field_ty: ty, var_idx })),
         _ => None,

--- a/compiler/rustc_mir_transform/src/simplify_try.rs
+++ b/compiler/rustc_mir_transform/src/simplify_try.rs
@@ -536,7 +536,11 @@ fn match_variant_field_place<'tcx>(place: Place<'tcx>) -> Option<(Local, VarFiel
     match place.as_ref() {
         PlaceRef {
             local,
-            projection: &[ProjectionElem::Downcast(_, var_idx), ProjectionElem::Field(field, ty)],
+            projection:
+                &[
+                    ProjectionElem::Downcast(_, var_idx),
+                    ProjectionElem::Field(field, ty, ProjectionMode::Weak),
+                ],
         } => Some((local, VarField { field, field_ty: ty, var_idx })),
         _ => None,
     }

--- a/src/test/mir-opt/building/issue_101867.main.built.after.mir
+++ b/src/test/mir-opt/building/issue_101867.main.built.after.mir
@@ -57,7 +57,7 @@ fn main() -> () {
     }
 
     bb5: {
-        _5 = ((_1 as Some).0: u8);       // scope 1 at $DIR/issue_101867.rs:+2:14: +2:15
+        _5 = ((_1 as Some).0: u8, Strong); // scope 1 at $DIR/issue_101867.rs:+2:14: +2:15
         _0 = const ();                   // scope 0 at $DIR/issue_101867.rs:+0:11: +5:2
         StorageDead(_5);                 // scope 1 at $DIR/issue_101867.rs:+5:1: +5:2
         StorageDead(_1);                 // scope 0 at $DIR/issue_101867.rs:+5:1: +5:2

--- a/src/test/mir-opt/building/match_false_edges.full_tested_match.built.after.mir
+++ b/src/test/mir-opt/building/match_false_edges.full_tested_match.built.after.mir
@@ -50,7 +50,7 @@ fn full_tested_match() -> () {
 
     bb5: {
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
-        _6 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+        _6 = &((_2 as Some).0: i32, Strong); // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
         _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
         StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
         _7 = guard() -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
@@ -68,7 +68,7 @@ fn full_tested_match() -> () {
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:+2:26: +2:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:+2:26: +2:27
         StorageLive(_5);                 // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
-        _5 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+        _5 = ((_2 as Some).0: i32, Strong); // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
         StorageLive(_8);                 // scope 2 at $DIR/match_false_edges.rs:+2:35: +2:36
         _8 = _5;                         // scope 2 at $DIR/match_false_edges.rs:+2:35: +2:36
         _1 = (const 1_i32, move _8);     // scope 2 at $DIR/match_false_edges.rs:+2:31: +2:37
@@ -90,7 +90,7 @@ fn full_tested_match() -> () {
 
     bb10: {
         StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:+3:14: +3:15
-        _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:+3:14: +3:15
+        _9 = ((_2 as Some).0: i32, Strong); // scope 0 at $DIR/match_false_edges.rs:+3:14: +3:15
         StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:+3:24: +3:25
         _10 = _9;                        // scope 3 at $DIR/match_false_edges.rs:+3:24: +3:25
         _1 = (const 2_i32, move _10);    // scope 3 at $DIR/match_false_edges.rs:+3:20: +3:26

--- a/src/test/mir-opt/building/match_false_edges.full_tested_match2.built.after.mir
+++ b/src/test/mir-opt/building/match_false_edges.full_tested_match2.built.after.mir
@@ -41,7 +41,7 @@ fn full_tested_match2() -> () {
 
     bb3: {
         StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
-        _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
+        _9 = ((_2 as Some).0: i32, Strong); // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
         StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:+4:24: +4:25
         _10 = _9;                        // scope 3 at $DIR/match_false_edges.rs:+4:24: +4:25
         _1 = (const 2_i32, move _10);    // scope 3 at $DIR/match_false_edges.rs:+4:20: +4:26
@@ -56,7 +56,7 @@ fn full_tested_match2() -> () {
 
     bb5: {
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
-        _6 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+        _6 = &((_2 as Some).0: i32, Strong); // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
         _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
         StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
         _7 = guard() -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
@@ -74,7 +74,7 @@ fn full_tested_match2() -> () {
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:+2:26: +2:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:+2:26: +2:27
         StorageLive(_5);                 // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
-        _5 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+        _5 = ((_2 as Some).0: i32, Strong); // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
         StorageLive(_8);                 // scope 2 at $DIR/match_false_edges.rs:+2:35: +2:36
         _8 = _5;                         // scope 2 at $DIR/match_false_edges.rs:+2:35: +2:36
         _1 = (const 1_i32, move _8);     // scope 2 at $DIR/match_false_edges.rs:+2:31: +2:37

--- a/src/test/mir-opt/building/match_false_edges.main.built.after.mir
+++ b/src/test/mir-opt/building/match_false_edges.main.built.after.mir
@@ -77,7 +77,7 @@ fn main() -> () {
 
     bb8: {
         StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:16
-        _7 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:16
+        _7 = &((_2 as Some).0: i32, Strong); // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:16
         _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:26
         StorageLive(_8);                 // scope 0 at $DIR/match_false_edges.rs:+2:21: +2:28
         _8 = guard() -> [return: bb9, unwind: bb20]; // scope 0 at $DIR/match_false_edges.rs:+2:21: +2:28
@@ -95,7 +95,7 @@ fn main() -> () {
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:+2:27: +2:28
         FakeRead(ForGuardBinding, _7);   // scope 0 at $DIR/match_false_edges.rs:+2:27: +2:28
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:16
-        _6 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:16
+        _6 = ((_2 as Some).0: i32, Strong); // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:16
         _1 = const 1_i32;                // scope 2 at $DIR/match_false_edges.rs:+2:32: +2:33
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:+2:32: +2:33
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:32: +2:33
@@ -122,7 +122,7 @@ fn main() -> () {
 
     bb14: {
         StorageLive(_11);                // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
-        _11 = &((_2 as Some).0: i32);    // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
+        _11 = &((_2 as Some).0: i32, Strong); // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
         _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:26
         StorageLive(_12);                // scope 0 at $DIR/match_false_edges.rs:+4:20: +4:29
         StorageLive(_13);                // scope 0 at $DIR/match_false_edges.rs:+4:27: +4:28
@@ -143,7 +143,7 @@ fn main() -> () {
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:+4:28: +4:29
         FakeRead(ForGuardBinding, _11);  // scope 0 at $DIR/match_false_edges.rs:+4:28: +4:29
         StorageLive(_10);                // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
-        _10 = ((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
+        _10 = ((_2 as Some).0: i32, Strong); // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
         _1 = const 3_i32;                // scope 4 at $DIR/match_false_edges.rs:+4:33: +4:34
         StorageDead(_10);                // scope 0 at $DIR/match_false_edges.rs:+4:33: +4:34
         StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:+4:33: +4:34

--- a/src/test/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstCombine.diff
+++ b/src/test/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstCombine.diff
@@ -18,7 +18,7 @@
           StorageLive(_2);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
           StorageLive(_3);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
           StorageLive(_4);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
-          _4 = &((*_1).0: T);              // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
+          _4 = &((*_1).0: T, Strong);      // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
 -         _3 = &(*_4);                     // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
 +         _3 = _4;                         // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
           _2 = <T as Clone>::clone(move _3) -> bb1; // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
@@ -32,7 +32,7 @@
           StorageLive(_5);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
           StorageLive(_6);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
           StorageLive(_7);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
-          _7 = &((*_1).1: u64);            // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
+          _7 = &((*_1).1: u64, Strong);    // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
 -         _6 = &(*_7);                     // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
 -         _5 = <u64 as Clone>::clone(move _6) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
 -                                          // mir::Constant
@@ -48,7 +48,7 @@
           StorageLive(_8);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
           StorageLive(_9);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
           StorageLive(_10);                // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
-          _10 = &((*_1).2: [f32; 3]);      // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
+          _10 = &((*_1).2: [f32; 3], Strong); // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
 -         _9 = &(*_10);                    // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
 -         _8 = <[f32; 3] as Clone>::clone(move _9) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
 -                                          // mir::Constant
@@ -62,9 +62,9 @@
       bb3: {
           StorageDead(_9);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:10:15: 10:16
           Deinit(_0);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
-          (_0.0: T) = move _2;             // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
-          (_0.1: u64) = move _5;           // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
-          (_0.2: [f32; 3]) = move _8;      // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
+          (_0.0: T, Strong) = move _2;     // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
+          (_0.1: u64, Strong) = move _5;   // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
+          (_0.2: [f32; 3], Strong) = move _8; // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
           StorageDead(_8);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15
           StorageDead(_5);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15
           StorageDead(_2);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15

--- a/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -94,7 +94,7 @@
           _18 = const 123_u32;             // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
           StorageLive(_11);                // scope 6 at $DIR/const_debuginfo.rs:+10:9: +10:10
           Deinit(_11);                     // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
-          ((_11 as Some).0: u16) = const 99_u16; // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
+          ((_11 as Some).0: u16, Strong) = const 99_u16; // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
           discriminant(_11) = 1;           // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
           StorageLive(_19);                // scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10
           StorageLive(_20);                // scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10

--- a/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
@@ -15,10 +15,10 @@
           StorageLive(_2);                 // scope 0 at $DIR/aggregate.rs:+1:13: +1:24
           StorageLive(_3);                 // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
           Deinit(_3);                      // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
-          (_3.0: i32) = const 0_i32;       // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
-          (_3.1: i32) = const 1_i32;       // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
-          (_3.2: i32) = const 2_i32;       // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
--         _2 = (_3.1: i32);                // scope 0 at $DIR/aggregate.rs:+1:13: +1:24
+          (_3.0: i32, Strong) = const 0_i32; // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
+          (_3.1: i32, Strong) = const 1_i32; // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
+          (_3.2: i32, Strong) = const 2_i32; // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
+-         _2 = (_3.1: i32, Strong);        // scope 0 at $DIR/aggregate.rs:+1:13: +1:24
 -         _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/aggregate.rs:+1:13: +1:28
 +         _2 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:+1:13: +1:24
 +         _1 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:+1:13: +1:28

--- a/src/test/mir-opt/const_prop/aggregate.main.PreCodegen.after.mir
+++ b/src/test/mir-opt/const_prop/aggregate.main.PreCodegen.after.mir
@@ -14,9 +14,9 @@ fn main() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/aggregate.rs:+1:13: +1:24
         StorageLive(_3);                 // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
         Deinit(_3);                      // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
-        (_3.0: i32) = const 0_i32;       // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
-        (_3.1: i32) = const 1_i32;       // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
-        (_3.2: i32) = const 2_i32;       // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
+        (_3.0: i32, Strong) = const 0_i32; // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
+        (_3.1: i32, Strong) = const 1_i32; // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
+        (_3.2: i32, Strong) = const 2_i32; // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
         _2 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:+1:13: +1:24
         _1 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:+1:13: +1:28
         StorageDead(_2);                 // scope 0 at $DIR/aggregate.rs:+1:27: +1:28

--- a/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
@@ -35,11 +35,11 @@
       bb1: {
           StorageLive(_7);                 // scope 0 at $DIR/boxes.rs:+1:14: +1:22
           _7 = ShallowInitBox(move _6, i32); // scope 0 at $DIR/boxes.rs:+1:14: +1:22
-          _8 = (((_7.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: *const i32); // scope 0 at $DIR/boxes.rs:+1:19: +1:21
+          _8 = (((_7.0: std::ptr::Unique<i32>, Strong).0: std::ptr::NonNull<i32>, Strong).0: *const i32, Strong); // scope 0 at $DIR/boxes.rs:+1:19: +1:21
           (*_8) = const 42_i32;            // scope 0 at $DIR/boxes.rs:+1:19: +1:21
           _3 = move _7;                    // scope 0 at $DIR/boxes.rs:+1:14: +1:22
           StorageDead(_7);                 // scope 0 at $DIR/boxes.rs:+1:21: +1:22
-          _9 = (((_3.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: *const i32); // scope 0 at $DIR/boxes.rs:+1:13: +1:22
+          _9 = (((_3.0: std::ptr::Unique<i32>, Strong).0: std::ptr::NonNull<i32>, Strong).0: *const i32, Strong); // scope 0 at $DIR/boxes.rs:+1:13: +1:22
           _2 = (*_9);                      // scope 0 at $DIR/boxes.rs:+1:13: +1:22
           _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/boxes.rs:+1:13: +1:26
           StorageDead(_2);                 // scope 0 at $DIR/boxes.rs:+1:25: +1:26

--- a/src/test/mir-opt/const_prop/checked_add.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/checked_add.main.ConstProp.diff
@@ -12,13 +12,13 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/checked_add.rs:+1:9: +1:10
 -         _2 = CheckedAdd(const 1_u32, const 1_u32); // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
--         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
+-         assert(!move (_2.1: bool, Strong), "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
 +         _2 = const (2_u32, false);       // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
       }
   
       bb1: {
--         _1 = move (_2.0: u32);           // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
+-         _1 = move (_2.0: u32, Strong);   // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
 +         _1 = const 2_u32;                // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
           _0 = const ();                   // scope 0 at $DIR/checked_add.rs:+0:11: +2:2
           StorageDead(_1);                 // scope 0 at $DIR/checked_add.rs:+2:1: +2:2

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
@@ -18,7 +18,7 @@
           StorageLive(_2);                 // scope 0 at $DIR/discriminant.rs:+1:13: +1:64
           StorageLive(_3);                 // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
           Deinit(_3);                      // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
-          ((_3 as Some).0: bool) = const true; // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
+          ((_3 as Some).0: bool, Strong) = const true; // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
           discriminant(_3) = 1;            // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
 -         _4 = discriminant(_3);           // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
 -         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
@@ -27,7 +27,7 @@
       }
   
       bb1: {
-          switchInt(((_3 as Some).0: bool)) -> [false: bb3, otherwise: bb2]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
+          switchInt(((_3 as Some).0: bool, Strong)) -> [false: bb3, otherwise: bb2]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
       }
   
       bb2: {

--- a/src/test/mir-opt/const_prop/indirect.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/indirect.main.ConstProp.diff
@@ -15,14 +15,14 @@
           StorageLive(_2);                 // scope 0 at $DIR/indirect.rs:+1:13: +1:25
 -         _2 = const 2_u32 as u8 (IntToInt); // scope 0 at $DIR/indirect.rs:+1:13: +1:25
 -         _3 = CheckedAdd(_2, const 1_u8); // scope 0 at $DIR/indirect.rs:+1:13: +1:29
--         assert(!move (_3.1: bool), "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:+1:13: +1:29
+-         assert(!move (_3.1: bool, Strong), "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:+1:13: +1:29
 +         _2 = const 2_u8;                 // scope 0 at $DIR/indirect.rs:+1:13: +1:25
 +         _3 = const (3_u8, false);        // scope 0 at $DIR/indirect.rs:+1:13: +1:29
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:+1:13: +1:29
       }
   
       bb1: {
--         _1 = move (_3.0: u8);            // scope 0 at $DIR/indirect.rs:+1:13: +1:29
+-         _1 = move (_3.0: u8, Strong);    // scope 0 at $DIR/indirect.rs:+1:13: +1:29
 +         _1 = const 3_u8;                 // scope 0 at $DIR/indirect.rs:+1:13: +1:29
           StorageDead(_2);                 // scope 0 at $DIR/indirect.rs:+1:28: +1:29
           _0 = const ();                   // scope 0 at $DIR/indirect.rs:+0:11: +2:2

--- a/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
@@ -35,16 +35,16 @@
           StorageLive(_1);                 // scope 0 at $DIR/invalid_constant.rs:+6:9: +6:22
           StorageLive(_2);                 // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:63
           Deinit(_2);                      // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:63
-          (_2.0: u32) = const 1114113_u32; // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:63
--         _1 = (_2.1: char);               // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:67
+          (_2.0: u32, Strong) = const 1114113_u32; // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:63
+-         _1 = (_2.1: char, Strong);       // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:67
 +         _1 = const {transmute(0x00110001): char}; // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:67
           StorageDead(_2);                 // scope 0 at $DIR/invalid_constant.rs:+6:69: +6:70
           StorageLive(_3);                 // scope 1 at $DIR/invalid_constant.rs:+13:9: +13:21
           StorageLive(_4);                 // scope 1 at $DIR/invalid_constant.rs:+13:25: +13:59
           StorageLive(_5);                 // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
           Deinit(_5);                      // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
-          (_5.0: u32) = const 4_u32;       // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
--         _4 = (_5.1: E);                  // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:57
+          (_5.0: u32, Strong) = const 4_u32; // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
+-         _4 = (_5.1: E, Strong);          // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:57
 -         _3 = [move _4];                  // scope 1 at $DIR/invalid_constant.rs:+13:24: +13:60
 +         _4 = const Scalar(0x00000004): E; // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:57
 +                                          // mir::Constant
@@ -60,7 +60,7 @@
           StorageLive(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:35: +20:73
           StorageLive(_8);                 // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
           Deinit(_8);                      // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
-          (_8.0: u32) = const 0_u32;       // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
+          (_8.0: u32, Strong) = const 0_u32; // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
           nop;                             // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:71
           nop;                             // scope 3 at $DIR/invalid_constant.rs:+20:34: +20:74
           StorageDead(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:73: +20:74

--- a/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
@@ -14,8 +14,8 @@
           nop;                             // scope 0 at $DIR/issue_66971.rs:+1:13: +1:15
           Deinit(_2);                      // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
           nop;                             // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
-          (_2.1: u8) = const 0_u8;         // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
-          (_2.2: u8) = const 0_u8;         // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
+          (_2.1: u8, Strong) = const 0_u8; // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
+          (_2.2: u8, Strong) = const 0_u8; // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
           StorageDead(_3);                 // scope 0 at $DIR/issue_66971.rs:+1:21: +1:22
           _1 = encode(move _2) -> bb1;     // scope 0 at $DIR/issue_66971.rs:+1:5: +1:23
                                            // mir::Constant

--- a/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
@@ -12,11 +12,11 @@
           StorageLive(_2);                 // scope 0 at $DIR/issue_67019.rs:+1:10: +1:19
           StorageLive(_3);                 // scope 0 at $DIR/issue_67019.rs:+1:11: +1:17
           Deinit(_3);                      // scope 0 at $DIR/issue_67019.rs:+1:11: +1:17
-          (_3.0: u8) = const 1_u8;         // scope 0 at $DIR/issue_67019.rs:+1:11: +1:17
-          (_3.1: u8) = const 2_u8;         // scope 0 at $DIR/issue_67019.rs:+1:11: +1:17
+          (_3.0: u8, Strong) = const 1_u8; // scope 0 at $DIR/issue_67019.rs:+1:11: +1:17
+          (_3.1: u8, Strong) = const 2_u8; // scope 0 at $DIR/issue_67019.rs:+1:11: +1:17
           Deinit(_2);                      // scope 0 at $DIR/issue_67019.rs:+1:10: +1:19
--         (_2.0: (u8, u8)) = move _3;      // scope 0 at $DIR/issue_67019.rs:+1:10: +1:19
-+         (_2.0: (u8, u8)) = const (1_u8, 2_u8); // scope 0 at $DIR/issue_67019.rs:+1:10: +1:19
+-         (_2.0: (u8, u8), Strong) = move _3; // scope 0 at $DIR/issue_67019.rs:+1:10: +1:19
++         (_2.0: (u8, u8), Strong) = const (1_u8, 2_u8); // scope 0 at $DIR/issue_67019.rs:+1:10: +1:19
           StorageDead(_3);                 // scope 0 at $DIR/issue_67019.rs:+1:18: +1:19
           _1 = test(move _2) -> bb1;       // scope 0 at $DIR/issue_67019.rs:+1:5: +1:20
                                            // mir::Constant

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate.main.ConstProp.diff
@@ -15,9 +15,9 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate.rs:+1:9: +1:14
           Deinit(_1);                      // scope 0 at $DIR/mutable_variable_aggregate.rs:+1:17: +1:25
-          (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/mutable_variable_aggregate.rs:+1:17: +1:25
-          (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/mutable_variable_aggregate.rs:+1:17: +1:25
-          (_1.1: i32) = const 99_i32;      // scope 1 at $DIR/mutable_variable_aggregate.rs:+2:5: +2:13
+          (_1.0: i32, Strong) = const 42_i32; // scope 0 at $DIR/mutable_variable_aggregate.rs:+1:17: +1:25
+          (_1.1: i32, Strong) = const 43_i32; // scope 0 at $DIR/mutable_variable_aggregate.rs:+1:17: +1:25
+          (_1.1: i32, Strong) = const 99_i32; // scope 1 at $DIR/mutable_variable_aggregate.rs:+2:5: +2:13
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate.rs:+3:9: +3:10
 -         _2 = _1;                         // scope 1 at $DIR/mutable_variable_aggregate.rs:+3:13: +3:14
 +         _2 = const (42_i32, 99_i32);     // scope 1 at $DIR/mutable_variable_aggregate.rs:+3:13: +3:14

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.main.ConstProp.diff
@@ -19,11 +19,11 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+1:9: +1:14
           Deinit(_1);                      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+1:17: +1:25
-          (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+1:17: +1:25
-          (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+1:17: +1:25
+          (_1.0: i32, Strong) = const 42_i32; // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+1:17: +1:25
+          (_1.1: i32, Strong) = const 43_i32; // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+1:17: +1:25
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:+2:9: +2:10
           _2 = &mut _1;                    // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:+2:13: +2:19
-          ((*_2).1: i32) = const 99_i32;   // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+3:5: +3:13
+          ((*_2).1: i32, Strong) = const 99_i32; // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+3:5: +3:13
           StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+4:9: +4:10
           _3 = _1;                         // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+4:13: +4:14
           nop;                             // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+0:11: +5:2

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
@@ -21,10 +21,10 @@
       }
   
       bb1: {
-          (_1.1: i32) = const 99_i32;      // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+2:5: +2:13
-          (_1.0: i32) = const 42_i32;      // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+3:5: +3:13
+          (_1.1: i32, Strong) = const 99_i32; // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+2:5: +2:13
+          (_1.0: i32, Strong) = const 42_i32; // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+3:5: +3:13
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+4:9: +4:10
--         _2 = (_1.1: i32);                // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+4:13: +4:16
+-         _2 = (_1.1: i32, Strong);        // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+4:13: +4:16
 +         _2 = const 99_i32;               // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+4:13: +4:16
           nop;                             // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:+0:11: +5:2
           StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+5:1: +5:2

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
@@ -27,13 +27,13 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
 -         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
--         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+-         assert(!move (_2.1: bool, Strong), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
 +         _2 = const (4_i32, false);       // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
       }
   
       bb1: {
--         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+-         _1 = move (_2.0: i32, Strong);   // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
 +         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
           StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
           StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.diff
@@ -27,11 +27,11 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
           _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
-          assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+          assert(!move (_2.1: bool, Strong), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
       }
   
       bb1: {
-          _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+          _1 = move (_2.0: i32, Strong);   // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
           StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
           StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
           _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32]; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
@@ -49,9 +49,9 @@
           StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
 -         StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
 -         Deinit(_9);                      // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
--         (_9.0: u32) = const 12_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
--         (_9.1: u32) = const 42_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
--         _8 = (_9.1: u32);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
+-         (_9.0: u32, Strong) = const 12_u32; // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+-         (_9.1: u32, Strong) = const 42_u32; // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+-         _8 = (_9.1: u32, Strong);        // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
 -         StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:38: +3:39
 +         StorageLive(_10);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
 +         StorageLive(_11);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36

--- a/src/test/mir-opt/const_prop/ref_deref_project.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/ref_deref_project.main.ConstProp.diff
@@ -15,7 +15,7 @@
                                            // mir::Constant
                                            // + span: $DIR/ref_deref_project.rs:6:6: 6:17
                                            // + literal: Const { ty: &(i32, i32), val: Unevaluated(main, [], Some(promoted[0])) }
-          _2 = &((*_4).1: i32);            // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
+          _2 = &((*_4).1: i32, Strong);    // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
           _1 = (*_2);                      // scope 0 at $DIR/ref_deref_project.rs:+1:5: +1:17
           StorageDead(_2);                 // scope 0 at $DIR/ref_deref_project.rs:+1:17: +1:18
           StorageDead(_1);                 // scope 0 at $DIR/ref_deref_project.rs:+1:17: +1:18

--- a/src/test/mir-opt/const_prop/ref_deref_project.main.PromoteTemps.diff
+++ b/src/test/mir-opt/const_prop/ref_deref_project.main.PromoteTemps.diff
@@ -13,12 +13,12 @@
           StorageLive(_2);                 // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
 -         StorageLive(_3);                 // scope 0 at $DIR/ref_deref_project.rs:+1:8: +1:14
 -         _3 = (const 4_i32, const 5_i32); // scope 0 at $DIR/ref_deref_project.rs:+1:8: +1:14
--         _2 = &(_3.1: i32);               // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
+-         _2 = &(_3.1: i32, Strong);       // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
 +         _4 = const _;                    // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
 +                                          // mir::Constant
 +                                          // + span: $DIR/ref_deref_project.rs:6:6: 6:17
 +                                          // + literal: Const { ty: &(i32, i32), val: Unevaluated(main, [], Some(promoted[0])) }
-+         _2 = &((*_4).1: i32);            // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
++         _2 = &((*_4).1: i32, Strong);    // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
           _1 = (*_2);                      // scope 0 at $DIR/ref_deref_project.rs:+1:5: +1:17
 -         StorageDead(_3);                 // scope 0 at $DIR/ref_deref_project.rs:+1:17: +1:18
           StorageDead(_2);                 // scope 0 at $DIR/ref_deref_project.rs:+1:17: +1:18

--- a/src/test/mir-opt/const_prop/return_place.add.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/return_place.add.ConstProp.diff
@@ -7,13 +7,13 @@
   
       bb0: {
 -         _1 = CheckedAdd(const 2_u32, const 2_u32); // scope 0 at $DIR/return_place.rs:+1:5: +1:10
--         assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:+1:5: +1:10
+-         assert(!move (_1.1: bool, Strong), "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:+1:5: +1:10
 +         _1 = const (4_u32, false);       // scope 0 at $DIR/return_place.rs:+1:5: +1:10
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:+1:5: +1:10
       }
   
       bb1: {
--         _0 = move (_1.0: u32);           // scope 0 at $DIR/return_place.rs:+1:5: +1:10
+-         _0 = move (_1.0: u32, Strong);   // scope 0 at $DIR/return_place.rs:+1:5: +1:10
 +         _0 = const 4_u32;                // scope 0 at $DIR/return_place.rs:+1:5: +1:10
           return;                          // scope 0 at $DIR/return_place.rs:+2:2: +2:2
       }

--- a/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
@@ -13,8 +13,8 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:+1:9: +1:10
           Deinit(_1);                      // scope 0 at $DIR/tuple_literal_propagation.rs:+1:13: +1:19
-          (_1.0: u32) = const 1_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:+1:13: +1:19
-          (_1.1: u32) = const 2_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:+1:13: +1:19
+          (_1.0: u32, Strong) = const 1_u32; // scope 0 at $DIR/tuple_literal_propagation.rs:+1:13: +1:19
+          (_1.1: u32, Strong) = const 2_u32; // scope 0 at $DIR/tuple_literal_propagation.rs:+1:13: +1:19
           StorageLive(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:+3:5: +3:15
           StorageLive(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:+3:13: +3:14
 -         _3 = _1;                         // scope 1 at $DIR/tuple_literal_propagation.rs:+3:13: +3:14

--- a/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
@@ -20,17 +20,17 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
           Deinit(_1);                      // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
-          (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
+          (_1.0: i32, Strong) = const 1_i32; // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
           StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:+2:5: +4:6
           StorageLive(_3);                 // scope 2 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
-          _3 = &raw mut (_1.0: i32);       // scope 2 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
+          _3 = &raw mut (_1.0: i32, Strong); // scope 2 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
           (*_3) = const 5_i32;             // scope 2 at $DIR/const_prop_miscompile.rs:+3:9: +3:26
           StorageDead(_3);                 // scope 2 at $DIR/const_prop_miscompile.rs:+3:26: +3:27
           nop;                             // scope 2 at $DIR/const_prop_miscompile.rs:+2:5: +4:6
           StorageDead(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:+4:5: +4:6
           StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:9: +5:10
           StorageLive(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:20
-          _5 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:+5:15: +5:18
+          _5 = (_1.0: i32, Strong);        // scope 1 at $DIR/const_prop_miscompile.rs:+5:15: +5:18
           _4 = Eq(move _5, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:25
           StorageDead(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:24: +5:25
           nop;                             // scope 0 at $DIR/const_prop_miscompile.rs:+0:10: +6:2

--- a/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
@@ -17,14 +17,14 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
           Deinit(_1);                      // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
-          (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
+          (_1.0: i32, Strong) = const 1_i32; // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
           StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:+2:6: +2:14
-          _2 = &mut (_1.0: i32);           // scope 1 at $DIR/const_prop_miscompile.rs:+2:6: +2:14
+          _2 = &mut (_1.0: i32, Strong);   // scope 1 at $DIR/const_prop_miscompile.rs:+2:6: +2:14
           (*_2) = const 5_i32;             // scope 1 at $DIR/const_prop_miscompile.rs:+2:5: +2:18
           StorageDead(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:+2:18: +2:19
           StorageLive(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:+3:9: +3:10
           StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+3:13: +3:20
-          _4 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:+3:15: +3:18
+          _4 = (_1.0: i32, Strong);        // scope 1 at $DIR/const_prop_miscompile.rs:+3:15: +3:18
           _3 = Eq(move _4, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:+3:13: +3:25
           StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+3:24: +3:25
           nop;                             // scope 0 at $DIR/const_prop_miscompile.rs:+0:10: +4:2

--- a/src/test/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.diff
@@ -41,14 +41,14 @@
           StorageLive(_5);                 // scope 2 at $DIR/checked.rs:+3:17: +3:18
 -         _5 = _2;                         // scope 2 at $DIR/checked.rs:+3:17: +3:18
 -         _6 = CheckedAdd(_4, _5);         // scope 2 at $DIR/checked.rs:+3:13: +3:18
--         assert(!move (_6.1: bool), "attempt to compute `{} + {}`, which would overflow", move _4, move _5) -> bb1; // scope 2 at $DIR/checked.rs:+3:13: +3:18
+-         assert(!move (_6.1: bool, Strong), "attempt to compute `{} + {}`, which would overflow", move _4, move _5) -> bb1; // scope 2 at $DIR/checked.rs:+3:13: +3:18
 +         _5 = const 2_i32;                // scope 2 at $DIR/checked.rs:+3:17: +3:18
 +         _6 = CheckedAdd(const 1_i32, const 2_i32); // scope 2 at $DIR/checked.rs:+3:13: +3:18
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_i32, const 2_i32) -> bb1; // scope 2 at $DIR/checked.rs:+3:13: +3:18
       }
   
       bb1: {
--         _3 = move (_6.0: i32);           // scope 2 at $DIR/checked.rs:+3:13: +3:18
+-         _3 = move (_6.0: i32, Strong);   // scope 2 at $DIR/checked.rs:+3:13: +3:18
 +         _3 = const 3_i32;                // scope 2 at $DIR/checked.rs:+3:13: +3:18
           StorageDead(_5);                 // scope 2 at $DIR/checked.rs:+3:17: +3:18
           StorageDead(_4);                 // scope 2 at $DIR/checked.rs:+3:17: +3:18
@@ -58,14 +58,14 @@
           StorageLive(_9);                 // scope 4 at $DIR/checked.rs:+6:13: +6:14
 -         _9 = _7;                         // scope 4 at $DIR/checked.rs:+6:13: +6:14
 -         _10 = CheckedAdd(_9, const 1_i32); // scope 4 at $DIR/checked.rs:+6:13: +6:18
--         assert(!move (_10.1: bool), "attempt to compute `{} + {}`, which would overflow", move _9, const 1_i32) -> bb2; // scope 4 at $DIR/checked.rs:+6:13: +6:18
+-         assert(!move (_10.1: bool, Strong), "attempt to compute `{} + {}`, which would overflow", move _9, const 1_i32) -> bb2; // scope 4 at $DIR/checked.rs:+6:13: +6:18
 +         _9 = const i32::MAX;             // scope 4 at $DIR/checked.rs:+6:13: +6:14
 +         _10 = CheckedAdd(const i32::MAX, const 1_i32); // scope 4 at $DIR/checked.rs:+6:13: +6:18
-+         assert(!move (_10.1: bool), "attempt to compute `{} + {}`, which would overflow", const i32::MAX, const 1_i32) -> bb2; // scope 4 at $DIR/checked.rs:+6:13: +6:18
++         assert(!move (_10.1: bool, Strong), "attempt to compute `{} + {}`, which would overflow", const i32::MAX, const 1_i32) -> bb2; // scope 4 at $DIR/checked.rs:+6:13: +6:18
       }
   
       bb2: {
--         _8 = move (_10.0: i32);          // scope 4 at $DIR/checked.rs:+6:13: +6:18
+-         _8 = move (_10.0: i32, Strong);  // scope 4 at $DIR/checked.rs:+6:13: +6:18
 +         _8 = const i32::MIN;             // scope 4 at $DIR/checked.rs:+6:13: +6:18
           StorageDead(_9);                 // scope 4 at $DIR/checked.rs:+6:17: +6:18
           _0 = const ();                   // scope 0 at $DIR/checked.rs:+0:11: +7:2

--- a/src/test/mir-opt/dataflow-const-prop/enum.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/enum.main.DataflowConstProp.diff
@@ -24,7 +24,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/enum.rs:+1:9: +1:10
           Deinit(_1);                      // scope 0 at $DIR/enum.rs:+1:13: +1:21
-          ((_1 as V1).0: i32) = const 0_i32; // scope 0 at $DIR/enum.rs:+1:13: +1:21
+          ((_1 as V1).0: i32, Strong) = const 0_i32; // scope 0 at $DIR/enum.rs:+1:13: +1:21
           discriminant(_1) = 0;            // scope 0 at $DIR/enum.rs:+1:13: +1:21
           StorageLive(_2);                 // scope 1 at $DIR/enum.rs:+2:9: +2:10
           _3 = discriminant(_1);           // scope 1 at $DIR/enum.rs:+2:19: +2:20
@@ -33,7 +33,7 @@
   
       bb1: {
           StorageLive(_5);                 // scope 1 at $DIR/enum.rs:+2:44: +2:45
-          _5 = ((_1 as V2).0: i32);        // scope 1 at $DIR/enum.rs:+2:44: +2:45
+          _5 = ((_1 as V2).0: i32, Strong); // scope 1 at $DIR/enum.rs:+2:44: +2:45
           _2 = _5;                         // scope 4 at $DIR/enum.rs:+2:50: +2:51
           StorageDead(_5);                 // scope 1 at $DIR/enum.rs:+2:50: +2:51
           goto -> bb4;                     // scope 1 at $DIR/enum.rs:+2:50: +2:51
@@ -45,7 +45,7 @@
   
       bb3: {
           StorageLive(_4);                 // scope 1 at $DIR/enum.rs:+2:29: +2:30
-          _4 = ((_1 as V1).0: i32);        // scope 1 at $DIR/enum.rs:+2:29: +2:30
+          _4 = ((_1 as V1).0: i32, Strong); // scope 1 at $DIR/enum.rs:+2:29: +2:30
           _2 = _4;                         // scope 3 at $DIR/enum.rs:+2:35: +2:36
           StorageDead(_4);                 // scope 1 at $DIR/enum.rs:+2:35: +2:36
           goto -> bb4;                     // scope 1 at $DIR/enum.rs:+2:35: +2:36

--- a/src/test/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.diff
@@ -27,11 +27,11 @@
           StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           _5 = const 1_u8;                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           _6 = CheckedAdd(const u8::MAX, const 1_u8); // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-          assert(!move (_6.1: bool), "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> bb1; // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
+          assert(!move (_6.1: bool, Strong), "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> bb1; // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
       }
   
       bb1: {
--         _1 = move (_6.0: u8);            // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
+-         _1 = move (_6.0: u8, Strong);    // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
 +         _1 = const 0_u8;                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL

--- a/src/test/mir-opt/dataflow-const-prop/repr_transparent.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/repr_transparent.main.DataflowConstProp.diff
@@ -18,22 +18,22 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/repr_transparent.rs:+1:9: +1:10
           Deinit(_1);                      // scope 0 at $DIR/repr_transparent.rs:+1:13: +1:19
-          (_1.0: i32) = const 0_i32;       // scope 0 at $DIR/repr_transparent.rs:+1:13: +1:19
+          (_1.0: i32, Strong) = const 0_i32; // scope 0 at $DIR/repr_transparent.rs:+1:13: +1:19
           StorageLive(_2);                 // scope 1 at $DIR/repr_transparent.rs:+2:9: +2:10
           StorageLive(_3);                 // scope 1 at $DIR/repr_transparent.rs:+2:17: +2:26
           StorageLive(_4);                 // scope 1 at $DIR/repr_transparent.rs:+2:17: +2:20
--         _4 = (_1.0: i32);                // scope 1 at $DIR/repr_transparent.rs:+2:17: +2:20
+-         _4 = (_1.0: i32, Strong);        // scope 1 at $DIR/repr_transparent.rs:+2:17: +2:20
 +         _4 = const 0_i32;                // scope 1 at $DIR/repr_transparent.rs:+2:17: +2:20
           StorageLive(_5);                 // scope 1 at $DIR/repr_transparent.rs:+2:23: +2:26
--         _5 = (_1.0: i32);                // scope 1 at $DIR/repr_transparent.rs:+2:23: +2:26
+-         _5 = (_1.0: i32, Strong);        // scope 1 at $DIR/repr_transparent.rs:+2:23: +2:26
 -         _3 = Add(move _4, move _5);      // scope 1 at $DIR/repr_transparent.rs:+2:17: +2:26
 +         _5 = const 0_i32;                // scope 1 at $DIR/repr_transparent.rs:+2:23: +2:26
 +         _3 = const 0_i32;                // scope 1 at $DIR/repr_transparent.rs:+2:17: +2:26
           StorageDead(_5);                 // scope 1 at $DIR/repr_transparent.rs:+2:25: +2:26
           StorageDead(_4);                 // scope 1 at $DIR/repr_transparent.rs:+2:25: +2:26
           Deinit(_2);                      // scope 1 at $DIR/repr_transparent.rs:+2:13: +2:27
--         (_2.0: i32) = move _3;           // scope 1 at $DIR/repr_transparent.rs:+2:13: +2:27
-+         (_2.0: i32) = const 0_i32;       // scope 1 at $DIR/repr_transparent.rs:+2:13: +2:27
+-         (_2.0: i32, Strong) = move _3;   // scope 1 at $DIR/repr_transparent.rs:+2:13: +2:27
++         (_2.0: i32, Strong) = const 0_i32; // scope 1 at $DIR/repr_transparent.rs:+2:13: +2:27
           StorageDead(_3);                 // scope 1 at $DIR/repr_transparent.rs:+2:26: +2:27
           _0 = const ();                   // scope 0 at $DIR/repr_transparent.rs:+0:11: +3:2
           StorageDead(_2);                 // scope 1 at $DIR/repr_transparent.rs:+3:1: +3:2

--- a/src/test/mir-opt/dataflow-const-prop/sibling_ptr.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/sibling_ptr.main.DataflowConstProp.diff
@@ -24,11 +24,11 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/sibling_ptr.rs:+1:9: +1:14
           Deinit(_1);                      // scope 0 at $DIR/sibling_ptr.rs:+1:27: +1:33
-          (_1.0: u8) = const 0_u8;         // scope 0 at $DIR/sibling_ptr.rs:+1:27: +1:33
-          (_1.1: u8) = const 0_u8;         // scope 0 at $DIR/sibling_ptr.rs:+1:27: +1:33
+          (_1.0: u8, Strong) = const 0_u8; // scope 0 at $DIR/sibling_ptr.rs:+1:27: +1:33
+          (_1.1: u8, Strong) = const 0_u8; // scope 0 at $DIR/sibling_ptr.rs:+1:27: +1:33
           StorageLive(_2);                 // scope 1 at $DIR/sibling_ptr.rs:+2:5: +5:6
           StorageLive(_3);                 // scope 2 at $DIR/sibling_ptr.rs:+3:13: +3:14
-          _3 = &raw mut (_1.0: u8);        // scope 2 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+          _3 = &raw mut (_1.0: u8, Strong); // scope 2 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
           StorageLive(_4);                 // scope 3 at $DIR/sibling_ptr.rs:+4:10: +4:18
           StorageLive(_5);                 // scope 3 at $DIR/sibling_ptr.rs:+4:10: +4:11
           _5 = _3;                         // scope 3 at $DIR/sibling_ptr.rs:+4:10: +4:11
@@ -46,7 +46,7 @@
           StorageDead(_3);                 // scope 2 at $DIR/sibling_ptr.rs:+5:5: +5:6
           StorageDead(_2);                 // scope 1 at $DIR/sibling_ptr.rs:+5:5: +5:6
           StorageLive(_6);                 // scope 1 at $DIR/sibling_ptr.rs:+6:9: +6:11
-          _6 = (_1.1: u8);                 // scope 1 at $DIR/sibling_ptr.rs:+6:14: +6:17
+          _6 = (_1.1: u8, Strong);         // scope 1 at $DIR/sibling_ptr.rs:+6:14: +6:17
           _0 = const ();                   // scope 0 at $DIR/sibling_ptr.rs:+0:11: +7:2
           StorageDead(_6);                 // scope 1 at $DIR/sibling_ptr.rs:+7:1: +7:2
           StorageDead(_1);                 // scope 0 at $DIR/sibling_ptr.rs:+7:1: +7:2

--- a/src/test/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.diff
@@ -22,21 +22,21 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/struct.rs:+1:9: +1:14
           Deinit(_1);                      // scope 0 at $DIR/struct.rs:+1:17: +1:21
-          (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/struct.rs:+1:17: +1:21
+          (_1.0: i32, Strong) = const 1_i32; // scope 0 at $DIR/struct.rs:+1:17: +1:21
           StorageLive(_2);                 // scope 1 at $DIR/struct.rs:+2:9: +2:10
           StorageLive(_3);                 // scope 1 at $DIR/struct.rs:+2:13: +2:16
--         _3 = (_1.0: i32);                // scope 1 at $DIR/struct.rs:+2:13: +2:16
+-         _3 = (_1.0: i32, Strong);        // scope 1 at $DIR/struct.rs:+2:13: +2:16
 -         _2 = Add(move _3, const 2_i32);  // scope 1 at $DIR/struct.rs:+2:13: +2:20
 +         _3 = const 1_i32;                // scope 1 at $DIR/struct.rs:+2:13: +2:16
 +         _2 = const 3_i32;                // scope 1 at $DIR/struct.rs:+2:13: +2:20
           StorageDead(_3);                 // scope 1 at $DIR/struct.rs:+2:19: +2:20
-          (_1.0: i32) = const 3_i32;       // scope 2 at $DIR/struct.rs:+3:5: +3:12
+          (_1.0: i32, Strong) = const 3_i32; // scope 2 at $DIR/struct.rs:+3:5: +3:12
           StorageLive(_4);                 // scope 2 at $DIR/struct.rs:+4:9: +4:10
           StorageLive(_5);                 // scope 2 at $DIR/struct.rs:+4:13: +4:14
 -         _5 = _2;                         // scope 2 at $DIR/struct.rs:+4:13: +4:14
 +         _5 = const 3_i32;                // scope 2 at $DIR/struct.rs:+4:13: +4:14
           StorageLive(_6);                 // scope 2 at $DIR/struct.rs:+4:17: +4:20
--         _6 = (_1.0: i32);                // scope 2 at $DIR/struct.rs:+4:17: +4:20
+-         _6 = (_1.0: i32, Strong);        // scope 2 at $DIR/struct.rs:+4:17: +4:20
 -         _4 = Add(move _5, move _6);      // scope 2 at $DIR/struct.rs:+4:13: +4:20
 +         _6 = const 3_i32;                // scope 2 at $DIR/struct.rs:+4:17: +4:20
 +         _4 = const 6_i32;                // scope 2 at $DIR/struct.rs:+4:13: +4:20

--- a/src/test/mir-opt/dataflow-const-prop/tuple.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/tuple.main.DataflowConstProp.diff
@@ -26,15 +26,15 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/tuple.rs:+1:9: +1:14
           Deinit(_1);                      // scope 0 at $DIR/tuple.rs:+1:17: +1:23
-          (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/tuple.rs:+1:17: +1:23
-          (_1.1: i32) = const 2_i32;       // scope 0 at $DIR/tuple.rs:+1:17: +1:23
+          (_1.0: i32, Strong) = const 1_i32; // scope 0 at $DIR/tuple.rs:+1:17: +1:23
+          (_1.1: i32, Strong) = const 2_i32; // scope 0 at $DIR/tuple.rs:+1:17: +1:23
           StorageLive(_2);                 // scope 1 at $DIR/tuple.rs:+2:9: +2:10
           StorageLive(_3);                 // scope 1 at $DIR/tuple.rs:+2:13: +2:22
           StorageLive(_4);                 // scope 1 at $DIR/tuple.rs:+2:13: +2:16
--         _4 = (_1.0: i32);                // scope 1 at $DIR/tuple.rs:+2:13: +2:16
+-         _4 = (_1.0: i32, Strong);        // scope 1 at $DIR/tuple.rs:+2:13: +2:16
 +         _4 = const 1_i32;                // scope 1 at $DIR/tuple.rs:+2:13: +2:16
           StorageLive(_5);                 // scope 1 at $DIR/tuple.rs:+2:19: +2:22
--         _5 = (_1.1: i32);                // scope 1 at $DIR/tuple.rs:+2:19: +2:22
+-         _5 = (_1.1: i32, Strong);        // scope 1 at $DIR/tuple.rs:+2:19: +2:22
 -         _3 = Add(move _4, move _5);      // scope 1 at $DIR/tuple.rs:+2:13: +2:22
 +         _5 = const 2_i32;                // scope 1 at $DIR/tuple.rs:+2:19: +2:22
 +         _3 = const 3_i32;                // scope 1 at $DIR/tuple.rs:+2:13: +2:22
@@ -44,15 +44,15 @@
 +         _2 = const 6_i32;                // scope 1 at $DIR/tuple.rs:+2:13: +2:26
           StorageDead(_3);                 // scope 1 at $DIR/tuple.rs:+2:25: +2:26
           Deinit(_1);                      // scope 2 at $DIR/tuple.rs:+3:5: +3:15
-          (_1.0: i32) = const 2_i32;       // scope 2 at $DIR/tuple.rs:+3:5: +3:15
-          (_1.1: i32) = const 3_i32;       // scope 2 at $DIR/tuple.rs:+3:5: +3:15
+          (_1.0: i32, Strong) = const 2_i32; // scope 2 at $DIR/tuple.rs:+3:5: +3:15
+          (_1.1: i32, Strong) = const 3_i32; // scope 2 at $DIR/tuple.rs:+3:5: +3:15
           StorageLive(_6);                 // scope 2 at $DIR/tuple.rs:+4:9: +4:10
           StorageLive(_7);                 // scope 2 at $DIR/tuple.rs:+4:13: +4:22
           StorageLive(_8);                 // scope 2 at $DIR/tuple.rs:+4:13: +4:16
--         _8 = (_1.0: i32);                // scope 2 at $DIR/tuple.rs:+4:13: +4:16
+-         _8 = (_1.0: i32, Strong);        // scope 2 at $DIR/tuple.rs:+4:13: +4:16
 +         _8 = const 2_i32;                // scope 2 at $DIR/tuple.rs:+4:13: +4:16
           StorageLive(_9);                 // scope 2 at $DIR/tuple.rs:+4:19: +4:22
--         _9 = (_1.1: i32);                // scope 2 at $DIR/tuple.rs:+4:19: +4:22
+-         _9 = (_1.1: i32, Strong);        // scope 2 at $DIR/tuple.rs:+4:19: +4:22
 -         _7 = Add(move _8, move _9);      // scope 2 at $DIR/tuple.rs:+4:13: +4:22
 +         _9 = const 3_i32;                // scope 2 at $DIR/tuple.rs:+4:19: +4:22
 +         _7 = const 5_i32;                // scope 2 at $DIR/tuple.rs:+4:13: +4:22

--- a/src/test/mir-opt/deaggregator_test.bar.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test.bar.Deaggregator.diff
@@ -11,9 +11,9 @@
           _2 = _1;                         // scope 0 at $DIR/deaggregator_test.rs:+1:14: +1:15
 -         _0 = Baz { x: move _2, y: const 0f32, z: const false }; // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
 +         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
-+         (_0.0: usize) = move _2;         // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
-+         (_0.1: f32) = const 0f32;        // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
-+         (_0.2: bool) = const false;      // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
++         (_0.0: usize, Strong) = move _2; // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
++         (_0.1: f32, Strong) = const 0f32; // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
++         (_0.2: bool, Strong) = const false; // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
           StorageDead(_2);                 // scope 0 at $DIR/deaggregator_test.rs:+1:34: +1:35
           return;                          // scope 0 at $DIR/deaggregator_test.rs:+2:2: +2:2
       }

--- a/src/test/mir-opt/deaggregator_test_enum.bar.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum.bar.Deaggregator.diff
@@ -11,7 +11,7 @@
           _2 = _1;                         // scope 0 at $DIR/deaggregator_test_enum.rs:+1:19: +1:20
 -         _0 = Baz::Foo { x: move _2 };    // scope 0 at $DIR/deaggregator_test_enum.rs:+1:5: +1:22
 +         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum.rs:+1:5: +1:22
-+         ((_0 as Foo).0: usize) = move _2; // scope 0 at $DIR/deaggregator_test_enum.rs:+1:5: +1:22
++         ((_0 as Foo).0: usize, Strong) = move _2; // scope 0 at $DIR/deaggregator_test_enum.rs:+1:5: +1:22
 +         discriminant(_0) = 1;            // scope 0 at $DIR/deaggregator_test_enum.rs:+1:5: +1:22
           StorageDead(_2);                 // scope 0 at $DIR/deaggregator_test_enum.rs:+1:21: +1:22
           return;                          // scope 0 at $DIR/deaggregator_test_enum.rs:+2:2: +2:2

--- a/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
@@ -20,7 +20,7 @@
           _4 = _2;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:16: +2:17
 -         _0 = Foo::A(move _4);            // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:9: +2:18
 +         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:9: +2:18
-+         ((_0 as A).0: i32) = move _4;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:9: +2:18
++         ((_0 as A).0: i32, Strong) = move _4; // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:9: +2:18
 +         discriminant(_0) = 0;            // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:9: +2:18
           StorageDead(_4);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:17: +2:18
           goto -> bb3;                     // scope 0 at $DIR/deaggregator_test_enum_2.rs:+1:5: +5:6
@@ -31,7 +31,7 @@
           _5 = _2;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:16: +4:17
 -         _0 = Foo::B(move _5);            // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:9: +4:18
 +         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:9: +4:18
-+         ((_0 as B).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:9: +4:18
++         ((_0 as B).0: i32, Strong) = move _5; // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:9: +4:18
 +         discriminant(_0) = 1;            // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:9: +4:18
           StorageDead(_5);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:17: +4:18
           goto -> bb3;                     // scope 0 at $DIR/deaggregator_test_enum_2.rs:+1:5: +5:6

--- a/src/test/mir-opt/deaggregator_test_multiple.test.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_multiple.test.Deaggregator.diff
@@ -15,7 +15,7 @@
           _3 = _1;                         // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:13: +1:14
 -         _2 = Foo::A(move _3);            // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:6: +1:15
 +         Deinit(_2);                      // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:6: +1:15
-+         ((_2 as A).0: i32) = move _3;    // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:6: +1:15
++         ((_2 as A).0: i32, Strong) = move _3; // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:6: +1:15
 +         discriminant(_2) = 0;            // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:6: +1:15
           StorageDead(_3);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:14: +1:15
           StorageLive(_4);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:17: +1:26
@@ -23,7 +23,7 @@
           _5 = _1;                         // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:24: +1:25
 -         _4 = Foo::A(move _5);            // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:17: +1:26
 +         Deinit(_4);                      // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:17: +1:26
-+         ((_4 as A).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:17: +1:26
++         ((_4 as A).0: i32, Strong) = move _5; // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:17: +1:26
 +         discriminant(_4) = 0;            // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:17: +1:26
           StorageDead(_5);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:25: +1:26
           _0 = [move _2, move _4];         // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:5: +1:27

--- a/src/test/mir-opt/deref-patterns/string.foo.PreCodegen.after.mir
+++ b/src/test/mir-opt/deref-patterns/string.foo.PreCodegen.after.mir
@@ -29,7 +29,7 @@ fn foo(_1: Option<String>) -> i32 {
     }
 
     bb2: {
-        _2 = &((_1 as Some).0: std::string::String); // scope 0 at $DIR/string.rs:+2:14: +2:17
+        _2 = &((_1 as Some).0: std::string::String, Strong); // scope 0 at $DIR/string.rs:+2:14: +2:17
         _3 = <String as Deref>::deref(move _2) -> bb3; // scope 0 at $DIR/string.rs:+2:14: +2:17
                                          // mir::Constant
                                          // + span: $DIR/string.rs:9:14: 9:17

--- a/src/test/mir-opt/derefer_complex_case.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_complex_case.main.Derefer.diff
@@ -67,8 +67,8 @@
   
       bb4: {
           StorageLive(_12);                // scope 1 at $DIR/derefer_complex_case.rs:+1:10: +1:13
--         _12 = (*((_7 as Some).0: &i32)); // scope 1 at $DIR/derefer_complex_case.rs:+1:10: +1:13
-+         _15 = deref_copy ((_7 as Some).0: &i32); // scope 1 at $DIR/derefer_complex_case.rs:+1:10: +1:13
+-         _12 = (*((_7 as Some).0: &i32, Strong)); // scope 1 at $DIR/derefer_complex_case.rs:+1:10: +1:13
++         _15 = deref_copy ((_7 as Some).0: &i32, Strong); // scope 1 at $DIR/derefer_complex_case.rs:+1:10: +1:13
 +         _12 = (*_15);                    // scope 1 at $DIR/derefer_complex_case.rs:+1:10: +1:13
           StorageLive(_13);                // scope 2 at $DIR/derefer_complex_case.rs:+1:34: +1:37
           _13 = _12;                       // scope 2 at $DIR/derefer_complex_case.rs:+1:34: +1:37

--- a/src/test/mir-opt/derefer_test.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_test.main.Derefer.diff
@@ -32,13 +32,13 @@
           _2 = (const 99_i32, move _3);    // scope 1 at $DIR/derefer_test.rs:+2:17: +2:29
           StorageDead(_3);                 // scope 1 at $DIR/derefer_test.rs:+2:28: +2:29
           StorageLive(_4);                 // scope 2 at $DIR/derefer_test.rs:+3:9: +3:10
--         _4 = &mut ((*(_2.1: &mut (i32, i32))).0: i32); // scope 2 at $DIR/derefer_test.rs:+3:13: +3:26
-+         _6 = deref_copy (_2.1: &mut (i32, i32)); // scope 2 at $DIR/derefer_test.rs:+3:13: +3:26
-+         _4 = &mut ((*_6).0: i32);        // scope 2 at $DIR/derefer_test.rs:+3:13: +3:26
+-         _4 = &mut ((*(_2.1: &mut (i32, i32), Strong)).0: i32, Strong); // scope 2 at $DIR/derefer_test.rs:+3:13: +3:26
++         _6 = deref_copy (_2.1: &mut (i32, i32), Strong); // scope 2 at $DIR/derefer_test.rs:+3:13: +3:26
++         _4 = &mut ((*_6).0: i32, Strong); // scope 2 at $DIR/derefer_test.rs:+3:13: +3:26
           StorageLive(_5);                 // scope 3 at $DIR/derefer_test.rs:+4:9: +4:10
--         _5 = &mut ((*(_2.1: &mut (i32, i32))).1: i32); // scope 3 at $DIR/derefer_test.rs:+4:13: +4:26
-+         _7 = deref_copy (_2.1: &mut (i32, i32)); // scope 3 at $DIR/derefer_test.rs:+4:13: +4:26
-+         _5 = &mut ((*_7).1: i32);        // scope 3 at $DIR/derefer_test.rs:+4:13: +4:26
+-         _5 = &mut ((*(_2.1: &mut (i32, i32), Strong)).1: i32, Strong); // scope 3 at $DIR/derefer_test.rs:+4:13: +4:26
++         _7 = deref_copy (_2.1: &mut (i32, i32), Strong); // scope 3 at $DIR/derefer_test.rs:+4:13: +4:26
++         _5 = &mut ((*_7).1: i32, Strong); // scope 3 at $DIR/derefer_test.rs:+4:13: +4:26
           _0 = const ();                   // scope 0 at $DIR/derefer_test.rs:+0:11: +5:2
           StorageDead(_5);                 // scope 3 at $DIR/derefer_test.rs:+5:1: +5:2
           StorageDead(_4);                 // scope 2 at $DIR/derefer_test.rs:+5:1: +5:2

--- a/src/test/mir-opt/derefer_test_multiple.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_test_multiple.main.Derefer.diff
@@ -56,17 +56,17 @@
           _6 = (const 13_i32, move _7);    // scope 3 at $DIR/derefer_test_multiple.rs:+4:17: +4:29
           StorageDead(_7);                 // scope 3 at $DIR/derefer_test_multiple.rs:+4:28: +4:29
           StorageLive(_8);                 // scope 4 at $DIR/derefer_test_multiple.rs:+5:9: +5:10
--         _8 = &mut ((*((*((*(_6.1: &mut (i32, &mut (i32, &mut (i32, i32))))).1: &mut (i32, &mut (i32, i32)))).1: &mut (i32, i32))).1: i32); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
-+         _10 = deref_copy (_6.1: &mut (i32, &mut (i32, &mut (i32, i32)))); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
-+         _11 = deref_copy ((*_10).1: &mut (i32, &mut (i32, i32))); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
-+         _12 = deref_copy ((*_11).1: &mut (i32, i32)); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
-+         _8 = &mut ((*_12).1: i32);       // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
+-         _8 = &mut ((*((*((*(_6.1: &mut (i32, &mut (i32, &mut (i32, i32))), Strong)).1: &mut (i32, &mut (i32, i32)), Strong)).1: &mut (i32, i32), Strong)).1: i32, Strong); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         _10 = deref_copy (_6.1: &mut (i32, &mut (i32, &mut (i32, i32))), Strong); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         _11 = deref_copy ((*_10).1: &mut (i32, &mut (i32, i32)), Strong); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         _12 = deref_copy ((*_11).1: &mut (i32, i32), Strong); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         _8 = &mut ((*_12).1: i32, Strong); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
           StorageLive(_9);                 // scope 5 at $DIR/derefer_test_multiple.rs:+6:9: +6:10
--         _9 = &mut ((*((*((*(_6.1: &mut (i32, &mut (i32, &mut (i32, i32))))).1: &mut (i32, &mut (i32, i32)))).1: &mut (i32, i32))).1: i32); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
-+         _13 = deref_copy (_6.1: &mut (i32, &mut (i32, &mut (i32, i32)))); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
-+         _14 = deref_copy ((*_13).1: &mut (i32, &mut (i32, i32))); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
-+         _15 = deref_copy ((*_14).1: &mut (i32, i32)); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
-+         _9 = &mut ((*_15).1: i32);       // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
+-         _9 = &mut ((*((*((*(_6.1: &mut (i32, &mut (i32, &mut (i32, i32))), Strong)).1: &mut (i32, &mut (i32, i32)), Strong)).1: &mut (i32, i32), Strong)).1: i32, Strong); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         _13 = deref_copy (_6.1: &mut (i32, &mut (i32, &mut (i32, i32))), Strong); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         _14 = deref_copy ((*_13).1: &mut (i32, &mut (i32, i32)), Strong); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         _15 = deref_copy ((*_14).1: &mut (i32, i32), Strong); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         _9 = &mut ((*_15).1: i32, Strong); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
           _0 = const ();                   // scope 0 at $DIR/derefer_test_multiple.rs:+0:12: +7:2
           StorageDead(_9);                 // scope 5 at $DIR/derefer_test_multiple.rs:+7:1: +7:2
           StorageDead(_8);                 // scope 4 at $DIR/derefer_test_multiple.rs:+7:1: +7:2

--- a/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
@@ -26,14 +26,14 @@
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
           Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
-          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.0: std::option::Option<u32>, Strong) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.1: std::option::Option<u32>, Strong) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
-          _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          _7 = discriminant((_3.0: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
 -         switchInt(move _7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 +         StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         _10 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         _10 = discriminant((_3.1: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 +         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 +         _11 = Ne(_7, move _10);          // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 +         StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
@@ -48,15 +48,15 @@
       }
   
       bb2: {
--         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+-         _6 = discriminant((_3.1: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
 -         switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 -     }
 - 
 -     bb3: {
           StorageLive(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
-          _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+          _8 = (((_3.0: std::option::Option<u32>, Strong) as Some).0: u32, Strong); // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
-          _9 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
+          _9 = (((_3.1: std::option::Option<u32>, Strong) as Some).0: u32, Strong); // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
           StorageDead(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32

--- a/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
@@ -27,14 +27,14 @@
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
           Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
-          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.0: std::option::Option<u32>, Strong) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.1: std::option::Option<u32>, Strong) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
-          _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          _8 = discriminant((_3.0: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
 -         switchInt(move _8) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 +         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         _11 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         _11 = discriminant((_3.1: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 +         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 +         _12 = Ne(_8, move _11);          // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 +         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
@@ -42,7 +42,7 @@
       }
   
       bb1: {
--         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+-         _6 = discriminant((_3.1: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
 -         switchInt(move _6) -> [0_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 -     }
 - 
@@ -54,16 +54,16 @@
       }
   
 -     bb3: {
--         _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+-         _7 = discriminant((_3.1: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
 -         switchInt(move _7) -> [1_isize: bb4, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 -     }
 - 
 -     bb4: {
 +     bb2: {
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
-          _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+          _9 = (((_3.0: std::option::Option<u32>, Strong) as Some).0: u32, Strong); // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
           StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
-          _10 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
+          _10 = (((_3.1: std::option::Option<u32>, Strong) as Some).0: u32, Strong); // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
           StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32

--- a/src/test/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
@@ -26,14 +26,14 @@
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
           Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
-          (_3.1: std::option::Option<bool>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.0: std::option::Option<u32>, Strong) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.1: std::option::Option<bool>, Strong) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
-          _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          _7 = discriminant((_3.0: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
 -         switchInt(move _7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 +         StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
-+         _10 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         _10 = discriminant((_3.1: std::option::Option<bool>, Strong)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 +         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 +         _11 = Ne(_7, move _10);          // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 +         StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
@@ -48,15 +48,15 @@
       }
   
       bb2: {
--         _6 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+-         _6 = discriminant((_3.1: std::option::Option<bool>, Strong)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
 -         switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 -     }
 - 
 -     bb3: {
           StorageLive(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
-          _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+          _8 = (((_3.0: std::option::Option<u32>, Strong) as Some).0: u32, Strong); // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
-          _9 = (((_3.1: std::option::Option<bool>) as Some).0: bool); // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
+          _9 = (((_3.1: std::option::Option<bool>, Strong) as Some).0: bool, Strong); // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
           StorageDead(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32

--- a/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
@@ -35,16 +35,16 @@
           StorageLive(_7);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:18: +1:19
           _7 = _3;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:18: +1:19
           Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
-          (_4.0: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
-          (_4.1: std::option::Option<u32>) = move _6; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
-          (_4.2: std::option::Option<u32>) = move _7; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          (_4.0: std::option::Option<u32>, Strong) = move _5; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          (_4.1: std::option::Option<u32>, Strong) = move _6; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          (_4.2: std::option::Option<u32>, Strong) = move _7; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
           StorageDead(_7);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:19: +1:20
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:19: +1:20
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:19: +1:20
-          _10 = discriminant((_4.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          _10 = discriminant((_4.0: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
 -         switchInt(move _10) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
 +         StorageLive(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
-+         _14 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
++         _14 = discriminant((_4.1: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
 +         StorageLive(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
 +         _15 = Ne(_10, move _14);         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
 +         StorageDead(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
@@ -60,12 +60,12 @@
       }
   
       bb2: {
--         _9 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+-         _9 = discriminant((_4.1: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
 -         switchInt(move _9) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
 -     }
 - 
 -     bb3: {
-          _8 = discriminant((_4.2: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          _8 = discriminant((_4.2: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
 -         switchInt(move _8) -> [1_isize: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
 +         switchInt(move _8) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
       }
@@ -73,11 +73,11 @@
 -     bb4: {
 +     bb3: {
           StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:15: +2:16
-          _11 = (((_4.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:15: +2:16
+          _11 = (((_4.0: std::option::Option<u32>, Strong) as Some).0: u32, Strong); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:15: +2:16
           StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:24: +2:25
-          _12 = (((_4.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:24: +2:25
+          _12 = (((_4.1: std::option::Option<u32>, Strong) as Some).0: u32, Strong); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:24: +2:25
           StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:33: +2:34
-          _13 = (((_4.2: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:33: +2:34
+          _13 = (((_4.2: std::option::Option<u32>, Strong) as Some).0: u32, Strong); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:33: +2:34
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
           StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
           StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -74,17 +74,17 @@
           StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:18: +5:23
           _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:18: +5:23
           Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
-          (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
-          (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          (_4.0: &ViewportPercentageLength, Strong) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          (_4.1: &ViewportPercentageLength, Strong) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:23: +5:24
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:23: +5:24
-          _34 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _34 = deref_copy (_4.0: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           _11 = discriminant((*_34));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb1: {
-          _35 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _35 = deref_copy (_4.1: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           _7 = discriminant((*_35));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
@@ -93,7 +93,7 @@
           StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:25: +10:27
           Deinit(_33);                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:25: +10:27
           Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
-          ((_0 as Err).0: ()) = move _33;  // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
+          ((_0 as Err).0: (), Strong) = move _33; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
           discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
           StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:27: +10:28
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+11:6: +11:7
@@ -102,30 +102,30 @@
       }
   
       bb3: {
-          _36 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _36 = deref_copy (_4.1: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           _8 = discriminant((*_36));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb4: {
-          _37 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _37 = deref_copy (_4.1: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           _9 = discriminant((*_37));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb5: {
-          _38 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _38 = deref_copy (_4.1: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           _10 = discriminant((*_38));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
           switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb6: {
           StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
-          _39 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
-          _12 = (((*_39) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+          _39 = deref_copy (_4.0: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+          _12 = (((*_39) as Vw).0: f32, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
           StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
-          _40 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
-          _13 = (((*_40) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+          _40 = deref_copy (_4.1: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+          _13 = (((*_40) as Vw).0: f32, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
           StorageLive(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
           StorageLive(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:41
           _15 = _12;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:41
@@ -135,7 +135,7 @@
           StorageDead(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:48: +6:49
           StorageDead(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:48: +6:49
           Deinit(_3);                      // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
-          ((_3 as Vw).0: f32) = move _14;  // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
+          ((_3 as Vw).0: f32, Strong) = move _14; // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
           discriminant(_3) = 0;            // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
           StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
           StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
@@ -145,11 +145,11 @@
   
       bb7: {
           StorageLive(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
-          _41 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
-          _17 = (((*_41) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+          _41 = deref_copy (_4.0: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+          _17 = (((*_41) as Vh).0: f32, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
           StorageLive(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
-          _42 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
-          _18 = (((*_42) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+          _42 = deref_copy (_4.1: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+          _18 = (((*_42) as Vh).0: f32, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
           StorageLive(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
           StorageLive(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:41
           _20 = _17;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:41
@@ -159,7 +159,7 @@
           StorageDead(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:48: +7:49
           StorageDead(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:48: +7:49
           Deinit(_3);                      // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
-          ((_3 as Vh).0: f32) = move _19;  // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
+          ((_3 as Vh).0: f32, Strong) = move _19; // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
           discriminant(_3) = 1;            // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
           StorageDead(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
           StorageDead(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
@@ -169,11 +169,11 @@
   
       bb8: {
           StorageLive(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
-          _43 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
-          _22 = (((*_43) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+          _43 = deref_copy (_4.0: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+          _22 = (((*_43) as Vmin).0: f32, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
           StorageLive(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
-          _44 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
-          _23 = (((*_44) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+          _44 = deref_copy (_4.1: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+          _23 = (((*_44) as Vmin).0: f32, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
           StorageLive(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
           StorageLive(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:47
           _25 = _22;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:47
@@ -183,7 +183,7 @@
           StorageDead(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:54: +8:55
           StorageDead(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:54: +8:55
           Deinit(_3);                      // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
-          ((_3 as Vmin).0: f32) = move _24; // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
+          ((_3 as Vmin).0: f32, Strong) = move _24; // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
           discriminant(_3) = 2;            // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
           StorageDead(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
           StorageDead(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
@@ -193,11 +193,11 @@
   
       bb9: {
           StorageLive(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
-          _45 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
-          _27 = (((*_45) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+          _45 = deref_copy (_4.0: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+          _27 = (((*_45) as Vmax).0: f32, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
           StorageLive(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
-          _46 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
-          _28 = (((*_46) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+          _46 = deref_copy (_4.1: &ViewportPercentageLength, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+          _28 = (((*_46) as Vmax).0: f32, Strong); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
           StorageLive(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
           StorageLive(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:47
           _30 = _27;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:47
@@ -207,7 +207,7 @@
           StorageDead(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:54: +9:55
           StorageDead(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:54: +9:55
           Deinit(_3);                      // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
-          ((_3 as Vmax).0: f32) = move _29; // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
+          ((_3 as Vmax).0: f32, Strong) = move _29; // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
           discriminant(_3) = 3;            // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
           StorageDead(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
           StorageDead(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
@@ -217,7 +217,7 @@
   
       bb10: {
           Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
-          ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
+          ((_0 as Ok).0: ViewportPercentageLength, Strong) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
           discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+11:6: +11:7
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:1: +12:2

--- a/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
@@ -33,16 +33,16 @@
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:15: +1:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:15: +1:16
           Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
-          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          (_3.0: std::option::Option<u32>, Strong) = move _4; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          (_3.1: std::option::Option<u32>, Strong) = move _5; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:16: +1:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:16: +1:17
-          _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          _8 = discriminant((_3.0: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
           switchInt(move _8) -> [0_isize: bb1, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:5: +1:17
       }
   
       bb1: {
-          _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          _6 = discriminant((_3.1: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
           switchInt(move _6) -> [0_isize: bb2, 1_isize: bb7, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:5: +1:17
       }
   
@@ -56,15 +56,15 @@
       }
   
       bb4: {
-          _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          _7 = discriminant((_3.1: std::option::Option<u32>, Strong)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
           switchInt(move _7) -> [0_isize: bb6, 1_isize: bb5, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:5: +1:17
       }
   
       bb5: {
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:15: +2:16
-          _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:15: +2:16
+          _9 = (((_3.0: std::option::Option<u32>, Strong) as Some).0: u32, Strong); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:15: +2:16
           StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:24: +2:25
-          _10 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:24: +2:25
+          _10 = (((_3.1: std::option::Option<u32>, Strong) as Some).0: u32, Strong); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:24: +2:25
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch_noopt.rs:+2:31: +2:32
           StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:31: +2:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:31: +2:32
@@ -73,7 +73,7 @@
   
       bb6: {
           StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+3:15: +3:16
-          _11 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+3:15: +3:16
+          _11 = (((_3.0: std::option::Option<u32>, Strong) as Some).0: u32, Strong); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+3:15: +3:16
           _0 = const 1_u32;                // scope 2 at $DIR/early_otherwise_branch_noopt.rs:+3:28: +3:29
           StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+3:28: +3:29
           goto -> bb8;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+3:28: +3:29
@@ -81,7 +81,7 @@
   
       bb7: {
           StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+4:21: +4:22
-          _12 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+4:21: +4:22
+          _12 = (((_3.1: std::option::Option<u32>, Strong) as Some).0: u32, Strong); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+4:21: +4:22
           _0 = const 2_u32;                // scope 3 at $DIR/early_otherwise_branch_noopt.rs:+4:28: +4:29
           StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+4:28: +4:29
           goto -> bb8;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+4:28: +4:29

--- a/src/test/mir-opt/early_otherwise_branch_soundness.no_deref_ptr.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_soundness.no_deref_ptr.EarlyOtherwiseBranch.diff
@@ -34,7 +34,7 @@
   
       bb4: {
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:18: +4:19
-          _5 = (((*_2) as Some).0: i32);   // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:18: +4:19
+          _5 = (((*_2) as Some).0: i32, Strong); // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:18: +4:19
           _0 = _5;                         // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+4:24: +4:25
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:24: +4:25
           goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:24: +4:25

--- a/src/test/mir-opt/early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
@@ -16,7 +16,7 @@
       }
   
       bb1: {
-          _4 = deref_copy (((*_1) as Some).0: &E<'_>); // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
+          _4 = deref_copy (((*_1) as Some).0: &E<'_>, Strong); // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
           _2 = discriminant((*_4));        // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
           switchInt(move _2) -> [1_isize: bb2, otherwise: bb3]; // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
       }

--- a/src/test/mir-opt/exponential_or.match_tuple.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/exponential_or.match_tuple.SimplifyCfg-initial.after.mir
@@ -19,7 +19,7 @@ fn match_tuple(_1: (u32, bool, Option<i32>, u32)) -> u32 {
 
     bb0: {
         FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/exponential_or.rs:+1:11: +1:12
-        switchInt((_1.0: u32)) -> [1_u32: bb2, 4_u32: bb2, otherwise: bb1]; // scope 0 at $DIR/exponential_or.rs:+2:15: +2:20
+        switchInt((_1.0: u32, Strong)) -> [1_u32: bb2, 4_u32: bb2, otherwise: bb1]; // scope 0 at $DIR/exponential_or.rs:+2:15: +2:20
     }
 
     bb1: {
@@ -28,31 +28,31 @@ fn match_tuple(_1: (u32, bool, Option<i32>, u32)) -> u32 {
     }
 
     bb2: {
-        _2 = discriminant((_1.2: std::option::Option<i32>)); // scope 0 at $DIR/exponential_or.rs:+2:37: +2:55
+        _2 = discriminant((_1.2: std::option::Option<i32>, Strong)); // scope 0 at $DIR/exponential_or.rs:+2:37: +2:55
         switchInt(move _2) -> [0_isize: bb4, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/exponential_or.rs:+2:37: +2:55
     }
 
     bb3: {
-        switchInt((((_1.2: std::option::Option<i32>) as Some).0: i32)) -> [1_i32: bb4, 8_i32: bb4, otherwise: bb1]; // scope 0 at $DIR/exponential_or.rs:+2:37: +2:55
+        switchInt((((_1.2: std::option::Option<i32>, Strong) as Some).0: i32, Strong)) -> [1_i32: bb4, 8_i32: bb4, otherwise: bb1]; // scope 0 at $DIR/exponential_or.rs:+2:37: +2:55
     }
 
     bb4: {
-        _5 = Le(const 6_u32, (_1.3: u32)); // scope 0 at $DIR/exponential_or.rs:+2:62: +2:67
+        _5 = Le(const 6_u32, (_1.3: u32, Strong)); // scope 0 at $DIR/exponential_or.rs:+2:62: +2:67
         switchInt(move _5) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/exponential_or.rs:+2:62: +2:67
     }
 
     bb5: {
-        _6 = Le((_1.3: u32), const 9_u32); // scope 0 at $DIR/exponential_or.rs:+2:62: +2:67
+        _6 = Le((_1.3: u32, Strong), const 9_u32); // scope 0 at $DIR/exponential_or.rs:+2:62: +2:67
         switchInt(move _6) -> [false: bb6, otherwise: bb8]; // scope 0 at $DIR/exponential_or.rs:+2:62: +2:67
     }
 
     bb6: {
-        _3 = Le(const 13_u32, (_1.3: u32)); // scope 0 at $DIR/exponential_or.rs:+2:70: +2:77
+        _3 = Le(const 13_u32, (_1.3: u32, Strong)); // scope 0 at $DIR/exponential_or.rs:+2:70: +2:77
         switchInt(move _3) -> [false: bb1, otherwise: bb7]; // scope 0 at $DIR/exponential_or.rs:+2:70: +2:77
     }
 
     bb7: {
-        _4 = Le((_1.3: u32), const 16_u32); // scope 0 at $DIR/exponential_or.rs:+2:70: +2:77
+        _4 = Le((_1.3: u32, Strong), const 16_u32); // scope 0 at $DIR/exponential_or.rs:+2:70: +2:77
         switchInt(move _4) -> [false: bb1, otherwise: bb8]; // scope 0 at $DIR/exponential_or.rs:+2:70: +2:77
     }
 
@@ -62,9 +62,9 @@ fn match_tuple(_1: (u32, bool, Option<i32>, u32)) -> u32 {
 
     bb9: {
         StorageLive(_7);                 // scope 0 at $DIR/exponential_or.rs:+2:10: +2:11
-        _7 = (_1.0: u32);                // scope 0 at $DIR/exponential_or.rs:+2:10: +2:11
+        _7 = (_1.0: u32, Strong);        // scope 0 at $DIR/exponential_or.rs:+2:10: +2:11
         StorageLive(_8);                 // scope 0 at $DIR/exponential_or.rs:+2:57: +2:58
-        _8 = (_1.3: u32);                // scope 0 at $DIR/exponential_or.rs:+2:57: +2:58
+        _8 = (_1.3: u32, Strong);        // scope 0 at $DIR/exponential_or.rs:+2:57: +2:58
         StorageLive(_9);                 // scope 1 at $DIR/exponential_or.rs:+2:83: +2:84
         _9 = _7;                         // scope 1 at $DIR/exponential_or.rs:+2:83: +2:84
         StorageLive(_10);                // scope 1 at $DIR/exponential_or.rs:+2:87: +2:88

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -80,7 +80,7 @@
   
       bb6: {
           StorageLive(_10);                // scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
-          _10 = ((_7 as Some).0: usize);   // scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
+          _10 = ((_7 as Some).0: usize, Strong); // scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
           StorageLive(_11);                // scope 3 at $DIR/funky_arms.rs:+15:43: +15:46
           _11 = &mut (*_1);                // scope 3 at $DIR/funky_arms.rs:+15:43: +15:46
           StorageLive(_12);                // scope 3 at $DIR/funky_arms.rs:+15:48: +15:51

--- a/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
+++ b/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
@@ -24,7 +24,7 @@ fn main::{closure#0}(_1: *mut [generator@$DIR/generator_drop_cleanup.rs:10:15: 1
     let mut _7: ();                      // in scope 0 at $DIR/generator_drop_cleanup.rs:+0:15: +3:6
     let mut _8: u32;                     // in scope 0 at $DIR/generator_drop_cleanup.rs:+0:15: +3:6
     scope 1 {
-        debug _s => (((*_1) as variant#3).0: std::string::String); // in scope 1 at $DIR/generator_drop_cleanup.rs:+1:13: +1:15
+        debug _s => (((*_1) as variant#3).0: std::string::String, Strong); // in scope 1 at $DIR/generator_drop_cleanup.rs:+1:13: +1:15
     }
 
     bb0: {
@@ -35,7 +35,7 @@ fn main::{closure#0}(_1: *mut [generator@$DIR/generator_drop_cleanup.rs:10:15: 1
     bb1: {
         StorageDead(_5);                 // scope 1 at $DIR/generator_drop_cleanup.rs:+2:13: +2:14
         StorageDead(_4);                 // scope 1 at $DIR/generator_drop_cleanup.rs:+2:14: +2:15
-        drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/generator_drop_cleanup.rs:+3:5: +3:6
+        drop((((*_1) as variant#3).0: std::string::String, Strong)) -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/generator_drop_cleanup.rs:+3:5: +3:6
     }
 
     bb2: {

--- a/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
@@ -27,18 +27,18 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator_tiny.rs:19:16: 19:24
     let _10: u8;                         // in scope 0 at $DIR/generator_tiny.rs:+0:17: +0:19
     let mut _11: u32;                    // in scope 0 at $DIR/generator_tiny.rs:+0:16: +6:6
     scope 1 {
-        debug _d => (((*(_1.0: &mut [generator@$DIR/generator_tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop); // in scope 1 at $DIR/generator_tiny.rs:+1:13: +1:15
+        debug _d => (((*(_1.0: &mut [generator@$DIR/generator_tiny.rs:19:16: 19:24], Strong)) as variant#3).0: HasDrop, Strong); // in scope 1 at $DIR/generator_tiny.rs:+1:13: +1:15
     }
 
     bb0: {
-        _11 = discriminant((*(_1.0: &mut [generator@$DIR/generator_tiny.rs:19:16: 19:24]))); // scope 0 at $DIR/generator_tiny.rs:+0:16: +6:6
+        _11 = discriminant((*(_1.0: &mut [generator@$DIR/generator_tiny.rs:19:16: 19:24], Strong))); // scope 0 at $DIR/generator_tiny.rs:+0:16: +6:6
         switchInt(move _11) -> [0_u32: bb1, 3_u32: bb5, otherwise: bb6]; // scope 0 at $DIR/generator_tiny.rs:+0:16: +6:6
     }
 
     bb1: {
         _10 = move _2;                   // scope 0 at $DIR/generator_tiny.rs:+0:16: +6:6
         nop;                             // scope 0 at $DIR/generator_tiny.rs:+1:13: +1:15
-        (((*(_1.0: &mut [generator@$DIR/generator_tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop) = HasDrop; // scope 0 at $DIR/generator_tiny.rs:+1:18: +1:25
+        (((*(_1.0: &mut [generator@$DIR/generator_tiny.rs:19:16: 19:24], Strong)) as variant#3).0: HasDrop, Strong) = HasDrop; // scope 0 at $DIR/generator_tiny.rs:+1:18: +1:25
         StorageLive(_4);                 // scope 1 at $DIR/generator_tiny.rs:+2:9: +5:10
         goto -> bb2;                     // scope 1 at $DIR/generator_tiny.rs:+2:9: +5:10
     }
@@ -48,9 +48,9 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator_tiny.rs:19:16: 19:24
         StorageLive(_7);                 // scope 1 at $DIR/generator_tiny.rs:+3:13: +3:18
         _7 = ();                         // scope 1 at $DIR/generator_tiny.rs:+3:13: +3:18
         Deinit(_0);                      // scope 1 at $DIR/generator_tiny.rs:+3:13: +3:18
-        ((_0 as Yielded).0: ()) = move _7; // scope 1 at $DIR/generator_tiny.rs:+3:13: +3:18
+        ((_0 as Yielded).0: (), Strong) = move _7; // scope 1 at $DIR/generator_tiny.rs:+3:13: +3:18
         discriminant(_0) = 0;            // scope 1 at $DIR/generator_tiny.rs:+3:13: +3:18
-        discriminant((*(_1.0: &mut [generator@$DIR/generator_tiny.rs:19:16: 19:24]))) = 3; // scope 1 at $DIR/generator_tiny.rs:+3:13: +3:18
+        discriminant((*(_1.0: &mut [generator@$DIR/generator_tiny.rs:19:16: 19:24], Strong))) = 3; // scope 1 at $DIR/generator_tiny.rs:+3:13: +3:18
         return;                          // scope 1 at $DIR/generator_tiny.rs:+3:13: +3:18
     }
 

--- a/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
@@ -30,12 +30,12 @@ fn foo(_1: T, _2: i32) -> i32 {
         StorageLive(_7);                 // scope 1 at $DIR/inline_closure.rs:+2:10: +2:11
         _7 = _2;                         // scope 1 at $DIR/inline_closure.rs:+2:10: +2:11
         Deinit(_5);                      // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
-        (_5.0: i32) = move _6;           // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
-        (_5.1: i32) = move _7;           // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
+        (_5.0: i32, Strong) = move _6;   // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
+        (_5.1: i32, Strong) = move _7;   // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
         StorageLive(_8);                 // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
-        _8 = move (_5.0: i32);           // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
+        _8 = move (_5.0: i32, Strong);   // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
         StorageLive(_9);                 // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
-        _9 = move (_5.1: i32);           // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
+        _9 = move (_5.1: i32, Strong);   // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
         _0 = _8;                         // scope 2 at $DIR/inline_closure.rs:+1:22: +1:24
         StorageDead(_9);                 // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12
         StorageDead(_8);                 // scope 1 at $DIR/inline_closure.rs:+2:5: +2:12

--- a/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
@@ -33,12 +33,12 @@ fn foo(_1: T, _2: &i32) -> i32 {
         StorageLive(_7);                 // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:10: +5:11
         _7 = &(*_2);                     // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:10: +5:11
         Deinit(_5);                      // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
-        (_5.0: &i32) = move _6;          // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
-        (_5.1: &i32) = move _7;          // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
+        (_5.0: &i32, Strong) = move _6;  // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
+        (_5.1: &i32, Strong) = move _7;  // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
         StorageLive(_8);                 // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
-        _8 = move (_5.0: &i32);          // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
+        _8 = move (_5.0: &i32, Strong);  // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
         StorageLive(_9);                 // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
-        _9 = move (_5.1: &i32);          // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
+        _9 = move (_5.1: &i32, Strong);  // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
         _0 = (*_8);                      // scope 3 at $DIR/inline_closure_borrows_arg.rs:+3:9: +3:18
         StorageDead(_9);                 // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12
         StorageDead(_8);                 // scope 1 at $DIR/inline_closure_borrows_arg.rs:+5:5: +5:12

--- a/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
@@ -15,8 +15,8 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         debug x => _3;                   // in scope 1 at $DIR/inline_closure_captures.rs:+1:9: +1:10
         scope 2 (inlined foo::<T>::{closure#0}) { // at $DIR/inline_closure_captures.rs:12:5: 12:9
             debug _q => _9;              // in scope 2 at $DIR/inline_closure_captures.rs:+1:14: +1:16
-            debug q => (*((*_6).0: &i32)); // in scope 2 at $DIR/inline_closure_captures.rs:+0:23: +0:24
-            debug t => (*((*_6).1: &T)); // in scope 2 at $DIR/inline_closure_captures.rs:+0:17: +0:18
+            debug q => (*((*_6).0: &i32, Strong)); // in scope 2 at $DIR/inline_closure_captures.rs:+0:23: +0:24
+            debug t => (*((*_6).1: &T, Strong)); // in scope 2 at $DIR/inline_closure_captures.rs:+0:17: +0:18
             let mut _10: i32;            // in scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
             let mut _11: T;              // in scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
             let mut _12: &i32;           // in scope 2 at $DIR/inline_closure_captures.rs:+1:13: +1:24
@@ -31,8 +31,8 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         StorageLive(_5);                 // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
         _5 = &_1;                        // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
         Deinit(_3);                      // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
-        (_3.0: &i32) = move _4;          // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
-        (_3.1: &T) = move _5;            // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
+        (_3.0: &i32, Strong) = move _4;  // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
+        (_3.1: &T, Strong) = move _5;    // scope 0 at $DIR/inline_closure_captures.rs:+1:13: +1:24
         StorageDead(_5);                 // scope 0 at $DIR/inline_closure_captures.rs:+1:16: +1:17
         StorageDead(_4);                 // scope 0 at $DIR/inline_closure_captures.rs:+1:16: +1:17
         StorageLive(_6);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:6
@@ -41,18 +41,18 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         StorageLive(_8);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:7: +2:8
         _8 = _2;                         // scope 1 at $DIR/inline_closure_captures.rs:+2:7: +2:8
         Deinit(_7);                      // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
-        (_7.0: i32) = move _8;           // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
+        (_7.0: i32, Strong) = move _8;   // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
         StorageLive(_9);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
-        _9 = move (_7.0: i32);           // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
+        _9 = move (_7.0: i32, Strong);   // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
         StorageLive(_10);                // scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
-        _12 = deref_copy ((*_6).0: &i32); // scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
+        _12 = deref_copy ((*_6).0: &i32, Strong); // scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
         _10 = (*_12);                    // scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
         StorageLive(_11);                // scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
-        _13 = deref_copy ((*_6).1: &T);  // scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
+        _13 = deref_copy ((*_6).1: &T, Strong); // scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
         _11 = (*_13);                    // scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
         Deinit(_0);                      // scope 2 at $DIR/inline_closure_captures.rs:+1:18: +1:24
-        (_0.0: i32) = move _10;          // scope 2 at $DIR/inline_closure_captures.rs:+1:18: +1:24
-        (_0.1: T) = move _11;            // scope 2 at $DIR/inline_closure_captures.rs:+1:18: +1:24
+        (_0.0: i32, Strong) = move _10;  // scope 2 at $DIR/inline_closure_captures.rs:+1:18: +1:24
+        (_0.1: T, Strong) = move _11;    // scope 2 at $DIR/inline_closure_captures.rs:+1:18: +1:24
         StorageDead(_11);                // scope 2 at $DIR/inline_closure_captures.rs:+1:23: +1:24
         StorageDead(_10);                // scope 2 at $DIR/inline_closure_captures.rs:+1:23: +1:24
         StorageDead(_9);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9

--- a/src/test/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_generator.main.Inline.diff
@@ -60,7 +60,7 @@
 +         StorageLive(_6);                 // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         _6 = move _5;                    // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         Deinit(_2);                      // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
-+         (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]) = move _6; // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
++         (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8], Strong) = move _6; // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         StorageDead(_6);                 // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         StorageDead(_5);                 // scope 4 at $SRC_DIR/core/src/pin.rs:LL:COL
           StorageDead(_3);                 // scope 0 at $DIR/inline_generator.rs:+1:31: +1:32
@@ -70,7 +70,7 @@
 -                                          // + literal: Const { ty: for<'a> fn(Pin<&'a mut [generator@$DIR/inline_generator.rs:15:5: 15:8]>, bool) -> GeneratorState<<[generator@$DIR/inline_generator.rs:15:5: 15:8] as Generator<bool>>::Yield, <[generator@$DIR/inline_generator.rs:15:5: 15:8] as Generator<bool>>::Return> {<[generator@$DIR/inline_generator.rs:15:5: 15:8] as Generator<bool>>::resume}, val: Value(<ZST>) }
 +         StorageLive(_7);                 // scope 0 at $DIR/inline_generator.rs:+1:14: +1:46
 +         _7 = const false;                // scope 0 at $DIR/inline_generator.rs:+1:14: +1:46
-+         _10 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
++         _10 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8], Strong); // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
 +         _9 = discriminant((*_10));       // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
 +         switchInt(move _9) -> [0_u32: bb3, 1_u32: bb8, 3_u32: bb7, otherwise: bb9]; // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
       }
@@ -107,9 +107,9 @@
 + 
 +     bb6: {
 +         Deinit(_1);                      // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
-+         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
++         ((_1 as Yielded).0: i32, Strong) = move _8; // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
 +         discriminant(_1) = 0;            // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
-+         _11 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
++         _11 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8], Strong); // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
 +         discriminant((*_11)) = 3;        // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
 +         goto -> bb1;                     // scope 0 at $DIR/inline_generator.rs:15:11: 15:39
 +     }
@@ -118,9 +118,9 @@
 +         StorageLive(_8);                 // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
 +         StorageDead(_8);                 // scope 6 at $DIR/inline_generator.rs:15:38: 15:39
 +         Deinit(_1);                      // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
-+         ((_1 as Complete).0: bool) = move _7; // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
++         ((_1 as Complete).0: bool, Strong) = move _7; // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
 +         discriminant(_1) = 1;            // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
-+         _12 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
++         _12 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8], Strong); // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
 +         discriminant((*_12)) = 1;        // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
 +         goto -> bb1;                     // scope 0 at $DIR/inline_generator.rs:15:41: 15:41
 +     }

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.diff
@@ -33,7 +33,7 @@
       bb1: {
           StorageLive(_5);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
           _5 = ShallowInitBox(move _4, std::vec::Vec<u32>); // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
-          _7 = (((_5.0: std::ptr::Unique<std::vec::Vec<u32>>).0: std::ptr::NonNull<std::vec::Vec<u32>>).0: *const std::vec::Vec<u32>); // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
+          _7 = (((_5.0: std::ptr::Unique<std::vec::Vec<u32>>, Strong).0: std::ptr::NonNull<std::vec::Vec<u32>>, Strong).0: *const std::vec::Vec<u32>, Strong); // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
 -         (*_7) = Vec::<u32>::new() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
 +         StorageLive(_8);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
 +         _8 = &mut (*_7);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
@@ -50,8 +50,8 @@
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Unevaluated(alloc::raw_vec::RawVec::<T>::NEW, [u32], None) }
 +         Deinit((*_8));                   // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-+         ((*_8).0: alloc::raw_vec::RawVec<u32>) = move _9; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-+         ((*_8).1: usize) = const 0_usize; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
++         ((*_8).0: alloc::raw_vec::RawVec<u32>, Strong) = move _9; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
++         ((*_8).1: usize, Strong) = const 0_usize; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         StorageDead(_9);                 // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         StorageDead(_8);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
           _1 = move _5;                    // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
@@ -73,7 +73,7 @@
 -     }
 - 
 -     bb5 (cleanup): {
--         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_5.1: std::alloc::Global)) -> bb4; // scope 0 at $DIR/inline_into_box_place.rs:+1:42: +1:43
+-         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>, Strong), move (_5.1: std::alloc::Global, Strong)) -> bb4; // scope 0 at $DIR/inline_into_box_place.rs:+1:42: +1:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline_into_box_place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(Unique<Vec<u32>>, std::alloc::Global) {alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>}, val: Value(<ZST>) }

--- a/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
+++ b/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
@@ -50,7 +50,7 @@
 +     }
 + 
 +     bb3: {
-+         drop((((*_5) as Some).0: B)) -> bb2; // scope 3 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
++         drop((((*_5) as Some).0: B, Strong)) -> bb2; // scope 3 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
       }
   }
   

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
@@ -22,7 +22,7 @@ fn b(_1: &mut Box<T>) -> &mut T {
         StorageLive(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         StorageLive(_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _7 = deref_copy (*_4);           // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        _8 = (((_7.0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>).0: *const T); // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        _8 = (((_7.0: std::ptr::Unique<T>, Strong).0: std::ptr::NonNull<T>, Strong).0: *const T, Strong); // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _6 = &mut (*_8);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _5 = &mut (*_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
@@ -16,7 +16,7 @@ fn d(_1: &Box<T>) -> &T {
         StorageLive(_3);                 // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
         _3 = &(*_1);                     // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
         _4 = deref_copy (*_3);           // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        _5 = (((_4.0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>).0: *const T); // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        _5 = (((_4.0: std::ptr::Unique<T>, Strong).0: std::ptr::NonNull<T>, Strong).0: *const T, Strong); // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _2 = &(*_5);                     // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _0 = &(*_2);                     // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
         StorageDead(_3);                 // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:14: +1:15

--- a/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
@@ -27,9 +27,9 @@ fn main() -> () {
         StorageLive(_4);                 // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:7: +2:9
         Deinit(_4);                      // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:7: +2:9
         Deinit(_3);                      // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
-        (_3.0: ()) = move _4;            // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
+        (_3.0: (), Strong) = move _4;    // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
         StorageLive(_5);                 // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
-        _5 = move (_3.0: ());            // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
+        _5 = move (_3.0: (), Strong);    // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
         StorageLive(_6);                 // scope 2 at $DIR/issue_76997_inline_scopes_parenting.rs:+1:23: +1:24
         StorageDead(_6);                 // scope 2 at $DIR/issue_76997_inline_scopes_parenting.rs:+1:32: +1:33
         StorageDead(_5);                 // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10

--- a/src/test/mir-opt/issue_101973.inner.ConstProp.diff
+++ b/src/test/mir-opt/issue_101973.inner.ConstProp.diff
@@ -39,20 +39,20 @@
           StorageLive(_12);                // scope 2 at $DIR/issue_101973.rs:7:12: 7:27
           StorageLive(_13);                // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
           _14 = CheckedShr(_5, const 0_i32); // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
-          assert(!move (_14.1: bool), "attempt to shift right by `{}`, which would overflow", const 0_i32) -> bb3; // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
+          assert(!move (_14.1: bool, Strong), "attempt to shift right by `{}`, which would overflow", const 0_i32) -> bb3; // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
       }
   
       bb1: {
-          _8 = move (_10.0: u32);          // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
+          _8 = move (_10.0: u32, Strong);  // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
           StorageDead(_9);                 // scope 0 at $DIR/issue_101973.rs:+1:44: +1:45
           _7 = BitAnd(move _8, const 15_u32); // scope 0 at $DIR/issue_101973.rs:+1:31: +1:52
           StorageDead(_8);                 // scope 0 at $DIR/issue_101973.rs:+1:51: +1:52
           _11 = CheckedShl(_7, const 1_i32); // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
-          assert(!move (_11.1: bool), "attempt to shift left by `{}`, which would overflow", const 1_i32) -> bb2; // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
+          assert(!move (_11.1: bool, Strong), "attempt to shift left by `{}`, which would overflow", const 1_i32) -> bb2; // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
       }
   
       bb2: {
-          _6 = move (_11.0: u32);          // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
+          _6 = move (_11.0: u32, Strong);  // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
           StorageDead(_7);                 // scope 0 at $DIR/issue_101973.rs:+1:56: +1:57
           StorageLive(_15);                // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
           _15 = _4;                        // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
@@ -65,7 +65,7 @@
       }
   
       bb3: {
-          _13 = move (_14.0: u32);         // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
+          _13 = move (_14.0: u32, Strong); // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
           _12 = BitAnd(move _13, const 255_u32); // scope 2 at $DIR/issue_101973.rs:7:12: 7:27
           StorageDead(_13);                // scope 2 at $DIR/issue_101973.rs:7:26: 7:27
           _4 = BitOr(const 0_u32, move _12); // scope 2 at $DIR/issue_101973.rs:7:5: 7:27
@@ -77,7 +77,7 @@
           StorageLive(_9);                 // scope 0 at $DIR/issue_101973.rs:+1:33: +1:39
           _9 = _1;                         // scope 0 at $DIR/issue_101973.rs:+1:33: +1:39
           _10 = CheckedShr(_9, const 8_i32); // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
-          assert(!move (_10.1: bool), "attempt to shift right by `{}`, which would overflow", const 8_i32) -> bb1; // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
+          assert(!move (_10.1: bool, Strong), "attempt to shift right by `{}`, which would overflow", const 8_i32) -> bb1; // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
       }
   
       bb4: {

--- a/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.mir
+++ b/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.mir
@@ -6,11 +6,11 @@
 
     bb0: {
         _1 = CheckedAdd(const 1_usize, const 1_usize); // scope 0 at $DIR/issue_41697.rs:+0:19: +0:22
-        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_usize, const 1_usize) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue_41697.rs:+0:19: +0:22
+        assert(!move (_1.1: bool, Strong), "attempt to compute `{} + {}`, which would overflow", const 1_usize, const 1_usize) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue_41697.rs:+0:19: +0:22
     }
 
     bb1: {
-        _0 = move (_1.0: usize);         // scope 0 at $DIR/issue_41697.rs:+0:19: +0:22
+        _0 = move (_1.0: usize, Strong); // scope 0 at $DIR/issue_41697.rs:+0:19: +0:22
         return;                          // scope 0 at $DIR/issue_41697.rs:+0:19: +0:22
     }
 

--- a/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
@@ -58,7 +58,7 @@ fn main() -> () {
     bb5: {
         StorageLive(_6);                 // scope 2 at $DIR/issue_41888.rs:+4:21: +4:23
         _9 = const false;                // scope 2 at $DIR/issue_41888.rs:+4:21: +4:23
-        _6 = move ((_1 as F).0: K);      // scope 2 at $DIR/issue_41888.rs:+4:21: +4:23
+        _6 = move ((_1 as F).0: K, Strong); // scope 2 at $DIR/issue_41888.rs:+4:21: +4:23
         _0 = const ();                   // scope 2 at $DIR/issue_41888.rs:+4:29: +7:10
         StorageDead(_6);                 // scope 1 at $DIR/issue_41888.rs:+7:9: +7:10
         goto -> bb8;                     // scope 1 at $DIR/issue_41888.rs:+4:9: +7:10

--- a/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
@@ -57,7 +57,7 @@ fn test() -> Option<Box<u32>> {
 
     bb3: {
         StorageLive(_12);                // scope 0 at $DIR/issue_62289.rs:+1:15: +1:20
-        _12 = ((_6 as Continue).0: u32); // scope 0 at $DIR/issue_62289.rs:+1:15: +1:20
+        _12 = ((_6 as Continue).0: u32, Strong); // scope 0 at $DIR/issue_62289.rs:+1:15: +1:20
         (*_5) = _12;                     // scope 5 at $DIR/issue_62289.rs:+1:15: +1:20
         StorageDead(_12);                // scope 0 at $DIR/issue_62289.rs:+1:19: +1:20
         _1 = move _5;                    // scope 0 at $DIR/issue_62289.rs:+1:10: +1:21
@@ -70,7 +70,7 @@ fn test() -> Option<Box<u32>> {
 
     bb5: {
         StorageLive(_9);                 // scope 0 at $DIR/issue_62289.rs:+1:19: +1:20
-        _9 = ((_6 as Break).0: std::option::Option<std::convert::Infallible>); // scope 0 at $DIR/issue_62289.rs:+1:19: +1:20
+        _9 = ((_6 as Break).0: std::option::Option<std::convert::Infallible>, Strong); // scope 0 at $DIR/issue_62289.rs:+1:19: +1:20
         StorageLive(_11);                // scope 3 at $DIR/issue_62289.rs:+1:19: +1:20
         _11 = _9;                        // scope 3 at $DIR/issue_62289.rs:+1:19: +1:20
         _0 = <Option<Box<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _11) -> [return: bb6, unwind: bb12]; // scope 3 at $DIR/issue_62289.rs:+1:15: +1:20

--- a/src/test/mir-opt/issue_72181.bar.built.after.mir
+++ b/src/test/mir-opt/issue_72181.bar.built.after.mir
@@ -9,7 +9,7 @@ fn bar(_1: [(Never, u32); 1]) -> u32 {
 
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/issue_72181.rs:+0:13: +0:14
-        _2 = (_1[0 of 1].1: u32);        // scope 0 at $DIR/issue_72181.rs:+0:13: +0:14
+        _2 = (_1[0 of 1].1: u32, Strong); // scope 0 at $DIR/issue_72181.rs:+0:13: +0:14
         _0 = _2;                         // scope 1 at $DIR/issue_72181.rs:+0:46: +0:47
         StorageDead(_2);                 // scope 0 at $DIR/issue_72181.rs:+0:48: +0:49
         return;                          // scope 0 at $DIR/issue_72181.rs:+0:49: +0:49

--- a/src/test/mir-opt/issue_72181.foo.built.after.mir
+++ b/src/test/mir-opt/issue_72181.foo.built.after.mir
@@ -16,7 +16,7 @@ fn foo(_1: [(Never, u32); 1]) -> u32 {
     }
 
     bb1: {
-        _0 = (_1[_2].1: u32);            // scope 0 at $DIR/issue_72181.rs:+0:40: +0:47
+        _0 = (_1[_2].1: u32, Strong);    // scope 0 at $DIR/issue_72181.rs:+0:40: +0:47
         StorageDead(_2);                 // scope 0 at $DIR/issue_72181.rs:+0:48: +0:49
         return;                          // scope 0 at $DIR/issue_72181.rs:+0:49: +0:49
     }

--- a/src/test/mir-opt/issue_72181.main.built.after.mir
+++ b/src/test/mir-opt/issue_72181.main.built.after.mir
@@ -48,7 +48,7 @@ fn main() -> () {
     }
 
     bb2: {
-        _5 = (_2[_6].0: u64);            // scope 4 at $DIR/issue_72181.rs:+4:22: +4:28
+        _5 = (_2[_6].0: u64, Strong);    // scope 4 at $DIR/issue_72181.rs:+4:22: +4:28
         StorageDead(_6);                 // scope 2 at $DIR/issue_72181.rs:+4:30: +4:31
         StorageDead(_5);                 // scope 2 at $DIR/issue_72181.rs:+4:30: +4:31
         _0 = const ();                   // scope 0 at $DIR/issue_72181.rs:+0:11: +5:2

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff
@@ -54,7 +54,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/issue_73223.rs:+1:9: +1:14
           StorageLive(_2);                 // scope 0 at $DIR/issue_73223.rs:+1:23: +1:30
           Deinit(_2);                      // scope 0 at $DIR/issue_73223.rs:+1:23: +1:30
-          ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue_73223.rs:+1:23: +1:30
+          ((_2 as Some).0: i32, Strong) = const 1_i32; // scope 0 at $DIR/issue_73223.rs:+1:23: +1:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue_73223.rs:+1:23: +1:30
           _3 = const 1_isize;              // scope 0 at $DIR/issue_73223.rs:+1:23: +1:30
           goto -> bb3;                     // scope 0 at $DIR/issue_73223.rs:+1:17: +1:30
@@ -73,7 +73,7 @@
   
       bb3: {
           StorageLive(_4);                 // scope 0 at $DIR/issue_73223.rs:+2:14: +2:15
-          _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue_73223.rs:+2:14: +2:15
+          _4 = ((_2 as Some).0: i32, Strong); // scope 0 at $DIR/issue_73223.rs:+2:14: +2:15
           _1 = _4;                         // scope 2 at $DIR/issue_73223.rs:+2:20: +2:21
           StorageDead(_4);                 // scope 0 at $DIR/issue_73223.rs:+2:20: +2:21
           StorageDead(_2);                 // scope 0 at $DIR/issue_73223.rs:+4:6: +4:7
@@ -81,7 +81,7 @@
           StorageLive(_7);                 // scope 1 at $DIR/issue_73223.rs:+6:22: +6:27
           _7 = _1;                         // scope 1 at $DIR/issue_73223.rs:+6:22: +6:27
           Deinit(_6);                      // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
-          ((_6 as Some).0: i32) = move _7; // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
+          ((_6 as Some).0: i32, Strong) = move _7; // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
           discriminant(_6) = 1;            // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
           StorageDead(_7);                 // scope 1 at $DIR/issue_73223.rs:+6:27: +6:28
           StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/issue_99325.main.built.after.mir
+++ b/src/test/mir-opt/issue_99325.main.built.after.mir
@@ -89,9 +89,9 @@ fn main() -> () {
         StorageDead(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         FakeRead(ForMatchedPlace(None), _2); // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_8);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _8 = (_2.0: &&[u8]);             // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _8 = (_2.0: &&[u8], Strong);     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_9);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _9 = (_2.1: &&[u8; 4]);          // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _9 = (_2.1: &&[u8; 4], Strong);  // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_10);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_11);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_12);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -198,9 +198,9 @@ fn main() -> () {
         StorageDead(_25);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         FakeRead(ForMatchedPlace(None), _24); // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_29);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _29 = (_24.0: &&[u8]);           // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _29 = (_24.0: &&[u8], Strong);   // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_30);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _30 = (_24.1: &&[u8; 4]);        // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _30 = (_24.1: &&[u8; 4], Strong); // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_31);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_32);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_33);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -85,7 +85,7 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb8: {
-        _0 = move ((_2 as Some).0: u32); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        _0 = move ((_2 as Some).0: u32, Strong); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         StorageDead(_2);                 // scope 0 at $DIR/issue_59352.rs:+2:49: +2:50
         goto -> bb4;                     // scope 0 at $DIR/issue_59352.rs:+2:5: +2:63
     }

--- a/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
@@ -68,7 +68,7 @@
       bb7: {
           StorageDead(_6);                 // scope 4 at $DIR/issue_75439.rs:+5:35: +5:36
           Deinit(_0);                      // scope 3 at $DIR/issue_75439.rs:+5:9: +5:39
-          ((_0 as Some).0: [u8; 4]) = move _5; // scope 3 at $DIR/issue_75439.rs:+5:9: +5:39
+          ((_0 as Some).0: [u8; 4], Strong) = move _5; // scope 3 at $DIR/issue_75439.rs:+5:9: +5:39
           discriminant(_0) = 1;            // scope 3 at $DIR/issue_75439.rs:+5:9: +5:39
           StorageDead(_5);                 // scope 3 at $DIR/issue_75439.rs:+5:38: +5:39
           StorageDead(_4);                 // scope 1 at $DIR/issue_75439.rs:+6:5: +6:6

--- a/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -32,18 +32,18 @@
   
       bb0: {
 -         FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match_arm_scopes.rs:+1:11: +1:16
--         switchInt((_2.0: bool)) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +1:16
-+         switchInt((_2.0: bool)) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +1:16
+-         switchInt((_2.0: bool, Strong)) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +1:16
++         switchInt((_2.0: bool, Strong)) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +1:16
       }
   
       bb1: {
 -         falseEdge -> [real: bb8, imaginary: bb3]; // scope 0 at $DIR/match_arm_scopes.rs:+2:9: +2:22
-+         switchInt((_2.1: bool)) -> [false: bb10, otherwise: bb2]; // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +1:16
++         switchInt((_2.1: bool, Strong)) -> [false: bb10, otherwise: bb2]; // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +1:16
       }
   
       bb2: {
--         switchInt((_2.1: bool)) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +1:16
-+         switchInt((_2.0: bool)) -> [false: bb3, otherwise: bb17]; // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +1:16
+-         switchInt((_2.1: bool, Strong)) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +1:16
++         switchInt((_2.0: bool, Strong)) -> [false: bb3, otherwise: bb17]; // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +1:16
       }
   
       bb3: {
@@ -51,7 +51,7 @@
 -     }
 - 
 -     bb4: {
--         switchInt((_2.0: bool)) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +1:16
+-         switchInt((_2.0: bool, Strong)) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +1:16
 -     }
 - 
 -     bb5: {
@@ -60,9 +60,9 @@
 - 
 -     bb6: {
           StorageLive(_15);                // scope 0 at $DIR/match_arm_scopes.rs:+3:32: +3:33
-          _15 = (_2.1: bool);              // scope 0 at $DIR/match_arm_scopes.rs:+3:32: +3:33
+          _15 = (_2.1: bool, Strong);      // scope 0 at $DIR/match_arm_scopes.rs:+3:32: +3:33
           StorageLive(_16);                // scope 0 at $DIR/match_arm_scopes.rs:+3:35: +3:36
-          _16 = move (_2.2: std::string::String); // scope 0 at $DIR/match_arm_scopes.rs:+3:35: +3:36
+          _16 = move (_2.2: std::string::String, Strong); // scope 0 at $DIR/match_arm_scopes.rs:+3:35: +3:36
 -         goto -> bb19;                    // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +4:6
 +         goto -> bb16;                    // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +4:6
       }
@@ -77,11 +77,11 @@
 -     bb8: {
 +     bb5: {
           StorageLive(_6);                 // scope 0 at $DIR/match_arm_scopes.rs:+2:17: +2:18
-          _6 = &(_2.1: bool);              // scope 0 at $DIR/match_arm_scopes.rs:+2:17: +2:18
+          _6 = &(_2.1: bool, Strong);      // scope 0 at $DIR/match_arm_scopes.rs:+2:17: +2:18
           StorageLive(_8);                 // scope 0 at $DIR/match_arm_scopes.rs:+2:20: +2:21
-          _8 = &(_2.2: std::string::String); // scope 0 at $DIR/match_arm_scopes.rs:+2:20: +2:21
--         _3 = &shallow (_2.0: bool);      // scope 0 at $DIR/match_arm_scopes.rs:+1:11: +1:16
--         _4 = &shallow (_2.1: bool);      // scope 0 at $DIR/match_arm_scopes.rs:+1:11: +1:16
+          _8 = &(_2.2: std::string::String, Strong); // scope 0 at $DIR/match_arm_scopes.rs:+2:20: +2:21
+-         _3 = &shallow (_2.0: bool, Strong); // scope 0 at $DIR/match_arm_scopes.rs:+1:11: +1:16
+-         _4 = &shallow (_2.1: bool, Strong); // scope 0 at $DIR/match_arm_scopes.rs:+1:11: +1:16
           StorageLive(_9);                 // scope 0 at $DIR/match_arm_scopes.rs:+2:42: +2:73
           StorageLive(_10);                // scope 0 at $DIR/match_arm_scopes.rs:+2:45: +2:49
           _10 = _1;                        // scope 0 at $DIR/match_arm_scopes.rs:+2:45: +2:49
@@ -114,9 +114,9 @@
 -         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_arm_scopes.rs:+2:72: +2:73
 -         FakeRead(ForGuardBinding, _8);   // scope 0 at $DIR/match_arm_scopes.rs:+2:72: +2:73
           StorageLive(_5);                 // scope 0 at $DIR/match_arm_scopes.rs:+2:17: +2:18
-          _5 = (_2.1: bool);               // scope 0 at $DIR/match_arm_scopes.rs:+2:17: +2:18
+          _5 = (_2.1: bool, Strong);       // scope 0 at $DIR/match_arm_scopes.rs:+2:17: +2:18
           StorageLive(_7);                 // scope 0 at $DIR/match_arm_scopes.rs:+2:20: +2:21
-          _7 = move (_2.2: std::string::String); // scope 0 at $DIR/match_arm_scopes.rs:+2:20: +2:21
+          _7 = move (_2.2: std::string::String, Strong); // scope 0 at $DIR/match_arm_scopes.rs:+2:20: +2:21
 -         goto -> bb7;                     // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +4:6
 +         goto -> bb4;                     // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +4:6
       }
@@ -134,11 +134,11 @@
 -     bb13: {
 +     bb10: {
           StorageLive(_6);                 // scope 0 at $DIR/match_arm_scopes.rs:+2:26: +2:27
-          _6 = &(_2.0: bool);              // scope 0 at $DIR/match_arm_scopes.rs:+2:26: +2:27
+          _6 = &(_2.0: bool, Strong);      // scope 0 at $DIR/match_arm_scopes.rs:+2:26: +2:27
           StorageLive(_8);                 // scope 0 at $DIR/match_arm_scopes.rs:+2:36: +2:37
-          _8 = &(_2.2: std::string::String); // scope 0 at $DIR/match_arm_scopes.rs:+2:36: +2:37
--         _3 = &shallow (_2.0: bool);      // scope 0 at $DIR/match_arm_scopes.rs:+1:11: +1:16
--         _4 = &shallow (_2.1: bool);      // scope 0 at $DIR/match_arm_scopes.rs:+1:11: +1:16
+          _8 = &(_2.2: std::string::String, Strong); // scope 0 at $DIR/match_arm_scopes.rs:+2:36: +2:37
+-         _3 = &shallow (_2.0: bool, Strong); // scope 0 at $DIR/match_arm_scopes.rs:+1:11: +1:16
+-         _4 = &shallow (_2.1: bool, Strong); // scope 0 at $DIR/match_arm_scopes.rs:+1:11: +1:16
           StorageLive(_12);                // scope 0 at $DIR/match_arm_scopes.rs:+2:42: +2:73
           StorageLive(_13);                // scope 0 at $DIR/match_arm_scopes.rs:+2:45: +2:49
           _13 = _1;                        // scope 0 at $DIR/match_arm_scopes.rs:+2:45: +2:49
@@ -171,9 +171,9 @@
 -         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_arm_scopes.rs:+2:72: +2:73
 -         FakeRead(ForGuardBinding, _8);   // scope 0 at $DIR/match_arm_scopes.rs:+2:72: +2:73
           StorageLive(_5);                 // scope 0 at $DIR/match_arm_scopes.rs:+2:26: +2:27
-          _5 = (_2.0: bool);               // scope 0 at $DIR/match_arm_scopes.rs:+2:26: +2:27
+          _5 = (_2.0: bool, Strong);       // scope 0 at $DIR/match_arm_scopes.rs:+2:26: +2:27
           StorageLive(_7);                 // scope 0 at $DIR/match_arm_scopes.rs:+2:36: +2:37
-          _7 = move (_2.2: std::string::String); // scope 0 at $DIR/match_arm_scopes.rs:+2:36: +2:37
+          _7 = move (_2.2: std::string::String, Strong); // scope 0 at $DIR/match_arm_scopes.rs:+2:36: +2:37
 -         goto -> bb7;                     // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +4:6
 +         goto -> bb4;                     // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +4:6
       }
@@ -208,9 +208,9 @@
 -     bb20: {
 +     bb17: {
           StorageLive(_15);                // scope 0 at $DIR/match_arm_scopes.rs:+3:16: +3:17
-          _15 = (_2.1: bool);              // scope 0 at $DIR/match_arm_scopes.rs:+3:16: +3:17
+          _15 = (_2.1: bool, Strong);      // scope 0 at $DIR/match_arm_scopes.rs:+3:16: +3:17
           StorageLive(_16);                // scope 0 at $DIR/match_arm_scopes.rs:+3:19: +3:20
-          _16 = move (_2.2: std::string::String); // scope 0 at $DIR/match_arm_scopes.rs:+3:19: +3:20
+          _16 = move (_2.2: std::string::String, Strong); // scope 0 at $DIR/match_arm_scopes.rs:+3:19: +3:20
 -         goto -> bb19;                    // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +4:6
 +         goto -> bb16;                    // scope 0 at $DIR/match_arm_scopes.rs:+1:5: +4:6
       }

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.diff
@@ -70,10 +70,10 @@
           StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:+23:15: +23:16
           _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:+23:15: +23:16
           Deinit(_0);                      // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
-          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
-          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
-          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
-          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.0: bool, Strong) = move _7;  // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.1: bool, Strong) = move _8;  // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.2: bool, Strong) = move _9;  // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.3: bool, Strong) = move _10; // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
           StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17
           StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17
           StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17

--- a/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
@@ -35,7 +35,7 @@ fn unwrap(_1: Option<T>) -> T {
 
     bb3: {
         StorageLive(_3);                 // scope 0 at $DIR/no_drop_for_inactive_variant.rs:+2:14: +2:15
-        _3 = move ((_1 as Some).0: T);   // scope 0 at $DIR/no_drop_for_inactive_variant.rs:+2:14: +2:15
+        _3 = move ((_1 as Some).0: T, Strong); // scope 0 at $DIR/no_drop_for_inactive_variant.rs:+2:14: +2:15
         _0 = move _3;                    // scope 1 at $DIR/no_drop_for_inactive_variant.rs:+2:20: +2:21
         StorageDead(_3);                 // scope 0 at $DIR/no_drop_for_inactive_variant.rs:+2:20: +2:21
         _5 = discriminant(_1);           // scope 0 at $DIR/no_drop_for_inactive_variant.rs:+5:1: +5:2

--- a/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.mir
@@ -17,22 +17,22 @@ fn main() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:24: +1:42
         StorageLive(_3);                 // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:32: +1:41
         Deinit(_3);                      // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:32: +1:41
-        (_3.0: usize) = const 0_usize;   // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:32: +1:41
+        (_3.0: usize, Strong) = const 0_usize; // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:32: +1:41
         Deinit(_2);                      // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:24: +1:42
-        (_2.0: Droppy) = move _3;        // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:24: +1:42
+        (_2.0: Droppy, Strong) = move _3; // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:24: +1:42
         StorageDead(_3);                 // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:41: +1:42
         Deinit(_1);                      // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:17: +1:43
-        (_1.0: Aligned) = move _2;       // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:17: +1:43
+        (_1.0: Aligned, Strong) = move _2; // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:17: +1:43
         StorageDead(_2);                 // scope 0 at $DIR/packed_struct_drop_aligned.rs:+1:42: +1:43
         StorageLive(_4);                 // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:11: +2:29
         StorageLive(_5);                 // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:19: +2:28
         Deinit(_5);                      // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:19: +2:28
-        (_5.0: usize) = const 0_usize;   // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:19: +2:28
+        (_5.0: usize, Strong) = const 0_usize; // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:19: +2:28
         Deinit(_4);                      // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:11: +2:29
-        (_4.0: Droppy) = move _5;        // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:11: +2:29
+        (_4.0: Droppy, Strong) = move _5; // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:11: +2:29
         StorageDead(_5);                 // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:28: +2:29
         StorageLive(_6);                 // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:5: +2:8
-        _6 = move (_1.0: Aligned);       // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:5: +2:8
+        _6 = move (_1.0: Aligned, Weak); // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:5: +2:8
         drop(_6) -> [return: bb4, unwind: bb3]; // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:5: +2:8
     }
 
@@ -46,13 +46,13 @@ fn main() -> () {
     }
 
     bb3 (cleanup): {
-        (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:5: +2:8
+        (_1.0: Aligned, Weak) = move _4; // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:5: +2:8
         drop(_1) -> bb2;                 // scope 0 at $DIR/packed_struct_drop_aligned.rs:+3:1: +3:2
     }
 
     bb4: {
         StorageDead(_6);                 // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:5: +2:8
-        (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:5: +2:8
+        (_1.0: Aligned, Weak) = move _4; // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:5: +2:8
         StorageDead(_4);                 // scope 1 at $DIR/packed_struct_drop_aligned.rs:+2:28: +2:29
         _0 = const ();                   // scope 0 at $DIR/packed_struct_drop_aligned.rs:+0:11: +3:2
         drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/packed_struct_drop_aligned.rs:+3:1: +3:2

--- a/src/test/mir-opt/remove_fake_borrows.match_guard.CleanupNonCodegenStatements.diff
+++ b/src/test/mir-opt/remove_fake_borrows.match_guard.CleanupNonCodegenStatements.diff
@@ -25,7 +25,7 @@
       }
   
       bb2: {
-          switchInt((*(*((_1 as Some).0: &&i32)))) -> [0_i32: bb3, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:+1:5: +1:12
+          switchInt((*(*((_1 as Some).0: &&i32, Strong)))) -> [0_i32: bb3, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:+1:5: +1:12
       }
   
       bb3: {
@@ -34,9 +34,9 @@
   
       bb4: {
 -         _4 = &shallow _1;                // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
--         _5 = &shallow (*((_1 as Some).0: &&i32)); // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
--         _6 = &shallow ((_1 as Some).0: &&i32); // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
--         _7 = &shallow (*(*((_1 as Some).0: &&i32))); // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+-         _5 = &shallow (*((_1 as Some).0: &&i32, Strong)); // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+-         _6 = &shallow ((_1 as Some).0: &&i32, Strong); // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+-         _7 = &shallow (*(*((_1 as Some).0: &&i32, Strong))); // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12

--- a/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
+++ b/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
@@ -32,8 +32,8 @@
 -         StorageLive(_2);                 // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
 -         StorageLive(_3);                 // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
           Deinit(_3);                      // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
-          (_3.0: i32) = const 0_i32;       // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
-          (_3.1: i32) = const 10_i32;      // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          (_3.0: i32, Strong) = const 0_i32; // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          (_3.1: i32, Strong) = const 10_i32; // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
           _2 = <std::ops::Range<i32> as IntoIterator>::into_iter(move _3) -> bb1; // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
                                            // mir::Constant
                                            // + span: $DIR/remove_storage_markers.rs:10:14: 10:19
@@ -68,7 +68,7 @@
   
       bb4: {
 -         StorageLive(_12);                // scope 2 at $DIR/remove_storage_markers.rs:+2:9: +2:10
-          _12 = ((_7 as Some).0: i32);     // scope 2 at $DIR/remove_storage_markers.rs:+2:9: +2:10
+          _12 = ((_7 as Some).0: i32, Strong); // scope 2 at $DIR/remove_storage_markers.rs:+2:9: +2:10
 -         StorageLive(_13);                // scope 3 at $DIR/remove_storage_markers.rs:+3:16: +3:17
           _13 = _12;                       // scope 3 at $DIR/remove_storage_markers.rs:+3:16: +3:17
           _1 = Add(_1, move _13);          // scope 3 at $DIR/remove_storage_markers.rs:+3:9: +3:17

--- a/src/test/mir-opt/remove_zsts_dont_touch_unions.get_union.RemoveZsts.after.mir
+++ b/src/test/mir-opt/remove_zsts_dont_touch_unions.get_union.RemoveZsts.after.mir
@@ -8,7 +8,7 @@ fn get_union() -> Foo {
         StorageLive(_1);                 // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:14: +1:16
         nop;                             // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:14: +1:16
         Deinit(_0);                      // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:5: +1:18
-        (_0.0: ()) = move _1;            // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:5: +1:18
+        (_0.0: (), Strong) = move _1;    // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:5: +1:18
         StorageDead(_1);                 // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:17: +1:18
         return;                          // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+2:2: +2:2
     }

--- a/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
@@ -129,16 +129,16 @@ fn array_casts() -> () {
         _18 = &(*_35);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         Retag(_18);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         Deinit(_13);                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        (_13.0: &usize) = move _14;      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        (_13.1: &usize) = move _18;      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        (_13.0: &usize, Strong) = move _14; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        (_13.1: &usize, Strong) = move _18; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         Retag(_13);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_14);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_20);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _20 = (_13.0: &usize);           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _20 = (_13.0: &usize, Strong);   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         Retag(_20);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_21);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _21 = (_13.1: &usize);           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _21 = (_13.1: &usize, Strong);   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         Retag(_21);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_22);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_23);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
@@ -63,7 +63,7 @@ fn main() -> () {
         StorageLive(_4);                 // scope 1 at $DIR/retag.rs:+3:17: +3:36
         StorageLive(_5);                 // scope 1 at $DIR/retag.rs:+3:17: +3:24
         Deinit(_5);                      // scope 1 at $DIR/retag.rs:+3:17: +3:24
-        (_5.0: i32) = const 0_i32;       // scope 1 at $DIR/retag.rs:+3:17: +3:24
+        (_5.0: i32, Strong) = const 0_i32; // scope 1 at $DIR/retag.rs:+3:17: +3:24
         _4 = &_5;                        // scope 1 at $DIR/retag.rs:+3:17: +3:36
         Retag(_4);                       // scope 1 at $DIR/retag.rs:+3:17: +3:36
         StorageLive(_6);                 // scope 1 at $DIR/retag.rs:+3:29: +3:35
@@ -137,7 +137,7 @@ fn main() -> () {
         StorageLive(_20);                // scope 7 at $DIR/retag.rs:+18:5: +18:24
         StorageLive(_21);                // scope 7 at $DIR/retag.rs:+18:5: +18:12
         Deinit(_21);                     // scope 7 at $DIR/retag.rs:+18:5: +18:12
-        (_21.0: i32) = const 0_i32;      // scope 7 at $DIR/retag.rs:+18:5: +18:12
+        (_21.0: i32, Strong) = const 0_i32; // scope 7 at $DIR/retag.rs:+18:5: +18:12
         _20 = &_21;                      // scope 7 at $DIR/retag.rs:+18:5: +18:24
         Retag(_20);                      // scope 7 at $DIR/retag.rs:+18:5: +18:24
         StorageLive(_22);                // scope 7 at $DIR/retag.rs:+18:21: +18:23

--- a/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -68,11 +68,11 @@
 - 
 -     bb2: {
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-          _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          _9 = ((_3 as Continue).0: i32, Strong); // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
           _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:+1:8: +1:10
           StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
           Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
-          ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
+          ((_0 as Ok).0: i32, Strong) = move _2; // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
           discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+1:10: +1:11
           StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:+2:1: +2:2
@@ -87,18 +87,18 @@
 -     bb4: {
 +     bb3: {
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
-          _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>, Strong); // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
           _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
           StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-          _16 = move ((_8 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+          _16 = move ((_8 as Err).0: i32, Strong); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           _18 = move _16;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           _17 = move _18;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           Deinit(_0);                      // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_0 as Err).0: i32) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_0 as Err).0: i32, Strong) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -112,16 +112,16 @@
 -     bb5: {
 +     bb4: {
           StorageLive(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          _13 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _13 = move ((_4 as Err).0: i32, Strong); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           _15 = move _13;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           Deinit(_14);                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_14 as Err).0: i32) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_14 as Err).0: i32, Strong) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_14) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           Deinit(_3);                      // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>, Strong) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -139,11 +139,11 @@
 -     bb7: {
 +     bb6: {
           StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _11 = move ((_4 as Ok).0: i32, Strong); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           _12 = move _11;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           Deinit(_3);                      // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_3 as Continue).0: i32) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Continue).0: i32, Strong) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL

--- a/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
@@ -35,11 +35,11 @@
   
       bb1: {
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+8:17: +8:18
-          _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:+8:17: +8:18
+          _6 = ((_1 as Err).0: usize, Strong); // scope 0 at $DIR/separate_const_switch.rs:+8:17: +8:18
           StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:+8:42: +8:43
           _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:+8:42: +8:43
           Deinit(_2);                      // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
-          ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
+          ((_2 as Break).0: usize, Strong) = move _7; // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
           discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
           StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:+8:43: +8:44
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
@@ -54,11 +54,11 @@
   
       bb3: {
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
-          _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
+          _4 = ((_1 as Ok).0: i32, Strong); // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
           StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
           _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
           Deinit(_2);                      // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
-          ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
+          ((_2 as Continue).0: i32, Strong) = move _5; // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
           discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
           StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:45: +7:46
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:45: +7:46
@@ -74,7 +74,7 @@
 -     bb5: {
 +     bb4: {
           StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
-          _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
+          _11 = ((_2 as Break).0: usize, Strong); // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
           Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
           discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
           StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
@@ -90,11 +90,11 @@
 -     bb7: {
 +     bb6: {
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
-          _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
+          _9 = ((_2 as Continue).0: i32, Strong); // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
           StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
           _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
           Deinit(_0);                      // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
-          ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
+          ((_0 as Some).0: i32, Strong) = move _10; // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
           discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
           StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:43: +11:44
           StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44

--- a/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
@@ -16,10 +16,10 @@
 -         Deinit(_3);                      // scope 0 at $DIR/simplify_locals.rs:+2:11: +2:15
 -         discriminant(_3) = 0;            // scope 0 at $DIR/simplify_locals.rs:+2:11: +2:15
 -         Deinit(_2);                      // scope 0 at $DIR/simplify_locals.rs:+2:6: +2:16
--         (_2.0: i32) = const 10_i32;      // scope 0 at $DIR/simplify_locals.rs:+2:6: +2:16
--         (_2.1: E) = move _3;             // scope 0 at $DIR/simplify_locals.rs:+2:6: +2:16
+-         (_2.0: i32, Strong) = const 10_i32; // scope 0 at $DIR/simplify_locals.rs:+2:6: +2:16
+-         (_2.1: E, Strong) = move _3;     // scope 0 at $DIR/simplify_locals.rs:+2:6: +2:16
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify_locals.rs:+2:15: +2:16
--         (_2.1: E) = move _1;             // scope 0 at $DIR/simplify_locals.rs:+2:5: +2:26
+-         (_2.1: E, Strong) = move _1;     // scope 0 at $DIR/simplify_locals.rs:+2:5: +2:26
 -         StorageDead(_1);                 // scope 0 at $DIR/simplify_locals.rs:+2:25: +2:26
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify_locals.rs:+2:26: +2:27
           _0 = const ();                   // scope 0 at $DIR/simplify_locals.rs:+0:9: +3:2

--- a/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
@@ -24,22 +24,22 @@
           Deinit(_3);                      // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:51: +1:68
           discriminant(_3) = 0;            // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:51: +1:68
           Deinit(_1);                      // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:30: +1:69
-          (_1.0: std::option::Option<u8>) = move _2; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:30: +1:69
-          (_1.1: std::option::Option<T>) = move _3; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:30: +1:69
+          (_1.0: std::option::Option<u8>, Strong) = move _2; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:30: +1:69
+          (_1.1: std::option::Option<T>, Strong) = move _3; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:30: +1:69
           StorageDead(_3);                 // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:68: +1:69
           StorageDead(_2);                 // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:68: +1:69
-          _5 = discriminant((_1.0: std::option::Option<u8>)); // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:12: +1:27
+          _5 = discriminant((_1.0: std::option::Option<u8>, Strong)); // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:12: +1:27
           switchInt(move _5) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:12: +1:27
       }
   
       bb1: {
-          _4 = discriminant((_1.1: std::option::Option<T>)); // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:12: +1:27
+          _4 = discriminant((_1.1: std::option::Option<T>, Strong)); // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:12: +1:27
           switchInt(move _4) -> [0_isize: bb2, otherwise: bb3]; // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:12: +1:27
       }
   
       bb2: {
           StorageLive(_6);                 // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:18: +1:19
-          _6 = (((_1.0: std::option::Option<u8>) as Some).0: u8); // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:18: +1:19
+          _6 = (((_1.0: std::option::Option<u8>, Strong) as Some).0: u8, Strong); // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+1:18: +1:19
 -         StorageLive(_7);                 // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+2:12: +2:20
 -         StorageLive(_8);                 // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+2:12: +2:13
 -         _8 = _6;                         // scope 1 at $DIR/simplify_locals_fixedpoint.rs:+2:12: +2:13

--- a/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
@@ -32,8 +32,8 @@
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:25: +1:27
 -         Deinit(_3);                      // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:25: +1:27
 -         Deinit(_1);                      // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:20: +1:28
--         (_1.0: ()) = move _2;            // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:20: +1:28
--         (_1.1: ()) = move _3;            // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:20: +1:28
+-         (_1.0: (), Strong) = move _2;    // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:20: +1:28
+-         (_1.1: (), Strong) = move _3;    // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:20: +1:28
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:27: +1:28
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:27: +1:28
 -         StorageDead(_1);                 // scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+1:28: +1:29
@@ -44,8 +44,8 @@
 -         StorageLive(_7);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:18: +2:20
 -         Deinit(_7);                      // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:18: +2:20
 -         Deinit(_5);                      // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
--         (_5.0: ()) = move _6;            // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
--         (_5.1: ()) = move _7;            // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
+-         (_5.0: (), Strong) = move _6;    // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
+-         (_5.1: (), Strong) = move _7;    // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
 -         StorageDead(_7);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:20: +2:21
 -         StorageDead(_6);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:20: +2:21
 -         _4 = use_zst(move _5) -> bb1;    // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:5: +2:22
@@ -56,8 +56,8 @@
 +         StorageLive(_4);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:18: +2:20
 +         Deinit(_4);                      // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:18: +2:20
 +         Deinit(_2);                      // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
-+         (_2.0: ()) = move _3;            // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
-+         (_2.1: ()) = move _4;            // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
++         (_2.0: (), Strong) = move _3;    // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
++         (_2.1: (), Strong) = move _4;    // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:13: +2:21
 +         StorageDead(_4);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:20: +2:21
 +         StorageDead(_3);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:20: +2:21
 +         _1 = use_zst(move _2) -> bb1;    // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+2:5: +2:22
@@ -74,8 +74,8 @@
 -         StorageLive(_10);                // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:30
 -         StorageLive(_11);                // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:28
 -         Deinit(_11);                     // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:28
--         (_11.0: u8) = const 40_u8;       // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:28
--         _10 = (_11.0: u8);               // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:30
+-         (_11.0: u8, Strong) = const 40_u8; // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:28
+-         _10 = (_11.0: u8, Strong);       // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:30
 -         _9 = Add(move _10, const 2_u8);  // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:34
 -         StorageDead(_10);                // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:33: +4:34
 -         _8 = use_u8(move _9) -> bb2;     // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:5: +4:35
@@ -86,8 +86,8 @@
 +         StorageLive(_7);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:30
 +         StorageLive(_8);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:28
 +         Deinit(_8);                      // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:28
-+         (_8.0: u8) = const 40_u8;        // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:28
-+         _7 = (_8.0: u8);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:30
++         (_8.0: u8, Strong) = const 40_u8; // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:28
++         _7 = (_8.0: u8, Strong);         // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:30
 +         _6 = Add(move _7, const 2_u8);   // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:12: +4:34
 +         StorageDead(_7);                 // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:33: +4:34
 +         _5 = use_u8(move _6) -> bb2;     // scope 1 at $DIR/simplify_locals_removes_unused_consts.rs:+4:5: +4:35

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.diff
@@ -23,11 +23,11 @@
   
       bb1: {
           StorageLive(_3);                 // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:14: +3:15
-          _3 = move ((_1 as Some).0: std::boxed::Box<()>); // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:14: +3:15
+          _3 = move ((_1 as Some).0: std::boxed::Box<()>, Strong); // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:14: +3:15
           StorageLive(_4);                 // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:25: +3:26
           _4 = move _3;                    // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:25: +3:26
           Deinit(_0);                      // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:20: +3:27
-          ((_0 as Some).0: std::boxed::Box<()>) = move _4; // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:20: +3:27
+          ((_0 as Some).0: std::boxed::Box<()>, Strong) = move _4; // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:20: +3:27
           discriminant(_0) = 1;            // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:20: +3:27
           StorageDead(_4);                 // scope 1 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:26: +3:27
           StorageDead(_3);                 // scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+3:26: +3:27

--- a/src/test/mir-opt/sroa.dropping.ScalarReplacementOfAggregates.diff
+++ b/src/test/mir-opt/sroa.dropping.ScalarReplacementOfAggregates.diff
@@ -14,26 +14,26 @@
           StorageLive(_2);                 // scope 0 at $DIR/sroa.rs:+1:5: +1:30
           StorageLive(_3);                 // scope 0 at $DIR/sroa.rs:+1:7: +1:13
           Deinit(_3);                      // scope 0 at $DIR/sroa.rs:+1:7: +1:13
-          (_3.0: usize) = const 0_usize;   // scope 0 at $DIR/sroa.rs:+1:7: +1:13
+          (_3.0: usize, Strong) = const 0_usize; // scope 0 at $DIR/sroa.rs:+1:7: +1:13
           StorageLive(_4);                 // scope 0 at $DIR/sroa.rs:+1:15: +1:21
           Deinit(_4);                      // scope 0 at $DIR/sroa.rs:+1:15: +1:21
-          (_4.0: usize) = const 1_usize;   // scope 0 at $DIR/sroa.rs:+1:15: +1:21
+          (_4.0: usize, Strong) = const 1_usize; // scope 0 at $DIR/sroa.rs:+1:15: +1:21
           StorageLive(_5);                 // scope 0 at $DIR/sroa.rs:+1:23: +1:29
           Deinit(_5);                      // scope 0 at $DIR/sroa.rs:+1:23: +1:29
-          (_5.0: usize) = const 2_usize;   // scope 0 at $DIR/sroa.rs:+1:23: +1:29
+          (_5.0: usize, Strong) = const 2_usize; // scope 0 at $DIR/sroa.rs:+1:23: +1:29
           Deinit(_2);                      // scope 0 at $DIR/sroa.rs:+1:5: +1:30
-          (_2.0: Tag) = move _3;           // scope 0 at $DIR/sroa.rs:+1:5: +1:30
-          (_2.1: Tag) = move _4;           // scope 0 at $DIR/sroa.rs:+1:5: +1:30
-          (_2.2: Tag) = move _5;           // scope 0 at $DIR/sroa.rs:+1:5: +1:30
+          (_2.0: Tag, Strong) = move _3;   // scope 0 at $DIR/sroa.rs:+1:5: +1:30
+          (_2.1: Tag, Strong) = move _4;   // scope 0 at $DIR/sroa.rs:+1:5: +1:30
+          (_2.2: Tag, Strong) = move _5;   // scope 0 at $DIR/sroa.rs:+1:5: +1:30
           StorageDead(_5);                 // scope 0 at $DIR/sroa.rs:+1:29: +1:30
           StorageDead(_4);                 // scope 0 at $DIR/sroa.rs:+1:29: +1:30
           StorageDead(_3);                 // scope 0 at $DIR/sroa.rs:+1:29: +1:30
-          _1 = move (_2.1: Tag);           // scope 0 at $DIR/sroa.rs:+1:5: +1:32
+          _1 = move (_2.1: Tag, Weak);     // scope 0 at $DIR/sroa.rs:+1:5: +1:32
           drop(_1) -> bb1;                 // scope 0 at $DIR/sroa.rs:+1:32: +1:33
       }
   
       bb1: {
-          drop((_2.0: Tag)) -> bb3;        // scope 0 at $DIR/sroa.rs:+1:32: +1:33
+          drop((_2.0: Tag, Strong)) -> bb3; // scope 0 at $DIR/sroa.rs:+1:32: +1:33
       }
   
       bb2: {
@@ -44,7 +44,7 @@
       }
   
       bb3: {
-          drop((_2.2: Tag)) -> bb2;        // scope 0 at $DIR/sroa.rs:+1:32: +1:33
+          drop((_2.2: Tag, Strong)) -> bb2; // scope 0 at $DIR/sroa.rs:+1:32: +1:33
       }
   }
   

--- a/src/test/mir-opt/sroa.enums.ScalarReplacementOfAggregates.diff
+++ b/src/test/mir-opt/sroa.enums.ScalarReplacementOfAggregates.diff
@@ -17,7 +17,7 @@
           StorageLive(_3);                 // scope 1 at $DIR/sroa.rs:+1:27: +1:28
           _3 = _1;                         // scope 1 at $DIR/sroa.rs:+1:27: +1:28
           Deinit(_2);                      // scope 1 at $DIR/sroa.rs:+1:22: +1:29
-          ((_2 as Some).0: usize) = move _3; // scope 1 at $DIR/sroa.rs:+1:22: +1:29
+          ((_2 as Some).0: usize, Strong) = move _3; // scope 1 at $DIR/sroa.rs:+1:22: +1:29
           discriminant(_2) = 1;            // scope 1 at $DIR/sroa.rs:+1:22: +1:29
           StorageDead(_3);                 // scope 1 at $DIR/sroa.rs:+1:28: +1:29
           _4 = discriminant(_2);           // scope 1 at $DIR/sroa.rs:+1:12: +1:19
@@ -26,7 +26,7 @@
   
       bb1: {
           StorageLive(_5);                 // scope 1 at $DIR/sroa.rs:+1:17: +1:18
-          _5 = ((_2 as Some).0: usize);    // scope 1 at $DIR/sroa.rs:+1:17: +1:18
+          _5 = ((_2 as Some).0: usize, Strong); // scope 1 at $DIR/sroa.rs:+1:17: +1:18
           _0 = _5;                         // scope 1 at $DIR/sroa.rs:+1:32: +1:33
           StorageDead(_5);                 // scope 0 at $DIR/sroa.rs:+1:34: +1:35
           goto -> bb3;                     // scope 0 at $DIR/sroa.rs:+1:5: +1:46

--- a/src/test/mir-opt/sroa.escaping.ScalarReplacementOfAggregates.diff
+++ b/src/test/mir-opt/sroa.escaping.ScalarReplacementOfAggregates.diff
@@ -23,11 +23,11 @@
   
       bb1: {
           Deinit(_4);                      // scope 0 at $DIR/sroa.rs:+2:8: +2:39
-          (_4.0: u32) = const 1_u32;       // scope 0 at $DIR/sroa.rs:+2:8: +2:39
-          (_4.1: u32) = const 2_u32;       // scope 0 at $DIR/sroa.rs:+2:8: +2:39
-          (_4.2: u32) = move _5;           // scope 0 at $DIR/sroa.rs:+2:8: +2:39
+          (_4.0: u32, Strong) = const 1_u32; // scope 0 at $DIR/sroa.rs:+2:8: +2:39
+          (_4.1: u32, Strong) = const 2_u32; // scope 0 at $DIR/sroa.rs:+2:8: +2:39
+          (_4.2: u32, Strong) = move _5;   // scope 0 at $DIR/sroa.rs:+2:8: +2:39
           StorageDead(_5);                 // scope 0 at $DIR/sroa.rs:+2:38: +2:39
-          _3 = &(_4.0: u32);               // scope 0 at $DIR/sroa.rs:+2:7: +2:41
+          _3 = &(_4.0: u32, Weak);         // scope 0 at $DIR/sroa.rs:+2:7: +2:41
           _2 = &raw const (*_3);           // scope 0 at $DIR/sroa.rs:+2:7: +2:41
           _1 = f(move _2) -> bb2;          // scope 0 at $DIR/sroa.rs:+2:5: +2:42
                                            // mir::Constant

--- a/src/test/mir-opt/sroa.flat.ScalarReplacementOfAggregates.diff
+++ b/src/test/mir-opt/sroa.flat.ScalarReplacementOfAggregates.diff
@@ -39,12 +39,12 @@
           Deinit(_6);                      // scope 0 at $DIR/sroa.rs:+1:45: +1:47
           StorageLive(_7);                 // scope 0 at $DIR/sroa.rs:+1:60: +1:68
           Deinit(_7);                      // scope 0 at $DIR/sroa.rs:+1:60: +1:68
-          ((_7 as Some).0: isize) = const -4_isize; // scope 0 at $DIR/sroa.rs:+1:60: +1:68
+          ((_7 as Some).0: isize, Strong) = const -4_isize; // scope 0 at $DIR/sroa.rs:+1:60: +1:68
           discriminant(_7) = 1;            // scope 0 at $DIR/sroa.rs:+1:60: +1:68
 -         Deinit(_5);                      // scope 0 at $DIR/sroa.rs:+1:30: +1:70
--         (_5.0: u8) = const 5_u8;         // scope 0 at $DIR/sroa.rs:+1:30: +1:70
--         (_5.1: ()) = move _6;            // scope 0 at $DIR/sroa.rs:+1:30: +1:70
--         (_5.2: &str) = const "a";        // scope 0 at $DIR/sroa.rs:+1:30: +1:70
+-         (_5.0: u8, Strong) = const 5_u8; // scope 0 at $DIR/sroa.rs:+1:30: +1:70
+-         (_5.1: (), Strong) = move _6;    // scope 0 at $DIR/sroa.rs:+1:30: +1:70
+-         (_5.2: &str, Strong) = const "a"; // scope 0 at $DIR/sroa.rs:+1:30: +1:70
 +         Deinit(_8);                      // scope 0 at $DIR/sroa.rs:+1:30: +1:70
 +         Deinit(_9);                      // scope 0 at $DIR/sroa.rs:+1:30: +1:70
 +         Deinit(_10);                     // scope 0 at $DIR/sroa.rs:+1:30: +1:70
@@ -55,21 +55,21 @@
                                            // mir::Constant
                                            // + span: $DIR/sroa.rs:57:52: 57:55
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
--         (_5.3: std::option::Option<isize>) = move _7; // scope 0 at $DIR/sroa.rs:+1:30: +1:70
+-         (_5.3: std::option::Option<isize>, Strong) = move _7; // scope 0 at $DIR/sroa.rs:+1:30: +1:70
 +         _11 = move _7;                   // scope 0 at $DIR/sroa.rs:+1:30: +1:70
           StorageDead(_7);                 // scope 0 at $DIR/sroa.rs:+1:69: +1:70
           StorageDead(_6);                 // scope 0 at $DIR/sroa.rs:+1:69: +1:70
           StorageLive(_1);                 // scope 0 at $DIR/sroa.rs:+1:15: +1:16
--         _1 = (_5.0: u8);                 // scope 0 at $DIR/sroa.rs:+1:15: +1:16
+-         _1 = (_5.0: u8, Strong);         // scope 0 at $DIR/sroa.rs:+1:15: +1:16
 +         _1 = _8;                         // scope 0 at $DIR/sroa.rs:+1:15: +1:16
           StorageLive(_2);                 // scope 0 at $DIR/sroa.rs:+1:18: +1:19
--         _2 = (_5.1: ());                 // scope 0 at $DIR/sroa.rs:+1:18: +1:19
+-         _2 = (_5.1: (), Strong);         // scope 0 at $DIR/sroa.rs:+1:18: +1:19
 +         _2 = _9;                         // scope 0 at $DIR/sroa.rs:+1:18: +1:19
           StorageLive(_3);                 // scope 0 at $DIR/sroa.rs:+1:21: +1:22
--         _3 = (_5.2: &str);               // scope 0 at $DIR/sroa.rs:+1:21: +1:22
+-         _3 = (_5.2: &str, Strong);       // scope 0 at $DIR/sroa.rs:+1:21: +1:22
 +         _3 = _10;                        // scope 0 at $DIR/sroa.rs:+1:21: +1:22
           StorageLive(_4);                 // scope 0 at $DIR/sroa.rs:+1:24: +1:25
--         _4 = (_5.3: std::option::Option<isize>); // scope 0 at $DIR/sroa.rs:+1:24: +1:25
+-         _4 = (_5.3: std::option::Option<isize>, Strong); // scope 0 at $DIR/sroa.rs:+1:24: +1:25
 -         StorageDead(_5);                 // scope 0 at $DIR/sroa.rs:+1:70: +1:71
 +         _4 = _11;                        // scope 0 at $DIR/sroa.rs:+1:24: +1:25
 +         StorageDead(_8);                 // scope 0 at $DIR/sroa.rs:+1:70: +1:71

--- a/src/test/mir-opt/sroa.structs.ScalarReplacementOfAggregates.diff
+++ b/src/test/mir-opt/sroa.structs.ScalarReplacementOfAggregates.diff
@@ -16,14 +16,14 @@
           StorageLive(_3);                 // scope 0 at $DIR/sroa.rs:+6:18: +6:19
           _3 = _1;                         // scope 0 at $DIR/sroa.rs:+6:18: +6:19
 -         Deinit(_2);                      // scope 0 at $DIR/sroa.rs:+6:5: +6:21
--         (_2.0: usize) = const 0_usize;   // scope 0 at $DIR/sroa.rs:+6:5: +6:21
--         (_2.1: f32) = move _3;           // scope 0 at $DIR/sroa.rs:+6:5: +6:21
+-         (_2.0: usize, Strong) = const 0_usize; // scope 0 at $DIR/sroa.rs:+6:5: +6:21
+-         (_2.1: f32, Strong) = move _3;   // scope 0 at $DIR/sroa.rs:+6:5: +6:21
 +         Deinit(_4);                      // scope 0 at $DIR/sroa.rs:+6:5: +6:21
 +         Deinit(_5);                      // scope 0 at $DIR/sroa.rs:+6:5: +6:21
 +         _4 = const 0_usize;              // scope 0 at $DIR/sroa.rs:+6:5: +6:21
 +         _5 = move _3;                    // scope 0 at $DIR/sroa.rs:+6:5: +6:21
           StorageDead(_3);                 // scope 0 at $DIR/sroa.rs:+6:20: +6:21
--         _0 = (_2.1: f32);                // scope 0 at $DIR/sroa.rs:+6:5: +6:23
+-         _0 = (_2.1: f32, Strong);        // scope 0 at $DIR/sroa.rs:+6:5: +6:23
 -         StorageDead(_2);                 // scope 0 at $DIR/sroa.rs:+7:1: +7:2
 +         _0 = _5;                         // scope 0 at $DIR/sroa.rs:+6:5: +6:23
 +         StorageDead(_4);                 // scope 0 at $DIR/sroa.rs:+7:1: +7:2

--- a/src/test/mir-opt/sroa.unions.ScalarReplacementOfAggregates.diff
+++ b/src/test/mir-opt/sroa.unions.ScalarReplacementOfAggregates.diff
@@ -14,9 +14,9 @@
           StorageLive(_3);                 // scope 1 at $DIR/sroa.rs:+5:24: +5:25
           _3 = _1;                         // scope 1 at $DIR/sroa.rs:+5:24: +5:25
           Deinit(_2);                      // scope 1 at $DIR/sroa.rs:+5:14: +5:27
-          (_2.0: f32) = move _3;           // scope 1 at $DIR/sroa.rs:+5:14: +5:27
+          (_2.0: f32, Strong) = move _3;   // scope 1 at $DIR/sroa.rs:+5:14: +5:27
           StorageDead(_3);                 // scope 1 at $DIR/sroa.rs:+5:26: +5:27
-          _0 = (_2.1: u32);                // scope 1 at $DIR/sroa.rs:+5:14: +5:29
+          _0 = (_2.1: u32, Strong);        // scope 1 at $DIR/sroa.rs:+5:14: +5:29
           StorageDead(_2);                 // scope 0 at $DIR/sroa.rs:+6:1: +6:2
           return;                          // scope 0 at $DIR/sroa.rs:+6:2: +6:2
       }

--- a/src/test/mir-opt/try_identity_e2e.new.PreCodegen.after.mir
+++ b/src/test/mir-opt/try_identity_e2e.new.PreCodegen.after.mir
@@ -30,27 +30,27 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb1: {
-        _5 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity_e2e.rs:+5:21: +5:22
+        _5 = move ((_1 as Err).0: E, Strong); // scope 0 at $DIR/try_identity_e2e.rs:+5:21: +5:22
         Deinit(_2);                      // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
-        ((_2 as Break).0: E) = move _5;  // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
+        ((_2 as Break).0: E, Strong) = move _5; // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
         discriminant(_2) = 1;            // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
         _6 = discriminant(_2);           // scope 0 at $DIR/try_identity_e2e.rs:+2:15: +7:10
         switchInt(move _6) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 0 at $DIR/try_identity_e2e.rs:+2:9: +7:10
     }
 
     bb2: {
-        _4 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity_e2e.rs:+4:20: +4:21
+        _4 = move ((_1 as Ok).0: T, Strong); // scope 0 at $DIR/try_identity_e2e.rs:+4:20: +4:21
         Deinit(_2);                      // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
-        ((_2 as Continue).0: T) = move _4; // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
+        ((_2 as Continue).0: T, Strong) = move _4; // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
         discriminant(_2) = 0;            // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
         _6 = discriminant(_2);           // scope 0 at $DIR/try_identity_e2e.rs:+2:15: +7:10
         switchInt(move _6) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 0 at $DIR/try_identity_e2e.rs:+2:9: +7:10
     }
 
     bb3: {
-        _8 = move ((_2 as Break).0: E);  // scope 0 at $DIR/try_identity_e2e.rs:+9:32: +9:33
+        _8 = move ((_2 as Break).0: E, Strong); // scope 0 at $DIR/try_identity_e2e.rs:+9:32: +9:33
         Deinit(_0);                      // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
-        ((_0 as Err).0: E) = move _8;    // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
+        ((_0 as Err).0: E, Strong) = move _8; // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
         discriminant(_0) = 1;            // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
         StorageDead(_2);                 // scope 0 at $DIR/try_identity_e2e.rs:+12:1: +12:2
         return;                          // scope 0 at $DIR/try_identity_e2e.rs:+12:1: +12:2
@@ -61,9 +61,9 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb5: {
-        _7 = move ((_2 as Continue).0: T); // scope 0 at $DIR/try_identity_e2e.rs:+8:35: +8:36
+        _7 = move ((_2 as Continue).0: T, Strong); // scope 0 at $DIR/try_identity_e2e.rs:+8:35: +8:36
         Deinit(_0);                      // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +11:6
-        ((_0 as Ok).0: T) = move _7;     // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +11:6
+        ((_0 as Ok).0: T, Strong) = move _7; // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +11:6
         discriminant(_0) = 0;            // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +11:6
         StorageDead(_2);                 // scope 0 at $DIR/try_identity_e2e.rs:+12:1: +12:2
         return;                          // scope 0 at $DIR/try_identity_e2e.rs:+12:1: +12:2

--- a/src/test/mir-opt/try_identity_e2e.old.PreCodegen.after.mir
+++ b/src/test/mir-opt/try_identity_e2e.old.PreCodegen.after.mir
@@ -19,9 +19,9 @@ fn old(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb1: {
-        _4 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity_e2e.rs:+4:17: +4:18
+        _4 = move ((_1 as Err).0: E, Strong); // scope 0 at $DIR/try_identity_e2e.rs:+4:17: +4:18
         Deinit(_0);                      // scope 2 at $DIR/try_identity_e2e.rs:+4:30: +4:36
-        ((_0 as Err).0: E) = move _4;    // scope 2 at $DIR/try_identity_e2e.rs:+4:30: +4:36
+        ((_0 as Err).0: E, Strong) = move _4; // scope 2 at $DIR/try_identity_e2e.rs:+4:30: +4:36
         discriminant(_0) = 1;            // scope 2 at $DIR/try_identity_e2e.rs:+4:30: +4:36
         return;                          // scope 0 at $DIR/try_identity_e2e.rs:+7:1: +7:2
     }
@@ -31,9 +31,9 @@ fn old(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb3: {
-        _3 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity_e2e.rs:+3:16: +3:17
+        _3 = move ((_1 as Ok).0: T, Strong); // scope 0 at $DIR/try_identity_e2e.rs:+3:16: +3:17
         Deinit(_0);                      // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +6:6
-        ((_0 as Ok).0: T) = move _3;     // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +6:6
+        ((_0 as Ok).0: T, Strong) = move _3; // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +6:6
         discriminant(_0) = 0;            // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +6:6
         return;                          // scope 0 at $DIR/try_identity_e2e.rs:+7:1: +7:2
     }

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -25,12 +25,12 @@ fn main() -> () {
         Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
         discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
         Deinit(_1);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
-        (_1.0: u32) = const 51_u32;      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
-        (_1.1: Test1) = move _2;         // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
+        (_1.0: u32, Strong) = const 51_u32; // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
+        (_1.1: Test1, Strong) = move _2; // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
         StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:47: +1:48
         StorageLive(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +8:6
         StorageLive(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
-        _4 = &(_1.1: Test1);             // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
+        _4 = &(_1.1: Test1, Strong);     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
         _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
         switchInt(move _5) -> [2_isize: bb3, 3_isize: bb1, otherwise: bb2]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
     }
@@ -65,7 +65,7 @@ fn main() -> () {
         StorageDead(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
         StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
         StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +15:6
-        _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
+        _10 = discriminant((_1.1: Test1, Strong)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
         switchInt(move _10) -> [2_isize: bb7, 3_isize: bb5, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
     }
 

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
@@ -26,12 +26,12 @@
           Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
           discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
           Deinit(_1);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
-          (_1.0: u32) = const 51_u32;      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
-          (_1.1: Test1) = move _2;         // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
+          (_1.0: u32, Strong) = const 51_u32; // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
+          (_1.1: Test1, Strong) = move _2; // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
           StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:47: +1:48
           StorageLive(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +8:6
           StorageLive(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
-          _4 = &(_1.1: Test1);             // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
+          _4 = &(_1.1: Test1, Strong);     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
           _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
 -         switchInt(move _5) -> [0_isize: bb3, 1_isize: bb4, 2_isize: bb5, 3_isize: bb1, otherwise: bb2]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
 +         switchInt(move _5) -> [2_isize: bb5, 3_isize: bb1, otherwise: bb2]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
@@ -86,7 +86,7 @@
           StorageDead(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
           StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
           StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +15:6
-          _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
+          _10 = discriminant((_1.1: Test1, Strong)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
 -         switchInt(move _10) -> [0_isize: bb9, 1_isize: bb10, 2_isize: bb11, 3_isize: bb7, otherwise: bb8]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
 +         switchInt(move _10) -> [2_isize: bb11, 3_isize: bb7, otherwise: bb8]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
       }

--- a/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
@@ -33,7 +33,7 @@
   
       bb2: {
 -         StorageLive(_3);                 // scope 1 at $DIR/unreachable.rs:+1:17: +1:19
--         _3 = move ((_1 as Some).0: Empty); // scope 1 at $DIR/unreachable.rs:+1:17: +1:19
+-         _3 = move ((_1 as Some).0: Empty, Strong); // scope 1 at $DIR/unreachable.rs:+1:17: +1:19
 -         StorageLive(_4);                 // scope 1 at $DIR/unreachable.rs:+2:13: +2:19
 -         StorageLive(_5);                 // scope 2 at $DIR/unreachable.rs:+4:9: +8:10
 -         StorageLive(_6);                 // scope 2 at $DIR/unreachable.rs:+4:12: +4:16

--- a/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
@@ -34,7 +34,7 @@
   
       bb2: {
           StorageLive(_4);                 // scope 2 at $DIR/unreachable_diverging.rs:+2:17: +2:21
-          _4 = move ((_2 as Some).0: Empty); // scope 2 at $DIR/unreachable_diverging.rs:+2:17: +2:21
+          _4 = move ((_2 as Some).0: Empty, Strong); // scope 2 at $DIR/unreachable_diverging.rs:+2:17: +2:21
           StorageLive(_5);                 // scope 2 at $DIR/unreachable_diverging.rs:+3:9: +5:10
           StorageLive(_6);                 // scope 2 at $DIR/unreachable_diverging.rs:+3:12: +3:13
           _6 = _1;                         // scope 2 at $DIR/unreachable_diverging.rs:+3:12: +3:13

--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.built.after.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.built.after.mir
@@ -5,7 +5,7 @@ fn Test::X(_1: usize) -> Test {
 
     bb0: {
         Deinit(_0);                      // scope 0 at $DIR/unusual_item_types.rs:+0:5: +0:6
-        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual_item_types.rs:+0:5: +0:6
+        ((_0 as X).0: usize, Strong) = move _1; // scope 0 at $DIR/unusual_item_types.rs:+0:5: +0:6
         discriminant(_0) = 0;            // scope 0 at $DIR/unusual_item_types.rs:+0:5: +0:6
         return;                          // scope 0 at $DIR/unusual_item_types.rs:+0:5: +0:6
     }

--- a/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.mir
+++ b/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.mir
@@ -22,11 +22,11 @@ fn std::ptr::drop_in_place(_1: *mut Vec<i32>) -> () {
     }
 
     bb4 (cleanup): {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb2; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>, Strong)) -> bb2; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb5: {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>, Strong)) -> [return: bb3, unwind: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb6: {

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.diff
@@ -30,7 +30,7 @@
       }
   
       bb1: {
-          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb2, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
+          switchInt(((_3 as Some).0: u32, Strong)) -> [0_u32: bb2, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
       }
   
       bb2: {

--- a/src/tools/miri/src/borrow_tracker/stacked_borrows/diagnostics.rs
+++ b/src/tools/miri/src/borrow_tracker/stacked_borrows/diagnostics.rs
@@ -475,7 +475,7 @@ fn operation_summary(operation: &str, alloc_id: AllocId, alloc_range: AllocRange
 }
 
 fn error_cause(stack: &Stack, prov_extra: ProvenanceExtra) -> &'static str {
-    if let ProvenanceExtra::Concrete(tag) = prov_extra {
+    if let ProvenanceExtra::Concrete(tag, _, _) = prov_extra {
         if (0..stack.len())
             .map(|i| stack.get(i).unwrap())
             .any(|item| item.tag() == tag && item.perm() != Permission::Disabled)

--- a/src/tools/miri/src/borrow_tracker/stacked_borrows/stack.rs
+++ b/src/tools/miri/src/borrow_tracker/stacked_borrows/stack.rs
@@ -193,7 +193,7 @@ impl<'tcx> Stack {
         #[cfg(all(feature = "stack-cache", debug_assertions))]
         self.verify_cache_consistency();
 
-        let ProvenanceExtra::Concrete(tag) = tag else {
+        let ProvenanceExtra::Concrete(tag, _, _) = tag else {
             // Handle the wildcard case.
             // Go search the stack for an exposed tag.
             if let Some(idx) =

--- a/src/tools/miri/src/eval.rs
+++ b/src/tools/miri/src/eval.rs
@@ -13,6 +13,7 @@ use crate::borrow_tracker::RetagFields;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::def::Namespace;
 use rustc_hir::def_id::DefId;
+use rustc_middle::mir::ProjectionMode;
 use rustc_middle::ty::{
     self,
     layout::{LayoutCx, LayoutOf},
@@ -305,7 +306,7 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
         )?;
         let argvs_place = ecx.allocate(argvs_layout, MiriMemoryKind::Machine.into())?;
         for (idx, arg) in argvs.into_iter().enumerate() {
-            let place = ecx.mplace_field(&argvs_place, idx)?;
+            let place = ecx.mplace_field(&argvs_place, idx, ProjectionMode::Strong)?;
             ecx.write_immediate(arg, &place.into())?;
         }
         ecx.mark_immutable(&argvs_place);
@@ -338,7 +339,7 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
             ecx.machine.cmd_line = Some(*cmd_place);
             // Store the UTF-16 string. We just allocated so we know the bounds are fine.
             for (idx, &c) in cmd_utf16.iter().enumerate() {
-                let place = ecx.mplace_field(&cmd_place, idx)?;
+                let place = ecx.mplace_field(&cmd_place, idx, ProjectionMode::Strong)?;
                 ecx.write_scalar(Scalar::from_u16(c), &place.into())?;
             }
             ecx.mark_immutable(&cmd_place);

--- a/src/tools/miri/src/intptrcast.rs
+++ b/src/tools/miri/src/intptrcast.rs
@@ -222,7 +222,7 @@ impl<'mir, 'tcx> GlobalStateInner {
     pub fn abs_ptr_to_rel(
         ecx: &MiriInterpCx<'mir, 'tcx>,
         ptr: Pointer<Provenance>,
-    ) -> Option<(AllocId, Size)> {
+    ) -> Option<(AllocId, Size, Size)> {
         let (tag, addr) = ptr.into_parts(); // addr is absolute (Tag provenance)
 
         let alloc_id = if let Provenance::Concrete { alloc_id, .. } = tag {
@@ -240,6 +240,7 @@ impl<'mir, 'tcx> GlobalStateInner {
         let neg_base_addr = (base_addr as i64).wrapping_neg();
         Some((
             alloc_id,
+            Size::from_bytes(base_addr),
             Size::from_bytes(dl.overflowing_signed_offset(addr.bytes(), neg_base_addr).0),
         ))
     }

--- a/src/tools/miri/src/shims/env.rs
+++ b/src/tools/miri/src/shims/env.rs
@@ -5,6 +5,7 @@ use std::mem;
 
 use rustc_const_eval::interpret::Pointer;
 use rustc_data_structures::fx::FxHashMap;
+use rustc_middle::mir;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_target::abi::Size;
 
@@ -451,7 +452,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         )?;
         let vars_place = this.allocate(vars_layout, MiriMemoryKind::Runtime.into())?;
         for (idx, var) in vars.into_iter().enumerate() {
-            let place = this.mplace_field(&vars_place, idx)?;
+            let place = this.mplace_field(&vars_place, idx, mir::ProjectionMode::Strong)?;
             this.write_pointer(var, &place.into())?;
         }
         this.write_pointer(vars_place.ptr, &this.machine.env_vars.environ.unwrap().into())?;

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -253,6 +253,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
 
         // First: functions that diverge.
         let ret = match ret {
+            #[rustfmt::skip]
             None =>
                 match link_name.as_str() {
                     "miri_start_panic" => {
@@ -274,7 +275,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                             panic_impl_instance,
                         )));
                     }
-                    #[rustfmt::skip]
                     | "exit"
                     | "ExitProcess"
                     => {
@@ -825,9 +825,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 #[allow(clippy::integer_arithmetic)] // it's a u128, we can shift by 64
                 let (c_out, sum) = ((wide_sum >> 64).truncate::<u8>(), wide_sum.truncate::<u64>());
 
-                let c_out_field = this.place_field(dest, 0)?;
+                let c_out_field = this.place_field(dest, 0, mir::ProjectionMode::Strong)?;
                 this.write_scalar(Scalar::from_u8(c_out), &c_out_field)?;
-                let sum_field = this.place_field(dest, 1)?;
+                let sum_field = this.place_field(dest, 1, mir::ProjectionMode::Strong)?;
                 this.write_scalar(Scalar::from_u64(sum), &sum_field)?;
             }
             "llvm.x86.sse2.pause" if this.tcx.sess.target.arch == "x86" || this.tcx.sess.target.arch == "x86_64" => {

--- a/src/tools/miri/src/shims/unix/foreign_items.rs
+++ b/src/tools/miri/src/shims/unix/foreign_items.rs
@@ -2,6 +2,7 @@ use std::ffi::OsStr;
 
 use log::trace;
 
+use rustc_middle::mir;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_span::Symbol;
 use rustc_target::abi::{Align, Size};
@@ -581,7 +582,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 #[allow(deprecated)]
                 let home_dir = std::env::home_dir().unwrap();
                 let (written, _) = this.write_path_to_c_str(&home_dir, buf, buflen)?;
-                let pw_dir = this.mplace_field_named(&pwd, "pw_dir")?;
+                let pw_dir = this.mplace_field_named(&pwd, "pw_dir", mir::ProjectionMode::Strong)?;
                 this.write_pointer(buf, &pw_dir.into())?;
 
                 if written {

--- a/src/tools/miri/src/shims/unix/fs.rs
+++ b/src/tools/miri/src/shims/unix/fs.rs
@@ -11,6 +11,7 @@ use std::time::SystemTime;
 use log::trace;
 
 use rustc_data_structures::fx::FxHashMap;
+use rustc_middle::mir;
 use rustc_target::abi::{Align, Size};
 
 use crate::shims::os_str::bytes_to_os_str;
@@ -1134,7 +1135,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 ("tv_sec", access_sec.into()),
                 ("tv_nsec", access_nsec.into()),
             ],
-            &this.mplace_field_named(&statxbuf, "stx_atime")?,
+            &this.mplace_field_named(&statxbuf, "stx_atime", mir::ProjectionMode::Strong)?,
         )?;
         #[rustfmt::skip]
         this.write_int_fields_named(
@@ -1142,7 +1143,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 ("tv_sec", created_sec.into()),
                 ("tv_nsec", created_nsec.into()),
             ],
-            &this.mplace_field_named(&statxbuf, "stx_btime")?,
+            &this.mplace_field_named(&statxbuf, "stx_btime", mir::ProjectionMode::Strong)?,
         )?;
         #[rustfmt::skip]
         this.write_int_fields_named(
@@ -1150,7 +1151,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 ("tv_sec", 0.into()),
                 ("tv_nsec", 0.into()),
             ],
-            &this.mplace_field_named(&statxbuf, "stx_ctime")?,
+            &this.mplace_field_named(&statxbuf, "stx_ctime", mir::ProjectionMode::Strong)?,
         )?;
         #[rustfmt::skip]
         this.write_int_fields_named(
@@ -1158,7 +1159,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 ("tv_sec", modified_sec.into()),
                 ("tv_nsec", modified_nsec.into()),
             ],
-            &this.mplace_field_named(&statxbuf, "stx_mtime")?,
+            &this.mplace_field_named(&statxbuf, "stx_mtime", mir::ProjectionMode::Strong)?,
         )?;
 
         Ok(0)
@@ -1414,7 +1415,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 // }
 
                 let entry_place = this.deref_operand(entry_op)?;
-                let name_place = this.mplace_field(&entry_place, 5)?;
+                let name_place = this.mplace_field(&entry_place, 5, mir::ProjectionMode::Strong)?;
 
                 let file_name = dir_entry.file_name(); // not a Path as there are no separators!
                 let (name_fits, file_name_buf_len) = this.write_os_str_to_c_str(

--- a/src/tools/miri/src/shims/windows/dlsym.rs
+++ b/src/tools/miri/src/shims/windows/dlsym.rs
@@ -101,8 +101,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 };
                 // We have to put the result into io_status_block.
                 if let Some(n) = written {
-                    let io_status_information =
-                        this.mplace_field_named(&io_status_block, "Information")?;
+                    let io_status_information = this.mplace_field_named(
+                        &io_status_block,
+                        "Information",
+                        mir::ProjectionMode::Strong,
+                    )?;
                     this.write_scalar(
                         Scalar::from_machine_usize(n.into(), this),
                         &io_status_information.into(),

--- a/src/tools/miri/tests/fail/box-cell-alias.stderr
+++ b/src/tools/miri/tests/fail/box-cell-alias.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x0..0x1] for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/box-cell-alias.rs:LL:CC
    |
 LL |     unsafe { (*ptr).set(20) };
    |              ^^^^^^^^^^^^^^
    |              |
-   |              trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |              trying to retag from <TAG>[0x0..0x1] for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |              this error occurs as part of retag at ALLOC[0x0..0x1]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/field-access.rs
+++ b/src/tools/miri/tests/fail/field-access.rs
@@ -1,0 +1,15 @@
+fn main() {
+    struct Foo { x: u8, y: u8 };
+
+    let a = Foo { x: 0, y: 1 };
+
+    let ap: *const Foo = &a as *const _;
+    let xp = unsafe { std::ptr::addr_of!((*ap).x) };
+    let yp = unsafe { std::ptr::addr_of!((*ap).y) };
+
+    let xpp1 = unsafe { xp.offset(1) };
+    assert_eq!(xpp1, yp);
+
+    let bad_y = unsafe { *xpp1 }; //~ ERROR: only permits access to offsets 0..1
+    println!("{}", bad_y);
+}

--- a/src/tools/miri/tests/fail/field-access.stderr
+++ b/src/tools/miri/tests/fail/field-access.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: dereferencing pointer failed: pointer to ALLOC only permits access to offsets 0..1, so access of 1 byte starting at offset 1 is out-of-bounds
+  --> $DIR/field-access.rs:LL:CC
+   |
+LL |     let bad_y = unsafe { *xpp1 };
+   |                          ^^^^^ dereferencing pointer failed: pointer to ALLOC only permits access to offsets 0..1, so access of 1 byte starting at offset 1 is out-of-bounds
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/field-access.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+

--- a/src/tools/miri/tests/fail/issue-miri-1112.stderr
+++ b/src/tools/miri/tests/fail/issue-miri-1112.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: constructing invalid value: encountered $HEX[ALLOC]<TAG>, but expected a vtable pointer
+error: Undefined Behavior: constructing invalid value: encountered $HEX[ALLOC]<TAG>[$HEX..$HEX], but expected a vtable pointer
   --> $DIR/issue-miri-1112.rs:LL:CC
    |
 LL |         let obj = std::mem::transmute::<FatPointer, *mut FunnyPointer>(obj);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered $HEX[ALLOC]<TAG>, but expected a vtable pointer
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered $HEX[ALLOC]<TAG>[$HEX..$HEX], but expected a vtable pointer
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/alias_through_mutation.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/alias_through_mutation.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/alias_through_mutation.rs:LL:CC
    |
 LL |     let _val = *target_alias;
    |                ^^^^^^^^^^^^^
    |                |
-   |                attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG>[0x0..0x4] because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/aliasing_mut1.rs:LL:CC
    |
 LL | pub fn safe(_x: &mut i32, _y: &mut i32) {}
-   |                           ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+   |                           ^^ not granting access to tag <TAG>[0x0..0x4] because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG>[0x0..0x4] because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/aliasing_mut2.rs:LL:CC
    |
 LL | pub fn safe(_x: &i32, _y: &mut i32) {}
-   |                       ^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+   |                       ^^ not granting access to tag <TAG>[0x0..0x4] because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut3.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut3.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x0..0x4] for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/aliasing_mut3.rs:LL:CC
    |
 LL | pub fn safe(_x: &mut i32, _y: &i32) {}
    |                           ^^
    |                           |
-   |                           trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                           trying to retag from <TAG>[0x0..0x4] for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                           this error occurs as part of FnEntry retag at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut4.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut4.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG>[0x0..0x4] because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/aliasing_mut4.rs:LL:CC
    |
 LL | pub fn safe(_x: &i32, _y: &mut Cell<i32>) {}
-   |                       ^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+   |                       ^^ not granting access to tag <TAG>[0x0..0x4] because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/box_exclusive_violation1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/box_exclusive_violation1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/box_exclusive_violation1.rs:LL:CC
    |
 LL |         *LEAK = 7;
    |         ^^^^^^^^^
    |         |
-   |         attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |         this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/box_noalias_violation.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/box_noalias_violation.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is weakly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG>[0x0..0x4] because that would remove [Unique for <TAG>] which is weakly protected because it is an argument of call ID
   --> $DIR/box_noalias_violation.rs:LL:CC
    |
 LL |     *y
-   |     ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is weakly protected because it is an argument of call ID
+   |     ^^ not granting access to tag <TAG>[0x0..0x4] because that would remove [Unique for <TAG>] which is weakly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/buggy_as_mut_slice.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/buggy_as_mut_slice.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a write access using <TAG>[0x0..0xc] at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
   --> $DIR/buggy_as_mut_slice.rs:LL:CC
    |
 LL |     v1[1] = 5;
    |     ^^^^^^^^^
    |     |
-   |     attempting a write access using <TAG> at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+   |     attempting a write access using <TAG>[0x0..0xc] at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
    |     this error occurs as part of an access at ALLOC[0x4..0x8]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/buggy_split_at_mut.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/buggy_split_at_mut.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for Unique permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x0..0x10] for Unique permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/buggy_split_at_mut.rs:LL:CC
    |
 LL |     let (a, b) = safe::split_at_mut(&mut array, 0);
    |          ^
    |          |
-   |          trying to retag from <TAG> for Unique permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |          trying to retag from <TAG>[0x0..0x10] for Unique permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |          this error occurs as part of retag at ALLOC[0x0..0x10]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/disable_mut_does_not_merge_srw.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/disable_mut_does_not_merge_srw.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/disable_mut_does_not_merge_srw.rs:LL:CC
    |
 LL |         let _val = *raw;
    |                    ^^^^
    |                    |
-   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                    this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/fnentry_invalidation.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/fnentry_invalidation.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/fnentry_invalidation.rs:LL:CC
    |
 LL |         let _oof = *z;
    |                    ^^
    |                    |
-   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                    this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/fnentry_invalidation2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/fnentry_invalidation2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0xc] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/fnentry_invalidation2.rs:LL:CC
    |
 LL |         let _oof = *ptr;
    |                    ^^^^
    |                    |
-   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    attempting a read access using <TAG>[0x0..0xc] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                    this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_dealloc1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_dealloc1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: attempting deallocation using <TAG> at ALLOC, but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting deallocation using <TAG>[0x0..0x1] at ALLOC, but that tag does not exist in the borrow stack for this location
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempting deallocation using <TAG> at ALLOC, but that tag does not exist in the borrow stack for this location
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempting deallocation using <TAG>[0x0..0x1] at ALLOC, but that tag does not exist in the borrow stack for this location
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_read1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_read1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read1.rs:LL:CC
    |
 LL |     let _val = *xref; // ...but any use of raw will invalidate our ref.
    |                ^^^^^
    |                |
-   |                attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_read2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_read2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read2.rs:LL:CC
    |
 LL |     let _val = *xref; // ...but any use of raw will invalidate our ref.
    |                ^^^^^
    |                |
-   |                attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_read3.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_read3.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read3.rs:LL:CC
    |
 LL |     let _val = *xref2;
    |                ^^^^^^
    |                |
-   |                attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_read4.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_read4.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read4.rs:LL:CC
    |
 LL |     let _illegal = *xref2;
    |                    ^^^^^^
    |                    |
-   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                    this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_read5.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_read5.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[$HEX], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[$HEX..$HEX] at ALLOC[$HEX], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read5.rs:LL:CC
    |
 LL |     let _val = *xref; // the mutable one is dead and gone
    |                ^^^^^
    |                |
-   |                attempting a read access using <TAG> at ALLOC[$HEX], but that tag does not exist in the borrow stack for this location
+   |                attempting a read access using <TAG>[$HEX..$HEX] at ALLOC[$HEX], but that tag does not exist in the borrow stack for this location
    |                this error occurs as part of an access at ALLOC[$HEX..$HEX]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_read6.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_read6.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read6.rs:LL:CC
    |
 LL |         let _val = *raw;
    |                    ^^^^
    |                    |
-   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                    this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_read7.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_read7.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x0..0x4] for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read7.rs:LL:CC
    |
 LL |         let _val = *x.get_mut();
    |                     ^^^^^^^^^^^
    |                     |
-   |                     trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                     trying to retag from <TAG>[0x0..0x4] for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                     this error occurs as part of two-phase retag at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_read8.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_read8.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read8.rs:LL:CC
    |
 LL |         let _fail = *y1;
    |                     ^^^
    |                     |
-   |                     attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                     attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                     this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_read_despite_exposed1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_read_despite_exposed1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read_despite_exposed1.rs:LL:CC
    |
 LL |         let _val = *root2;
    |                    ^^^^^^
    |                    |
-   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                    this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_read_despite_exposed2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_read_despite_exposed2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read_despite_exposed2.rs:LL:CC
    |
 LL |         let _val = *root2;
    |                    ^^^^^^
    |                    |
-   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                    this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_write1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_write1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
+error: Undefined Behavior: attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
   --> $DIR/illegal_write1.rs:LL:CC
    |
 LL |         unsafe { *x = 42 };
    |                  ^^^^^^^
    |                  |
-   |                  attempting a write access using <TAG> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
+   |                  attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
    |                  this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_write2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_write2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_write2.rs:LL:CC
    |
 LL |     unsafe { *target2 = 13 };
    |              ^^^^^^^^^^^^^
    |              |
-   |              attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |              attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |              this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_write3.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_write3.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
+error: Undefined Behavior: attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
   --> $DIR/illegal_write3.rs:LL:CC
    |
 LL |     unsafe { *ptr = 42 };
    |              ^^^^^^^^^
    |              |
-   |              attempting a write access using <TAG> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
+   |              attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
    |              this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_write4.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_write4.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_write4.rs:LL:CC
    |
 LL |     let _val = *reference;
    |                ^^^^^^^^^^
    |                |
-   |                attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_write5.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_write5.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_write5.rs:LL:CC
    |
 LL |     let _val = *xref;
    |                ^^^^^
    |                |
-   |                attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_write6.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_write6.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG>[0x0..0x4] because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/illegal_write6.rs:LL:CC
    |
 LL |     unsafe { *y = 2 };
-   |              ^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+   |              ^^^^^^ not granting access to tag <TAG>[0x0..0x4] because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_write_despite_exposed1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_write_despite_exposed1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_write_despite_exposed1.rs:LL:CC
    |
 LL |         let _val = *root2;
    |                    ^^^^^^
    |                    |
-   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                    this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/interior_mut1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/interior_mut1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x0..0x4] for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/interior_mut1.rs:LL:CC
    |
 LL |         let _val = *inner_shr.get();
    |                     ^^^^^^^^^^^^^^^
    |                     |
-   |                     trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                     trying to retag from <TAG>[0x0..0x4] for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                     this error occurs as part of retag at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/interior_mut2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/interior_mut2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x0..0x4] for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/interior_mut2.rs:LL:CC
    |
 LL |         let _val = *inner_shr.get();
    |                     ^^^^^^^^^^^^^^^
    |                     |
-   |                     trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                     trying to retag from <TAG>[0x0..0x4] for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                     this error occurs as part of retag at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/invalidate_against_protector1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/invalidate_against_protector1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG>[0x0..0x4] because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/invalidate_against_protector1.rs:LL:CC
    |
 LL |     let _val = unsafe { *x };
-   |                         ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+   |                         ^^ not granting access to tag <TAG>[0x0..0x4] because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/invalidate_against_protector2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/invalidate_against_protector2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG>[0x0..0x4] because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/invalidate_against_protector2.rs:LL:CC
    |
 LL |     unsafe { *x = 0 };
-   |              ^^^^^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+   |              ^^^^^^ not granting access to tag <TAG>[0x0..0x4] because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/invalidate_against_protector3.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/invalidate_against_protector3.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG>[0x0..0x4] because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/invalidate_against_protector3.rs:LL:CC
    |
 LL |     unsafe { *x = 0 };
-   |              ^^^^^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+   |              ^^^^^^ not granting access to tag <TAG>[0x0..0x4] because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/load_invalid_mut.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/load_invalid_mut.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for Unique permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x0..0x4] for Unique permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/load_invalid_mut.rs:LL:CC
    |
 LL |     let _val = *xref_in_mem;
    |                ^^^^^^^^^^^^
    |                |
-   |                trying to retag from <TAG> for Unique permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                trying to retag from <TAG>[0x0..0x4] for Unique permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                this error occurs as part of retag at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/load_invalid_shr.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/load_invalid_shr.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x0..0x4] for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/load_invalid_shr.rs:LL:CC
    |
 LL |     let _val = *xref_in_mem;
    |                ^^^^^^^^^^^^
    |                |
-   |                trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                trying to retag from <TAG>[0x0..0x4] for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                this error occurs as part of retag at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/mut_exclusive_violation1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/mut_exclusive_violation1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/mut_exclusive_violation1.rs:LL:CC
    |
 LL |         *LEAK = 7;
    |         ^^^^^^^^^
    |         |
-   |         attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |         this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/mut_exclusive_violation2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/mut_exclusive_violation2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/mut_exclusive_violation2.rs:LL:CC
    |
 LL |         let _val = *raw1;
    |                    ^^^^^
    |                    |
-   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                    this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/newtype_pair_retagging.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/newtype_pair_retagging.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG>[0x0..0x4] because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
 LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG>[0x0..0x4] because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/newtype_retagging.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/newtype_retagging.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG>[0x0..0x4] because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
 LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG>[0x0..0x4] because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/notunpin_dereferenceable_fakeread.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/notunpin_dereferenceable_fakeread.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/notunpin_dereferenceable_fakeread.rs:LL:CC
    |
 LL |         *fieldref = 0;
    |         ^^^^^^^^^^^^^
    |         |
-   |         attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |         this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/outdated_local.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/outdated_local.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/outdated_local.rs:LL:CC
    |
 LL |     assert_eq!(unsafe { *y }, 1);
    |                         ^^
    |                         |
-   |                         attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                         attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                         this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/pass_invalid_mut.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/pass_invalid_mut.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x0..0x4] for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/pass_invalid_mut.rs:LL:CC
    |
 LL |     foo(xref);
    |         ^^^^
    |         |
-   |         trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         trying to retag from <TAG>[0x0..0x4] for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |         this error occurs as part of two-phase retag at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/pass_invalid_shr.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/pass_invalid_shr.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x0..0x4] for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/pass_invalid_shr.rs:LL:CC
    |
 LL |     foo(xref);
    |         ^^^^
    |         |
-   |         trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         trying to retag from <TAG>[0x0..0x4] for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |         this error occurs as part of retag at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/pointer_smuggling.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/pointer_smuggling.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x1] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/pointer_smuggling.rs:LL:CC
    |
 LL |     let _x = unsafe { *PTR };
    |                       ^^^^
    |                       |
-   |                       attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                       attempting a read access using <TAG>[0x0..0x1] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                       this error occurs as part of an access at ALLOC[0x0..0x1]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/raw_tracking.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/raw_tracking.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/raw_tracking.rs:LL:CC
    |
 LL |     unsafe { *raw1 = 13 };
    |              ^^^^^^^^^^
    |              |
-   |              attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |              attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |              this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/return_invalid_mut.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/return_invalid_mut.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x4..0x8] for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
   --> $DIR/return_invalid_mut.rs:LL:CC
    |
 LL |     ret
    |     ^^^
    |     |
-   |     trying to retag from <TAG> for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+   |     trying to retag from <TAG>[0x4..0x8] for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
    |     this error occurs as part of retag at ALLOC[0x4..0x8]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/return_invalid_mut_option.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/return_invalid_mut_option.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x4..0x8] for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
   --> $DIR/return_invalid_mut_option.rs:LL:CC
    |
 LL |     ret
    |     ^^^
    |     |
-   |     trying to retag from <TAG> for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+   |     trying to retag from <TAG>[0x4..0x8] for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
    |     this error occurs as part of retag at ALLOC[0x4..0x8]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/return_invalid_mut_tuple.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/return_invalid_mut_tuple.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x4..0x8] for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
   --> $DIR/return_invalid_mut_tuple.rs:LL:CC
    |
 LL |     ret
    |     ^^^
    |     |
-   |     trying to retag from <TAG> for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+   |     trying to retag from <TAG>[0x4..0x8] for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
    |     this error occurs as part of retag at ALLOC[0x4..0x8]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/return_invalid_shr.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/return_invalid_shr.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x4..0x8] for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
   --> $DIR/return_invalid_shr.rs:LL:CC
    |
 LL |     ret
    |     ^^^
    |     |
-   |     trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+   |     trying to retag from <TAG>[0x4..0x8] for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
    |     this error occurs as part of retag at ALLOC[0x4..0x8]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/return_invalid_shr_option.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/return_invalid_shr_option.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x4..0x8] for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
   --> $DIR/return_invalid_shr_option.rs:LL:CC
    |
 LL |     ret
    |     ^^^
    |     |
-   |     trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+   |     trying to retag from <TAG>[0x4..0x8] for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
    |     this error occurs as part of retag at ALLOC[0x4..0x8]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/return_invalid_shr_tuple.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/return_invalid_shr_tuple.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x4..0x8] for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
   --> $DIR/return_invalid_shr_tuple.rs:LL:CC
    |
 LL |     ret
    |     ^^^
    |     |
-   |     trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+   |     trying to retag from <TAG>[0x4..0x8] for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
    |     this error occurs as part of retag at ALLOC[0x4..0x8]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x0..0x4] for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/shared_rw_borrows_are_weak1.rs:LL:CC
    |
 LL |         y.get_mut();
    |         ^^^^^^^^^^^
    |         |
-   |         trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         trying to retag from <TAG>[0x0..0x4] for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |         this error occurs as part of two-phase retag at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[$HEX], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[$HEX..$HEX] at ALLOC[$HEX], but that tag does not exist in the borrow stack for this location
   --> $DIR/shared_rw_borrows_are_weak2.rs:LL:CC
    |
 LL |         let _val = *y;
    |                    ^^
    |                    |
-   |                    attempting a read access using <TAG> at ALLOC[$HEX], but that tag does not exist in the borrow stack for this location
+   |                    attempting a read access using <TAG>[$HEX..$HEX] at ALLOC[$HEX], but that tag does not exist in the borrow stack for this location
    |                    this error occurs as part of an access at ALLOC[$HEX..$HEX]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/shr_frozen_violation1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/shr_frozen_violation1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
+error: Undefined Behavior: attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
   --> $DIR/shr_frozen_violation1.rs:LL:CC
    |
 LL |         *(x as *const i32 as *mut i32) = 7;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         attempting a write access using <TAG> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
+   |         attempting a write access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
    |         this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/track_caller.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/track_caller.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/track_caller.rs:LL:CC
    |
 LL |     let _val = *xref; // ...but any use of raw will invalidate our ref.
    |                ^^^^^
    |                |
-   |                attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                attempting a read access using <TAG>[0x0..0x4] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/transmute-is-no-escape.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/transmute-is-no-escape.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a write access using <TAG>[0x0..0x8] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/transmute-is-no-escape.rs:LL:CC
    |
 LL |     unsafe { *raw = 13 };
    |              ^^^^^^^^^
    |              |
-   |              attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |              attempting a write access using <TAG>[0x0..0x8] at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |              this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/unescaped_static.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/unescaped_static.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x1], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a read access using <TAG>[0x0..0x2] at ALLOC[0x1], but that tag does not exist in the borrow stack for this location
   --> $DIR/unescaped_static.rs:LL:CC
    |
 LL |     let _val = unsafe { *ptr_to_first.add(1) };
    |                         ^^^^^^^^^^^^^^^^^^^^
    |                         |
-   |                         attempting a read access using <TAG> at ALLOC[0x1], but that tag does not exist in the borrow stack for this location
+   |                         attempting a read access using <TAG>[0x0..0x2] at ALLOC[0x1], but that tag does not exist in the borrow stack for this location
    |                         this error occurs as part of an access at ALLOC[0x1..0x2]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/stacked_borrows/zst_slice.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/zst_slice.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: trying to retag from <TAG>[0x0..0xc] for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
   --> RUSTLIB/core/src/slice/mod.rs:LL:CC
    |
 LL |         unsafe { &*index.get_unchecked(self) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                  |
-   |                  trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
+   |                  trying to retag from <TAG>[0x0..0xc] for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
    |                  this error occurs as part of retag at ALLOC[0x4..0x8]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/src/tools/miri/tests/fail/uninit_buffer_with_provenance.stderr
+++ b/src/tools/miri/tests/fail/uninit_buffer_with_provenance.stderr
@@ -19,7 +19,7 @@ note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a
 
 Uninitialized memory occurred at ALLOC[0x4..0x8], in this allocation:
 ALLOC (Rust heap, size: 16, align: 8) {
-    ╾42[ALLOC]<TAG> (1 ptr byte)╼ 12 13 ╾43[ALLOC]<TAG> (1 ptr byte)╼ __ __ __ __ __ __ __ __ __ __ __ __ │ ━..━░░░░░░░░░░░░
+    ╾42[ALLOC]<TAG>[$HEX..$HEX] (1 ptr byte)╼ 12 13 ╾43[ALLOC]<TAG>[$HEX..$HEX] (1 ptr byte)╼ __ __ __ __ __ __ __ __ __ __ __ __ │ ━..━░░░░░░░░░░░░
 }
 ALLOC (global (static or const), size: 1, align: 1) {
     2a                                              │ *


### PR DESCRIPTION
This is an experiment to have miri disallow accessing one struct field using a pointer to another.
See the test `src/tools/miri/tests/fail/field-access.rs`

The idea is to annotate each `PlaceElem::Field` with a `ProjectionMode`.  `ProjectionMode` has 2 possible values:
- `ProjectionMode::Weak`: the projected place has the same provenance;
- `ProjectionMode::Strong`: the projected place cannot be used to access memory outside of the field.

The provenance for miri is completed to have the byte range of allowed access.
(There is probably a better way to encode this than directly in `Provenance::Concrete`.)

The main knob is `compiler/rustc_mir_build/src/build/expr/as_place.rs`, to chose when we put a `Strong`/`Weak` mode.
This draft puts as much `Strong` as for the demonstration.

cc @RalfJung 