### PR TITLE
rustdoc: align stability badge to baseline instead of bottom

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -981,6 +981,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	white-space: pre-wrap;
 	border-radius: 3px;
 	display: inline;
+	vertical-align: baseline;
 }
 
 .stab.portability > code {


### PR DESCRIPTION
| desc | img |
|------|-----|
| before | ![image](https://user-images.githubusercontent.com/1593513/207412598-3a6468ca-a169-4810-a689-4797688385df.png) |
| | |
| after | ![image](https://user-images.githubusercontent.com/1593513/207412720-b120269a-48a3-40e9-a9b0-6769bb05e104.png) |

Preview: http://notriddle.com/notriddle-rustdoc-demos/stab-baseline/test_dingus/index.html

Based on comment from https://github.com/rust-lang/rust/pull/105509#discussion_r1044816673

r? @joshtriplett 