### PR TITLE
rustdoc: remove no-op CSS `.scrape-example .src-line-numbers { margin: 0 }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1970,7 +1970,6 @@ in storage.js
 }
 
 .scraped-example .code-wrapper .src-line-numbers {
-	margin: 0;
 	padding: 14px 0;
 }
 


### PR DESCRIPTION
This is the default CSS for `<pre>` tags in `.code-wrapper` anyway, so this line does nothing.