### PR TITLE
Fix failing codegen tests on s390x

### DIFF
--- a/src/test/codegen/catch-unwind.rs
+++ b/src/test/codegen/catch-unwind.rs
@@ -8,6 +8,8 @@
 // On riscv the closure is another function, placed before fn foo so CHECK can't
 // find it
 // ignore-riscv64 FIXME
+// On s390x the closure is also in another function
+// ignore-s390x FIXME
 
 #![crate_type = "lib"]
 #![feature(c_unwind)]

--- a/src/test/codegen/remap_path_prefix/main.rs
+++ b/src/test/codegen/remap_path_prefix/main.rs
@@ -12,7 +12,7 @@ mod aux_mod;
 include!("aux_mod.rs");
 
 // Here we check that the expansion of the file!() macro is mapped.
-// CHECK: @alloc2 = private unnamed_addr constant <{ [34 x i8] }> <{ [34 x i8] c"/the/src/remap_path_prefix/main.rs" }>, align 1
+// CHECK: @alloc2 = private unnamed_addr constant <{ [34 x i8] }> <{ [34 x i8] c"/the/src/remap_path_prefix/main.rs" }>
 pub static FILE_PATH: &'static str = file!();
 
 fn main() {

--- a/src/test/codegen/repr-transparent-aggregates-1.rs
+++ b/src/test/codegen/repr-transparent-aggregates-1.rs
@@ -8,6 +8,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-riscv64 see codegen/riscv-abi
+// ignore-s390x
 // ignore-windows
 // See repr-transparent.rs
 

--- a/src/test/codegen/repr-transparent.rs
+++ b/src/test/codegen/repr-transparent.rs
@@ -2,6 +2,7 @@
 
 // ignore-riscv64 riscv64 has an i128 type used with test_Vector
 // see codegen/riscv-abi for riscv functiona call tests
+// ignore-s390x s390x with default march passes vector types per reference
 
 #![crate_type="lib"]
 #![feature(repr_simd, transparent_unions)]

--- a/src/test/codegen/uninit-consts.rs
+++ b/src/test/codegen/uninit-consts.rs
@@ -14,7 +14,7 @@ pub struct PartiallyUninit {
 
 // CHECK: [[FULLY_UNINIT:@[0-9]+]] = private unnamed_addr constant <{ [10 x i8] }> undef
 
-// CHECK: [[PARTIALLY_UNINIT:@[0-9]+]] = private unnamed_addr constant <{ [4 x i8], [12 x i8] }> <{ [4 x i8] c"\EF\BE\AD\DE", [12 x i8] undef }>, align 4
+// CHECK: [[PARTIALLY_UNINIT:@[0-9]+]] = private unnamed_addr constant <{ [4 x i8], [12 x i8] }> <{ [4 x i8] c"{{\\EF\\BE\\AD\\DE|\\DE\\AD\\BE\\EF}}", [12 x i8] undef }>, align 4
 
 // This shouldn't contain undef, since it contains more chunks
 // than the default value of uninit_const_chunk_threshold.


### PR DESCRIPTION
Several codegen tests are currently failing due to making assumptions that are not valid for the s390x architecture:

- catch-unwind.rs: fails due to inlining differences. Already ignored on another platform for the same reason. Solution: Ignore on s390x.

- remap_path_prefix/main.rs: fails due to different alignment requirement for string constants. Solution: Do not test for the alignment requirement.

- repr-transparent-aggregates-1.rs: many ABI assumptions. Already ignored on many platforms for the same reason. Solution: Ignore on s390x.

- repr-transparent.rs: no vector ABI by default on s390x. Already ignored on another platform for a similar reason. Solution: Ignore on s390x.

- uninit-consts.rs: hard-coded little-endian constant. Solution: Match both little- and big-endian versions.

Fixes part of https://github.com/rust-lang/rust/issues/105383.