### PR TITLE
Relax ordering rules for `asm!` operands

### DIFF
--- a/tests/ui/asm/aarch64/parse-error.rs
+++ b/tests/ui/asm/aarch64/parse-error.rs
@@ -37,8 +37,7 @@ fn main() {
         asm!("", options(nomem, foo));
         //~^ ERROR expected one of
         asm!("{}", options(), const foo);
-        //~^ ERROR arguments are not allowed after options
-        //~^^ ERROR attempt to use a non-constant value in a constant
+        //~^ ERROR attempt to use a non-constant value in a constant
         asm!("", clobber_abi(foo));
         //~^ ERROR expected string literal
         asm!("", clobber_abi("C" foo));
@@ -46,12 +45,10 @@ fn main() {
         asm!("", clobber_abi("C", foo));
         //~^ ERROR expected string literal
         asm!("{}", clobber_abi("C"), const foo);
-        //~^ ERROR arguments are not allowed after clobber_abi
-        //~^^ ERROR attempt to use a non-constant value in a constant
+        //~^ ERROR attempt to use a non-constant value in a constant
         asm!("", options(), clobber_abi("C"));
-        //~^ ERROR clobber_abi is not allowed after options
         asm!("{}", options(), clobber_abi("C"), const foo);
-        //~^ ERROR clobber_abi is not allowed after options
+        //~^ ERROR attempt to use a non-constant value in a constant
         asm!("{a}", a = const foo, a = const bar);
         //~^ ERROR duplicate argument named `a`
         //~^^ ERROR argument never used
@@ -60,11 +57,9 @@ fn main() {
         asm!("", a = in("x0") foo);
         //~^ ERROR explicit register arguments cannot have names
         asm!("{a}", in("x0") foo, a = const bar);
-        //~^ ERROR named arguments cannot follow explicit register arguments
-        //~^^ ERROR attempt to use a non-constant value in a constant
+        //~^ ERROR attempt to use a non-constant value in a constant
         asm!("{a}", in("x0") foo, a = const bar);
-        //~^ ERROR named arguments cannot follow explicit register arguments
-        //~^^ ERROR attempt to use a non-constant value in a constant
+        //~^ ERROR attempt to use a non-constant value in a constant
         asm!("{1}", in("x0") foo, const bar);
         //~^ ERROR positional arguments cannot follow named arguments or explicit register arguments
         //~^^ ERROR attempt to use a non-constant value in a constant
@@ -106,7 +101,6 @@ global_asm!("", options(nomem FOO));
 global_asm!("", options(nomem, FOO));
 //~^ ERROR expected one of
 global_asm!("{}", options(), const FOO);
-//~^ ERROR arguments are not allowed after options
 global_asm!("", clobber_abi(FOO));
 //~^ ERROR expected string literal
 global_asm!("", clobber_abi("C" FOO));
@@ -114,12 +108,11 @@ global_asm!("", clobber_abi("C" FOO));
 global_asm!("", clobber_abi("C", FOO));
 //~^ ERROR expected string literal
 global_asm!("{}", clobber_abi("C"), const FOO);
-//~^ ERROR arguments are not allowed after clobber_abi
-//~^^ ERROR `clobber_abi` cannot be used with `global_asm!`
+//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
 global_asm!("", options(), clobber_abi("C"));
-//~^ ERROR clobber_abi is not allowed after options
+//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
 global_asm!("{}", options(), clobber_abi("C"), const FOO);
-//~^ ERROR clobber_abi is not allowed after options
+//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
 global_asm!("{a}", a = const FOO, a = const BAR);
 //~^ ERROR duplicate argument named `a`
 //~^^ ERROR argument never used

--- a/tests/ui/asm/aarch64/parse-error.stderr
+++ b/tests/ui/asm/aarch64/parse-error.stderr
@@ -82,58 +82,26 @@ error: expected one of `)`, `att_syntax`, `may_unwind`, `nomem`, `noreturn`, `no
 LL |         asm!("", options(nomem, foo));
    |                                 ^^^ expected one of 10 possible tokens
 
-error: arguments are not allowed after options
-  --> $DIR/parse-error.rs:39:31
-   |
-LL |         asm!("{}", options(), const foo);
-   |                    ---------  ^^^^^^^^^ argument
-   |                    |
-   |                    previous options
-
 error: expected string literal
-  --> $DIR/parse-error.rs:42:30
+  --> $DIR/parse-error.rs:41:30
    |
 LL |         asm!("", clobber_abi(foo));
    |                              ^^^ not a string literal
 
 error: expected one of `)` or `,`, found `foo`
-  --> $DIR/parse-error.rs:44:34
+  --> $DIR/parse-error.rs:43:34
    |
 LL |         asm!("", clobber_abi("C" foo));
    |                                  ^^^ expected one of `)` or `,`
 
 error: expected string literal
-  --> $DIR/parse-error.rs:46:35
+  --> $DIR/parse-error.rs:45:35
    |
 LL |         asm!("", clobber_abi("C", foo));
    |                                   ^^^ not a string literal
 
-error: arguments are not allowed after clobber_abi
-  --> $DIR/parse-error.rs:48:38
-   |
-LL |         asm!("{}", clobber_abi("C"), const foo);
-   |                    ----------------  ^^^^^^^^^ argument
-   |                    |
-   |                    clobber_abi
-
-error: clobber_abi is not allowed after options
-  --> $DIR/parse-error.rs:51:29
-   |
-LL |         asm!("", options(), clobber_abi("C"));
-   |                  ---------  ^^^^^^^^^^^^^^^^
-   |                  |
-   |                  options
-
-error: clobber_abi is not allowed after options
-  --> $DIR/parse-error.rs:53:31
-   |
-LL |         asm!("{}", options(), clobber_abi("C"), const foo);
-   |                    ---------  ^^^^^^^^^^^^^^^^
-   |                    |
-   |                    options
-
 error: duplicate argument named `a`
-  --> $DIR/parse-error.rs:55:36
+  --> $DIR/parse-error.rs:52:36
    |
 LL |         asm!("{a}", a = const foo, a = const bar);
    |                     -------------  ^^^^^^^^^^^^^ duplicate argument
@@ -141,7 +109,7 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    |                     previously here
 
 error: argument never used
-  --> $DIR/parse-error.rs:55:36
+  --> $DIR/parse-error.rs:52:36
    |
 LL |         asm!("{a}", a = const foo, a = const bar);
    |                                    ^^^^^^^^^^^^^ argument never used
@@ -149,29 +117,13 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {1} */"`
 
 error: explicit register arguments cannot have names
-  --> $DIR/parse-error.rs:60:18
+  --> $DIR/parse-error.rs:57:18
    |
 LL |         asm!("", a = in("x0") foo);
    |                  ^^^^^^^^^^^^^^^^
 
-error: named arguments cannot follow explicit register arguments
-  --> $DIR/parse-error.rs:62:35
-   |
-LL |         asm!("{a}", in("x0") foo, a = const bar);
-   |                     ------------  ^^^^^^^^^^^^^ named argument
-   |                     |
-   |                     explicit register argument
-
-error: named arguments cannot follow explicit register arguments
-  --> $DIR/parse-error.rs:65:35
-   |
-LL |         asm!("{a}", in("x0") foo, a = const bar);
-   |                     ------------  ^^^^^^^^^^^^^ named argument
-   |                     |
-   |                     explicit register argument
-
 error: positional arguments cannot follow named arguments or explicit register arguments
-  --> $DIR/parse-error.rs:68:35
+  --> $DIR/parse-error.rs:63:35
    |
 LL |         asm!("{1}", in("x0") foo, const bar);
    |                     ------------  ^^^^^^^^^ positional argument
@@ -179,19 +131,19 @@ LL |         asm!("{1}", in("x0") foo, const bar);
    |                     explicit register argument
 
 error: expected one of `clobber_abi`, `const`, `in`, `inlateout`, `inout`, `lateout`, `options`, `out`, or `sym`, found `""`
-  --> $DIR/parse-error.rs:71:29
+  --> $DIR/parse-error.rs:66:29
    |
 LL |         asm!("", options(), "");
    |                             ^^ expected one of 9 possible tokens
 
 error: expected one of `clobber_abi`, `const`, `in`, `inlateout`, `inout`, `lateout`, `options`, `out`, or `sym`, found `"{}"`
-  --> $DIR/parse-error.rs:73:33
+  --> $DIR/parse-error.rs:68:33
    |
 LL |         asm!("{}", in(reg) foo, "{}", out(reg) foo);
    |                                 ^^^^ expected one of 9 possible tokens
 
 error: asm template must be a string literal
-  --> $DIR/parse-error.rs:75:14
+  --> $DIR/parse-error.rs:70:14
    |
 LL |         asm!(format!("{{{}}}", 0), in(reg) foo);
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -199,7 +151,7 @@ LL |         asm!(format!("{{{}}}", 0), in(reg) foo);
    = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm template must be a string literal
-  --> $DIR/parse-error.rs:77:21
+  --> $DIR/parse-error.rs:72:21
    |
 LL |         asm!("{1}", format!("{{{}}}", 0), in(reg) foo, out(reg) bar);
    |                     ^^^^^^^^^^^^^^^^^^^^
@@ -207,135 +159,115 @@ LL |         asm!("{1}", format!("{{{}}}", 0), in(reg) foo, out(reg) bar);
    = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: _ cannot be used for input operands
-  --> $DIR/parse-error.rs:79:28
+  --> $DIR/parse-error.rs:74:28
    |
 LL |         asm!("{}", in(reg) _);
    |                            ^
 
 error: _ cannot be used for input operands
-  --> $DIR/parse-error.rs:81:31
+  --> $DIR/parse-error.rs:76:31
    |
 LL |         asm!("{}", inout(reg) _);
    |                               ^
 
 error: _ cannot be used for input operands
-  --> $DIR/parse-error.rs:83:35
+  --> $DIR/parse-error.rs:78:35
    |
 LL |         asm!("{}", inlateout(reg) _);
    |                                   ^
 
 error: requires at least a template string argument
-  --> $DIR/parse-error.rs:90:1
+  --> $DIR/parse-error.rs:85:1
    |
 LL | global_asm!();
    | ^^^^^^^^^^^^^
 
 error: asm template must be a string literal
-  --> $DIR/parse-error.rs:92:13
+  --> $DIR/parse-error.rs:87:13
    |
 LL | global_asm!(FOO);
    |             ^^^
 
 error: expected token: `,`
-  --> $DIR/parse-error.rs:94:18
+  --> $DIR/parse-error.rs:89:18
    |
 LL | global_asm!("{}" FOO);
    |                  ^^^ expected `,`
 
 error: expected operand, options, or additional template string
-  --> $DIR/parse-error.rs:96:19
+  --> $DIR/parse-error.rs:91:19
    |
 LL | global_asm!("{}", FOO);
    |                   ^^^ expected operand, options, or additional template string
 
 error: expected expression, found end of macro arguments
-  --> $DIR/parse-error.rs:98:24
+  --> $DIR/parse-error.rs:93:24
    |
 LL | global_asm!("{}", const);
    |                        ^ expected expression
 
 error: expected one of `,`, `.`, `?`, or an operator, found `FOO`
-  --> $DIR/parse-error.rs:100:30
+  --> $DIR/parse-error.rs:95:30
    |
 LL | global_asm!("{}", const(reg) FOO);
    |                              ^^^ expected one of `,`, `.`, `?`, or an operator
 
 error: expected one of `)`, `att_syntax`, or `raw`, found `FOO`
-  --> $DIR/parse-error.rs:102:25
+  --> $DIR/parse-error.rs:97:25
    |
 LL | global_asm!("", options(FOO));
    |                         ^^^ expected one of `)`, `att_syntax`, or `raw`
 
 error: expected one of `)`, `att_syntax`, or `raw`, found `nomem`
-  --> $DIR/parse-error.rs:104:25
+  --> $DIR/parse-error.rs:99:25
    |
 LL | global_asm!("", options(nomem FOO));
    |                         ^^^^^ expected one of `)`, `att_syntax`, or `raw`
 
 error: expected one of `)`, `att_syntax`, or `raw`, found `nomem`
-  --> $DIR/parse-error.rs:106:25
+  --> $DIR/parse-error.rs:101:25
    |
 LL | global_asm!("", options(nomem, FOO));
    |                         ^^^^^ expected one of `)`, `att_syntax`, or `raw`
 
-error: arguments are not allowed after options
-  --> $DIR/parse-error.rs:108:30
-   |
-LL | global_asm!("{}", options(), const FOO);
-   |                   ---------  ^^^^^^^^^ argument
-   |                   |
-   |                   previous options
-
 error: expected string literal
-  --> $DIR/parse-error.rs:110:29
+  --> $DIR/parse-error.rs:104:29
    |
 LL | global_asm!("", clobber_abi(FOO));
    |                             ^^^ not a string literal
 
 error: expected one of `)` or `,`, found `FOO`
-  --> $DIR/parse-error.rs:112:33
+  --> $DIR/parse-error.rs:106:33
    |
 LL | global_asm!("", clobber_abi("C" FOO));
    |                                 ^^^ expected one of `)` or `,`
 
 error: expected string literal
-  --> $DIR/parse-error.rs:114:34
+  --> $DIR/parse-error.rs:108:34
    |
 LL | global_asm!("", clobber_abi("C", FOO));
    |                                  ^^^ not a string literal
 
-error: arguments are not allowed after clobber_abi
-  --> $DIR/parse-error.rs:116:37
-   |
-LL | global_asm!("{}", clobber_abi("C"), const FOO);
-   |                   ----------------  ^^^^^^^^^ argument
-   |                   |
-   |                   clobber_abi
-
 error: `clobber_abi` cannot be used with `global_asm!`
-  --> $DIR/parse-error.rs:116:19
+  --> $DIR/parse-error.rs:110:19
    |
 LL | global_asm!("{}", clobber_abi("C"), const FOO);
    |                   ^^^^^^^^^^^^^^^^
 
-error: clobber_abi is not allowed after options
-  --> $DIR/parse-error.rs:119:28
+error: `clobber_abi` cannot be used with `global_asm!`
+  --> $DIR/parse-error.rs:112:28
    |
 LL | global_asm!("", options(), clobber_abi("C"));
-   |                 ---------  ^^^^^^^^^^^^^^^^
-   |                 |
-   |                 options
+   |                            ^^^^^^^^^^^^^^^^
 
-error: clobber_abi is not allowed after options
-  --> $DIR/parse-error.rs:121:30
+error: `clobber_abi` cannot be used with `global_asm!`
+  --> $DIR/parse-error.rs:114:30
    |
 LL | global_asm!("{}", options(), clobber_abi("C"), const FOO);
-   |                   ---------  ^^^^^^^^^^^^^^^^
-   |                   |
-   |                   options
+   |                              ^^^^^^^^^^^^^^^^
 
 error: duplicate argument named `a`
-  --> $DIR/parse-error.rs:123:35
+  --> $DIR/parse-error.rs:116:35
    |
 LL | global_asm!("{a}", a = const FOO, a = const BAR);
    |                    -------------  ^^^^^^^^^^^^^ duplicate argument
@@ -343,7 +275,7 @@ LL | global_asm!("{a}", a = const FOO, a = const BAR);
    |                    previously here
 
 error: argument never used
-  --> $DIR/parse-error.rs:123:35
+  --> $DIR/parse-error.rs:116:35
    |
 LL | global_asm!("{a}", a = const FOO, a = const BAR);
    |                                   ^^^^^^^^^^^^^ argument never used
@@ -351,19 +283,19 @@ LL | global_asm!("{a}", a = const FOO, a = const BAR);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {1} */"`
 
 error: expected one of `clobber_abi`, `const`, `options`, or `sym`, found `""`
-  --> $DIR/parse-error.rs:126:28
+  --> $DIR/parse-error.rs:119:28
    |
 LL | global_asm!("", options(), "");
    |                            ^^ expected one of `clobber_abi`, `const`, `options`, or `sym`
 
 error: expected one of `clobber_abi`, `const`, `options`, or `sym`, found `"{}"`
-  --> $DIR/parse-error.rs:128:30
+  --> $DIR/parse-error.rs:121:30
    |
 LL | global_asm!("{}", const FOO, "{}", const FOO);
    |                              ^^^^ expected one of `clobber_abi`, `const`, `options`, or `sym`
 
 error: asm template must be a string literal
-  --> $DIR/parse-error.rs:130:13
+  --> $DIR/parse-error.rs:123:13
    |
 LL | global_asm!(format!("{{{}}}", 0), const FOO);
    |             ^^^^^^^^^^^^^^^^^^^^
@@ -371,7 +303,7 @@ LL | global_asm!(format!("{{{}}}", 0), const FOO);
    = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm template must be a string literal
-  --> $DIR/parse-error.rs:132:20
+  --> $DIR/parse-error.rs:125:20
    |
 LL | global_asm!("{1}", format!("{{{}}}", 0), const FOO, const BAR);
    |                    ^^^^^^^^^^^^^^^^^^^^
@@ -388,7 +320,7 @@ LL |         asm!("{}", options(), const foo);
    |                                     ^^^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:48:44
+  --> $DIR/parse-error.rs:47:44
    |
 LL |     let mut foo = 0;
    |     ----------- help: consider using `const` instead of `let`: `const foo`
@@ -397,7 +329,16 @@ LL |         asm!("{}", clobber_abi("C"), const foo);
    |                                            ^^^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:55:31
+  --> $DIR/parse-error.rs:50:55
+   |
+LL |     let mut foo = 0;
+   |     ----------- help: consider using `const` instead of `let`: `const foo`
+...
+LL |         asm!("{}", options(), clobber_abi("C"), const foo);
+   |                                                       ^^^ non-constant value
+
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/parse-error.rs:52:31
    |
 LL |     let mut foo = 0;
    |     ----------- help: consider using `const` instead of `let`: `const foo`
@@ -406,7 +347,7 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    |                               ^^^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:55:46
+  --> $DIR/parse-error.rs:52:46
    |
 LL |     let mut bar = 0;
    |     ----------- help: consider using `const` instead of `let`: `const bar`
@@ -415,7 +356,7 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    |                                              ^^^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:62:45
+  --> $DIR/parse-error.rs:59:45
    |
 LL |     let mut bar = 0;
    |     ----------- help: consider using `const` instead of `let`: `const bar`
@@ -424,7 +365,7 @@ LL |         asm!("{a}", in("x0") foo, a = const bar);
    |                                             ^^^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:65:45
+  --> $DIR/parse-error.rs:61:45
    |
 LL |     let mut bar = 0;
    |     ----------- help: consider using `const` instead of `let`: `const bar`
@@ -433,7 +374,7 @@ LL |         asm!("{a}", in("x0") foo, a = const bar);
    |                                             ^^^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:68:41
+  --> $DIR/parse-error.rs:63:41
    |
 LL |     let mut bar = 0;
    |     ----------- help: consider using `const` instead of `let`: `const bar`
@@ -441,6 +382,6 @@ LL |     let mut bar = 0;
 LL |         asm!("{1}", in("x0") foo, const bar);
    |                                         ^^^ non-constant value
 
-error: aborting due to 64 previous errors
+error: aborting due to 57 previous errors
 
 For more information about this error, try `rustc --explain E0435`.

--- a/tests/ui/asm/bad-template.aarch64_mirunsafeck.stderr
+++ b/tests/ui/asm/bad-template.aarch64_mirunsafeck.stderr
@@ -81,6 +81,11 @@ note: explicit register arguments cannot be used in the asm template
    |
 LL |         asm!("{}", in("x0") foo);
    |                    ^^^^^^^^^^^^
+help: use the register name directly in the assembly code
+  --> $DIR/bad-template.rs:48:20
+   |
+LL |         asm!("{}", in("x0") foo);
+   |                    ^^^^^^^^^^^^
 
 error: asm template modifier must be a single character
   --> $DIR/bad-template.rs:50:17

--- a/tests/ui/asm/bad-template.aarch64_thirunsafeck.stderr
+++ b/tests/ui/asm/bad-template.aarch64_thirunsafeck.stderr
@@ -81,6 +81,11 @@ note: explicit register arguments cannot be used in the asm template
    |
 LL |         asm!("{}", in("x0") foo);
    |                    ^^^^^^^^^^^^
+help: use the register name directly in the assembly code
+  --> $DIR/bad-template.rs:48:20
+   |
+LL |         asm!("{}", in("x0") foo);
+   |                    ^^^^^^^^^^^^
 
 error: asm template modifier must be a single character
   --> $DIR/bad-template.rs:50:17

--- a/tests/ui/asm/bad-template.x86_64_mirunsafeck.stderr
+++ b/tests/ui/asm/bad-template.x86_64_mirunsafeck.stderr
@@ -81,6 +81,11 @@ note: explicit register arguments cannot be used in the asm template
    |
 LL |         asm!("{}", in("eax") foo);
    |                    ^^^^^^^^^^^^^
+help: use the register name directly in the assembly code
+  --> $DIR/bad-template.rs:45:20
+   |
+LL |         asm!("{}", in("eax") foo);
+   |                    ^^^^^^^^^^^^^
 
 error: asm template modifier must be a single character
   --> $DIR/bad-template.rs:50:17

--- a/tests/ui/asm/bad-template.x86_64_thirunsafeck.stderr
+++ b/tests/ui/asm/bad-template.x86_64_thirunsafeck.stderr
@@ -81,6 +81,11 @@ note: explicit register arguments cannot be used in the asm template
    |
 LL |         asm!("{}", in("eax") foo);
    |                    ^^^^^^^^^^^^^
+help: use the register name directly in the assembly code
+  --> $DIR/bad-template.rs:45:20
+   |
+LL |         asm!("{}", in("eax") foo);
+   |                    ^^^^^^^^^^^^^
 
 error: asm template modifier must be a single character
   --> $DIR/bad-template.rs:50:17

--- a/tests/ui/asm/x86_64/parse-error.rs
+++ b/tests/ui/asm/x86_64/parse-error.rs
@@ -37,8 +37,7 @@ fn main() {
         asm!("", options(nomem, foo));
         //~^ ERROR expected one of
         asm!("{}", options(), const foo);
-        //~^ ERROR arguments are not allowed after options
-        //~^^ ERROR attempt to use a non-constant value in a constant
+        //~^ ERROR attempt to use a non-constant value in a constant
         asm!("", clobber_abi());
         //~^ ERROR at least one abi must be provided
         asm!("", clobber_abi(foo));
@@ -48,12 +47,10 @@ fn main() {
         asm!("", clobber_abi("C", foo));
         //~^ ERROR expected string literal
         asm!("{}", clobber_abi("C"), const foo);
-        //~^ ERROR arguments are not allowed after clobber_abi
-        //~^^ ERROR attempt to use a non-constant value in a constant
+        //~^ ERROR attempt to use a non-constant value in a constant
         asm!("", options(), clobber_abi("C"));
-        //~^ ERROR clobber_abi is not allowed after options
         asm!("{}", options(), clobber_abi("C"), const foo);
-        //~^ ERROR clobber_abi is not allowed after options
+        //~^ ERROR attempt to use a non-constant value in a constant
         asm!("{a}", a = const foo, a = const bar);
         //~^ ERROR duplicate argument named `a`
         //~^^ ERROR argument never used
@@ -62,11 +59,9 @@ fn main() {
         asm!("", a = in("eax") foo);
         //~^ ERROR explicit register arguments cannot have names
         asm!("{a}", in("eax") foo, a = const bar);
-        //~^ ERROR named arguments cannot follow explicit register arguments
-        //~^^ ERROR attempt to use a non-constant value in a constant
+        //~^ ERROR attempt to use a non-constant value in a constant
         asm!("{a}", in("eax") foo, a = const bar);
-        //~^ ERROR named arguments cannot follow explicit register arguments
-        //~^^ ERROR attempt to use a non-constant value in a constant
+        //~^ ERROR attempt to use a non-constant value in a constant
         asm!("{1}", in("eax") foo, const bar);
         //~^ ERROR positional arguments cannot follow named arguments or explicit register arguments
         //~^^ ERROR attempt to use a non-constant value in a constant
@@ -108,7 +103,6 @@ global_asm!("", options(nomem FOO));
 global_asm!("", options(nomem, FOO));
 //~^ ERROR expected one of
 global_asm!("{}", options(), const FOO);
-//~^ ERROR arguments are not allowed after options
 global_asm!("", clobber_abi(FOO));
 //~^ ERROR expected string literal
 global_asm!("", clobber_abi("C" FOO));
@@ -116,12 +110,11 @@ global_asm!("", clobber_abi("C" FOO));
 global_asm!("", clobber_abi("C", FOO));
 //~^ ERROR expected string literal
 global_asm!("{}", clobber_abi("C"), const FOO);
-//~^ ERROR arguments are not allowed after clobber_abi
-//~^^ ERROR `clobber_abi` cannot be used with `global_asm!`
+//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
 global_asm!("", options(), clobber_abi("C"));
-//~^ ERROR clobber_abi is not allowed after options
+//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
 global_asm!("{}", options(), clobber_abi("C"), const FOO);
-//~^ ERROR clobber_abi is not allowed after options
+//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
 global_asm!("", clobber_abi("C"), clobber_abi("C"));
 //~^ ERROR `clobber_abi` cannot be used with `global_asm!`
 global_asm!("{a}", a = const FOO, a = const BAR);

--- a/tests/ui/asm/x86_64/parse-error.stderr
+++ b/tests/ui/asm/x86_64/parse-error.stderr
@@ -82,64 +82,32 @@ error: expected one of `)`, `att_syntax`, `may_unwind`, `nomem`, `noreturn`, `no
 LL |         asm!("", options(nomem, foo));
    |                                 ^^^ expected one of 10 possible tokens
 
-error: arguments are not allowed after options
-  --> $DIR/parse-error.rs:39:31
-   |
-LL |         asm!("{}", options(), const foo);
-   |                    ---------  ^^^^^^^^^ argument
-   |                    |
-   |                    previous options
-
 error: at least one abi must be provided as an argument to `clobber_abi`
-  --> $DIR/parse-error.rs:42:30
+  --> $DIR/parse-error.rs:41:30
    |
 LL |         asm!("", clobber_abi());
    |                              ^
 
 error: expected string literal
-  --> $DIR/parse-error.rs:44:30
+  --> $DIR/parse-error.rs:43:30
    |
 LL |         asm!("", clobber_abi(foo));
    |                              ^^^ not a string literal
 
 error: expected one of `)` or `,`, found `foo`
-  --> $DIR/parse-error.rs:46:34
+  --> $DIR/parse-error.rs:45:34
    |
 LL |         asm!("", clobber_abi("C" foo));
    |                                  ^^^ expected one of `)` or `,`
 
 error: expected string literal
-  --> $DIR/parse-error.rs:48:35
+  --> $DIR/parse-error.rs:47:35
    |
 LL |         asm!("", clobber_abi("C", foo));
    |                                   ^^^ not a string literal
 
-error: arguments are not allowed after clobber_abi
-  --> $DIR/parse-error.rs:50:38
-   |
-LL |         asm!("{}", clobber_abi("C"), const foo);
-   |                    ----------------  ^^^^^^^^^ argument
-   |                    |
-   |                    clobber_abi
-
-error: clobber_abi is not allowed after options
-  --> $DIR/parse-error.rs:53:29
-   |
-LL |         asm!("", options(), clobber_abi("C"));
-   |                  ---------  ^^^^^^^^^^^^^^^^
-   |                  |
-   |                  options
-
-error: clobber_abi is not allowed after options
-  --> $DIR/parse-error.rs:55:31
-   |
-LL |         asm!("{}", options(), clobber_abi("C"), const foo);
-   |                    ---------  ^^^^^^^^^^^^^^^^
-   |                    |
-   |                    options
-
 error: duplicate argument named `a`
-  --> $DIR/parse-error.rs:57:36
+  --> $DIR/parse-error.rs:54:36
    |
 LL |         asm!("{a}", a = const foo, a = const bar);
    |                     -------------  ^^^^^^^^^^^^^ duplicate argument
@@ -147,7 +115,7 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    |                     previously here
 
 error: argument never used
-  --> $DIR/parse-error.rs:57:36
+  --> $DIR/parse-error.rs:54:36
    |
 LL |         asm!("{a}", a = const foo, a = const bar);
    |                                    ^^^^^^^^^^^^^ argument never used
@@ -155,29 +123,13 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {1} */"`
 
 error: explicit register arguments cannot have names
-  --> $DIR/parse-error.rs:62:18
+  --> $DIR/parse-error.rs:59:18
    |
 LL |         asm!("", a = in("eax") foo);
    |                  ^^^^^^^^^^^^^^^^^
 
-error: named arguments cannot follow explicit register arguments
-  --> $DIR/parse-error.rs:64:36
-   |
-LL |         asm!("{a}", in("eax") foo, a = const bar);
-   |                     -------------  ^^^^^^^^^^^^^ named argument
-   |                     |
-   |                     explicit register argument
-
-error: named arguments cannot follow explicit register arguments
-  --> $DIR/parse-error.rs:67:36
-   |
-LL |         asm!("{a}", in("eax") foo, a = const bar);
-   |                     -------------  ^^^^^^^^^^^^^ named argument
-   |                     |
-   |                     explicit register argument
-
 error: positional arguments cannot follow named arguments or explicit register arguments
-  --> $DIR/parse-error.rs:70:36
+  --> $DIR/parse-error.rs:65:36
    |
 LL |         asm!("{1}", in("eax") foo, const bar);
    |                     -------------  ^^^^^^^^^ positional argument
@@ -185,19 +137,19 @@ LL |         asm!("{1}", in("eax") foo, const bar);
    |                     explicit register argument
 
 error: expected one of `clobber_abi`, `const`, `in`, `inlateout`, `inout`, `lateout`, `options`, `out`, or `sym`, found `""`
-  --> $DIR/parse-error.rs:73:29
+  --> $DIR/parse-error.rs:68:29
    |
 LL |         asm!("", options(), "");
    |                             ^^ expected one of 9 possible tokens
 
 error: expected one of `clobber_abi`, `const`, `in`, `inlateout`, `inout`, `lateout`, `options`, `out`, or `sym`, found `"{}"`
-  --> $DIR/parse-error.rs:75:33
+  --> $DIR/parse-error.rs:70:33
    |
 LL |         asm!("{}", in(reg) foo, "{}", out(reg) foo);
    |                                 ^^^^ expected one of 9 possible tokens
 
 error: asm template must be a string literal
-  --> $DIR/parse-error.rs:77:14
+  --> $DIR/parse-error.rs:72:14
    |
 LL |         asm!(format!("{{{}}}", 0), in(reg) foo);
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -205,7 +157,7 @@ LL |         asm!(format!("{{{}}}", 0), in(reg) foo);
    = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm template must be a string literal
-  --> $DIR/parse-error.rs:79:21
+  --> $DIR/parse-error.rs:74:21
    |
 LL |         asm!("{1}", format!("{{{}}}", 0), in(reg) foo, out(reg) bar);
    |                     ^^^^^^^^^^^^^^^^^^^^
@@ -213,141 +165,121 @@ LL |         asm!("{1}", format!("{{{}}}", 0), in(reg) foo, out(reg) bar);
    = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: _ cannot be used for input operands
-  --> $DIR/parse-error.rs:81:28
+  --> $DIR/parse-error.rs:76:28
    |
 LL |         asm!("{}", in(reg) _);
    |                            ^
 
 error: _ cannot be used for input operands
-  --> $DIR/parse-error.rs:83:31
+  --> $DIR/parse-error.rs:78:31
    |
 LL |         asm!("{}", inout(reg) _);
    |                               ^
 
 error: _ cannot be used for input operands
-  --> $DIR/parse-error.rs:85:35
+  --> $DIR/parse-error.rs:80:35
    |
 LL |         asm!("{}", inlateout(reg) _);
    |                                   ^
 
 error: requires at least a template string argument
-  --> $DIR/parse-error.rs:92:1
+  --> $DIR/parse-error.rs:87:1
    |
 LL | global_asm!();
    | ^^^^^^^^^^^^^
 
 error: asm template must be a string literal
-  --> $DIR/parse-error.rs:94:13
+  --> $DIR/parse-error.rs:89:13
    |
 LL | global_asm!(FOO);
    |             ^^^
 
 error: expected token: `,`
-  --> $DIR/parse-error.rs:96:18
+  --> $DIR/parse-error.rs:91:18
    |
 LL | global_asm!("{}" FOO);
    |                  ^^^ expected `,`
 
 error: expected operand, options, or additional template string
-  --> $DIR/parse-error.rs:98:19
+  --> $DIR/parse-error.rs:93:19
    |
 LL | global_asm!("{}", FOO);
    |                   ^^^ expected operand, options, or additional template string
 
 error: expected expression, found end of macro arguments
-  --> $DIR/parse-error.rs:100:24
+  --> $DIR/parse-error.rs:95:24
    |
 LL | global_asm!("{}", const);
    |                        ^ expected expression
 
 error: expected one of `,`, `.`, `?`, or an operator, found `FOO`
-  --> $DIR/parse-error.rs:102:30
+  --> $DIR/parse-error.rs:97:30
    |
 LL | global_asm!("{}", const(reg) FOO);
    |                              ^^^ expected one of `,`, `.`, `?`, or an operator
 
 error: expected one of `)`, `att_syntax`, or `raw`, found `FOO`
-  --> $DIR/parse-error.rs:104:25
+  --> $DIR/parse-error.rs:99:25
    |
 LL | global_asm!("", options(FOO));
    |                         ^^^ expected one of `)`, `att_syntax`, or `raw`
 
 error: expected one of `)`, `att_syntax`, or `raw`, found `nomem`
-  --> $DIR/parse-error.rs:106:25
+  --> $DIR/parse-error.rs:101:25
    |
 LL | global_asm!("", options(nomem FOO));
    |                         ^^^^^ expected one of `)`, `att_syntax`, or `raw`
 
 error: expected one of `)`, `att_syntax`, or `raw`, found `nomem`
-  --> $DIR/parse-error.rs:108:25
+  --> $DIR/parse-error.rs:103:25
    |
 LL | global_asm!("", options(nomem, FOO));
    |                         ^^^^^ expected one of `)`, `att_syntax`, or `raw`
 
-error: arguments are not allowed after options
-  --> $DIR/parse-error.rs:110:30
-   |
-LL | global_asm!("{}", options(), const FOO);
-   |                   ---------  ^^^^^^^^^ argument
-   |                   |
-   |                   previous options
-
 error: expected string literal
-  --> $DIR/parse-error.rs:112:29
+  --> $DIR/parse-error.rs:106:29
    |
 LL | global_asm!("", clobber_abi(FOO));
    |                             ^^^ not a string literal
 
 error: expected one of `)` or `,`, found `FOO`
-  --> $DIR/parse-error.rs:114:33
+  --> $DIR/parse-error.rs:108:33
    |
 LL | global_asm!("", clobber_abi("C" FOO));
    |                                 ^^^ expected one of `)` or `,`
 
 error: expected string literal
-  --> $DIR/parse-error.rs:116:34
+  --> $DIR/parse-error.rs:110:34
    |
 LL | global_asm!("", clobber_abi("C", FOO));
    |                                  ^^^ not a string literal
 
-error: arguments are not allowed after clobber_abi
-  --> $DIR/parse-error.rs:118:37
-   |
-LL | global_asm!("{}", clobber_abi("C"), const FOO);
-   |                   ----------------  ^^^^^^^^^ argument
-   |                   |
-   |                   clobber_abi
-
 error: `clobber_abi` cannot be used with `global_asm!`
-  --> $DIR/parse-error.rs:118:19
+  --> $DIR/parse-error.rs:112:19
    |
 LL | global_asm!("{}", clobber_abi("C"), const FOO);
    |                   ^^^^^^^^^^^^^^^^
 
-error: clobber_abi is not allowed after options
-  --> $DIR/parse-error.rs:121:28
+error: `clobber_abi` cannot be used with `global_asm!`
+  --> $DIR/parse-error.rs:114:28
    |
 LL | global_asm!("", options(), clobber_abi("C"));
-   |                 ---------  ^^^^^^^^^^^^^^^^
-   |                 |
-   |                 options
-
-error: clobber_abi is not allowed after options
-  --> $DIR/parse-error.rs:123:30
-   |
-LL | global_asm!("{}", options(), clobber_abi("C"), const FOO);
-   |                   ---------  ^^^^^^^^^^^^^^^^
-   |                   |
-   |                   options
+   |                            ^^^^^^^^^^^^^^^^
 
 error: `clobber_abi` cannot be used with `global_asm!`
-  --> $DIR/parse-error.rs:125:17
+  --> $DIR/parse-error.rs:116:30
+   |
+LL | global_asm!("{}", options(), clobber_abi("C"), const FOO);
+   |                              ^^^^^^^^^^^^^^^^
+
+error: `clobber_abi` cannot be used with `global_asm!`
+  --> $DIR/parse-error.rs:118:17
    |
 LL | global_asm!("", clobber_abi("C"), clobber_abi("C"));
    |                 ^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^
 
 error: duplicate argument named `a`
-  --> $DIR/parse-error.rs:127:35
+  --> $DIR/parse-error.rs:120:35
    |
 LL | global_asm!("{a}", a = const FOO, a = const BAR);
    |                    -------------  ^^^^^^^^^^^^^ duplicate argument
@@ -355,7 +287,7 @@ LL | global_asm!("{a}", a = const FOO, a = const BAR);
    |                    previously here
 
 error: argument never used
-  --> $DIR/parse-error.rs:127:35
+  --> $DIR/parse-error.rs:120:35
    |
 LL | global_asm!("{a}", a = const FOO, a = const BAR);
    |                                   ^^^^^^^^^^^^^ argument never used
@@ -363,19 +295,19 @@ LL | global_asm!("{a}", a = const FOO, a = const BAR);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {1} */"`
 
 error: expected one of `clobber_abi`, `const`, `options`, or `sym`, found `""`
-  --> $DIR/parse-error.rs:130:28
+  --> $DIR/parse-error.rs:123:28
    |
 LL | global_asm!("", options(), "");
    |                            ^^ expected one of `clobber_abi`, `const`, `options`, or `sym`
 
 error: expected one of `clobber_abi`, `const`, `options`, or `sym`, found `"{}"`
-  --> $DIR/parse-error.rs:132:30
+  --> $DIR/parse-error.rs:125:30
    |
 LL | global_asm!("{}", const FOO, "{}", const FOO);
    |                              ^^^^ expected one of `clobber_abi`, `const`, `options`, or `sym`
 
 error: asm template must be a string literal
-  --> $DIR/parse-error.rs:134:13
+  --> $DIR/parse-error.rs:127:13
    |
 LL | global_asm!(format!("{{{}}}", 0), const FOO);
    |             ^^^^^^^^^^^^^^^^^^^^
@@ -383,7 +315,7 @@ LL | global_asm!(format!("{{{}}}", 0), const FOO);
    = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm template must be a string literal
-  --> $DIR/parse-error.rs:136:20
+  --> $DIR/parse-error.rs:129:20
    |
 LL | global_asm!("{1}", format!("{{{}}}", 0), const FOO, const BAR);
    |                    ^^^^^^^^^^^^^^^^^^^^
@@ -400,7 +332,7 @@ LL |         asm!("{}", options(), const foo);
    |                                     ^^^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:50:44
+  --> $DIR/parse-error.rs:49:44
    |
 LL |     let mut foo = 0;
    |     ----------- help: consider using `const` instead of `let`: `const foo`
@@ -409,7 +341,16 @@ LL |         asm!("{}", clobber_abi("C"), const foo);
    |                                            ^^^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:57:31
+  --> $DIR/parse-error.rs:52:55
+   |
+LL |     let mut foo = 0;
+   |     ----------- help: consider using `const` instead of `let`: `const foo`
+...
+LL |         asm!("{}", options(), clobber_abi("C"), const foo);
+   |                                                       ^^^ non-constant value
+
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/parse-error.rs:54:31
    |
 LL |     let mut foo = 0;
    |     ----------- help: consider using `const` instead of `let`: `const foo`
@@ -418,7 +359,7 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    |                               ^^^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:57:46
+  --> $DIR/parse-error.rs:54:46
    |
 LL |     let mut bar = 0;
    |     ----------- help: consider using `const` instead of `let`: `const bar`
@@ -427,7 +368,7 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    |                                              ^^^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:64:46
+  --> $DIR/parse-error.rs:61:46
    |
 LL |     let mut bar = 0;
    |     ----------- help: consider using `const` instead of `let`: `const bar`
@@ -436,7 +377,7 @@ LL |         asm!("{a}", in("eax") foo, a = const bar);
    |                                              ^^^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:67:46
+  --> $DIR/parse-error.rs:63:46
    |
 LL |     let mut bar = 0;
    |     ----------- help: consider using `const` instead of `let`: `const bar`
@@ -445,7 +386,7 @@ LL |         asm!("{a}", in("eax") foo, a = const bar);
    |                                              ^^^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:70:42
+  --> $DIR/parse-error.rs:65:42
    |
 LL |     let mut bar = 0;
    |     ----------- help: consider using `const` instead of `let`: `const bar`
@@ -453,6 +394,6 @@ LL |     let mut bar = 0;
 LL |         asm!("{1}", in("eax") foo, const bar);
    |                                          ^^^ non-constant value
 
-error: aborting due to 66 previous errors
+error: aborting due to 59 previous errors
 
 For more information about this error, try `rustc --explain E0435`.


### PR DESCRIPTION
The `asm!` and `global_asm!` macros require their operands to appear strictly in the following order:
- Template strings
- Positional operands
- Named operands
- Explicit register operands
- `clobber_abi`
- `options`

This is overly strict and can be inconvienent when building complex `asm!` statements with macros. This PR relaxes the ordering requirements as follows:
- Template strings must still come before all other operands.
- Positional operands must still come before named and explicit register operands.
- Named and explicit register operands can be freely mixed.
- `options` and `clobber_abi` can appear in any position after the template strings.

r? @joshtriplett 