### PR TITLE
unstable-book: Add `ignore` to `abi_efiapi` example code

### DIFF
--- a/src/doc/unstable-book/src/language-features/abi-efiapi.md
+++ b/src/doc/unstable-book/src/language-features/abi-efiapi.md
@@ -12,7 +12,7 @@ Specification].
 
 Example:
 
-```rust
+```rust,ignore (not-all-targets-support-uefi)
 #![feature(abi_efiapi)]
 
 extern "efiapi" { fn f1(); }


### PR DESCRIPTION
This example doesn't compile on targets that don't support UEFI, as reported here:
https://github.com/rust-lang/rust/pull/104793#issuecomment-1339783727