### PR TITLE
Fix warning when libcore is compiled with no_fp_fmt_parse

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -4,11 +4,13 @@
 
 use crate::ascii;
 use crate::convert::TryInto;
-use crate::error::Error;
 use crate::intrinsics;
 use crate::mem;
 use crate::ops::{Add, Mul, Sub};
 use crate::str::FromStr;
+
+#[cfg(not(no_fp_fmt_parse))]
+use crate::error::Error;
 
 // Used because the `?` operator is not allowed in a const context.
 macro_rules! try_opt {


### PR DESCRIPTION
Discovered when trying to compile Rust-for-Linux with Rust 1.66 beta.

It'll be helpful if this is backported to beta (should be trivial enough for backporting), so Rust-for-Linux's rust version bump wouldn't need to do `--cap-lints allow` for libcore.