### PR TITLE
Fix invalid float literal suggestions when recovering an integer

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1854,7 +1854,16 @@ impl<'a> Parser<'a> {
                 if let token::Literal(token::Lit { kind: token::Integer, symbol, suffix }) =
                     next_token.kind
                 {
-                    if self.token.span.hi() == next_token.span.lo() {
+                    // If this integer looks like a float, then recover as such.
+                    //
+                    // We will never encounter the exponent part of a floating
+                    // point literal here, since there's no use of the exponent
+                    // syntax that also constitutes a valid integer, so we need
+                    // not check for that.
+                    if suffix.map_or(true, |s| s == sym::f32 || s == sym::f64)
+                        && symbol.as_str().chars().all(|c| c.is_numeric() || c == '_')
+                        && self.token.span.hi() == next_token.span.lo()
+                    {
                         let s = String::from("0.") + symbol.as_str();
                         let kind = TokenKind::lit(token::Float, Symbol::intern(&s), suffix);
                         return Some(Token::new(kind, self.token.span.to(next_token.span)));

--- a/tests/ui/suggestions/recover-invalid-float-invalid.rs
+++ b/tests/ui/suggestions/recover-invalid-float-invalid.rs
@@ -1,0 +1,24 @@
+// Check that suggestions to add a zero to integers with a preceding dot only appear when the change
+// will result in a valid floating point literal.
+
+fn main() {}
+
+fn a() {
+    _ = .3u32;
+    //~^ ERROR expected expression, found `.`
+}
+
+fn b() {
+    _ = .0b0;
+    //~^ ERROR expected expression, found `.`
+}
+
+fn c() {
+    _ = .0o07;
+    //~^ ERROR expected expression, found `.`
+}
+
+fn d() {
+    _ = .0x0ABC;
+    //~^ ERROR expected expression, found `.`
+}

--- a/tests/ui/suggestions/recover-invalid-float-invalid.stderr
+++ b/tests/ui/suggestions/recover-invalid-float-invalid.stderr
@@ -1,0 +1,26 @@
+error: expected expression, found `.`
+  --> $DIR/recover-invalid-float-invalid.rs:7:9
+   |
+LL |     _ = .3u32;
+   |         ^ expected expression
+
+error: expected expression, found `.`
+  --> $DIR/recover-invalid-float-invalid.rs:12:9
+   |
+LL |     _ = .0b0;
+   |         ^ expected expression
+
+error: expected expression, found `.`
+  --> $DIR/recover-invalid-float-invalid.rs:17:9
+   |
+LL |     _ = .0o07;
+   |         ^ expected expression
+
+error: expected expression, found `.`
+  --> $DIR/recover-invalid-float-invalid.rs:22:9
+   |
+LL |     _ = .0x0ABC;
+   |         ^ expected expression
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Only suggest adding a zero to integers with a preceding dot when the change will result in a valid floating point literal.

For example, `.0x0` should not be turned into `0.0x0`.

r? nnethercote