### PR TITLE
Add 0..=isize::MAX range metadata to size loads from vtables

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -775,6 +775,18 @@ impl Integer {
         }
     }
 
+    /// Returns the largest signed value that can be represented by this Integer.
+    #[inline]
+    pub fn signed_max(self) -> i128 {
+        match self {
+            I8 => i8::MAX as i128,
+            I16 => i16::MAX as i128,
+            I32 => i32::MAX as i128,
+            I64 => i64::MAX as i128,
+            I128 => i128::MAX,
+        }
+    }
+
     /// Finds the smallest Integer type which can represent the signed value.
     #[inline]
     pub fn fit_signed(x: i128) -> Integer {

--- a/compiler/rustc_codegen_ssa/src/glue.rs
+++ b/compiler/rustc_codegen_ssa/src/glue.rs
@@ -29,6 +29,9 @@ pub fn size_and_align_of_dst<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             let align = meth::VirtualIndex::from_index(ty::COMMON_VTABLE_ENTRIES_ALIGN)
                 .get_usize(bx, vtable);
 
+            // Size is always <= isize::MAX.
+            let size_bound = bx.data_layout().ptr_sized_integer().signed_max() as u128;
+            bx.range_metadata(size, WrappingRange { start: 0, end: size_bound });
             // Alignment is always nonzero.
             bx.range_metadata(align, WrappingRange { start: 1, end: !0 });
 

--- a/src/test/codegen/dst-vtable-align-nonzero.rs
+++ b/src/test/codegen/dst-vtable-align-nonzero.rs
@@ -1,4 +1,4 @@
-// compile-flags: -O
+// compile-flags: -O -Z merge-functions=disabled
 
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]
@@ -55,9 +55,7 @@ pub fn align_load_from_align_of_val(x: &dyn Trait) -> usize {
 pub unsafe fn align_load_from_vtable_align_intrinsic(x: &dyn Trait) -> usize {
     let (data, vtable): (*const (), *const ()) = core::mem::transmute(x);
     // CHECK: {{%[0-9]+}} = load [[USIZE]], {{.+}} !range [[RANGE_META]]
-    let align = core::intrinsics::vtable_align(vtable);
-    // make this function unique so it doesn't get merged with the previous
-    align + 1
+    core::intrinsics::vtable_align(vtable)
 }
 
 // CHECK: [[RANGE_META]] = !{[[USIZE]] 1, [[USIZE]] 0}

--- a/src/test/codegen/dst-vtable-align-nonzero.rs
+++ b/src/test/codegen/dst-vtable-align-nonzero.rs
@@ -1,6 +1,7 @@
 // compile-flags: -O
 
 #![crate_type = "lib"]
+#![feature(core_intrinsics)]
 
 // This test checks that we annotate alignment loads from vtables with nonzero range metadata,
 // and that this allows LLVM to eliminate redundant `align >= 1` checks.
@@ -40,6 +41,23 @@ pub fn does_not_eliminate_runtime_check_when_align_2(
     // CHECK: {{icmp|llvm.umax}}
     // CHECK: ret
     &x.dst
+}
+
+// CHECK-LABEL: @align_load_from_align_of_val
+#[no_mangle]
+pub fn align_load_from_align_of_val(x: &dyn Trait) -> usize {
+    // CHECK: {{%[0-9]+}} = load [[USIZE]], {{.+}} !range [[RANGE_META]]
+    core::mem::align_of_val(x)
+}
+
+// CHECK-LABEL: @align_load_from_vtable_align_intrinsic
+#[no_mangle]
+pub unsafe fn align_load_from_vtable_align_intrinsic(x: &dyn Trait) -> usize {
+    let (data, vtable): (*const (), *const ()) = core::mem::transmute(x);
+    // CHECK: {{%[0-9]+}} = load [[USIZE]], {{.+}} !range [[RANGE_META]]
+    let align = core::intrinsics::vtable_align(vtable);
+    // make this function unique so it doesn't get merged with the previous
+    align + 1
 }
 
 // CHECK: [[RANGE_META]] = !{[[USIZE]] 1, [[USIZE]] 0}

--- a/src/test/codegen/dst-vtable-size-range.rs
+++ b/src/test/codegen/dst-vtable-size-range.rs
@@ -1,4 +1,4 @@
-// compile-flags: -O
+// compile-flags: -O -Z merge-functions=disabled
 
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]
@@ -29,9 +29,7 @@ pub fn size_load_from_size_of_val(x: &dyn Trait) -> usize {
 pub unsafe fn size_load_from_vtable_size_intrinsic(x: &dyn Trait) -> usize {
     let (data, vtable): (*const (), *const ()) = core::mem::transmute(x);
     // CHECK: {{%[0-9]+}} = load [[USIZE]], {{.+}} !range [[RANGE_META]]
-    let size = core::intrinsics::vtable_size(vtable);
-    // make this function unique so it doesn't get merged with the previous
-    size + 1
+    core::intrinsics::vtable_size(vtable)
 }
 
 // CHECK: [[RANGE_META]] = !{[[USIZE]] 0, [[USIZE]] [[EXCLUSIVE_BOUND]]}

--- a/src/test/codegen/dst-vtable-size-range.rs
+++ b/src/test/codegen/dst-vtable-size-range.rs
@@ -1,0 +1,37 @@
+// compile-flags: -O
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics)]
+
+// Check that we annotate size loads from vtables with 0..(isize::MAX + 1) range metadata.
+
+pub trait Trait {
+    fn f(&self);
+}
+
+// Note that rustc uses inclusive bounds, but LLVM uses exclusive bounds for range metadata.
+// CHECK-LABEL: @generate_exclusive_bound
+#[no_mangle]
+pub fn generate_exclusive_bound() -> usize {
+    // CHECK: ret [[USIZE:i[0-9]+]] [[EXCLUSIVE_BOUND:[-0-9]+]]
+    isize::MAX as usize + 1
+}
+
+// CHECK-LABEL: @size_load_from_size_of_val
+#[no_mangle]
+pub fn size_load_from_size_of_val(x: &dyn Trait) -> usize {
+    // CHECK: {{%[0-9]+}} = load [[USIZE]], {{.+}} !range [[RANGE_META:![0-9]+]]
+    core::mem::size_of_val(x)
+}
+
+// CHECK-LABEL: @size_load_from_vtable_size_intrinsic
+#[no_mangle]
+pub unsafe fn size_load_from_vtable_size_intrinsic(x: &dyn Trait) -> usize {
+    let (data, vtable): (*const (), *const ()) = core::mem::transmute(x);
+    // CHECK: {{%[0-9]+}} = load [[USIZE]], {{.+}} !range [[RANGE_META]]
+    let size = core::intrinsics::vtable_size(vtable);
+    // make this function unique so it doesn't get merged with the previous
+    size + 1
+}
+
+// CHECK: [[RANGE_META]] = !{[[USIZE]] 0, [[USIZE]] [[EXCLUSIVE_BOUND]]}


### PR DESCRIPTION
This is the (much belated) size counterpart to #91569.

Inspired by https://rust-lang.zulipchat.com/#narrow/stream/187780-t-compiler.2Fwg-llvm/topic/Range.20metadata.20for.20.60size_of_val.60.20and.20other.20isize.3A.3AMAX.20limits. This could help optimize layout computations based on the size of a dyn trait. Though, admittedly, adding this to vtables wouldn't be as beneficial as adding it to slice len, which is used much more often.

Miri detects this UB already: https://github.com/rust-lang/rust/blob/b7cc99142ad0cfe47e2fe9f7a82eaf5b672c0573/compiler/rustc_const_eval/src/interpret/traits.rs#L119-L121
(In fact Miri goes further, [assuming a 48-bit address space on 64-bit platforms](https://github.com/rust-lang/rust/blob/9db224fc908059986c179fc6ec433944e9cfce50/compiler/rustc_abi/src/lib.rs#L312-L331), but I don't think we can assume that in an optimization.)