### PR TITLE
Implement `Fn` traits for `Rc` and `Arc`

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1555,6 +1555,29 @@ impl<T: ?Sized> Deref for Rc<T> {
     }
 }
 
+#[stable(feature = "rc_closure_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<Args, F: Fn<Args> + ?Sized> Fn<Args> for Rc<F> {
+    extern "rust-call" fn call(&self, args: Args) -> Self::Output {
+        <F as Fn<Args>>::call(self, args)
+    }
+}
+
+#[stable(feature = "rc_closure_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<Args, F: Fn<Args> + ?Sized> FnMut<Args> for Rc<F> {
+    extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output {
+        <F as Fn<Args>>::call(self, args)
+    }
+}
+
+#[stable(feature = "rc_closure_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<Args, F: Fn<Args> + ?Sized> FnOnce<Args> for Rc<F> {
+    type Output = F::Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output {
+        <F as Fn<Args>>::call(&self, args)
+    }
+}
+
 #[unstable(feature = "receiver_trait", issue = "none")]
 impl<T: ?Sized> Receiver for Rc<T> {}
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1392,6 +1392,29 @@ impl<T: ?Sized> Deref for Arc<T> {
     }
 }
 
+#[stable(feature = "rc_closure_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<Args, F: Fn<Args> + ?Sized> Fn<Args> for Arc<F> {
+    extern "rust-call" fn call(&self, args: Args) -> Self::Output {
+        <F as Fn<Args>>::call(self, args)
+    }
+}
+
+#[stable(feature = "rc_closure_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<Args, F: Fn<Args> + ?Sized> FnMut<Args> for Arc<F> {
+    extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output {
+        <F as Fn<Args>>::call(self, args)
+    }
+}
+
+#[stable(feature = "rc_closure_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<Args, F: Fn<Args> + ?Sized> FnOnce<Args> for Arc<F> {
+    type Output = F::Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output {
+        <F as Fn<Args>>::call(&self, args)
+    }
+}
+
 #[unstable(feature = "receiver_trait", issue = "none")]
 impl<T: ?Sized> Receiver for Arc<T> {}
 


### PR DESCRIPTION
These use the same semantics as the implementations for `&F` by only covering `F: Fn`.

This change enables passing reference-counted closures to functions that expect `Fn + 'static` or `Fn + Clone`.

ACP: https://github.com/rust-lang/libs-team/issues/143