### PR TITLE
Extend rustdoc hashtag prepended line test

### DIFF
--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -345,4 +345,12 @@ fn test_ascii_with_prepending_hashtag() {
 #..#.####.####.####..##..
 </code></pre></div>",
     );
+    t(
+        r#"```markdown
+# hello
+```"#,
+        "<div class=\"example-wrap\"><pre class=\"language-markdown\"><code>\
+# hello
+</code></pre></div>",
+    );
 }


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/105539. This case wasn't checked so better add it.

r? @notriddle 