### PR TITLE
Allow .. to be parsed as let initializer

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -379,6 +379,10 @@ impl Token {
         }
     }
 
+    pub fn is_range_seperator(&self) -> bool {
+        [DotDot, DotDotDot, DotDotEq].contains(&self.kind)
+    }
+
     pub fn is_op(&self) -> bool {
         match self.kind {
             Eq | Lt | Le | EqEq | Ne | Ge | Gt | AndAnd | OrOr | Not | Tilde | BinOp(_)

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -379,7 +379,7 @@ impl Token {
         }
     }
 
-    pub fn is_range_seperator(&self) -> bool {
+    pub fn is_range_separator(&self) -> bool {
         [DotDot, DotDotDot, DotDotEq].contains(&self.kind)
     }
 

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -180,7 +180,7 @@ impl<'a> Parser<'a> {
                 LhsExpr::AttributesParsed(attrs) => Some(attrs),
                 _ => None,
             };
-            if [token::DotDot, token::DotDotDot, token::DotDotEq].contains(&self.token.kind) {
+            if self.token.is_range_seperator() {
                 return self.parse_prefix_range_expr(attrs);
             } else {
                 self.parse_prefix_expr(attrs)?
@@ -512,7 +512,7 @@ impl<'a> Parser<'a> {
         }
 
         debug_assert!(
-            [token::DotDot, token::DotDotDot, token::DotDotEq].contains(&self.token.kind),
+            self.token.is_range_seperator(),
             "parse_prefix_range_expr: token {:?} is not DotDot/DotDotEq",
             self.token
         );
@@ -896,7 +896,11 @@ impl<'a> Parser<'a> {
         let has_lifetime = self.token.is_lifetime() && self.look_ahead(1, |t| t != &token::Colon);
         let lifetime = has_lifetime.then(|| self.expect_lifetime()); // For recovery, see below.
         let (borrow_kind, mutbl) = self.parse_borrow_modifiers(lo);
-        let expr = self.parse_prefix_expr(None);
+        let expr = if self.token.is_range_seperator() {
+            self.parse_prefix_range_expr(None)
+        } else {
+            self.parse_prefix_expr(None)
+        };
         let (hi, expr) = self.interpolated_or_expr_span(expr)?;
         let span = lo.to(hi);
         if let Some(lt) = lifetime {

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -180,7 +180,7 @@ impl<'a> Parser<'a> {
                 LhsExpr::AttributesParsed(attrs) => Some(attrs),
                 _ => None,
             };
-            if self.token.is_range_seperator() {
+            if self.token.is_range_separator() {
                 return self.parse_prefix_range_expr(attrs);
             } else {
                 self.parse_prefix_expr(attrs)?
@@ -512,7 +512,7 @@ impl<'a> Parser<'a> {
         }
 
         debug_assert!(
-            self.token.is_range_seperator(),
+            self.token.is_range_separator(),
             "parse_prefix_range_expr: token {:?} is not DotDot/DotDotEq",
             self.token
         );
@@ -896,7 +896,7 @@ impl<'a> Parser<'a> {
         let has_lifetime = self.token.is_lifetime() && self.look_ahead(1, |t| t != &token::Colon);
         let lifetime = has_lifetime.then(|| self.expect_lifetime()); // For recovery, see below.
         let (borrow_kind, mutbl) = self.parse_borrow_modifiers(lo);
-        let expr = if self.token.is_range_seperator() {
+        let expr = if self.token.is_range_separator() {
             self.parse_prefix_range_expr(None)
         } else {
             self.parse_prefix_expr(None)

--- a/src/test/ui/parser/issue-105634.rs
+++ b/src/test/ui/parser/issue-105634.rs
@@ -1,0 +1,8 @@
+// run-pass
+
+fn main() {
+    let _a = ..;
+    let _b = ..=10;
+    let _c = &..;
+    let _d = &..=10;
+}

--- a/src/test/ui/parser/issue-105634.rs
+++ b/src/test/ui/parser/issue-105634.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 fn main() {
     let _a = ..;


### PR DESCRIPTION
.. and ..= are valid expressions, however when used in a let statement
it is not parsed.
Fixes #105634