### PR TITLE
Extend -Zdump-mir output with two-phase borrow info

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2022,8 +2022,9 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                 let kind_str = match borrow_kind {
                     BorrowKind::Shared => "",
                     BorrowKind::Shallow => "shallow ",
-                    BorrowKind::Mut { allow_two_phase_borrow: false } | BorrowKind::Unique => "mut ",
-                    BorrowKind::Mut { allow_two_phase_borrow: true} => "/*2pb*/mut ",
+                    BorrowKind::Unique => "mut ", // FIXME should this say `/*uniq*/mut`?
+                    BorrowKind::Mut { allow_two_phase_borrow: false } => "mut ",
+                    BorrowKind::Mut { allow_two_phase_borrow: true } => "/*2pb*/mut ",
                 };
 
                 // When printing regions, add trailing space if necessary.

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2022,7 +2022,8 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                 let kind_str = match borrow_kind {
                     BorrowKind::Shared => "",
                     BorrowKind::Shallow => "shallow ",
-                    BorrowKind::Mut { .. } | BorrowKind::Unique => "mut ",
+                    BorrowKind::Mut { allow_two_phase_borrow: false } | BorrowKind::Unique => "mut ",
+                    BorrowKind::Mut { allow_two_phase_borrow: true} => "/*2pb*/mut ",
                 };
 
                 // When printing regions, add trailing space if necessary.

--- a/src/test/mir-opt/derefer_complex_case.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_complex_case.main.Derefer.diff
@@ -52,7 +52,7 @@
           StorageLive(_8);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
           StorageLive(_9);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
           _9 = &mut _4;                    // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
-          _8 = &mut (*_9);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          _8 = &/*2pb*/mut (*_9);          // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
           _7 = <std::slice::Iter<'_, i32> as Iterator>::next(move _8) -> bb3; // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
                                            // mir::Constant
                                            // + span: $DIR/derefer_complex_case.rs:6:17: 6:26

--- a/src/test/mir-opt/dest-prop/simple.nrvo.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/simple.nrvo.DestinationPropagation.diff
@@ -24,7 +24,7 @@
           StorageLive(_5);                 // scope 1 at $DIR/simple.rs:+2:10: +2:18
           StorageLive(_6);                 // scope 1 at $DIR/simple.rs:+2:10: +2:18
           _6 = &mut _2;                    // scope 1 at $DIR/simple.rs:+2:10: +2:18
-          _5 = &mut (*_6);                 // scope 1 at $DIR/simple.rs:+2:10: +2:18
+          _5 = &/*2pb*/mut (*_6);          // scope 1 at $DIR/simple.rs:+2:10: +2:18
 -         _3 = move _4(move _5) -> bb1;    // scope 1 at $DIR/simple.rs:+2:5: +2:19
 +         _3 = move _1(move _5) -> bb1;    // scope 1 at $DIR/simple.rs:+2:5: +2:19
       }

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -82,7 +82,7 @@
           StorageLive(_10);                // scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
           _10 = ((_7 as Some).0: usize);   // scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
           StorageLive(_11);                // scope 3 at $DIR/funky_arms.rs:+15:43: +15:46
-          _11 = &mut (*_1);                // scope 3 at $DIR/funky_arms.rs:+15:43: +15:46
+          _11 = &/*2pb*/mut (*_1);         // scope 3 at $DIR/funky_arms.rs:+15:43: +15:46
           StorageLive(_12);                // scope 3 at $DIR/funky_arms.rs:+15:48: +15:51
           _12 = _2;                        // scope 3 at $DIR/funky_arms.rs:+15:48: +15:51
           StorageLive(_13);                // scope 3 at $DIR/funky_arms.rs:+15:53: +15:57
@@ -115,7 +115,7 @@
   
       bb8: {
           StorageLive(_18);                // scope 2 at $DIR/funky_arms.rs:+17:46: +17:49
-          _18 = &mut (*_1);                // scope 2 at $DIR/funky_arms.rs:+17:46: +17:49
+          _18 = &/*2pb*/mut (*_1);         // scope 2 at $DIR/funky_arms.rs:+17:46: +17:49
           StorageLive(_19);                // scope 2 at $DIR/funky_arms.rs:+17:51: +17:54
           _19 = _2;                        // scope 2 at $DIR/funky_arms.rs:+17:51: +17:54
           StorageLive(_20);                // scope 2 at $DIR/funky_arms.rs:+17:56: +17:60

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
@@ -15,7 +15,7 @@ fn a(_1: &mut [T]) -> &mut [T] {
         StorageLive(_2);                 // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
         StorageLive(_3);                 // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
         StorageLive(_4);                 // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
-        _4 = &mut (*_1);                 // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
+        _4 = &/*2pb*/mut (*_1);          // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
         StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         _5 = &mut (*_4);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
@@ -18,7 +18,7 @@ fn b(_1: &mut Box<T>) -> &mut T {
         StorageLive(_2);                 // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
         StorageLive(_3);                 // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
         StorageLive(_4);                 // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
-        _4 = &mut (*_1);                 // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
+        _4 = &/*2pb*/mut (*_1);          // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
         StorageLive(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         StorageLive(_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _7 = deref_copy (*_4);           // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/src/test/mir-opt/nrvo_simple.nrvo.RenameReturnPlace.diff
+++ b/src/test/mir-opt/nrvo_simple.nrvo.RenameReturnPlace.diff
@@ -26,7 +26,7 @@
           StorageLive(_6);                 // scope 1 at $DIR/nrvo_simple.rs:+2:10: +2:18
 -         _6 = &mut _2;                    // scope 1 at $DIR/nrvo_simple.rs:+2:10: +2:18
 +         _6 = &mut _0;                    // scope 1 at $DIR/nrvo_simple.rs:+2:10: +2:18
-          _5 = &mut (*_6);                 // scope 1 at $DIR/nrvo_simple.rs:+2:10: +2:18
+          _5 = &/*2pb*/mut (*_6);          // scope 1 at $DIR/nrvo_simple.rs:+2:10: +2:18
           _3 = move _4(move _5) -> bb1;    // scope 1 at $DIR/nrvo_simple.rs:+2:5: +2:19
       }
   

--- a/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
+++ b/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
@@ -53,7 +53,7 @@
 -         StorageLive(_8);                 // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
 -         StorageLive(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
           _9 = &mut _4;                    // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
-          _8 = &mut (*_9);                 // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          _8 = &/*2pb*/mut (*_9);          // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
           _7 = <std::ops::Range<i32> as Iterator>::next(move _8) -> bb3; // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
                                            // mir::Constant
                                            // + span: $DIR/remove_storage_markers.rs:10:14: 10:19

--- a/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
@@ -68,7 +68,7 @@ fn main() -> () {
         StorageLive(_6);                 // scope 1 at $DIR/retag.rs:+3:29: +3:35
         StorageLive(_7);                 // scope 1 at $DIR/retag.rs:+3:29: +3:35
         _7 = &mut _1;                    // scope 1 at $DIR/retag.rs:+3:29: +3:35
-        _6 = &mut (*_7);                 // scope 1 at $DIR/retag.rs:+3:29: +3:35
+        _6 = &/*2pb*/mut (*_7);          // scope 1 at $DIR/retag.rs:+3:29: +3:35
         _3 = Test::foo(move _4, move _6) -> [return: bb1, unwind: bb8]; // scope 1 at $DIR/retag.rs:+3:17: +3:36
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:33:25: 33:28


### PR DESCRIPTION
This should cause no breakage since its just injecting a comment `/*2pb*/` (and the `-Zdump-mir` output is unstable anyway).