### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -620,7 +620,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         self.impl_trait_defs = current_impl_trait_defs;
         self.impl_trait_bounds = current_impl_trait_bounds;
 
-        debug_assert!(self.children.iter().find(|(id, _)| id == &def_id).is_none());
+        debug_assert!(!self.children.iter().any(|(id, _)| id == &def_id));
         self.children.push((def_id, hir::MaybeOwner::Owner(info)));
     }
 

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -2059,12 +2059,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
     ) -> Option<InitIndex> {
         let mpi = self.move_data.rev_lookup.find_local(local);
         let ii = &self.move_data.init_path_map[mpi];
-        for &index in ii {
-            if flow_state.ever_inits.contains(index) {
-                return Some(index);
-            }
-        }
-        None
+        ii.into_iter().find(|&&index| flow_state.ever_inits.contains(index)).copied()
     }
 
     /// Adds the place into the used mutable variables set

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -233,8 +233,8 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         // Set KCFI operand bundle
         let is_indirect_call = unsafe { llvm::LLVMIsAFunction(llfn).is_none() };
         let kcfi_bundle =
-            if self.tcx.sess.is_sanitizer_kcfi_enabled() && fn_abi.is_some() && is_indirect_call {
-                let kcfi_typeid = kcfi_typeid_for_fnabi(self.tcx, fn_abi.unwrap());
+            if self.tcx.sess.is_sanitizer_kcfi_enabled() && let Some(fn_abi) = fn_abi && is_indirect_call {
+                let kcfi_typeid = kcfi_typeid_for_fnabi(self.tcx, fn_abi);
                 Some(llvm::OperandBundleDef::new("kcfi", &[self.const_u32(kcfi_typeid)]))
             } else {
                 None

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -123,7 +123,7 @@ fn try_filter_fat_archs<'a>(
 ) -> io::Result<Option<(&'a [u8], u64)>> {
     let archs = archs.map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
-    let desired = match archs.iter().filter(|a| a.architecture() == target_arch).next() {
+    let desired = match archs.iter().find(|a| a.architecture() == target_arch) {
         Some(a) => a,
         None => return Ok(None),
     };

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -1128,9 +1128,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         let hir = self.tcx.hir();
-        let cond_parent = hir.parent_iter(expr.hir_id).skip_while(|(_, node)| {
-            matches!(node, hir::Node::Expr(hir::Expr { kind: hir::ExprKind::Binary(op, _, _), .. }) if op.node == hir::BinOpKind::And)
-        }).next();
+        let cond_parent = hir.parent_iter(expr.hir_id).find(|(_, node)| {
+            !matches!(node, hir::Node::Expr(hir::Expr { kind: hir::ExprKind::Binary(op, _, _), .. }) if op.node == hir::BinOpKind::And)
+        });
         // Don't suggest:
         //     `let Some(_) = a.is_some() && b`
         //                     ++++++++++

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -488,7 +488,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                         // If this empty region is from a universe that can
                         // name the placeholder, then the placeholder is
                         // larger; otherwise, the only ancestor is `'static`.
-                        if a_ui.can_name(placeholder.universe) { true } else { false }
+                        return a_ui.can_name(placeholder.universe);
                     }
                 }
             }

--- a/compiler/rustc_infer/src/infer/undo_log.rs
+++ b/compiler/rustc_infer/src/infer/undo_log.rs
@@ -87,16 +87,10 @@ impl<'tcx> Rollback<UndoLog<'tcx>> for InferCtxtInner<'tcx> {
 
 /// The combined undo log for all the various unification tables. For each change to the storage
 /// for any kind of inference variable, we record an UndoLog entry in the vector here.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(crate) struct InferCtxtUndoLogs<'tcx> {
     logs: Vec<UndoLog<'tcx>>,
     num_open_snapshots: usize,
-}
-
-impl Default for InferCtxtUndoLogs<'_> {
-    fn default() -> Self {
-        Self { logs: Default::default(), num_open_snapshots: Default::default() }
-    }
 }
 
 /// The UndoLogs trait defines how we undo a particular kind of action (of type T). We can undo any

