### PR TITLE
rustdoc: remove no-op mobile CSS `#sidebar-toggle { text-align }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1748,7 +1748,6 @@ in storage.js
 		top: 100px;
 		width: 30px;
 		font-size: 1.5rem;
-		text-align: center;
 		padding: 0;
 		z-index: 10;
 		border-top-right-radius: 3px;


### PR DESCRIPTION
Since 8b001b4da0716936e0ca32303cc0e3c5e53e42f8 make the sidebar toggle a flex container, and already centers its content in desktop mode, this rule doesn't do anything.