### PR TITLE
add function to tell the identical errors for ambiguity_errors

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1686,7 +1686,7 @@ impl<'a> Resolver<'a> {
             .or_insert_with(|| self.arenas.alloc_name_resolution())
     }
 
-    // Test if AmbiguityError ambi is any identical to any one inside ambiguity_errors
+    /// Test if AmbiguityError ambi is any identical to any one inside ambiguity_errors
     fn matches_previous_ambiguity_error(&mut self, ambi: &AmbiguityError<'_>) -> bool {
         for ambiguity_error in &self.ambiguity_errors {
             // if the span location and ident as well as its span are the same

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1686,6 +1686,24 @@ impl<'a> Resolver<'a> {
             .or_insert_with(|| self.arenas.alloc_name_resolution())
     }
 
+    // Test if AmbiguityError ambi is any identical to any one inside ambiguity_errors
+    fn matches_previous_ambiguity_error(&mut self, ambi: &AmbiguityError<'_>) -> bool {
+        for ambiguity_error in &self.ambiguity_errors {
+            // if the span location and ident as well as its span are the same
+            if ambiguity_error.kind == ambi.kind
+                && ambiguity_error.ident == ambi.ident
+                && ambiguity_error.ident.span == ambi.ident.span
+                && ambiguity_error.b1.span == ambi.b1.span
+                && ambiguity_error.b2.span == ambi.b2.span
+                && ambiguity_error.misc1 == ambi.misc1
+                && ambiguity_error.misc2 == ambi.misc2
+            {
+                return true;
+            }
+        }
+        false
+    }
+
     fn record_use(
         &mut self,
         ident: Ident,
@@ -1693,14 +1711,18 @@ impl<'a> Resolver<'a> {
         is_lexical_scope: bool,
     ) {
         if let Some((b2, kind)) = used_binding.ambiguity {
-            self.ambiguity_errors.push(AmbiguityError {
+            let ambiguity_error = AmbiguityError {
                 kind,
                 ident,
                 b1: used_binding,
                 b2,
                 misc1: AmbiguityErrorMisc::None,
                 misc2: AmbiguityErrorMisc::None,
-            });
+            };
+            if !self.matches_previous_ambiguity_error(&ambiguity_error) {
+                // avoid dumplicated span information to be emitt out
+                self.ambiguity_errors.push(ambiguity_error);
+            }
         }
         if let NameBindingKind::Import { import, binding, ref used } = used_binding.kind {
             // Avoid marking `extern crate` items that refer to a name from extern prelude,

--- a/src/test/ui/imports/local-modularized-tricky-fail-1.rs
+++ b/src/test/ui/imports/local-modularized-tricky-fail-1.rs
@@ -26,7 +26,6 @@ mod inner1 {
 }
 
 exported!(); //~ ERROR `exported` is ambiguous
-             //~| ERROR `exported` is ambiguous
 
 mod inner2 {
     define_exported!();

--- a/src/test/ui/imports/local-modularized-tricky-fail-1.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-1.stderr
@@ -23,33 +23,8 @@ LL | use inner1::*;
    = help: consider adding an explicit import of `exported` to disambiguate
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `exported` is ambiguous
-  --> $DIR/local-modularized-tricky-fail-1.rs:28:1
-   |
-LL | exported!();
-   | ^^^^^^^^ ambiguous name
-   |
-   = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
-note: `exported` could refer to the macro defined here
-  --> $DIR/local-modularized-tricky-fail-1.rs:5:5
-   |
-LL | /     macro_rules! exported {
-LL | |         () => ()
-LL | |     }
-   | |_____^
-...
-LL |       define_exported!();
-   |       ------------------ in this macro invocation
-note: `exported` could also refer to the macro imported here
-  --> $DIR/local-modularized-tricky-fail-1.rs:22:5
-   |
-LL | use inner1::*;
-   |     ^^^^^^^^^
-   = help: consider adding an explicit import of `exported` to disambiguate
-   = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0659]: `panic` is ambiguous
-  --> $DIR/local-modularized-tricky-fail-1.rs:36:5
+  --> $DIR/local-modularized-tricky-fail-1.rs:35:5
    |
 LL |     panic!();
    |     ^^^^^ ambiguous name
@@ -70,7 +45,7 @@ LL |       define_panic!();
    = note: this error originates in the macro `define_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `include` is ambiguous
-  --> $DIR/local-modularized-tricky-fail-1.rs:47:1
+  --> $DIR/local-modularized-tricky-fail-1.rs:46:1
    |
 LL | include!();
    | ^^^^^^^ ambiguous name
@@ -90,6 +65,6 @@ LL |       define_include!();
    = help: use `crate::include` to refer to this macro unambiguously
    = note: this error originates in the macro `define_include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0659`.

--- a/src/test/ui/imports/macros.rs
+++ b/src/test/ui/imports/macros.rs
@@ -14,7 +14,6 @@ mod m1 {
 mod m2 {
     use two_macros::*;
     m! { //~ ERROR ambiguous
-         //~| ERROR ambiguous
         use foo::m;
     }
 }

--- a/src/test/ui/imports/macros.stderr
+++ b/src/test/ui/imports/macros.stderr
@@ -6,7 +6,7 @@ LL |     m! {
    |
    = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
 note: `m` could refer to the macro imported here
-  --> $DIR/macros.rs:18:13
+  --> $DIR/macros.rs:17:13
    |
 LL |         use foo::m;
    |             ^^^^^^
@@ -18,43 +18,24 @@ LL |     use two_macros::*;
    = help: consider adding an explicit import of `m` to disambiguate
 
 error[E0659]: `m` is ambiguous
-  --> $DIR/macros.rs:16:5
-   |
-LL |     m! {
-   |     ^ ambiguous name
-   |
-   = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
-note: `m` could refer to the macro imported here
-  --> $DIR/macros.rs:18:13
-   |
-LL |         use foo::m;
-   |             ^^^^^^
-note: `m` could also refer to the macro imported here
-  --> $DIR/macros.rs:15:9
-   |
-LL |     use two_macros::*;
-   |         ^^^^^^^^^^^^^
-   = help: consider adding an explicit import of `m` to disambiguate
-
-error[E0659]: `m` is ambiguous
-  --> $DIR/macros.rs:30:9
+  --> $DIR/macros.rs:29:9
    |
 LL |         m! {
    |         ^ ambiguous name
    |
    = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro imported here
-  --> $DIR/macros.rs:31:17
+  --> $DIR/macros.rs:30:17
    |
 LL |             use two_macros::n as m;
    |                 ^^^^^^^^^^^^^^^^^^
 note: `m` could also refer to the macro imported here
-  --> $DIR/macros.rs:23:9
+  --> $DIR/macros.rs:22:9
    |
 LL |     use two_macros::m;
    |         ^^^^^^^^^^^^^
    = help: use `self::m` to refer to this macro unambiguously
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0659`.


### PR DESCRIPTION
if 2 errors of the kind and ident and span of the ident, b1, b2 and misc1 misc2 are the same we call these 2 ambiguity errors identical
prevent identical ambiguity error from pushing into vector of ambiguity_errors this will fix #105177