### PR TITLE
Change pattern borrowing suggestions to be verbose and remove invalid suggestion

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -481,6 +481,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 let (pat_span, suggestion, to_remove) = if inner_pat_snippet.starts_with("mut")
                     && inner_pat_snippet["mut".len()..].starts_with(rustc_lexer::is_whitespace)
                 {
+                    let inner_pat_snippet = inner_pat_snippet["mut".len()..].trim_start();
                     let pat_span = pat_span.with_hi(
                         pat_span.lo()
                             + BytePos((pat_snippet.len() - inner_pat_snippet.len()) as u32),

--- a/compiler/rustc_mir_build/src/build/block.rs
+++ b/compiler/rustc_mir_build/src/build/block.rs
@@ -231,7 +231,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                         remainder_span,
                                         pattern,
                                         None,
-                                        Some((None, initializer_span)),
+                                        Some((Some(&destination), initializer_span)),
                                     );
                                     this.visit_primary_bindings(
                                         pattern,

--- a/src/test/ui/borrowck/access-mode-in-closures.stderr
+++ b/src/test/ui/borrowck/access-mode-in-closures.stderr
@@ -3,10 +3,14 @@ error[E0507]: cannot move out of `s` which is behind a shared reference
    |
 LL |         match *s { S(v) => v }
    |               ^^     -
-   |               |      |
-   |               |      data moved here
-   |               |      move occurs because `v` has type `Vec<isize>`, which does not implement the `Copy` trait
-   |               help: consider borrowing here: `&*s`
+   |                      |
+   |                      data moved here
+   |                      move occurs because `v` has type `Vec<isize>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         match &*s { S(v) => v }
+   |               +
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/access-mode-in-closures.stderr
+++ b/src/test/ui/borrowck/access-mode-in-closures.stderr
@@ -7,10 +7,11 @@ LL |         match *s { S(v) => v }
    |                      data moved here
    |                      move occurs because `v` has type `Vec<isize>`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |         match &*s { S(v) => v }
-   |               +
+LL -         match *s { S(v) => v }
+LL +         match s { S(v) => v }
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-for-loop-correct-cmt-for-pattern.stderr
+++ b/src/test/ui/borrowck/borrowck-for-loop-correct-cmt-for-pattern.stderr
@@ -2,31 +2,46 @@ error[E0507]: cannot move out of a shared reference
   --> $DIR/borrowck-for-loop-correct-cmt-for-pattern.rs:12:15
    |
 LL |     for &a in x.iter() {
-   |         --    ^^^^^^^^
-   |         ||
-   |         |data moved here
-   |         |move occurs because `a` has type `&mut i32`, which does not implement the `Copy` trait
-   |         help: consider removing the `&`: `a`
+   |          -    ^^^^^^^^
+   |          |
+   |          data moved here
+   |          move occurs because `a` has type `&mut i32`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     for &a in x.iter() {
+LL +     for a in x.iter() {
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/borrowck-for-loop-correct-cmt-for-pattern.rs:18:15
    |
 LL |     for &a in &f.a {
-   |         --    ^^^^
-   |         ||
-   |         |data moved here
-   |         |move occurs because `a` has type `Box<isize>`, which does not implement the `Copy` trait
-   |         help: consider removing the `&`: `a`
+   |          -    ^^^^
+   |          |
+   |          data moved here
+   |          move occurs because `a` has type `Box<isize>`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     for &a in &f.a {
+LL +     for a in &f.a {
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/borrowck-for-loop-correct-cmt-for-pattern.rs:22:15
    |
 LL |     for &a in x.iter() {
-   |         --    ^^^^^^^^
-   |         ||
-   |         |data moved here
-   |         |move occurs because `a` has type `Box<i32>`, which does not implement the `Copy` trait
-   |         help: consider removing the `&`: `a`
+   |          -    ^^^^^^^^
+   |          |
+   |          data moved here
+   |          move occurs because `a` has type `Box<i32>`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     for &a in x.iter() {
+LL +     for a in x.iter() {
+   |
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/borrowck-issue-2657-2.fixed
+++ b/src/test/ui/borrowck/borrowck-issue-2657-2.fixed
@@ -5,7 +5,7 @@ fn main() {
 
     match x {
       Some(ref y) => {
-        let _b = *y; //~ ERROR cannot move out
+        let _b = y; //~ ERROR cannot move out
       }
       _ => {}
     }

--- a/src/test/ui/borrowck/borrowck-issue-2657-2.stderr
+++ b/src/test/ui/borrowck/borrowck-issue-2657-2.stderr
@@ -1,13 +1,14 @@
 error[E0507]: cannot move out of `*y` which is behind a shared reference
-  --> $DIR/borrowck-issue-2657-2.rs:7:18
+  --> $DIR/borrowck-issue-2657-2.rs:8:18
    |
 LL |         let _b = *y;
    |                  ^^ move occurs because `*y` has type `Box<i32>`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |         let _b = &*y;
-   |                  +
+LL -         let _b = *y;
+LL +         let _b = y;
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-issue-2657-2.stderr
+++ b/src/test/ui/borrowck/borrowck-issue-2657-2.stderr
@@ -2,10 +2,12 @@ error[E0507]: cannot move out of `*y` which is behind a shared reference
   --> $DIR/borrowck-issue-2657-2.rs:7:18
    |
 LL |         let _b = *y;
-   |                  ^^
-   |                  |
-   |                  move occurs because `*y` has type `Box<i32>`, which does not implement the `Copy` trait
-   |                  help: consider borrowing here: `&*y`
+   |                  ^^ move occurs because `*y` has type `Box<i32>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         let _b = &*y;
+   |                  +
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-move-error-with-note.fixed
+++ b/src/test/ui/borrowck/borrowck-move-error-with-note.fixed
@@ -10,7 +10,7 @@ enum Foo {
 
 fn blah() {
     let f = &Foo::Foo1(Box::new(1), Box::new(2));
-    match *f { //~ ERROR cannot move out of
+    match &*f { //~ ERROR cannot move out of
         Foo::Foo1(num1,
                   num2) => (),
         Foo::Foo2(num) => (),
@@ -30,8 +30,8 @@ fn move_in_match() {
     match (S {f: "foo".to_string(), g: "bar".to_string()}) {
         //~^ ERROR cannot move out of type `S`, which implements the `Drop` trait
         S {
-            f: _s,
-            g: _t
+            f: ref _s,
+            g: ref _t
         } => {}
     }
 }
@@ -45,7 +45,7 @@ fn free<T>(_: T) {}
 
 fn blah2() {
     let a = &A { a: Box::new(1) };
-    match a.a { //~ ERROR cannot move out of
+    match &a.a { //~ ERROR cannot move out of
         n => {
             free(n)
         }

--- a/src/test/ui/borrowck/borrowck-move-error-with-note.fixed
+++ b/src/test/ui/borrowck/borrowck-move-error-with-note.fixed
@@ -10,7 +10,7 @@ enum Foo {
 
 fn blah() {
     let f = &Foo::Foo1(Box::new(1), Box::new(2));
-    match &*f { //~ ERROR cannot move out of
+    match f { //~ ERROR cannot move out of
         Foo::Foo1(num1,
                   num2) => (),
         Foo::Foo2(num) => (),

--- a/src/test/ui/borrowck/borrowck-move-error-with-note.stderr
+++ b/src/test/ui/borrowck/borrowck-move-error-with-note.stderr
@@ -11,10 +11,11 @@ LL |         Foo::Foo2(num) => (),
    |                   --- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     match &*f {
-   |           +
+LL -     match *f {
+LL +     match f {
+   |
 
 error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
   --> $DIR/borrowck-move-error-with-note.rs:30:11

--- a/src/test/ui/borrowck/borrowck-move-error-with-note.stderr
+++ b/src/test/ui/borrowck/borrowck-move-error-with-note.stderr
@@ -2,7 +2,7 @@ error[E0507]: cannot move out of `f` as enum variant `Foo1` which is behind a sh
   --> $DIR/borrowck-move-error-with-note.rs:11:11
    |
 LL |     match *f {
-   |           ^^ help: consider borrowing here: `&*f`
+   |           ^^
 LL |         Foo::Foo1(num1,
    |                   ---- data moved here
 LL |                   num2) => (),
@@ -11,6 +11,10 @@ LL |         Foo::Foo2(num) => (),
    |                   --- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing here
+   |
+LL |     match &*f {
+   |           +
 
 error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
   --> $DIR/borrowck-move-error-with-note.rs:28:11
@@ -29,12 +33,17 @@ error[E0507]: cannot move out of `a.a` which is behind a shared reference
   --> $DIR/borrowck-move-error-with-note.rs:46:11
    |
 LL |     match a.a {
-   |           ^^^ help: consider borrowing here: `&a.a`
+   |           ^^^
 LL |         n => {
    |         -
    |         |
    |         data moved here
    |         move occurs because `n` has type `Box<isize>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &a.a {
+   |           +
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/borrowck-move-error-with-note.stderr
+++ b/src/test/ui/borrowck/borrowck-move-error-with-note.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of `f` as enum variant `Foo1` which is behind a shared reference
-  --> $DIR/borrowck-move-error-with-note.rs:11:11
+  --> $DIR/borrowck-move-error-with-note.rs:13:11
    |
 LL |     match *f {
    |           ^^
@@ -17,7 +17,7 @@ LL |     match &*f {
    |           +
 
 error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
-  --> $DIR/borrowck-move-error-with-note.rs:28:11
+  --> $DIR/borrowck-move-error-with-note.rs:30:11
    |
 LL |     match (S {f: "foo".to_string(), g: "bar".to_string()}) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot move out of here
@@ -28,9 +28,17 @@ LL |             g: _t
    |                -- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |             f: ref _s,
+   |                +++
+help: consider borrowing the pattern binding
+   |
+LL |             g: ref _t
+   |                +++
 
 error[E0507]: cannot move out of `a.a` which is behind a shared reference
-  --> $DIR/borrowck-move-error-with-note.rs:46:11
+  --> $DIR/borrowck-move-error-with-note.rs:48:11
    |
 LL |     match a.a {
    |           ^^^

--- a/src/test/ui/borrowck/borrowck-move-from-unsafe-ptr.stderr
+++ b/src/test/ui/borrowck/borrowck-move-from-unsafe-ptr.stderr
@@ -2,10 +2,12 @@ error[E0507]: cannot move out of `*x` which is behind a raw pointer
   --> $DIR/borrowck-move-from-unsafe-ptr.rs:2:13
    |
 LL |     let y = *x;
-   |             ^^
-   |             |
-   |             move occurs because `*x` has type `Box<isize>`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&*x`
+   |             ^^ move occurs because `*x` has type `Box<isize>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let y = &*x;
+   |             +
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-move-from-unsafe-ptr.stderr
+++ b/src/test/ui/borrowck/borrowck-move-from-unsafe-ptr.stderr
@@ -4,10 +4,11 @@ error[E0507]: cannot move out of `*x` which is behind a raw pointer
 LL |     let y = *x;
    |             ^^ move occurs because `*x` has type `Box<isize>`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let y = &*x;
-   |             +
+LL -     let y = *x;
+LL +     let y = x;
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-move-in-irrefut-pat.stderr
+++ b/src/test/ui/borrowck/borrowck-move-in-irrefut-pat.stderr
@@ -3,30 +3,45 @@ error[E0507]: cannot move out of a shared reference
    |
 LL | fn arg_item(&_x: &String) {}
    |             ^--
-   |             ||
-   |             |data moved here
-   |             |move occurs because `_x` has type `String`, which does not implement the `Copy` trait
-   |             help: consider removing the `&`: `_x`
+   |              |
+   |              data moved here
+   |              move occurs because `_x` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL - fn arg_item(&_x: &String) {}
+LL + fn arg_item(_x: &String) {}
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/borrowck-move-in-irrefut-pat.rs:7:11
    |
 LL |     with(|&_x| ())
    |           ^--
-   |           ||
-   |           |data moved here
-   |           |move occurs because `_x` has type `String`, which does not implement the `Copy` trait
-   |           help: consider removing the `&`: `_x`
+   |            |
+   |            data moved here
+   |            move occurs because `_x` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     with(|&_x| ())
+LL +     with(|_x| ())
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/borrowck-move-in-irrefut-pat.rs:12:15
    |
 LL |     let &_x = &"hi".to_string();
-   |         ---   ^^^^^^^^^^^^^^^^^
-   |         ||
-   |         |data moved here
-   |         |move occurs because `_x` has type `String`, which does not implement the `Copy` trait
-   |         help: consider removing the `&`: `_x`
+   |          --   ^^^^^^^^^^^^^^^^^
+   |          |
+   |          data moved here
+   |          move occurs because `_x` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     let &_x = &"hi".to_string();
+LL +     let _x = &"hi".to_string();
+   |
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/borrowck-move-out-of-overloaded-deref.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-of-overloaded-deref.stderr
@@ -2,10 +2,12 @@ error[E0507]: cannot move out of an `Rc`
   --> $DIR/borrowck-move-out-of-overloaded-deref.rs:4:14
    |
 LL |     let _x = *Rc::new("hi".to_string());
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |              |
-   |              move occurs because value has type `String`, which does not implement the `Copy` trait
-   |              help: consider borrowing here: `&*Rc::new("hi".to_string())`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let _x = &*Rc::new("hi".to_string());
+   |              +
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-move-out-of-overloaded-deref.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-of-overloaded-deref.stderr
@@ -4,10 +4,11 @@ error[E0507]: cannot move out of an `Rc`
 LL |     let _x = *Rc::new("hi".to_string());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let _x = &*Rc::new("hi".to_string());
-   |              +
+LL -     let _x = *Rc::new("hi".to_string());
+LL +     let _x = Rc::new("hi".to_string());
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-move-out-of-struct-with-dtor.fixed
+++ b/src/test/ui/borrowck/borrowck-move-out-of-struct-with-dtor.fixed
@@ -8,16 +8,16 @@ impl Drop for S {
 fn move_in_match() {
     match (S {f:"foo".to_string()}) {
         //~^ ERROR [E0509]
-        S {f:_s} => {}
+        S {f:ref _s} => {}
     }
 }
 
 fn move_in_let() {
-    let S {f:_s} = S {f:"foo".to_string()};
+    let S {f:ref _s} = S {f:"foo".to_string()};
     //~^ ERROR [E0509]
 }
 
-fn move_in_fn_arg(S {f:_s}: S) {
+fn move_in_fn_arg(S {f:ref _s}: S) {
     //~^ ERROR [E0509]
 }
 

--- a/src/test/ui/borrowck/borrowck-move-out-of-struct-with-dtor.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-of-struct-with-dtor.stderr
@@ -1,5 +1,5 @@
 error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
-  --> $DIR/borrowck-move-out-of-struct-with-dtor.rs:7:11
+  --> $DIR/borrowck-move-out-of-struct-with-dtor.rs:9:11
    |
 LL |     match (S {f:"foo".to_string()}) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot move out of here
@@ -9,18 +9,28 @@ LL |         S {f:_s} => {}
    |              |
    |              data moved here
    |              move occurs because `_s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         S {f:ref _s} => {}
+   |              +++
 
 error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
-  --> $DIR/borrowck-move-out-of-struct-with-dtor.rs:14:20
+  --> $DIR/borrowck-move-out-of-struct-with-dtor.rs:16:20
    |
 LL |     let S {f:_s} = S {f:"foo".to_string()};
    |              --    ^^^^^^^^^^^^^^^^^^^^^^^ cannot move out of here
    |              |
    |              data moved here
    |              move occurs because `_s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     let S {f:ref _s} = S {f:"foo".to_string()};
+   |              +++
 
 error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
-  --> $DIR/borrowck-move-out-of-struct-with-dtor.rs:18:19
+  --> $DIR/borrowck-move-out-of-struct-with-dtor.rs:20:19
    |
 LL | fn move_in_fn_arg(S {f:_s}: S) {
    |                   ^^^^^--^
@@ -28,6 +38,11 @@ LL | fn move_in_fn_arg(S {f:_s}: S) {
    |                   |    data moved here
    |                   |    move occurs because `_s` has type `String`, which does not implement the `Copy` trait
    |                   cannot move out of here
+   |
+help: consider borrowing the pattern binding
+   |
+LL | fn move_in_fn_arg(S {f:ref _s}: S) {
+   |                        +++
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/borrowck-move-out-of-tuple-struct-with-dtor.fixed
+++ b/src/test/ui/borrowck/borrowck-move-out-of-tuple-struct-with-dtor.fixed
@@ -8,16 +8,16 @@ impl Drop for S {
 fn move_in_match() {
     match S("foo".to_string()) {
         //~^ ERROR cannot move out of type `S`, which implements the `Drop` trait
-        S(_s) => {}
+        S(ref _s) => {}
     }
 }
 
 fn move_in_let() {
-    let S(_s) = S("foo".to_string());
+    let S(ref _s) = S("foo".to_string());
     //~^ ERROR cannot move out of type `S`, which implements the `Drop` trait
 }
 
-fn move_in_fn_arg(S(_s): S) {
+fn move_in_fn_arg(S(ref _s): S) {
     //~^ ERROR cannot move out of type `S`, which implements the `Drop` trait
 }
 

--- a/src/test/ui/borrowck/borrowck-move-out-of-tuple-struct-with-dtor.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-of-tuple-struct-with-dtor.stderr
@@ -1,5 +1,5 @@
 error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
-  --> $DIR/borrowck-move-out-of-tuple-struct-with-dtor.rs:7:11
+  --> $DIR/borrowck-move-out-of-tuple-struct-with-dtor.rs:9:11
    |
 LL |     match S("foo".to_string()) {
    |           ^^^^^^^^^^^^^^^^^^^^ cannot move out of here
@@ -9,18 +9,28 @@ LL |         S(_s) => {}
    |           |
    |           data moved here
    |           move occurs because `_s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         S(ref _s) => {}
+   |           +++
 
 error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
-  --> $DIR/borrowck-move-out-of-tuple-struct-with-dtor.rs:14:17
+  --> $DIR/borrowck-move-out-of-tuple-struct-with-dtor.rs:16:17
    |
 LL |     let S(_s) = S("foo".to_string());
    |           --    ^^^^^^^^^^^^^^^^^^^^ cannot move out of here
    |           |
    |           data moved here
    |           move occurs because `_s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     let S(ref _s) = S("foo".to_string());
+   |           +++
 
 error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
-  --> $DIR/borrowck-move-out-of-tuple-struct-with-dtor.rs:18:19
+  --> $DIR/borrowck-move-out-of-tuple-struct-with-dtor.rs:20:19
    |
 LL | fn move_in_fn_arg(S(_s): S) {
    |                   ^^--^
@@ -28,6 +38,11 @@ LL | fn move_in_fn_arg(S(_s): S) {
    |                   | data moved here
    |                   | move occurs because `_s` has type `String`, which does not implement the `Copy` trait
    |                   cannot move out of here
+   |
+help: consider borrowing the pattern binding
+   |
+LL | fn move_in_fn_arg(S(ref _s): S) {
+   |                     +++
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/borrowck-move-out-of-vec-tail.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-of-vec-tail.stderr
@@ -10,10 +10,10 @@ LL |                   Foo { string: b }] => {
    |                                 - ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider removing the `&`
+help: consider removing the borrow
    |
-LL ~                 [Foo { string: a },
-LL ~                   Foo { string: b }] => {
+LL -                 &[Foo { string: a },
+LL +                 [Foo { string: a },
    |
 
 error: aborting due to previous error

--- a/src/test/ui/borrowck/borrowck-overloaded-index-move-from-vec.stderr
+++ b/src/test/ui/borrowck/borrowck-overloaded-index-move-from-vec.stderr
@@ -2,10 +2,12 @@ error[E0507]: cannot move out of index of `MyVec<Box<i32>>`
   --> $DIR/borrowck-overloaded-index-move-from-vec.rs:20:15
    |
 LL |     let bad = v[0];
-   |               ^^^^
-   |               |
-   |               move occurs because value has type `Box<i32>`, which does not implement the `Copy` trait
-   |               help: consider borrowing here: `&v[0]`
+   |               ^^^^ move occurs because value has type `Box<i32>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let bad = &v[0];
+   |               +
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-vec-pattern-nesting.rs
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-nesting.rs
@@ -37,7 +37,7 @@ fn c() {
         &mut [_a,
         //~^ NOTE data moved here
         //~| NOTE move occurs because `_a` has type
-        //~| HELP consider removing the `&mut`
+        //~| HELP consider removing the mutable borrow
             ..
         ] => {
         }
@@ -56,7 +56,7 @@ fn d() {
         //~^ ERROR cannot move out
         //~| NOTE cannot move out
         &mut [
-        //~^ HELP consider removing the `&mut`
+        //~^ HELP consider removing the mutable borrow
          _b] => {}
         //~^ NOTE data moved here
         //~| NOTE move occurs because `_b` has type
@@ -79,7 +79,7 @@ fn e() {
         //~^ NOTE data moved here
         //~| NOTE and here
         //~| NOTE and here
-        //~| HELP consider removing the `&mut`
+        //~| HELP consider removing the mutable borrow
         _ => {}
     }
     let a = vec[0]; //~ ERROR cannot move out

--- a/src/test/ui/borrowck/borrowck-vec-pattern-nesting.stderr
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-nesting.stderr
@@ -37,7 +37,7 @@ LL |         &mut [_a,
 help: consider removing the mutable borrow
    |
 LL -         &mut [_a,
-LL +         mut [_a,
+LL +         [_a,
    |
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
@@ -69,7 +69,7 @@ LL |          _b] => {}
 help: consider removing the mutable borrow
    |
 LL -         &mut [
-LL +         mut [
+LL +         [
    |
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
@@ -102,7 +102,7 @@ LL |         &mut [_a, _b, _c] => {}
 help: consider removing the mutable borrow
    |
 LL -         &mut [_a, _b, _c] => {}
-LL +         mut [_a, _b, _c] => {}
+LL +         [_a, _b, _c] => {}
    |
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice

--- a/src/test/ui/borrowck/borrowck-vec-pattern-nesting.stderr
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-nesting.stderr
@@ -34,14 +34,10 @@ LL |         &mut [_a,
    |               data moved here
    |               move occurs because `_a` has type `Box<isize>`, which does not implement the `Copy` trait
    |
-help: consider removing the `&mut`
+help: consider removing the mutable borrow
    |
-LL ~         [_a,
-LL +
-LL +
-LL +
-LL +             ..
-LL ~         ] => {
+LL -         &mut [_a,
+LL +         mut [_a,
    |
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
@@ -52,7 +48,11 @@ LL |     let a = vec[0];
    |             |
    |             cannot move out of here
    |             move occurs because `vec[_]` has type `Box<isize>`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&vec[0]`
+   |
+help: consider borrowing here
+   |
+LL |     let a = &vec[0];
+   |             +
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
   --> $DIR/borrowck-vec-pattern-nesting.rs:55:11
@@ -66,11 +66,10 @@ LL |          _b] => {}
    |          data moved here
    |          move occurs because `_b` has type `Box<isize>`, which does not implement the `Copy` trait
    |
-help: consider removing the `&mut`
+help: consider removing the mutable borrow
    |
-LL ~         [
-LL +
-LL ~          _b] => {}
+LL -         &mut [
+LL +         mut [
    |
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
@@ -81,7 +80,11 @@ LL |     let a = vec[0];
    |             |
    |             cannot move out of here
    |             move occurs because `vec[_]` has type `Box<isize>`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&vec[0]`
+   |
+help: consider borrowing here
+   |
+LL |     let a = &vec[0];
+   |             +
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
   --> $DIR/borrowck-vec-pattern-nesting.rs:74:11
@@ -90,14 +93,17 @@ LL |     match vec {
    |           ^^^ cannot move out of here
 ...
 LL |         &mut [_a, _b, _c] => {}
-   |         -----------------
-   |         |     |   |   |
-   |         |     |   |   ...and here
-   |         |     |   ...and here
-   |         |     data moved here
-   |         help: consider removing the `&mut`: `[_a, _b, _c]`
+   |               --  --  -- ...and here
+   |               |   |
+   |               |   ...and here
+   |               data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the mutable borrow
+   |
+LL -         &mut [_a, _b, _c] => {}
+LL +         mut [_a, _b, _c] => {}
+   |
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
   --> $DIR/borrowck-vec-pattern-nesting.rs:85:13
@@ -107,7 +113,11 @@ LL |     let a = vec[0];
    |             |
    |             cannot move out of here
    |             move occurs because `vec[_]` has type `Box<isize>`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&vec[0]`
+   |
+help: consider borrowing here
+   |
+LL |     let a = &vec[0];
+   |             +
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/borrowck/issue-17718-static-move.stderr
+++ b/src/test/ui/borrowck/issue-17718-static-move.stderr
@@ -2,10 +2,12 @@ error[E0507]: cannot move out of static item `FOO`
   --> $DIR/issue-17718-static-move.rs:6:14
    |
 LL |     let _a = FOO;
-   |              ^^^
-   |              |
-   |              move occurs because `FOO` has type `Foo`, which does not implement the `Copy` trait
-   |              help: consider borrowing here: `&FOO`
+   |              ^^^ move occurs because `FOO` has type `Foo`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let _a = &FOO;
+   |              +
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/issue-20801.stderr
+++ b/src/test/ui/borrowck/issue-20801.stderr
@@ -4,10 +4,11 @@ error[E0507]: cannot move out of a mutable reference
 LL |     let a = unsafe { *mut_ref() };
    |                      ^^^^^^^^^^ move occurs because value has type `T`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let a = unsafe { &*mut_ref() };
-   |                      +
+LL -     let a = unsafe { *mut_ref() };
+LL +     let a = unsafe { mut_ref() };
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/issue-20801.rs:29:22
@@ -15,10 +16,11 @@ error[E0507]: cannot move out of a shared reference
 LL |     let b = unsafe { *imm_ref() };
    |                      ^^^^^^^^^^ move occurs because value has type `T`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let b = unsafe { &*imm_ref() };
-   |                      +
+LL -     let b = unsafe { *imm_ref() };
+LL +     let b = unsafe { imm_ref() };
+   |
 
 error[E0507]: cannot move out of a raw pointer
   --> $DIR/issue-20801.rs:32:22
@@ -26,10 +28,11 @@ error[E0507]: cannot move out of a raw pointer
 LL |     let c = unsafe { *mut_ptr() };
    |                      ^^^^^^^^^^ move occurs because value has type `T`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let c = unsafe { &*mut_ptr() };
-   |                      +
+LL -     let c = unsafe { *mut_ptr() };
+LL +     let c = unsafe { mut_ptr() };
+   |
 
 error[E0507]: cannot move out of a raw pointer
   --> $DIR/issue-20801.rs:35:22
@@ -37,10 +40,11 @@ error[E0507]: cannot move out of a raw pointer
 LL |     let d = unsafe { *const_ptr() };
    |                      ^^^^^^^^^^^^ move occurs because value has type `T`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let d = unsafe { &*const_ptr() };
-   |                      +
+LL -     let d = unsafe { *const_ptr() };
+LL +     let d = unsafe { const_ptr() };
+   |
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/borrowck/issue-20801.stderr
+++ b/src/test/ui/borrowck/issue-20801.stderr
@@ -2,37 +2,45 @@ error[E0507]: cannot move out of a mutable reference
   --> $DIR/issue-20801.rs:26:22
    |
 LL |     let a = unsafe { *mut_ref() };
-   |                      ^^^^^^^^^^
-   |                      |
-   |                      move occurs because value has type `T`, which does not implement the `Copy` trait
-   |                      help: consider borrowing here: `&*mut_ref()`
+   |                      ^^^^^^^^^^ move occurs because value has type `T`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let a = unsafe { &*mut_ref() };
+   |                      +
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/issue-20801.rs:29:22
    |
 LL |     let b = unsafe { *imm_ref() };
-   |                      ^^^^^^^^^^
-   |                      |
-   |                      move occurs because value has type `T`, which does not implement the `Copy` trait
-   |                      help: consider borrowing here: `&*imm_ref()`
+   |                      ^^^^^^^^^^ move occurs because value has type `T`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let b = unsafe { &*imm_ref() };
+   |                      +
 
 error[E0507]: cannot move out of a raw pointer
   --> $DIR/issue-20801.rs:32:22
    |
 LL |     let c = unsafe { *mut_ptr() };
-   |                      ^^^^^^^^^^
-   |                      |
-   |                      move occurs because value has type `T`, which does not implement the `Copy` trait
-   |                      help: consider borrowing here: `&*mut_ptr()`
+   |                      ^^^^^^^^^^ move occurs because value has type `T`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let c = unsafe { &*mut_ptr() };
+   |                      +
 
 error[E0507]: cannot move out of a raw pointer
   --> $DIR/issue-20801.rs:35:22
    |
 LL |     let d = unsafe { *const_ptr() };
-   |                      ^^^^^^^^^^^^
-   |                      |
-   |                      move occurs because value has type `T`, which does not implement the `Copy` trait
-   |                      help: consider borrowing here: `&*const_ptr()`
+   |                      ^^^^^^^^^^^^ move occurs because value has type `T`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let d = unsafe { &*const_ptr() };
+   |                      +
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/borrowck/issue-47215-ice-from-drop-elab.stderr
+++ b/src/test/ui/borrowck/issue-47215-ice-from-drop-elab.stderr
@@ -2,10 +2,12 @@ error[E0507]: cannot move out of static item `X`
   --> $DIR/issue-47215-ice-from-drop-elab.rs:17:21
    |
 LL |         let mut x = X;
-   |                     ^
-   |                     |
-   |                     move occurs because `X` has type `AtomicUsize`, which does not implement the `Copy` trait
-   |                     help: consider borrowing here: `&X`
+   |                     ^ move occurs because `X` has type `AtomicUsize`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         let mut x = &X;
+   |                     +
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/issue-51301.stderr
+++ b/src/test/ui/borrowck/issue-51301.stderr
@@ -6,6 +6,11 @@ LL |             .find(|(&event_type, _)| event == event_type)
    |                      |
    |                      data moved here
    |                      move occurs because `event_type` has type `EventType`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |             .find(|(&ref event_type, _)| event == event_type)
+   |                      +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/issue-51415.fixed
+++ b/src/test/ui/borrowck/issue-51415.fixed
@@ -4,7 +4,7 @@
 
 fn main() {
     let a = vec![String::from("a")];
-    let opt = a.iter().enumerate().find(|(_, &s)| {
+    let opt = a.iter().enumerate().find(|(_, &ref s)| {
         //~^ ERROR cannot move out
         *s == String::from("d")
     }).map(|(i, _)| i);

--- a/src/test/ui/borrowck/issue-51415.stderr
+++ b/src/test/ui/borrowck/issue-51415.stderr
@@ -1,11 +1,16 @@
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/issue-51415.rs:6:42
+  --> $DIR/issue-51415.rs:7:42
    |
 LL |     let opt = a.iter().enumerate().find(|(_, &s)| {
    |                                          ^^^^^-^
    |                                               |
    |                                               data moved here
    |                                               move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     let opt = a.iter().enumerate().find(|(_, &ref s)| {
+   |                                               +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/issue-54597-reject-move-out-of-borrow-via-pat.stderr
+++ b/src/test/ui/borrowck/issue-54597-reject-move-out-of-borrow-via-pat.stderr
@@ -2,10 +2,12 @@ error[E0507]: cannot move out of `*array` which is behind a shared reference
   --> $DIR/issue-54597-reject-move-out-of-borrow-via-pat.rs:14:13
    |
 LL |             *array
-   |             ^^^^^^
-   |             |
-   |             move occurs because `*array` has type `Vec<Value>`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&*array`
+   |             ^^^^^^ move occurs because `*array` has type `Vec<Value>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |             &*array
+   |             +
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/issue-54597-reject-move-out-of-borrow-via-pat.stderr
+++ b/src/test/ui/borrowck/issue-54597-reject-move-out-of-borrow-via-pat.stderr
@@ -4,10 +4,11 @@ error[E0507]: cannot move out of `*array` which is behind a shared reference
 LL |             *array
    |             ^^^^^^ move occurs because `*array` has type `Vec<Value>`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |             &*array
-   |             +
+LL -             *array
+LL +             array
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/issue-87456-point-to-closure.stderr
+++ b/src/test/ui/borrowck/issue-87456-point-to-closure.stderr
@@ -8,10 +8,12 @@ LL |     take_mut(|| {
    |              -- captured by this `FnMut` closure
 LL |
 LL |         let _foo: String = val;
-   |                            ^^^
-   |                            |
-   |                            move occurs because `val` has type `String`, which does not implement the `Copy` trait
-   |                            help: consider borrowing here: `&val`
+   |                            ^^^ move occurs because `val` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         let _foo: String = &val;
+   |                            +
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/move-error-snippets.stderr
+++ b/src/test/ui/borrowck/move-error-snippets.stderr
@@ -2,10 +2,7 @@ error[E0507]: cannot move out of static item `D`
   --> $DIR/move-error-snippets-ext.rs:5:17
    |
 LL |         let a = $c;
-   |                 ^^
-   |                 |
-   |                 move occurs because `D` has type `A`, which does not implement the `Copy` trait
-   |                 help: consider borrowing here: `&$c`
+   |                 ^^ move occurs because `D` has type `A`, which does not implement the `Copy` trait
    |
   ::: $DIR/move-error-snippets.rs:21:1
    |
@@ -13,6 +10,10 @@ LL | sss!();
    | ------ in this macro invocation
    |
    = note: this error originates in the macro `aaa` which comes from the expansion of the macro `sss` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider borrowing here
+   |
+LL |         let a = &$c;
+   |                 +
 
 error: aborting due to previous error
 

--- a/src/test/ui/by-move-pattern-binding.rs
+++ b/src/test/ui/by-move-pattern-binding.rs
@@ -19,4 +19,11 @@ fn main() {
         &E::Foo => {}
         &E::Bar(ref identifier) => println!("{}", *identifier)
     };
+    if let &E::Bar(identifier) = &s.x { //~ ERROR cannot move
+        f(identifier.clone());
+    };
+    let &E::Bar(identifier) = &s.x else { //~ ERROR cannot move
+        return;
+    };
+    f(identifier.clone());
 }

--- a/src/test/ui/by-move-pattern-binding.stderr
+++ b/src/test/ui/by-move-pattern-binding.stderr
@@ -5,12 +5,43 @@ LL |     match &s.x {
    |           ^^^^
 LL |         &E::Foo => {}
 LL |         &E::Bar(identifier) => f(identifier.clone())
-   |         -------------------
-   |         |       |
-   |         |       data moved here
-   |         |       move occurs because `identifier` has type `String`, which does not implement the `Copy` trait
-   |         help: consider removing the `&`: `E::Bar(identifier)`
+   |                 ----------
+   |                 |
+   |                 data moved here
+   |                 move occurs because `identifier` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -         &E::Bar(identifier) => f(identifier.clone())
+LL +         E::Bar(identifier) => f(identifier.clone())
+   |
 
-error: aborting due to previous error
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/by-move-pattern-binding.rs:22:34
+   |
+LL |     if let &E::Bar(identifier) = &s.x {
+   |                    ----------    ^^^^
+   |                    |
+   |                    data moved here
+   |                    move occurs because `identifier` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     if let &E::Bar(identifier) = &s.x {
+LL +     if let E::Bar(identifier) = &s.x {
+   |
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/by-move-pattern-binding.rs:25:17
+   |
+LL |     let &E::Bar(identifier) = &s.x else {
+   |                 ^^^^^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let &E::Bar(&identifier) = &s.x else {
+   |                 +
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/by-move-pattern-binding.stderr
+++ b/src/test/ui/by-move-pattern-binding.stderr
@@ -32,15 +32,19 @@ LL +     if let E::Bar(identifier) = &s.x {
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/by-move-pattern-binding.rs:25:17
+  --> $DIR/by-move-pattern-binding.rs:25:31
    |
 LL |     let &E::Bar(identifier) = &s.x else {
-   |                 ^^^^^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
+   |                 ----------    ^^^^
+   |                 |
+   |                 data moved here
+   |                 move occurs because `identifier` has type `String`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the borrow
    |
-LL |     let &E::Bar(&identifier) = &s.x else {
-   |                 +
+LL -     let &E::Bar(identifier) = &s.x else {
+LL +     let E::Bar(identifier) = &s.x else {
+   |
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/check-static-values-constraints.stderr
+++ b/src/test/ui/check-static-values-constraints.stderr
@@ -58,10 +58,12 @@ error[E0507]: cannot move out of static item `x`
   --> $DIR/check-static-values-constraints.rs:110:45
    |
 LL |     let y = { static x: Box<isize> = box 3; x };
-   |                                             ^
-   |                                             |
-   |                                             move occurs because `x` has type `Box<isize>`, which does not implement the `Copy` trait
-   |                                             help: consider borrowing here: `&x`
+   |                                             ^ move occurs because `x` has type `Box<isize>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let y = { static x: Box<isize> = box 3; &x };
+   |                                             +
 
 error[E0010]: allocations are not allowed in statics
   --> $DIR/check-static-values-constraints.rs:110:38

--- a/src/test/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-let.fixed
+++ b/src/test/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-let.fixed
@@ -9,11 +9,13 @@ impl Drop for X {
     }
 }
 
+fn unwrap(x: X) -> String {
+    let X { x: ref y } = x; //~ ERROR cannot move out of type
+    y.to_string()
+}
+
 fn main() {
     let x = X { x: "hello".to_string() };
-
-    match x {
-    //~^ ERROR cannot move out of type `X`, which implements the `Drop` trait
-        X { x: y } => println!("contents: {}", y)
-    }
+    let y = unwrap(x);
+    println!("contents: {}", y);
 }

--- a/src/test/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-let.rs
+++ b/src/test/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-let.rs
@@ -1,3 +1,4 @@
+// run-rustfix
 struct X {
     x: String,
 }
@@ -10,7 +11,7 @@ impl Drop for X {
 
 fn unwrap(x: X) -> String {
     let X { x: y } = x; //~ ERROR cannot move out of type
-    y
+    y.to_string()
 }
 
 fn main() {

--- a/src/test/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-let.stderr
+++ b/src/test/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-let.stderr
@@ -1,11 +1,16 @@
 error[E0509]: cannot move out of type `X`, which implements the `Drop` trait
-  --> $DIR/disallowed-deconstructing-destructing-struct-let.rs:12:22
+  --> $DIR/disallowed-deconstructing-destructing-struct-let.rs:13:22
    |
 LL |     let X { x: y } = x;
    |                -     ^ cannot move out of here
    |                |
    |                data moved here
    |                move occurs because `y` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     let X { x: ref y } = x;
+   |                +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-match.fixed
+++ b/src/test/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-match.fixed
@@ -14,6 +14,6 @@ fn main() {
 
     match x {
     //~^ ERROR cannot move out of type `X`, which implements the `Drop` trait
-        X { x: y } => println!("contents: {}", y)
+        X { x: ref y } => println!("contents: {}", y)
     }
 }

--- a/src/test/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-match.stderr
+++ b/src/test/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-match.stderr
@@ -1,5 +1,5 @@
 error[E0509]: cannot move out of type `X`, which implements the `Drop` trait
-  --> $DIR/disallowed-deconstructing-destructing-struct-match.rs:14:11
+  --> $DIR/disallowed-deconstructing-destructing-struct-match.rs:15:11
    |
 LL |     match x {
    |           ^ cannot move out of here
@@ -9,6 +9,11 @@ LL |         X { x: y } => println!("contents: {}", y)
    |                |
    |                data moved here
    |                move occurs because `y` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         X { x: ref y } => println!("contents: {}", y)
+   |                +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0508-fail.stderr
+++ b/src/test/ui/error-codes/E0508-fail.stderr
@@ -6,7 +6,11 @@ LL |     let _value = array[0];
    |                  |
    |                  cannot move out of here
    |                  move occurs because `array[_]` has type `NonCopy`, which does not implement the `Copy` trait
-   |                  help: consider borrowing here: `&array[0]`
+   |
+help: consider borrowing here
+   |
+LL |     let _value = &array[0];
+   |                  +
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0508.stderr
+++ b/src/test/ui/error-codes/E0508.stderr
@@ -6,7 +6,11 @@ LL |     let _value = array[0];
    |                  |
    |                  cannot move out of here
    |                  move occurs because `array[_]` has type `NonCopy`, which does not implement the `Copy` trait
-   |                  help: consider borrowing here: `&array[0]`
+   |
+help: consider borrowing here
+   |
+LL |     let _value = &array[0];
+   |                  +
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0509.stderr
+++ b/src/test/ui/error-codes/E0509.stderr
@@ -6,7 +6,11 @@ LL |     let fancy_field = drop_struct.fancy;
    |                       |
    |                       cannot move out of here
    |                       move occurs because `drop_struct.fancy` has type `FancyNum`, which does not implement the `Copy` trait
-   |                       help: consider borrowing here: `&drop_struct.fancy`
+   |
+help: consider borrowing here
+   |
+LL |     let fancy_field = &drop_struct.fancy;
+   |                       +
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-12567.stderr
+++ b/src/test/ui/issues/issue-12567.stderr
@@ -11,6 +11,14 @@ LL |         (&[hd1, ..], &[hd2, ..])
    |            --- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |         (&[], &[ref hd, ..]) | (&[hd, ..], &[])
+   |                 +++
+help: consider borrowing the pattern binding
+   |
+LL |         (&[ref hd1, ..], &[hd2, ..])
+   |            +++
 
 error[E0508]: cannot move out of type `[T]`, a non-copy slice
   --> $DIR/issue-12567.rs:2:11
@@ -25,6 +33,14 @@ LL |         (&[hd1, ..], &[hd2, ..])
    |                        --- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |         (&[], &[ref hd, ..]) | (&[hd, ..], &[])
+   |                 +++
+help: consider borrowing the pattern binding
+   |
+LL |         (&[hd1, ..], &[ref hd2, ..])
+   |                        +++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-40402-ref-hints/issue-40402-1.stderr
+++ b/src/test/ui/issues/issue-40402-ref-hints/issue-40402-1.stderr
@@ -2,10 +2,12 @@ error[E0507]: cannot move out of index of `Vec<String>`
   --> $DIR/issue-40402-1.rs:9:13
    |
 LL |     let e = f.v[0];
-   |             ^^^^^^
-   |             |
-   |             move occurs because value has type `String`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&f.v[0]`
+   |             ^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let e = &f.v[0];
+   |             +
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-40402-ref-hints/issue-40402-2.stderr
+++ b/src/test/ui/issues/issue-40402-ref-hints/issue-40402-2.stderr
@@ -2,12 +2,16 @@ error[E0507]: cannot move out of index of `Vec<(String, String)>`
   --> $DIR/issue-40402-2.rs:5:18
    |
 LL |     let (a, b) = x[0];
-   |          -  -    ^^^^ help: consider borrowing here: `&x[0]`
+   |          -  -    ^^^^
    |          |  |
    |          |  ...and here
    |          data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing here
+   |
+LL |     let (a, b) = &x[0];
+   |                  +
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/issue-99470-move-out-of-some.stderr
+++ b/src/test/ui/moves/issue-99470-move-out-of-some.stderr
@@ -5,11 +5,16 @@ LL |     match x {
    |           ^
 LL |
 LL |         &Some(_y) => (),
-   |         ---------
-   |         |     |
-   |         |     data moved here
-   |         |     move occurs because `_y` has type `Box<i32>`, which does not implement the `Copy` trait
-   |         help: consider removing the `&`: `Some(_y)`
+   |               --
+   |               |
+   |               data moved here
+   |               move occurs because `_y` has type `Box<i32>`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -         &Some(_y) => (),
+LL +         Some(_y) => (),
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/move-out-of-array-ref.stderr
+++ b/src/test/ui/moves/move-out-of-array-ref.stderr
@@ -2,45 +2,57 @@ error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
   --> $DIR/move-out-of-array-ref.rs:8:24
    |
 LL |     let [_, e, _, _] = *a;
-   |             -          ^^
-   |             |          |
-   |             |          cannot move out of here
-   |             |          help: consider borrowing here: `&*a`
+   |             -          ^^ cannot move out of here
+   |             |
    |             data moved here
    |             move occurs because `e` has type `D`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let [_, e, _, _] = &*a;
+   |                        +
 
 error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
   --> $DIR/move-out-of-array-ref.rs:13:27
    |
 LL |     let [_, s @ .. , _] = *a;
-   |             -             ^^
-   |             |             |
-   |             |             cannot move out of here
-   |             |             help: consider borrowing here: `&*a`
+   |             -             ^^ cannot move out of here
+   |             |
    |             data moved here
    |             move occurs because `s` has type `[D; 2]`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let [_, s @ .. , _] = &*a;
+   |                           +
 
 error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
   --> $DIR/move-out-of-array-ref.rs:18:24
    |
 LL |     let [_, e, _, _] = *a;
-   |             -          ^^
-   |             |          |
-   |             |          cannot move out of here
-   |             |          help: consider borrowing here: `&*a`
+   |             -          ^^ cannot move out of here
+   |             |
    |             data moved here
    |             move occurs because `e` has type `D`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let [_, e, _, _] = &*a;
+   |                        +
 
 error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
   --> $DIR/move-out-of-array-ref.rs:23:27
    |
 LL |     let [_, s @ .. , _] = *a;
-   |             -             ^^
-   |             |             |
-   |             |             cannot move out of here
-   |             |             help: consider borrowing here: `&*a`
+   |             -             ^^ cannot move out of here
+   |             |
    |             data moved here
    |             move occurs because `s` has type `[D; 2]`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let [_, s @ .. , _] = &*a;
+   |                           +
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/moves/move-out-of-array-ref.stderr
+++ b/src/test/ui/moves/move-out-of-array-ref.stderr
@@ -7,10 +7,11 @@ LL |     let [_, e, _, _] = *a;
    |             data moved here
    |             move occurs because `e` has type `D`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let [_, e, _, _] = &*a;
-   |                        +
+LL -     let [_, e, _, _] = *a;
+LL +     let [_, e, _, _] = a;
+   |
 
 error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
   --> $DIR/move-out-of-array-ref.rs:13:27
@@ -21,10 +22,11 @@ LL |     let [_, s @ .. , _] = *a;
    |             data moved here
    |             move occurs because `s` has type `[D; 2]`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let [_, s @ .. , _] = &*a;
-   |                           +
+LL -     let [_, s @ .. , _] = *a;
+LL +     let [_, s @ .. , _] = a;
+   |
 
 error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
   --> $DIR/move-out-of-array-ref.rs:18:24
@@ -35,10 +37,11 @@ LL |     let [_, e, _, _] = *a;
    |             data moved here
    |             move occurs because `e` has type `D`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let [_, e, _, _] = &*a;
-   |                        +
+LL -     let [_, e, _, _] = *a;
+LL +     let [_, e, _, _] = a;
+   |
 
 error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
   --> $DIR/move-out-of-array-ref.rs:23:27
@@ -49,10 +52,11 @@ LL |     let [_, s @ .. , _] = *a;
    |             data moved here
    |             move occurs because `s` has type `[D; 2]`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let [_, s @ .. , _] = &*a;
-   |                           +
+LL -     let [_, s @ .. , _] = *a;
+LL +     let [_, s @ .. , _] = a;
+   |
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/moves/move-out-of-slice-1.stderr
+++ b/src/test/ui/moves/move-out-of-slice-1.stderr
@@ -8,6 +8,11 @@ LL |         box [a] => {},
    |              |
    |              data moved here
    |              move occurs because `a` has type `A`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         box [ref a] => {},
+   |              +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/move-out-of-slice-2.rs
+++ b/src/test/ui/moves/move-out-of-slice-2.rs
@@ -1,5 +1,6 @@
 #![feature(unsized_locals)]
 //~^ WARN the feature `unsized_locals` is incomplete
+#![allow(unused)]
 
 struct A;
 #[derive(Clone, Copy)]

--- a/src/test/ui/moves/move-out-of-slice-2.stderr
+++ b/src/test/ui/moves/move-out-of-slice-2.stderr
@@ -8,7 +8,7 @@ LL | #![feature(unsized_locals)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0508]: cannot move out of type `[A]`, a non-copy slice
-  --> $DIR/move-out-of-slice-2.rs:10:11
+  --> $DIR/move-out-of-slice-2.rs:11:11
    |
 LL |     match *a {
    |           ^^ cannot move out of here
@@ -18,9 +18,14 @@ LL |         [a @ ..] => {}
    |          |
    |          data moved here
    |          move occurs because `a` has type `[A]`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         [ref a @ ..] => {}
+   |          +++
 
 error[E0508]: cannot move out of type `[A]`, a non-copy slice
-  --> $DIR/move-out-of-slice-2.rs:16:11
+  --> $DIR/move-out-of-slice-2.rs:17:11
    |
 LL |     match *b {
    |           ^^ cannot move out of here
@@ -30,9 +35,14 @@ LL |         [_, _, b @ .., _] => {}
    |                |
    |                data moved here
    |                move occurs because `b` has type `[A]`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         [_, _, ref b @ .., _] => {}
+   |                +++
 
 error[E0508]: cannot move out of type `[C]`, a non-copy slice
-  --> $DIR/move-out-of-slice-2.rs:24:11
+  --> $DIR/move-out-of-slice-2.rs:25:11
    |
 LL |     match *c {
    |           ^^ cannot move out of here
@@ -42,9 +52,14 @@ LL |         [c @ ..] => {}
    |          |
    |          data moved here
    |          move occurs because `c` has type `[C]`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         [ref c @ ..] => {}
+   |          +++
 
 error[E0508]: cannot move out of type `[C]`, a non-copy slice
-  --> $DIR/move-out-of-slice-2.rs:30:11
+  --> $DIR/move-out-of-slice-2.rs:31:11
    |
 LL |     match *d {
    |           ^^ cannot move out of here
@@ -54,6 +69,11 @@ LL |         [_, _, d @ .., _] => {}
    |                |
    |                data moved here
    |                move occurs because `d` has type `[C]`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         [_, _, ref d @ .., _] => {}
+   |                +++
 
 error: aborting due to 4 previous errors; 1 warning emitted
 

--- a/src/test/ui/moves/moves-based-on-type-block-bad.stderr
+++ b/src/test/ui/moves/moves-based-on-type-block-bad.stderr
@@ -2,13 +2,18 @@ error[E0507]: cannot move out of `hellothere.x` as enum variant `Bar` which is b
   --> $DIR/moves-based-on-type-block-bad.rs:22:19
    |
 LL |             match hellothere.x {
-   |                   ^^^^^^^^^^^^ help: consider borrowing here: `&hellothere.x`
+   |                   ^^^^^^^^^^^^
 LL |                 box E::Foo(_) => {}
 LL |                 box E::Bar(x) => println!("{}", x.to_string()),
    |                            -
    |                            |
    |                            data moved here
    |                            move occurs because `x` has type `Box<isize>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |             match &hellothere.x {
+   |                   +
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/cannot-move-block-spans.stderr
+++ b/src/test/ui/nll/cannot-move-block-spans.stderr
@@ -4,10 +4,11 @@ error[E0507]: cannot move out of `*r` which is behind a shared reference
 LL |     let x = { *r };
    |               ^^ move occurs because `*r` has type `String`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let x = { &*r };
-   |               +
+LL -     let x = { *r };
+LL +     let x = { r };
+   |
 
 error[E0507]: cannot move out of `*r` which is behind a shared reference
   --> $DIR/cannot-move-block-spans.rs:6:22
@@ -15,10 +16,11 @@ error[E0507]: cannot move out of `*r` which is behind a shared reference
 LL |     let y = unsafe { *r };
    |                      ^^ move occurs because `*r` has type `String`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let y = unsafe { &*r };
-   |                      +
+LL -     let y = unsafe { *r };
+LL +     let y = unsafe { r };
+   |
 
 error[E0507]: cannot move out of `*r` which is behind a shared reference
   --> $DIR/cannot-move-block-spans.rs:7:26
@@ -26,10 +28,11 @@ error[E0507]: cannot move out of `*r` which is behind a shared reference
 LL |     let z = loop { break *r; };
    |                          ^^ move occurs because `*r` has type `String`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let z = loop { break &*r; };
-   |                          +
+LL -     let z = loop { break *r; };
+LL +     let z = loop { break r; };
+   |
 
 error[E0508]: cannot move out of type `[String; 2]`, a non-copy array
   --> $DIR/cannot-move-block-spans.rs:11:15
@@ -79,10 +82,11 @@ error[E0507]: cannot move out of `*r` which is behind a shared reference
 LL |     let x = { let mut u = 0; u += 1; *r };
    |                                      ^^ move occurs because `*r` has type `String`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let x = { let mut u = 0; u += 1; &*r };
-   |                                      +
+LL -     let x = { let mut u = 0; u += 1; *r };
+LL +     let x = { let mut u = 0; u += 1; r };
+   |
 
 error[E0507]: cannot move out of `*r` which is behind a shared reference
   --> $DIR/cannot-move-block-spans.rs:18:45
@@ -90,10 +94,11 @@ error[E0507]: cannot move out of `*r` which is behind a shared reference
 LL |     let y = unsafe { let mut u = 0; u += 1; *r };
    |                                             ^^ move occurs because `*r` has type `String`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let y = unsafe { let mut u = 0; u += 1; &*r };
-   |                                             +
+LL -     let y = unsafe { let mut u = 0; u += 1; *r };
+LL +     let y = unsafe { let mut u = 0; u += 1; r };
+   |
 
 error[E0507]: cannot move out of `*r` which is behind a shared reference
   --> $DIR/cannot-move-block-spans.rs:19:49
@@ -101,10 +106,11 @@ error[E0507]: cannot move out of `*r` which is behind a shared reference
 LL |     let z = loop { let mut u = 0; u += 1; break *r; u += 2; };
    |                                                 ^^ move occurs because `*r` has type `String`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let z = loop { let mut u = 0; u += 1; break &*r; u += 2; };
-   |                                                 +
+LL -     let z = loop { let mut u = 0; u += 1; break *r; u += 2; };
+LL +     let z = loop { let mut u = 0; u += 1; break r; u += 2; };
+   |
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/nll/cannot-move-block-spans.stderr
+++ b/src/test/ui/nll/cannot-move-block-spans.stderr
@@ -2,28 +2,34 @@ error[E0507]: cannot move out of `*r` which is behind a shared reference
   --> $DIR/cannot-move-block-spans.rs:5:15
    |
 LL |     let x = { *r };
-   |               ^^
-   |               |
-   |               move occurs because `*r` has type `String`, which does not implement the `Copy` trait
-   |               help: consider borrowing here: `&*r`
+   |               ^^ move occurs because `*r` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let x = { &*r };
+   |               +
 
 error[E0507]: cannot move out of `*r` which is behind a shared reference
   --> $DIR/cannot-move-block-spans.rs:6:22
    |
 LL |     let y = unsafe { *r };
-   |                      ^^
-   |                      |
-   |                      move occurs because `*r` has type `String`, which does not implement the `Copy` trait
-   |                      help: consider borrowing here: `&*r`
+   |                      ^^ move occurs because `*r` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let y = unsafe { &*r };
+   |                      +
 
 error[E0507]: cannot move out of `*r` which is behind a shared reference
   --> $DIR/cannot-move-block-spans.rs:7:26
    |
 LL |     let z = loop { break *r; };
-   |                          ^^
-   |                          |
-   |                          move occurs because `*r` has type `String`, which does not implement the `Copy` trait
-   |                          help: consider borrowing here: `&*r`
+   |                          ^^ move occurs because `*r` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let z = loop { break &*r; };
+   |                          +
 
 error[E0508]: cannot move out of type `[String; 2]`, a non-copy array
   --> $DIR/cannot-move-block-spans.rs:11:15
@@ -33,7 +39,11 @@ LL |     let x = { arr[0] };
    |               |
    |               cannot move out of here
    |               move occurs because `arr[_]` has type `String`, which does not implement the `Copy` trait
-   |               help: consider borrowing here: `&arr[0]`
+   |
+help: consider borrowing here
+   |
+LL |     let x = { &arr[0] };
+   |               +
 
 error[E0508]: cannot move out of type `[String; 2]`, a non-copy array
   --> $DIR/cannot-move-block-spans.rs:12:22
@@ -43,7 +53,11 @@ LL |     let y = unsafe { arr[0] };
    |                      |
    |                      cannot move out of here
    |                      move occurs because `arr[_]` has type `String`, which does not implement the `Copy` trait
-   |                      help: consider borrowing here: `&arr[0]`
+   |
+help: consider borrowing here
+   |
+LL |     let y = unsafe { &arr[0] };
+   |                      +
 
 error[E0508]: cannot move out of type `[String; 2]`, a non-copy array
   --> $DIR/cannot-move-block-spans.rs:13:26
@@ -53,34 +67,44 @@ LL |     let z = loop { break arr[0]; };
    |                          |
    |                          cannot move out of here
    |                          move occurs because `arr[_]` has type `String`, which does not implement the `Copy` trait
-   |                          help: consider borrowing here: `&arr[0]`
+   |
+help: consider borrowing here
+   |
+LL |     let z = loop { break &arr[0]; };
+   |                          +
 
 error[E0507]: cannot move out of `*r` which is behind a shared reference
   --> $DIR/cannot-move-block-spans.rs:17:38
    |
 LL |     let x = { let mut u = 0; u += 1; *r };
-   |                                      ^^
-   |                                      |
-   |                                      move occurs because `*r` has type `String`, which does not implement the `Copy` trait
-   |                                      help: consider borrowing here: `&*r`
+   |                                      ^^ move occurs because `*r` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let x = { let mut u = 0; u += 1; &*r };
+   |                                      +
 
 error[E0507]: cannot move out of `*r` which is behind a shared reference
   --> $DIR/cannot-move-block-spans.rs:18:45
    |
 LL |     let y = unsafe { let mut u = 0; u += 1; *r };
-   |                                             ^^
-   |                                             |
-   |                                             move occurs because `*r` has type `String`, which does not implement the `Copy` trait
-   |                                             help: consider borrowing here: `&*r`
+   |                                             ^^ move occurs because `*r` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let y = unsafe { let mut u = 0; u += 1; &*r };
+   |                                             +
 
 error[E0507]: cannot move out of `*r` which is behind a shared reference
   --> $DIR/cannot-move-block-spans.rs:19:49
    |
 LL |     let z = loop { let mut u = 0; u += 1; break *r; u += 2; };
-   |                                                 ^^
-   |                                                 |
-   |                                                 move occurs because `*r` has type `String`, which does not implement the `Copy` trait
-   |                                                 help: consider borrowing here: `&*r`
+   |                                                 ^^ move occurs because `*r` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let z = loop { let mut u = 0; u += 1; break &*r; u += 2; };
+   |                                                 +
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/nll/issue-52059-report-when-borrow-and-drop-conflict.stderr
+++ b/src/test/ui/nll/issue-52059-report-when-borrow-and-drop-conflict.stderr
@@ -36,7 +36,11 @@ LL |     let p = s.url; p
    |             |
    |             cannot move out of here
    |             move occurs because `s.url` has type `&mut String`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&s.url`
+   |
+help: consider borrowing here
+   |
+LL |     let p = &s.url; p
+   |             +
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/nll/move-errors.stderr
+++ b/src/test/ui/nll/move-errors.stderr
@@ -4,10 +4,11 @@ error[E0507]: cannot move out of `*a` which is behind a shared reference
 LL |     let b = *a;
    |             ^^ move occurs because `*a` has type `A`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let b = &*a;
-   |             +
+LL -     let b = *a;
+LL +     let b = a;
+   |
 
 error[E0508]: cannot move out of type `[A; 1]`, a non-copy array
   --> $DIR/move-errors.rs:12:13
@@ -29,10 +30,11 @@ error[E0507]: cannot move out of `**r` which is behind a shared reference
 LL |     let s = **r;
    |             ^^^ move occurs because `**r` has type `A`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let s = &**r;
-   |             +
+LL -     let s = **r;
+LL +     let s = *r;
+   |
 
 error[E0507]: cannot move out of an `Rc`
   --> $DIR/move-errors.rs:27:13
@@ -40,10 +42,11 @@ error[E0507]: cannot move out of an `Rc`
 LL |     let s = *r;
    |             ^^ move occurs because value has type `A`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let s = &*r;
-   |             +
+LL -     let s = *r;
+LL +     let s = r;
+   |
 
 error[E0508]: cannot move out of type `[A; 1]`, a non-copy array
   --> $DIR/move-errors.rs:32:13
@@ -68,10 +71,11 @@ LL |     let A(s) = *a;
    |           data moved here
    |           move occurs because `s` has type `String`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let A(s) = &*a;
-   |                +
+LL -     let A(s) = *a;
+LL +     let A(s) = a;
+   |
 
 error[E0509]: cannot move out of type `D`, which implements the `Drop` trait
   --> $DIR/move-errors.rs:44:19
@@ -194,10 +198,11 @@ LL |         Ok(s) | Err(s) => (),
    |            data moved here
    |            move occurs because `s` has type `String`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     match &*x {
-   |           +
+LL -     match *x {
+LL +     match x {
+   |
 
 error: aborting due to 14 previous errors
 

--- a/src/test/ui/nll/move-errors.stderr
+++ b/src/test/ui/nll/move-errors.stderr
@@ -2,10 +2,12 @@ error[E0507]: cannot move out of `*a` which is behind a shared reference
   --> $DIR/move-errors.rs:6:13
    |
 LL |     let b = *a;
-   |             ^^
-   |             |
-   |             move occurs because `*a` has type `A`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&*a`
+   |             ^^ move occurs because `*a` has type `A`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let b = &*a;
+   |             +
 
 error[E0508]: cannot move out of type `[A; 1]`, a non-copy array
   --> $DIR/move-errors.rs:12:13
@@ -15,25 +17,33 @@ LL |     let b = a[0];
    |             |
    |             cannot move out of here
    |             move occurs because `a[_]` has type `A`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&a[0]`
+   |
+help: consider borrowing here
+   |
+LL |     let b = &a[0];
+   |             +
 
 error[E0507]: cannot move out of `**r` which is behind a shared reference
   --> $DIR/move-errors.rs:19:13
    |
 LL |     let s = **r;
-   |             ^^^
-   |             |
-   |             move occurs because `**r` has type `A`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&**r`
+   |             ^^^ move occurs because `**r` has type `A`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let s = &**r;
+   |             +
 
 error[E0507]: cannot move out of an `Rc`
   --> $DIR/move-errors.rs:27:13
    |
 LL |     let s = *r;
-   |             ^^
-   |             |
-   |             move occurs because value has type `A`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&*r`
+   |             ^^ move occurs because value has type `A`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let s = &*r;
+   |             +
 
 error[E0508]: cannot move out of type `[A; 1]`, a non-copy array
   --> $DIR/move-errors.rs:32:13
@@ -43,16 +53,25 @@ LL |     let a = [A("".to_string())][0];
    |             |
    |             cannot move out of here
    |             move occurs because value has type `A`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&[A("".to_string())][0]`
+   |
+help: consider borrowing here
+   |
+LL |     let a = &[A("".to_string())][0];
+   |             +
 
 error[E0507]: cannot move out of `a` which is behind a shared reference
   --> $DIR/move-errors.rs:38:16
    |
 LL |     let A(s) = *a;
-   |           -    ^^ help: consider borrowing here: `&*a`
+   |           -    ^^
    |           |
    |           data moved here
    |           move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let A(s) = &*a;
+   |                +
 
 error[E0509]: cannot move out of type `D`, which implements the `Drop` trait
   --> $DIR/move-errors.rs:44:19
@@ -73,10 +92,7 @@ error[E0508]: cannot move out of type `[B; 1]`, a non-copy array
   --> $DIR/move-errors.rs:74:11
    |
 LL |     match x[0] {
-   |           ^^^^
-   |           |
-   |           cannot move out of here
-   |           help: consider borrowing here: `&x[0]`
+   |           ^^^^ cannot move out of here
 LL |
 LL |         B::U(d) => (),
    |              - data moved here
@@ -84,6 +100,10 @@ LL |         B::V(s) => (),
    |              - ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing here
+   |
+LL |     match &x[0] {
+   |           +
 
 error[E0509]: cannot move out of type `D`, which implements the `Drop` trait
   --> $DIR/move-errors.rs:83:11
@@ -138,13 +158,18 @@ error[E0507]: cannot move out of `x` as enum variant `Err` which is behind a sha
   --> $DIR/move-errors.rs:110:11
    |
 LL |     match *x {
-   |           ^^ help: consider borrowing here: `&*x`
+   |           ^^
 LL |
 LL |         Ok(s) | Err(s) => (),
    |            -
    |            |
    |            data moved here
    |            move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &*x {
+   |           +
 
 error: aborting due to 14 previous errors
 

--- a/src/test/ui/nll/move-errors.stderr
+++ b/src/test/ui/nll/move-errors.stderr
@@ -81,6 +81,11 @@ LL |     let C(D(s)) = c;
    |             |
    |             data moved here
    |             move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     let C(D(ref s)) = c;
+   |             +++
 
 error[E0507]: cannot move out of `*a` which is behind a shared reference
   --> $DIR/move-errors.rs:51:9
@@ -116,6 +121,11 @@ LL |         B::U(D(s)) => (),
    |                |
    |                data moved here
    |                move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         B::U(D(ref s)) => (),
+   |                +++
 
 error[E0509]: cannot move out of type `D`, which implements the `Drop` trait
   --> $DIR/move-errors.rs:92:11
@@ -128,6 +138,11 @@ LL |         (D(s), &t) => (),
    |            |
    |            data moved here
    |            move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         (D(ref s), &t) => (),
+   |            +++
 
 error[E0507]: cannot move out of `*x.1` which is behind a shared reference
   --> $DIR/move-errors.rs:92:11
@@ -140,6 +155,11 @@ LL |         (D(s), &t) => (),
    |                 |
    |                 data moved here
    |                 move occurs because `t` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         (D(s), &ref t) => (),
+   |                 +++
 
 error[E0509]: cannot move out of type `F`, which implements the `Drop` trait
   --> $DIR/move-errors.rs:102:11
@@ -153,6 +173,14 @@ LL |         F(s, mut t) => (),
    |           data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |         F(ref s, mut t) => (),
+   |           +++
+help: consider borrowing the pattern binding
+   |
+LL |         F(s, ref mut t) => (),
+   |              +++
 
 error[E0507]: cannot move out of `x` as enum variant `Err` which is behind a shared reference
   --> $DIR/move-errors.rs:110:11

--- a/src/test/ui/pattern/move-ref-patterns/move-ref-patterns-default-binding-modes-fixable.fixed
+++ b/src/test/ui/pattern/move-ref-patterns/move-ref-patterns-default-binding-modes-fixable.fixed
@@ -1,0 +1,12 @@
+// run-rustfix
+#![allow(unused_variables)]
+fn main() {
+    struct U;
+
+    // A tuple is a "non-reference pattern".
+    // A `mut` binding pattern resets the binding mode to by-value.
+
+    let mut p = (U, U);
+    let (a, ref mut b) = &mut p;
+    //~^ ERROR cannot move out of a mutable reference
+}

--- a/src/test/ui/pattern/move-ref-patterns/move-ref-patterns-default-binding-modes-fixable.rs
+++ b/src/test/ui/pattern/move-ref-patterns/move-ref-patterns-default-binding-modes-fixable.rs
@@ -1,0 +1,12 @@
+// run-rustfix
+#![allow(unused_variables)]
+fn main() {
+    struct U;
+
+    // A tuple is a "non-reference pattern".
+    // A `mut` binding pattern resets the binding mode to by-value.
+
+    let mut p = (U, U);
+    let (a, mut b) = &mut p;
+    //~^ ERROR cannot move out of a mutable reference
+}

--- a/src/test/ui/pattern/move-ref-patterns/move-ref-patterns-default-binding-modes-fixable.stderr
+++ b/src/test/ui/pattern/move-ref-patterns/move-ref-patterns-default-binding-modes-fixable.stderr
@@ -1,15 +1,15 @@
-error[E0507]: cannot move out of a shared reference
-  --> $DIR/move-ref-patterns-default-binding-modes.rs:8:22
+error[E0507]: cannot move out of a mutable reference
+  --> $DIR/move-ref-patterns-default-binding-modes-fixable.rs:10:22
    |
-LL |     let (a, mut b) = &p;
-   |             -----    ^^
+LL |     let (a, mut b) = &mut p;
+   |             -----    ^^^^^^
    |             |
    |             data moved here
    |             move occurs because `b` has type `U`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
-LL |     let (a, ref mut b) = &p;
+LL |     let (a, ref mut b) = &mut p;
    |             +++
 
 error: aborting due to previous error

--- a/src/test/ui/pattern/move-ref-patterns/move-ref-patterns-default-binding-modes.rs
+++ b/src/test/ui/pattern/move-ref-patterns/move-ref-patterns-default-binding-modes.rs
@@ -7,8 +7,4 @@ fn main() {
     let p = (U, U);
     let (a, mut b) = &p;
     //~^ ERROR cannot move out of a shared reference
-
-    let mut p = (U, U);
-    let (a, mut b) = &mut p;
-    //~^ ERROR cannot move out of a mutable reference
 }

--- a/src/test/ui/rfc-2005-default-binding-mode/for.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/for.stderr
@@ -6,6 +6,11 @@ LL |     for (n, mut m) in &tups {
    |             |
    |             data moved here
    |             move occurs because `m` has type `Foo`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     for (n, ref mut m) in &tups {
+   |             +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/std-uncopyable-atomics.stderr
+++ b/src/test/ui/std-uncopyable-atomics.stderr
@@ -4,10 +4,11 @@ error[E0507]: cannot move out of a shared reference
 LL |     let x = *&x;
    |             ^^^ move occurs because value has type `std::sync::atomic::AtomicBool`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let x = &*&x;
-   |             +
+LL -     let x = *&x;
+LL +     let x = &x;
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/std-uncopyable-atomics.rs:11:13
@@ -15,10 +16,11 @@ error[E0507]: cannot move out of a shared reference
 LL |     let x = *&x;
    |             ^^^ move occurs because value has type `std::sync::atomic::AtomicIsize`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let x = &*&x;
-   |             +
+LL -     let x = *&x;
+LL +     let x = &x;
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/std-uncopyable-atomics.rs:13:13
@@ -26,10 +28,11 @@ error[E0507]: cannot move out of a shared reference
 LL |     let x = *&x;
    |             ^^^ move occurs because value has type `std::sync::atomic::AtomicUsize`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let x = &*&x;
-   |             +
+LL -     let x = *&x;
+LL +     let x = &x;
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/std-uncopyable-atomics.rs:15:13
@@ -37,10 +40,11 @@ error[E0507]: cannot move out of a shared reference
 LL |     let x = *&x;
    |             ^^^ move occurs because value has type `std::sync::atomic::AtomicPtr<usize>`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let x = &*&x;
-   |             +
+LL -     let x = *&x;
+LL +     let x = &x;
+   |
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/std-uncopyable-atomics.stderr
+++ b/src/test/ui/std-uncopyable-atomics.stderr
@@ -2,37 +2,45 @@ error[E0507]: cannot move out of a shared reference
   --> $DIR/std-uncopyable-atomics.rs:9:13
    |
 LL |     let x = *&x;
-   |             ^^^
-   |             |
-   |             move occurs because value has type `std::sync::atomic::AtomicBool`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&*&x`
+   |             ^^^ move occurs because value has type `std::sync::atomic::AtomicBool`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let x = &*&x;
+   |             +
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/std-uncopyable-atomics.rs:11:13
    |
 LL |     let x = *&x;
-   |             ^^^
-   |             |
-   |             move occurs because value has type `std::sync::atomic::AtomicIsize`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&*&x`
+   |             ^^^ move occurs because value has type `std::sync::atomic::AtomicIsize`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let x = &*&x;
+   |             +
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/std-uncopyable-atomics.rs:13:13
    |
 LL |     let x = *&x;
-   |             ^^^
-   |             |
-   |             move occurs because value has type `std::sync::atomic::AtomicUsize`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&*&x`
+   |             ^^^ move occurs because value has type `std::sync::atomic::AtomicUsize`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let x = &*&x;
+   |             +
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/std-uncopyable-atomics.rs:15:13
    |
 LL |     let x = *&x;
-   |             ^^^
-   |             |
-   |             move occurs because value has type `std::sync::atomic::AtomicPtr<usize>`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&*&x`
+   |             ^^^ move occurs because value has type `std::sync::atomic::AtomicPtr<usize>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let x = &*&x;
+   |             +
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/dont-suggest-ref/duplicate-suggestions.rs
+++ b/src/test/ui/suggestions/dont-suggest-ref/duplicate-suggestions.rs
@@ -38,31 +38,25 @@ pub fn main() {
 
     let &(X(_t), X(_u)) = &(x.clone(), x.clone());
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&`
-    //~| SUGGESTION (X(_t), X(_u))
+    //~| HELP consider removing the borrow
     if let &(Either::One(_t), Either::Two(_u)) = &(e.clone(), e.clone()) { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&`
-    //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+    //~| HELP consider removing the borrow
     while let &(Either::One(_t), Either::Two(_u)) = &(e.clone(), e.clone()) { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&`
-    //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+    //~| HELP consider removing the borrow
     match &(e.clone(), e.clone()) {
         //~^ ERROR cannot move
         &(Either::One(_t), Either::Two(_u)) => (),
-        //~^ HELP consider removing the `&`
-        //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+        //~^ HELP consider removing the borrow
         &(Either::Two(_t), Either::One(_u)) => (),
-        //~^ HELP consider removing the `&`
-        //~| SUGGESTION (Either::Two(_t), Either::One(_u))
+        //~^ HELP consider removing the borrow
         _ => (),
     }
     match &(e.clone(), e.clone()) {
         //~^ ERROR cannot move
         &(Either::One(_t), Either::Two(_u))
-        //~^ HELP consider removing the `&`
-        //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+        //~^ HELP consider removing the borrow
         | &(Either::Two(_t), Either::One(_u)) => (),
         // FIXME: would really like a suggestion here too
         _ => (),
@@ -70,51 +64,42 @@ pub fn main() {
     match &(e.clone(), e.clone()) {
         //~^ ERROR cannot move
         &(Either::One(_t), Either::Two(_u)) => (),
-        //~^ HELP consider removing the `&`
-        //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+        //~^ HELP consider removing the borrow
         &(Either::Two(ref _t), Either::One(ref _u)) => (),
         _ => (),
     }
     match &(e.clone(), e.clone()) {
         //~^ ERROR cannot move
         &(Either::One(_t), Either::Two(_u)) => (),
-        //~^ HELP consider removing the `&`
-        //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+        //~^ HELP consider removing the borrow
         (Either::Two(_t), Either::One(_u)) => (),
         _ => (),
     }
     fn f5(&(X(_t), X(_u)): &(X, X)) { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&`
-    //~| SUGGESTION (X(_t), X(_u))
+    //~| HELP consider removing the borrow
 
     let &mut (X(_t), X(_u)) = &mut (xm.clone(), xm.clone());
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&mut`
-    //~| SUGGESTION (X(_t), X(_u))
+    //~| HELP consider removing the mutable borrow
     if let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&mut`
-    //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+    //~| HELP consider removing the mutable borrow
     while let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&mut`
-    //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+    //~| HELP consider removing the mutable borrow
     match &mut (em.clone(), em.clone()) {
         //~^ ERROR cannot move
         &mut (Either::One(_t), Either::Two(_u)) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+        //~^ HELP consider removing the mutable borrow
         &mut (Either::Two(_t), Either::One(_u)) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION (Either::Two(_t), Either::One(_u))
+        //~^ HELP consider removing the mutable borrow
         _ => (),
     }
     match &mut (em.clone(), em.clone()) {
         //~^ ERROR cannot move
         &mut (Either::One(_t), Either::Two(_u))
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+        //~^ HELP consider removing the mutable borrow
         | &mut (Either::Two(_t), Either::One(_u)) => (),
         // FIXME: would really like a suggestion here too
         _ => (),
@@ -122,29 +107,25 @@ pub fn main() {
     match &mut (em.clone(), em.clone()) {
         //~^ ERROR cannot move
         &mut (Either::One(_t), Either::Two(_u)) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+        //~^ HELP consider removing the mutable borrow
         &mut (Either::Two(ref _t), Either::One(ref _u)) => (),
         _ => (),
     }
     match &mut (em.clone(), em.clone()) {
         //~^ ERROR cannot move
         &mut (Either::One(_t), Either::Two(_u)) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+        //~^ HELP consider removing the mutable borrow
         &mut (Either::Two(ref mut _t), Either::One(ref mut _u)) => (),
         _ => (),
     }
     match &mut (em.clone(), em.clone()) {
         //~^ ERROR cannot move
         &mut (Either::One(_t), Either::Two(_u)) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION (Either::One(_t), Either::Two(_u))
+        //~^ HELP consider removing the mutable borrow
         (Either::Two(_t), Either::One(_u)) => (),
         _ => (),
     }
     fn f6(&mut (X(_t), X(_u)): &mut (X, X)) { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&mut`
-    //~| SUGGESTION (X(_t), X(_u))
+    //~| HELP consider removing the mutable borrow
 }

--- a/src/test/ui/suggestions/dont-suggest-ref/duplicate-suggestions.stderr
+++ b/src/test/ui/suggestions/dont-suggest-ref/duplicate-suggestions.stderr
@@ -2,40 +2,52 @@ error[E0507]: cannot move out of a shared reference
   --> $DIR/duplicate-suggestions.rs:39:27
    |
 LL |     let &(X(_t), X(_u)) = &(x.clone(), x.clone());
-   |         ---------------   ^^^^^^^^^^^^^^^^^^^^^^^
-   |         |   |      |
-   |         |   |      ...and here
-   |         |   data moved here
-   |         help: consider removing the `&`: `(X(_t), X(_u))`
+   |             --     --     ^^^^^^^^^^^^^^^^^^^^^^^
+   |             |      |
+   |             |      ...and here
+   |             data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the borrow
+   |
+LL -     let &(X(_t), X(_u)) = &(x.clone(), x.clone());
+LL +     let (X(_t), X(_u)) = &(x.clone(), x.clone());
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/duplicate-suggestions.rs:43:50
+  --> $DIR/duplicate-suggestions.rs:42:50
    |
 LL |     if let &(Either::One(_t), Either::Two(_u)) = &(e.clone(), e.clone()) { }
-   |            -----------------------------------   ^^^^^^^^^^^^^^^^^^^^^^^
-   |            |             |                |
-   |            |             |                ...and here
-   |            |             data moved here
-   |            help: consider removing the `&`: `(Either::One(_t), Either::Two(_u))`
+   |                          --               --     ^^^^^^^^^^^^^^^^^^^^^^^
+   |                          |                |
+   |                          |                ...and here
+   |                          data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the borrow
+   |
+LL -     if let &(Either::One(_t), Either::Two(_u)) = &(e.clone(), e.clone()) { }
+LL +     if let (Either::One(_t), Either::Two(_u)) = &(e.clone(), e.clone()) { }
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/duplicate-suggestions.rs:47:53
+  --> $DIR/duplicate-suggestions.rs:45:53
    |
 LL |     while let &(Either::One(_t), Either::Two(_u)) = &(e.clone(), e.clone()) { }
-   |               -----------------------------------   ^^^^^^^^^^^^^^^^^^^^^^^
-   |               |             |                |
-   |               |             |                ...and here
-   |               |             data moved here
-   |               help: consider removing the `&`: `(Either::One(_t), Either::Two(_u))`
+   |                             --               --     ^^^^^^^^^^^^^^^^^^^^^^^
+   |                             |                |
+   |                             |                ...and here
+   |                             data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the borrow
+   |
+LL -     while let &(Either::One(_t), Either::Two(_u)) = &(e.clone(), e.clone()) { }
+LL +     while let (Either::One(_t), Either::Two(_u)) = &(e.clone(), e.clone()) { }
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/duplicate-suggestions.rs:51:11
+  --> $DIR/duplicate-suggestions.rs:48:11
    |
 LL |     match &(e.clone(), e.clone()) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,22 +56,24 @@ LL |         &(Either::One(_t), Either::Two(_u)) => (),
    |                       --               -- ...and here
    |                       |
    |                       data moved here
-...
+LL |
 LL |         &(Either::Two(_t), Either::One(_u)) => (),
    |                       -- ...and here   -- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider removing the `&`
+help: consider removing the borrow
    |
-LL |         (Either::One(_t), Either::Two(_u)) => (),
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-help: consider removing the `&`
+LL -         &(Either::One(_t), Either::Two(_u)) => (),
+LL +         (Either::One(_t), Either::Two(_u)) => (),
    |
-LL |         (Either::Two(_t), Either::One(_u)) => (),
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+help: consider removing the borrow
+   |
+LL -         &(Either::Two(_t), Either::One(_u)) => (),
+LL +         (Either::Two(_t), Either::One(_u)) => (),
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/duplicate-suggestions.rs:61:11
+  --> $DIR/duplicate-suggestions.rs:56:11
    |
 LL |     match &(e.clone(), e.clone()) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -70,82 +84,98 @@ LL |         &(Either::One(_t), Either::Two(_u))
    |                       data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider removing the `&`
+help: consider removing the borrow
    |
-LL ~         (Either::One(_t), Either::Two(_u))
-LL +
-LL +
-LL ~         | &(Either::Two(_t), Either::One(_u)) => (),
+LL -         &(Either::One(_t), Either::Two(_u))
+LL +         (Either::One(_t), Either::Two(_u))
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/duplicate-suggestions.rs:70:11
+  --> $DIR/duplicate-suggestions.rs:64:11
    |
 LL |     match &(e.clone(), e.clone()) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |         &(Either::One(_t), Either::Two(_u)) => (),
-   |         -----------------------------------
-   |         |             |                |
-   |         |             |                ...and here
-   |         |             data moved here
-   |         help: consider removing the `&`: `(Either::One(_t), Either::Two(_u))`
+   |                       --               -- ...and here
+   |                       |
+   |                       data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the borrow
+   |
+LL -         &(Either::One(_t), Either::Two(_u)) => (),
+LL +         (Either::One(_t), Either::Two(_u)) => (),
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/duplicate-suggestions.rs:78:11
+  --> $DIR/duplicate-suggestions.rs:71:11
    |
 LL |     match &(e.clone(), e.clone()) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |         &(Either::One(_t), Either::Two(_u)) => (),
-   |         -----------------------------------
-   |         |             |                |
-   |         |             |                ...and here
-   |         |             data moved here
-   |         help: consider removing the `&`: `(Either::One(_t), Either::Two(_u))`
+   |                       --               -- ...and here
+   |                       |
+   |                       data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the borrow
+   |
+LL -         &(Either::One(_t), Either::Two(_u)) => (),
+LL +         (Either::One(_t), Either::Two(_u)) => (),
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/duplicate-suggestions.rs:91:31
+  --> $DIR/duplicate-suggestions.rs:82:31
    |
 LL |     let &mut (X(_t), X(_u)) = &mut (xm.clone(), xm.clone());
-   |         -------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |         |       |      |
-   |         |       |      ...and here
-   |         |       data moved here
-   |         help: consider removing the `&mut`: `(X(_t), X(_u))`
+   |                 --     --     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |      |
+   |                 |      ...and here
+   |                 data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the mutable borrow
+   |
+LL -     let &mut (X(_t), X(_u)) = &mut (xm.clone(), xm.clone());
+LL +     let mut (X(_t), X(_u)) = &mut (xm.clone(), xm.clone());
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/duplicate-suggestions.rs:95:54
+  --> $DIR/duplicate-suggestions.rs:85:54
    |
 LL |     if let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
-   |            ---------------------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |            |                 |                |
-   |            |                 |                ...and here
-   |            |                 data moved here
-   |            help: consider removing the `&mut`: `(Either::One(_t), Either::Two(_u))`
+   |                              --               --     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              |                |
+   |                              |                ...and here
+   |                              data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the mutable borrow
+   |
+LL -     if let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
+LL +     if let mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/duplicate-suggestions.rs:99:57
+  --> $DIR/duplicate-suggestions.rs:88:57
    |
 LL |     while let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
-   |               ---------------------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |               |                 |                |
-   |               |                 |                ...and here
-   |               |                 data moved here
-   |               help: consider removing the `&mut`: `(Either::One(_t), Either::Two(_u))`
+   |                                 --               --     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 |                |
+   |                                 |                ...and here
+   |                                 data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the mutable borrow
+   |
+LL -     while let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
+LL +     while let mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/duplicate-suggestions.rs:103:11
+  --> $DIR/duplicate-suggestions.rs:91:11
    |
 LL |     match &mut (em.clone(), em.clone()) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -154,22 +184,24 @@ LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
    |                           --               -- ...and here
    |                           |
    |                           data moved here
-...
+LL |
 LL |         &mut (Either::Two(_t), Either::One(_u)) => (),
    |                           -- ...and here   -- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider removing the `&mut`
+help: consider removing the mutable borrow
    |
-LL |         (Either::One(_t), Either::Two(_u)) => (),
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-help: consider removing the `&mut`
+LL -         &mut (Either::One(_t), Either::Two(_u)) => (),
+LL +         mut (Either::One(_t), Either::Two(_u)) => (),
    |
-LL |         (Either::Two(_t), Either::One(_u)) => (),
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+help: consider removing the mutable borrow
+   |
+LL -         &mut (Either::Two(_t), Either::One(_u)) => (),
+LL +         mut (Either::Two(_t), Either::One(_u)) => (),
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/duplicate-suggestions.rs:113:11
+  --> $DIR/duplicate-suggestions.rs:99:11
    |
 LL |     match &mut (em.clone(), em.clone()) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -180,82 +212,97 @@ LL |         &mut (Either::One(_t), Either::Two(_u))
    |                           data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider removing the `&mut`
+help: consider removing the mutable borrow
    |
-LL ~         (Either::One(_t), Either::Two(_u))
-LL +
-LL +
-LL ~         | &mut (Either::Two(_t), Either::One(_u)) => (),
+LL -         &mut (Either::One(_t), Either::Two(_u))
+LL +         mut (Either::One(_t), Either::Two(_u))
    |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/duplicate-suggestions.rs:122:11
+  --> $DIR/duplicate-suggestions.rs:107:11
    |
 LL |     match &mut (em.clone(), em.clone()) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
-   |         ---------------------------------------
-   |         |                 |                |
-   |         |                 |                ...and here
-   |         |                 data moved here
-   |         help: consider removing the `&mut`: `(Either::One(_t), Either::Two(_u))`
+   |                           --               -- ...and here
+   |                           |
+   |                           data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the mutable borrow
+   |
+LL -         &mut (Either::One(_t), Either::Two(_u)) => (),
+LL +         mut (Either::One(_t), Either::Two(_u)) => (),
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/duplicate-suggestions.rs:130:11
+  --> $DIR/duplicate-suggestions.rs:114:11
    |
 LL |     match &mut (em.clone(), em.clone()) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
-   |         ---------------------------------------
-   |         |                 |                |
-   |         |                 |                ...and here
-   |         |                 data moved here
-   |         help: consider removing the `&mut`: `(Either::One(_t), Either::Two(_u))`
+   |                           --               -- ...and here
+   |                           |
+   |                           data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the mutable borrow
+   |
+LL -         &mut (Either::One(_t), Either::Two(_u)) => (),
+LL +         mut (Either::One(_t), Either::Two(_u)) => (),
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/duplicate-suggestions.rs:138:11
+  --> $DIR/duplicate-suggestions.rs:121:11
    |
 LL |     match &mut (em.clone(), em.clone()) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
-   |         ---------------------------------------
-   |         |                 |                |
-   |         |                 |                ...and here
-   |         |                 data moved here
-   |         help: consider removing the `&mut`: `(Either::One(_t), Either::Two(_u))`
+   |                           --               -- ...and here
+   |                           |
+   |                           data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the mutable borrow
+   |
+LL -         &mut (Either::One(_t), Either::Two(_u)) => (),
+LL +         mut (Either::One(_t), Either::Two(_u)) => (),
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/duplicate-suggestions.rs:86:11
+  --> $DIR/duplicate-suggestions.rs:78:11
    |
 LL |     fn f5(&(X(_t), X(_u)): &(X, X)) { }
    |           ^^^^--^^^^^--^^
-   |           |   |      |
-   |           |   |      ...and here
-   |           |   data moved here
-   |           help: consider removing the `&`: `(X(_t), X(_u))`
+   |               |      |
+   |               |      ...and here
+   |               data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the borrow
+   |
+LL -     fn f5(&(X(_t), X(_u)): &(X, X)) { }
+LL +     fn f5((X(_t), X(_u)): &(X, X)) { }
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/duplicate-suggestions.rs:146:11
+  --> $DIR/duplicate-suggestions.rs:128:11
    |
 LL |     fn f6(&mut (X(_t), X(_u)): &mut (X, X)) { }
    |           ^^^^^^^^--^^^^^--^^
-   |           |       |      |
-   |           |       |      ...and here
-   |           |       data moved here
-   |           help: consider removing the `&mut`: `(X(_t), X(_u))`
+   |                   |      |
+   |                   |      ...and here
+   |                   data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the mutable borrow
+   |
+LL -     fn f6(&mut (X(_t), X(_u)): &mut (X, X)) { }
+LL +     fn f6(mut (X(_t), X(_u)): &mut (X, X)) { }
+   |
 
 error: aborting due to 17 previous errors
 

--- a/src/test/ui/suggestions/dont-suggest-ref/duplicate-suggestions.stderr
+++ b/src/test/ui/suggestions/dont-suggest-ref/duplicate-suggestions.stderr
@@ -139,7 +139,7 @@ LL |     let &mut (X(_t), X(_u)) = &mut (xm.clone(), xm.clone());
 help: consider removing the mutable borrow
    |
 LL -     let &mut (X(_t), X(_u)) = &mut (xm.clone(), xm.clone());
-LL +     let mut (X(_t), X(_u)) = &mut (xm.clone(), xm.clone());
+LL +     let (X(_t), X(_u)) = &mut (xm.clone(), xm.clone());
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -155,7 +155,7 @@ LL |     if let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.c
 help: consider removing the mutable borrow
    |
 LL -     if let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
-LL +     if let mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
+LL +     if let (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -171,7 +171,7 @@ LL |     while let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), e
 help: consider removing the mutable borrow
    |
 LL -     while let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
-LL +     while let mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
+LL +     while let (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -192,12 +192,12 @@ LL |         &mut (Either::Two(_t), Either::One(_u)) => (),
 help: consider removing the mutable borrow
    |
 LL -         &mut (Either::One(_t), Either::Two(_u)) => (),
-LL +         mut (Either::One(_t), Either::Two(_u)) => (),
+LL +         (Either::One(_t), Either::Two(_u)) => (),
    |
 help: consider removing the mutable borrow
    |
 LL -         &mut (Either::Two(_t), Either::One(_u)) => (),
-LL +         mut (Either::Two(_t), Either::One(_u)) => (),
+LL +         (Either::Two(_t), Either::One(_u)) => (),
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -215,7 +215,7 @@ LL |         &mut (Either::One(_t), Either::Two(_u))
 help: consider removing the mutable borrow
    |
 LL -         &mut (Either::One(_t), Either::Two(_u))
-LL +         mut (Either::One(_t), Either::Two(_u))
+LL +         (Either::One(_t), Either::Two(_u))
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -233,7 +233,7 @@ LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
 help: consider removing the mutable borrow
    |
 LL -         &mut (Either::One(_t), Either::Two(_u)) => (),
-LL +         mut (Either::One(_t), Either::Two(_u)) => (),
+LL +         (Either::One(_t), Either::Two(_u)) => (),
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -251,7 +251,7 @@ LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
 help: consider removing the mutable borrow
    |
 LL -         &mut (Either::One(_t), Either::Two(_u)) => (),
-LL +         mut (Either::One(_t), Either::Two(_u)) => (),
+LL +         (Either::One(_t), Either::Two(_u)) => (),
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -269,7 +269,7 @@ LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
 help: consider removing the mutable borrow
    |
 LL -         &mut (Either::One(_t), Either::Two(_u)) => (),
-LL +         mut (Either::One(_t), Either::Two(_u)) => (),
+LL +         (Either::One(_t), Either::Two(_u)) => (),
    |
 
 error[E0507]: cannot move out of a shared reference
@@ -301,7 +301,7 @@ LL |     fn f6(&mut (X(_t), X(_u)): &mut (X, X)) { }
 help: consider removing the mutable borrow
    |
 LL -     fn f6(&mut (X(_t), X(_u)): &mut (X, X)) { }
-LL +     fn f6(mut (X(_t), X(_u)): &mut (X, X)) { }
+LL +     fn f6((X(_t), X(_u)): &mut (X, X)) { }
    |
 
 error: aborting due to 17 previous errors

--- a/src/test/ui/suggestions/dont-suggest-ref/move-into-closure.rs
+++ b/src/test/ui/suggestions/dont-suggest-ref/move-into-closure.rs
@@ -28,26 +28,21 @@ fn move_into_fn() {
         let X(_t) = x;
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &x
         if let Either::One(_t) = e { }
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &e
         while let Either::One(_t) = e { }
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &e
         match e {
             //~^ ERROR cannot move
             //~| HELP consider borrowing here
-            //~| SUGGESTION &e
             Either::One(_t)
             | Either::Two(_t) => (),
         }
         match e {
             //~^ ERROR cannot move
             //~| HELP consider borrowing here
-            //~| SUGGESTION &e
             Either::One(_t) => (),
             Either::Two(ref _t) => (),
             // FIXME: should suggest removing `ref` too
@@ -56,26 +51,21 @@ fn move_into_fn() {
         let X(mut _t) = x;
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &x
         if let Either::One(mut _t) = em { }
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &em
         while let Either::One(mut _t) = em { }
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &em
         match em {
             //~^ ERROR cannot move
             //~| HELP consider borrowing here
-            //~| SUGGESTION &em
             Either::One(mut _t)
             | Either::Two(mut _t) => (),
         }
         match em {
             //~^ ERROR cannot move
             //~| HELP consider borrowing here
-            //~| SUGGESTION &em
             Either::One(mut _t) => (),
             Either::Two(ref _t) => (),
             // FIXME: should suggest removing `ref` too
@@ -95,26 +85,21 @@ fn move_into_fnmut() {
         let X(_t) = x;
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &x
         if let Either::One(_t) = e { }
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &e
         while let Either::One(_t) = e { }
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &e
         match e {
             //~^ ERROR cannot move
             //~| HELP consider borrowing here
-            //~| SUGGESTION &e
             Either::One(_t)
             | Either::Two(_t) => (),
         }
         match e {
             //~^ ERROR cannot move
             //~| HELP consider borrowing here
-            //~| SUGGESTION &e
             Either::One(_t) => (),
             Either::Two(ref _t) => (),
             // FIXME: should suggest removing `ref` too
@@ -123,26 +108,21 @@ fn move_into_fnmut() {
         let X(mut _t) = x;
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &x
         if let Either::One(mut _t) = em { }
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &em
         while let Either::One(mut _t) = em { }
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &em
         match em {
             //~^ ERROR cannot move
             //~| HELP consider borrowing here
-            //~| SUGGESTION &em
             Either::One(mut _t)
             | Either::Two(mut _t) => (),
         }
         match em {
             //~^ ERROR cannot move
             //~| HELP consider borrowing here
-            //~| SUGGESTION &em
             Either::One(mut _t) => (),
             Either::Two(ref _t) => (),
             // FIXME: should suggest removing `ref` too
@@ -150,7 +130,6 @@ fn move_into_fnmut() {
         match em {
             //~^ ERROR cannot move
             //~| HELP consider borrowing here
-            //~| SUGGESTION &em
             Either::One(mut _t) => (),
             Either::Two(ref mut _t) => (),
             // FIXME: should suggest removing `ref` too

--- a/src/test/ui/suggestions/dont-suggest-ref/move-into-closure.stderr
+++ b/src/test/ui/suggestions/dont-suggest-ref/move-into-closure.stderr
@@ -7,13 +7,18 @@ LL |     let x = X(Y);
 LL |     consume_fn(|| {
    |                -- captured by this `Fn` closure
 LL |         let X(_t) = x;
-   |               --    ^ help: consider borrowing here: `&x`
+   |               --    ^
    |               |
    |               data moved here
    |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         let X(_t) = &x;
+   |                     +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:32:34
+  --> $DIR/move-into-closure.rs:31:34
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -22,13 +27,18 @@ LL |     consume_fn(|| {
    |                -- captured by this `Fn` closure
 ...
 LL |         if let Either::One(_t) = e { }
-   |                            --    ^ help: consider borrowing here: `&e`
+   |                            --    ^
    |                            |
    |                            data moved here
    |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         if let Either::One(_t) = &e { }
+   |                                  +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:36:37
+  --> $DIR/move-into-closure.rs:34:37
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -37,13 +47,18 @@ LL |     consume_fn(|| {
    |                -- captured by this `Fn` closure
 ...
 LL |         while let Either::One(_t) = e { }
-   |                               --    ^ help: consider borrowing here: `&e`
+   |                               --    ^
    |                               |
    |                               data moved here
    |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         while let Either::One(_t) = &e { }
+   |                                     +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:40:15
+  --> $DIR/move-into-closure.rs:37:15
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -52,16 +67,21 @@ LL |     consume_fn(|| {
    |                -- captured by this `Fn` closure
 ...
 LL |         match e {
-   |               ^ help: consider borrowing here: `&e`
+   |               ^
 ...
 LL |             Either::One(_t)
    |                         --
    |                         |
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         match &e {
+   |               +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:47:15
+  --> $DIR/move-into-closure.rs:43:15
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -70,16 +90,21 @@ LL |     consume_fn(|| {
    |                -- captured by this `Fn` closure
 ...
 LL |         match e {
-   |               ^ help: consider borrowing here: `&e`
+   |               ^
 ...
 LL |             Either::One(_t) => (),
    |                         --
    |                         |
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         match &e {
+   |               +
 
 error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:56:25
+  --> $DIR/move-into-closure.rs:51:25
    |
 LL |     let x = X(Y);
    |         - captured outer variable
@@ -88,13 +113,18 @@ LL |     consume_fn(|| {
    |                -- captured by this `Fn` closure
 ...
 LL |         let X(mut _t) = x;
-   |               ------    ^ help: consider borrowing here: `&x`
+   |               ------    ^
    |               |
    |               data moved here
    |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         let X(mut _t) = &x;
+   |                         +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:60:38
+  --> $DIR/move-into-closure.rs:54:38
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -103,13 +133,18 @@ LL |     consume_fn(|| {
    |                -- captured by this `Fn` closure
 ...
 LL |         if let Either::One(mut _t) = em { }
-   |                            ------    ^^ help: consider borrowing here: `&em`
+   |                            ------    ^^
    |                            |
    |                            data moved here
    |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         if let Either::One(mut _t) = &em { }
+   |                                      +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:64:41
+  --> $DIR/move-into-closure.rs:57:41
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -118,13 +153,18 @@ LL |     consume_fn(|| {
    |                -- captured by this `Fn` closure
 ...
 LL |         while let Either::One(mut _t) = em { }
-   |                               ------    ^^ help: consider borrowing here: `&em`
+   |                               ------    ^^
    |                               |
    |                               data moved here
    |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         while let Either::One(mut _t) = &em { }
+   |                                         +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:68:15
+  --> $DIR/move-into-closure.rs:60:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -133,16 +173,21 @@ LL |     consume_fn(|| {
    |                -- captured by this `Fn` closure
 ...
 LL |         match em {
-   |               ^^ help: consider borrowing here: `&em`
+   |               ^^
 ...
 LL |             Either::One(mut _t)
    |                         ------
    |                         |
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         match &em {
+   |               +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:75:15
+  --> $DIR/move-into-closure.rs:66:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -151,16 +196,21 @@ LL |     consume_fn(|| {
    |                -- captured by this `Fn` closure
 ...
 LL |         match em {
-   |               ^^ help: consider borrowing here: `&em`
+   |               ^^
 ...
 LL |             Either::One(mut _t) => (),
    |                         ------
    |                         |
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         match &em {
+   |               +
 
 error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:95:21
+  --> $DIR/move-into-closure.rs:85:21
    |
 LL |     let x = X(Y);
    |         - captured outer variable
@@ -168,13 +218,18 @@ LL |     let x = X(Y);
 LL |     consume_fnmut(|| {
    |                   -- captured by this `FnMut` closure
 LL |         let X(_t) = x;
-   |               --    ^ help: consider borrowing here: `&x`
+   |               --    ^
    |               |
    |               data moved here
    |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         let X(_t) = &x;
+   |                     +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:99:34
+  --> $DIR/move-into-closure.rs:88:34
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -183,13 +238,18 @@ LL |     consume_fnmut(|| {
    |                   -- captured by this `FnMut` closure
 ...
 LL |         if let Either::One(_t) = e { }
-   |                            --    ^ help: consider borrowing here: `&e`
+   |                            --    ^
    |                            |
    |                            data moved here
    |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         if let Either::One(_t) = &e { }
+   |                                  +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:103:37
+  --> $DIR/move-into-closure.rs:91:37
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -198,13 +258,18 @@ LL |     consume_fnmut(|| {
    |                   -- captured by this `FnMut` closure
 ...
 LL |         while let Either::One(_t) = e { }
-   |                               --    ^ help: consider borrowing here: `&e`
+   |                               --    ^
    |                               |
    |                               data moved here
    |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         while let Either::One(_t) = &e { }
+   |                                     +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:107:15
+  --> $DIR/move-into-closure.rs:94:15
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -213,16 +278,21 @@ LL |     consume_fnmut(|| {
    |                   -- captured by this `FnMut` closure
 ...
 LL |         match e {
-   |               ^ help: consider borrowing here: `&e`
+   |               ^
 ...
 LL |             Either::One(_t)
    |                         --
    |                         |
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         match &e {
+   |               +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:114:15
+  --> $DIR/move-into-closure.rs:100:15
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -231,16 +301,21 @@ LL |     consume_fnmut(|| {
    |                   -- captured by this `FnMut` closure
 ...
 LL |         match e {
-   |               ^ help: consider borrowing here: `&e`
+   |               ^
 ...
 LL |             Either::One(_t) => (),
    |                         --
    |                         |
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         match &e {
+   |               +
 
 error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:123:25
+  --> $DIR/move-into-closure.rs:108:25
    |
 LL |     let x = X(Y);
    |         - captured outer variable
@@ -249,13 +324,18 @@ LL |     consume_fnmut(|| {
    |                   -- captured by this `FnMut` closure
 ...
 LL |         let X(mut _t) = x;
-   |               ------    ^ help: consider borrowing here: `&x`
+   |               ------    ^
    |               |
    |               data moved here
    |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         let X(mut _t) = &x;
+   |                         +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:127:38
+  --> $DIR/move-into-closure.rs:111:38
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -264,13 +344,18 @@ LL |     consume_fnmut(|| {
    |                   -- captured by this `FnMut` closure
 ...
 LL |         if let Either::One(mut _t) = em { }
-   |                            ------    ^^ help: consider borrowing here: `&em`
+   |                            ------    ^^
    |                            |
    |                            data moved here
    |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         if let Either::One(mut _t) = &em { }
+   |                                      +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:131:41
+  --> $DIR/move-into-closure.rs:114:41
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -279,13 +364,18 @@ LL |     consume_fnmut(|| {
    |                   -- captured by this `FnMut` closure
 ...
 LL |         while let Either::One(mut _t) = em { }
-   |                               ------    ^^ help: consider borrowing here: `&em`
+   |                               ------    ^^
    |                               |
    |                               data moved here
    |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         while let Either::One(mut _t) = &em { }
+   |                                         +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:135:15
+  --> $DIR/move-into-closure.rs:117:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -294,16 +384,21 @@ LL |     consume_fnmut(|| {
    |                   -- captured by this `FnMut` closure
 ...
 LL |         match em {
-   |               ^^ help: consider borrowing here: `&em`
+   |               ^^
 ...
 LL |             Either::One(mut _t)
    |                         ------
    |                         |
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         match &em {
+   |               +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:142:15
+  --> $DIR/move-into-closure.rs:123:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -312,16 +407,21 @@ LL |     consume_fnmut(|| {
    |                   -- captured by this `FnMut` closure
 ...
 LL |         match em {
-   |               ^^ help: consider borrowing here: `&em`
+   |               ^^
 ...
 LL |             Either::One(mut _t) => (),
    |                         ------
    |                         |
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         match &em {
+   |               +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:150:15
+  --> $DIR/move-into-closure.rs:130:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -330,13 +430,18 @@ LL |     consume_fnmut(|| {
    |                   -- captured by this `FnMut` closure
 ...
 LL |         match em {
-   |               ^^ help: consider borrowing here: `&em`
+   |               ^^
 ...
 LL |             Either::One(mut _t) => (),
    |                         ------
    |                         |
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         match &em {
+   |               +
 
 error: aborting due to 21 previous errors
 

--- a/src/test/ui/suggestions/dont-suggest-ref/simple.rs
+++ b/src/test/ui/suggestions/dont-suggest-ref/simple.rs
@@ -319,7 +319,6 @@ struct Testing {
 fn testing(a: &Testing) {
     let Some(_s) = a.a else {
         //~^ ERROR cannot move
-        //~| HELP consider borrowing
         return;
     };
 }

--- a/src/test/ui/suggestions/dont-suggest-ref/simple.rs
+++ b/src/test/ui/suggestions/dont-suggest-ref/simple.rs
@@ -219,31 +219,42 @@ pub fn main() {
 
     let (&X(_t),) = (&x.clone(),);
     //~^ ERROR cannot move
+    //~| HELP consider borrowing the pattern binding
     if let (&Either::One(_t),) = (&e.clone(),) { }
     //~^ ERROR cannot move
+    //~| HELP consider borrowing the pattern binding
     while let (&Either::One(_t),) = (&e.clone(),) { }
     //~^ ERROR cannot move
+    //~| HELP consider borrowing the pattern binding
     match (&e.clone(),) {
         //~^ ERROR cannot move
         (&Either::One(_t),)
+        //~^ HELP consider borrowing the pattern binding
         | (&Either::Two(_t),) => (),
     }
     fn f3((&X(_t),): (&X,)) { }
     //~^ ERROR cannot move
+    //~| HELP consider borrowing the pattern binding
 
     let (&mut X(_t),) = (&mut xm.clone(),);
     //~^ ERROR cannot move
+    //~| HELP consider borrowing the pattern binding
     if let (&mut Either::One(_t),) = (&mut em.clone(),) { }
     //~^ ERROR cannot move
+    //~| HELP consider borrowing the pattern binding
     while let (&mut Either::One(_t),) = (&mut em.clone(),) { }
     //~^ ERROR cannot move
+    //~| HELP consider borrowing the pattern binding
     match (&mut em.clone(),) {
         //~^ ERROR cannot move
         (&mut Either::One(_t),) => (),
+        //~^ HELP consider borrowing the pattern binding
         (&mut Either::Two(_t),) => (),
+        //~^ HELP consider borrowing the pattern binding
     }
     fn f4((&mut X(_t),): (&mut X,)) { }
     //~^ ERROR cannot move
+    //~| HELP consider borrowing the pattern binding
 
     // move from &Either/&X value
 
@@ -319,6 +330,7 @@ struct Testing {
 fn testing(a: &Testing) {
     let Some(_s) = a.a else {
         //~^ ERROR cannot move
+        //~| HELP consider borrowing the pattern binding
         return;
     };
 }

--- a/src/test/ui/suggestions/dont-suggest-ref/simple.rs
+++ b/src/test/ui/suggestions/dont-suggest-ref/simple.rs
@@ -37,22 +37,22 @@ pub fn main() {
 
     let X(_t) = *s;
     //~^ ERROR cannot move
-    //~| HELP consider borrowing here
+    //~| HELP consider removing the dereference here
     if let Either::One(_t) = *r { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing here
+    //~| HELP consider removing the dereference here
     while let Either::One(_t) = *r { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing here
+    //~| HELP consider removing the dereference here
     match *r {
         //~^ ERROR cannot move
-        //~| HELP consider borrowing here
+        //~| HELP consider removing the dereference here
         Either::One(_t)
         | Either::Two(_t) => (),
     }
     match *r {
         //~^ ERROR cannot move
-        //~| HELP consider borrowing here
+        //~| HELP consider removing the dereference here
         Either::One(_t) => (),
         Either::Two(ref _t) => (),
         // FIXME: should suggest removing `ref` too
@@ -60,29 +60,29 @@ pub fn main() {
 
     let X(_t) = *sm;
     //~^ ERROR cannot move
-    //~| HELP consider borrowing here
+    //~| HELP consider removing the dereference here
     if let Either::One(_t) = *rm { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing here
+    //~| HELP consider removing the dereference here
     while let Either::One(_t) = *rm { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing here
+    //~| HELP consider removing the dereference here
     match *rm {
         //~^ ERROR cannot move
-        //~| HELP consider borrowing here
+        //~| HELP consider removing the dereference here
         Either::One(_t)
         | Either::Two(_t) => (),
     }
     match *rm {
         //~^ ERROR cannot move
-        //~| HELP consider borrowing here
+        //~| HELP consider removing the dereference here
         Either::One(_t) => (),
         Either::Two(ref _t) => (),
         // FIXME: should suggest removing `ref` too
     }
     match *rm {
         //~^ ERROR cannot move
-        //~| HELP consider borrowing here
+        //~| HELP consider removing the dereference here
         Either::One(_t) => (),
         Either::Two(ref mut _t) => (),
         // FIXME: should suggest removing `ref` too

--- a/src/test/ui/suggestions/dont-suggest-ref/simple.rs
+++ b/src/test/ui/suggestions/dont-suggest-ref/simple.rs
@@ -38,26 +38,21 @@ pub fn main() {
     let X(_t) = *s;
     //~^ ERROR cannot move
     //~| HELP consider borrowing here
-    //~| SUGGESTION s
     if let Either::One(_t) = *r { }
     //~^ ERROR cannot move
     //~| HELP consider borrowing here
-    //~| SUGGESTION r
     while let Either::One(_t) = *r { }
     //~^ ERROR cannot move
     //~| HELP consider borrowing here
-    //~| SUGGESTION r
     match *r {
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION r
         Either::One(_t)
         | Either::Two(_t) => (),
     }
     match *r {
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION r
         Either::One(_t) => (),
         Either::Two(ref _t) => (),
         // FIXME: should suggest removing `ref` too
@@ -66,26 +61,21 @@ pub fn main() {
     let X(_t) = *sm;
     //~^ ERROR cannot move
     //~| HELP consider borrowing here
-    //~| SUGGESTION sm
     if let Either::One(_t) = *rm { }
     //~^ ERROR cannot move
     //~| HELP consider borrowing here
-    //~| SUGGESTION rm
     while let Either::One(_t) = *rm { }
     //~^ ERROR cannot move
     //~| HELP consider borrowing here
-    //~| SUGGESTION rm
     match *rm {
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION rm
         Either::One(_t)
         | Either::Two(_t) => (),
     }
     match *rm {
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION rm
         Either::One(_t) => (),
         Either::Two(ref _t) => (),
         // FIXME: should suggest removing `ref` too
@@ -93,7 +83,6 @@ pub fn main() {
     match *rm {
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION rm
         Either::One(_t) => (),
         Either::Two(ref mut _t) => (),
         // FIXME: should suggest removing `ref` too
@@ -102,26 +91,21 @@ pub fn main() {
     let X(_t) = vs[0];
     //~^ ERROR cannot move
     //~| HELP consider borrowing here
-    //~| SUGGESTION &vs[0]
     if let Either::One(_t) = vr[0] { }
     //~^ ERROR cannot move
     //~| HELP consider borrowing here
-    //~| SUGGESTION &vr[0]
     while let Either::One(_t) = vr[0] { }
     //~^ ERROR cannot move
     //~| HELP consider borrowing here
-    //~| SUGGESTION &vr[0]
     match vr[0] {
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &vr[0]
         Either::One(_t)
         | Either::Two(_t) => (),
     }
     match vr[0] {
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &vr[0]
         Either::One(_t) => (),
         Either::Two(ref _t) => (),
         // FIXME: should suggest removing `ref` too
@@ -130,26 +114,21 @@ pub fn main() {
     let X(_t) = vsm[0];
     //~^ ERROR cannot move
     //~| HELP consider borrowing here
-    //~| SUGGESTION &vsm[0]
     if let Either::One(_t) = vrm[0] { }
     //~^ ERROR cannot move
     //~| HELP consider borrowing here
-    //~| SUGGESTION &vrm[0]
     while let Either::One(_t) = vrm[0] { }
     //~^ ERROR cannot move
     //~| HELP consider borrowing here
-    //~| SUGGESTION &vrm[0]
     match vrm[0] {
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &vrm[0]
         Either::One(_t)
         | Either::Two(_t) => (),
     }
     match vrm[0] {
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &vrm[0]
         Either::One(_t) => (),
         Either::Two(ref _t) => (),
         // FIXME: should suggest removing `ref` too
@@ -157,7 +136,6 @@ pub fn main() {
     match vrm[0] {
         //~^ ERROR cannot move
         //~| HELP consider borrowing here
-        //~| SUGGESTION &vrm[0]
         Either::One(_t) => (),
         Either::Two(ref mut _t) => (),
         // FIXME: should suggest removing `ref` too
@@ -167,89 +145,73 @@ pub fn main() {
 
     let &X(_t) = s;
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&`
-    //~| SUGGESTION X(_t)
+    //~| HELP consider removing
     if let &Either::One(_t) = r { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&`
-    //~| SUGGESTION Either::One(_t)
+    //~| HELP consider removing
     while let &Either::One(_t) = r { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&`
-    //~| SUGGESTION Either::One(_t)
+    //~| HELP consider removing
     match r {
         //~^ ERROR cannot move
         &Either::One(_t)
-        //~^ HELP consider removing the `&`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         | &Either::Two(_t) => (),
         // FIXME: would really like a suggestion here too
     }
     match r {
         //~^ ERROR cannot move
         &Either::One(_t) => (),
-        //~^ HELP consider removing the `&`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         &Either::Two(ref _t) => (),
     }
     match r {
         //~^ ERROR cannot move
         &Either::One(_t) => (),
-        //~^ HELP consider removing the `&`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         Either::Two(_t) => (),
     }
     fn f1(&X(_t): &X) { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&`
-    //~| SUGGESTION X(_t)
+    //~| HELP consider removing
 
     let &mut X(_t) = sm;
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&mut`
-    //~| SUGGESTION X(_t)
+    //~| HELP consider removing
     if let &mut Either::One(_t) = rm { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&mut`
-    //~| SUGGESTION Either::One(_t)
+    //~| HELP consider removing
     while let &mut Either::One(_t) = rm { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&mut`
-    //~| SUGGESTION Either::One(_t)
+    //~| HELP consider removing
     match rm {
         //~^ ERROR cannot move
         &mut Either::One(_t) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         &mut Either::Two(_t) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION Either::Two(_t)
+        //~^ HELP consider removing
     }
     match rm {
         //~^ ERROR cannot move
         &mut Either::One(_t) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         &mut Either::Two(ref _t) => (),
     }
     match rm {
         //~^ ERROR cannot move
         &mut Either::One(_t) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         &mut Either::Two(ref mut _t) => (),
     }
     match rm {
         //~^ ERROR cannot move
         &mut Either::One(_t) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         Either::Two(_t) => (),
     }
     fn f2(&mut X(_t): &mut X) { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&mut`
-    //~| SUGGESTION X(_t)
+    //~| HELP consider removing
 
     // move from tuple of &Either/&X
 
@@ -287,78 +249,77 @@ pub fn main() {
 
     let &X(_t) = &x;
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&`
-    //~| SUGGESTION X(_t)
+    //~| HELP consider removing
     if let &Either::One(_t) = &e { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&`
-    //~| SUGGESTION Either::One(_t)
+    //~| HELP consider removing
     while let &Either::One(_t) = &e { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&`
-    //~| SUGGESTION Either::One(_t)
+    //~| HELP consider removing
     match &e {
         //~^ ERROR cannot move
         &Either::One(_t)
-        //~^ HELP consider removing the `&`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         | &Either::Two(_t) => (),
         // FIXME: would really like a suggestion here too
     }
     match &e {
         //~^ ERROR cannot move
         &Either::One(_t) => (),
-        //~^ HELP consider removing the `&`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         &Either::Two(ref _t) => (),
     }
     match &e {
         //~^ ERROR cannot move
         &Either::One(_t) => (),
-        //~^ HELP consider removing the `&`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         Either::Two(_t) => (),
     }
 
     let &mut X(_t) = &mut xm;
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&mut`
-    //~| SUGGESTION X(_t)
+    //~| HELP consider removing
     if let &mut Either::One(_t) = &mut em { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&mut`
-    //~| SUGGESTION Either::One(_t)
+    //~| HELP consider removing
     while let &mut Either::One(_t) = &mut em { }
     //~^ ERROR cannot move
-    //~| HELP consider removing the `&mut`
-    //~| SUGGESTION Either::One(_t)
+    //~| HELP consider removing
     match &mut em {
         //~^ ERROR cannot move
         &mut Either::One(_t)
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         | &mut Either::Two(_t) => (),
         // FIXME: would really like a suggestion here too
     }
     match &mut em {
         //~^ ERROR cannot move
         &mut Either::One(_t) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         &mut Either::Two(ref _t) => (),
     }
     match &mut em {
         //~^ ERROR cannot move
         &mut Either::One(_t) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         &mut Either::Two(ref mut _t) => (),
     }
     match &mut em {
         //~^ ERROR cannot move
         &mut Either::One(_t) => (),
-        //~^ HELP consider removing the `&mut`
-        //~| SUGGESTION Either::One(_t)
+        //~^ HELP consider removing
         Either::Two(_t) => (),
     }
+}
+
+struct Testing {
+    a: Option<String>
+}
+
+fn testing(a: &Testing) {
+    let Some(_s) = a.a else {
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing
+        return;
+    };
 }

--- a/src/test/ui/suggestions/dont-suggest-ref/simple.stderr
+++ b/src/test/ui/suggestions/dont-suggest-ref/simple.stderr
@@ -566,27 +566,42 @@ LL |     let (&X(_t),) = (&x.clone(),);
    |             |
    |             data moved here
    |             move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     let (&X(ref _t),) = (&x.clone(),);
+   |             +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:222:34
+  --> $DIR/simple.rs:223:34
    |
 LL |     if let (&Either::One(_t),) = (&e.clone(),) { }
    |                          --      ^^^^^^^^^^^^^
    |                          |
    |                          data moved here
    |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     if let (&Either::One(ref _t),) = (&e.clone(),) { }
+   |                          +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:224:37
+  --> $DIR/simple.rs:226:37
    |
 LL |     while let (&Either::One(_t),) = (&e.clone(),) { }
    |                             --      ^^^^^^^^^^^^^
    |                             |
    |                             data moved here
    |                             move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     while let (&Either::One(ref _t),) = (&e.clone(),) { }
+   |                             +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:226:11
+  --> $DIR/simple.rs:229:11
    |
 LL |     match (&e.clone(),) {
    |           ^^^^^^^^^^^^^
@@ -596,49 +611,78 @@ LL |         (&Either::One(_t),)
    |                       |
    |                       data moved here
    |                       move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         (&Either::One(ref _t),)
+   |                       +++
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:234:25
+  --> $DIR/simple.rs:239:25
    |
 LL |     let (&mut X(_t),) = (&mut xm.clone(),);
    |                 --      ^^^^^^^^^^^^^^^^^^
    |                 |
    |                 data moved here
    |                 move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     let (&mut X(ref _t),) = (&mut xm.clone(),);
+   |                 +++
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:236:38
+  --> $DIR/simple.rs:242:38
    |
 LL |     if let (&mut Either::One(_t),) = (&mut em.clone(),) { }
    |                              --      ^^^^^^^^^^^^^^^^^^
    |                              |
    |                              data moved here
    |                              move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     if let (&mut Either::One(ref _t),) = (&mut em.clone(),) { }
+   |                              +++
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:238:41
+  --> $DIR/simple.rs:245:41
    |
 LL |     while let (&mut Either::One(_t),) = (&mut em.clone(),) { }
    |                                 --      ^^^^^^^^^^^^^^^^^^
    |                                 |
    |                                 data moved here
    |                                 move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     while let (&mut Either::One(ref _t),) = (&mut em.clone(),) { }
+   |                                 +++
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:240:11
+  --> $DIR/simple.rs:248:11
    |
 LL |     match (&mut em.clone(),) {
    |           ^^^^^^^^^^^^^^^^^^
 LL |
 LL |         (&mut Either::One(_t),) => (),
    |                           -- data moved here
+LL |
 LL |         (&mut Either::Two(_t),) => (),
    |                           -- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |         (&mut Either::One(ref _t),) => (),
+   |                           +++
+help: consider borrowing the pattern binding
+   |
+LL |         (&mut Either::Two(ref _t),) => (),
+   |                           +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:250:18
+  --> $DIR/simple.rs:261:18
    |
 LL |     let &X(_t) = &x;
    |            --    ^^
@@ -653,7 +697,7 @@ LL +     let X(_t) = &x;
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:253:31
+  --> $DIR/simple.rs:264:31
    |
 LL |     if let &Either::One(_t) = &e { }
    |                         --    ^^
@@ -668,7 +712,7 @@ LL +     if let Either::One(_t) = &e { }
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:256:34
+  --> $DIR/simple.rs:267:34
    |
 LL |     while let &Either::One(_t) = &e { }
    |                            --    ^^
@@ -683,7 +727,7 @@ LL +     while let Either::One(_t) = &e { }
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:259:11
+  --> $DIR/simple.rs:270:11
    |
 LL |     match &e {
    |           ^^
@@ -701,7 +745,7 @@ LL +         Either::One(_t)
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:266:11
+  --> $DIR/simple.rs:277:11
    |
 LL |     match &e {
    |           ^^
@@ -719,7 +763,7 @@ LL +         Either::One(_t) => (),
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:272:11
+  --> $DIR/simple.rs:283:11
    |
 LL |     match &e {
    |           ^^
@@ -737,7 +781,7 @@ LL +         Either::One(_t) => (),
    |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:279:22
+  --> $DIR/simple.rs:290:22
    |
 LL |     let &mut X(_t) = &mut xm;
    |                --    ^^^^^^^
@@ -752,7 +796,7 @@ LL +     let mut X(_t) = &mut xm;
    |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:282:35
+  --> $DIR/simple.rs:293:35
    |
 LL |     if let &mut Either::One(_t) = &mut em { }
    |                             --    ^^^^^^^
@@ -767,7 +811,7 @@ LL +     if let mut Either::One(_t) = &mut em { }
    |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:285:38
+  --> $DIR/simple.rs:296:38
    |
 LL |     while let &mut Either::One(_t) = &mut em { }
    |                                --    ^^^^^^^
@@ -782,7 +826,7 @@ LL +     while let mut Either::One(_t) = &mut em { }
    |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:288:11
+  --> $DIR/simple.rs:299:11
    |
 LL |     match &mut em {
    |           ^^^^^^^
@@ -800,7 +844,7 @@ LL +         mut Either::One(_t)
    |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:295:11
+  --> $DIR/simple.rs:306:11
    |
 LL |     match &mut em {
    |           ^^^^^^^
@@ -818,7 +862,7 @@ LL +         mut Either::One(_t) => (),
    |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:301:11
+  --> $DIR/simple.rs:312:11
    |
 LL |     match &mut em {
    |           ^^^^^^^
@@ -836,7 +880,7 @@ LL +         mut Either::One(_t) => (),
    |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:307:11
+  --> $DIR/simple.rs:318:11
    |
 LL |     match &mut em {
    |           ^^^^^^^
@@ -884,31 +928,46 @@ LL +     fn f2(mut X(_t): &mut X) { }
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:231:11
+  --> $DIR/simple.rs:235:11
    |
 LL |     fn f3((&X(_t),): (&X,)) { }
    |           ^^^^--^^^
    |               |
    |               data moved here
    |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     fn f3((&X(ref _t),): (&X,)) { }
+   |               +++
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:245:11
+  --> $DIR/simple.rs:255:11
    |
 LL |     fn f4((&mut X(_t),): (&mut X,)) { }
    |           ^^^^^^^^--^^^
    |                   |
    |                   data moved here
    |                   move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     fn f4((&mut X(ref _t),): (&mut X,)) { }
+   |                   +++
 
 error[E0507]: cannot move out of `a.a` as enum variant `Some` which is behind a shared reference
-  --> $DIR/simple.rs:320:20
+  --> $DIR/simple.rs:331:20
    |
 LL |     let Some(_s) = a.a else {
    |              --    ^^^
    |              |
    |              data moved here
    |              move occurs because `_s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     let Some(ref _s) = a.a else {
+   |              +++
 
 error: aborting due to 61 previous errors
 

--- a/src/test/ui/suggestions/dont-suggest-ref/simple.stderr
+++ b/src/test/ui/suggestions/dont-suggest-ref/simple.stderr
@@ -2,262 +2,387 @@ error[E0507]: cannot move out of `s` which is behind a shared reference
   --> $DIR/simple.rs:38:17
    |
 LL |     let X(_t) = *s;
-   |           --    ^^ help: consider borrowing here: `&*s`
+   |           --    ^^
    |           |
    |           data moved here
    |           move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let X(_t) = &*s;
+   |                 +
 
 error[E0507]: cannot move out of `r` as enum variant `One` which is behind a shared reference
-  --> $DIR/simple.rs:42:30
+  --> $DIR/simple.rs:41:30
    |
 LL |     if let Either::One(_t) = *r { }
-   |                        --    ^^ help: consider borrowing here: `&*r`
+   |                        --    ^^
    |                        |
    |                        data moved here
    |                        move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     if let Either::One(_t) = &*r { }
+   |                              +
 
 error[E0507]: cannot move out of `r` as enum variant `One` which is behind a shared reference
-  --> $DIR/simple.rs:46:33
+  --> $DIR/simple.rs:44:33
    |
 LL |     while let Either::One(_t) = *r { }
-   |                           --    ^^ help: consider borrowing here: `&*r`
+   |                           --    ^^
    |                           |
    |                           data moved here
    |                           move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     while let Either::One(_t) = &*r { }
+   |                                 +
 
 error[E0507]: cannot move out of `r` as enum variant `Two` which is behind a shared reference
-  --> $DIR/simple.rs:50:11
+  --> $DIR/simple.rs:47:11
    |
 LL |     match *r {
-   |           ^^ help: consider borrowing here: `&*r`
+   |           ^^
 ...
 LL |         Either::One(_t)
    |                     --
    |                     |
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &*r {
+   |           +
 
 error[E0507]: cannot move out of `r` as enum variant `One` which is behind a shared reference
-  --> $DIR/simple.rs:57:11
+  --> $DIR/simple.rs:53:11
    |
 LL |     match *r {
-   |           ^^ help: consider borrowing here: `&*r`
+   |           ^^
 ...
 LL |         Either::One(_t) => (),
    |                     --
    |                     |
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &*r {
+   |           +
 
 error[E0507]: cannot move out of `sm` which is behind a mutable reference
-  --> $DIR/simple.rs:66:17
+  --> $DIR/simple.rs:61:17
    |
 LL |     let X(_t) = *sm;
-   |           --    ^^^ help: consider borrowing here: `&*sm`
+   |           --    ^^^
    |           |
    |           data moved here
    |           move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let X(_t) = &*sm;
+   |                 +
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
-  --> $DIR/simple.rs:70:30
+  --> $DIR/simple.rs:64:30
    |
 LL |     if let Either::One(_t) = *rm { }
-   |                        --    ^^^ help: consider borrowing here: `&*rm`
+   |                        --    ^^^
    |                        |
    |                        data moved here
    |                        move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     if let Either::One(_t) = &*rm { }
+   |                              +
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
-  --> $DIR/simple.rs:74:33
+  --> $DIR/simple.rs:67:33
    |
 LL |     while let Either::One(_t) = *rm { }
-   |                           --    ^^^ help: consider borrowing here: `&*rm`
+   |                           --    ^^^
    |                           |
    |                           data moved here
    |                           move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     while let Either::One(_t) = &*rm { }
+   |                                 +
 
 error[E0507]: cannot move out of `rm` as enum variant `Two` which is behind a mutable reference
-  --> $DIR/simple.rs:78:11
+  --> $DIR/simple.rs:70:11
    |
 LL |     match *rm {
-   |           ^^^ help: consider borrowing here: `&*rm`
+   |           ^^^
 ...
 LL |         Either::One(_t)
    |                     --
    |                     |
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &*rm {
+   |           +
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
-  --> $DIR/simple.rs:85:11
+  --> $DIR/simple.rs:76:11
    |
 LL |     match *rm {
-   |           ^^^ help: consider borrowing here: `&*rm`
+   |           ^^^
 ...
 LL |         Either::One(_t) => (),
    |                     --
    |                     |
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &*rm {
+   |           +
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
-  --> $DIR/simple.rs:93:11
+  --> $DIR/simple.rs:83:11
    |
 LL |     match *rm {
-   |           ^^^ help: consider borrowing here: `&*rm`
+   |           ^^^
 ...
 LL |         Either::One(_t) => (),
    |                     --
    |                     |
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &*rm {
+   |           +
 
 error[E0507]: cannot move out of index of `Vec<X>`
-  --> $DIR/simple.rs:102:17
+  --> $DIR/simple.rs:91:17
    |
 LL |     let X(_t) = vs[0];
-   |           --    ^^^^^ help: consider borrowing here: `&vs[0]`
+   |           --    ^^^^^
    |           |
    |           data moved here
    |           move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let X(_t) = &vs[0];
+   |                 +
 
 error[E0507]: cannot move out of index of `Vec<Either>`
-  --> $DIR/simple.rs:106:30
+  --> $DIR/simple.rs:94:30
    |
 LL |     if let Either::One(_t) = vr[0] { }
-   |                        --    ^^^^^ help: consider borrowing here: `&vr[0]`
+   |                        --    ^^^^^
    |                        |
    |                        data moved here
    |                        move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     if let Either::One(_t) = &vr[0] { }
+   |                              +
 
 error[E0507]: cannot move out of index of `Vec<Either>`
-  --> $DIR/simple.rs:110:33
+  --> $DIR/simple.rs:97:33
    |
 LL |     while let Either::One(_t) = vr[0] { }
-   |                           --    ^^^^^ help: consider borrowing here: `&vr[0]`
+   |                           --    ^^^^^
    |                           |
    |                           data moved here
    |                           move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     while let Either::One(_t) = &vr[0] { }
+   |                                 +
 
 error[E0507]: cannot move out of index of `Vec<Either>`
-  --> $DIR/simple.rs:114:11
+  --> $DIR/simple.rs:100:11
    |
 LL |     match vr[0] {
-   |           ^^^^^ help: consider borrowing here: `&vr[0]`
+   |           ^^^^^
 ...
 LL |         Either::One(_t)
    |                     --
    |                     |
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &vr[0] {
+   |           +
 
 error[E0507]: cannot move out of index of `Vec<Either>`
-  --> $DIR/simple.rs:121:11
+  --> $DIR/simple.rs:106:11
    |
 LL |     match vr[0] {
-   |           ^^^^^ help: consider borrowing here: `&vr[0]`
+   |           ^^^^^
 ...
 LL |         Either::One(_t) => (),
    |                     --
    |                     |
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &vr[0] {
+   |           +
 
 error[E0507]: cannot move out of index of `Vec<X>`
-  --> $DIR/simple.rs:130:17
+  --> $DIR/simple.rs:114:17
    |
 LL |     let X(_t) = vsm[0];
-   |           --    ^^^^^^ help: consider borrowing here: `&vsm[0]`
+   |           --    ^^^^^^
    |           |
    |           data moved here
    |           move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let X(_t) = &vsm[0];
+   |                 +
 
 error[E0507]: cannot move out of index of `Vec<Either>`
-  --> $DIR/simple.rs:134:30
+  --> $DIR/simple.rs:117:30
    |
 LL |     if let Either::One(_t) = vrm[0] { }
-   |                        --    ^^^^^^ help: consider borrowing here: `&vrm[0]`
+   |                        --    ^^^^^^
    |                        |
    |                        data moved here
    |                        move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     if let Either::One(_t) = &vrm[0] { }
+   |                              +
 
 error[E0507]: cannot move out of index of `Vec<Either>`
-  --> $DIR/simple.rs:138:33
+  --> $DIR/simple.rs:120:33
    |
 LL |     while let Either::One(_t) = vrm[0] { }
-   |                           --    ^^^^^^ help: consider borrowing here: `&vrm[0]`
+   |                           --    ^^^^^^
    |                           |
    |                           data moved here
    |                           move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     while let Either::One(_t) = &vrm[0] { }
+   |                                 +
 
 error[E0507]: cannot move out of index of `Vec<Either>`
-  --> $DIR/simple.rs:142:11
+  --> $DIR/simple.rs:123:11
    |
 LL |     match vrm[0] {
-   |           ^^^^^^ help: consider borrowing here: `&vrm[0]`
+   |           ^^^^^^
 ...
 LL |         Either::One(_t)
    |                     --
    |                     |
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &vrm[0] {
+   |           +
 
 error[E0507]: cannot move out of index of `Vec<Either>`
-  --> $DIR/simple.rs:149:11
+  --> $DIR/simple.rs:129:11
    |
 LL |     match vrm[0] {
-   |           ^^^^^^ help: consider borrowing here: `&vrm[0]`
+   |           ^^^^^^
 ...
 LL |         Either::One(_t) => (),
    |                     --
    |                     |
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &vrm[0] {
+   |           +
 
 error[E0507]: cannot move out of index of `Vec<Either>`
-  --> $DIR/simple.rs:157:11
+  --> $DIR/simple.rs:136:11
    |
 LL |     match vrm[0] {
-   |           ^^^^^^ help: consider borrowing here: `&vrm[0]`
+   |           ^^^^^^
 ...
 LL |         Either::One(_t) => (),
    |                     --
    |                     |
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &vrm[0] {
+   |           +
 
 error[E0507]: cannot move out of `s` which is behind a shared reference
-  --> $DIR/simple.rs:168:18
+  --> $DIR/simple.rs:146:18
    |
 LL |     let &X(_t) = s;
-   |         ------   ^
-   |         |  |
-   |         |  data moved here
-   |         |  move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
-   |         help: consider removing the `&`: `X(_t)`
+   |            --    ^
+   |            |
+   |            data moved here
+   |            move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     let &X(_t) = s;
+LL +     let X(_t) = s;
+   |
 
 error[E0507]: cannot move out of `r` as enum variant `One` which is behind a shared reference
-  --> $DIR/simple.rs:172:31
+  --> $DIR/simple.rs:149:31
    |
 LL |     if let &Either::One(_t) = r { }
-   |            ----------------   ^
-   |            |            |
-   |            |            data moved here
-   |            |            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |            help: consider removing the `&`: `Either::One(_t)`
+   |                         --    ^
+   |                         |
+   |                         data moved here
+   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     if let &Either::One(_t) = r { }
+LL +     if let Either::One(_t) = r { }
+   |
 
 error[E0507]: cannot move out of `r` as enum variant `One` which is behind a shared reference
-  --> $DIR/simple.rs:176:34
+  --> $DIR/simple.rs:152:34
    |
 LL |     while let &Either::One(_t) = r { }
-   |               ----------------   ^
-   |               |            |
-   |               |            data moved here
-   |               |            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |               help: consider removing the `&`: `Either::One(_t)`
+   |                            --    ^
+   |                            |
+   |                            data moved here
+   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     while let &Either::One(_t) = r { }
+LL +     while let Either::One(_t) = r { }
+   |
 
 error[E0507]: cannot move out of `r` as enum variant `Two` which is behind a shared reference
-  --> $DIR/simple.rs:180:11
+  --> $DIR/simple.rs:155:11
    |
 LL |     match r {
    |           ^
@@ -268,133 +393,173 @@ LL |         &Either::One(_t)
    |                      data moved here
    |                      move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider removing the `&`
+help: consider removing the borrow
    |
-LL ~         Either::One(_t)
-LL +
-LL +
-LL ~         | &Either::Two(_t) => (),
+LL -         &Either::One(_t)
+LL +         Either::One(_t)
    |
 
 error[E0507]: cannot move out of `r` as enum variant `One` which is behind a shared reference
-  --> $DIR/simple.rs:188:11
+  --> $DIR/simple.rs:162:11
    |
 LL |     match r {
    |           ^
 LL |
 LL |         &Either::One(_t) => (),
-   |         ----------------
-   |         |            |
-   |         |            data moved here
-   |         |            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |         help: consider removing the `&`: `Either::One(_t)`
+   |                      --
+   |                      |
+   |                      data moved here
+   |                      move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -         &Either::One(_t) => (),
+LL +         Either::One(_t) => (),
+   |
 
 error[E0507]: cannot move out of `r` as enum variant `One` which is behind a shared reference
-  --> $DIR/simple.rs:195:11
+  --> $DIR/simple.rs:168:11
    |
 LL |     match r {
    |           ^
 LL |
 LL |         &Either::One(_t) => (),
-   |         ----------------
-   |         |            |
-   |         |            data moved here
-   |         |            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |         help: consider removing the `&`: `Either::One(_t)`
+   |                      --
+   |                      |
+   |                      data moved here
+   |                      move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -         &Either::One(_t) => (),
+LL +         Either::One(_t) => (),
+   |
 
 error[E0507]: cannot move out of `sm` which is behind a mutable reference
-  --> $DIR/simple.rs:207:22
+  --> $DIR/simple.rs:178:22
    |
 LL |     let &mut X(_t) = sm;
-   |         ----------   ^^
-   |         |      |
-   |         |      data moved here
-   |         |      move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
-   |         help: consider removing the `&mut`: `X(_t)`
+   |                --    ^^
+   |                |
+   |                data moved here
+   |                move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -     let &mut X(_t) = sm;
+LL +     let mut X(_t) = sm;
+   |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
-  --> $DIR/simple.rs:211:35
+  --> $DIR/simple.rs:181:35
    |
 LL |     if let &mut Either::One(_t) = rm { }
-   |            --------------------   ^^
-   |            |                |
-   |            |                data moved here
-   |            |                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |            help: consider removing the `&mut`: `Either::One(_t)`
+   |                             --    ^^
+   |                             |
+   |                             data moved here
+   |                             move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -     if let &mut Either::One(_t) = rm { }
+LL +     if let mut Either::One(_t) = rm { }
+   |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
-  --> $DIR/simple.rs:215:38
+  --> $DIR/simple.rs:184:38
    |
 LL |     while let &mut Either::One(_t) = rm { }
-   |               --------------------   ^^
-   |               |                |
-   |               |                data moved here
-   |               |                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |               help: consider removing the `&mut`: `Either::One(_t)`
+   |                                --    ^^
+   |                                |
+   |                                data moved here
+   |                                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -     while let &mut Either::One(_t) = rm { }
+LL +     while let mut Either::One(_t) = rm { }
+   |
 
 error[E0507]: cannot move out of `rm` as enum variant `Two` which is behind a mutable reference
-  --> $DIR/simple.rs:219:11
+  --> $DIR/simple.rs:187:11
    |
 LL |     match rm {
    |           ^^
 LL |
 LL |         &mut Either::One(_t) => (),
    |                          -- data moved here
-...
+LL |
 LL |         &mut Either::Two(_t) => (),
    |                          -- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider removing the `&mut`
+help: consider removing the mutable borrow
    |
-LL |         Either::One(_t) => (),
-   |         ~~~~~~~~~~~~~~~
-help: consider removing the `&mut`
+LL -         &mut Either::One(_t) => (),
+LL +         mut Either::One(_t) => (),
    |
-LL |         Either::Two(_t) => (),
-   |         ~~~~~~~~~~~~~~~
+help: consider removing the mutable borrow
+   |
+LL -         &mut Either::Two(_t) => (),
+LL +         mut Either::Two(_t) => (),
+   |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
-  --> $DIR/simple.rs:228:11
+  --> $DIR/simple.rs:194:11
    |
 LL |     match rm {
    |           ^^
 LL |
 LL |         &mut Either::One(_t) => (),
-   |         --------------------
-   |         |                |
-   |         |                data moved here
-   |         |                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |         help: consider removing the `&mut`: `Either::One(_t)`
+   |                          --
+   |                          |
+   |                          data moved here
+   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -         &mut Either::One(_t) => (),
+LL +         mut Either::One(_t) => (),
+   |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
-  --> $DIR/simple.rs:235:11
+  --> $DIR/simple.rs:200:11
    |
 LL |     match rm {
    |           ^^
 LL |
 LL |         &mut Either::One(_t) => (),
-   |         --------------------
-   |         |                |
-   |         |                data moved here
-   |         |                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |         help: consider removing the `&mut`: `Either::One(_t)`
+   |                          --
+   |                          |
+   |                          data moved here
+   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -         &mut Either::One(_t) => (),
+LL +         mut Either::One(_t) => (),
+   |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
-  --> $DIR/simple.rs:242:11
+  --> $DIR/simple.rs:206:11
    |
 LL |     match rm {
    |           ^^
 LL |
 LL |         &mut Either::One(_t) => (),
-   |         --------------------
-   |         |                |
-   |         |                data moved here
-   |         |                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |         help: consider removing the `&mut`: `Either::One(_t)`
+   |                          --
+   |                          |
+   |                          data moved here
+   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -         &mut Either::One(_t) => (),
+LL +         mut Either::One(_t) => (),
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:258:21
+  --> $DIR/simple.rs:220:21
    |
 LL |     let (&X(_t),) = (&x.clone(),);
    |             --      ^^^^^^^^^^^^^
@@ -403,7 +568,7 @@ LL |     let (&X(_t),) = (&x.clone(),);
    |             move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:260:34
+  --> $DIR/simple.rs:222:34
    |
 LL |     if let (&Either::One(_t),) = (&e.clone(),) { }
    |                          --      ^^^^^^^^^^^^^
@@ -412,7 +577,7 @@ LL |     if let (&Either::One(_t),) = (&e.clone(),) { }
    |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:262:37
+  --> $DIR/simple.rs:224:37
    |
 LL |     while let (&Either::One(_t),) = (&e.clone(),) { }
    |                             --      ^^^^^^^^^^^^^
@@ -421,7 +586,7 @@ LL |     while let (&Either::One(_t),) = (&e.clone(),) { }
    |                             move occurs because `_t` has type `X`, which does not implement the `Copy` trait
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:264:11
+  --> $DIR/simple.rs:226:11
    |
 LL |     match (&e.clone(),) {
    |           ^^^^^^^^^^^^^
@@ -433,7 +598,7 @@ LL |         (&Either::One(_t),)
    |                       move occurs because `_t` has type `X`, which does not implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:272:25
+  --> $DIR/simple.rs:234:25
    |
 LL |     let (&mut X(_t),) = (&mut xm.clone(),);
    |                 --      ^^^^^^^^^^^^^^^^^^
@@ -442,7 +607,7 @@ LL |     let (&mut X(_t),) = (&mut xm.clone(),);
    |                 move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:274:38
+  --> $DIR/simple.rs:236:38
    |
 LL |     if let (&mut Either::One(_t),) = (&mut em.clone(),) { }
    |                              --      ^^^^^^^^^^^^^^^^^^
@@ -451,7 +616,7 @@ LL |     if let (&mut Either::One(_t),) = (&mut em.clone(),) { }
    |                              move occurs because `_t` has type `X`, which does not implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:276:41
+  --> $DIR/simple.rs:238:41
    |
 LL |     while let (&mut Either::One(_t),) = (&mut em.clone(),) { }
    |                                 --      ^^^^^^^^^^^^^^^^^^
@@ -460,7 +625,7 @@ LL |     while let (&mut Either::One(_t),) = (&mut em.clone(),) { }
    |                                 move occurs because `_t` has type `X`, which does not implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:278:11
+  --> $DIR/simple.rs:240:11
    |
 LL |     match (&mut em.clone(),) {
    |           ^^^^^^^^^^^^^^^^^^
@@ -473,37 +638,52 @@ LL |         (&mut Either::Two(_t),) => (),
    = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:288:18
+  --> $DIR/simple.rs:250:18
    |
 LL |     let &X(_t) = &x;
-   |         ------   ^^
-   |         |  |
-   |         |  data moved here
-   |         |  move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
-   |         help: consider removing the `&`: `X(_t)`
+   |            --    ^^
+   |            |
+   |            data moved here
+   |            move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     let &X(_t) = &x;
+LL +     let X(_t) = &x;
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:292:31
+  --> $DIR/simple.rs:253:31
    |
 LL |     if let &Either::One(_t) = &e { }
-   |            ----------------   ^^
-   |            |            |
-   |            |            data moved here
-   |            |            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |            help: consider removing the `&`: `Either::One(_t)`
+   |                         --    ^^
+   |                         |
+   |                         data moved here
+   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     if let &Either::One(_t) = &e { }
+LL +     if let Either::One(_t) = &e { }
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:296:34
+  --> $DIR/simple.rs:256:34
    |
 LL |     while let &Either::One(_t) = &e { }
-   |               ----------------   ^^
-   |               |            |
-   |               |            data moved here
-   |               |            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |               help: consider removing the `&`: `Either::One(_t)`
+   |                            --    ^^
+   |                            |
+   |                            data moved here
+   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     while let &Either::One(_t) = &e { }
+LL +     while let Either::One(_t) = &e { }
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:300:11
+  --> $DIR/simple.rs:259:11
    |
 LL |     match &e {
    |           ^^
@@ -514,72 +694,95 @@ LL |         &Either::One(_t)
    |                      data moved here
    |                      move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider removing the `&`
+help: consider removing the borrow
    |
-LL ~         Either::One(_t)
-LL +
-LL +
-LL ~         | &Either::Two(_t) => (),
+LL -         &Either::One(_t)
+LL +         Either::One(_t)
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:308:11
+  --> $DIR/simple.rs:266:11
    |
 LL |     match &e {
    |           ^^
 LL |
 LL |         &Either::One(_t) => (),
-   |         ----------------
-   |         |            |
-   |         |            data moved here
-   |         |            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |         help: consider removing the `&`: `Either::One(_t)`
+   |                      --
+   |                      |
+   |                      data moved here
+   |                      move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -         &Either::One(_t) => (),
+LL +         Either::One(_t) => (),
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:315:11
+  --> $DIR/simple.rs:272:11
    |
 LL |     match &e {
    |           ^^
 LL |
 LL |         &Either::One(_t) => (),
-   |         ----------------
-   |         |            |
-   |         |            data moved here
-   |         |            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |         help: consider removing the `&`: `Either::One(_t)`
+   |                      --
+   |                      |
+   |                      data moved here
+   |                      move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -         &Either::One(_t) => (),
+LL +         Either::One(_t) => (),
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:323:22
+  --> $DIR/simple.rs:279:22
    |
 LL |     let &mut X(_t) = &mut xm;
-   |         ----------   ^^^^^^^
-   |         |      |
-   |         |      data moved here
-   |         |      move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
-   |         help: consider removing the `&mut`: `X(_t)`
+   |                --    ^^^^^^^
+   |                |
+   |                data moved here
+   |                move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -     let &mut X(_t) = &mut xm;
+LL +     let mut X(_t) = &mut xm;
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:327:35
+  --> $DIR/simple.rs:282:35
    |
 LL |     if let &mut Either::One(_t) = &mut em { }
-   |            --------------------   ^^^^^^^
-   |            |                |
-   |            |                data moved here
-   |            |                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |            help: consider removing the `&mut`: `Either::One(_t)`
+   |                             --    ^^^^^^^
+   |                             |
+   |                             data moved here
+   |                             move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -     if let &mut Either::One(_t) = &mut em { }
+LL +     if let mut Either::One(_t) = &mut em { }
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:331:38
+  --> $DIR/simple.rs:285:38
    |
 LL |     while let &mut Either::One(_t) = &mut em { }
-   |               --------------------   ^^^^^^^
-   |               |                |
-   |               |                data moved here
-   |               |                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |               help: consider removing the `&mut`: `Either::One(_t)`
+   |                                --    ^^^^^^^
+   |                                |
+   |                                data moved here
+   |                                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -     while let &mut Either::One(_t) = &mut em { }
+LL +     while let mut Either::One(_t) = &mut em { }
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:335:11
+  --> $DIR/simple.rs:288:11
    |
 LL |     match &mut em {
    |           ^^^^^^^
@@ -590,75 +793,98 @@ LL |         &mut Either::One(_t)
    |                          data moved here
    |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider removing the `&mut`
+help: consider removing the mutable borrow
    |
-LL ~         Either::One(_t)
-LL +
-LL +
-LL ~         | &mut Either::Two(_t) => (),
+LL -         &mut Either::One(_t)
+LL +         mut Either::One(_t)
    |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:343:11
+  --> $DIR/simple.rs:295:11
    |
 LL |     match &mut em {
    |           ^^^^^^^
 LL |
 LL |         &mut Either::One(_t) => (),
-   |         --------------------
-   |         |                |
-   |         |                data moved here
-   |         |                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |         help: consider removing the `&mut`: `Either::One(_t)`
+   |                          --
+   |                          |
+   |                          data moved here
+   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -         &mut Either::One(_t) => (),
+LL +         mut Either::One(_t) => (),
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:350:11
+  --> $DIR/simple.rs:301:11
    |
 LL |     match &mut em {
    |           ^^^^^^^
 LL |
 LL |         &mut Either::One(_t) => (),
-   |         --------------------
-   |         |                |
-   |         |                data moved here
-   |         |                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |         help: consider removing the `&mut`: `Either::One(_t)`
+   |                          --
+   |                          |
+   |                          data moved here
+   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -         &mut Either::One(_t) => (),
+LL +         mut Either::One(_t) => (),
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:357:11
+  --> $DIR/simple.rs:307:11
    |
 LL |     match &mut em {
    |           ^^^^^^^
 LL |
 LL |         &mut Either::One(_t) => (),
-   |         --------------------
-   |         |                |
-   |         |                data moved here
-   |         |                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
-   |         help: consider removing the `&mut`: `Either::One(_t)`
+   |                          --
+   |                          |
+   |                          data moved here
+   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -         &mut Either::One(_t) => (),
+LL +         mut Either::One(_t) => (),
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:202:11
+  --> $DIR/simple.rs:174:11
    |
 LL |     fn f1(&X(_t): &X) { }
    |           ^^^--^
-   |           |  |
-   |           |  data moved here
-   |           |  move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
-   |           help: consider removing the `&`: `X(_t)`
+   |              |
+   |              data moved here
+   |              move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     fn f1(&X(_t): &X) { }
+LL +     fn f1(X(_t): &X) { }
+   |
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:249:11
+  --> $DIR/simple.rs:212:11
    |
 LL |     fn f2(&mut X(_t): &mut X) { }
    |           ^^^^^^^--^
-   |           |      |
-   |           |      data moved here
-   |           |      move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
-   |           help: consider removing the `&mut`: `X(_t)`
+   |                  |
+   |                  data moved here
+   |                  move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: consider removing the mutable borrow
+   |
+LL -     fn f2(&mut X(_t): &mut X) { }
+LL +     fn f2(mut X(_t): &mut X) { }
+   |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/simple.rs:269:11
+  --> $DIR/simple.rs:231:11
    |
 LL |     fn f3((&X(_t),): (&X,)) { }
    |           ^^^^--^^^
@@ -667,7 +893,7 @@ LL |     fn f3((&X(_t),): (&X,)) { }
    |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/simple.rs:283:11
+  --> $DIR/simple.rs:245:11
    |
 LL |     fn f4((&mut X(_t),): (&mut X,)) { }
    |           ^^^^^^^^--^^^
@@ -675,6 +901,17 @@ LL |     fn f4((&mut X(_t),): (&mut X,)) { }
    |                   data moved here
    |                   move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
 
-error: aborting due to 60 previous errors
+error[E0507]: cannot move out of `a.a` as enum variant `Some` which is behind a shared reference
+  --> $DIR/simple.rs:320:14
+   |
+LL |     let Some(_s) = a.a else {
+   |              ^^ move occurs because `a.a.0` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let Some(&_s) = a.a else {
+   |              +
+
+error: aborting due to 61 previous errors
 
 For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/suggestions/dont-suggest-ref/simple.stderr
+++ b/src/test/ui/suggestions/dont-suggest-ref/simple.stderr
@@ -902,15 +902,13 @@ LL |     fn f4((&mut X(_t),): (&mut X,)) { }
    |                   move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
 
 error[E0507]: cannot move out of `a.a` as enum variant `Some` which is behind a shared reference
-  --> $DIR/simple.rs:320:14
+  --> $DIR/simple.rs:320:20
    |
 LL |     let Some(_s) = a.a else {
-   |              ^^ move occurs because `a.a.0` has type `String`, which does not implement the `Copy` trait
-   |
-help: consider borrowing here
-   |
-LL |     let Some(&_s) = a.a else {
-   |              +
+   |              --    ^^^
+   |              |
+   |              data moved here
+   |              move occurs because `_s` has type `String`, which does not implement the `Copy` trait
 
 error: aborting due to 61 previous errors
 

--- a/src/test/ui/suggestions/dont-suggest-ref/simple.stderr
+++ b/src/test/ui/suggestions/dont-suggest-ref/simple.stderr
@@ -447,7 +447,7 @@ LL |     let &mut X(_t) = sm;
 help: consider removing the mutable borrow
    |
 LL -     let &mut X(_t) = sm;
-LL +     let mut X(_t) = sm;
+LL +     let X(_t) = sm;
    |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
@@ -462,7 +462,7 @@ LL |     if let &mut Either::One(_t) = rm { }
 help: consider removing the mutable borrow
    |
 LL -     if let &mut Either::One(_t) = rm { }
-LL +     if let mut Either::One(_t) = rm { }
+LL +     if let Either::One(_t) = rm { }
    |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
@@ -477,7 +477,7 @@ LL |     while let &mut Either::One(_t) = rm { }
 help: consider removing the mutable borrow
    |
 LL -     while let &mut Either::One(_t) = rm { }
-LL +     while let mut Either::One(_t) = rm { }
+LL +     while let Either::One(_t) = rm { }
    |
 
 error[E0507]: cannot move out of `rm` as enum variant `Two` which is behind a mutable reference
@@ -496,12 +496,12 @@ LL |         &mut Either::Two(_t) => (),
 help: consider removing the mutable borrow
    |
 LL -         &mut Either::One(_t) => (),
-LL +         mut Either::One(_t) => (),
+LL +         Either::One(_t) => (),
    |
 help: consider removing the mutable borrow
    |
 LL -         &mut Either::Two(_t) => (),
-LL +         mut Either::Two(_t) => (),
+LL +         Either::Two(_t) => (),
    |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
@@ -519,7 +519,7 @@ LL |         &mut Either::One(_t) => (),
 help: consider removing the mutable borrow
    |
 LL -         &mut Either::One(_t) => (),
-LL +         mut Either::One(_t) => (),
+LL +         Either::One(_t) => (),
    |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
@@ -537,7 +537,7 @@ LL |         &mut Either::One(_t) => (),
 help: consider removing the mutable borrow
    |
 LL -         &mut Either::One(_t) => (),
-LL +         mut Either::One(_t) => (),
+LL +         Either::One(_t) => (),
    |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
@@ -555,7 +555,7 @@ LL |         &mut Either::One(_t) => (),
 help: consider removing the mutable borrow
    |
 LL -         &mut Either::One(_t) => (),
-LL +         mut Either::One(_t) => (),
+LL +         Either::One(_t) => (),
    |
 
 error[E0507]: cannot move out of a shared reference
@@ -792,7 +792,7 @@ LL |     let &mut X(_t) = &mut xm;
 help: consider removing the mutable borrow
    |
 LL -     let &mut X(_t) = &mut xm;
-LL +     let mut X(_t) = &mut xm;
+LL +     let X(_t) = &mut xm;
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -807,7 +807,7 @@ LL |     if let &mut Either::One(_t) = &mut em { }
 help: consider removing the mutable borrow
    |
 LL -     if let &mut Either::One(_t) = &mut em { }
-LL +     if let mut Either::One(_t) = &mut em { }
+LL +     if let Either::One(_t) = &mut em { }
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -822,7 +822,7 @@ LL |     while let &mut Either::One(_t) = &mut em { }
 help: consider removing the mutable borrow
    |
 LL -     while let &mut Either::One(_t) = &mut em { }
-LL +     while let mut Either::One(_t) = &mut em { }
+LL +     while let Either::One(_t) = &mut em { }
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -840,7 +840,7 @@ LL |         &mut Either::One(_t)
 help: consider removing the mutable borrow
    |
 LL -         &mut Either::One(_t)
-LL +         mut Either::One(_t)
+LL +         Either::One(_t)
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -858,7 +858,7 @@ LL |         &mut Either::One(_t) => (),
 help: consider removing the mutable borrow
    |
 LL -         &mut Either::One(_t) => (),
-LL +         mut Either::One(_t) => (),
+LL +         Either::One(_t) => (),
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -876,7 +876,7 @@ LL |         &mut Either::One(_t) => (),
 help: consider removing the mutable borrow
    |
 LL -         &mut Either::One(_t) => (),
-LL +         mut Either::One(_t) => (),
+LL +         Either::One(_t) => (),
    |
 
 error[E0507]: cannot move out of a mutable reference
@@ -894,7 +894,7 @@ LL |         &mut Either::One(_t) => (),
 help: consider removing the mutable borrow
    |
 LL -         &mut Either::One(_t) => (),
-LL +         mut Either::One(_t) => (),
+LL +         Either::One(_t) => (),
    |
 
 error[E0507]: cannot move out of a shared reference
@@ -924,7 +924,7 @@ LL |     fn f2(&mut X(_t): &mut X) { }
 help: consider removing the mutable borrow
    |
 LL -     fn f2(&mut X(_t): &mut X) { }
-LL +     fn f2(mut X(_t): &mut X) { }
+LL +     fn f2(X(_t): &mut X) { }
    |
 
 error[E0507]: cannot move out of a shared reference

--- a/src/test/ui/suggestions/dont-suggest-ref/simple.stderr
+++ b/src/test/ui/suggestions/dont-suggest-ref/simple.stderr
@@ -7,10 +7,11 @@ LL |     let X(_t) = *s;
    |           data moved here
    |           move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let X(_t) = &*s;
-   |                 +
+LL -     let X(_t) = *s;
+LL +     let X(_t) = s;
+   |
 
 error[E0507]: cannot move out of `r` as enum variant `One` which is behind a shared reference
   --> $DIR/simple.rs:41:30
@@ -21,10 +22,11 @@ LL |     if let Either::One(_t) = *r { }
    |                        data moved here
    |                        move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     if let Either::One(_t) = &*r { }
-   |                              +
+LL -     if let Either::One(_t) = *r { }
+LL +     if let Either::One(_t) = r { }
+   |
 
 error[E0507]: cannot move out of `r` as enum variant `One` which is behind a shared reference
   --> $DIR/simple.rs:44:33
@@ -35,10 +37,11 @@ LL |     while let Either::One(_t) = *r { }
    |                           data moved here
    |                           move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     while let Either::One(_t) = &*r { }
-   |                                 +
+LL -     while let Either::One(_t) = *r { }
+LL +     while let Either::One(_t) = r { }
+   |
 
 error[E0507]: cannot move out of `r` as enum variant `Two` which is behind a shared reference
   --> $DIR/simple.rs:47:11
@@ -52,10 +55,11 @@ LL |         Either::One(_t)
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     match &*r {
-   |           +
+LL -     match *r {
+LL +     match r {
+   |
 
 error[E0507]: cannot move out of `r` as enum variant `One` which is behind a shared reference
   --> $DIR/simple.rs:53:11
@@ -69,10 +73,11 @@ LL |         Either::One(_t) => (),
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     match &*r {
-   |           +
+LL -     match *r {
+LL +     match r {
+   |
 
 error[E0507]: cannot move out of `sm` which is behind a mutable reference
   --> $DIR/simple.rs:61:17
@@ -83,10 +88,11 @@ LL |     let X(_t) = *sm;
    |           data moved here
    |           move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     let X(_t) = &*sm;
-   |                 +
+LL -     let X(_t) = *sm;
+LL +     let X(_t) = sm;
+   |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
   --> $DIR/simple.rs:64:30
@@ -97,10 +103,11 @@ LL |     if let Either::One(_t) = *rm { }
    |                        data moved here
    |                        move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     if let Either::One(_t) = &*rm { }
-   |                              +
+LL -     if let Either::One(_t) = *rm { }
+LL +     if let Either::One(_t) = rm { }
+   |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
   --> $DIR/simple.rs:67:33
@@ -111,10 +118,11 @@ LL |     while let Either::One(_t) = *rm { }
    |                           data moved here
    |                           move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     while let Either::One(_t) = &*rm { }
-   |                                 +
+LL -     while let Either::One(_t) = *rm { }
+LL +     while let Either::One(_t) = rm { }
+   |
 
 error[E0507]: cannot move out of `rm` as enum variant `Two` which is behind a mutable reference
   --> $DIR/simple.rs:70:11
@@ -128,10 +136,11 @@ LL |         Either::One(_t)
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     match &*rm {
-   |           +
+LL -     match *rm {
+LL +     match rm {
+   |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
   --> $DIR/simple.rs:76:11
@@ -145,10 +154,11 @@ LL |         Either::One(_t) => (),
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     match &*rm {
-   |           +
+LL -     match *rm {
+LL +     match rm {
+   |
 
 error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mutable reference
   --> $DIR/simple.rs:83:11
@@ -162,10 +172,11 @@ LL |         Either::One(_t) => (),
    |                     data moved here
    |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing here
+help: consider removing the dereference here
    |
-LL |     match &*rm {
-   |           +
+LL -     match *rm {
+LL +     match rm {
+   |
 
 error[E0507]: cannot move out of index of `Vec<X>`
   --> $DIR/simple.rs:91:17

--- a/src/test/ui/suggestions/option-content-move-from-tuple-match.stderr
+++ b/src/test/ui/suggestions/option-content-move-from-tuple-match.stderr
@@ -9,6 +9,11 @@ LL |         (None, &c) => &c.unwrap(),
    |                 |
    |                 data moved here
    |                 move occurs because `c` has type `Option<String>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         (None, &ref c) => &c.unwrap(),
+   |                 +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-borrow-move-parent-sibling.mirunsafeck.stderr
+++ b/src/test/ui/union/union-borrow-move-parent-sibling.mirunsafeck.stderr
@@ -14,10 +14,12 @@ error[E0507]: cannot move out of dereference of `ManuallyDrop<((MockVec<u8>, Moc
   --> $DIR/union-borrow-move-parent-sibling.rs:62:13
    |
 LL |     let a = u.x.0;
-   |             ^^^^^
-   |             |
-   |             move occurs because value has type `(MockVec<u8>, MockVec<u8>)`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&u.x.0`
+   |             ^^^^^ move occurs because value has type `(MockVec<u8>, MockVec<u8>)`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let a = &u.x.0;
+   |             +
 
 error[E0382]: use of moved value: `u`
   --> $DIR/union-borrow-move-parent-sibling.rs:64:13
@@ -46,10 +48,12 @@ error[E0507]: cannot move out of dereference of `ManuallyDrop<((MockVec<u8>, Moc
   --> $DIR/union-borrow-move-parent-sibling.rs:76:13
    |
 LL |     let a = (u.x.0).0;
-   |             ^^^^^^^^^
-   |             |
-   |             move occurs because value has type `MockVec<u8>`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&(u.x.0).0`
+   |             ^^^^^^^^^ move occurs because value has type `MockVec<u8>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let a = &(u.x.0).0;
+   |             +
 
 error[E0382]: use of moved value: `u`
   --> $DIR/union-borrow-move-parent-sibling.rs:78:13

--- a/src/test/ui/union/union-borrow-move-parent-sibling.thirunsafeck.stderr
+++ b/src/test/ui/union/union-borrow-move-parent-sibling.thirunsafeck.stderr
@@ -14,10 +14,12 @@ error[E0507]: cannot move out of dereference of `ManuallyDrop<((MockVec<u8>, Moc
   --> $DIR/union-borrow-move-parent-sibling.rs:62:13
    |
 LL |     let a = u.x.0;
-   |             ^^^^^
-   |             |
-   |             move occurs because value has type `(MockVec<u8>, MockVec<u8>)`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&u.x.0`
+   |             ^^^^^ move occurs because value has type `(MockVec<u8>, MockVec<u8>)`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let a = &u.x.0;
+   |             +
 
 error[E0382]: use of moved value: `u`
   --> $DIR/union-borrow-move-parent-sibling.rs:64:13
@@ -46,10 +48,12 @@ error[E0507]: cannot move out of dereference of `ManuallyDrop<((MockVec<u8>, Moc
   --> $DIR/union-borrow-move-parent-sibling.rs:76:13
    |
 LL |     let a = (u.x.0).0;
-   |             ^^^^^^^^^
-   |             |
-   |             move occurs because value has type `MockVec<u8>`, which does not implement the `Copy` trait
-   |             help: consider borrowing here: `&(u.x.0).0`
+   |             ^^^^^^^^^ move occurs because value has type `MockVec<u8>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     let a = &(u.x.0).0;
+   |             +
 
 error[E0382]: use of moved value: `u`
   --> $DIR/union-borrow-move-parent-sibling.rs:78:13


### PR DESCRIPTION
Synthesize a more accurate span and use verbose suggestion output to
make the message clearer.

Do not suggest borrowing binding in pattern in let else. Fix #104838.