### PR TITLE
core: ensure `no_fp_fmt_parse` builds are warning-free

### DIFF
--- a/src/test/run-make-fulldeps/core-no-fp-fmt-parse/Makefile
+++ b/src/test/run-make-fulldeps/core-no-fp-fmt-parse/Makefile
@@ -1,4 +1,4 @@
 include ../tools.mk
 
 all:
-	$(RUSTC) --edition=2021 --crate-type=rlib ../../../../library/core/src/lib.rs --cfg no_fp_fmt_parse
+	$(RUSTC) --edition=2021 -Dwarnings --crate-type=rlib ../../../../library/core/src/lib.rs --cfg no_fp_fmt_parse


### PR DESCRIPTION
Rust recently introduced a new `unused_imports` warning in `no_fp_fmt_parse` builds, which was fixed in
https://github.com/rust-lang/rust/pull/105434.

To avoid accumulating more over time, let's keep the builds warning-free. This ensures projects compiling `core` with this custom config do not see the warnings in the future and that they can keep enabling `-Dwarnings`.

Similarly, https://github.com/rust-lang/rust/pull/98652 did it for `alloc`'s `no_global_oom_handling`.