### PR TITLE
rustdoc: remove unused CSS `.sub-settings`

### DIFF
--- a/src/librustdoc/html/static/css/settings.css
+++ b/src/librustdoc/html/static/css/settings.css
@@ -59,12 +59,6 @@
 	cursor: pointer;
 }
 
-.setting-line > .sub-settings {
-	padding-left: 42px;
-	width: 100%;
-	display: block;
-}
-
 #settings .setting-line {
 	margin: 1.2em 0.6em;
 }


### PR DESCRIPTION
Obsoleted when 9625ed8be7fa66c3ee5f78180a3d5911817096f6 changed the DOM.