### PR TITLE
Clarify `catch_unwind` docs about panic hooks

### DIFF
--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -114,6 +114,9 @@ where
 /// aborting the process as well. This function *only* catches unwinding panics,
 /// not those that abort the process.
 ///
+/// Note that if a custom panic hook has been set, it will be invoked before
+/// the panic is caught, before unwinding.
+///
 /// Also note that unwinding into Rust code with a foreign exception (e.g.
 /// an exception thrown from C++ code) is undefined behavior.
 ///


### PR DESCRIPTION
Makes it clear from `catch_unwind` docs that the panic hook will be called before the panic is caught.

Fixes #105432 
