### PR TITLE
rustdoc: Prevent auto/blanket impl retrieval if there were compiler errors

### DIFF
--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -19,6 +19,12 @@ pub(crate) const COLLECT_TRAIT_IMPLS: Pass = Pass {
 };
 
 pub(crate) fn collect_trait_impls(mut krate: Crate, cx: &mut DocContext<'_>) -> Crate {
+    // We need to check if there are errors before running this pass because it would crash when
+    // we try to get auto and blanket implementations.
+    if cx.tcx.sess.diagnostic().has_errors_or_lint_errors().is_some() {
+        return krate;
+    }
+
     let synth_impls = cx.sess().time("collect_synthetic_impls", || {
         let mut synth = SyntheticImplCollector { cx, impls: Vec::new() };
         synth.visit_crate(&krate);

--- a/src/test/rustdoc-ui/unable-fulfill-trait.rs
+++ b/src/test/rustdoc-ui/unable-fulfill-trait.rs
@@ -1,0 +1,13 @@
+// This test ensures that it's not crashing rustdoc.
+
+pub struct Foo<'a, 'b, T> {
+    field1: dyn Bar<'a, 'b,>,
+    //~^ ERROR
+    //~^^ ERROR
+}
+
+pub trait Bar<'x, 's, U>
+    where U: 'x,
+    Self:'x,
+    Self:'s
+{}

--- a/src/test/rustdoc-ui/unable-fulfill-trait.stderr
+++ b/src/test/rustdoc-ui/unable-fulfill-trait.stderr
@@ -1,0 +1,26 @@
+error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/unable-fulfill-trait.rs:4:17
+   |
+LL |     field1: dyn Bar<'a, 'b,>,
+   |                 ^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `U`
+  --> $DIR/unable-fulfill-trait.rs:9:11
+   |
+LL | pub trait Bar<'x, 's, U>
+   |           ^^^         -
+help: add missing generic argument
+   |
+LL |     field1: dyn Bar<'a, 'b, U,>,
+   |                           +++
+
+error[E0227]: ambiguous lifetime bound, explicit lifetime bound required
+  --> $DIR/unable-fulfill-trait.rs:4:13
+   |
+LL |     field1: dyn Bar<'a, 'b,>,
+   |             ^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0227.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/105404.

I'm not sure happy about this fix but since it's how passes work (ie, even if there are errors, it runs all passes), I think it's fine as is.

Just as a sidenote: I also gave a try to prevent running all passes in case there were compiler errors but then a lot of rustdoc tests were failing so I went for this fix instead.

r? @notriddle 