### PR TITLE
Dedup bounds with parent impl block

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -464,7 +464,7 @@ pub(crate) fn build_impl(
                 })
                 .map(|item| clean_impl_item(item, cx))
                 .collect::<Vec<_>>(),
-            clean_generics(impl_.generics, cx),
+            clean_generics(impl_.generics, did, cx, false),
         ),
         None => (
             tcx.associated_items(did)

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -728,7 +728,6 @@ fn main_args(at_args: &[String]) -> MainResult {
             };
         }
     };
-
     let diag = core::new_handler(
         options.error_format,
         None,

--- a/src/test/rustdoc/bounds-parent-child-duplicates.rs
+++ b/src/test/rustdoc/bounds-parent-child-duplicates.rs
@@ -1,0 +1,43 @@
+// This test ensures that if a child item's bounds are duplicated with the parent, they are not
+// generated in the documentation.
+
+#![crate_name = "foo"]
+
+pub trait Bar {}
+pub trait Bar2 {}
+pub trait Bar3 {}
+pub trait Bar4 {}
+
+// @has 'foo/trait.Foo.html'
+pub trait Foo<'a, T: Bar + 'a> where T: Bar2 {
+    // @has - '//*[@id="method.foo"]/h4' 'fn foo()'
+    // `Bar` shouldn't appear in the bounds.
+    // @!has - '//*[@id="method.foo"]/h4' 'Bar'
+    fn foo() where T: Bar {}
+    // @has - '//*[@id="method.foo2"]/h4' 'fn foo2()'
+    // `Bar2` shouldn't appear in the bounds.
+    // @!has - '//*[@id="method.foo2"]/h4' 'Bar2'
+    fn foo2() where T: Bar2 {}
+    // @has - '//*[@id="method.foo3"]/h4' "fn foo3<'b>()where T: Bar3, 'a: 'b,"
+    fn foo3<'b>() where T: Bar3, 'a: 'b {}
+    // @has - '//*[@id="method.foo4"]/h4' "fn foo4()where T: Bar3,"
+    fn foo4() where T: Bar2 + Bar3 {}
+}
+
+pub struct X;
+
+// @has 'foo/struct.X.html'
+impl<'a, T: Bar> X where T: Bar2 {
+    // @has - '//*[@id="method.foo"]/h4' 'fn foo()'
+    // @!has - '//*[@id="method.foo"]/h4' 'Bar'
+    // `Bar` shouldn't appear in the bounds.
+    pub fn foo() where T: Bar {}
+    // @has - '//*[@id="method.foo2"]/h4' 'fn foo2()'
+    // `Bar2` shouldn't appear in the bounds.
+    // @!has - '//*[@id="method.foo2"]/h4' 'Bar2'
+    pub fn foo2() where T: Bar2 {}
+    // @has - '//*[@id="method.foo3"]/h4' "fn foo3<'b>()where T: Bar3, 'a: 'b,"
+    pub fn foo3<'b>() where 'a: 'b, T: Bar3 {}
+    // @has - '//*[@id="method.foo4"]/h4' "fn foo4()where T: Bar3,"
+    pub fn foo4() where T: Bar2 + Bar3 {}
+}


### PR DESCRIPTION
This is another approach than #105325 to solve https://github.com/rust-lang/rust/issues/104886.

Thanks a lot to both @oli-obk and @compiler-errors for their great help!

I added a FIXME to not forget to complete switch to rustc calls instead of relying on hir currently for generics. @oli-obk suggested something that I'll need to try out. :)

r? @compiler-errors 

PS: We might want to run a perf check before approving too