### PR TITLE
rustdoc: simplify popover CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -902,10 +902,11 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	top: 100%;
 	right: 0;
 	z-index: 2;
-	display: block;
 	margin-top: 7px;
 	border-radius: 3px;
 	border: 1px solid var(--border-color);
+	background-color: var(--main-background-color);
+	color: var(--main-color);
 	--popover-arrow-offset: 11px;
 }
 
@@ -916,14 +917,10 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	right: var(--popover-arrow-offset);
 	border: solid var(--border-color);
 	border-width: 1px 1px 0 0;
+	background-color: var(--main-background-color);
 	padding: 4px;
 	transform: rotate(-45deg);
 	top: -5px;
-}
-
-.popover, .popover::before {
-	background-color: var(--main-background-color);
-	color: var(--main-color);
 }
 
 /* use larger max-width for help popover, but not for help.html */


### PR DESCRIPTION
* Merge the color-changing block into the regular rules, which was probably written that way because it used to be in the theme files, but has no reason to be written this way now that it's in rustdoc.css

* Get rid of redundant `display: block`, since `position: absolute` blockifies the layout anyway.