### PR TITLE
Format only modified files

### DIFF
--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Several unsupported `./configure` options have been removed: `optimize`, `parallel-compiler`. These can still be enabled with `--set`, although it isn't recommended.
 - `remote-test-server`'s `verbose` argument has been removed in favor of the `--verbose` flag
 - `remote-test-server`'s `remote` argument has been removed in favor of the `--bind` flag. Use `--bind 0.0.0.0:12345` to replicate the behavior of the `remote` argument.
+- `x.py fmt` now formats only files modified between the merge-base of HEAD and the last commit in the master branch of the rust-lang repository and the current working directory. To restore old behaviour, use `x.py fmt .`. The check mode is not affected by this change. [#105702](https://github.com/rust-lang/rust/pull/105702)
 
 ### Non-breaking changes
 

--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -21,6 +21,7 @@ pub fn clean(build: &Build, all: bool) {
         rm_rf(&build.out.join("tmp"));
         rm_rf(&build.out.join("dist"));
         rm_rf(&build.out.join("bootstrap"));
+        rm_rf(&build.out.join("rustfmt.stamp"));
 
         for host in &build.hosts {
             let entries = match build.out.join(host.triple).read_dir() {

--- a/src/bootstrap/format.rs
+++ b/src/bootstrap/format.rs
@@ -1,7 +1,7 @@
 //! Runs rustfmt on the repository.
 
 use crate::builder::Builder;
-use crate::util::{output, t};
+use crate::util::{output, program_out_of_date, t};
 use ignore::WalkBuilder;
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
@@ -42,6 +42,68 @@ fn rustfmt(src: &Path, rustfmt: &Path, paths: &[PathBuf], check: bool) -> impl F
         }
         true
     }
+}
+
+fn verify_timestamp(build: &Builder<'_>) -> bool {
+    let stamp_file = {
+        let mut s = build.out.clone();
+        s.push("rustfmt.stamp");
+        s
+    };
+
+    let mut cmd = Command::new(match build.initial_rustfmt() {
+        Some(p) => p,
+        None => return false,
+    });
+    cmd.arg("--version");
+    let output = match cmd.output() {
+        Ok(status) => status,
+        Err(_) => return false,
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let version = String::from_utf8(output.stdout).unwrap();
+    !program_out_of_date(&stamp_file, &version)
+}
+
+fn update_timestamp(build: &Builder<'_>) {
+    let stamp_file = {
+        let mut s = build.out.clone();
+        s.push("rustfmt.stamp");
+        s
+    };
+
+    let mut cmd = Command::new(match build.initial_rustfmt() {
+        Some(p) => p,
+        None => return,
+    });
+    cmd.arg("--version");
+    let output = match cmd.output() {
+        Ok(status) => status,
+        Err(_) => return,
+    };
+    if !output.status.success() {
+        return;
+    }
+    let version = String::from_utf8(output.stdout).unwrap();
+
+    t!(std::fs::write(stamp_file, version))
+}
+
+fn get_modified_files(build: &Builder<'_>) -> Option<Vec<String>> {
+    let Ok(remote) = get_rust_lang_rust_remote() else {return None;};
+    if !verify_timestamp(build) {
+        return None;
+    }
+    let base =
+        output(build.config.git().arg("merge-base").arg("HEAD").arg(format!("{remote}/master")));
+    Some(
+        output(build.config.git().arg("diff").arg("--name-only").arg(base.trim()))
+            .lines()
+            .map(|s| s.trim().to_owned())
+            .collect(),
+    )
 }
 
 /// Finds the remote for rust-lang/rust.
@@ -140,20 +202,11 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
                 ignore_fmt.add(&format!("!/{}", untracked_path)).expect(&untracked_path);
             }
             if !check && paths.is_empty() {
-                let remote = t!(get_rust_lang_rust_remote());
-                let base = output(
-                    build
-                        .config
-                        .git()
-                        .arg("merge-base")
-                        .arg("HEAD")
-                        .arg(format!("{remote}/master")),
-                );
-                let files =
-                    output(build.config.git().arg("diff").arg("--name-only").arg(base.trim()));
-                for file in files.lines() {
-                    println!("formatting modified file {file}");
-                    ignore_fmt.add(&format!("/{file}")).expect(file);
+                if let Some(files) = get_modified_files(build) {
+                    for file in files {
+                        println!("formatting modified file {file}");
+                        ignore_fmt.add(&format!("/{file}")).expect(&file);
+                    }
                 }
             }
         } else {
@@ -233,4 +286,6 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
     drop(tx);
 
     thread.join().unwrap();
+
+    update_timestamp(build);
 }


### PR DESCRIPTION
As discussed on #105688, this makes x fmt only format modified files.

Fixes #105688