### PR TITLE
docs: add long error explanation for error E0472

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -248,6 +248,7 @@ E0464: include_str!("./error_codes/E0464.md"),
 E0466: include_str!("./error_codes/E0466.md"),
 E0468: include_str!("./error_codes/E0468.md"),
 E0469: include_str!("./error_codes/E0469.md"),
+E0472: include_str!("./error_codes/E0472.md"),
 E0477: include_str!("./error_codes/E0477.md"),
 E0478: include_str!("./error_codes/E0478.md"),
 E0482: include_str!("./error_codes/E0482.md"),
@@ -600,7 +601,6 @@ E0791: include_str!("./error_codes/E0791.md"),
 //  E0467, // removed
 //  E0470, // removed
 //  E0471, // constant evaluation error (in pattern)
-    E0472, // llvm_asm! is unsupported on this target
 //  E0473, // dereference of reference outside its lifetime
 //  E0474, // captured variable `..` does not outlive the enclosing closure
 //  E0475, // index of slice outside its lifetime

--- a/compiler/rustc_error_codes/src/error_codes/E0472.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0472.md
@@ -1,0 +1,31 @@
+Inline assembly (`asm!`) is not supported on this target.
+
+Example of erroneous code:
+
+```ignore (cannot-change-target)
+// compile-flags: --target sparc64-unknown-linux-gnu
+#![no_std]
+
+use core::arch::asm;
+
+fn main() {
+    unsafe {
+        asm!(""); // error: inline assembly is not supported on this target
+    }
+}
+```
+
+The Rust compiler does not support inline assembly, with the `asm!` macro
+(previously `llvm_asm!`), for all targets. All Tier 1 targets do support this
+macro but support among Tier 2 and 3 targets is not guaranteed (even when they
+have `std` support). Note that this error is related to
+`error[E0658]: inline assembly is not stable yet on this architecture`, but
+distinct in that with `E0472` support is not planned or in progress.
+
+There is no way to easily fix this issue, however:
+ * Consider if you really need inline assembly, is there some other way to
+   achieve your goal (intrinsics, etc)?
+ * Consider writing your assembly externally, linking with it and calling it
+   from Rust.
+ * Consider contributing to <https://github.com/rust-lang/rust> and help
+   integrate support for your target!

--- a/src/test/ui/asm/bad-arch.mirunsafeck.stderr
+++ b/src/test/ui/asm/bad-arch.mirunsafeck.stderr
@@ -14,3 +14,4 @@ LL | global_asm!("");
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0472`.

--- a/src/test/ui/asm/bad-arch.thirunsafeck.stderr
+++ b/src/test/ui/asm/bad-arch.thirunsafeck.stderr
@@ -14,3 +14,4 @@ LL | global_asm!("");
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0472`.


### PR DESCRIPTION
Add long-form error docs for E0472: "inline assembly not supported on this target" and update UI tests.

R? @GuillaumeGomez