### PR TITLE
Don't perform invalid checks in `codegen_attrs`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -68,7 +68,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: DefId) -> CodegenFnAttrs {
     // report a delayed bug, just in case `check_attr` isn't doing its job.
     let validate_fn_only_attr = |attr_sp| -> bool {
         let def_kind = tcx.def_kind(did);
-        if let DefKind::Fn | DefKind::AssocFn = def_kind {
+        if let DefKind::Fn | DefKind::AssocFn | DefKind::Variant | DefKind::Ctor(..) = def_kind {
             true
         } else {
             tcx.sess.delay_span_bug(attr_sp, "this attribute can only be applied to functions");

--- a/src/test/ui/attributes/issue-105594-invalid-attr-validation.rs
+++ b/src/test/ui/attributes/issue-105594-invalid-attr-validation.rs
@@ -1,0 +1,13 @@
+// This checks that the attribute validation ICE in issue #105594 doesn't
+// recur.
+//
+// ignore-thumbv8m.base
+#![feature(cmse_nonsecure_entry)]
+
+fn main() {}
+
+#[track_caller] //~ ERROR attribute should be applied to a function
+static _A: () = ();
+
+#[cmse_nonsecure_entry] //~ ERROR attribute should be applied to a function
+static _B: () = (); //~| ERROR #[cmse_nonsecure_entry]` is only valid for targets

--- a/src/test/ui/attributes/issue-105594-invalid-attr-validation.stderr
+++ b/src/test/ui/attributes/issue-105594-invalid-attr-validation.stderr
@@ -1,0 +1,26 @@
+error[E0739]: attribute should be applied to a function definition
+  --> $DIR/issue-105594-invalid-attr-validation.rs:9:1
+   |
+LL | #[track_caller]
+   | ^^^^^^^^^^^^^^^
+LL | static _A: () = ();
+   | ------------------- not a function definition
+
+error: attribute should be applied to a function definition
+  --> $DIR/issue-105594-invalid-attr-validation.rs:12:1
+   |
+LL | #[cmse_nonsecure_entry]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+LL | static _B: () = ();
+   | ------------------- not a function definition
+
+error[E0775]: `#[cmse_nonsecure_entry]` is only valid for targets with the TrustZone-M extension
+  --> $DIR/issue-105594-invalid-attr-validation.rs:12:1
+   |
+LL | #[cmse_nonsecure_entry]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0739, E0775.
+For more information about an error, try `rustc --explain E0739`.


### PR DESCRIPTION
The attributes `#[track_caller]` and `#[cmse_nonsecure_entry]` are only valid on functions. When validating one of these attributes, codegen_attrs previously called `fn_sig`, [which can only be used on functions](https://github.com/rust-lang/rust/pull/105201), on the item the attribute was attached to, assuming that the item was a function without checking. This led to [ICEs in situations where the attribute was incorrectly used on non-functions](https://github.com/rust-lang/rust/issues/105594).

With this change, we skip calling `fn_sig` if the item the attribute is attached to must be a function but isn't, because `check_attr` will reject such cases without codegen_attrs's intervention.

As a side note, some of the attributes in codegen_attrs are only valid on functions, but that property isn't actually checked. I'm planning to fix that in a follow up PR since it's a behavior change that will need to be validated rather than an obvious bugfix. Thankfully, all the attributes like that I've found so far are unstable.

Fixes #105594.

r? @cjgillot