### PR TITLE
Update the wasi toolchain.

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-2/build-wasi-toolchain.sh
+++ b/src/ci/docker/host-x86_64/dist-various-2/build-wasi-toolchain.sh
@@ -2,15 +2,15 @@
 
 set -ex
 
-# Originally from https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-curl https://ci-mirrors.rust-lang.org/rustc/2022-05-10-clang%2Bllvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz | \
+# Originally from https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+curl https://ci-mirrors.rust-lang.org/rustc/2022-12-06-clang%2Bllvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz | \
   tar xJf -
-bin="$PWD/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04/bin"
+bin="$PWD/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04/bin"
 
 git clone https://github.com/WebAssembly/wasi-libc
 
 cd wasi-libc
-git reset --hard 9886d3d6200fcc3726329966860fc058707406cd
+git reset --hard 8b7148f69ae241a2749b3defe4606da8143b72e0
 make -j$(nproc) \
     CC="$bin/clang" \
     NM="$bin/llvm-nm" \


### PR DESCRIPTION
Update the WASI build to LLVM 15.0 and the wasi-libc version from [wasi-sdk-17].

This will require a ci-mirrors.rust-lang.org file load. Specifically, we need [this LLVM release tarball] uploaded to be downloadable from [this URL].

The biggest change in wasi-sdk-17 is that user exports no longer automatically run constructor functions. More details at: https://github.com/WebAssembly/WASI/issues/493.

[this LLVM release tarball]: https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz
[this URL]: https://ci-mirrors.rust-lang.org/rustc/2022-12-06-clang%2Bllvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz
[wasi-sdk-17]: https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-17

