### PR TITLE
Fix lint perf regressions

### DIFF
--- a/compiler/rustc_lint/src/late.rs
+++ b/compiler/rustc_lint/src/late.rs
@@ -23,6 +23,7 @@ use rustc_hir::intravisit as hir_visit;
 use rustc_hir::intravisit::Visitor;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::{self, TyCtxt};
+use rustc_session::lint::LintPass;
 use rustc_span::Span;
 
 use std::any::Any;
@@ -36,17 +37,17 @@ pub fn unerased_lint_store(tcx: TyCtxt<'_>) -> &LintStore {
 }
 
 macro_rules! lint_callback { ($cx:expr, $f:ident, $($args:expr),*) => ({
-    for pass in $cx.passes.iter_mut() {
-        pass.$f(&$cx.context, $($args),*);
-    }
+    $cx.pass.$f(&$cx.context, $($args),*);
 }) }
 
-struct LateContextAndPasses<'tcx> {
+/// Implements the AST traversal for late lint passes. `T` provides the the
+/// `check_*` methods.
+pub struct LateContextAndPass<'tcx, T: LateLintPass<'tcx>> {
     context: LateContext<'tcx>,
-    passes: Vec<LateLintPassObject<'tcx>>,
+    pass: T,
 }
 
-impl<'tcx> LateContextAndPasses<'tcx> {
+impl<'tcx, T: LateLintPass<'tcx>> LateContextAndPass<'tcx, T> {
     /// Merge the lints specified by any lint attributes into the
     /// current lint context, call the provided function, then reset the
     /// lints in effect to their previous state.
@@ -82,7 +83,7 @@ impl<'tcx> LateContextAndPasses<'tcx> {
     }
 }
 
-impl<'tcx> hir_visit::Visitor<'tcx> for LateContextAndPasses<'tcx> {
+impl<'tcx, T: LateLintPass<'tcx>> hir_visit::Visitor<'tcx> for LateContextAndPass<'tcx, T> {
     type NestedFilter = nested_filter::All;
 
     /// Because lints are scoped lexically, we want to walk nested
@@ -302,6 +303,35 @@ impl<'tcx> hir_visit::Visitor<'tcx> for LateContextAndPasses<'tcx> {
     }
 }
 
