### PR TITLE
Avoid redundant copying in `VecDeque -> Vec`

### DIFF
--- a/library/alloc/benches/lib.rs
+++ b/library/alloc/benches/lib.rs
@@ -7,6 +7,7 @@
 #![feature(slice_partition_dedup)]
 #![feature(strict_provenance)]
 #![feature(test)]
+#![feature(vec_deque_set_len)]
 #![deny(fuzzy_provenance_casts)]
 
 extern crate test;

--- a/library/alloc/benches/vec_deque.rs
+++ b/library/alloc/benches/vec_deque.rs
@@ -123,3 +123,31 @@ fn bench_extend_chained_bytes(b: &mut Bencher) {
         ring.extend(black_box(input1.iter().chain(input2.iter())));
     });
 }
+
+#[bench]
+fn bench_vec_deque_to_vec(b: &mut Bencher) {
+    let mut ring = VecDeque::from(vec![0; 1024]);
+    ring.shrink_to_fit();
+    assert_eq!(ring.len(), ring.capacity());
+
+    b.iter(move || {
+        assert_eq!(ring.capacity(), 1024);
+        unsafe {
+            ring.set_head(512);
+            ring.set_len(768);
+        }
+
+        let v = Vec::from(std::mem::take(&mut ring));
+        ring = VecDeque::from(v);
+
+        assert_eq!(ring.capacity(), 1024);
+
+        unsafe {
+            ring.set_head(512);
+            ring.set_len(769);
+        }
+
+        let v = Vec::from(std::mem::take(&mut ring));
+        ring = VecDeque::from(v);
+    })
+}

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -523,6 +523,18 @@ impl<T, A: Allocator> VecDeque<T, A> {
         }
         debug_assert!(self.head < self.capacity() || self.capacity() == 0);
     }
+
+    #[doc(hidden)]
+    #[unstable(feature = "vec_deque_set_len", issue = "none", reason = "implementation detail")]
+    pub unsafe fn set_head(&mut self, head: usize) {
+        self.head = head;
+    }
+
+    #[doc(hidden)]
+    #[unstable(feature = "vec_deque_set_len", issue = "none", reason = "implementation detail")]
+    pub unsafe fn set_len(&mut self, len: usize) {
+        self.len = len;
+    }
 }
 
 impl<T> VecDeque<T> {


### PR DESCRIPTION
Add `make_contiguous_inner(&mut self, left_align: bool)`, which allows the `impl From<VecDeque<T>> for Vec<T>` to always move the elements to the beginning of the buffer instead of potentially moving the elements twice. I also added `#[inline]` to `Vec::from(VecDeque)` as the other conversion is already inline, and added `#[inline]` to `make_contiguous` as it just forwards to `make_contiguous_inner`.