### PR TITLE
Temporarily disable building rustc with ThinLTO on `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-msvc`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,7 @@ jobs:
             os: windows-latest-xl
           - name: dist-x86_64-msvc
             env:
-              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --host=x86_64-pc-windows-msvc --target=x86_64-pc-windows-msvc --enable-full-tools --enable-profiler --set rust.lto=thin"
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --host=x86_64-pc-windows-msvc --target=x86_64-pc-windows-msvc --enable-full-tools --enable-profiler"
               SCRIPT: PGO_HOST=x86_64-pc-windows-msvc src/ci/pgo.sh python x.py dist bootstrap --include-default-paths
               DIST_REQUIRE_ALL_TOOLS: 1
             os: windows-latest-xl

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -79,8 +79,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set llvm.thin-lto=true \
       --set llvm.ninja=false \
       --set rust.jemalloc \
-      --set rust.use-lld=true \
-      --set rust.lto=thin
+      --set rust.use-lld=true
 ENV SCRIPT ../src/ci/pgo.sh python3 ../x.py dist \
     --host $HOSTS --target $HOSTS \
     --include-default-paths \

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -667,7 +667,6 @@ jobs:
                 --target=x86_64-pc-windows-msvc
                 --enable-full-tools
                 --enable-profiler
-                --set rust.lto=thin
               SCRIPT: PGO_HOST=x86_64-pc-windows-msvc src/ci/pgo.sh python x.py dist bootstrap --include-default-paths
               DIST_REQUIRE_ALL_TOOLS: 1
             <<: *job-windows-xl


### PR DESCRIPTION
Context: we recently started building `librustc_driver.so` with ThinLTO on:
- `x86_64-unknown-linux-gnu` in #101403, `nightly-2022-10-24`
- `x86_64-pc-windows-msvc` in #103591, `nightly-2022-12-12`
- `x86_64-apple-darwin` in #103647, `nightly-2022-12-12`

Unfortunately, it appears to regress the message we print during ICEs sometimes, including the query stack and explanation on how to open a GH issue. This was noticed in #105637 on mac (where I've enabled ThinLTO recently, and why I was pinged because of the regression and started looking into this), but is present on all the above targets today. There's also a summary and examples in [that issue here](https://github.com/rust-lang/rust/issues/105637#issuecomment-1348308424) and some more discussion in this [zulip prioritization topic](https://rust-lang.zulipchat.com/#narrow/stream/245100-t-compiler.2Fwg-prioritization.2Falerts/topic/.23105637.20Missing.20ICE.20info.20after.20some.20compiler.20panics).

Since this is useful information for reporting issues, triage and bisections, it impacts the quality of bug reports. The issue was deemed P-critical, so this PR works around it by temporarily disabling ThinLTO on linux/windows (this setting is already being temporarily disabled for mac as well in #105646) until we can fully investigate and fix the underlying issue causing this early abort (e.g. some UB somewhere causing problems now because of the newly enabled optimizations).

Since this issue impacts the quality of bug reports, it could be more important than the perf ThinLTO provides. I don't have the time to fully investigate the cause right now, but maybe someone else does. (I believe we'd rather workaround the issue than live with it ?)

To that end, I'll cc:
- t-compiler leads @pnkfelix and @wesleywiser on: whether this workaround is the approach we want to take, and if the issue/PR should be nominated for discussion at the next t-compiler meeting, if anyone from the team would be available/willing to investigate, etc
- the prioritization working group @rust-lang/wg-prioritization 
- the authors of this original work, @bjorn3 and @Kobzol 

(Note: #101403 will land in 1.66 on 12/15 in 2 days, but rebuilding stable artifacts this late was deemed not worth it in the zulip topic linked above)

(Opening as draft to not merge early)