### PR TITLE
Suggest associated const on possible capitalization mistake

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -104,16 +104,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         if let Some(mut err) = self.demand_suptype_diag(expr.span, expected_ty, ty) {
-            // FIXME(compiler-errors): We probably should fold some of the
-            // `suggest_` functions from  `emit_coerce_suggestions` into here,
-            // since some of those aren't necessarily just coerce suggestions.
-            let _ = self.suggest_deref_ref_or_into(
+            let _ = self.emit_type_mismatch_suggestions(
                 &mut err,
                 expr.peel_drop_temps(),
-                expected_ty,
                 ty,
+                expected_ty,
                 None,
-            ) || self.suggest_option_to_bool(&mut err, expr, ty, expected_ty);
+                None,
+            );
             extend_err(&mut err);
             err.emit();
         }

--- a/src/test/ui/suggestions/assoc-ct-for-assoc-method.rs
+++ b/src/test/ui/suggestions/assoc-ct-for-assoc-method.rs
@@ -1,0 +1,25 @@
+struct MyS;
+
+impl MyS {
+    const FOO: i32 = 1;
+    fn foo() -> MyS {
+        MyS
+    }
+}
+
+fn main() {
+    let x: i32 = MyS::foo;
+    //~^ ERROR mismatched types
+    //~| HELP try referring to the
+
+    let z: i32 = i32::max;
+    //~^ ERROR mismatched types
+    //~| HELP try referring to the
+
+    // This example is still broken though... This is a hard suggestion to make,
+    // because we don't have access to the associated const probing code to make
+    // this suggestion where it's emitted, i.e. in trait selection.
+    let y: i32 = i32::max - 42;
+    //~^ ERROR cannot subtract
+    //~| HELP use parentheses
+}

--- a/src/test/ui/suggestions/assoc-ct-for-assoc-method.stderr
+++ b/src/test/ui/suggestions/assoc-ct-for-assoc-method.stderr
@@ -1,0 +1,47 @@
+error[E0308]: mismatched types
+  --> $DIR/assoc-ct-for-assoc-method.rs:11:18
+   |
+LL |     let x: i32 = MyS::foo;
+   |            ---   ^^^^^^^^ expected `i32`, found fn item
+   |            |
+   |            expected due to this
+   |
+   = note: expected type `i32`
+           found fn item `fn() -> MyS {MyS::foo}`
+help: try referring to the associated const `FOO` instead
+   |
+LL |     let x: i32 = MyS::FOO;
+   |                       ~~~
+
+error[E0308]: mismatched types
+  --> $DIR/assoc-ct-for-assoc-method.rs:15:18
+   |
+LL |     let z: i32 = i32::max;
+   |            ---   ^^^^^^^^ expected `i32`, found fn item
+   |            |
+   |            expected due to this
+   |
+   = note: expected type `i32`
+           found fn item `fn(i32, i32) -> i32 {<i32 as Ord>::max}`
+help: try referring to the associated const `MAX` instead
+   |
+LL |     let z: i32 = i32::MAX;
+   |                       ~~~
+
+error[E0369]: cannot subtract `{integer}` from `fn(i32, i32) -> i32 {<i32 as Ord>::max}`
+  --> $DIR/assoc-ct-for-assoc-method.rs:22:27
+   |
+LL |     let y: i32 = i32::max - 42;
+   |                  -------- ^ -- {integer}
+   |                  |
+   |                  fn(i32, i32) -> i32 {<i32 as Ord>::max}
+   |
+help: use parentheses to call this associated function
+   |
+LL |     let y: i32 = i32::max(/* i32 */, /* i32 */) - 42;
+   |                          ++++++++++++++++++++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0369.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Suggest `i32::MAX` if we typed `i32::max` without making a function call.

Fixes #93844