### PR TITLE
Enable profiler in dist-powerpc64le-linux

### DIFF
--- a/src/ci/docker/host-x86_64/dist-powerpc64le-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-powerpc64le-linux/Dockerfile
@@ -24,5 +24,5 @@ ENV \
 
 ENV HOSTS=powerpc64le-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
+ENV RUST_CONFIGURE_ARGS --enable-extended --enable-profiler --disable-docs
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS


### PR DESCRIPTION
Build the profiler runtime to allow using -C profile-generate and -C instrument-coverage on POWER little endian systems.

I have verified locally that the runtime builds and the profiler is working fine on the platform.

Similar pull request for a different system: https://github.com/rust-lang/rust/pull/104304