### PR TITLE
rustc_session: remove dead code from check_expected_reuse()

### DIFF
--- a/compiler/rustc_session/src/cgu_reuse_tracker.rs
+++ b/compiler/rustc_session/src/cgu_reuse_tracker.rs
@@ -119,13 +119,13 @@ impl CguReuseTracker {
 
                     if error {
                         let at_least = if at_least { 1 } else { 0 };
-                        IncorrectCguReuseType {
+                        sess.emit_err(IncorrectCguReuseType {
                             span: error_span.0,
                             cgu_user_name,
                             actual_reuse,
                             expected_reuse,
                             at_least,
-                        };
+                        });
                     }
                 } else {
                     sess.emit_fatal(CguNotRecorded { cgu_user_name, cgu_name });


### PR DESCRIPTION
looks like we construct this `IncorrectCguReuseType` but actually never do anything with it. So by skipping that, we can actually remove half the function which is a bit weird... :sweat_smile: 