### PR TITLE
Dest prop: Support removing writes when this unblocks optimizations

### DIFF
--- a/src/test/mir-opt/dest-prop/move.move_simple.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/move.move_simple.DestinationPropagation.diff
@@ -1,0 +1,38 @@
+- // MIR for `move_simple` before DestinationPropagation
++ // MIR for `move_simple` after DestinationPropagation
+  
+  fn move_simple(_1: i32) -> () {
+      debug x => _1;                       // in scope 0 at $DIR/move.rs:+0:16: +0:17
+      let mut _0: ();                      // return place in scope 0 at $DIR/move.rs:+0:24: +0:24
+      let _2: ();                          // in scope 0 at $DIR/move.rs:+1:5: +1:19
+      let mut _3: i32;                     // in scope 0 at $DIR/move.rs:+1:14: +1:15
+      let mut _4: i32;                     // in scope 0 at $DIR/move.rs:+1:17: +1:18
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/move.rs:+1:5: +1:19
+-         StorageLive(_3);                 // scope 0 at $DIR/move.rs:+1:14: +1:15
+-         _3 = _1;                         // scope 0 at $DIR/move.rs:+1:14: +1:15
+-         StorageLive(_4);                 // scope 0 at $DIR/move.rs:+1:17: +1:18
+-         _4 = _1;                         // scope 0 at $DIR/move.rs:+1:17: +1:18
+-         _2 = use_both(move _3, move _4) -> bb1; // scope 0 at $DIR/move.rs:+1:5: +1:19
++         nop;                             // scope 0 at $DIR/move.rs:+1:14: +1:15
++         nop;                             // scope 0 at $DIR/move.rs:+1:14: +1:15
++         nop;                             // scope 0 at $DIR/move.rs:+1:17: +1:18
++         nop;                             // scope 0 at $DIR/move.rs:+1:17: +1:18
++         _2 = use_both(_1, _1) -> bb1;    // scope 0 at $DIR/move.rs:+1:5: +1:19
+                                           // mir::Constant
+                                           // + span: $DIR/move.rs:8:5: 8:13
+                                           // + literal: Const { ty: fn(i32, i32) {use_both}, val: Value(<ZST>) }
+      }
+  
+      bb1: {
+-         StorageDead(_4);                 // scope 0 at $DIR/move.rs:+1:18: +1:19
+-         StorageDead(_3);                 // scope 0 at $DIR/move.rs:+1:18: +1:19
++         nop;                             // scope 0 at $DIR/move.rs:+1:18: +1:19
++         nop;                             // scope 0 at $DIR/move.rs:+1:18: +1:19
+          StorageDead(_2);                 // scope 0 at $DIR/move.rs:+1:19: +1:20
+          _0 = const ();                   // scope 0 at $DIR/move.rs:+0:24: +2:2
+          return;                          // scope 0 at $DIR/move.rs:+2:2: +2:2
+      }
+  }
+  

--- a/src/test/mir-opt/dest-prop/move.rs
+++ b/src/test/mir-opt/dest-prop/move.rs
@@ -1,0 +1,13 @@
+// unit-test: DestinationPropagation
+
+#[inline(never)]
+fn use_both(_: i32, _: i32) {}
+
+// EMIT_MIR move.move_simple.DestinationPropagation.diff
+fn move_simple(x: i32) {
+    use_both(x, x);
+}
+
+fn main() {
+    move_simple(1);
+}

--- a/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -5,21 +5,20 @@ fn num_to_digit(_1: char) -> u32 {
     let mut _0: u32;                     // return place in scope 0 at $DIR/issue_59352.rs:+0:35: +0:38
     let mut _2: std::option::Option<u32>; // in scope 0 at $DIR/issue_59352.rs:+2:26: +2:41
     let mut _3: u32;                     // in scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
-    let mut _9: isize;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _8: isize;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 (inlined char::methods::<impl char>::is_digit) { // at $DIR/issue_59352.rs:14:8: 14:23
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         debug radix => _3;               // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         let mut _4: &std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         let _5: std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        let mut _6: char;                // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         scope 2 (inlined Option::<u32>::is_some) { // at $SRC_DIR/core/src/char/methods.rs:LL:COL
             debug self => _4;            // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
         }
     }
     scope 3 (inlined #[track_caller] Option::<u32>::unwrap) { // at $DIR/issue_59352.rs:14:26: 14:50
         debug self => _2;                // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        let mut _7: isize;               // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        let mut _8: !;                   // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        let mut _6: isize;               // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        let mut _7: !;                   // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         scope 4 {
             debug val => _0;             // in scope 4 at $SRC_DIR/core/src/option.rs:LL:COL
         }
