### PR TITLE
Don't call `diagnostic_hir_wf_check` query if we have infer variables

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -555,6 +555,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 // can get a better error message by performing HIR-based well-formedness checking.
                 if let ObligationCauseCode::WellFormed(Some(wf_loc)) =
                     root_obligation.cause.code().peel_derives()
+                    && !obligation.predicate.has_non_region_infer()
                 {
                     if let Some(cause) = self
                         .tcx

--- a/src/test/ui/wf/hir-wf-canonicalized.rs
+++ b/src/test/ui/wf/hir-wf-canonicalized.rs
@@ -1,0 +1,18 @@
+// incremental
+
+trait Foo {
+    type V;
+}
+
+trait Callback<T: Foo>: Fn(&Bar<'_, T>, &T::V) {}
+
+struct Bar<'a, T> {
+    callback: Box<dyn Callback<dyn Callback<Bar<'a, T>>>>,
+    //~^ ERROR the trait bound `Bar<'a, T>: Foo` is not satisfied
+    //~| ERROR the trait bound `(dyn Callback<Bar<'a, T>, for<'b, 'c, 'd> Output = ()> + 'static): Foo` is not satisfied
+    //~| ERROR the size for values of type `(dyn Callback<Bar<'a, T>, for<'b, 'c, 'd> Output = ()> + 'static)` cannot be known at compilation time
+}
+
+impl<T: Foo> Bar<'_, Bar<'_, T>> {}
+
+fn main() {}

--- a/src/test/ui/wf/hir-wf-canonicalized.stderr
+++ b/src/test/ui/wf/hir-wf-canonicalized.stderr
@@ -1,0 +1,32 @@
+error[E0277]: the trait bound `Bar<'a, T>: Foo` is not satisfied
+  --> $DIR/hir-wf-canonicalized.rs:10:15
+   |
+LL |     callback: Box<dyn Callback<dyn Callback<Bar<'a, T>>>>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `Bar<'a, T>`
+
+error[E0277]: the trait bound `(dyn Callback<Bar<'a, T>, for<'b, 'c, 'd> Output = ()> + 'static): Foo` is not satisfied
+  --> $DIR/hir-wf-canonicalized.rs:10:15
+   |
+LL |     callback: Box<dyn Callback<dyn Callback<Bar<'a, T>>>>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `(dyn Callback<Bar<'a, T>, for<'b, 'c, 'd> Output = ()> + 'static)`
+
+error[E0277]: the size for values of type `(dyn Callback<Bar<'a, T>, for<'b, 'c, 'd> Output = ()> + 'static)` cannot be known at compilation time
+  --> $DIR/hir-wf-canonicalized.rs:10:15
+   |
+LL |     callback: Box<dyn Callback<dyn Callback<Bar<'a, T>>>>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Callback<Bar<'a, T>, for<'b, 'c, 'd> Output = ()> + 'static)`
+note: required by a bound in `Bar`
+  --> $DIR/hir-wf-canonicalized.rs:9:16
+   |
+LL | struct Bar<'a, T> {
+   |                ^ required by this bound in `Bar`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | struct Bar<'a, T: ?Sized> {
+   |                 ++++++++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #105260