--- a/compiler/rustc_middle/src/middle/privacy.rs
+++ b/compiler/rustc_middle/src/middle/privacy.rs
@@ -103,12 +103,7 @@ impl EffectiveVisibilities {
 
     pub fn public_at_level(&self, id: LocalDefId) -> Option<Level> {
         self.effective_vis(id).and_then(|effective_vis| {
-            for level in Level::all_levels() {
-                if effective_vis.is_public_at_level(level) {
-                    return Some(level);
-                }
-            }
-            None
+            Level::all_levels().into_iter().find(|&level| effective_vis.is_public_at_level(level))
         })
     }
 

--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -182,7 +182,7 @@ fn replace_flattened_locals<'tcx>(
     let mut fragments = IndexVec::new();
     for (k, v) in &replacements.fields {
         fragments.ensure_contains_elem(k.local, || Vec::new());
-        fragments[k.local].push((&k.projection[..], *v));
+        fragments[k.local].push((k.projection, *v));
     }
     debug!(?fragments);
 

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -595,8 +595,8 @@ fn check_recursion_limit<'tcx>(
         let def_path_str = tcx.def_path_str(def_id);
         let (shrunk, written_to_path) = shrunk_instance_name(tcx, &instance);
         let mut path = PathBuf::new();
-        let was_written = if written_to_path.is_some() {
-            path = written_to_path.unwrap();
+        let was_written = if let Some(written_to_path) = written_to_path {
+            path = written_to_path;
             Some(())
         } else {
             None

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -277,8 +277,7 @@ impl<'a> Parser<'a> {
                         if let Some(arg) = args
                             .iter()
                             .rev()
-                            .skip_while(|arg| matches!(arg, AngleBracketedArg::Constraint(_)))
-                            .next()
+                            .find(|arg| !matches!(arg, AngleBracketedArg::Constraint(_)))
                         {
                             err.span_suggestion_verbose(
                                 arg.span().shrink_to_hi(),

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -787,7 +787,6 @@ impl<'tcx> DeadVisitor<'tcx> {
         let mut dead_codes = dead_codes
             .iter()
             .filter(|v| !v.name.as_str().starts_with('_'))
-            .map(|v| v)
             .collect::<Vec<&DeadVariant>>();
         if dead_codes.is_empty() {
             return;

--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -122,7 +122,7 @@ pub fn sysroot_candidates() -> SmallVec<[PathBuf; 2]> {
     let target = crate::config::host_triple();
     let mut sysroot_candidates: SmallVec<[PathBuf; 2]> =
         smallvec![get_or_default_sysroot().expect("Failed finding sysroot")];
-    let path = current_dll_path().and_then(|s| Ok(s.canonicalize().map_err(|e| e.to_string())?));
+    let path = current_dll_path().and_then(|s| s.canonicalize().map_err(|e| e.to_string()));
     if let Ok(dll) = path {
         // use `parent` twice to chop off the file name and then also the
         // directory containing the dll which should be either `lib` or `bin`.
@@ -165,7 +165,7 @@ pub fn get_or_default_sysroot() -> Result<PathBuf, String> {
     }
 
     fn default_from_rustc_driver_dll() -> Result<PathBuf, String> {
-        let dll = current_dll_path().and_then(|s| Ok(canonicalize(s)))?;
+        let dll = current_dll_path().map(|s| canonicalize(s))?;
 
         // `dll` will be in one of the following two:
         // - compiler's libdir: $sysroot/lib/*.dll

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1789,7 +1789,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         self.note_conflicting_closure_bounds(cause, &mut err);
 
         if let Some(found_node) = found_node {
-            hint_missing_borrow(span, found_span, found, expected, found_node, &mut err);
+            hint_missing_borrow(span, found, expected, found_node, &mut err);
         }
 
         err
@@ -3455,7 +3455,6 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 /// Add a hint to add a missing borrow or remove an unnecessary one.
 fn hint_missing_borrow<'tcx>(
     span: Span,
-    found_span: Span,
     found: Ty<'tcx>,
     expected: Ty<'tcx>,
     found_node: Node<'_>,
@@ -3474,9 +3473,8 @@ fn hint_missing_borrow<'tcx>(
         }
     };
 
-    let fn_decl = found_node
-        .fn_decl()
-        .unwrap_or_else(|| span_bug!(found_span, "found node must be a function"));
+    // This could be a variant constructor, for example.
+    let Some(fn_decl) = found_node.fn_decl() else { return; };
 
     let arg_spans = fn_decl.inputs.iter().map(|ty| ty.span);
 

--- a/compiler/rustc_transmute/src/maybe_transmutable/query_context.rs
+++ b/compiler/rustc_transmute/src/maybe_transmutable/query_context.rs
@@ -76,11 +76,7 @@ mod rustc {
                 }
             };
 
-            let ret = if self.visibility(def_id).is_accessible_from(parent, *self) {
-                true
-            } else {
-                false
-            };
+            let ret: bool = self.visibility(def_id).is_accessible_from(parent, *self);
 
             trace!(?ret, "ret");
             ret

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2471,8 +2471,8 @@ impl Display for char {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> Pointer for *const T {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        // Cast is needed here because `.addr()` requires `T: Sized`.
-        pointer_fmt_inner((*self as *const ()).addr(), f)
+        // Cast is needed here because `.expose_addr()` requires `T: Sized`.
+        pointer_fmt_inner((*self as *const ()).expose_addr(), f)
     }
 }
 

--- a/library/test/src/cli.rs
+++ b/library/test/src/cli.rs
@@ -354,8 +354,7 @@ fn get_shuffle_seed(matches: &getopts::Matches, allow_unstable: bool) -> OptPart
             Err(e) => {
                 return Err(format!(
                     "argument for --shuffle-seed must be a number \
-                     (error: {})",
-                    e
+                     (error: {e})"
                 ));
             }
         },
@@ -383,8 +382,7 @@ fn get_test_threads(matches: &getopts::Matches) -> OptPartRes<Option<usize>> {
             Err(e) => {
                 return Err(format!(
                     "argument for --test-threads must be a number > 0 \
-                     (error: {})",
-                    e
+                     (error: {e})"
                 ));
             }
         },
@@ -418,8 +416,7 @@ fn get_format(
         Some(v) => {
             return Err(format!(
                 "argument for --format must be pretty, terse, json or junit (was \
-                 {})",
-                v
+                 {v})"
             ));
         }
     };
@@ -436,8 +433,7 @@ fn get_color_config(matches: &getopts::Matches) -> OptPartRes<ColorConfig> {
         Some(v) => {
             return Err(format!(
                 "argument for --color must be auto, always, or never (was \
-                 {})",
-                v
+                 {v})"
             ));
         }
     };

--- a/library/test/src/formatters/json.rs
+++ b/library/test/src/formatters/json.rs
@@ -53,7 +53,7 @@ impl<T: Write> JsonFormatter<T> {
             self.write_message(&*format!(r#", "stdout": "{}""#, EscapedString(stdout)))?;
         }
         if let Some(extra) = extra {
-            self.write_message(&*format!(r#", {}"#, extra))?;
+            self.write_message(&*format!(r#", {extra}"#))?;
         }
         self.writeln_message(" }")
     }
@@ -62,13 +62,12 @@ impl<T: Write> JsonFormatter<T> {
 impl<T: Write> OutputFormatter for JsonFormatter<T> {
     fn write_run_start(&mut self, test_count: usize, shuffle_seed: Option<u64>) -> io::Result<()> {
         let shuffle_seed_json = if let Some(shuffle_seed) = shuffle_seed {
-            format!(r#", "shuffle_seed": {}"#, shuffle_seed)
+            format!(r#", "shuffle_seed": {shuffle_seed}"#)
         } else {
             String::new()
         };
         self.writeln_message(&*format!(
-            r#"{{ "type": "suite", "event": "started", "test_count": {}{} }}"#,
-            test_count, shuffle_seed_json
+            r#"{{ "type": "suite", "event": "started", "test_count": {test_count}{shuffle_seed_json} }}"#
         ))
     }
 

--- a/library/test/src/formatters/mod.rs
+++ b/library/test/src/formatters/mod.rs
@@ -38,5 +38,5 @@ pub(crate) fn write_stderr_delimiter(test_output: &mut Vec<u8>, test_name: &Test
         Some(_) => test_output.push(b'\n'),
         None => (),
     }
-    writeln!(test_output, "---- {} stderr ----", test_name).unwrap();
+    writeln!(test_output, "---- {test_name} stderr ----").unwrap();
 }

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -47,7 +47,7 @@ impl<T: Write> PrettyFormatter<T> {
 
     pub fn write_ignored(&mut self, message: Option<&'static str>) -> io::Result<()> {
         if let Some(message) = message {
-            self.write_short_result(&format!("ignored, {}", message), term::color::YELLOW)
+            self.write_short_result(&format!("ignored, {message}"), term::color::YELLOW)
         } else {
             self.write_short_result("ignored", term::color::YELLOW)
         }

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -213,8 +213,7 @@ pub fn assert_test_result<T: Termination>(result: T) -> Result<(), String> {
     } else {
         Err(format!(
             "the test returned a termination value with a non-zero status code \
-             ({}) which indicates a failure",
-            code
+             ({code}) which indicates a failure"
         ))
     }
 }
@@ -750,7 +749,7 @@ fn spawn_test_subprocess(
         })() {
             Ok(r) => r,
             Err(e) => {
-                write!(&mut test_output, "Unexpected error: {}", e).unwrap();
+                write!(&mut test_output, "Unexpected error: {e}").unwrap();
                 TrFailed
             }
         };

--- a/library/test/src/test_result.rs
+++ b/library/test/src/test_result.rs
@@ -44,9 +44,8 @@ pub fn calc_result<'a>(
             } else if let Some(panic_str) = maybe_panic_str {
                 TestResult::TrFailedMsg(format!(
                     r#"panic did not contain expected string
-      panic message: `{:?}`,
- expected substring: `{:?}`"#,
-                    panic_str, msg
+      panic message: `{panic_str:?}`,
+ expected substring: `{msg:?}`"#
                 ))
             } else {
                 TestResult::TrFailedMsg(format!(

--- a/library/test/src/time.rs
+++ b/library/test/src/time.rs
@@ -107,16 +107,14 @@ impl TimeThreshold {
         let durations_str = env::var(env_var_name).ok()?;
         let (warn_str, critical_str) = durations_str.split_once(',').unwrap_or_else(|| {
             panic!(
-                "Duration variable {} expected to have 2 numbers separated by comma, but got {}",
-                env_var_name, durations_str
+                "Duration variable {env_var_name} expected to have 2 numbers separated by comma, but got {durations_str}"
             )
         });
 
         let parse_u64 = |v| {
             u64::from_str(v).unwrap_or_else(|_| {
                 panic!(
-                    "Duration value in variable {} is expected to be a number, but got {}",
-                    env_var_name, v
+                    "Duration value in variable {env_var_name} is expected to be a number, but got {v}"
                 )
             })
         };

--- a/src/test/ui/generator/ref-upvar-not-send.rs
+++ b/src/test/ui/generator/ref-upvar-not-send.rs
@@ -1,0 +1,31 @@
+// For `Send` generators, suggest a `T: Sync` requirement for `&T` upvars,
+// and suggest a `T: Send` requirement for `&mut T` upvars.
+
+#![feature(generators)]
+
+fn assert_send<T: Send>(_: T) {}
+//~^ NOTE required by a bound in `assert_send`
+//~| NOTE required by this bound in `assert_send`
+//~| NOTE required by a bound in `assert_send`
+//~| NOTE required by this bound in `assert_send`
+
+fn main() {
+    let x: &*mut () = &std::ptr::null_mut();
+    let y: &mut *mut () = &mut std::ptr::null_mut();
+    assert_send(move || {
+        //~^ ERROR generator cannot be sent between threads safely
+        //~| NOTE generator is not `Send`
+        yield;
+        let _x = x;
+    });
+    //~^^ NOTE captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
+    //~| NOTE has type `&*mut ()` which is not `Send`, because `*mut ()` is not `Sync`
+    assert_send(move || {
+        //~^ ERROR generator cannot be sent between threads safely
+        //~| NOTE generator is not `Send`
+        yield;
+        let _y = y;
+    });
+    //~^^ NOTE captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
+    //~| NOTE has type `&mut *mut ()` which is not `Send`, because `*mut ()` is not `Send`
+}

--- a/src/test/ui/generator/ref-upvar-not-send.stderr
+++ b/src/test/ui/generator/ref-upvar-not-send.stderr
@@ -1,0 +1,50 @@
+error: generator cannot be sent between threads safely
+  --> $DIR/ref-upvar-not-send.rs:15:17
+   |
+LL |       assert_send(move || {
+   |  _________________^
+LL | |
+LL | |
+LL | |         yield;
+LL | |         let _x = x;
+LL | |     });
+   | |_____^ generator is not `Send`
+   |
+   = help: the trait `Sync` is not implemented for `*mut ()`
+note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
+  --> $DIR/ref-upvar-not-send.rs:19:18
+   |
+LL |         let _x = x;
+   |                  ^ has type `&*mut ()` which is not `Send`, because `*mut ()` is not `Sync`
+note: required by a bound in `assert_send`
+  --> $DIR/ref-upvar-not-send.rs:6:19
+   |
+LL | fn assert_send<T: Send>(_: T) {}
+   |                   ^^^^ required by this bound in `assert_send`
+
+error: generator cannot be sent between threads safely
+  --> $DIR/ref-upvar-not-send.rs:23:17
+   |
+LL |       assert_send(move || {
+   |  _________________^
+LL | |
+LL | |
+LL | |         yield;
+LL | |         let _y = y;
+LL | |     });
+   | |_____^ generator is not `Send`
+   |
+   = help: within `[generator@$DIR/ref-upvar-not-send.rs:23:17: 23:24]`, the trait `Send` is not implemented for `*mut ()`
+note: captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
+  --> $DIR/ref-upvar-not-send.rs:27:18
+   |
+LL |         let _y = y;
+   |                  ^ has type `&mut *mut ()` which is not `Send`, because `*mut ()` is not `Send`
+note: required by a bound in `assert_send`
+  --> $DIR/ref-upvar-not-send.rs:6:19
+   |
+LL | fn assert_send<T: Send>(_: T) {}
+   |                   ^^^^ required by this bound in `assert_send`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/suggestions/enum-variant-arg-mismatch.rs
+++ b/src/test/ui/suggestions/enum-variant-arg-mismatch.rs
@@ -1,0 +1,10 @@
+pub enum Sexpr<'a> {
+    Ident(&'a str),
+}
+
+fn map<'a, F: Fn(String) -> Sexpr<'a>>(f: F) {}
+
+fn main() {
+    map(Sexpr::Ident);
+    //~^ ERROR type mismatch in function arguments
+}

--- a/src/test/ui/suggestions/enum-variant-arg-mismatch.stderr
+++ b/src/test/ui/suggestions/enum-variant-arg-mismatch.stderr
@@ -1,0 +1,22 @@
+error[E0631]: type mismatch in function arguments
+  --> $DIR/enum-variant-arg-mismatch.rs:8:9
+   |
+LL |     Ident(&'a str),
+   |     ----- found signature defined here
+...
+LL |     map(Sexpr::Ident);
+   |     --- ^^^^^^^^^^^^ expected due to this
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(String) -> _`
+              found function signature `fn(&str) -> _`
+note: required by a bound in `map`
+  --> $DIR/enum-variant-arg-mismatch.rs:5:15
+   |
+LL | fn map<'a, F: Fn(String) -> Sexpr<'a>>(f: F) {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `map`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0631`.


### PR DESCRIPTION
Successful merges:

 - #105682 (Use `expose_addr()` in `fmt::Pointer`)
 - #105839 (Suggest a `T: Send` bound for `&mut T` upvars in `Send` generators)
 - #105864 (clippy::complexity fixes)
 - #105882 (Don't ICE in closure arg borrow suggestion)
 - #105889 (Fix `uninlined_format_args` in libtest)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=105682,105839,105864,105882,105889)
<!-- homu-ignore:end -->