### PR TITLE
Point at GAT `where` clause when an obligation is unsatisfied

### DIFF
--- a/src/test/ui/generic-associated-types/own-bound-span.rs
+++ b/src/test/ui/generic-associated-types/own-bound-span.rs
@@ -1,0 +1,17 @@
+struct S;
+
+trait D {
+    type P<T: Copy>;
+    //~^ NOTE required by this bound in `D::P`
+    //~| NOTE required by a bound in `D::P`
+}
+
+impl D for S {
+    type P<T: Copy> = ();
+}
+
+fn main() {
+    let _: <S as D>::P<String>;
+    //~^ ERROR the trait bound `String: Copy` is not satisfied
+    //~| NOTE the trait `Copy` is not implemented for `String`
+}

--- a/src/test/ui/generic-associated-types/own-bound-span.stderr
+++ b/src/test/ui/generic-associated-types/own-bound-span.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `String: Copy` is not satisfied
+  --> $DIR/own-bound-span.rs:14:12
+   |
+LL |     let _: <S as D>::P<String>;
+   |            ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |
+note: required by a bound in `D::P`
+  --> $DIR/own-bound-span.rs:4:15
+   |
+LL |     type P<T: Copy>;
+   |               ^^^^ required by this bound in `D::P`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/object-safety/object-safety-supertrait-mentions-GAT.stderr
+++ b/src/test/ui/object-safety/object-safety-supertrait-mentions-GAT.stderr
@@ -3,10 +3,10 @@ error[E0311]: the parameter type `Self` may not live long enough
    = help: consider adding an explicit lifetime bound `Self: 'a`...
    = note: ...so that the type `Self` will meet its required lifetime bounds...
 note: ...that is required by this bound
-  --> $DIR/object-safety-supertrait-mentions-GAT.rs:9:39
+  --> $DIR/object-safety-supertrait-mentions-GAT.rs:6:15
    |
-LL | trait SuperTrait<T>: for<'a> GatTrait<Gat<'a> = T> {
-   |                                       ^^^^^^^^^^^
+LL |         Self: 'a;
+   |               ^^
 
 error: associated item referring to unboxed trait object for its own trait
   --> $DIR/object-safety-supertrait-mentions-GAT.rs:10:20


### PR DESCRIPTION
Slightly helps with #105306