### PR TITLE
Don't bug if we're trying to cast `dyn*` to another type

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -847,13 +847,15 @@ impl<'a, 'tcx> CastCheck<'tcx> {
 
             (Int(_) | Float, Int(_) | Float) => Ok(CastKind::NumericCast),
 
-            (_, DynStar) | (DynStar, _) => {
+            (_, DynStar) => {
                 if fcx.tcx.features().dyn_star {
                     bug!("should be handled by `try_coerce`")
                 } else {
                     Err(CastError::IllegalCast)
                 }
             }
+
+            (DynStar, _) => Err(CastError::IllegalCast),
         }
     }
 

--- a/src/test/ui/dyn-star/dyn-to-rigid.rs
+++ b/src/test/ui/dyn-star/dyn-to-rigid.rs
@@ -1,0 +1,11 @@
+#![feature(dyn_star)]
+#![allow(incomplete_features)]
+
+trait Tr {}
+
+fn f(x: dyn* Tr) -> usize {
+    x as usize
+    //~^ ERROR casting `(dyn* Tr + 'static)` as `usize` is invalid
+}
+
+fn main() {}

--- a/src/test/ui/dyn-star/dyn-to-rigid.stderr
+++ b/src/test/ui/dyn-star/dyn-to-rigid.stderr
@@ -1,0 +1,9 @@
+error[E0606]: casting `(dyn* Tr + 'static)` as `usize` is invalid
+  --> $DIR/dyn-to-rigid.rs:7:5
+   |
+LL |     x as usize
+   |     ^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0606`.


### PR DESCRIPTION
Fixes #105097