### PR TITLE
str.lines() docstring: clarify that line endings are not returned

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -970,8 +970,10 @@ impl str {
 
     /// An iterator over the lines of a string, as string slices.
     ///
-    /// Lines are ended with either a newline (`\n`) or a carriage return with
-    /// a line feed (`\r\n`).
+    /// Lines are split at line endings that are either newlines (`\n`) or
+    /// sequences of a carriage return followed by a line feed (`\r\n`).
+    ///
+    /// Line terminators are not included in the lines returned by the iterator.
     ///
     /// The final line ending is optional. A string that ends with a final line
     /// ending will return the same lines as an otherwise identical string


### PR DESCRIPTION
Previously, the str.lines() docstring stated that lines are split at line endings, but not whether those were returned or not.  This new version of the docstring states this explicitly, avoiding the need of getting to doctests to get an answer to this FAQ.