### PR TITLE
Normalize inherent associated types after substitution

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -1930,6 +1930,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     adt_substs,
                 );
                 let ty = tcx.bound_type_of(assoc_ty_did).subst(tcx, item_substs);
+                let ty = self.normalize_ty(span, ty);
                 return Ok((ty, DefKind::AssocTy, assoc_ty_did));
             }
         }

--- a/src/test/ui/associated-inherent-types/normalize-projection-0.rs
+++ b/src/test/ui/associated-inherent-types/normalize-projection-0.rs
@@ -1,0 +1,22 @@
+// check-pass
+
+#![feature(inherent_associated_types)]
+#![allow(incomplete_features)]
+
+struct S<T>(T);
+
+impl<T: O> S<T> {
+    type P = <T as O>::P;
+}
+
+trait O {
+    type P;
+}
+
+impl O for i32 {
+    type P = String;
+}
+
+fn main() {
+    let _: S<i32>::P = String::new();
+}

--- a/src/test/ui/associated-inherent-types/normalize-projection-1.rs
+++ b/src/test/ui/associated-inherent-types/normalize-projection-1.rs
@@ -1,0 +1,22 @@
+// check-pass
+
+#![feature(inherent_associated_types)]
+#![allow(incomplete_features)]
+
+struct S;
+
+impl S {
+    type P<T: O> = <T as O>::P;
+}
+
+trait O {
+    type P;
+}
+
+impl O for i32 {
+    type P = String;
+}
+
+fn main() {
+    let _: S::P<i32> = String::new();
+}


### PR DESCRIPTION
Fixes #105314.

r? @cjgillot (#105224)
@rustbot label F-inherent_associated_types