### PR TITLE
Ignore errors when including clear_expected_if_blessed

### DIFF
--- a/src/test/run-make/coverage-reports/Makefile
+++ b/src/test/run-make/coverage-reports/Makefile
@@ -80,7 +80,7 @@ ifdef RUSTC_BLESS_TEST
 	rm -f expected_*
 endif
 
-include clear_expected_if_blessed
+-include clear_expected_if_blessed
 
 %: $(SOURCEDIR)/lib/%.rs
 	# Compile the test library with coverage instrumentation


### PR DESCRIPTION
Include is there only for the effect executing the rule. The file is not intended to be remade successfully to be actually included.

I erroneously changed this in #100912.