### PR TITLE
Group trait implementation in doc sidebar by source module 

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -634,6 +634,8 @@ fn generate_macro_def_id_path(
     Ok((url, ItemType::Macro, fqp))
 }
 
+/// Find the link to the node with [DefId], it returns the link string, "short type description",
+/// and the fully qualified name of that node. The `root_path` will be prepended to the link string if exists.
 pub(crate) fn href_with_root_path(
     did: DefId,
     cx: &Context<'_>,
@@ -716,6 +718,7 @@ pub(crate) fn href_with_root_path(
     Ok((url_parts.finish(), shortty, fqp.to_vec()))
 }
 
+/// Equivalent to [href_with_root_path] with empty `root_path`.
 pub(crate) fn href(
     did: DefId,
     cx: &Context<'_>,

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2145,28 +2145,34 @@ pub(crate) fn sidebar_render_assoc_items(
     };
 
     let concrete_format = format_impls_grouped(concrete, id_map);
-    print_sidebar_block_grouped(
-        out,
-        "trait-implementations",
-        "Trait Implementations",
-        concrete_format.into_iter(),
-    );
+    if !concrete_format.is_empty() {
+        print_sidebar_block_grouped(
+            out,
+            "trait-implementations",
+            "Trait Implementations",
+            concrete_format.into_iter(),
+        );
+    }
 
     let synthetic_format = format_impls_grouped(synthetic, id_map);
-    print_sidebar_block_grouped(
-        out,
-        "synthetic-implementations",
-        "Auto Trait Implementations",
-        synthetic_format.into_iter(),
-    );
+    if !synthetic_format.is_empty() {
+        print_sidebar_block_grouped(
+            out,
+            "synthetic-implementations",
+            "Auto Trait Implementations",
+            synthetic_format.into_iter(),
+        );
+    }
 
     let blanket_format = format_impls_grouped(blanket_impl, id_map);
-    print_sidebar_block_grouped(
-        out,
-        "blanket-implementations",
-        "Blanket Implementations",
-        blanket_format.into_iter(),
-    );
+    if !blanket_format.is_empty() {
+        print_sidebar_block_grouped(
+            out,
+            "blanket-implementations",
+            "Blanket Implementations",
+            blanket_format.into_iter(),
+        );
+    }
 }
 
 fn sidebar_assoc_items(cx: &Context<'_>, out: &mut Buffer, it: &clean::Item) {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2152,51 +2152,21 @@ pub(crate) fn sidebar_render_assoc_items(
         concrete_format.into_iter(),
     );
 
-    let format_impls = |impls: Vec<&Impl>, id_map: &mut IdMap| {
-        let mut links = FxHashSet::default();
+    let synthetic_format = format_impls_grouped(synthetic, id_map);
+    print_sidebar_block_grouped(
+        out,
+        "synthetic-implementations",
+        "Auto Trait Implementations",
+        synthetic_format.into_iter(),
+    );
 
-        let mut ret = impls
-            .iter()
-            .filter_map(|it| {
-                let trait_ = it.inner_impl().trait_.as_ref()?;
-                let encoded =
-                    id_map.derive(get_id_for_impl(&it.inner_impl().for_, Some(trait_), cx));
-
-                let i_display = format!("{:#}", trait_.print(cx));
-                let out = Escape(&i_display);
-                let prefix = match it.inner_impl().polarity {
-                    ty::ImplPolarity::Positive | ty::ImplPolarity::Reservation => "",
-                    ty::ImplPolarity::Negative => "!",
-                };
-                let generated = format!("<a href=\"#{}\">{}{}</a>", encoded, prefix, out);
-                if links.insert(generated.clone()) { Some(generated) } else { None }
-            })
-            .into_iter()
-            .collect::<Vec<String>>();
-        ret.sort();
-        ret
-    };
-
-    let synthetic_format = format_impls(synthetic, id_map);
-    let blanket_format = format_impls(blanket_impl, id_map);
-
-    if !synthetic_format.is_empty() {
-        print_sidebar_block(
-            out,
-            "synthetic-implementations",
-            "Auto Trait Implementations",
-            synthetic_format.iter(),
-        );
-    }
-
-    if !blanket_format.is_empty() {
-        print_sidebar_block(
-            out,
-            "blanket-implementations",
-            "Blanket Implementations",
-            blanket_format.iter(),
-        );
-    }
+    let blanket_format = format_impls_grouped(blanket_impl, id_map);
+    print_sidebar_block_grouped(
+        out,
+        "blanket-implementations",
+        "Blanket Implementations",
+        blanket_format.into_iter(),
+    );
 }
 
 fn sidebar_assoc_items(cx: &Context<'_>, out: &mut Buffer, it: &clean::Item) {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -472,7 +472,7 @@ img {
 	width: 100px;
 }
 
-ul.block, .block li {
+ul.block, .block li, ul.sub-block, .sub-block li {
 	padding: 0;
 	margin: 0;
 	list-style: none;
@@ -497,6 +497,11 @@ ul.block, .block li {
 	margin: 0;
 }
 
+.sidebar h4 {
+	padding: 0;
+	margin: 0.2rem 0;
+}
+
 .sidebar-elems,
 .sidebar > h2 {
 	padding-left: 24px;
@@ -514,7 +519,12 @@ ul.block, .block li {
 	margin-bottom: 2em;
 }
 
-.sidebar-elems .block li a {
+.sidebar-elems .sub-block {
+	margin-bottom: 1.5em;
+}
+
+.sidebar-elems .block li a,
+.sidebar-elems .sub-block li a {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;


### PR DESCRIPTION
This should fix #105307, I'm pretty satisfied with the current rendering result: [page1](http://zyxin.xyz/rustdoc-group-test/dashu_base/sign/enum.Sign.html), [page2](http://zyxin.xyz/rustdoc-group-test/dashu_int/struct.UBig.html). However, it's my first time contributing to rust and please pardon me if there're some non-idiomatic code.

![image](https://user-images.githubusercontent.com/9154441/206499330-a5f004c6-74db-4206-9ff3-635a6236a7f2.png)
