### PR TITLE
Revert "Introduce lowering_arena to avoid creating AST nodes on the fly"

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1,6 +1,6 @@
 use super::errors::{InvalidAbi, InvalidAbiSuggestion, MisplacedRelaxTraitBound};
 use super::ResolverAstLoweringExt;
-use super::{Arena, AstOwner, ImplTraitContext, ImplTraitPosition};
+use super::{AstOwner, ImplTraitContext, ImplTraitPosition};
 use super::{FnDeclKind, LoweringContext, ParamMode};
 
 use rustc_ast::ptr::P;
@@ -24,7 +24,6 @@ use thin_vec::ThinVec;
 pub(super) struct ItemLowerer<'a, 'hir> {
     pub(super) tcx: TyCtxt<'hir>,
     pub(super) resolver: &'a mut ResolverAstLowering,
-    pub(super) ast_arena: &'a Arena<'static>,
     pub(super) ast_index: &'a IndexVec<LocalDefId, AstOwner<'a>>,
     pub(super) owners: &'a mut IndexVec<LocalDefId, hir::MaybeOwner<&'hir hir::OwnerInfo<'hir>>>,
 }
@@ -60,7 +59,6 @@ impl<'a, 'hir> ItemLowerer<'a, 'hir> {
             tcx: self.tcx,
             resolver: self.resolver,
             arena: self.tcx.hir_arena,
-            ast_arena: self.ast_arena,
 
             // HirId handling.
             bodies: Vec::new(),

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -42,7 +42,6 @@ extern crate tracing;
 
 use crate::errors::{AssocTyParentheses, AssocTyParenthesesSub, MisplacedImplTrait, TraitFnAsync};
 
-use rustc_arena::declare_arena;
 use rustc_ast::ptr::P;
 use rustc_ast::visit;
 use rustc_ast::{self as ast, *};
@@ -94,13 +93,6 @@ struct LoweringContext<'a, 'hir> {
     /// Used to allocate HIR nodes.
     arena: &'hir hir::Arena<'hir>,
 
-    /// Used to allocate temporary AST nodes for use during lowering.
-    /// This allows us to create "fake" AST -- these nodes can sometimes
-    /// be allocated on the stack, but other times we need them to live longer
-    /// than the current stack frame, so they can be collected into vectors
-    /// and things like that.
-    ast_arena: &'a Arena<'static>,
-
     /// Bodies inside the owner being lowered.
     bodies: Vec<(hir::ItemLocalId, &'hir hir::Body<'hir>)>,
     /// Attributes inside the owner being lowered.
@@ -145,15 +137,6 @@ struct LoweringContext<'a, 'hir> {
     /// field from the original parameter 'a to the new parameter 'a1.
     generics_def_id_map: Vec<FxHashMap<LocalDefId, LocalDefId>>,
 }
-
-declare_arena!([
-    [] tys: rustc_ast::Ty,
-    [] aba: rustc_ast::AngleBracketedArgs,
-    [] ptr: rustc_ast::PolyTraitRef,
-    // This _marker field is needed because `declare_arena` creates `Arena<'tcx>` and we need to
-    // use `'tcx`. If we don't have this we get a compile error.
-    [] _marker: std::marker::PhantomData<&'tcx ()>,
-]);
 
 trait ResolverAstLoweringExt {
     fn legacy_const_generic_args(&self, expr: &Expr) -> Option<Vec<usize>>;
@@ -442,13 +425,10 @@ pub fn lower_to_hir<'hir>(tcx: TyCtxt<'hir>, (): ()) -> hir::Crate<'hir> {
         tcx.definitions_untracked().def_index_count(),
     );
 
-    let ast_arena = Arena::default();
-
     for def_id in ast_index.indices() {
         item::ItemLowerer {
             tcx,
             resolver: &mut resolver,
-            ast_arena: &ast_arena,
             ast_index: &ast_index,
             owners: &mut owners,
         }
@@ -1001,8 +981,12 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 }
                 GenericArgs::Parenthesized(data) => {
                     self.emit_bad_parenthesized_trait_in_assoc_ty(data);
-                    let aba = self.ast_arena.aba.alloc(data.as_angle_bracketed_args());
-                    self.lower_angle_bracketed_parameter_data(aba, ParamMode::Explicit, itctx).0
+                    self.lower_angle_bracketed_parameter_data(
+                        &data.as_angle_bracketed_args(),
+                        ParamMode::Explicit,
+                        itctx,
+                    )
+                    .0
                 }
             };
             gen_args_ctor.into_generic_args(self)
@@ -1067,13 +1051,15 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
                     self.with_dyn_type_scope(false, |this| {
                         let node_id = this.next_node_id();
-                        let ty = this.ast_arena.tys.alloc(Ty {
-                            id: node_id,
-                            kind: TyKind::ImplTrait(impl_trait_node_id, bounds.clone()),
-                            span: this.lower_span(constraint.span),
-                            tokens: None,
-                        });
-                        let ty = this.lower_ty(ty, itctx);
+                        let ty = this.lower_ty(
+                            &Ty {
+                                id: node_id,
+                                kind: TyKind::ImplTrait(impl_trait_node_id, bounds.clone()),
+                                span: this.lower_span(constraint.span),
+                                tokens: None,
+                            },
+                            itctx,
+                        );
 
                         hir::TypeBindingKind::Equality { term: ty.into() }
                     })
@@ -1217,13 +1203,12 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             && let Some(Res::Def(DefKind::Trait | DefKind::TraitAlias, _)) = partial_res.full_res()
         {
             let (bounds, lifetime_bound) = self.with_dyn_type_scope(true, |this| {
-                let poly_trait_ref = this.ast_arena.ptr.alloc(PolyTraitRef {
-                    bound_generic_params: vec![],
-                    trait_ref: TraitRef { path: path.clone(), ref_id: t.id },
-                    span: t.span
-                });
                 let bound = this.lower_poly_trait_ref(
-                    poly_trait_ref,
+                    &PolyTraitRef {
+                        bound_generic_params: vec![],
+                        trait_ref: TraitRef { path: path.clone(), ref_id: t.id },
+                        span: t.span
+                    },
                     itctx,
                 );
                 let bounds = this.arena.alloc_from_iter([bound]);


### PR DESCRIPTION
This reverts commit d9a1faaa9cff6eab069ea8e5cd7862d0ae48e231 (#101499).

This was originally part of #101345 which has now been closed as a different approach is taken now.

r? @oli-obk 

cc @spastorino 