### PR TITLE
Account for return-position `impl Trait` in trait in `opt_suggest_box_span`

### DIFF
--- a/src/test/ui/impl-trait/in-trait/box-coerce-span-in-default.rs
+++ b/src/test/ui/impl-trait/in-trait/box-coerce-span-in-default.rs
@@ -1,0 +1,49 @@
+// check-pass
+
+#![feature(return_position_impl_trait_in_trait)]
+//~^ WARN the feature `return_position_impl_trait_in_trait` is incomplete
+
+struct TestA {}
+struct TestB {}
+
+impl TestTrait for TestA {
+    type Output = ();
+}
+impl TestTrait for TestB {
+    type Output = ();
+}
+
+trait TestTrait {
+    type Output;
+}
+
+impl<A, B> TestTrait for GreeterOutput<A, B>
+where
+    A: TestTrait<Output = ()>,
+    B: TestTrait<Output = ()>,
+{
+    type Output = ();
+}
+
+enum GreeterOutput<A, B>
+where
+    A: TestTrait<Output = ()>,
+    B: TestTrait<Output = ()>,
+{
+    SayHello(A),
+    SayGoodbye(B),
+}
+
+trait Greeter {
+    fn test_func(&self, func: &str) -> impl TestTrait<Output = ()> {
+        match func {
+            "SayHello" => GreeterOutput::SayHello(TestA {}),
+            "SayGoodbye" => GreeterOutput::SayGoodbye(TestB {}),
+            _ => GreeterOutput::SayHello(TestA {}),
+        }
+    }
+}
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/src/test/ui/impl-trait/in-trait/box-coerce-span-in-default.stderr
+++ b/src/test/ui/impl-trait/in-trait/box-coerce-span-in-default.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_position_impl_trait_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/box-coerce-span-in-default.rs:3:12
+   |
+LL | #![feature(return_position_impl_trait_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
RPITITs are the only types where their opaque bounds might normalize to some other self type than the opaque type itself. To avoid needing to do normalization, let's just match on either alias kind.

Ideally, we'd just get rid of `opt_suggest_box_span`. It's kind of a wart on type-checking `if`/`match`. I've recently refactored this expression for being confusing/wrong, but moving it into the error path is pretty hard.

Fixes #105838