### PR TITLE
normalize before handling simple checks for evaluatability of `ty::Const`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -30,7 +30,7 @@ pub fn is_const_evaluatable<'tcx>(
     span: Span,
 ) -> Result<(), NotConstEvaluatable> {
     let tcx = infcx.tcx;
-    match unexpanded_ct.kind() {
+    match tcx.expand_abstract_consts(unexpanded_ct).kind() {
         ty::ConstKind::Unevaluated(_) | ty::ConstKind::Expr(_) => (),
         ty::ConstKind::Param(_)
         | ty::ConstKind::Bound(_, _)

--- a/src/test/ui/const-generics/generic_const_exprs/normed_to_param_is_evaluatable.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/normed_to_param_is_evaluatable.rs
@@ -1,0 +1,12 @@
+// check-pass
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features, unused_braces)]
+
+#[rustfmt::skip]
+fn foo<const N: usize>() {
+    bar::<{{{{{{ N }}}}}}>();
+}
+
+fn bar<const N: usize>() {}
+
+fn main() {}


### PR DESCRIPTION
`{{{{{{{ N }}}}}}}` is desugared into a `ConstKind::Unevaluated` for an anonymous `const` item so when calling `is_const_evaluatable` on it we skip the `ConstKind::Param(_) => Ok(())` arm which is incorrect.