@@ -29,9 +28,7 @@ fn num_to_digit(_1: char) -> u32 {
         StorageLive(_3);                 // scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
         StorageLive(_4);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        _6 = _1;                         // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        _5 = char::methods::<impl char>::to_digit(move _6, const 8_u32) -> bb5; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        _5 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> bb5; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // + literal: Const { ty: fn(char, u32) -> Option<u32> {char::methods::<impl char>::to_digit}, val: Value(<ZST>) }
@@ -46,8 +43,8 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb2: {
-        _7 = discriminant(_2);           // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        switchInt(move _7) -> [0: bb6, 1: bb8, otherwise: bb7]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        _6 = discriminant(_2);           // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(move _6) -> [0: bb6, 1: bb8, otherwise: bb7]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
     bb3: {
@@ -61,17 +58,16 @@ fn num_to_digit(_1: char) -> u32 {
 
     bb5: {
         _4 = &_5;                        // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        _9 = discriminant((*_4));        // scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+        _8 = discriminant((*_4));        // scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
         StorageDead(_4);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageDead(_3);                 // scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
-        switchInt(move _9) -> [1: bb1, otherwise: bb3]; // scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
+        switchInt(move _8) -> [1: bb1, otherwise: bb3]; // scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
     }
 
     bb6: {
-        StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        _8 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageLive(_7);                 // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        _7 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/option.rs:LL:COL
                                          // + literal: Const { ty: fn(&'static str) -> ! {core::panicking::panic}, val: Value(<ZST>) }

--- a/src/test/mir-opt/lower_array_len_e2e.array_bound.PreCodegen.after.mir
+++ b/src/test/mir-opt/lower_array_len_e2e.array_bound.PreCodegen.after.mir
@@ -5,27 +5,23 @@ fn array_bound(_1: usize, _2: &[u8; N]) -> u8 {
     debug slice => _2;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+0:50: +0:55
     let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len_e2e.rs:+0:70: +0:72
     let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
-    let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:13
-    let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
-    let mut _6: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-    let mut _7: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+    let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
+    let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+    let mut _6: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
 
     bb0: {
         StorageLive(_3);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
-        StorageLive(_4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:13
-        _4 = _1;                         // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:13
-        StorageLive(_5);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
-        _5 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
-        _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
-        StorageDead(_5);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:26: +1:27
+        StorageLive(_4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
+        _4 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
+        _3 = Lt(_1, move _4);            // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:26: +1:27
         switchInt(move _3) -> [0: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
     }
 
     bb1: {
-        _6 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-        _7 = Lt(_1, _6);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-        assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _1) -> bb2; // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+        _5 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+        _6 = Lt(_1, _5);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+        assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _1) -> bb2; // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
     }
 
     bb2: {

--- a/src/test/mir-opt/lower_array_len_e2e.array_bound_mut.PreCodegen.after.mir
+++ b/src/test/mir-opt/lower_array_len_e2e.array_bound_mut.PreCodegen.after.mir
@@ -5,30 +5,26 @@ fn array_bound_mut(_1: usize, _2: &mut [u8; N]) -> u8 {
     debug slice => _2;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+0:54: +0:59
     let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len_e2e.rs:+0:78: +0:80
     let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
-    let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:13
-    let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
-    let mut _6: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-    let mut _7: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-    let _8: usize;                       // in scope 0 at $DIR/lower_array_len_e2e.rs:+4:15: +4:16
-    let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
-    let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
+    let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
+    let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+    let mut _6: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+    let _7: usize;                       // in scope 0 at $DIR/lower_array_len_e2e.rs:+4:15: +4:16
+    let mut _8: usize;                   // in scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
+    let mut _9: bool;                    // in scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
 
     bb0: {
         StorageLive(_3);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
-        StorageLive(_4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:13
-        _4 = _1;                         // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:13
-        StorageLive(_5);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
-        _5 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
-        _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
-        StorageDead(_5);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:26: +1:27
+        StorageLive(_4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
+        _4 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+1:16: +1:27
+        _3 = Lt(_1, move _4);            // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+1:26: +1:27
         switchInt(move _3) -> [0: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len_e2e.rs:+1:8: +1:27
     }
 
     bb1: {
-        _6 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-        _7 = Lt(_1, _6);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
-        assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _1) -> bb2; // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+        _5 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+        _6 = Lt(_1, _5);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
+        assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _1) -> bb2; // scope 0 at $DIR/lower_array_len_e2e.rs:+2:9: +2:21
     }
 
     bb2: {
@@ -37,16 +33,16 @@ fn array_bound_mut(_1: usize, _2: &mut [u8; N]) -> u8 {
     }
 
     bb3: {
-        StorageLive(_8);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+4:15: +4:16
-        _8 = const 0_usize;              // scope 0 at $DIR/lower_array_len_e2e.rs:+4:15: +4:16
-        _9 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
-        _10 = Lt(const 0_usize, _9);     // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
-        assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, const 0_usize) -> bb4; // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
+        StorageLive(_7);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+4:15: +4:16
+        _7 = const 0_usize;              // scope 0 at $DIR/lower_array_len_e2e.rs:+4:15: +4:16
+        _8 = const N;                    // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
+        _9 = Lt(const 0_usize, _8);      // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
+        assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, const 0_usize) -> bb4; // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:17
     }
 
     bb4: {
-        (*_2)[_8] = const 42_u8;         // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:22
-        StorageDead(_8);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+4:22: +4:23
+        (*_2)[_7] = const 42_u8;         // scope 0 at $DIR/lower_array_len_e2e.rs:+4:9: +4:22
+        StorageDead(_7);                 // scope 0 at $DIR/lower_array_len_e2e.rs:+4:22: +4:23
         _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len_e2e.rs:+6:9: +6:11
         goto -> bb5;                     // scope 0 at $DIR/lower_array_len_e2e.rs:+1:5: +7:6
     }

--- a/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
@@ -4,9 +4,7 @@ fn while_loop(_1: bool) -> () {
     debug c => _1;                       // in scope 0 at $DIR/while_storage.rs:+0:15: +0:16
     let mut _0: ();                      // return place in scope 0 at $DIR/while_storage.rs:+0:24: +0:24
     let mut _2: bool;                    // in scope 0 at $DIR/while_storage.rs:+1:11: +1:22
-    let mut _3: bool;                    // in scope 0 at $DIR/while_storage.rs:+1:20: +1:21
-    let mut _4: bool;                    // in scope 0 at $DIR/while_storage.rs:+2:12: +2:23
-    let mut _5: bool;                    // in scope 0 at $DIR/while_storage.rs:+2:21: +2:22
+    let mut _3: bool;                    // in scope 0 at $DIR/while_storage.rs:+2:12: +2:23
 
     bb0: {
         goto -> bb1;                     // scope 0 at $DIR/while_storage.rs:+1:5: +5:6
@@ -14,41 +12,35 @@ fn while_loop(_1: bool) -> () {
 
     bb1: {
         StorageLive(_2);                 // scope 0 at $DIR/while_storage.rs:+1:11: +1:22
-        StorageLive(_3);                 // scope 0 at $DIR/while_storage.rs:+1:20: +1:21
-        _3 = _1;                         // scope 0 at $DIR/while_storage.rs:+1:20: +1:21
-        _2 = get_bool(move _3) -> bb2;   // scope 0 at $DIR/while_storage.rs:+1:11: +1:22
+        _2 = get_bool(_1) -> bb2;        // scope 0 at $DIR/while_storage.rs:+1:11: +1:22
                                          // mir::Constant
                                          // + span: $DIR/while_storage.rs:10:11: 10:19
                                          // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_3);                 // scope 0 at $DIR/while_storage.rs:+1:21: +1:22
         switchInt(move _2) -> [0: bb7, otherwise: bb3]; // scope 0 at $DIR/while_storage.rs:+1:11: +1:22
     }
 
     bb3: {
-        StorageLive(_4);                 // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
-        StorageLive(_5);                 // scope 0 at $DIR/while_storage.rs:+2:21: +2:22
-        _5 = _1;                         // scope 0 at $DIR/while_storage.rs:+2:21: +2:22
-        _4 = get_bool(move _5) -> bb4;   // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
+        StorageLive(_3);                 // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
+        _3 = get_bool(_1) -> bb4;        // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
                                          // mir::Constant
                                          // + span: $DIR/while_storage.rs:11:12: 11:20
                                          // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(<ZST>) }
     }
 
     bb4: {
-        StorageDead(_5);                 // scope 0 at $DIR/while_storage.rs:+2:22: +2:23
-        switchInt(move _4) -> [0: bb6, otherwise: bb5]; // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
+        switchInt(move _3) -> [0: bb6, otherwise: bb5]; // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
     }
 
     bb5: {
-        StorageDead(_4);                 // scope 0 at $DIR/while_storage.rs:+4:9: +4:10
+        StorageDead(_3);                 // scope 0 at $DIR/while_storage.rs:+4:9: +4:10
         goto -> bb8;                     // scope 0 at no-location
     }
 
     bb6: {
-        StorageDead(_4);                 // scope 0 at $DIR/while_storage.rs:+4:9: +4:10
+        StorageDead(_3);                 // scope 0 at $DIR/while_storage.rs:+4:9: +4:10
         StorageDead(_2);                 // scope 0 at $DIR/while_storage.rs:+5:5: +5:6
         goto -> bb1;                     // scope 0 at $DIR/while_storage.rs:+1:5: +5:6
     }


### PR DESCRIPTION
The logic this uses is quite simple: When we collect information about writes, we mark some of these writes as "removable." In cases where a removable write would normally invalidate an optimization candidate, we then instead keep the candidate around and mark that particular write as being in need of removing (if we do decide to use the candidate). When we finally merge candidates, we remove all those writes.

Removable writes are `Operand::Move` (removable by turning into `Operand::Copy`) and `Deinit` statements (removable by deleting the statement).

This increases the number of times that the opt fires on a `-Zbuild-std` build of regex by ~10%.

r? @tmiasko 