### PR TITLE
Use `Lrc<[_]>` instead of `Vec<_>` in `rustc_ast::...::Comment`

### DIFF
--- a/compiler/rustc_ast/src/util/comments.rs
+++ b/compiler/rustc_ast/src/util/comments.rs
@@ -163,15 +163,19 @@ fn trim_whitespace_prefix(s: &str, col: CharPos) -> &str {
 }
 
 fn split_block_comment_into_lines(text: &str, col: CharPos) -> Lrc<[String]> {
-    let mut res: Vec<String> = vec![];
+    let mut res: Lrc<[String]> = iter::repeat(String::new()).take(text.lines().count()).collect();
     let mut lines = text.lines();
+    let res_slice = Lrc::get_mut(&mut res).unwrap();
     // just push the first line
-    res.extend(lines.next().map(|it| it.to_string()));
-    // for other lines, strip common whitespace prefix
-    for line in lines {
-        res.push(trim_whitespace_prefix(line, col).to_string())
+    if let Some(first) = lines.next() {
+        res_slice[0] = first.to_owned();
     }
-    res.into()
+    // for other lines, strip common whitespace prefix
+    for (line, out) in iter::zip(lines, &mut res_slice[1..]) {
+        *out = trim_whitespace_prefix(line, col).to_owned();
+    }
+
+    res
 }
 
 // it appears this function is called only from pprust... that's

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -64,7 +64,6 @@ impl<'a> Comments<'a> {
         Comments { sm, comments, current: 0 }
     }
 
-    // FIXME: This shouldn't probably clone lmao
     pub fn next(&self) -> Option<Comment> {
         self.comments.get(self.current).cloned()
     }
@@ -306,7 +305,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
             }
             CommentStyle::Isolated => {
                 self.hardbreak_if_not_bol();
-                for line in &cmnt.lines {
+                for line in &*cmnt.lines {
                     // Don't print empty lines because they will end up as trailing
                     // whitespace.
                     if !line.is_empty() {
@@ -324,7 +323,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
                     self.hardbreak()
                 } else {
                     self.visual_align();
-                    for line in &cmnt.lines {
+                    for line in &*cmnt.lines {
                         if !line.is_empty() {
                             self.word(line.clone());
                         }


### PR DESCRIPTION
`Comment` seems to be cloned quite a lot, so making the clone cheaper could be nice.

----

I've tried to remove cloning first, but it turns out to be hard b/c of borrock errors. It might be possible to eliminate cloning with a bigger refactor, but maybe this will have a positive impact of perf too.

r? @compiler-errors 