### PR TITLE
Check that impl method args are WF given implied-bounds from trait method

### DIFF
--- a/src/test/ui/implied-bounds/impl-implied-bounds-compatibility-unnormalized.rs
+++ b/src/test/ui/implied-bounds/impl-implied-bounds-compatibility-unnormalized.rs
@@ -1,0 +1,19 @@
+trait Project {
+    type Ty;
+}
+impl Project for &'_ &'_ () {
+    type Ty = ();
+}
+trait Trait {
+    fn get<'s>(s: &'s str, _: ()) -> &'static str;
+}
+impl Trait for () {
+    fn get<'s>(s: &'s str, _: <&'static &'s () as Project>::Ty) -> &'static str {
+        //~^ ERROR cannot infer an appropriate lifetime for lifetime parameter 's in generic type due to conflicting requirements
+        s
+    }
+}
+fn main() {
+    let val = <() as Trait>::get(&String::from("blah blah blah"), ());
+    println!("{}", val);
+}

--- a/src/test/ui/implied-bounds/impl-implied-bounds-compatibility-unnormalized.stderr
+++ b/src/test/ui/implied-bounds/impl-implied-bounds-compatibility-unnormalized.stderr
@@ -1,0 +1,28 @@
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter 's in generic type due to conflicting requirements
+  --> $DIR/impl-implied-bounds-compatibility-unnormalized.rs:11:5
+   |
+LL |     fn get<'s>(s: &'s str, _: <&'static &'s () as Project>::Ty) -> &'static str {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: first, the lifetime cannot outlive the lifetime `'s` as defined here...
+  --> $DIR/impl-implied-bounds-compatibility-unnormalized.rs:11:12
+   |
+LL |     fn get<'s>(s: &'s str, _: <&'static &'s () as Project>::Ty) -> &'static str {
+   |            ^^
+note: ...so that the method type is compatible with trait
+  --> $DIR/impl-implied-bounds-compatibility-unnormalized.rs:11:5
+   |
+LL |     fn get<'s>(s: &'s str, _: <&'static &'s () as Project>::Ty) -> &'static str {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected `fn(&'s str, ()) -> &'static str`
+              found `fn(&str, ()) -> &'static str`
+   = note: but, the lifetime must be valid for the static lifetime...
+note: ...so that the reference type `&'static &()` does not outlive the data it points at
+  --> $DIR/impl-implied-bounds-compatibility-unnormalized.rs:11:5
+   |
+LL |     fn get<'s>(s: &'s str, _: <&'static &'s () as Project>::Ty) -> &'static str {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0495`.

--- a/src/test/ui/implied-bounds/impl-implied-bounds-compatibility.rs
+++ b/src/test/ui/implied-bounds/impl-implied-bounds-compatibility.rs
@@ -1,0 +1,18 @@
+use std::cell::RefCell;
+
+pub struct MessageListeners<'a> {
+    listeners: RefCell<Vec<Box<dyn FnMut(()) + 'a>>>,
+}
+
+pub trait MessageListenersInterface {
+    fn listeners<'c>(&'c self) -> &'c MessageListeners<'c>;
+}
+
+impl<'a> MessageListenersInterface for MessageListeners<'a> {
+    fn listeners<'b>(&'b self) -> &'a MessageListeners<'b> {
+        //~^ ERROR cannot infer an appropriate lifetime for lifetime parameter 'b in generic type due to conflicting requirement
+        self
+    }
+}
+
+fn main() {}

--- a/src/test/ui/implied-bounds/impl-implied-bounds-compatibility.stderr
+++ b/src/test/ui/implied-bounds/impl-implied-bounds-compatibility.stderr
@@ -1,0 +1,32 @@
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter 'b in generic type due to conflicting requirements
+  --> $DIR/impl-implied-bounds-compatibility.rs:12:5
+   |
+LL |     fn listeners<'b>(&'b self) -> &'a MessageListeners<'b> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: first, the lifetime cannot outlive the lifetime `'c` as defined here...
+  --> $DIR/impl-implied-bounds-compatibility.rs:12:5
+   |
+LL |     fn listeners<'b>(&'b self) -> &'a MessageListeners<'b> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...so that the method type is compatible with trait
+  --> $DIR/impl-implied-bounds-compatibility.rs:12:5
+   |
+LL |     fn listeners<'b>(&'b self) -> &'a MessageListeners<'b> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected `fn(&'c MessageListeners<'a>) -> &'c MessageListeners<'c>`
+              found `fn(&MessageListeners<'a>) -> &'a MessageListeners<'_>`
+note: but, the lifetime must be valid for the lifetime `'a` as defined here...
+  --> $DIR/impl-implied-bounds-compatibility.rs:11:6
+   |
+LL | impl<'a> MessageListenersInterface for MessageListeners<'a> {
+   |      ^^
+note: ...so that the reference type `&'a MessageListeners<'_>` does not outlive the data it points at
+  --> $DIR/impl-implied-bounds-compatibility.rs:12:5
+   |
+LL |     fn listeners<'b>(&'b self) -> &'a MessageListeners<'b> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0495`.


### PR DESCRIPTION
Fixes #105295

Check out my explanation of the issue here: https://github.com/rust-lang/rust/issues/105295#issuecomment-1343710419. 

Basically, this PR registers some additional well-formed bounds to ensure that the argument implied bounds of an impl method are not stronger than those coming from the trait method.

r? types

-----

This *arguably* could live in wfcheck, but it'd be somewhat of a pain to move it there since we need the hybrid param-env we construct above in `compare_predicate_entailment`. Also, this really isn't a well-formedness check of the impl method -- this really is a form of (implied bounds) predicate entailment comparison...