### PR TITLE
Realistic `Path::as_mut_os_str` doctest

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2039,12 +2039,12 @@ impl Path {
     /// #![feature(path_as_mut_os_str)]
     /// use std::path::{Path, PathBuf};
     ///
-    /// let mut path = PathBuf::from("/Foo.TXT").into_boxed_path();
+    /// let mut path = PathBuf::from("Foo.TXT");
     ///
-    /// assert_ne!(&*path, Path::new("/foo.txt"));
+    /// assert_ne!(path, Path::new("foo.txt"));
     ///
     /// path.as_mut_os_str().make_ascii_lowercase();
-    /// assert_eq!(&*path, Path::new("/foo.txt"));
+    /// assert_eq!(path, Path::new("foo.txt"));
     /// ```
     #[unstable(feature = "path_as_mut_os_str", issue = "105021")]
     #[must_use]


### PR DESCRIPTION
With "Implement DerefMut for PathBuf" (#105018) now merged, it's
possible to exercise `Path::as_mut_os_str` (#105002) without going
through `into_boxed_path`.