### PR TITLE
rust: library: Add `setsid` method to `CommandExt` trait

### DIFF
--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -179,6 +179,9 @@ pub trait CommandExt: Sealed {
     /// ```
     #[stable(feature = "process_set_process_group", since = "1.64.0")]
     fn process_group(&mut self, pgroup: i32) -> &mut process::Command;
+
+    #[unstable(feature = "process_setsid", issue = "105376")]
+    fn setsid(&mut self) -> &mut process::Command;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -222,6 +225,11 @@ impl CommandExt for process::Command {
 
     fn process_group(&mut self, pgroup: i32) -> &mut process::Command {
         self.as_inner_mut().pgroup(pgroup);
+        self
+    }
+
+    fn setsid(&mut self) -> &mut process::Command {
+        self.as_inner_mut().setsid();
         self
     }
 }

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -107,6 +107,7 @@ pub struct Command {
     #[cfg(target_os = "linux")]
     create_pidfd: bool,
     pgroup: Option<pid_t>,
+    setsid: bool,
 }
 
 // Create a new type for argv, so that we can make it `Send` and `Sync`
@@ -197,6 +198,7 @@ impl Command {
             stdout: None,
             stderr: None,
             pgroup: None,
+            setsid: false,
         }
     }
 
@@ -222,6 +224,7 @@ impl Command {
             stderr: None,
             create_pidfd: false,
             pgroup: None,
+            setsid: false,
         }
     }
 
@@ -259,6 +262,10 @@ impl Command {
     }
     pub fn pgroup(&mut self, pgroup: pid_t) {
         self.pgroup = Some(pgroup);
+    }
+
+    pub fn setsid(&mut self) {
+        self.setsid = true;
     }
 
     #[cfg(target_os = "linux")]
@@ -331,6 +338,11 @@ impl Command {
     #[allow(dead_code)]
     pub fn get_pgroup(&self) -> Option<pid_t> {
         self.pgroup
+    }
+
+    #[allow(dead_code)]
+    pub fn get_setsid(&self) -> bool {
+        self.setsid
     }
 
     pub fn get_closures(&mut self) -> &mut Vec<Box<dyn FnMut() -> io::Result<()> + Send + Sync>> {

--- a/library/std/src/sys/unix/process/process_common/tests.rs
+++ b/library/std/src/sys/unix/process/process_common/tests.rs
@@ -137,6 +137,64 @@ fn test_process_group_no_posix_spawn() {
 }
 
 #[test]
+#[cfg_attr(
+    any(
+        // See test_process_mask
+        target_os = "macos",
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+    ),
+    ignore
+)]
+fn test_setsid_posix_spawn() {
+    // Spawn a cat subprocess that's just going to hang since there is no I/O.
+    let mut cmd = Command::new(OsStr::new("cat"));
+    cmd.setsid();
+    cmd.stdin(Stdio::MakePipe);
+    cmd.stdout(Stdio::MakePipe);
+    let (mut cat, _pipes) = t!(cmd.spawn(Stdio::Null, true));
+
+    unsafe {
+        // Setsid will create a new session and process group, so check that
+        // we can kill the process group, which means there *is* one.
+        t!(cvt(libc::kill(-(cat.id() as libc::pid_t), libc::SIGINT)));
+
+        t!(cat.wait());
+    }
+}
+
+#[test]
+#[cfg_attr(
+    any(
+        // See test_process_mask
+        target_os = "macos",
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+    ),
+    ignore
+)]
+fn test_setsid_no_posix_spawn() {
+    let mut cmd = Command::new(OsStr::new("cat"));
+    cmd.setsid();
+    cmd.stdin(Stdio::MakePipe);
+    cmd.stdout(Stdio::MakePipe);
+
+    unsafe {
+        // Same as above, create hang-y cat. This time, force using the non-posix_spawn path.
+        cmd.pre_exec(Box::new(|| Ok(()))); // pre_exec forces fork + exec rather than posix spawn.
+        let (mut cat, _pipes) = t!(cmd.spawn(Stdio::Null, true));
+
+        // Setsid will create a new session and process group, so check that
+        // we can kill the process group, which means there *is* one.
+        t!(cvt(libc::kill(-(cat.id() as libc::pid_t), libc::SIGINT)));
+
+        t!(cat.wait());
+    }
+}
+
+#[test]
 fn test_program_kind() {
     let vectors = &[
         ("foo", ProgramKind::PathLookup),

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -328,6 +328,10 @@ impl Command {
             cvt(libc::setpgid(0, pgroup))?;
         }
 
+        if self.get_setsid() {
+            cvt(libc::setsid())?;
+        }
+
         // emscripten has no signal support.
         #[cfg(not(target_os = "emscripten"))]
         {
@@ -467,6 +471,7 @@ impl Command {
         };
 
         let pgroup = self.get_pgroup();
+        let setsid = self.get_setsid();
 
         // Safety: -1 indicates we don't have a pidfd.
         let mut p = unsafe { Process::new(0, -1) };
@@ -548,6 +553,10 @@ impl Command {
                     default_set.as_ptr(),
                 ))?;
                 flags |= libc::POSIX_SPAWN_SETSIGDEF;
+            }
+
+            if setsid {
+                flags |= libc::POSIX_SPAWN_SETSID;
             }
 
             cvt_nz(libc::posix_spawnattr_setflags(attrs.0.as_mut_ptr(), flags as _))?;


### PR DESCRIPTION
Add a setsid method to the CommandExt trait so that callers can create a process in a new session and process group whilst still using the POSIX spawn fast path.

Tracking issue: #105376

ACP: https://github.com/rust-lang/libs-team/issues/184