### PR TITLE
Point at args in associated const fn pointers

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1918,15 +1918,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         receiver: Option<&'tcx hir::Expr<'tcx>>,
         args: &'tcx [hir::Expr<'tcx>],
     ) -> bool {
-        // Do not call `fn_sig` on non-functions.
-        if !matches!(
-            self.tcx.def_kind(def_id),
-            DefKind::Fn | DefKind::AssocFn | DefKind::Variant | DefKind::Ctor(..)
-        ) {
+        let ty = self.tcx.type_of(def_id);
+        if !ty.is_fn() {
             return false;
         }
-
-        let sig = self.tcx.fn_sig(def_id).skip_binder();
+        let sig = ty.fn_sig(self.tcx).skip_binder();
         let args_referencing_param: Vec<_> = sig
             .inputs()
             .iter()

--- a/src/test/ui/suggestions/assoc-const-as-fn.stderr
+++ b/src/test/ui/suggestions/assoc-const-as-fn.stderr
@@ -1,8 +1,10 @@
 error[E0277]: the trait bound `T: GlUniformScalar` is not satisfied
-  --> $DIR/assoc-const-as-fn.rs:14:5
+  --> $DIR/assoc-const-as-fn.rs:14:40
    |
 LL |     <T as GlUniformScalar>::FACTORY(1, value);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `GlUniformScalar` is not implemented for `T`
+   |     -------------------------------    ^^^^^ the trait `GlUniformScalar` is not implemented for `T`
+   |     |
+   |     required by a bound introduced by this call
    |
 help: consider further restricting this bound
    |


### PR DESCRIPTION
Tiny follow-up to #105201, not so sure it's worth it but :shrug: 

The UI test example is a bit more compelling when it's `GlUniformScalar::FACTORY`

r? @cjgillot 