### PR TITLE
Account for `match` expr in single line

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -729,7 +729,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             format!("this and all prior arms are found to be of type `{}`", t),
                         );
                     }
-                    let outer_error_span = if any_multiline_arm {
+                    let outer = if any_multiline_arm || !source_map.is_multiline(cause.span) {
                         // Cover just `match` and the scrutinee expression, not
                         // the entire match body, to reduce diagram noise.
                         cause.span.shrink_to_lo().to(scrut_span)
@@ -737,7 +737,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         cause.span
                     };
                     let msg = "`match` arms have incompatible types";
-                    err.span_label(outer_error_span, msg);
+                    err.span_label(outer, msg);
                     self.suggest_remove_semi_or_return_binding(
                         err,
                         prior_arm_block_id,

--- a/src/test/ui/match/single-line.rs
+++ b/src/test/ui/match/single-line.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _ = match Some(42) { Some(x) => x, None => "" }; //~ ERROR E0308
+}

--- a/src/test/ui/match/single-line.stderr
+++ b/src/test/ui/match/single-line.stderr
@@ -1,0 +1,12 @@
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/single-line.rs:2:52
+   |
+LL |     let _ = match Some(42) { Some(x) => x, None => "" };
+   |             --------------              -          ^^ expected integer, found `&str`
+   |             |                           |
+   |             |                           this is found to be of type `{integer}`
+   |             `match` arms have incompatible types
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
When encountering `match Some(42) { Some(x) => x, None => "" };`, output

```
error[E0308]: `match` arms have incompatible types
 --> f53.rs:2:52
  |
2 |     let _ = match Some(42) { Some(x) => x, None => "" };
  |             --------------              -          ^^ expected integer, found `&str`
  |             |                           |
  |             |                           this is found to be of type `{integer}`
  |             `match` arms have incompatible types
  ```