### PR TITLE
rustdoc: add CSS margin between `impl` docblock and its items

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1872,6 +1872,7 @@ in storage.js
 }
 
 .variants > .docblock,
+.implementors-toggle > .docblock,
 .impl-items > .rustdoc-toggle[open]:not(:last-child),
 .methods > .rustdoc-toggle[open]:not(:last-child),
 .implementors-toggle[open]:not(:last-child) {

--- a/src/test/rustdoc-gui/impl-doc.goml
+++ b/src/test/rustdoc-gui/impl-doc.goml
@@ -1,0 +1,9 @@
+// A docblock on an impl must have a margin to separate it from the contents.
+goto: "file://" + |DOC_PATH| + "/test_docs/struct.TypeWithImplDoc.html"
+
+// The text is about 24px tall, so if there's a margin, then their position will be >24px apart
+compare-elements-position-near-false: (
+	"#implementations-list > .implementors-toggle > .docblock > p",
+	"#implementations-list > .implementors-toggle > .impl-items",
+	{"y": 24}
+)

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -442,3 +442,11 @@ pub mod trait_members {
         fn function2() {}
     }
 }
+
+pub struct TypeWithImplDoc;
+
+/// impl doc
+impl TypeWithImplDoc {
+    /// fn doc
+    pub fn test_fn() {}
+}


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/1593513/207471025-c27c298b-4d48-461b-918b-a965b09db4f1.png)

## After

![image](https://user-images.githubusercontent.com/1593513/207471759-1bbabf71-0932-441c-b044-ad0e392ba552.png)
