### PR TITLE
Update rustix to 0.36.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4624,9 +4624,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.3"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",


### PR DESCRIPTION
Pull in fix for https://github.com/bytecodealliance/rustix/issues/467 on recent cargo nightlies.