### PR TITLE
Skip test on s390x as LLD does not support the platform

### DIFF
--- a/src/test/run-make/issue-71519/Makefile
+++ b/src/test/run-make/issue-71519/Makefile
@@ -2,6 +2,7 @@ include ../../run-make-fulldeps/tools.mk
 
 # ignore-msvc
 # needs-rust-lld
+# ignore-s390x lld does not yet support s390x as target
 all:
 	RUSTC_LOG=rustc_codegen_ssa::back::link=info $(RUSTC) -Z gcc-ld=lld -C link-args=-Wl,-v main.rs 2> $(TMPDIR)/output.txt
 	$(CGREP) -e "^LLD [0-9]+\.[0-9]+\.[0-9]+" < $(TMPDIR)/output.txt


### PR DESCRIPTION
test/run-make/issue-71519 requires use of lld as linker, but lld does not currently support the s390x architecture.