### PR TITLE
Add iter finish note on scan

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1413,7 +1413,7 @@ pub trait Iterator {
     /// assert_eq!(iter.next(), Some(-1));
     /// assert_eq!(iter.next(), Some(-2));
     /// assert_eq!(iter.next(), Some(-6));
-    /// assert_eq!(iter.next(), None);
+    /// assert_eq!(iter.next(), None);     // The iterator is finished.
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
I was working on advent of code 2022 day 8 and I was expecting scan to be able to return stuff after `None`, but it didn't seem to happen even though I didn't fuse the iterator.

It wasn't very clear to me on first look that the `None` determines the next state.