### PR TITLE
print argument name in arg mismatch if possible

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -28,7 +28,7 @@ use rustc_middle::ty::adjustment::AllowTwoPhase;
 use rustc_middle::ty::visit::TypeVisitable;
 use rustc_middle::ty::{self, DefIdTree, IsSuggestable, Ty, TypeSuperVisitable, TypeVisitor};
 use rustc_session::Session;
-use rustc_span::symbol::Ident;
+use rustc_span::symbol::{kw, Ident};
 use rustc_span::{self, sym, Span};
 use rustc_trait_selection::traits::{self, ObligationCauseCode, SelectionContext};
 
@@ -1141,6 +1141,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         "()".to_string()
                     } else if expected_ty.is_suggestable(tcx, false) {
                         format!("/* {} */", expected_ty)
+                    } else if let Some(fn_def_id) = fn_def_id
+                        && self.tcx.def_kind(fn_def_id).is_fn_like()
+                        && let self_implicit = matches!(call_expr.kind, hir::ExprKind::MethodCall(..)) as usize
+                        && let Some(arg) = self.tcx.fn_arg_names(fn_def_id).get(expected_idx.as_usize() + self_implicit)
+                        && arg.name != kw::SelfLower
+                    {
+                        format!("/* {} */", arg.name)
                     } else {
                         "/* value */".to_string()
                     }

--- a/src/test/ui/argument-suggestions/basic.stderr
+++ b/src/test/ui/argument-suggestions/basic.stderr
@@ -94,8 +94,8 @@ LL |     let closure = |x| x;
    |                   ^^^
 help: provide the argument
    |
-LL |     closure(/* value */);
-   |            ~~~~~~~~~~~~~
+LL |     closure(/* x */);
+   |            ~~~~~~~~~
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/error-codes/E0057.stderr
+++ b/src/test/ui/error-codes/E0057.stderr
@@ -11,8 +11,8 @@ LL |     let f = |x| x * 3;
    |             ^^^
 help: provide the argument
    |
-LL |     let a = f(/* value */);
-   |              ~~~~~~~~~~~~~
+LL |     let a = f(/* x */);
+   |              ~~~~~~~~~
 
 error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/E0057.rs:5:13

--- a/src/test/ui/higher-rank-trait-bounds/issue-58451.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/issue-58451.stderr
@@ -11,8 +11,8 @@ LL | fn f<I>(i: I)
    |    ^    ----
 help: provide the argument
    |
-LL |     f(&[f(/* value */)]);
-   |          ~~~~~~~~~~~~~
+LL |     f(&[f(/* i */)]);
+   |          ~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3044.stderr
+++ b/src/test/ui/issues/issue-3044.stderr
@@ -13,7 +13,7 @@ help: provide the argument
    |
 LL ~     needlesArr.iter().fold(|x, y| {
 LL +
-LL ~     }, /* value */);
+LL ~     }, /* f */);
    |
 
 error: aborting due to previous error


### PR DESCRIPTION
A bit more contextual than just `/* value */`, at least when the argument is named something related to its context.

The UI test cases are... not super convincing, but also they're minimized tests.