### PR TITLE
`get_or_insert` for HashMap and more

### DIFF
--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -906,9 +906,9 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq,
     {
-        match self.base.get(k) {
-            Some(value) => value,
-            None => {
+        match self.base.contains_key(k) {
+            true => self.base.get(k),
+            false => {
                 let value = (callback)();
                 self.base.insert(k, value);
                 self.base.get(k)

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -901,7 +901,7 @@ where
     /// assert_eq!()
     /// ```
     #[inline]
-    pub fn get_or_insert<Q: ?Sized>(&mut self, k: &Q, callback: fn() -> V) -> &V
+    pub fn get_or_insert<Q: ?Sized>(&mut self, k: K, callback: fn() -> V) -> &V
     where
         K: Borrow<Q>,
         Q: Hash + Eq,

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -901,7 +901,7 @@ where
     /// assert_eq!()
     /// ```
     #[inline]
-    pub fn get_or_insert<Q: ?Sized>(&self, k: &Q, callback: fn() -> V) -> &V
+    pub fn get_or_insert<Q: ?Sized>(&mut self, k: &Q, callback: fn() -> V) -> &V
     where
         K: Borrow<Q>,
         Q: Hash + Eq,
@@ -910,8 +910,8 @@ where
             Some(value) => value,
             None => {
                 let value = (callback)();
-                self.base.insert(value);
-                &value
+                self.base.insert(k, value);
+                self.base.get(k)
             }
         }
     }

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -880,6 +880,41 @@ where
     {
         self.base.get(k)
     }
+    
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// If the key isn't present in the map yet, it will add it with the callback.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    ///
+    /// let mut map = HashMap::new();
+    /// map.insert(1, "a");
+    /// assert_eq!(map.get_or_insert(&1, || "a"), Some(&"a"));
+    /// assert_eq!(map.get_or_insert(&2, || "b"), Some(&"b"));
+    /// assert_eq!()
+    /// ```
+    #[inline]
+    pub fn get_or_insert<Q: ?Sized>(&self, k: &Q, callback: fn() -> V) -> &V
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        match self.base.get(k) {
+            Some(value) => value,
+            None => {
+                let value = (callback)();
+                self.base.insert(value);
+                &value
+            }
+        }
+    }
 
     /// Returns the key-value pair corresponding to the supplied key.
     ///

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -907,11 +907,11 @@ where
         Q: Hash + Eq,
     {
         match self.base.contains_key(k) {
-            true => self.base.get(k),
+            true => self.base.get(k).unwrap(),
             false => {
                 let value = (callback)();
                 self.base.insert(k, value);
-                self.base.get(k)
+                self.base.get(k).unwrap()
             }
         }
     }


### PR DESCRIPTION
this adds a little helper method to HashMap for inserting a value if it isn't contained yet.

also planned with `get_mut` and other types like `Vec` or `HashSet`

---

this is my first PR so I'm looking forward for feedback :3