### PR TITLE
rustdoc: remove unnecessary CSS `kbd { cursor: default }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1396,7 +1396,6 @@ kbd {
 	vertical-align: middle;
 	border: solid 1px var(--border-color);
 	border-radius: 3px;
-	cursor: default;
 	color: var(--kbd--color);
 	background-color: var(--kbd-background);
 	box-shadow: inset 0 -1px 0 var(--kbd-box-shadow-color);

--- a/src/test/rustdoc-gui/help-page.goml
+++ b/src/test/rustdoc-gui/help-page.goml
@@ -27,7 +27,6 @@ define-function: (
             "color": |color|,
             "background-color": |background|,
             "box-shadow": |box_shadow| + " 0px -1px 0px 0px inset",
-            "cursor": "default",
         }, ALL)),
     ],
 )


### PR DESCRIPTION
Added along with theme picker changes in https://github.com/rust-lang/rust/pull/47686/files#diff-7dc22a0530802d77c2f2ec9e834024a5657b6eab4055520fca46edc99a544413R1144, but no reason seems to have been given at the time for why this particular rule was added.

Removing this rule results in `<kbd>` elements getting an I-bar, while the rule causes them to use the "default" arrow, but since selecting the text in these elements works fine, the I-bar is not misleading.