### PR TITLE
rustdoc: remove no-op CSS `.source pre { overflow: auto }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -523,7 +523,6 @@ ul.block, .block li {
 }
 
 .source .content pre.rust {
-	overflow: auto;
 	padding-left: 0;
 }
 


### PR DESCRIPTION
Since source pages use the `example-wrap` wrapper, this rule became redundant because there is already an `overflow-x: auto` rule.