### PR TITLE
Remove invalid case for mutable borrow suggestion

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1369,13 +1369,9 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         .span_take_while(span, |c| c.is_whitespace() || *c == '&');
                     if points_at_arg && mutability.is_not() && refs_number > 0 {
                         // If we have a call like foo(&mut buf), then don't suggest foo(&mut mut buf)
-                        if "mut"
-                            == snippet
-                                .chars()
-                                .filter(|c| !c.is_whitespace())
-                                .skip(refs_number)
-                                .take(3)
-                                .collect::<String>()
+                        if snippet
+                            .trim_start_matches(|c: char| c.is_whitespace() || c == '&')
+                            .starts_with("mut")
                         {
                             return;
                         }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1368,6 +1368,17 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         .source_map()
                         .span_take_while(span, |c| c.is_whitespace() || *c == '&');
                     if points_at_arg && mutability.is_not() && refs_number > 0 {
+                        // If we have a call like foo(&mut buf), then don't suggest foo(&mut mut buf)
+                        if "mut"
+                            == snippet
+                                .chars()
+                                .filter(|c| !c.is_whitespace())
+                                .skip(refs_number)
+                                .take(3)
+                                .collect::<String>()
+                        {
+                            return;
+                        }
                         err.span_suggestion_verbose(
                             sp,
                             "consider changing this borrow's mutability",

--- a/src/test/ui/suggestions/issue-105645.rs
+++ b/src/test/ui/suggestions/issue-105645.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let mut buf = [0u8; 50];
+    let mut bref = buf.as_slice();
+    foo(&mut bref);
+    //~^ ERROR 4:9: 4:18: the trait bound `&[u8]: std::io::Write` is not satisfied [E0277]
+}
+
+fn foo(_: &mut impl std::io::Write) {}

--- a/src/test/ui/suggestions/issue-105645.stderr
+++ b/src/test/ui/suggestions/issue-105645.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `&[u8]: std::io::Write` is not satisfied
+  --> $DIR/issue-105645.rs:4:9
+   |
+LL |     foo(&mut bref);
+   |     --- ^^^^^^^^^ the trait `std::io::Write` is not implemented for `&[u8]`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `std::io::Write` is implemented for `&mut [u8]`
+note: required by a bound in `foo`
+  --> $DIR/issue-105645.rs:8:21
+   |
+LL | fn foo(_: &mut impl std::io::Write) {}
+   |                     ^^^^^^^^^^^^^^ required by this bound in `foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
If we have a call such as `foo(&mut buf)` and after reference
collapsing the type is inferred as `&T` where-as the required type is
`&mut T`, don't suggest `foo(&mut mut buf)`. This is wrong syntactically
and the issue lies elsewhere, not in the borrow.

Fixes #105645
