### PR TITLE
Detect likely `.` -> `..` typo in method calls

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1604,7 +1604,6 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                         None,
                         Some(coercion_error),
                     );
-                    fcx.check_for_range_as_method_call(&mut err, expr, found, expected);
                 }
 
                 if visitor.ret_exprs.len() > 0 && let Some(expr) = expression {

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1604,6 +1604,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                         None,
                         Some(coercion_error),
                     );
+                    fcx.check_for_range_as_method_call(&mut err, expr, found, expected);
                 }
 
                 if visitor.ret_exprs.len() > 0 && let Some(expr) = expression {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3344,10 +3344,18 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 let suggestion = if let Some((start, end)) = this.diagnostic_metadata.in_range
                     && path[0].ident.span.lo() == end.span.lo()
                 {
+                    let mut sugg = ".";
+                    let mut span = start.span.between(end.span);
+                    if span.lo() + BytePos(2) == span.hi() {
+                        // There's no space between the start, the range op and the end, suggest
+                        // removal which will look better.
+                        span = span.with_lo(span.lo() + BytePos(1));
+                        sugg = "";
+                    }
                     Some((
-                        start.span.between(end.span),
+                        span,
                         "you might have meant to write a method call instead of a range",
-                        ".".to_string(),
+                        sugg.to_string(),
                         Applicability::MaybeIncorrect,
                     ))
                 } else if res.is_none() {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -16,7 +16,7 @@ use rustc_ast::ptr::P;
 use rustc_ast::visit::{self, AssocCtxt, BoundKind, FnCtxt, FnKind, Visitor};
 use rustc_ast::*;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
-use rustc_errors::{DiagnosticArgValue, DiagnosticId, IntoDiagnosticArg};
+use rustc_errors::{Applicability, DiagnosticArgValue, DiagnosticId, IntoDiagnosticArg};
 use rustc_hir::def::Namespace::{self, *};
 use rustc_hir::def::{self, CtorKind, DefKind, LifetimeRes, PartialRes, PerNS};
 use rustc_hir::def_id::{DefId, LocalDefId, CRATE_DEF_ID, LOCAL_CRATE};
@@ -535,6 +535,9 @@ struct DiagnosticMetadata<'ast> {
     /// Used to detect possible new binding written without `let` and to provide structured suggestion.
     in_assignment: Option<&'ast Expr>,
     is_assign_rhs: bool,
+
+    /// Used to detect possible `.` -> `..` typo when calling methods.
+    in_range: Option<(&'ast Expr, &'ast Expr)>,
 
     /// If we are currently in a trait object definition. Used to point at the bounds when
     /// encountering a struct or enum.
@@ -3320,6 +3323,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         );
     }
 
