### PR TITLE
rustdoc: clean up margin CSS for scraped examples

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2009,7 +2009,6 @@ in storage.js
 
 .more-examples-toggle .hide-more {
 	margin-left: 25px;
-	margin-bottom: 5px;
 	cursor: pointer;
 }
 
@@ -2037,16 +2036,12 @@ in storage.js
 	height: 100%;
 }
 
-.more-scraped-examples .scraped-example {
-	margin-bottom: 20px;
-}
-
-.more-scraped-examples .scraped-example:last-child {
-	margin-bottom: 0;
-}
-
-.example-links a {
+.more-scraped-examples .scraped-example, .example-links {
 	margin-top: 20px;
+}
+
+.more-scraped-examples .scraped-example:first-child {
+	margin-top: 5px;
 }
 
 .example-links ul {


### PR DESCRIPTION
* This stops applying a margin to the additional example links. Because these links are `display: inline`, it doesn't actually do anything.
* This switches from using a margin-bottom with a special exception for the examples themselves, plus an additional margin on the hide button, to instead using just margin-top on the examples, with an exception for the first one.

No user-visible changes should result from this.