### PR TITLE
Perform SimplifyLocals before ConstProp.

### DIFF
--- a/compiler/rustc_mir_transform/src/dead_store_elimination.rs
+++ b/compiler/rustc_mir_transform/src/dead_store_elimination.rs
@@ -71,7 +71,7 @@ pub fn eliminate<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>, borrowed: &BitS
         bbs[block].statements[statement_index].make_nop();
     }
 
-    crate::simplify::SimplifyLocals.run_pass(tcx, body)
+    crate::simplify::simplify_locals(body, tcx)
 }
 
 pub struct DeadStoreElimination;

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -560,6 +560,7 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             &multiple_return_terminators::MultipleReturnTerminators,
             &instcombine::InstCombine,
             &separate_const_switch::SeparateConstSwitch,
+            &simplify::SimplifyLocals::new("before-const-prop"),
             //
             // FIXME(#70073): This pass is responsible for both optimization as well as some lints.
             &const_prop::ConstProp,
@@ -578,7 +579,7 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             &o1(remove_noop_landing_pads::RemoveNoopLandingPads),
             &o1(simplify::SimplifyCfg::new("final")),
             &nrvo::RenameReturnPlace,
-            &simplify::SimplifyLocals,
+            &simplify::SimplifyLocals::new("final"),
             &multiple_return_terminators::MultipleReturnTerminators,
             &deduplicate_blocks::DeduplicateBlocks,
             // Some cleanup necessary at least for LLVM and potentially other codegen backends.

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -569,6 +569,7 @@ fn remove_unused_definitions(used_locals: &mut UsedLocals, body: &mut Body<'_>) 
 
                     StatementKind::SetDiscriminant { ref place, .. }
                     | StatementKind::Deinit(ref place) => used_locals.is_used(place.local),
+                    StatementKind::Nop => false,
                     _ => true,
                 };
 

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -379,9 +379,21 @@ fn save_unreachable_coverage(
     ));
 }
 
-pub struct SimplifyLocals;
+pub struct SimplifyLocals {
+    label: String,
+}
+
+impl SimplifyLocals {
+    pub fn new(label: &str) -> SimplifyLocals {
+        SimplifyLocals { label: format!("SimplifyLocals-{}", label) }
+    }
+}
 
 impl<'tcx> MirPass<'tcx> for SimplifyLocals {
+    fn name(&self) -> &str {
+        &self.label
+    }
+
     fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
         sess.mir_opt_level() > 0
     }