+    #[instrument(level = "debug", skip(self))]
     fn smart_resolve_path_fragment(
         &mut self,
         qself: &Option<P<QSelf>>,
@@ -3327,10 +3331,6 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         source: PathSource<'ast>,
         finalize: Finalize,
     ) -> PartialRes {
-        debug!(
-            "smart_resolve_path_fragment(qself={:?}, path={:?}, finalize={:?})",
-            qself, path, finalize,
-        );
         let ns = source.namespace();
 
         let Finalize { node_id, path_span, .. } = finalize;
@@ -3341,8 +3341,20 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
 
                 let def_id = this.parent_scope.module.nearest_parent_mod();
                 let instead = res.is_some();
-                let suggestion =
-                    if res.is_none() { this.report_missing_type_error(path) } else { None };
+                let suggestion = if let Some((start, end)) = this.diagnostic_metadata.in_range
+                    && path[0].ident.span.lo() == end.span.lo()
+                {
+                    Some((
+                        start.span.between(end.span),
+                        "you might have meant to write a method call instead of a range",
+                        ".".to_string(),
+                        Applicability::MaybeIncorrect,
+                    ))
+                } else if res.is_none() {
+                    this.report_missing_type_error(path)
+                } else {
+                    None
+                };
 
                 this.r.use_injections.push(UseError {
                     err,
@@ -4004,6 +4016,12 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 self.diagnostic_metadata.in_assignment = None;
                 self.visit_expr(rhs);
                 self.diagnostic_metadata.is_assign_rhs = false;
+            }
+            ExprKind::Range(Some(ref start), Some(ref end), RangeLimits::HalfOpen) => {
+                self.diagnostic_metadata.in_range = Some((start, end));
+                self.resolve_expr(start, Some(expr));
+                self.resolve_expr(end, Some(expr));
+                self.diagnostic_metadata.in_range = None;
             }
             _ => {
                 visit::walk_expr(self, expr);

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3354,7 +3354,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                     }
                     Some((
                         span,
-                        "you might have meant to write a method call instead of a range",
+                        "you might have meant to write `.` instead of `..`",
                         sugg.to_string(),
                         Applicability::MaybeIncorrect,
                     ))

--- a/src/test/ui/suggestions/method-access-to-range-literal-typo.rs
+++ b/src/test/ui/suggestions/method-access-to-range-literal-typo.rs
@@ -4,14 +4,22 @@ fn as_ref() -> Option<Vec<u8>> {
 struct Type {
     option: Option<Vec<u8>>
 }
+trait Trait {
+    fn foo(&self) -> Vec<u8>;
+}
+impl Trait for Option<Vec<u8>> {
+    fn foo(&self) -> Vec<u8> {
+        vec![1, 2, 3]
+    }
+}
 
 impl Type {
     fn method(&self) -> Option<Vec<u8>> {
         self.option..as_ref().map(|x| x)
         //~^ ERROR E0308
     }
-    fn method2(&self) -> Option<Vec<u8>> {
-        self.option..foo().map(|x| x)
+    fn method2(&self) -> &u8 {
+        self.option..foo().get(0)
         //~^ ERROR E0425
         //~| ERROR E0308
     }

--- a/src/test/ui/suggestions/method-access-to-range-literal-typo.rs
+++ b/src/test/ui/suggestions/method-access-to-range-literal-typo.rs
@@ -1,0 +1,22 @@
+fn as_ref() -> Option<Vec<u8>> {
+    None
+}
+struct Type {
+    option: Option<Vec<u8>>
+}
+
+impl Type {
+    fn method(&self) -> Option<Vec<u8>> {
+        self.option..as_ref().map(|x| x)
+        //~^ ERROR E0308
+    }
+    fn method2(&self) -> Option<Vec<u8>> {
+        self.option..foo().map(|x| x)
+        //~^ ERROR E0425
+        //~| ERROR E0308
+    }
+}
+
+fn main() {
+    let _ = Type { option: None }.method();
+}

--- a/src/test/ui/suggestions/method-access-to-range-literal-typo.stderr
+++ b/src/test/ui/suggestions/method-access-to-range-literal-typo.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find function `foo` in this scope
 LL |         self.option..foo().get(0)
    |                      ^^^ not found in this scope
    |
-help: you might have meant to write a method call instead of a range
+help: you might have meant to write `.` instead of `..`
    |
 LL -         self.option..foo().get(0)
 LL +         self.option.foo().get(0)

--- a/src/test/ui/suggestions/method-access-to-range-literal-typo.stderr
+++ b/src/test/ui/suggestions/method-access-to-range-literal-typo.stderr
@@ -1,0 +1,45 @@
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/method-access-to-range-literal-typo.rs:14:22
+   |
+LL |         self.option..foo().map(|x| x)
+   |                      ^^^ not found in this scope
+   |
+help: you might have meant to write a method call instead of a range
+   |
+LL |         self.option.foo().map(|x| x)
+   |                    ~
+
+error[E0308]: mismatched types
+  --> $DIR/method-access-to-range-literal-typo.rs:10:9
+   |
+LL |     fn method(&self) -> Option<Vec<u8>> {
+   |                         --------------- expected `Option<Vec<u8>>` because of return type
+LL |         self.option..as_ref().map(|x| x)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `Option`, found struct `Range`
+   |
+   = note: expected enum `Option<_>`
+            found struct `std::ops::Range<Option<_>>`
+help: you might have meant to write a method call instead of a range
+   |
+LL |         self.option.as_ref().map(|x| x)
+   |                    ~
+
+error[E0308]: mismatched types
+  --> $DIR/method-access-to-range-literal-typo.rs:14:9
+   |
+LL |     fn method2(&self) -> Option<Vec<u8>> {
+   |                          --------------- expected `Option<Vec<u8>>` because of return type
+LL |         self.option..foo().map(|x| x)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `Option`, found struct `Range`
+   |
+   = note: expected enum `Option<_>`
+            found struct `std::ops::Range<Option<_>>`
+help: you might have meant to write a method call instead of a range
+   |
+LL |         self.option.foo().map(|x| x)
+   |                    ~
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0425.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/method-access-to-range-literal-typo.stderr
+++ b/src/test/ui/suggestions/method-access-to-range-literal-typo.stderr
@@ -1,16 +1,17 @@
 error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/method-access-to-range-literal-typo.rs:14:22
+  --> $DIR/method-access-to-range-literal-typo.rs:22:22
    |
-LL |         self.option..foo().map(|x| x)
+LL |         self.option..foo().get(0)
    |                      ^^^ not found in this scope
    |
 help: you might have meant to write a method call instead of a range
    |
-LL |         self.option.foo().map(|x| x)
-   |                    ~
+LL -         self.option..foo().get(0)
+LL +         self.option.foo().get(0)
+   |
 
 error[E0308]: mismatched types
-  --> $DIR/method-access-to-range-literal-typo.rs:10:9
+  --> $DIR/method-access-to-range-literal-typo.rs:18:9
    |
 LL |     fn method(&self) -> Option<Vec<u8>> {
    |                         --------------- expected `Option<Vec<u8>>` because of return type
@@ -19,25 +20,27 @@ LL |         self.option..as_ref().map(|x| x)
    |
    = note: expected enum `Option<_>`
             found struct `std::ops::Range<Option<_>>`
-help: you might have meant to write a method call instead of a range
+help: you likely meant to write a method call instead of a range
    |
-LL |         self.option.as_ref().map(|x| x)
-   |                    ~
+LL -         self.option..as_ref().map(|x| x)
+LL +         self.option.as_ref().map(|x| x)
+   |
 
 error[E0308]: mismatched types
-  --> $DIR/method-access-to-range-literal-typo.rs:14:9
+  --> $DIR/method-access-to-range-literal-typo.rs:22:9
    |
-LL |     fn method2(&self) -> Option<Vec<u8>> {
-   |                          --------------- expected `Option<Vec<u8>>` because of return type
-LL |         self.option..foo().map(|x| x)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `Option`, found struct `Range`
+LL |     fn method2(&self) -> &u8 {
+   |                          --- expected `&u8` because of return type
+LL |         self.option..foo().get(0)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&u8`, found struct `Range`
    |
-   = note: expected enum `Option<_>`
-            found struct `std::ops::Range<Option<_>>`
-help: you might have meant to write a method call instead of a range
+   = note: expected reference `&u8`
+                 found struct `std::ops::Range<Option<Vec<u8>>>`
+help: you likely meant to write a method call instead of a range
    |
-LL |         self.option.foo().map(|x| x)
-   |                    ~
+LL -         self.option..foo().get(0)
+LL +         self.option.foo().get(0)
+   |
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fix #65015.