### PR TITLE
Don't ICE in `check_must_not_suspend_ty` for mismatched tuple arity

### DIFF
--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -607,10 +607,7 @@ fn check_must_not_suspend_ty<'tcx>(
         ty::Tuple(fields) => {
             let mut has_emitted = false;
             let comps = match data.expr.map(|e| &e.kind) {
-                Some(hir::ExprKind::Tup(comps)) => {
-                    debug_assert_eq!(comps.len(), fields.len());
-                    Some(comps)
-                }
+                Some(hir::ExprKind::Tup(comps)) if comps.len() == fields.len() => Some(comps),
                 _ => None,
             };
             for (i, ty) in fields.iter().enumerate() {

--- a/src/test/ui/lint/must_not_suspend/tuple-mismatch.rs
+++ b/src/test/ui/lint/must_not_suspend/tuple-mismatch.rs
@@ -1,0 +1,9 @@
+#![feature(generators)]
+
+fn main() {
+    let _generator = || {
+        yield ((), ((), ()));
+        yield ((), ());
+        //~^ ERROR mismatched types
+    };
+}

--- a/src/test/ui/lint/must_not_suspend/tuple-mismatch.stderr
+++ b/src/test/ui/lint/must_not_suspend/tuple-mismatch.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/tuple-mismatch.rs:6:20
+   |
+LL |         yield ((), ());
+   |                    ^^ expected tuple, found `()`
+   |
+   = note:  expected tuple `((), ())`
+           found unit type `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
These expressions are just used for their spans, so make it best-effort here.

Fixes #105728 