### PR TITLE
std::fmt: Use args directly in example code

### DIFF
--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -419,7 +419,7 @@
 //!         // documentation for details, and the function `pad` can be used
 //!         // to pad strings.
 //!         let decimals = f.precision().unwrap_or(3);
-//!         let string = format!("{:.*}", decimals, magnitude);
+//!         let string = format!("{magnitude:.decimals$}");
 //!         f.pad_integral(true, "", &string)
 //!     }
 //! }
@@ -518,7 +518,7 @@
 //! write!(&mut some_writer, "{}", format_args!("print with a {}", "macro"));
 //!
 //! fn my_fmt_fn(args: fmt::Arguments) {
-//!     write!(&mut io::stdout(), "{}", args);
+//!     write!(&mut io::stdout(), "{args}");
 //! }
 //! my_fmt_fn(format_args!(", or a {} too", "function"));
 //! ```


### PR DESCRIPTION
The lint "clippy::uninlined_format_args" recommends inline variables in format strings. Fix two places in the docs that do not do this. I noticed this because I copy/pasted one example in to my project, then noticed this lint error. This fixes:

```
error: variables can be used directly in the `format!` string
  --> src/main.rs:30:22
   |
30 |         let string = format!("{:.*}", decimals, magnitude);
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: variables can be used directly in the `format!` string
  --> src/main.rs:39:2
   |
39 |  write!(&mut io::stdout(), "{}", args).unwrap();
```