### PR TITLE
Update rustdoc code blocks so they use grid: display

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -527,9 +527,11 @@ ul.block, .block li {
 }
 
 .rustdoc .example-wrap {
-	display: flex;
+	display: grid;
+	grid-template-columns: max-content auto;
 	position: relative;
 	margin-bottom: 10px;
+	overflow-x: auto;
 }
 /* For the last child of a div, the margin will be taken care of
 	by the margin-top of the next item. */
@@ -539,13 +541,15 @@ ul.block, .block li {
 
 .rustdoc .example-wrap > pre {
 	margin: 0;
-	flex-grow: 1;
-	overflow-x: auto;
+}
+.rustdoc .example-wrap > pre:first-child:last-child {
+	/* When there is only one "column", we need to only apply "auto" from "grid-template-columns",
+	   otherwise it won't take the full width. */
+	grid-column-start: 2;
 }
 
 .rustdoc .example-wrap > pre.example-line-numbers,
 .rustdoc .example-wrap > pre.src-line-numbers {
-	flex-grow: 0;
 	overflow: initial;
 	text-align: right;
 	-webkit-user-select: none;
@@ -1978,8 +1982,6 @@ in storage.js
 }
 
 .scraped-example .code-wrapper .example-wrap {
-	display: grid;
-	grid-template-columns: max-content auto;
 	width: 100%;
 	overflow-x: auto;
 	overflow-y: hidden;

--- a/src/test/rustdoc-gui/code-blocks-overflow.goml
+++ b/src/test/rustdoc-gui/code-blocks-overflow.goml
@@ -1,8 +1,18 @@
 // This test ensures that codeblocks content don't overflow.
 goto: "file://" + |DOC_PATH| + "/lib2/sub_mod/struct.Foo.html"
 size: (1080, 600)
-// There should be two codeblocks: a rust one and a non-rust one.
-assert-count: (".docblock > .example-wrap", 2)
+// There should be three codeblocks: two rust ones and a non-rust one.
+assert-count: (".docblock > .example-wrap", 3)
 assert: ".docblock > .example-wrap > .language-txt"
 assert: ".docblock > .example-wrap > .rust-example-rendered"
-assert-css: (".docblock > .example-wrap > pre", {"width": "796px", "overflow-x": "auto"}, ALL)
+
+// We confirm that we don't display line numbers currently.
+assert-local-storage-false: {"rustdoc-line-numbers": "true"}
+
+assert-css: (".docblock > .example-wrap", {"width": "796px", "overflow-x": "auto"}, ALL)
+assert-css: (".docblock > .example-wrap > pre", {"width": "1756px"})
+
+// Confirm that there is no change when line numbers are displayed.
+local-storage: {"rustdoc-line-numbers": "true"}
+assert-css: (".docblock > .example-wrap", {"width": "796px", "overflow-x": "auto"}, ALL)
+assert-css: (".docblock > .example-wrap > pre", {"width": "1756px"})

--- a/src/test/rustdoc-gui/source-anchor-scroll.goml
+++ b/src/test/rustdoc-gui/source-anchor-scroll.goml
@@ -1,6 +1,7 @@
 // We check that when the anchor changes and is output of the displayed content,
 // the page is scrolled to it.
 goto: "file://" + |DOC_PATH| + "/src/link_to_definition/lib.rs.html"
+show-text: true
 
 // We reduce the window size to make it easier to make an element "out of the page".
 size: (600, 800)
@@ -12,9 +13,9 @@ assert-property: ("html", {"scrollTop": "125"})
 click: '//a[text() = "bar"]'
 assert-property: ("html", {"scrollTop": "156"})
 click: '//a[text() = "sub_fn"]'
-assert-property: ("html", {"scrollTop": "53"})
+assert-property: ("html", {"scrollTop": "76"})
 
 // We now check that clicking on lines doesn't change the scroll
 // Extra information: the "sub_fn" function header is on line 1.
 click: '//*[@id="6"]'
-assert-property: ("html", {"scrollTop": "53"})
+assert-property: ("html", {"scrollTop": "76"})

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -67,6 +67,10 @@ pub mod sub_mod {
     /// ```
     /// aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     /// ```
+    ///
+    /// ```
+    /// foo();
+    /// ```
     pub struct Foo;
 }
 


### PR DESCRIPTION
It's another approach to https://github.com/rust-lang/rust/pull/105823.

It generalizes the usage of `display: grid` for code blocks instead of just using it for scraped examples.

r? @notriddle 