### PR TITLE
rustdoc: remove no-op CSS `.item-info:before { color }`

### DIFF
--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -150,8 +150,6 @@ pre, .rustdoc.source .example-wrap {
 	color: #c5c5c5;
 }
 
-.content .item-info::before { color: #ccc; }
-
 .sidebar h2 a,
 .sidebar h3 a {
 	color: white;

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -85,8 +85,6 @@
 	--table-alt-row-background-color: #2A2A2A;
 }
 
-.content .item-info::before { color: #ccc; }
-
 body.source .example-wrap pre.rust a {
 	background: #333;
 }

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -82,8 +82,6 @@
 	--table-alt-row-background-color: #F5F5F5;
 }
 
-.content .item-info::before { color: #ccc; }
-
 body.source .example-wrap pre.rust a {
 	background: #eee;
 }


### PR DESCRIPTION
No content is set, so this pseudo-element does not exist. The CSS was obsoleted by 73d0f7c7b68784f1db0a1f53855c20d118a7e8b0.