### PR TITLE
fold instead of obliterating args

### DIFF
--- a/src/test/ui/const-generics/generic_const_exprs/issue-105608.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-105608.rs
@@ -1,5 +1,5 @@
-#![allow(incomplete_features, unstable_features)]
 #![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
 
 struct Combination<const STRATEGIES: usize>;
 

--- a/src/test/ui/const-generics/generic_const_exprs/issue-105608.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-105608.rs
@@ -1,0 +1,15 @@
+#![allow(incomplete_features, unstable_features)]
+#![feature(generic_const_exprs)]
+
+struct Combination<const STRATEGIES: usize>;
+
+impl<const STRATEGIES: usize> Combination<STRATEGIES> {
+    fn and<M>(self) -> Combination<{ STRATEGIES + 1 }> {
+        Combination
+    }
+}
+
+pub fn main() {
+    Combination::<0>.and::<_>().and::<_>();
+    //~^ ERROR: type annotations needed
+}

--- a/src/test/ui/const-generics/generic_const_exprs/issue-105608.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-105608.stderr
@@ -1,0 +1,14 @@
+error[E0282]: type annotations needed
+  --> $DIR/issue-105608.rs:13:22
+   |
+LL |     Combination::<0>.and::<_>().and::<_>();
+   |                      ^^^ cannot infer type of the type parameter `M` declared on the associated function `and`
+   |
+help: consider specifying the generic argument
+   |
+LL |     Combination::<0>.and::<_>().and::<_>();
+   |                         ~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
Fixes #105608

we call `const_eval_resolve` on the following constant:
```
def: playground::{impl#0}::and::{constant#0},
substs: [
  ConstKind::Unevaluated {
    def: playground::{impl#0}::and::{constant#0},
    substs: [
      ConstKind::Value(0x0),
      _,
    ]
  }
  _,
],
```
when expanded out to `ConstKind::Expr` there are no infer vars so we attempt to evaluate it after replacing infer vars with garbage, however the current logic for replacing with garbage replaces _the whole arg containing the infer var_ rather than just the infer var. This means that after garbage replacement has occured we attempt to evaluate:
```
def: playground::{impl#0}::and::{constant#0},
substs: [
  PLACEHOLDER,
  PLACEHOLDER,
],
```
Which then leads to ctfe being unable to evaluate the const. With this PR we attempt to evaluate:
```
def: playground::{impl#0}::and::{constant#0},
substs: [
  ConstKind::Unevaluated {
    def: playground::{impl#0}::and::{constant#0},
    substs: [
      ConstKind::Value(0x0),
      PLACEHOLDER,
    ]
  }
  PLACEHOLDER,
],
```
which ctfe _can_ handle.

I am not entirely sure why this function is supposed to replace params with placeholders rather than just inference vars :thinking: 