### PR TITLE
Suggest a `T: Send` bound for `&mut T` upvars in `Send` generators

### DIFF
--- a/src/test/ui/generator/ref-upvar-not-send.rs
+++ b/src/test/ui/generator/ref-upvar-not-send.rs
@@ -1,0 +1,31 @@
+// For `Send` generators, suggest a `T: Sync` requirement for `&T` upvars,
+// and suggest a `T: Send` requirement for `&mut T` upvars.
+
+#![feature(generators)]
+
+fn assert_send<T: Send>(_: T) {}
+//~^ NOTE required by a bound in `assert_send`
+//~| NOTE required by this bound in `assert_send`
+//~| NOTE required by a bound in `assert_send`
+//~| NOTE required by this bound in `assert_send`
+
+fn main() {
+    let x: &*mut () = &std::ptr::null_mut();
+    let y: &mut *mut () = &mut std::ptr::null_mut();
+    assert_send(move || {
+        //~^ ERROR generator cannot be sent between threads safely
+        //~| NOTE generator is not `Send`
+        yield;
+        let _x = x;
+    });
+    //~^^ NOTE captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
+    //~| NOTE has type `&*mut ()` which is not `Send`, because `*mut ()` is not `Sync`
+    assert_send(move || {
+        //~^ ERROR generator cannot be sent between threads safely
+        //~| NOTE generator is not `Send`
+        yield;
+        let _y = y;
+    });
+    //~^^ NOTE captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
+    //~| NOTE has type `&mut *mut ()` which is not `Send`, because `*mut ()` is not `Send`
+}

--- a/src/test/ui/generator/ref-upvar-not-send.stderr
+++ b/src/test/ui/generator/ref-upvar-not-send.stderr
@@ -1,0 +1,50 @@
+error: generator cannot be sent between threads safely
+  --> $DIR/ref-upvar-not-send.rs:15:17
+   |
+LL |       assert_send(move || {
+   |  _________________^
+LL | |
+LL | |
+LL | |         yield;
+LL | |         let _x = x;
+LL | |     });
+   | |_____^ generator is not `Send`
+   |
+   = help: the trait `Sync` is not implemented for `*mut ()`
+note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
+  --> $DIR/ref-upvar-not-send.rs:19:18
+   |
+LL |         let _x = x;
+   |                  ^ has type `&*mut ()` which is not `Send`, because `*mut ()` is not `Sync`
+note: required by a bound in `assert_send`
+  --> $DIR/ref-upvar-not-send.rs:6:19
+   |
+LL | fn assert_send<T: Send>(_: T) {}
+   |                   ^^^^ required by this bound in `assert_send`
+
+error: generator cannot be sent between threads safely
+  --> $DIR/ref-upvar-not-send.rs:23:17
+   |
+LL |       assert_send(move || {
+   |  _________________^
+LL | |
+LL | |
+LL | |         yield;
+LL | |         let _y = y;
+LL | |     });
+   | |_____^ generator is not `Send`
+   |
+   = help: within `[generator@$DIR/ref-upvar-not-send.rs:23:17: 23:24]`, the trait `Send` is not implemented for `*mut ()`
+note: captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
+  --> $DIR/ref-upvar-not-send.rs:27:18
+   |
+LL |         let _y = y;
+   |                  ^ has type `&mut *mut ()` which is not `Send`, because `*mut ()` is not `Send`
+note: required by a bound in `assert_send`
+  --> $DIR/ref-upvar-not-send.rs:6:19
+   |
+LL | fn assert_send<T: Send>(_: T) {}
+   |                   ^^^^ required by this bound in `assert_send`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Right now, we suggest a `T: Sync` bound for both `&T` and `&mut T` upvars. A user on URLO [found this confusing](https://users.rust-lang.org/t/error-complains-about-missing-sync-but-send-is-whats-missing/86021), so I wrote this quick fix to look at the mutability before making the suggestion.