--- a/src/test/codegen/zst-offset.rs
+++ b/src/test/codegen/zst-offset.rs
@@ -15,7 +15,7 @@ pub fn helper(_: usize) {
 pub fn scalar_layout(s: &(u64, ())) {
 // CHECK: getelementptr i8, {{.+}}, [[USIZE]] 8
     let x = &s.1;
-    &x; // keep variable in an alloca
+    witness(&x); // keep variable in an alloca
 }
 
 // Check that we correctly generate a GEP for a ZST that is not included in ScalarPair layout
@@ -24,7 +24,7 @@ pub fn scalar_layout(s: &(u64, ())) {
 pub fn scalarpair_layout(s: &(u64, u32, ())) {
 // CHECK: getelementptr i8, {{.+}}, [[USIZE]] 12
     let x = &s.2;
-    &x; // keep variable in an alloca
+    witness(&x); // keep variable in an alloca
 }
 
 #[repr(simd)]
@@ -36,5 +36,8 @@ pub struct U64x4(u64, u64, u64, u64);
 pub fn vector_layout(s: &(U64x4, ())) {
 // CHECK: getelementptr i8, {{.+}}, [[USIZE]] 32
     let x = &s.1;
-    &x; // keep variable in an alloca
+    witness(&x); // keep variable in an alloca
 }
+
+#[inline(never)]
+fn witness(_: &impl Sized) {}

--- a/src/test/incremental/hashes/closure_expressions.rs
+++ b/src/test/incremental/hashes/closure_expressions.rs
@@ -45,9 +45,9 @@ pub fn add_parameter() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes, typeck")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, typeck")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_parameter() {
     let x = 0u32;

--- a/src/test/mir-opt/const_allocation.main.ConstProp.after.32bit.mir
+++ b/src/test/mir-opt/const_allocation.main.ConstProp.after.32bit.mir
@@ -10,12 +10,12 @@ fn main() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
         _2 = const {alloc1: &&[(Option<i32>, &[&str])]}; // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
                                          // mir::Constant
-                                         // + span: $DIR/const_allocation.rs:8:5: 8:8
+                                         // + span: $DIR/const_allocation.rs:9:5: 9:8
                                          // + literal: Const { ty: &&[(Option<i32>, &[&str])], val: Value(Scalar(alloc1)) }
         _1 = (*_2);                      // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation.rs:+1:8: +1:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation.rs:+1:8: +1:9
-        nop;                             // scope 0 at $DIR/const_allocation.rs:+0:11: +2:2
+        _0 = const ();                   // scope 0 at $DIR/const_allocation.rs:+0:11: +2:2
         return;                          // scope 0 at $DIR/const_allocation.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/const_allocation.main.ConstProp.after.64bit.mir
+++ b/src/test/mir-opt/const_allocation.main.ConstProp.after.64bit.mir
@@ -10,12 +10,12 @@ fn main() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
         _2 = const {alloc1: &&[(Option<i32>, &[&str])]}; // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
                                          // mir::Constant
-                                         // + span: $DIR/const_allocation.rs:8:5: 8:8
+                                         // + span: $DIR/const_allocation.rs:9:5: 9:8
                                          // + literal: Const { ty: &&[(Option<i32>, &[&str])], val: Value(Scalar(alloc1)) }
         _1 = (*_2);                      // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation.rs:+1:8: +1:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation.rs:+1:8: +1:9
-        nop;                             // scope 0 at $DIR/const_allocation.rs:+0:11: +2:2
+        _0 = const ();                   // scope 0 at $DIR/const_allocation.rs:+0:11: +2:2
         return;                          // scope 0 at $DIR/const_allocation.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/const_allocation.rs
+++ b/src/test/mir-opt/const_allocation.rs
@@ -1,3 +1,4 @@
+// unit-test: ConstProp
 // ignore-endian-big
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 static FOO: &[(Option<i32>, &[&str])] =

--- a/src/test/mir-opt/const_allocation2.main.ConstProp.after.32bit.mir
+++ b/src/test/mir-opt/const_allocation2.main.ConstProp.after.32bit.mir
@@ -10,12 +10,12 @@ fn main() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
         _2 = const {alloc1: &&[(Option<i32>, &[&u8])]}; // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
                                          // mir::Constant
-                                         // + span: $DIR/const_allocation2.rs:5:5: 5:8
+                                         // + span: $DIR/const_allocation2.rs:6:5: 6:8
                                          // + literal: Const { ty: &&[(Option<i32>, &[&u8])], val: Value(Scalar(alloc1)) }
         _1 = (*_2);                      // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation2.rs:+1:8: +1:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation2.rs:+1:8: +1:9
-        nop;                             // scope 0 at $DIR/const_allocation2.rs:+0:11: +2:2
+        _0 = const ();                   // scope 0 at $DIR/const_allocation2.rs:+0:11: +2:2
         return;                          // scope 0 at $DIR/const_allocation2.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/const_allocation2.main.ConstProp.after.64bit.mir
+++ b/src/test/mir-opt/const_allocation2.main.ConstProp.after.64bit.mir
@@ -10,12 +10,12 @@ fn main() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
         _2 = const {alloc1: &&[(Option<i32>, &[&u8])]}; // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
                                          // mir::Constant
-                                         // + span: $DIR/const_allocation2.rs:5:5: 5:8
+                                         // + span: $DIR/const_allocation2.rs:6:5: 6:8
                                          // + literal: Const { ty: &&[(Option<i32>, &[&u8])], val: Value(Scalar(alloc1)) }
         _1 = (*_2);                      // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation2.rs:+1:8: +1:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation2.rs:+1:8: +1:9
-        nop;                             // scope 0 at $DIR/const_allocation2.rs:+0:11: +2:2
+        _0 = const ();                   // scope 0 at $DIR/const_allocation2.rs:+0:11: +2:2
         return;                          // scope 0 at $DIR/const_allocation2.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/const_allocation2.rs
+++ b/src/test/mir-opt/const_allocation2.rs
@@ -1,3 +1,4 @@
+// unit-test: ConstProp
 // ignore-endian-big
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR const_allocation2.main.ConstProp.after.mir

--- a/src/test/mir-opt/const_allocation3.main.ConstProp.after.32bit.mir
+++ b/src/test/mir-opt/const_allocation3.main.ConstProp.after.32bit.mir
@@ -10,12 +10,12 @@ fn main() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
         _2 = const {alloc1: &&Packed};   // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
                                          // mir::Constant
-                                         // + span: $DIR/const_allocation3.rs:5:5: 5:8
+                                         // + span: $DIR/const_allocation3.rs:6:5: 6:8
                                          // + literal: Const { ty: &&Packed, val: Value(Scalar(alloc1)) }
         _1 = (*_2);                      // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation3.rs:+1:8: +1:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation3.rs:+1:8: +1:9
-        nop;                             // scope 0 at $DIR/const_allocation3.rs:+0:11: +2:2
+        _0 = const ();                   // scope 0 at $DIR/const_allocation3.rs:+0:11: +2:2
         return;                          // scope 0 at $DIR/const_allocation3.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/const_allocation3.main.ConstProp.after.64bit.mir
+++ b/src/test/mir-opt/const_allocation3.main.ConstProp.after.64bit.mir
@@ -10,12 +10,12 @@ fn main() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
         _2 = const {alloc1: &&Packed};   // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
                                          // mir::Constant
-                                         // + span: $DIR/const_allocation3.rs:5:5: 5:8
+                                         // + span: $DIR/const_allocation3.rs:6:5: 6:8
                                          // + literal: Const { ty: &&Packed, val: Value(Scalar(alloc1)) }
         _1 = (*_2);                      // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation3.rs:+1:8: +1:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation3.rs:+1:8: +1:9
-        nop;                             // scope 0 at $DIR/const_allocation3.rs:+0:11: +2:2
+        _0 = const ();                   // scope 0 at $DIR/const_allocation3.rs:+0:11: +2:2
         return;                          // scope 0 at $DIR/const_allocation3.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/const_allocation3.rs
+++ b/src/test/mir-opt/const_allocation3.rs
@@ -1,3 +1,4 @@
+// unit-test: ConstProp
 // ignore-endian-big
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR const_allocation3.main.ConstProp.after.mir

--- a/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -8,8 +8,8 @@
       let mut _6: u8;                      // in scope 0 at $DIR/const_debuginfo.rs:+4:15: +4:16
       let mut _7: u8;                      // in scope 0 at $DIR/const_debuginfo.rs:+4:19: +4:20
       let mut _8: u8;                      // in scope 0 at $DIR/const_debuginfo.rs:+4:23: +4:24
-      let mut _14: u32;                    // in scope 0 at $DIR/const_debuginfo.rs:+13:13: +13:16
-      let mut _15: u32;                    // in scope 0 at $DIR/const_debuginfo.rs:+13:19: +13:22
+      let mut _12: u32;                    // in scope 0 at $DIR/const_debuginfo.rs:+13:13: +13:16
+      let mut _13: u32;                    // in scope 0 at $DIR/const_debuginfo.rs:+13:19: +13:22
       scope 1 {
 -         debug x => _1;                   // in scope 1 at $DIR/const_debuginfo.rs:+1:9: +1:10
 +         debug x => const 1_u8;           // in scope 1 at $DIR/const_debuginfo.rs:+1:9: +1:10
@@ -29,23 +29,21 @@
                       scope 5 {
 -                         debug s => _9;   // in scope 5 at $DIR/const_debuginfo.rs:+6:9: +6:10
 +                         debug s => const "hello, world!"; // in scope 5 at $DIR/const_debuginfo.rs:+6:9: +6:10
-                          let _10: (bool, bool, u32); // in scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
-                          let _16: bool;   // in scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
-                          let _17: bool;   // in scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
-                          let _18: u32;    // in scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
+                          let _14: bool;   // in scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
+                          let _15: bool;   // in scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
+                          let _16: u32;    // in scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
                           scope 6 {
-                              debug f => (bool, bool, u32){ .0 => _16, .1 => _17, .2 => _18, }; // in scope 6 at $DIR/const_debuginfo.rs:+8:9: +8:10
-                              let _11: std::option::Option<u16>; // in scope 6 at $DIR/const_debuginfo.rs:+10:9: +10:10
+                              debug f => (bool, bool, u32){ .0 => _14, .1 => _15, .2 => _16, }; // in scope 6 at $DIR/const_debuginfo.rs:+8:9: +8:10
+                              let _10: std::option::Option<u16>; // in scope 6 at $DIR/const_debuginfo.rs:+10:9: +10:10
                               scope 7 {
-                                  debug o => _11; // in scope 7 at $DIR/const_debuginfo.rs:+10:9: +10:10
-                                  let _12: Point; // in scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10
-                                  let _19: u32; // in scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10
-                                  let _20: u32; // in scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10
+                                  debug o => _10; // in scope 7 at $DIR/const_debuginfo.rs:+10:9: +10:10
+                                  let _17: u32; // in scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10
+                                  let _18: u32; // in scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10
                                   scope 8 {
-                                      debug p => Point{ .0 => _19, .1 => _20, }; // in scope 8 at $DIR/const_debuginfo.rs:+12:9: +12:10
-                                      let _13: u32; // in scope 8 at $DIR/const_debuginfo.rs:+13:9: +13:10
+                                      debug p => Point{ .0 => _17, .1 => _18, }; // in scope 8 at $DIR/const_debuginfo.rs:+12:9: +12:10
+                                      let _11: u32; // in scope 8 at $DIR/const_debuginfo.rs:+13:9: +13:10
                                       scope 9 {
--                                         debug a => _13; // in scope 9 at $DIR/const_debuginfo.rs:+13:9: +13:10
+-                                         debug a => _11; // in scope 9 at $DIR/const_debuginfo.rs:+13:9: +13:10
 +                                         debug a => const 64_u32; // in scope 9 at $DIR/const_debuginfo.rs:+13:9: +13:10
                                       }
                                   }
@@ -83,41 +81,41 @@
                                            // mir::Constant
                                            // + span: $DIR/const_debuginfo.rs:14:13: 14:28
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
+          StorageLive(_14);                // scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
+          StorageLive(_15);                // scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
           StorageLive(_16);                // scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
-          StorageLive(_17);                // scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
-          StorageLive(_18);                // scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
+          Deinit(_14);                     // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
+          Deinit(_15);                     // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
           Deinit(_16);                     // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
-          Deinit(_17);                     // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
-          Deinit(_18);                     // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
-          _16 = const true;                // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
-          _17 = const false;               // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
-          _18 = const 123_u32;             // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
-          StorageLive(_11);                // scope 6 at $DIR/const_debuginfo.rs:+10:9: +10:10
-          Deinit(_11);                     // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
-          ((_11 as Some).0: u16) = const 99_u16; // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
-          discriminant(_11) = 1;           // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
-          StorageLive(_19);                // scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10
-          StorageLive(_20);                // scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10
-          Deinit(_19);                     // scope 7 at $DIR/const_debuginfo.rs:+12:13: +12:35
-          Deinit(_20);                     // scope 7 at $DIR/const_debuginfo.rs:+12:13: +12:35
-          _19 = const 32_u32;              // scope 7 at $DIR/const_debuginfo.rs:+12:13: +12:35
-          _20 = const 32_u32;              // scope 7 at $DIR/const_debuginfo.rs:+12:13: +12:35
-          StorageLive(_13);                // scope 8 at $DIR/const_debuginfo.rs:+13:9: +13:10
-          StorageLive(_14);                // scope 8 at $DIR/const_debuginfo.rs:+13:13: +13:16
-          _14 = const 32_u32;              // scope 8 at $DIR/const_debuginfo.rs:+13:13: +13:16
-          StorageLive(_15);                // scope 8 at $DIR/const_debuginfo.rs:+13:19: +13:22
-          _15 = const 32_u32;              // scope 8 at $DIR/const_debuginfo.rs:+13:19: +13:22
-          _13 = const 64_u32;              // scope 8 at $DIR/const_debuginfo.rs:+13:13: +13:22
-          StorageDead(_15);                // scope 8 at $DIR/const_debuginfo.rs:+13:21: +13:22
-          StorageDead(_14);                // scope 8 at $DIR/const_debuginfo.rs:+13:21: +13:22
+          _14 = const true;                // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
+          _15 = const false;               // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
+          _16 = const 123_u32;             // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
+          StorageLive(_10);                // scope 6 at $DIR/const_debuginfo.rs:+10:9: +10:10
+          Deinit(_10);                     // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
+          ((_10 as Some).0: u16) = const 99_u16; // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
+          discriminant(_10) = 1;           // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
+          StorageLive(_17);                // scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10
+          StorageLive(_18);                // scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10
+          Deinit(_17);                     // scope 7 at $DIR/const_debuginfo.rs:+12:13: +12:35
+          Deinit(_18);                     // scope 7 at $DIR/const_debuginfo.rs:+12:13: +12:35
+          _17 = const 32_u32;              // scope 7 at $DIR/const_debuginfo.rs:+12:13: +12:35
+          _18 = const 32_u32;              // scope 7 at $DIR/const_debuginfo.rs:+12:13: +12:35
+          StorageLive(_11);                // scope 8 at $DIR/const_debuginfo.rs:+13:9: +13:10
+          StorageLive(_12);                // scope 8 at $DIR/const_debuginfo.rs:+13:13: +13:16
+          _12 = const 32_u32;              // scope 8 at $DIR/const_debuginfo.rs:+13:13: +13:16
+          StorageLive(_13);                // scope 8 at $DIR/const_debuginfo.rs:+13:19: +13:22
+          _13 = const 32_u32;              // scope 8 at $DIR/const_debuginfo.rs:+13:19: +13:22
+          _11 = const 64_u32;              // scope 8 at $DIR/const_debuginfo.rs:+13:13: +13:22
+          StorageDead(_13);                // scope 8 at $DIR/const_debuginfo.rs:+13:21: +13:22
+          StorageDead(_12);                // scope 8 at $DIR/const_debuginfo.rs:+13:21: +13:22
           nop;                             // scope 0 at $DIR/const_debuginfo.rs:+0:11: +14:2
-          StorageDead(_13);                // scope 8 at $DIR/const_debuginfo.rs:+14:1: +14:2
-          StorageDead(_19);                // scope 7 at $DIR/const_debuginfo.rs:+14:1: +14:2
-          StorageDead(_20);                // scope 7 at $DIR/const_debuginfo.rs:+14:1: +14:2
-          StorageDead(_11);                // scope 6 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_11);                // scope 8 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_17);                // scope 7 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_18);                // scope 7 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_10);                // scope 6 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_14);                // scope 5 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_15);                // scope 5 at $DIR/const_debuginfo.rs:+14:1: +14:2
           StorageDead(_16);                // scope 5 at $DIR/const_debuginfo.rs:+14:1: +14:2
-          StorageDead(_17);                // scope 5 at $DIR/const_debuginfo.rs:+14:1: +14:2
-          StorageDead(_18);                // scope 5 at $DIR/const_debuginfo.rs:+14:1: +14:2
           StorageDead(_9);                 // scope 4 at $DIR/const_debuginfo.rs:+14:1: +14:2
           StorageDead(_4);                 // scope 3 at $DIR/const_debuginfo.rs:+14:1: +14:2
           StorageDead(_3);                 // scope 2 at $DIR/const_debuginfo.rs:+14:1: +14:2

--- a/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -108,7 +108,6 @@
           _11 = const 64_u32;              // scope 8 at $DIR/const_debuginfo.rs:+13:13: +13:22
           StorageDead(_13);                // scope 8 at $DIR/const_debuginfo.rs:+13:21: +13:22
           StorageDead(_12);                // scope 8 at $DIR/const_debuginfo.rs:+13:21: +13:22
-          nop;                             // scope 0 at $DIR/const_debuginfo.rs:+0:11: +14:2
           StorageDead(_11);                // scope 8 at $DIR/const_debuginfo.rs:+14:1: +14:2
           StorageDead(_17);                // scope 7 at $DIR/const_debuginfo.rs:+14:1: +14:2
           StorageDead(_18);                // scope 7 at $DIR/const_debuginfo.rs:+14:1: +14:2

--- a/src/test/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
@@ -45,7 +45,6 @@
 -         _2 = Rem(const 1_i32, move _3);  // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
 +         _2 = Rem(const 1_i32, const 0_i32); // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
           StorageDead(_3);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:18: +2:19
-          nop;                             // scope 0 at $DIR/bad_op_mod_by_zero.rs:+0:11: +3:2
           StorageDead(_2);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:+3:1: +3:2
           StorageDead(_1);                 // scope 0 at $DIR/bad_op_mod_by_zero.rs:+3:1: +3:2
           return;                          // scope 0 at $DIR/bad_op_mod_by_zero.rs:+3:2: +3:2

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
@@ -6,17 +6,16 @@
       let _1: *const [i32];                // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:9: +1:10
       let mut _2: *const [i32; 3];         // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
       let _3: &[i32; 3];                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
-      let _4: [i32; 3];                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:26: +1:35
-      let _6: usize;                       // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
-      let mut _7: usize;                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
-      let mut _8: bool;                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
-      let mut _9: &[i32; 3];               // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+      let _5: usize;                       // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
+      let mut _6: usize;                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+      let mut _7: bool;                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+      let mut _8: &[i32; 3];               // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
       scope 1 {
           debug a => _1;                   // in scope 1 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:9: +1:10
           scope 2 {
-              let _5: i32;                 // in scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
+              let _4: i32;                 // in scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
               scope 3 {
-                  debug _b => _5;          // in scope 3 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
+                  debug _b => _4;          // in scope 3 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
               }
           }
       }
@@ -25,30 +24,30 @@
           StorageLive(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:9: +1:10
           StorageLive(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           StorageLive(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
-          _9 = const _;                    // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          _8 = const _;                    // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
                                            // mir::Constant
                                            // + span: $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
                                            // + literal: Const { ty: &[i32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
-          _3 = _9;                         // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          _3 = _8;                         // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           _2 = &raw const (*_3);           // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           _1 = move _2 as *const [i32] (Pointer(Unsize)); // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           StorageDead(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:34: +1:35
           StorageDead(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:35: +1:36
-          StorageLive(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
-          StorageLive(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
-          _6 = const 3_usize;              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
-          _7 = Len((*_1));                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
--         _8 = Lt(_6, _7);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
-+         _8 = Lt(const 3_usize, _7);      // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
-+         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+          StorageLive(_4);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
+          StorageLive(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
+          _5 = const 3_usize;              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
+          _6 = Len((*_1));                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+-         _7 = Lt(_5, _6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+-         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
++         _7 = Lt(const 3_usize, _6);      // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
++         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
       }
   
       bb1: {
-          _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
-          StorageDead(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:25: +3:26
+          _4 = (*_1)[_5];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+          StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:25: +3:26
           nop;                             // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+2:5: +4:6
-          StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+4:5: +4:6
+          StorageDead(_4);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+4:5: +4:6
           StorageDead(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+5:1: +5:2
           return;                          // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+5:2: +5:2
       }

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
@@ -46,7 +46,6 @@
       bb1: {
           _4 = (*_1)[_5];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
           StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:25: +3:26
-          nop;                             // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+2:5: +4:6
           StorageDead(_4);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+4:5: +4:6
           StorageDead(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+5:1: +5:2
           return;                          // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+5:2: +5:2

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
@@ -6,17 +6,16 @@
       let _1: *const [i32];                // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:9: +1:10
       let mut _2: *const [i32; 3];         // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
       let _3: &[i32; 3];                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
-      let _4: [i32; 3];                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:26: +1:35
-      let _6: usize;                       // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
-      let mut _7: usize;                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
-      let mut _8: bool;                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
-      let mut _9: &[i32; 3];               // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+      let _5: usize;                       // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
+      let mut _6: usize;                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+      let mut _7: bool;                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+      let mut _8: &[i32; 3];               // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
       scope 1 {
           debug a => _1;                   // in scope 1 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:9: +1:10
           scope 2 {
-              let _5: i32;                 // in scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
+              let _4: i32;                 // in scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
               scope 3 {
-                  debug _b => _5;          // in scope 3 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
+                  debug _b => _4;          // in scope 3 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
               }
           }
       }
@@ -25,30 +24,30 @@
           StorageLive(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:9: +1:10
           StorageLive(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           StorageLive(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
-          _9 = const _;                    // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          _8 = const _;                    // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
                                            // mir::Constant
                                            // + span: $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
                                            // + literal: Const { ty: &[i32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
-          _3 = _9;                         // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          _3 = _8;                         // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           _2 = &raw const (*_3);           // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           _1 = move _2 as *const [i32] (Pointer(Unsize)); // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           StorageDead(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:34: +1:35
           StorageDead(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:35: +1:36
-          StorageLive(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
-          StorageLive(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
-          _6 = const 3_usize;              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
-          _7 = Len((*_1));                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
--         _8 = Lt(_6, _7);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
-+         _8 = Lt(const 3_usize, _7);      // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
-+         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+          StorageLive(_4);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
+          StorageLive(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
+          _5 = const 3_usize;              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
+          _6 = Len((*_1));                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+-         _7 = Lt(_5, _6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+-         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
++         _7 = Lt(const 3_usize, _6);      // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
++         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
       }
   
       bb1: {
-          _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
-          StorageDead(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:25: +3:26
+          _4 = (*_1)[_5];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+          StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:25: +3:26
           nop;                             // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+2:5: +4:6
-          StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+4:5: +4:6
+          StorageDead(_4);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+4:5: +4:6
           StorageDead(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+5:1: +5:2
           return;                          // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+5:2: +5:2
       }

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
@@ -46,7 +46,6 @@
       bb1: {
           _4 = (*_1)[_5];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
           StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:25: +3:26
-          nop;                             // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+2:5: +4:6
           StorageDead(_4);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+4:5: +4:6
           StorageDead(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+5:1: +5:2
           return;                          // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+5:2: +5:2

--- a/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
@@ -25,7 +25,6 @@
       }
   
       bb2: {
-          nop;                             // scope 0 at $DIR/control_flow_simplification.rs:+3:6: +3:6
           StorageDead(_1);                 // scope 0 at $DIR/control_flow_simplification.rs:+3:5: +3:6
           return;                          // scope 0 at $DIR/control_flow_simplification.rs:+4:2: +4:2
       }

--- a/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
@@ -7,8 +7,6 @@
       let mut _2: main::InvalidChar;       // in scope 0 at $DIR/invalid_constant.rs:+6:34: +6:63
       let mut _4: E;                       // in scope 0 at $DIR/invalid_constant.rs:+13:25: +13:59
       let mut _5: main::InvalidTag;        // in scope 0 at $DIR/invalid_constant.rs:+13:34: +13:55
-      let mut _7: Empty;                   // in scope 0 at $DIR/invalid_constant.rs:+20:35: +20:73
-      let mut _8: main::NoVariants;        // in scope 0 at $DIR/invalid_constant.rs:+20:44: +20:65
       scope 1 {
           debug _invalid_char => _1;       // in scope 1 at $DIR/invalid_constant.rs:+6:9: +6:22
           let _3: [E; 1];                  // in scope 1 at $DIR/invalid_constant.rs:+13:9: +13:21
@@ -17,9 +15,9 @@
               let _6: [Empty; 1];          // in scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
               scope 5 {
                   debug _enum_without_variants => _6; // in scope 5 at $DIR/invalid_constant.rs:+20:9: +20:31
-                  let _9: main::Str<"���">; // in scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
+                  let _7: main::Str<"���">; // in scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
                   scope 7 {
-                      debug _non_utf8_str => _9; // in scope 7 at $DIR/invalid_constant.rs:+24:9: +24:22
+                      debug _non_utf8_str => _7; // in scope 7 at $DIR/invalid_constant.rs:+24:9: +24:22
                   }
               }
               scope 6 {
@@ -57,17 +55,11 @@
           StorageDead(_4);                 // scope 1 at $DIR/invalid_constant.rs:+13:59: +13:60
           StorageDead(_5);                 // scope 1 at $DIR/invalid_constant.rs:+13:60: +13:61
           StorageLive(_6);                 // scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
-          StorageLive(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:35: +20:73
-          StorageLive(_8);                 // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
-          Deinit(_8);                      // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
-          (_8.0: u32) = const 0_u32;       // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
           nop;                             // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:71
           nop;                             // scope 3 at $DIR/invalid_constant.rs:+20:34: +20:74
-          StorageDead(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:73: +20:74
-          StorageDead(_8);                 // scope 3 at $DIR/invalid_constant.rs:+20:74: +20:75
-          StorageLive(_9);                 // scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
+          StorageLive(_7);                 // scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
           nop;                             // scope 0 at $DIR/invalid_constant.rs:+0:11: +27:2
-          StorageDead(_9);                 // scope 5 at $DIR/invalid_constant.rs:+27:1: +27:2
+          StorageDead(_7);                 // scope 5 at $DIR/invalid_constant.rs:+27:1: +27:2
           StorageDead(_6);                 // scope 3 at $DIR/invalid_constant.rs:+27:1: +27:2
           StorageDead(_3);                 // scope 1 at $DIR/invalid_constant.rs:+27:1: +27:2
           StorageDead(_1);                 // scope 0 at $DIR/invalid_constant.rs:+27:1: +27:2

--- a/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
@@ -55,10 +55,7 @@
           StorageDead(_4);                 // scope 1 at $DIR/invalid_constant.rs:+13:59: +13:60
           StorageDead(_5);                 // scope 1 at $DIR/invalid_constant.rs:+13:60: +13:61
           StorageLive(_6);                 // scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
-          nop;                             // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:71
-          nop;                             // scope 3 at $DIR/invalid_constant.rs:+20:34: +20:74
           StorageLive(_7);                 // scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
-          nop;                             // scope 0 at $DIR/invalid_constant.rs:+0:11: +27:2
           StorageDead(_7);                 // scope 5 at $DIR/invalid_constant.rs:+27:1: +27:2
           StorageDead(_6);                 // scope 3 at $DIR/invalid_constant.rs:+27:1: +27:2
           StorageDead(_3);                 // scope 1 at $DIR/invalid_constant.rs:+27:1: +27:2

--- a/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
@@ -9,9 +9,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/issue_66971.rs:+1:5: +1:23
           StorageLive(_2);                 // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
-          nop;                             // scope 0 at $DIR/issue_66971.rs:+1:13: +1:15
           Deinit(_2);                      // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
-          nop;                             // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
           (_2.1: u8) = const 0_u8;         // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
           (_2.2: u8) = const 0_u8;         // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
           _1 = encode(move _2) -> bb1;     // scope 0 at $DIR/issue_66971.rs:+1:5: +1:23
@@ -23,7 +21,6 @@
       bb1: {
           StorageDead(_2);                 // scope 0 at $DIR/issue_66971.rs:+1:22: +1:23
           StorageDead(_1);                 // scope 0 at $DIR/issue_66971.rs:+1:23: +1:24
-          nop;                             // scope 0 at $DIR/issue_66971.rs:+0:11: +2:2
           return;                          // scope 0 at $DIR/issue_66971.rs:+2:2: +2:2
       }
   }

--- a/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
@@ -5,18 +5,15 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/issue_66971.rs:+0:11: +0:11
       let _1: ();                          // in scope 0 at $DIR/issue_66971.rs:+1:5: +1:23
       let mut _2: ((), u8, u8);            // in scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
-      let mut _3: ();                      // in scope 0 at $DIR/issue_66971.rs:+1:13: +1:15
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/issue_66971.rs:+1:5: +1:23
           StorageLive(_2);                 // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
-          StorageLive(_3);                 // scope 0 at $DIR/issue_66971.rs:+1:13: +1:15
           nop;                             // scope 0 at $DIR/issue_66971.rs:+1:13: +1:15
           Deinit(_2);                      // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
           nop;                             // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
           (_2.1: u8) = const 0_u8;         // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
           (_2.2: u8) = const 0_u8;         // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
-          StorageDead(_3);                 // scope 0 at $DIR/issue_66971.rs:+1:21: +1:22
           _1 = encode(move _2) -> bb1;     // scope 0 at $DIR/issue_66971.rs:+1:5: +1:23
                                            // mir::Constant
                                            // + span: $DIR/issue_66971.rs:17:5: 17:11

--- a/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
@@ -27,7 +27,6 @@
       bb1: {
           StorageDead(_2);                 // scope 0 at $DIR/issue_67019.rs:+1:19: +1:20
           StorageDead(_1);                 // scope 0 at $DIR/issue_67019.rs:+1:20: +1:21
-          nop;                             // scope 0 at $DIR/issue_67019.rs:+0:11: +2:2
           return;                          // scope 0 at $DIR/issue_67019.rs:+2:2: +2:2
       }
   }

--- a/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.diff
@@ -29,7 +29,6 @@
           _1 = _2[_3];                     // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
           StorageDead(_3);                 // scope 0 at $DIR/large_array_index.rs:+2:32: +2:33
           StorageDead(_2);                 // scope 0 at $DIR/large_array_index.rs:+2:32: +2:33
-          nop;                             // scope 0 at $DIR/large_array_index.rs:+0:11: +3:2
           StorageDead(_1);                 // scope 0 at $DIR/large_array_index.rs:+3:1: +3:2
           return;                          // scope 0 at $DIR/large_array_index.rs:+3:2: +3:2
       }

--- a/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.diff
@@ -29,7 +29,6 @@
           _1 = _2[_3];                     // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
           StorageDead(_3);                 // scope 0 at $DIR/large_array_index.rs:+2:32: +2:33
           StorageDead(_2);                 // scope 0 at $DIR/large_array_index.rs:+2:32: +2:33
-          nop;                             // scope 0 at $DIR/large_array_index.rs:+0:11: +3:2
           StorageDead(_1);                 // scope 0 at $DIR/large_array_index.rs:+3:1: +3:2
           return;                          // scope 0 at $DIR/large_array_index.rs:+3:2: +3:2
       }

--- a/src/test/mir-opt/const_prop/mutable_variable.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable.main.ConstProp.diff
@@ -19,7 +19,6 @@
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable.rs:+3:9: +3:10
 -         _2 = _1;                         // scope 1 at $DIR/mutable_variable.rs:+3:13: +3:14
 +         _2 = const 99_i32;               // scope 1 at $DIR/mutable_variable.rs:+3:13: +3:14
-          nop;                             // scope 0 at $DIR/mutable_variable.rs:+0:11: +4:2
           StorageDead(_2);                 // scope 1 at $DIR/mutable_variable.rs:+4:1: +4:2
           StorageDead(_1);                 // scope 0 at $DIR/mutable_variable.rs:+4:1: +4:2
           return;                          // scope 0 at $DIR/mutable_variable.rs:+4:2: +4:2

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate.main.ConstProp.diff
@@ -21,7 +21,6 @@
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate.rs:+3:9: +3:10
 -         _2 = _1;                         // scope 1 at $DIR/mutable_variable_aggregate.rs:+3:13: +3:14
 +         _2 = const (42_i32, 99_i32);     // scope 1 at $DIR/mutable_variable_aggregate.rs:+3:13: +3:14
-          nop;                             // scope 0 at $DIR/mutable_variable_aggregate.rs:+0:11: +4:2
           StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate.rs:+4:1: +4:2
           StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_aggregate.rs:+4:1: +4:2
           return;                          // scope 0 at $DIR/mutable_variable_aggregate.rs:+4:2: +4:2

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.main.ConstProp.diff
@@ -26,7 +26,6 @@
           ((*_2).1: i32) = const 99_i32;   // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+3:5: +3:13
           StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+4:9: +4:10
           _3 = _1;                         // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+4:13: +4:14
-          nop;                             // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+0:11: +5:2
           StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+5:1: +5:2
           StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:+5:1: +5:2
           StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+5:1: +5:2

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
@@ -26,7 +26,6 @@
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+4:9: +4:10
 -         _2 = (_1.1: i32);                // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+4:13: +4:16
 +         _2 = const 99_i32;               // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+4:13: +4:16
-          nop;                             // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:+0:11: +5:2
           StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+5:1: +5:2
           StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:+5:1: +5:2
           return;                          // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:+5:2: +5:2

--- a/src/test/mir-opt/const_prop/mutable_variable_no_prop.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_no_prop.main.ConstProp.diff
@@ -4,39 +4,36 @@
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable_no_prop.rs:+0:11: +0:11
       let mut _1: u32;                     // in scope 0 at $DIR/mutable_variable_no_prop.rs:+1:9: +1:14
-      let _2: ();                          // in scope 0 at $DIR/mutable_variable_no_prop.rs:+2:5: +4:6
-      let mut _3: u32;                     // in scope 0 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
-      let mut _4: *mut u32;                // in scope 0 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
+      let mut _2: u32;                     // in scope 0 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
+      let mut _3: *mut u32;                // in scope 0 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
       scope 1 {
           debug x => _1;                   // in scope 1 at $DIR/mutable_variable_no_prop.rs:+1:9: +1:14
-          let _5: u32;                     // in scope 1 at $DIR/mutable_variable_no_prop.rs:+5:9: +5:10
+          let _4: u32;                     // in scope 1 at $DIR/mutable_variable_no_prop.rs:+5:9: +5:10
           scope 2 {
           }
           scope 3 {
-              debug y => _5;               // in scope 3 at $DIR/mutable_variable_no_prop.rs:+5:9: +5:10
+              debug y => _4;               // in scope 3 at $DIR/mutable_variable_no_prop.rs:+5:9: +5:10
           }
       }
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_no_prop.rs:+1:9: +1:14
           _1 = const 42_u32;               // scope 0 at $DIR/mutable_variable_no_prop.rs:+1:17: +1:19
-          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:+2:5: +4:6
+          StorageLive(_2);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
           StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
-          StorageLive(_4);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
-          _4 = const {alloc1: *mut u32};   // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
+          _3 = const {alloc1: *mut u32};   // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
                                            // mir::Constant
                                            // + span: $DIR/mutable_variable_no_prop.rs:10:13: 10:19
                                            // + literal: Const { ty: *mut u32, val: Value(Scalar(alloc1)) }
-          _3 = (*_4);                      // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
-          _1 = move _3;                    // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:9: +3:19
-          StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:18: +3:19
-          StorageDead(_4);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:19: +3:20
+          _2 = (*_3);                      // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
+          _1 = move _2;                    // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:9: +3:19
+          StorageDead(_2);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:18: +3:19
+          StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:19: +3:20
           nop;                             // scope 2 at $DIR/mutable_variable_no_prop.rs:+2:5: +4:6
-          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:+4:5: +4:6
-          StorageLive(_5);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:+5:9: +5:10
-          _5 = _1;                         // scope 1 at $DIR/mutable_variable_no_prop.rs:+5:13: +5:14
+          StorageLive(_4);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:+5:9: +5:10
+          _4 = _1;                         // scope 1 at $DIR/mutable_variable_no_prop.rs:+5:13: +5:14
           nop;                             // scope 0 at $DIR/mutable_variable_no_prop.rs:+0:11: +6:2
-          StorageDead(_5);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:+6:1: +6:2
+          StorageDead(_4);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:+6:1: +6:2
           StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_no_prop.rs:+6:1: +6:2
           return;                          // scope 0 at $DIR/mutable_variable_no_prop.rs:+6:2: +6:2
       }

--- a/src/test/mir-opt/const_prop/mutable_variable_no_prop.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_no_prop.main.ConstProp.diff
@@ -29,10 +29,8 @@
           _1 = move _2;                    // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:9: +3:19
           StorageDead(_2);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:18: +3:19
           StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:19: +3:20
-          nop;                             // scope 2 at $DIR/mutable_variable_no_prop.rs:+2:5: +4:6
           StorageLive(_4);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:+5:9: +5:10
           _4 = _1;                         // scope 1 at $DIR/mutable_variable_no_prop.rs:+5:13: +5:14
-          nop;                             // scope 0 at $DIR/mutable_variable_no_prop.rs:+0:11: +6:2
           StorageDead(_4);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:+6:1: +6:2
           StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_no_prop.rs:+6:1: +6:2
           return;                          // scope 0 at $DIR/mutable_variable_no_prop.rs:+6:2: +6:2

--- a/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
@@ -4,20 +4,19 @@
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable_unprop_assign.rs:+0:11: +0:11
       let _1: i32;                         // in scope 0 at $DIR/mutable_variable_unprop_assign.rs:+1:9: +1:10
-      let mut _3: i32;                     // in scope 0 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
+      let mut _2: i32;                     // in scope 0 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
       scope 1 {
           debug a => _1;                   // in scope 1 at $DIR/mutable_variable_unprop_assign.rs:+1:9: +1:10
-          let mut _2: (i32, i32);          // in scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:9: +2:14
+          let mut _5: i32;                 // in scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:9: +2:14
           let mut _6: i32;                 // in scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:9: +2:14
-          let mut _7: i32;                 // in scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:9: +2:14
           scope 2 {
-              debug x => (i32, i32){ .0 => _6, .1 => _7, }; // in scope 2 at $DIR/mutable_variable_unprop_assign.rs:+2:9: +2:14
-              let _4: i32;                 // in scope 2 at $DIR/mutable_variable_unprop_assign.rs:+4:9: +4:10
+              debug x => (i32, i32){ .0 => _5, .1 => _6, }; // in scope 2 at $DIR/mutable_variable_unprop_assign.rs:+2:9: +2:14
+              let _3: i32;                 // in scope 2 at $DIR/mutable_variable_unprop_assign.rs:+4:9: +4:10
               scope 3 {
-                  debug y => _4;           // in scope 3 at $DIR/mutable_variable_unprop_assign.rs:+4:9: +4:10
-                  let _5: i32;             // in scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:9: +5:10
+                  debug y => _3;           // in scope 3 at $DIR/mutable_variable_unprop_assign.rs:+4:9: +4:10
+                  let _4: i32;             // in scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:9: +5:10
                   scope 4 {
-                      debug z => _5;       // in scope 4 at $DIR/mutable_variable_unprop_assign.rs:+5:9: +5:10
+                      debug z => _4;       // in scope 4 at $DIR/mutable_variable_unprop_assign.rs:+5:9: +5:10
                   }
               }
           }
@@ -32,26 +31,26 @@
       }
   
       bb1: {
+          StorageLive(_5);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:9: +2:14
           StorageLive(_6);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:9: +2:14
-          StorageLive(_7);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:9: +2:14
+          Deinit(_5);                      // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:29: +2:35
           Deinit(_6);                      // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:29: +2:35
-          Deinit(_7);                      // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:29: +2:35
-          _6 = const 1_i32;                // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:29: +2:35
-          _7 = const 2_i32;                // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:29: +2:35
-          StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
-          _3 = _1;                         // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
-          _7 = move _3;                    // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:5: +3:12
-          StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
-          StorageLive(_4);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+4:9: +4:10
-          _4 = _7;                         // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+4:13: +4:16
-          StorageLive(_5);                 // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:9: +5:10
--         _5 = _6;                         // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:13: +5:16
-+         _5 = const 1_i32;                // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:13: +5:16
+          _5 = const 1_i32;                // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:29: +2:35
+          _6 = const 2_i32;                // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:29: +2:35
+          StorageLive(_2);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
+          _2 = _1;                         // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
+          _6 = move _2;                    // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:5: +3:12
+          StorageDead(_2);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
+          StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+4:9: +4:10
+          _3 = _6;                         // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+4:13: +4:16
+          StorageLive(_4);                 // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:9: +5:10
+-         _4 = _5;                         // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:13: +5:16
++         _4 = const 1_i32;                // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:13: +5:16
           nop;                             // scope 0 at $DIR/mutable_variable_unprop_assign.rs:+0:11: +6:2
-          StorageDead(_5);                 // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
-          StorageDead(_4);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
+          StorageDead(_4);                 // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
+          StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
+          StorageDead(_5);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
           StorageDead(_6);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
-          StorageDead(_7);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
           StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
           return;                          // scope 0 at $DIR/mutable_variable_unprop_assign.rs:+6:2: +6:2
       }

--- a/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
@@ -46,7 +46,6 @@
           StorageLive(_4);                 // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:9: +5:10
 -         _4 = _5;                         // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:13: +5:16
 +         _4 = const 1_i32;                // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:13: +5:16
-          nop;                             // scope 0 at $DIR/mutable_variable_unprop_assign.rs:+0:11: +6:2
           StorageDead(_4);                 // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
           StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
           StorageDead(_5);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
@@ -9,9 +9,7 @@
       let _5: usize;                       // in scope 0 at $DIR/optimizes_into_variable.rs:+2:32: +2:33
       let mut _6: usize;                   // in scope 0 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
       let mut _7: bool;                    // in scope 0 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
-      let mut _9: Point;                   // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-      let mut _10: u32;                    // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-      let mut _11: u32;                    // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+      let mut _9: u32;                     // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
       scope 1 {
           debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
           let _3: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
@@ -53,16 +51,12 @@
           StorageDead(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:34: +2:35
           StorageDead(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:34: +2:35
           StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
-          StorageLive(_10);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-          StorageLive(_11);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-          Deinit(_10);                     // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-          Deinit(_11);                     // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-          _10 = const 12_u32;              // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-          _11 = const 42_u32;              // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
--         _8 = _11;                        // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
+          StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+          Deinit(_9);                      // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+          _9 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+-         _8 = _9;                         // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
 +         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
-          StorageDead(_10);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:38: +3:39
-          StorageDead(_11);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:38: +3:39
+          StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:38: +3:39
           nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +4:2
           StorageDead(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
           StorageDead(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
@@ -57,7 +57,6 @@
 -         _8 = _9;                         // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
 +         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
           StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:38: +3:39
-          nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +4:2
           StorageDead(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
           StorageDead(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
           StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+4:1: +4:2

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
@@ -9,9 +9,7 @@
       let _5: usize;                       // in scope 0 at $DIR/optimizes_into_variable.rs:+2:32: +2:33
       let mut _6: usize;                   // in scope 0 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
       let mut _7: bool;                    // in scope 0 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
-      let mut _9: Point;                   // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-      let mut _10: u32;                    // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-      let mut _11: u32;                    // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+      let mut _9: u32;                     // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
       scope 1 {
           debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
           let _3: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
@@ -53,16 +51,12 @@
           StorageDead(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:34: +2:35
           StorageDead(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:34: +2:35
           StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
-          StorageLive(_10);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-          StorageLive(_11);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-          Deinit(_10);                     // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-          Deinit(_11);                     // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-          _10 = const 12_u32;              // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
-          _11 = const 42_u32;              // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
--         _8 = _11;                        // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
+          StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+          Deinit(_9);                      // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+          _9 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+-         _8 = _9;                         // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
 +         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
-          StorageDead(_10);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:38: +3:39
-          StorageDead(_11);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:38: +3:39
+          StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:38: +3:39
           nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +4:2
           StorageDead(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
           StorageDead(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
@@ -57,7 +57,6 @@
 -         _8 = _9;                         // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
 +         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
           StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:38: +3:39
-          nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +4:2
           StorageDead(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
           StorageDead(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
           StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+4:1: +4:2

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals-final.after.32bit.mir
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals-final.after.32bit.mir
@@ -1,4 +1,4 @@
-// MIR for `main` after SimplifyLocals
+// MIR for `main` after SimplifyLocals-final
 
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +0:11

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals-final.after.64bit.mir
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals-final.after.64bit.mir
@@ -1,4 +1,4 @@
-// MIR for `main` after SimplifyLocals
+// MIR for `main` after SimplifyLocals-final
 
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +0:11

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.rs
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.rs
@@ -9,7 +9,7 @@ struct Point {
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR optimizes_into_variable.main.ScalarReplacementOfAggregates.diff
 // EMIT_MIR optimizes_into_variable.main.ConstProp.diff
-// EMIT_MIR optimizes_into_variable.main.SimplifyLocals.after.mir
+// EMIT_MIR optimizes_into_variable.main.SimplifyLocals-final.after.mir
 // EMIT_MIR optimizes_into_variable.main.PreCodegen.after.mir
 fn main() {
     let x = 2 + 2;

--- a/src/test/mir-opt/const_prop/read_immutable_static.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/read_immutable_static.main.ConstProp.diff
@@ -36,7 +36,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/read_immutable_static.rs:+1:21: +1:22
           StorageDead(_5);                 // scope 0 at $DIR/read_immutable_static.rs:+1:22: +1:23
           StorageDead(_3);                 // scope 0 at $DIR/read_immutable_static.rs:+1:22: +1:23
-          nop;                             // scope 0 at $DIR/read_immutable_static.rs:+0:11: +2:2
           StorageDead(_1);                 // scope 0 at $DIR/read_immutable_static.rs:+2:1: +2:2
           return;                          // scope 0 at $DIR/read_immutable_static.rs:+2:2: +2:2
       }

--- a/src/test/mir-opt/const_prop/ref_deref.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/ref_deref.main.ConstProp.diff
@@ -13,7 +13,7 @@
           StorageLive(_2);                 // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
           _4 = const _;                    // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
                                            // mir::Constant
-                                           // + span: $DIR/ref_deref.rs:5:6: 5:10
+                                           // + span: $DIR/ref_deref.rs:6:6: 6:10
                                            // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
           _2 = _4;                         // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
 -         _1 = (*_2);                      // scope 0 at $DIR/ref_deref.rs:+1:5: +1:10

--- a/src/test/mir-opt/const_prop/ref_deref.main.PromoteTemps.diff
+++ b/src/test/mir-opt/const_prop/ref_deref.main.PromoteTemps.diff
@@ -16,7 +16,7 @@
 -         _2 = &_3;                        // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
 +         _4 = const _;                    // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
 +                                          // mir::Constant
-+                                          // + span: $DIR/ref_deref.rs:5:6: 5:10
++                                          // + span: $DIR/ref_deref.rs:6:6: 6:10
 +                                          // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
 +         _2 = &(*_4);                     // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
           _1 = (*_2);                      // scope 0 at $DIR/ref_deref.rs:+1:5: +1:10

--- a/src/test/mir-opt/const_prop/ref_deref.rs
+++ b/src/test/mir-opt/const_prop/ref_deref.rs
@@ -1,3 +1,4 @@
+// compile-flags: -Zmir-enable-passes=-SimplifyLocals-before-const-prop
 // EMIT_MIR ref_deref.main.PromoteTemps.diff
 // EMIT_MIR ref_deref.main.ConstProp.diff
 

--- a/src/test/mir-opt/const_prop/ref_deref_project.rs
+++ b/src/test/mir-opt/const_prop/ref_deref_project.rs
@@ -1,4 +1,4 @@
-// unit-test
+// compile-flags: -Zmir-enable-passes=-SimplifyLocals-before-const-prop
 // EMIT_MIR ref_deref_project.main.PromoteTemps.diff
 // EMIT_MIR ref_deref_project.main.ConstProp.diff
 

--- a/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
@@ -3,25 +3,21 @@
   
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/reify_fn_ptr.rs:+0:11: +0:11
-      let mut _1: *const fn();             // in scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:41
-      let mut _2: usize;                   // in scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
-      let mut _3: fn();                    // in scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:17
+      let mut _1: usize;                   // in scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
+      let mut _2: fn();                    // in scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:17
       scope 1 {
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:41
-          StorageLive(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
-          StorageLive(_3);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:17
-          _3 = main as fn() (Pointer(ReifyFnPointer)); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:17
+          StorageLive(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
+          StorageLive(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:17
+          _2 = main as fn() (Pointer(ReifyFnPointer)); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:17
                                            // mir::Constant
                                            // + span: $DIR/reify_fn_ptr.rs:4:13: 4:17
                                            // + literal: Const { ty: fn() {main}, val: Value(<ZST>) }
-          _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
-          StorageDead(_3);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:25: +1:26
-          _1 = move _2 as *const fn() (PointerFromExposedAddress); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:41
-          StorageDead(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:40: +1:41
-          StorageDead(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:41: +1:42
+          _1 = move _2 as usize (PointerExposeAddress); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
+          StorageDead(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:25: +1:26
+          StorageDead(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:40: +1:41
           nop;                             // scope 0 at $DIR/reify_fn_ptr.rs:+0:11: +2:2
           return;                          // scope 0 at $DIR/reify_fn_ptr.rs:+2:2: +2:2
       }

--- a/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
@@ -18,7 +18,6 @@
           _1 = move _2 as usize (PointerExposeAddress); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
           StorageDead(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:25: +1:26
           StorageDead(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:40: +1:41
-          nop;                             // scope 0 at $DIR/reify_fn_ptr.rs:+0:11: +2:2
           return;                          // scope 0 at $DIR/reify_fn_ptr.rs:+2:2: +2:2
       }
   }

--- a/src/test/mir-opt/const_prop/repeat.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/repeat.main.ConstProp.32bit.diff
@@ -35,7 +35,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/repeat.rs:+1:31: +1:32
           StorageDead(_4);                 // scope 0 at $DIR/repeat.rs:+1:32: +1:33
           StorageDead(_3);                 // scope 0 at $DIR/repeat.rs:+1:32: +1:33
-          nop;                             // scope 0 at $DIR/repeat.rs:+0:11: +2:2
           StorageDead(_1);                 // scope 0 at $DIR/repeat.rs:+2:1: +2:2
           return;                          // scope 0 at $DIR/repeat.rs:+2:2: +2:2
       }

--- a/src/test/mir-opt/const_prop/repeat.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/repeat.main.ConstProp.64bit.diff
@@ -35,7 +35,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/repeat.rs:+1:31: +1:32
           StorageDead(_4);                 // scope 0 at $DIR/repeat.rs:+1:32: +1:33
           StorageDead(_3);                 // scope 0 at $DIR/repeat.rs:+1:32: +1:33
-          nop;                             // scope 0 at $DIR/repeat.rs:+0:11: +2:2
           StorageDead(_1);                 // scope 0 at $DIR/repeat.rs:+2:1: +2:2
           return;                          // scope 0 at $DIR/repeat.rs:+2:2: +2:2
       }

--- a/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
@@ -27,7 +27,6 @@
       bb1: {
           StorageDead(_3);                 // scope 1 at $DIR/scalar_literal_propagation.rs:+2:14: +2:15
           StorageDead(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:+2:15: +2:16
-          nop;                             // scope 0 at $DIR/scalar_literal_propagation.rs:+0:11: +3:2
           StorageDead(_1);                 // scope 0 at $DIR/scalar_literal_propagation.rs:+3:1: +3:2
           return;                          // scope 0 at $DIR/scalar_literal_propagation.rs:+3:2: +3:2
       }

--- a/src/test/mir-opt/const_prop/slice_len.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/slice_len.main.ConstProp.32bit.diff
@@ -20,7 +20,7 @@
           StorageLive(_4);                 // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           _9 = const _;                    // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
                                            // mir::Constant
-                                           // + span: $DIR/slice_len.rs:5:6: 5:19
+                                           // + span: $DIR/slice_len.rs:6:6: 6:19
                                            // + literal: Const { ty: &[u32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
           _4 = _9;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           _3 = _4;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19

--- a/src/test/mir-opt/const_prop/slice_len.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/slice_len.main.ConstProp.64bit.diff
@@ -20,7 +20,7 @@
           StorageLive(_4);                 // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           _9 = const _;                    // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
                                            // mir::Constant
-                                           // + span: $DIR/slice_len.rs:5:6: 5:19
+                                           // + span: $DIR/slice_len.rs:6:6: 6:19
                                            // + literal: Const { ty: &[u32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
           _4 = _9;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           _3 = _4;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19

--- a/src/test/mir-opt/const_prop/slice_len.rs
+++ b/src/test/mir-opt/const_prop/slice_len.rs
@@ -1,3 +1,4 @@
+// compile-flags: -Zmir-enable-passes=-SimplifyLocals-before-const-prop
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR slice_len.main.ConstProp.diff

--- a/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
@@ -28,7 +28,6 @@
       bb1: {
           StorageDead(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:+3:14: +3:15
           StorageDead(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:+3:15: +3:16
-          nop;                             // scope 0 at $DIR/tuple_literal_propagation.rs:+0:11: +4:2
           StorageDead(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:+4:1: +4:2
           return;                          // scope 0 at $DIR/tuple_literal_propagation.rs:+4:2: +4:2
       }

--- a/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
@@ -24,13 +24,11 @@
           _2 = &raw mut (_1.0: i32);       // scope 2 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
           (*_2) = const 5_i32;             // scope 2 at $DIR/const_prop_miscompile.rs:+3:9: +3:26
           StorageDead(_2);                 // scope 2 at $DIR/const_prop_miscompile.rs:+3:26: +3:27
-          nop;                             // scope 2 at $DIR/const_prop_miscompile.rs:+2:5: +4:6
           StorageLive(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:9: +5:10
           StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:20
           _4 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:+5:15: +5:18
           _3 = Eq(move _4, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:25
           StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:24: +5:25
-          nop;                             // scope 0 at $DIR/const_prop_miscompile.rs:+0:10: +6:2
           StorageDead(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:+6:1: +6:2
           StorageDead(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:+6:1: +6:2
           return;                          // scope 0 at $DIR/const_prop_miscompile.rs:+6:2: +6:2

--- a/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
@@ -4,16 +4,15 @@
   fn bar() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/const_prop_miscompile.rs:+0:10: +0:10
       let mut _1: (i32,);                  // in scope 0 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
-      let _2: ();                          // in scope 0 at $DIR/const_prop_miscompile.rs:+2:5: +4:6
-      let mut _3: *mut i32;                // in scope 0 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
-      let mut _5: i32;                     // in scope 0 at $DIR/const_prop_miscompile.rs:+5:13: +5:20
+      let mut _2: *mut i32;                // in scope 0 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
+      let mut _4: i32;                     // in scope 0 at $DIR/const_prop_miscompile.rs:+5:13: +5:20
       scope 1 {
           debug v => _1;                   // in scope 1 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
-          let _4: bool;                    // in scope 1 at $DIR/const_prop_miscompile.rs:+5:9: +5:10
+          let _3: bool;                    // in scope 1 at $DIR/const_prop_miscompile.rs:+5:9: +5:10
           scope 2 {
           }
           scope 3 {
-              debug y => _4;               // in scope 3 at $DIR/const_prop_miscompile.rs:+5:9: +5:10
+              debug y => _3;               // in scope 3 at $DIR/const_prop_miscompile.rs:+5:9: +5:10
           }
       }
   
@@ -21,20 +20,18 @@
           StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
           Deinit(_1);                      // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
           (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
-          StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:+2:5: +4:6
-          StorageLive(_3);                 // scope 2 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
-          _3 = &raw mut (_1.0: i32);       // scope 2 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
-          (*_3) = const 5_i32;             // scope 2 at $DIR/const_prop_miscompile.rs:+3:9: +3:26
-          StorageDead(_3);                 // scope 2 at $DIR/const_prop_miscompile.rs:+3:26: +3:27
+          StorageLive(_2);                 // scope 2 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
+          _2 = &raw mut (_1.0: i32);       // scope 2 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
+          (*_2) = const 5_i32;             // scope 2 at $DIR/const_prop_miscompile.rs:+3:9: +3:26
+          StorageDead(_2);                 // scope 2 at $DIR/const_prop_miscompile.rs:+3:26: +3:27
           nop;                             // scope 2 at $DIR/const_prop_miscompile.rs:+2:5: +4:6
-          StorageDead(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:+4:5: +4:6
-          StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:9: +5:10
-          StorageLive(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:20
-          _5 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:+5:15: +5:18
-          _4 = Eq(move _5, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:25
-          StorageDead(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:24: +5:25
+          StorageLive(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:9: +5:10
+          StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:20
+          _4 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:+5:15: +5:18
+          _3 = Eq(move _4, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:25
+          StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:24: +5:25
           nop;                             // scope 0 at $DIR/const_prop_miscompile.rs:+0:10: +6:2
-          StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+6:1: +6:2
+          StorageDead(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:+6:1: +6:2
           StorageDead(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:+6:1: +6:2
           return;                          // scope 0 at $DIR/const_prop_miscompile.rs:+6:2: +6:2
       }

--- a/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
@@ -27,7 +27,6 @@
           _4 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:+3:15: +3:18
           _3 = Eq(move _4, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:+3:13: +3:25
           StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+3:24: +3:25
-          nop;                             // scope 0 at $DIR/const_prop_miscompile.rs:+0:10: +4:2
           StorageDead(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:+4:1: +4:2
           StorageDead(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:+4:1: +4:2
           return;                          // scope 0 at $DIR/const_prop_miscompile.rs:+4:2: +4:2

--- a/src/test/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.diff
@@ -5,39 +5,34 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/inherit_overflow.rs:+0:11: +0:11
       let mut _1: u8;                      // in scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
       let mut _2: u8;                      // in scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
-      let mut _3: u8;                      // in scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
       scope 1 {
       }
       scope 2 (inlined <u8 as Add>::add) { // at $DIR/inherit_overflow.rs:7:13: 7:47
-          debug self => _2;                // in scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-          debug other => _3;               // in scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
+          debug self => _1;                // in scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
+          debug other => _2;               // in scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
+          let mut _3: u8;                  // in scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           let mut _4: u8;                  // in scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-          let mut _5: u8;                  // in scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-          let mut _6: (u8, bool);          // in scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
+          let mut _5: (u8, bool);          // in scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
       }
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
+          _1 = const u8::MAX;              // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
           StorageLive(_2);                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
-          _2 = const u8::MAX;              // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
-          StorageLive(_3);                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
-          _3 = const 1_u8;                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
+          _2 = const 1_u8;                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
+          StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
+          _3 = const u8::MAX;              // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-          _4 = const u8::MAX;              // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-          StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-          _5 = const 1_u8;                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-          _6 = CheckedAdd(const u8::MAX, const 1_u8); // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-          assert(!move (_6.1: bool), "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> bb1; // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
+          _4 = const 1_u8;                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
+          _5 = CheckedAdd(const u8::MAX, const 1_u8); // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
+          assert(!move (_5.1: bool), "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> bb1; // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
       }
   
       bb1: {
--         _1 = move (_6.0: u8);            // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-+         _1 = const 0_u8;                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-          StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
-          StorageDead(_3);                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
+          StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           StorageDead(_2);                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
-          StorageDead(_1);                 // scope 0 at $DIR/inherit_overflow.rs:+3:47: +3:48
+          StorageDead(_1);                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
           nop;                             // scope 0 at $DIR/inherit_overflow.rs:+0:11: +4:2
           return;                          // scope 0 at $DIR/inherit_overflow.rs:+4:2: +4:2
       }

--- a/src/test/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.diff
+++ b/src/test/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.diff
@@ -33,7 +33,6 @@
           StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           StorageDead(_2);                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
           StorageDead(_1);                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
-          nop;                             // scope 0 at $DIR/inherit_overflow.rs:+0:11: +4:2
           return;                          // scope 0 at $DIR/inherit_overflow.rs:+4:2: +4:2
       }
   }

--- a/src/test/mir-opt/dead-store-elimination/cycle.cycle.DeadStoreElimination.diff
+++ b/src/test/mir-opt/dead-store-elimination/cycle.cycle.DeadStoreElimination.diff
@@ -59,14 +59,6 @@
 -         _4 = const ();                   // scope 0 at $DIR/cycle.rs:+3:18: +8:6
 -         StorageDead(_6);                 // scope 0 at $DIR/cycle.rs:+8:5: +8:6
 +         StorageLive(_5);                 // scope 0 at $DIR/cycle.rs:+4:13: +4:17
-+         nop;                             // scope 0 at $DIR/cycle.rs:+4:20: +4:21
-+         nop;                             // scope 1 at $DIR/cycle.rs:+5:13: +5:14
-+         nop;                             // scope 1 at $DIR/cycle.rs:+5:9: +5:14
-+         nop;                             // scope 1 at $DIR/cycle.rs:+6:13: +6:14
-+         nop;                             // scope 1 at $DIR/cycle.rs:+6:9: +6:14
-+         nop;                             // scope 1 at $DIR/cycle.rs:+7:13: +7:17
-+         nop;                             // scope 1 at $DIR/cycle.rs:+7:9: +7:17
-+         nop;                             // scope 0 at $DIR/cycle.rs:+3:18: +8:6
           StorageDead(_5);                 // scope 0 at $DIR/cycle.rs:+8:5: +8:6
 +         StorageDead(_4);                 // scope 0 at $DIR/cycle.rs:+8:5: +8:6
           goto -> bb1;                     // scope 0 at $DIR/cycle.rs:+3:5: +8:6

--- a/src/test/mir-opt/dest-prop/dead_stores_better.f.DestinationPropagation.after.mir
+++ b/src/test/mir-opt/dest-prop/dead_stores_better.f.DestinationPropagation.after.mir
@@ -13,7 +13,6 @@ fn f(_1: usize) -> usize {
     bb0: {
         nop;                             // scope 0 at $DIR/dead_stores_better.rs:+1:9: +1:10
         nop;                             // scope 0 at $DIR/dead_stores_better.rs:+1:13: +1:14
-        nop;                             // scope 1 at $DIR/dead_stores_better.rs:+2:5: +2:10
         nop;                             // scope 1 at $DIR/dead_stores_better.rs:+3:9: +3:10
         nop;                             // scope 1 at $DIR/dead_stores_better.rs:+3:9: +3:10
         nop;                             // scope 1 at $DIR/dead_stores_better.rs:+3:5: +3:10

--- a/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
@@ -25,11 +25,8 @@
       }
   
       bb1: {
-          nop;                             // scope 0 at $DIR/union.rs:+5:14: +5:30
-          nop;                             // scope 0 at $DIR/union.rs:+5:14: +5:30
           StorageDead(_2);                 // scope 0 at $DIR/union.rs:+5:29: +5:30
           StorageLive(_3);                 // scope 1 at $DIR/union.rs:+7:10: +7:26
-          nop;                             // scope 2 at $DIR/union.rs:+7:19: +7:24
           StorageDead(_3);                 // scope 1 at $DIR/union.rs:+7:26: +7:27
           StorageDead(_1);                 // scope 0 at $DIR/union.rs:+8:1: +8:2
           return;                          // scope 0 at $DIR/union.rs:+8:2: +8:2

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff
@@ -7,41 +7,36 @@
       let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/issue_73223.rs:+1:23: +1:30
       let mut _3: isize;                   // in scope 0 at $DIR/issue_73223.rs:+2:9: +2:16
       let _4: i32;                         // in scope 0 at $DIR/issue_73223.rs:+2:14: +2:15
-      let mut _5: !;                       // in scope 0 at $DIR/issue_73223.rs:+3:17: +3:23
-      let mut _7: i32;                     // in scope 0 at $DIR/issue_73223.rs:+6:22: +6:27
-      let _8: ();                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _9: (&i32, &i32);            // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _10: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _11: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _12: i32;                        // in scope 0 at $DIR/issue_73223.rs:+7:23: +7:24
-      let mut _15: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _16: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _17: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _18: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _19: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _21: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _22: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _23: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _24: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _6: i32;                     // in scope 0 at $DIR/issue_73223.rs:+6:22: +6:27
+      let mut _7: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _8: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _11: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _12: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _13: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _14: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _16: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _17: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _18: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _19: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _20: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _21: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _22: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _24: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _25: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _26: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _27: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _29: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _30: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue_73223.rs:+1:9: +1:14
-          let _6: std::option::Option<i32>; // in scope 1 at $DIR/issue_73223.rs:+6:9: +6:14
+          let _5: std::option::Option<i32>; // in scope 1 at $DIR/issue_73223.rs:+6:9: +6:14
           scope 3 {
-              debug _prev => _6;           // in scope 3 at $DIR/issue_73223.rs:+6:9: +6:14
-              let _13: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let _14: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let mut _28: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              debug _prev => _5;           // in scope 3 at $DIR/issue_73223.rs:+6:9: +6:14
+              let _9: &i32;                // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let _10: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let mut _23: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               scope 4 {
-                  debug left_val => _13;   // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  debug right_val => _14;  // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let _20: core::panicking::AssertKind; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  debug left_val => _9;    // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  debug right_val => _10;  // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  let _15: core::panicking::AssertKind; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   scope 5 {
-                      debug kind => _20;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug kind => _15;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   }
               }
           }
@@ -77,70 +72,69 @@
           _1 = _4;                         // scope 2 at $DIR/issue_73223.rs:+2:20: +2:21
           StorageDead(_4);                 // scope 0 at $DIR/issue_73223.rs:+2:20: +2:21
           StorageDead(_2);                 // scope 0 at $DIR/issue_73223.rs:+4:6: +4:7
-          StorageLive(_6);                 // scope 1 at $DIR/issue_73223.rs:+6:9: +6:14
-          StorageLive(_7);                 // scope 1 at $DIR/issue_73223.rs:+6:22: +6:27
-          _7 = _1;                         // scope 1 at $DIR/issue_73223.rs:+6:22: +6:27
-          Deinit(_6);                      // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
-          ((_6 as Some).0: i32) = move _7; // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
-          discriminant(_6) = 1;            // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
-          StorageDead(_7);                 // scope 1 at $DIR/issue_73223.rs:+6:27: +6:28
+          StorageLive(_5);                 // scope 1 at $DIR/issue_73223.rs:+6:9: +6:14
+          StorageLive(_6);                 // scope 1 at $DIR/issue_73223.rs:+6:22: +6:27
+          _6 = _1;                         // scope 1 at $DIR/issue_73223.rs:+6:22: +6:27
+          Deinit(_5);                      // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
+          ((_5 as Some).0: i32) = move _6; // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
+          discriminant(_5) = 1;            // scope 1 at $DIR/issue_73223.rs:+6:17: +6:28
+          StorageDead(_6);                 // scope 1 at $DIR/issue_73223.rs:+6:27: +6:28
+          StorageLive(_24);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_25);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_7);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _7 = &_1;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_29);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_30);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _10 = &_1;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _28 = const _;                   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _23 = const _;                   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
-          _11 = _28;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          Deinit(_29);                     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          Deinit(_30);                     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _29 = move _10;                  // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _30 = move _11;                  // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _13 = _29;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _14 = _30;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_16);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_17);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _17 = (*_13);                    // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _18 = const 1_i32;               // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _16 = Eq(move _17, const 1_i32); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_17);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _15 = Not(move _16);             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_16);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          switchInt(move _15) -> [0: bb5, otherwise: bb4]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _8 = _23;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_24);                     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_25);                     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _24 = move _7;                   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _25 = move _8;                   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_7);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _9 = _24;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _10 = _25;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_11);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_12);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_13);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _13 = (*_9);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_14);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _14 = const 1_i32;               // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _12 = Eq(move _13, const 1_i32); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_14);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_13);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _11 = Not(move _12);             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_12);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          switchInt(move _11) -> [0: bb5, otherwise: bb4]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
       bb4: {
-          StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          Deinit(_20);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_20) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_21);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_22);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _22 = const core::panicking::AssertKind::Eq; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_15);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_15) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_16);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_17);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _17 = const core::panicking::AssertKind::Eq; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
-          StorageLive(_23);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_24);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _24 = _13;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _23 = _24;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_25);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_26);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _26 = _14;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _25 = _26;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_27);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          Deinit(_27);                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_27) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _21 = core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _23, move _25, move _27); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_19);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _19 = _9;                        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _18 = _19;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_20);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_21);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _21 = _10;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _20 = _21;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_22);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_22);                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_22) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _16 = core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _18, move _20, move _22); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a i32, &'b i32, Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(<ZST>) }
@@ -151,14 +145,13 @@
   
       bb5: {
           nop;                             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_29);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_30);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_24);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_25);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           nop;                             // scope 0 at $DIR/issue_73223.rs:+0:11: +8:2
-          StorageDead(_6);                 // scope 1 at $DIR/issue_73223.rs:+8:1: +8:2
+          StorageDead(_5);                 // scope 1 at $DIR/issue_73223.rs:+8:1: +8:2
           StorageDead(_1);                 // scope 0 at $DIR/issue_73223.rs:+8:1: +8:2
           return;                          // scope 0 at $DIR/issue_73223.rs:+8:2: +8:2
       }

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff
@@ -56,7 +56,6 @@
       }
   
       bb1: {
-          nop;                             // scope 0 at $DIR/issue_73223.rs:+3:17: +3:23
           StorageDead(_2);                 // scope 0 at $DIR/issue_73223.rs:+4:6: +4:7
           StorageDead(_1);                 // scope 0 at $DIR/issue_73223.rs:+8:1: +8:2
           return;                          // scope 0 at $DIR/issue_73223.rs:+8:2: +8:2
@@ -144,13 +143,11 @@
       }
   
       bb5: {
-          nop;                             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_24);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_25);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          nop;                             // scope 0 at $DIR/issue_73223.rs:+0:11: +8:2
           StorageDead(_5);                 // scope 1 at $DIR/issue_73223.rs:+8:1: +8:2
           StorageDead(_1);                 // scope 0 at $DIR/issue_73223.rs:+8:1: +8:2
           return;                          // scope 0 at $DIR/issue_73223.rs:+8:2: +8:2

--- a/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -11,26 +11,19 @@
       let mut _6: T;                       // in scope 0 at $DIR/issue_76432.rs:+1:21: +1:22
       let mut _7: T;                       // in scope 0 at $DIR/issue_76432.rs:+1:24: +1:25
       let mut _8: T;                       // in scope 0 at $DIR/issue_76432.rs:+1:27: +1:28
-      let _9: [*const T; 3];               // in scope 0 at $DIR/issue_76432.rs:+2:5: +5:6
+      let mut _9: usize;                   // in scope 0 at $DIR/issue_76432.rs:+3:9: +3:33
       let mut _10: usize;                  // in scope 0 at $DIR/issue_76432.rs:+3:9: +3:33
-      let mut _11: usize;                  // in scope 0 at $DIR/issue_76432.rs:+3:9: +3:33
-      let mut _12: bool;                   // in scope 0 at $DIR/issue_76432.rs:+3:9: +3:33
-      let mut _16: *const T;               // in scope 0 at $DIR/issue_76432.rs:+3:38: +3:52
-      let mut _17: *const T;               // in scope 0 at $DIR/issue_76432.rs:+3:38: +3:52
-      let mut _18: *const T;               // in scope 0 at $DIR/issue_76432.rs:+3:54: +3:68
-      let mut _19: *const T;               // in scope 0 at $DIR/issue_76432.rs:+3:54: +3:68
-      let mut _20: *const T;               // in scope 0 at $DIR/issue_76432.rs:+3:70: +3:84
-      let mut _21: *const T;               // in scope 0 at $DIR/issue_76432.rs:+3:70: +3:84
-      let mut _22: !;                      // in scope 0 at $SRC_DIR/core/src/panic.rs:LL:COL
+      let mut _11: bool;                   // in scope 0 at $DIR/issue_76432.rs:+3:9: +3:33
+      let mut _15: !;                      // in scope 0 at $SRC_DIR/core/src/panic.rs:LL:COL
       scope 1 {
           debug v => _2;                   // in scope 1 at $DIR/issue_76432.rs:+1:9: +1:10
-          let _13: &T;                     // in scope 1 at $DIR/issue_76432.rs:+3:10: +3:16
-          let _14: &T;                     // in scope 1 at $DIR/issue_76432.rs:+3:18: +3:24
-          let _15: &T;                     // in scope 1 at $DIR/issue_76432.rs:+3:26: +3:32
+          let _12: &T;                     // in scope 1 at $DIR/issue_76432.rs:+3:10: +3:16
+          let _13: &T;                     // in scope 1 at $DIR/issue_76432.rs:+3:18: +3:24
+          let _14: &T;                     // in scope 1 at $DIR/issue_76432.rs:+3:26: +3:32
           scope 2 {
-              debug v1 => _13;             // in scope 2 at $DIR/issue_76432.rs:+3:10: +3:16
-              debug v2 => _14;             // in scope 2 at $DIR/issue_76432.rs:+3:18: +3:24
-              debug v3 => _15;             // in scope 2 at $DIR/issue_76432.rs:+3:26: +3:32
+              debug v1 => _12;             // in scope 2 at $DIR/issue_76432.rs:+3:10: +3:16
+              debug v2 => _13;             // in scope 2 at $DIR/issue_76432.rs:+3:18: +3:24
+              debug v3 => _14;             // in scope 2 at $DIR/issue_76432.rs:+3:26: +3:32
           }
       }
   
@@ -54,18 +47,17 @@
           _2 = move _3 as &[T] (Pointer(Unsize)); // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
           StorageDead(_3);                 // scope 0 at $DIR/issue_76432.rs:+1:28: +1:29
           StorageDead(_4);                 // scope 0 at $DIR/issue_76432.rs:+1:29: +1:30
-          StorageLive(_9);                 // scope 1 at $DIR/issue_76432.rs:+2:5: +5:6
-          _10 = Len((*_2));                // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
-          _11 = const 3_usize;             // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
--         _12 = Eq(move _10, const 3_usize); // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
--         switchInt(move _12) -> [0: bb1, otherwise: bb2]; // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
+          _9 = Len((*_2));                 // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
+          _10 = const 3_usize;             // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
+-         _11 = Eq(move _9, const 3_usize); // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
+-         switchInt(move _11) -> [0: bb1, otherwise: bb2]; // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
 +         nop;                             // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
-+         switchInt(move _10) -> [3: bb2, otherwise: bb1]; // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
++         switchInt(move _9) -> [3: bb2, otherwise: bb1]; // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
       }
   
       bb1: {
-          StorageLive(_22);                // scope 1 at $SRC_DIR/core/src/panic.rs:LL:COL
-          _22 = core::panicking::panic(const "internal error: entered unreachable code"); // scope 1 at $SRC_DIR/core/src/panic.rs:LL:COL
+          StorageLive(_15);                // scope 1 at $SRC_DIR/core/src/panic.rs:LL:COL
+          _15 = core::panicking::panic(const "internal error: entered unreachable code"); // scope 1 at $SRC_DIR/core/src/panic.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/panic.rs:LL:COL
                                            // + literal: Const { ty: fn(&'static str) -> ! {core::panicking::panic}, val: Value(<ZST>) }
@@ -75,35 +67,15 @@
       }
   
       bb2: {
-          StorageLive(_13);                // scope 1 at $DIR/issue_76432.rs:+3:10: +3:16
-          _13 = &(*_2)[0 of 3];            // scope 1 at $DIR/issue_76432.rs:+3:10: +3:16
-          StorageLive(_14);                // scope 1 at $DIR/issue_76432.rs:+3:18: +3:24
-          _14 = &(*_2)[1 of 3];            // scope 1 at $DIR/issue_76432.rs:+3:18: +3:24
-          StorageLive(_15);                // scope 1 at $DIR/issue_76432.rs:+3:26: +3:32
-          _15 = &(*_2)[2 of 3];            // scope 1 at $DIR/issue_76432.rs:+3:26: +3:32
-          StorageLive(_16);                // scope 2 at $DIR/issue_76432.rs:+3:38: +3:52
-          StorageLive(_17);                // scope 2 at $DIR/issue_76432.rs:+3:38: +3:52
-          _17 = &raw const (*_13);         // scope 2 at $DIR/issue_76432.rs:+3:38: +3:40
-          _16 = _17;                       // scope 2 at $DIR/issue_76432.rs:+3:38: +3:52
-          StorageLive(_18);                // scope 2 at $DIR/issue_76432.rs:+3:54: +3:68
-          StorageLive(_19);                // scope 2 at $DIR/issue_76432.rs:+3:54: +3:68
-          _19 = &raw const (*_14);         // scope 2 at $DIR/issue_76432.rs:+3:54: +3:56
-          _18 = _19;                       // scope 2 at $DIR/issue_76432.rs:+3:54: +3:68
-          StorageLive(_20);                // scope 2 at $DIR/issue_76432.rs:+3:70: +3:84
-          StorageLive(_21);                // scope 2 at $DIR/issue_76432.rs:+3:70: +3:84
-          _21 = &raw const (*_15);         // scope 2 at $DIR/issue_76432.rs:+3:70: +3:72
-          _20 = _21;                       // scope 2 at $DIR/issue_76432.rs:+3:70: +3:84
-          _9 = [move _16, move _18, move _20]; // scope 2 at $DIR/issue_76432.rs:+3:37: +3:85
-          StorageDead(_21);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
-          StorageDead(_20);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
-          StorageDead(_19);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
-          StorageDead(_18);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
-          StorageDead(_17);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
-          StorageDead(_16);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
-          StorageDead(_15);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
+          StorageLive(_12);                // scope 1 at $DIR/issue_76432.rs:+3:10: +3:16
+          _12 = &(*_2)[0 of 3];            // scope 1 at $DIR/issue_76432.rs:+3:10: +3:16
+          StorageLive(_13);                // scope 1 at $DIR/issue_76432.rs:+3:18: +3:24
+          _13 = &(*_2)[1 of 3];            // scope 1 at $DIR/issue_76432.rs:+3:18: +3:24
+          StorageLive(_14);                // scope 1 at $DIR/issue_76432.rs:+3:26: +3:32
+          _14 = &(*_2)[2 of 3];            // scope 1 at $DIR/issue_76432.rs:+3:26: +3:32
           StorageDead(_14);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
           StorageDead(_13);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
-          StorageDead(_9);                 // scope 1 at $DIR/issue_76432.rs:+5:6: +5:7
+          StorageDead(_12);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
           nop;                             // scope 0 at $DIR/issue_76432.rs:+0:44: +6:2
           StorageDead(_5);                 // scope 0 at $DIR/issue_76432.rs:+6:1: +6:2
           StorageDead(_2);                 // scope 0 at $DIR/issue_76432.rs:+6:1: +6:2

--- a/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -76,7 +76,6 @@
           StorageDead(_14);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
           StorageDead(_13);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
           StorageDead(_12);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
-          nop;                             // scope 0 at $DIR/issue_76432.rs:+0:44: +6:2
           StorageDead(_5);                 // scope 0 at $DIR/issue_76432.rs:+6:1: +6:2
           StorageDead(_2);                 // scope 0 at $DIR/issue_76432.rs:+6:1: +6:2
           return;                          // scope 0 at $DIR/issue_76432.rs:+6:2: +6:2

--- a/src/test/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.diff
+++ b/src/test/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.diff
@@ -23,12 +23,10 @@
   
       bb2: {
           StorageDead(_2);                 // scope 0 at $DIR/simplify_if.rs:+2:15: +2:16
-          nop;                             // scope 0 at $DIR/simplify_if.rs:+1:14: +3:6
           goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:+1:5: +3:6
       }
   
       bb3: {
-          nop;                             // scope 0 at $DIR/simplify_if.rs:+3:6: +3:6
           goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:+1:5: +3:6
       }
   

--- a/src/test/mir-opt/simplify_locals.c.SimplifyLocals-before-const-prop.diff
+++ b/src/test/mir-opt/simplify_locals.c.SimplifyLocals-before-const-prop.diff
@@ -1,5 +1,5 @@
-- // MIR for `c` before SimplifyLocals
-+ // MIR for `c` after SimplifyLocals
+- // MIR for `c` before SimplifyLocals-before-const-prop
++ // MIR for `c` after SimplifyLocals-before-const-prop
   
   fn c() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/simplify_locals.rs:+0:8: +0:8

--- a/src/test/mir-opt/simplify_locals.d1.SimplifyLocals-before-const-prop.diff
+++ b/src/test/mir-opt/simplify_locals.d1.SimplifyLocals-before-const-prop.diff
@@ -1,5 +1,5 @@
-- // MIR for `d1` before SimplifyLocals
-+ // MIR for `d1` after SimplifyLocals
+- // MIR for `d1` before SimplifyLocals-before-const-prop
++ // MIR for `d1` after SimplifyLocals-before-const-prop
   
   fn d1() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/simplify_locals.rs:+0:9: +0:9

--- a/src/test/mir-opt/simplify_locals.d2.SimplifyLocals-before-const-prop.diff
+++ b/src/test/mir-opt/simplify_locals.d2.SimplifyLocals-before-const-prop.diff
@@ -1,5 +1,5 @@
-- // MIR for `d2` before SimplifyLocals
-+ // MIR for `d2` after SimplifyLocals
+- // MIR for `d2` before SimplifyLocals-before-const-prop
++ // MIR for `d2` after SimplifyLocals-before-const-prop
   
   fn d2() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/simplify_locals.rs:+0:9: +0:9

--- a/src/test/mir-opt/simplify_locals.expose_addr.SimplifyLocals-before-const-prop.diff
+++ b/src/test/mir-opt/simplify_locals.expose_addr.SimplifyLocals-before-const-prop.diff
@@ -1,5 +1,5 @@
-- // MIR for `expose_addr` before SimplifyLocals
-+ // MIR for `expose_addr` after SimplifyLocals
+- // MIR for `expose_addr` before SimplifyLocals-before-const-prop
++ // MIR for `expose_addr` after SimplifyLocals-before-const-prop
   
   fn expose_addr(_1: *const usize) -> () {
       debug p => _1;                       // in scope 0 at $DIR/simplify_locals.rs:+0:16: +0:17

--- a/src/test/mir-opt/simplify_locals.r.SimplifyLocals-before-const-prop.diff
+++ b/src/test/mir-opt/simplify_locals.r.SimplifyLocals-before-const-prop.diff
@@ -1,5 +1,5 @@
-- // MIR for `r` before SimplifyLocals
-+ // MIR for `r` after SimplifyLocals
+- // MIR for `r` before SimplifyLocals-before-const-prop
++ // MIR for `r` after SimplifyLocals-before-const-prop
   
   fn r() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/simplify_locals.rs:+0:8: +0:8

--- a/src/test/mir-opt/simplify_locals.rs
+++ b/src/test/mir-opt/simplify_locals.rs
@@ -1,4 +1,4 @@
-// unit-test: SimplifyLocals
+// unit-test: SimplifyLocals-before-const-prop
 
 
 #![feature(thread_local)]
@@ -9,26 +9,26 @@ enum E {
      B,
 }
 
-// EMIT_MIR simplify_locals.c.SimplifyLocals.diff
+// EMIT_MIR simplify_locals.c.SimplifyLocals-before-const-prop.diff
 fn c() {
     let bytes = [0u8; 10];
     // Unused cast
     let _: &[u8] = &bytes;
 }
 
-// EMIT_MIR simplify_locals.d1.SimplifyLocals.diff
+// EMIT_MIR simplify_locals.d1.SimplifyLocals-before-const-prop.diff
 fn d1() {
     // Unused set discriminant
     let _ = E::A;
 }
 
-// EMIT_MIR simplify_locals.d2.SimplifyLocals.diff
+// EMIT_MIR simplify_locals.d2.SimplifyLocals-before-const-prop.diff
 fn d2() {
     // Unused set discriminant
     {(10, E::A)}.1 = E::B;
 }
 
-// EMIT_MIR simplify_locals.r.SimplifyLocals.diff
+// EMIT_MIR simplify_locals.r.SimplifyLocals-before-const-prop.diff
 fn r() {
     let mut a = 1;
     // Unused references
@@ -38,31 +38,31 @@ fn r() {
 
 #[thread_local] static mut X: u32 = 0;
 
-// EMIT_MIR simplify_locals.t1.SimplifyLocals.diff
+// EMIT_MIR simplify_locals.t1.SimplifyLocals-before-const-prop.diff
 fn t1() {
     // Unused thread local
     unsafe { X };
 }
 
-// EMIT_MIR simplify_locals.t2.SimplifyLocals.diff
+// EMIT_MIR simplify_locals.t2.SimplifyLocals-before-const-prop.diff
 fn t2() {
     // Unused thread local
     unsafe { &mut X };
 }
 
-// EMIT_MIR simplify_locals.t3.SimplifyLocals.diff
+// EMIT_MIR simplify_locals.t3.SimplifyLocals-before-const-prop.diff
 fn t3() {
     // Unused thread local
     unsafe { *&mut X };
 }
 
-// EMIT_MIR simplify_locals.t4.SimplifyLocals.diff
+// EMIT_MIR simplify_locals.t4.SimplifyLocals-before-const-prop.diff
 fn t4() -> u32 {
     // Used thread local
     unsafe { X + 1 }
 }
 
-// EMIT_MIR simplify_locals.expose_addr.SimplifyLocals.diff
+// EMIT_MIR simplify_locals.expose_addr.SimplifyLocals-before-const-prop.diff
 fn expose_addr(p: *const usize) {
     // Used pointer to address cast. Has a side effect of exposing the provenance.
     p as usize;

--- a/src/test/mir-opt/simplify_locals.t1.SimplifyLocals-before-const-prop.diff
+++ b/src/test/mir-opt/simplify_locals.t1.SimplifyLocals-before-const-prop.diff
@@ -1,5 +1,5 @@
-- // MIR for `t1` before SimplifyLocals
-+ // MIR for `t1` after SimplifyLocals
+- // MIR for `t1` before SimplifyLocals-before-const-prop
++ // MIR for `t1` after SimplifyLocals-before-const-prop
   
   fn t1() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/simplify_locals.rs:+0:9: +0:9

--- a/src/test/mir-opt/simplify_locals.t2.SimplifyLocals-before-const-prop.diff
+++ b/src/test/mir-opt/simplify_locals.t2.SimplifyLocals-before-const-prop.diff
@@ -1,5 +1,5 @@
-- // MIR for `t2` before SimplifyLocals
-+ // MIR for `t2` after SimplifyLocals
+- // MIR for `t2` before SimplifyLocals-before-const-prop
++ // MIR for `t2` after SimplifyLocals-before-const-prop
   
   fn t2() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/simplify_locals.rs:+0:9: +0:9

--- a/src/test/mir-opt/simplify_locals.t3.SimplifyLocals-before-const-prop.diff
+++ b/src/test/mir-opt/simplify_locals.t3.SimplifyLocals-before-const-prop.diff
@@ -1,5 +1,5 @@
-- // MIR for `t3` before SimplifyLocals
-+ // MIR for `t3` after SimplifyLocals
+- // MIR for `t3` before SimplifyLocals-before-const-prop
++ // MIR for `t3` after SimplifyLocals-before-const-prop
   
   fn t3() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/simplify_locals.rs:+0:9: +0:9

--- a/src/test/mir-opt/simplify_locals.t4.SimplifyLocals-before-const-prop.diff
+++ b/src/test/mir-opt/simplify_locals.t4.SimplifyLocals-before-const-prop.diff
@@ -1,5 +1,5 @@
-- // MIR for `t4` before SimplifyLocals
-+ // MIR for `t4` after SimplifyLocals
+- // MIR for `t4` before SimplifyLocals-before-const-prop
++ // MIR for `t4` after SimplifyLocals-before-const-prop
   
   fn t4() -> u32 {
       let mut _0: u32;                     // return place in scope 0 at $DIR/simplify_locals.rs:+0:12: +0:15

--- a/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals-final.diff
+++ b/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals-final.diff
@@ -1,5 +1,5 @@
-- // MIR for `foo` before SimplifyLocals
-+ // MIR for `foo` after SimplifyLocals
+- // MIR for `foo` before SimplifyLocals-final
++ // MIR for `foo` after SimplifyLocals-final
   
   fn foo() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/simplify_locals_fixedpoint.rs:+0:13: +0:13

--- a/src/test/mir-opt/simplify_locals_fixedpoint.rs
+++ b/src/test/mir-opt/simplify_locals_fixedpoint.rs
@@ -12,4 +12,4 @@ fn main() {
     foo::<()>();
 }
 
-// EMIT_MIR simplify_locals_fixedpoint.foo.SimplifyLocals.diff
+// EMIT_MIR simplify_locals_fixedpoint.foo.SimplifyLocals-final.diff

--- a/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals-before-const-prop.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals-before-const-prop.diff
@@ -1,5 +1,5 @@
-- // MIR for `main` before SimplifyLocals
-+ // MIR for `main` after SimplifyLocals
+- // MIR for `main` before SimplifyLocals-before-const-prop
++ // MIR for `main` after SimplifyLocals-before-const-prop
   
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/simplify_locals_removes_unused_consts.rs:+0:11: +0:11

--- a/src/test/mir-opt/simplify_locals_removes_unused_consts.rs
+++ b/src/test/mir-opt/simplify_locals_removes_unused_consts.rs
@@ -1,4 +1,4 @@
-// unit-test: SimplifyLocals
+// unit-test: SimplifyLocals-before-const-prop
 // compile-flags: -C overflow-checks=no
 
 fn use_zst(_: ((), ())) {}
@@ -9,7 +9,7 @@ struct Temp {
 
 fn use_u8(_: u8) {}
 
-// EMIT_MIR simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
+// EMIT_MIR simplify_locals_removes_unused_consts.main.SimplifyLocals-before-const-prop.diff
 fn main() {
     let ((), ()) = ((), ());
     use_zst(((), ()));

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals-before-const-prop.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals-before-const-prop.diff
@@ -1,5 +1,5 @@
-- // MIR for `map` before SimplifyLocals
-+ // MIR for `map` after SimplifyLocals
+- // MIR for `map` before SimplifyLocals-before-const-prop
++ // MIR for `map` after SimplifyLocals-before-const-prop
   
   fn map(_1: Option<Box<()>>) -> Option<Box<()>> {
       debug x => _1;                       // in scope 0 at $DIR/simplify_locals_removes_unused_discriminant_reads.rs:+0:8: +0:9

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.rs
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.rs
@@ -1,4 +1,4 @@
-// unit-test: SimplifyLocals
+// unit-test: SimplifyLocals-before-const-prop
 
 fn map(x: Option<Box<()>>) -> Option<Box<()>> {
     match x {
@@ -11,4 +11,4 @@ fn main() {
     map(None);
 }
 
-// EMIT_MIR simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.diff
+// EMIT_MIR simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals-before-const-prop.diff

--- a/src/test/mir-opt/simplify_match.main.ConstProp.diff
+++ b/src/test/mir-opt/simplify_match.main.ConstProp.diff
@@ -21,7 +21,6 @@
       }
   
       bb1: {
-          nop;                             // scope 0 at $DIR/simplify_match.rs:+3:18: +3:20
           goto -> bb3;                     // scope 0 at $DIR/simplify_match.rs:+3:18: +3:20
       }
   

--- a/src/test/mir-opt/uninhabited_enum.process_never.SimplifyLocals-final.after.mir
+++ b/src/test/mir-opt/uninhabited_enum.process_never.SimplifyLocals-final.after.mir
@@ -1,4 +1,4 @@
-// MIR for `process_never` after SimplifyLocals
+// MIR for `process_never` after SimplifyLocals-final
 
 fn process_never(_1: *const !) -> () {
     debug input => _1;                   // in scope 0 at $DIR/uninhabited_enum.rs:+0:22: +0:27

--- a/src/test/mir-opt/uninhabited_enum.process_void.SimplifyLocals-final.after.mir
+++ b/src/test/mir-opt/uninhabited_enum.process_void.SimplifyLocals-final.after.mir
@@ -1,4 +1,4 @@
-// MIR for `process_void` after SimplifyLocals
+// MIR for `process_void` after SimplifyLocals-final
 
 fn process_void(_1: *const Void) -> () {
     debug input => _1;                   // in scope 0 at $DIR/uninhabited_enum.rs:+0:21: +0:26

--- a/src/test/mir-opt/uninhabited_enum.rs
+++ b/src/test/mir-opt/uninhabited_enum.rs
@@ -2,13 +2,13 @@
 
 pub enum Void {}
 
-// EMIT_MIR uninhabited_enum.process_never.SimplifyLocals.after.mir
+// EMIT_MIR uninhabited_enum.process_never.SimplifyLocals-final.after.mir
 #[no_mangle]
 pub fn process_never(input: *const !) {
    let _input = unsafe { &*input };
 }
 
-// EMIT_MIR uninhabited_enum.process_void.SimplifyLocals.after.mir
+// EMIT_MIR uninhabited_enum.process_void.SimplifyLocals-final.after.mir
 #[no_mangle]
 pub fn process_void(input: *const Void) {
    let _input = unsafe { &*input };

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.diff
@@ -30,12 +30,10 @@
   
       bb2: {
           _1 = const 1_i32;                // scope 2 at $DIR/while_let_loops.rs:+3:9: +3:15
-          nop;                             // scope 2 at $DIR/while_let_loops.rs:+4:9: +4:14
           goto -> bb4;                     // scope 2 at $DIR/while_let_loops.rs:+4:9: +4:14
       }
   
       bb3: {
-          nop;                             // scope 1 at $DIR/while_let_loops.rs:+2:5: +5:6
           goto -> bb4;                     // scope 1 at no-location
       }
   

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.diff
@@ -4,13 +4,8 @@
   fn change_loop_body() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/while_let_loops.rs:+0:27: +0:27
       let mut _1: i32;                     // in scope 0 at $DIR/while_let_loops.rs:+1:9: +1:15
-      let mut _2: ();                      // in scope 0 at $DIR/while_let_loops.rs:+0:1: +6:2
-      let mut _3: std::option::Option<u32>; // in scope 0 at $DIR/while_let_loops.rs:+2:28: +2:32
-      let mut _4: isize;                   // in scope 0 at $DIR/while_let_loops.rs:+2:15: +2:25
-      let mut _5: !;                       // in scope 0 at $DIR/while_let_loops.rs:+2:33: +5:6
-      let mut _6: !;                       // in scope 0 at $DIR/while_let_loops.rs:+2:5: +5:6
-      let _7: ();                          // in scope 0 at $DIR/while_let_loops.rs:+2:5: +5:6
-      let mut _8: !;                       // in scope 0 at $DIR/while_let_loops.rs:+2:5: +5:6
+      let mut _2: std::option::Option<u32>; // in scope 0 at $DIR/while_let_loops.rs:+2:28: +2:32
+      let mut _3: isize;                   // in scope 0 at $DIR/while_let_loops.rs:+2:15: +2:25
       scope 1 {
           debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:+1:9: +1:15
           scope 2 {
@@ -20,17 +15,17 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:+1:9: +1:15
           _1 = const 0_i32;                // scope 0 at $DIR/while_let_loops.rs:+1:18: +1:19
-          StorageLive(_3);                 // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
-          Deinit(_3);                      // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
-          discriminant(_3) = 0;            // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
--         _4 = discriminant(_3);           // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
--         switchInt(move _4) -> [1: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
-+         _4 = const 0_isize;              // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
+          StorageLive(_2);                 // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
+          Deinit(_2);                      // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
+          discriminant(_2) = 0;            // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
+-         _3 = discriminant(_2);           // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
+-         switchInt(move _3) -> [1: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
++         _3 = const 0_isize;              // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
 +         switchInt(const 0_isize) -> [1: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
       }
   
       bb1: {
-          switchInt(((_3 as Some).0: u32)) -> [0: bb2, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
+          switchInt(((_2 as Some).0: u32)) -> [0: bb2, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
       }
   
       bb2: {
@@ -40,14 +35,12 @@
       }
   
       bb3: {
-          StorageLive(_7);                 // scope 1 at $DIR/while_let_loops.rs:+2:5: +5:6
           nop;                             // scope 1 at $DIR/while_let_loops.rs:+2:5: +5:6
-          StorageDead(_7);                 // scope 1 at $DIR/while_let_loops.rs:+5:5: +5:6
           goto -> bb4;                     // scope 1 at no-location
       }
   
       bb4: {
-          StorageDead(_3);                 // scope 1 at $DIR/while_let_loops.rs:+5:5: +5:6
+          StorageDead(_2);                 // scope 1 at $DIR/while_let_loops.rs:+5:5: +5:6
           StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:+6:1: +6:2
           return;                          // scope 0 at $DIR/while_let_loops.rs:+6:2: +6:2
       }

--- a/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
@@ -44,7 +44,7 @@ fn while_loop(_1: bool) -> () {
 
     bb5: {
         StorageDead(_4);                 // scope 0 at $DIR/while_storage.rs:+4:9: +4:10
-        goto -> bb8;                     // scope 0 at no-location
+        goto -> bb7;                     // scope 0 at no-location
     }
 
     bb6: {
@@ -54,10 +54,6 @@ fn while_loop(_1: bool) -> () {
     }
 
     bb7: {
-        goto -> bb8;                     // scope 0 at no-location
-    }
-
-    bb8: {
         StorageDead(_2);                 // scope 0 at $DIR/while_storage.rs:+5:5: +5:6
         return;                          // scope 0 at $DIR/while_storage.rs:+6:2: +6:2
     }

--- a/src/test/ui/consts/invalid-union.32bit.stderr
+++ b/src/test/ui/consts/invalid-union.32bit.stderr
@@ -21,12 +21,6 @@ note: erroneous constant used
 LL |     let _: &'static _ = &C;
    |                         ^^
 
-note: erroneous constant used
-  --> $DIR/invalid-union.rs:43:25
-   |
-LL |     let _: &'static _ = &C;
-   |                         ^^
-
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/invalid-union.64bit.stderr
+++ b/src/test/ui/consts/invalid-union.64bit.stderr
@@ -21,12 +21,6 @@ note: erroneous constant used
 LL |     let _: &'static _ = &C;
    |                         ^^
 
-note: erroneous constant used
-  --> $DIR/invalid-union.rs:43:25
-   |
-LL |     let _: &'static _ = &C;
-   |                         ^^
-
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
MIR before `ConstProp` may have a lot of dead writes, this makes `ConstProp` do unnecessary work.

r? @ghost 