### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -5407,7 +5407,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]


### PR DESCRIPTION
11 commits in cc0a320879c17207bbfb96b5d778e28a2c62030d..c994a4a638370bc7e0ffcbb0e2865afdfa7d4415 2022-12-14 14:46:57 +0000 to 2022-12-18 21:50:58 +0000
- Fix examples of proc-macro crates being scraped for examples (rust-lang/cargo#11497)
- Enable triagebot's relabel functionality (rust-lang/cargo#11498)
- Revert "temporarily disable test `lto::test_profile`" (rust-lang/cargo#11495)
- Bump to 0.69.0, update changelog (rust-lang/cargo#11493)
- Fix typo (rust-lang/cargo#11491)
- Display CPU info in CI (rust-lang/cargo#11488)
- Fix collision_doc_profile test error (rust-lang/cargo#11489)
- fix: Make auto-fix note work with `clippy` (rust-lang/cargo#11399)
- fix(add): use the possessive in error message (rust-lang/cargo#11483)
- Document home crate in contrib docs (rust-lang/cargo#11481)
- Split up registry documentation into multiple sections (rust-lang/cargo#11480)

r? @ghost