### PR TITLE
rustdoc: remove redundant CSS `.import-item .stab { font-size }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1015,7 +1015,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 .import-item .stab {
 	border-radius: 3px;
 	display: inline-block;
-	font-size: 0.875rem;
 	line-height: 1.2;
 	margin-bottom: 0;
 	margin-left: 0.3125em;


### PR DESCRIPTION
This sets the exact same font size that `.stab` has by default anyway. It used to be slightly different, but dd5ff428edbc7cd4fa600b81f27bbec28589704f made it identical.