### PR TITLE
rustdoc: Fix badge alignment

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -766,6 +766,9 @@ table,
 .item-left {
 	padding-right: 1.25rem;
 }
+.item-left > a, .item-left > span {
+	vertical-align: middle;
+}
 
 .search-results-title {
 	margin-top: 0;

--- a/src/test/rustdoc-gui/stab-badge.goml
+++ b/src/test/rustdoc-gui/stab-badge.goml
@@ -1,6 +1,21 @@
 // All stability badges should have rounded corners and colored backgrounds.
 goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
 show-text: true
+
+// Checking the alignment of the badges text with the item name.
+assert-css: (
+    "//*[@class='item-table']//*[@class='item-left module-item']/*[@class='stab deprecated']",
+    {"padding-top": "2px"},
+)
+assert-position: (
+    "//*[@class='item-table']//*[@class='item-left module-item']/*[@class='stab deprecated']",
+    {"y": 1892},
+)
+assert-position: (
+    "//*[@class='item-table']//*[@class='item-left module-item']/*[@class='stab deprecated']/preceding-sibling::a",
+    {"y": 1894}, // 1892 + 2 because of padding
+)
+
 define-function: (
 	"check-badge",
 	(theme, background, color),


### PR DESCRIPTION
It fixes a bug discovered by @joshtriplett.

It'll conflict with https://github.com/rust-lang/rust/pull/105504 so I'll just rebase once the conflict arises. :)

r? @notriddle 