+// Combines multiple lint passes into a single pass, at runtime. Each
+// `check_foo` method in `$methods` within this pass simply calls `check_foo`
+// once per `$pass`. Compare with `declare_combined_late_lint_pass`, which is
+// similar, but combines lint passes at compile time.
+struct RuntimeCombinedLateLintPass<'a, 'tcx> {
+    passes: &'a mut [LateLintPassObject<'tcx>],
+}
+
+#[allow(rustc::lint_pass_impl_without_macro)]
+impl LintPass for RuntimeCombinedLateLintPass<'_, '_> {
+    fn name(&self) -> &'static str {
+        panic!()
+    }
+}
+
+macro_rules! impl_late_lint_pass {
+    ([], [$($(#[$attr:meta])* fn $f:ident($($param:ident: $arg:ty),*);)*]) => {
+        impl<'tcx> LateLintPass<'tcx> for RuntimeCombinedLateLintPass<'_, 'tcx> {
+            $(fn $f(&mut self, context: &LateContext<'tcx>, $($param: $arg),*) {
+                for pass in self.passes.iter_mut() {
+                    pass.$f(context, $($param),*);
+                }
+            })*
+        }
+    };
+}
+
+crate::late_lint_methods!(impl_late_lint_pass, []);
+
 pub(super) fn late_lint_mod<'tcx, T: LateLintPass<'tcx> + 'tcx>(
     tcx: TyCtxt<'tcx>,
     module_def_id: LocalDefId,
@@ -320,10 +350,11 @@ pub(super) fn late_lint_mod<'tcx, T: LateLintPass<'tcx> + 'tcx>(
     };
 
     let mut passes: Vec<_> =
-        unerased_lint_store(tcx).late_module_passes.iter().map(|pass| (pass)(tcx)).collect();
+        unerased_lint_store(tcx).late_module_passes.iter().map(|mk_pass| (mk_pass)(tcx)).collect();
     passes.push(Box::new(builtin_lints));
+    let pass = RuntimeCombinedLateLintPass { passes: &mut passes[..] };
 
-    let mut cx = LateContextAndPasses { context, passes };
+    let mut cx = LateContextAndPass { context, pass };
 
     let (module, _span, hir_id) = tcx.hir().get_module(module_def_id);
     cx.process_mod(module, hir_id);
@@ -349,11 +380,12 @@ fn late_lint_crate<'tcx, T: LateLintPass<'tcx> + 'tcx>(tcx: TyCtxt<'tcx>, builti
         only_module: false,
     };
 
-    let mut passes =
-        unerased_lint_store(tcx).late_passes.iter().map(|p| (p)(tcx)).collect::<Vec<_>>();
+    let mut passes: Vec<_> =
+        unerased_lint_store(tcx).late_passes.iter().map(|mk_pass| (mk_pass)(tcx)).collect();
     passes.push(Box::new(builtin_lints));
+    let pass = RuntimeCombinedLateLintPass { passes: &mut passes[..] };
 
-    let mut cx = LateContextAndPasses { context, passes };
+    let mut cx = LateContextAndPass { context, pass };
 
     // Visit the whole crate.
     cx.with_lint_attrs(hir::CRATE_HIR_ID, |cx| {

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -127,7 +127,6 @@ fn lint_mod(tcx: TyCtxt<'_>, module_def_id: LocalDefId) {
     late::late_lint_mod(tcx, module_def_id, BuiltinCombinedModuleLateLintPass::new());
 }
 
-// See the comment on `BuiltinCombinedEarlyLintPass`, which is similar.
 early_lint_methods!(
     declare_combined_early_lint_pass,
     [
@@ -138,9 +137,6 @@ early_lint_methods!(
     ]
 );
 
-// Declare `BuiltinCombinedEarlyLintPass`, a lint pass that combines multiple
-// lint passes into a single pass for maximum speed. Each `check_foo` method
-// within this pass simply calls `check_foo` once per listed lint.
 early_lint_methods!(
     declare_combined_early_lint_pass,
     [
@@ -168,7 +164,6 @@ early_lint_methods!(
 
 // FIXME: Make a separate lint type which does not require typeck tables.
 
-// See the comment on `BuiltinCombinedEarlyLintPass`, which is similar.
 late_lint_methods!(
     declare_combined_late_lint_pass,
     [
@@ -188,7 +183,6 @@ late_lint_methods!(
     ]
 );
 
-// See the comment on `BuiltinCombinedEarlyLintPass`, which is similar.
 late_lint_methods!(
     declare_combined_late_lint_pass,
     [

--- a/compiler/rustc_lint/src/passes.rs
+++ b/compiler/rustc_lint/src/passes.rs
@@ -95,6 +95,11 @@ macro_rules! expand_combined_late_lint_pass_methods {
     )
 }
 
+/// Combines multiple lints passes into a single lint pass, at compile time,
+/// for maximum speed. Each `check_foo` method in `$methods` within this pass
+/// simply calls `check_foo` once per `$pass`. Compare with
+/// `LateLintPassObjects`, which is similar, but combines lint passes at
+/// runtime.
 #[macro_export]
 macro_rules! declare_combined_late_lint_pass {
     ([$v:vis $name:ident, [$($pass:ident: $constructor:expr,)*]], $methods:tt) => (
@@ -198,6 +203,11 @@ macro_rules! expand_combined_early_lint_pass_methods {
     )
 }
 
+/// Combines multiple lints passes into a single lint pass, at compile time,
+/// for maximum speed. Each `check_foo` method in `$methods` within this pass
+/// simply calls `check_foo` once per `$pass`. Compare with
+/// `EarlyLintPassObjects`, which is similar, but combines lint passes at
+/// runtime.
 #[macro_export]
 macro_rules! declare_combined_early_lint_pass {
     ([$v:vis $name:ident, [$($pass:ident: $constructor:expr,)*]], $methods:tt) => (


### PR DESCRIPTION
#104863 caused small but widespread regressions in lint performance. I tried to improve things in #105291 and #105416 with minimal success, before fully understanding what caused the regression. This PR effectively reverts all of #105291 and part of #104863 to fix the perf regression.

r? @cjgillot  