### PR TITLE
Remove unused flex-grow CSS rule

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -539,13 +539,11 @@ ul.block, .block li {
 
 .rustdoc .example-wrap > pre {
 	margin: 0;
-	flex-grow: 1;
 	overflow-x: auto;
 }
 
 .rustdoc .example-wrap > pre.example-line-numbers,
 .rustdoc .example-wrap > pre.src-line-numbers {
-	flex-grow: 0;
 	overflow: initial;
 	text-align: right;
 	-webkit-user-select: none;


### PR DESCRIPTION
It's not a flex item so the rule has no effect on it.

r? @notriddle 