### PR TITLE
Suggest constraining type parameter with `Clone`

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -13,7 +13,9 @@ use rustc_hir_analysis::astconv::AstConv;
 use rustc_infer::infer;
 use rustc_infer::traits::{self, StatementAsExpression};
 use rustc_middle::lint::in_external_macro;
-use rustc_middle::ty::{self, Binder, DefIdTree, IsSuggestable, Ty};
+use rustc_middle::ty::{
+    self, suggest_constraining_type_params, Binder, DefIdTree, IsSuggestable, Ty,
+};
 use rustc_session::errors::ExprParenthesesNeeded;
 use rustc_span::symbol::sym;
 use rustc_span::Span;
@@ -1293,6 +1295,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     "`{expected_ty}` does not implement `Clone`, so `{found_ty}` was cloned instead"
                 ),
             );
+            let owner = self.tcx.hir().enclosing_body_owner(expr.hir_id);
+            if let ty::Param(param) = expected_ty.kind()
+                && let Some(generics) = self.tcx.hir().get_generics(owner)
+            {
+                suggest_constraining_type_params(
+                    self.tcx,
+                    generics,
+                    diag,
+                    vec![(param.name.as_str(), "Clone", Some(clone_trait_did))].into_iter(),
+                );
+            }
         }
     }
 

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1848,7 +1848,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.suggest_derive(err, &preds);
     }
 
-    fn suggest_derive(
+    pub fn suggest_derive(
         &self,
         err: &mut Diagnostic,
         unsatisfied_predicates: &[(

--- a/src/test/ui/suggestions/clone-on-unconstrained-borrowed-type-param.fixed
+++ b/src/test/ui/suggestions/clone-on-unconstrained-borrowed-type-param.fixed
@@ -1,0 +1,8 @@
+// run-rustfix
+fn wat<T: Clone>(t: &T) -> T {
+    t.clone() //~ ERROR E0308
+}
+
+fn main() {
+    wat(&42);
+}

--- a/src/test/ui/suggestions/clone-on-unconstrained-borrowed-type-param.fixed
+++ b/src/test/ui/suggestions/clone-on-unconstrained-borrowed-type-param.fixed
@@ -3,6 +3,14 @@ fn wat<T: Clone>(t: &T) -> T {
     t.clone() //~ ERROR E0308
 }
 
+#[derive(Clone)]
+struct Foo;
+
+fn wut(t: &Foo) -> Foo {
+    t.clone() //~ ERROR E0308
+}
+
 fn main() {
     wat(&42);
+    wut(&Foo);
 }

--- a/src/test/ui/suggestions/clone-on-unconstrained-borrowed-type-param.rs
+++ b/src/test/ui/suggestions/clone-on-unconstrained-borrowed-type-param.rs
@@ -3,6 +3,13 @@ fn wat<T>(t: &T) -> T {
     t.clone() //~ ERROR E0308
 }
 
+struct Foo;
+
+fn wut(t: &Foo) -> Foo {
+    t.clone() //~ ERROR E0308
+}
+
 fn main() {
     wat(&42);
+    wut(&Foo);
 }

--- a/src/test/ui/suggestions/clone-on-unconstrained-borrowed-type-param.rs
+++ b/src/test/ui/suggestions/clone-on-unconstrained-borrowed-type-param.rs
@@ -1,0 +1,8 @@
+// run-rustfix
+fn wat<T>(t: &T) -> T {
+    t.clone() //~ ERROR E0308
+}
+
+fn main() {
+    wat(&42);
+}

--- a/src/test/ui/suggestions/clone-on-unconstrained-borrowed-type-param.stderr
+++ b/src/test/ui/suggestions/clone-on-unconstrained-borrowed-type-param.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/clone-on-unconstrained-borrowed-type-param.rs:3:5
+   |
+LL | fn wat<T>(t: &T) -> T {
+   |        -            - expected `T` because of return type
+   |        |
+   |        this type parameter
+LL |     t.clone()
+   |     ^^^^^^^^^ expected type parameter `T`, found `&T`
+   |
+   = note: expected type parameter `T`
+                   found reference `&T`
+note: `T` does not implement `Clone`, so `&T` was cloned instead
+  --> $DIR/clone-on-unconstrained-borrowed-type-param.rs:3:5
+   |
+LL |     t.clone()
+   |     ^
+help: consider restricting type parameter `T`
+   |
+LL | fn wat<T: Clone>(t: &T) -> T {
+   |         +++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/clone-on-unconstrained-borrowed-type-param.stderr
+++ b/src/test/ui/suggestions/clone-on-unconstrained-borrowed-type-param.stderr
@@ -20,6 +20,24 @@ help: consider restricting type parameter `T`
 LL | fn wat<T: Clone>(t: &T) -> T {
    |         +++++++
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/clone-on-unconstrained-borrowed-type-param.rs:9:5
+   |
+LL | fn wut(t: &Foo) -> Foo {
+   |                    --- expected `Foo` because of return type
+LL |     t.clone()
+   |     ^^^^^^^^^ expected struct `Foo`, found `&Foo`
+   |
+note: `Foo` does not implement `Clone`, so `&Foo` was cloned instead
+  --> $DIR/clone-on-unconstrained-borrowed-type-param.rs:9:5
+   |
+LL |     t.clone()
+   |     ^
+help: consider annotating `Foo` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/typeck/explain_clone_autoref.stderr
+++ b/src/test/ui/typeck/explain_clone_autoref.stderr
@@ -12,6 +12,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |     nc.clone()
    |     ^^
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fix #34896.