### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2555,8 +2555,8 @@ pub enum AttrStyle {
 
 rustc_index::newtype_index! {
     #[custom_encodable]
+    #[debug_format = "AttrId({})]"]
     pub struct AttrId {
-        DEBUG_FORMAT = "AttrId({})"
     }
 }
 

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2554,8 +2554,8 @@ pub enum AttrStyle {
 }
 
 rustc_index::newtype_index! {
+    #[custom_encodable]
     pub struct AttrId {
-        ENCODABLE = custom
         DEBUG_FORMAT = "AttrId({})"
     }
 }

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2556,8 +2556,7 @@ pub enum AttrStyle {
 rustc_index::newtype_index! {
     #[custom_encodable]
     #[debug_format = "AttrId({})]"]
-    pub struct AttrId {
-    }
+    pub struct AttrId {}
 }
 
 impl<S: Encoder> Encodable<S> for AttrId {

--- a/compiler/rustc_ast/src/node_id.rs
+++ b/compiler/rustc_ast/src/node_id.rs
@@ -8,8 +8,8 @@ rustc_index::newtype_index! {
     /// This is later turned into [`DefId`] and `HirId` for the HIR.
     ///
     /// [`DefId`]: rustc_span::def_id::DefId
+    #[debug_format = "NodeId({})"]
     pub struct NodeId {
-        DEBUG_FORMAT = "NodeId({})"
     }
 }
 

--- a/compiler/rustc_ast/src/node_id.rs
+++ b/compiler/rustc_ast/src/node_id.rs
@@ -9,8 +9,7 @@ rustc_index::newtype_index! {
     ///
     /// [`DefId`]: rustc_span::def_id::DefId
     #[debug_format = "NodeId({})"]
-    pub struct NodeId {
-    }
+    pub struct NodeId {}
 }
 
 rustc_data_structures::define_id_collections!(NodeMap, NodeSet, NodeMapEntry, NodeId);

--- a/compiler/rustc_borrowck/src/constraints/mod.rs
+++ b/compiler/rustc_borrowck/src/constraints/mod.rs
@@ -115,13 +115,13 @@ impl<'tcx> fmt::Debug for OutlivesConstraint<'tcx> {
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "OutlivesConstraintIndex({})"]
     pub struct OutlivesConstraintIndex {
-        DEBUG_FORMAT = "OutlivesConstraintIndex({})"
     }
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "ConstraintSccIndex({})"]
     pub struct ConstraintSccIndex {
-        DEBUG_FORMAT = "ConstraintSccIndex({})"
     }
 }

--- a/compiler/rustc_borrowck/src/constraints/mod.rs
+++ b/compiler/rustc_borrowck/src/constraints/mod.rs
@@ -116,12 +116,10 @@ impl<'tcx> fmt::Debug for OutlivesConstraint<'tcx> {
 
 rustc_index::newtype_index! {
     #[debug_format = "OutlivesConstraintIndex({})"]
-    pub struct OutlivesConstraintIndex {
-    }
+    pub struct OutlivesConstraintIndex {}
 }
 
 rustc_index::newtype_index! {
     #[debug_format = "ConstraintSccIndex({})"]
-    pub struct ConstraintSccIndex {
-    }
+    pub struct ConstraintSccIndex {}
 }

--- a/compiler/rustc_borrowck/src/dataflow.rs
+++ b/compiler/rustc_borrowck/src/dataflow.rs
@@ -108,8 +108,8 @@ impl_visitable! {
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "bw{}"]
     pub struct BorrowIndex {
-        DEBUG_FORMAT = "bw{}"
     }
 }
 

--- a/compiler/rustc_borrowck/src/dataflow.rs
+++ b/compiler/rustc_borrowck/src/dataflow.rs
@@ -109,8 +109,7 @@ impl_visitable! {
 
 rustc_index::newtype_index! {
     #[debug_format = "bw{}"]
-    pub struct BorrowIndex {
-    }
+    pub struct BorrowIndex {}
 }
 
 /// `Borrows` stores the data used in the analyses that track the flow

--- a/compiler/rustc_borrowck/src/location.rs
+++ b/compiler/rustc_borrowck/src/location.rs
@@ -20,8 +20,8 @@ pub struct LocationTable {
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "LocationIndex({})"]
     pub struct LocationIndex {
-        DEBUG_FORMAT = "LocationIndex({})"
     }
 }
 

--- a/compiler/rustc_borrowck/src/location.rs
+++ b/compiler/rustc_borrowck/src/location.rs
@@ -21,8 +21,7 @@ pub struct LocationTable {
 
 rustc_index::newtype_index! {
     #[debug_format = "LocationIndex({})"]
-    pub struct LocationIndex {
-    }
+    pub struct LocationIndex {}
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/compiler/rustc_borrowck/src/member_constraints.rs
+++ b/compiler/rustc_borrowck/src/member_constraints.rs
@@ -56,8 +56,7 @@ pub(crate) struct NllMemberConstraint<'tcx> {
 
 rustc_index::newtype_index! {
     #[debug_format = "MemberConstraintIndex({})"]
-    pub(crate) struct NllMemberConstraintIndex {
-    }
+    pub(crate) struct NllMemberConstraintIndex {}
 }
 
 impl Default for MemberConstraintSet<'_, ty::RegionVid> {

--- a/compiler/rustc_borrowck/src/member_constraints.rs
+++ b/compiler/rustc_borrowck/src/member_constraints.rs
@@ -55,8 +55,8 @@ pub(crate) struct NllMemberConstraint<'tcx> {
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "MemberConstraintIndex({})"]
     pub(crate) struct NllMemberConstraintIndex {
-        DEBUG_FORMAT = "MemberConstraintIndex({})"
     }
 }
 

--- a/compiler/rustc_borrowck/src/region_infer/values.rs
+++ b/compiler/rustc_borrowck/src/region_infer/values.rs
@@ -90,12 +90,14 @@ impl RegionValueElements {
 rustc_index::newtype_index! {
     /// A single integer representing a `Location` in the MIR control-flow
     /// graph. Constructed efficiently from `RegionValueElements`.
-    pub struct PointIndex { DEBUG_FORMAT = "PointIndex({})" }
+    #[debug_format = "PointIndex({})"]
+    pub struct PointIndex {}
 }
 
 rustc_index::newtype_index! {
     /// A single integer representing a `ty::Placeholder`.
-    pub struct PlaceholderIndex { DEBUG_FORMAT = "PlaceholderIndex({})" }
+    #[debug_format = "PlaceholderIndex({})"]
+    pub struct PlaceholderIndex {}
 }
 
 /// An individual element in a region value -- the value of a

--- a/compiler/rustc_borrowck/src/type_check/liveness/local_use_map.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/local_use_map.rs
@@ -46,7 +46,7 @@ struct Appearance {
 }
 
 rustc_index::newtype_index! {
-    pub struct AppearanceIndex { .. }
+    pub struct AppearanceIndex {}
 }
 
 impl vll::LinkElem for Appearance {

--- a/compiler/rustc_data_structures/src/graph/dominators/mod.rs
+++ b/compiler/rustc_data_structures/src/graph/dominators/mod.rs
@@ -22,7 +22,7 @@ struct PreOrderFrame<Iter> {
 }
 
 rustc_index::newtype_index! {
-    struct PreorderIndex { .. }
+    struct PreorderIndex {}
 }
 
 pub fn dominators<G: ControlFlowGraph>(graph: G) -> Dominators<G::Node> {

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -239,6 +239,7 @@ E0452: include_str!("./error_codes/E0452.md"),
 E0453: include_str!("./error_codes/E0453.md"),
 E0454: include_str!("./error_codes/E0454.md"),
 E0455: include_str!("./error_codes/E0455.md"),
+E0457: include_str!("./error_codes/E0457.md"),
 E0458: include_str!("./error_codes/E0458.md"),
 E0459: include_str!("./error_codes/E0459.md"),
 E0460: include_str!("./error_codes/E0460.md"),
@@ -593,7 +594,6 @@ E0791: include_str!("./error_codes/E0791.md"),
 //  E0421, // merged into 531
 //  E0427, // merged into 530
 //  E0456, // plugin `..` is not available for triple `..`
-    E0457, // plugin `..` only found in rlib format, but must be available...
     E0461, // couldn't find crate `..` with expected target triple ..
     E0462, // found staticlib `..` instead of rlib or dylib
     E0465, // multiple .. candidates for `..` found

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -241,6 +241,7 @@ E0454: include_str!("./error_codes/E0454.md"),
 E0455: include_str!("./error_codes/E0455.md"),
 E0458: include_str!("./error_codes/E0458.md"),
 E0459: include_str!("./error_codes/E0459.md"),
+E0460: include_str!("./error_codes/E0460.md"),
 E0463: include_str!("./error_codes/E0463.md"),
 E0464: include_str!("./error_codes/E0464.md"),
 E0466: include_str!("./error_codes/E0466.md"),
@@ -593,7 +594,6 @@ E0791: include_str!("./error_codes/E0791.md"),
 //  E0427, // merged into 530
 //  E0456, // plugin `..` is not available for triple `..`
     E0457, // plugin `..` only found in rlib format, but must be available...
-    E0460, // found possibly newer version of crate `..`
     E0461, // couldn't find crate `..` with expected target triple ..
     E0462, // found staticlib `..` instead of rlib or dylib
     E0465, // multiple .. candidates for `..` found

--- a/compiler/rustc_error_codes/src/error_codes/E0457.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0457.md
@@ -1,0 +1,36 @@
+Plugin `..` only found in rlib format, but must be available in dylib format.
+
+Erroronous code example:
+
+`rlib-plugin.rs`
+```ignore (needs-linkage-with-other-tests)
+#![crate_type = "rlib"]
+#![feature(rustc_private)]
+
+extern crate rustc_middle;
+extern crate rustc_driver;
+
+use rustc_driver::plugin::Registry;
+
+#[no_mangle]
+fn __rustc_plugin_registrar(_: &mut Registry) {}
+```
+
+`main.rs`
+```ignore (needs-linkage-with-other-tests)
+#![feature(plugin)]
+#![plugin(rlib_plugin)] // error: plugin `rlib_plugin` only found in rlib
+                        //        format, but must be available in dylib
+
+fn main() {}
+```
+
+The compiler exposes a plugin interface to allow altering the compile process
+(adding lints, etc). Plugins must be defined in their own crates (similar to
+[proc-macro](../reference/procedural-macros.html) isolation) and then compiled
+and linked to another crate. Plugin crates *must* be compiled to the
+dynamically-linked dylib format, and not the statically-linked rlib format.
+Learn more about different output types in
+[this section](../reference/linkage.html) of the Rust reference.
+
+This error is easily fixed by recompiling the plugin crate in the dylib format.

--- a/compiler/rustc_error_codes/src/error_codes/E0460.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0460.md
@@ -64,8 +64,8 @@ dependencies, without using the compiler's own dependency management that
 causes this issue.
 
 This error can be fixed by:
-* Using [Cargo], the Rust package manager, automatically fixing this issue.
-* Recompiling crate `a` so that both crate `b` and `main` have a uniform
-version to depend on.
+ * Using [Cargo], the Rust package manager, automatically fixing this issue.
+ * Recompiling crate `a` so that both crate `b` and `main` have a uniform
+   version to depend on.
 
 [Cargo]: ../cargo/index.html

--- a/compiler/rustc_error_codes/src/error_codes/E0460.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0460.md
@@ -1,0 +1,71 @@
+Found possibly newer version of crate `..` which `..` depends on.
+
+Consider these erroneous files:
+
+`a1.rs`
+```ignore (needs-linkage-with-other-tests)
+#![crate_name = "a"]
+
+pub fn foo<T>() {}
+```
+
+`a2.rs`
+```ignore (needs-linkage-with-other-tests)
+#![crate_name = "a"]
+
+pub fn foo<T>() {
+    println!("foo<T>()");
+}
+```
+
+`b.rs`
+```ignore (needs-linkage-with-other-tests)
+#![crate_name = "b"]
+
+extern crate a; // linked with `a1.rs`
+
+pub fn foo() {
+    a::foo::<isize>();
+}
+```
+
+`main.rs`
+```ignore (needs-linkage-with-other-tests)
+extern crate a; // linked with `a2.rs`
+extern crate b; // error: found possibly newer version of crate `a` which `b`
+                //        depends on
+
+fn main() {}
+```
+
+The dependency graph of this program can be represented as follows:
+```text
+    crate `main`
+         |
+         +-------------+
+         |             |
+         |             v
+depends: |         crate `b`
+ `a` v1  |             |
+         |             | depends:
+         |             |  `a` v2
+         v             |
+      crate `a` <------+
+```
+
+Crate `main` depends on crate `a` (version 1) and crate `b` which in turn
+depends on crate `a` (version 2); this discrepancy in versions cannot be
+reconciled. This difference in versions typically occurs when one crate is
+compiled and linked, then updated and linked to another crate. The crate
+"version" is a SVH (Strict Version Hash) of the crate in an
+implementation-specific way. Note that this error can *only* occur when
+directly compiling and linking with `rustc`; [Cargo] automatically resolves
+dependencies, without using the compiler's own dependency management that
+causes this issue.
+
+This error can be fixed by:
+* Using [Cargo], the Rust package manager, automatically fixing this issue.
+* Recompiling crate `a` so that both crate `b` and `main` have a uniform
+version to depend on.
+
+[Cargo]: ../cargo/index.html

--- a/compiler/rustc_hir/src/hir_id.rs
+++ b/compiler/rustc_hir/src/hir_id.rs
@@ -138,7 +138,7 @@ rustc_index::newtype_index! {
     /// an "item-like" to something else can be implemented by a `Vec` instead of a
     /// tree or hash map.
     #[derive(HashStable_Generic)]
-    pub struct ItemLocalId { .. }
+    pub struct ItemLocalId {}
 }
 
 impl ItemLocalId {

--- a/compiler/rustc_hir_analysis/src/coherence/inherent_impls_overlap.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/inherent_impls_overlap.rs
@@ -198,8 +198,8 @@ impl<'tcx> InherentOverlapChecker<'tcx> {
             // entire graph when there are many connected regions.
 
             rustc_index::newtype_index! {
+                #[custom_encodable]
                 pub struct RegionId {
-                    ENCODABLE = custom
                 }
             }
             struct ConnectedRegion {

--- a/compiler/rustc_hir_analysis/src/coherence/inherent_impls_overlap.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/inherent_impls_overlap.rs
@@ -199,9 +199,9 @@ impl<'tcx> InherentOverlapChecker<'tcx> {
 
             rustc_index::newtype_index! {
                 #[custom_encodable]
-                pub struct RegionId {
-                }
+                pub struct RegionId {}
             }
+
             struct ConnectedRegion {
                 idents: SmallVec<[Symbol; 8]>,
                 impl_blocks: FxHashSet<usize>,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/arg_matrix.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/arg_matrix.rs
@@ -5,14 +5,12 @@ use rustc_middle::ty::error::TypeError;
 
 rustc_index::newtype_index! {
     #[debug_format = "ExpectedIdx({})"]
-    pub(crate) struct ExpectedIdx {
-    }
+    pub(crate) struct ExpectedIdx {}
 }
 
 rustc_index::newtype_index! {
     #[debug_format = "ProvidedIdx({})"]
-    pub(crate) struct ProvidedIdx {
-    }
+    pub(crate) struct ProvidedIdx {}
 }
 
 impl ExpectedIdx {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/arg_matrix.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/arg_matrix.rs
@@ -4,14 +4,14 @@ use rustc_index::vec::IndexVec;
 use rustc_middle::ty::error::TypeError;
 
 rustc_index::newtype_index! {
+    #[debug_format = "ExpectedIdx({})"]
     pub(crate) struct ExpectedIdx {
-        DEBUG_FORMAT = "ExpectedIdx({})",
     }
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "ProvidedIdx({})"]
     pub(crate) struct ProvidedIdx {
-        DEBUG_FORMAT = "ProvidedIdx({})",
     }
 }
 

--- a/compiler/rustc_hir_typeck/src/generator_interior/drop_ranges/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/drop_ranges/mod.rs
@@ -96,14 +96,14 @@ fn for_each_consumable<'tcx>(hir: Map<'tcx>, place: TrackedValue, mut f: impl Fn
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "id({})"]
     pub struct PostOrderId {
-        DEBUG_FORMAT = "id({})",
     }
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "hidx({})"]
     pub struct TrackedValueIndex {
-        DEBUG_FORMAT = "hidx({})",
     }
 }
 

--- a/compiler/rustc_hir_typeck/src/generator_interior/drop_ranges/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/drop_ranges/mod.rs
@@ -97,14 +97,12 @@ fn for_each_consumable<'tcx>(hir: Map<'tcx>, place: TrackedValue, mut f: impl Fn
 
 rustc_index::newtype_index! {
     #[debug_format = "id({})"]
-    pub struct PostOrderId {
-    }
+    pub struct PostOrderId {}
 }
 
 rustc_index::newtype_index! {
     #[debug_format = "hidx({})"]
-    pub struct TrackedValueIndex {
-    }
+    pub struct TrackedValueIndex {}
 }
 
 /// Identifies a value whose drop state we need to track.

--- a/compiler/rustc_index/src/vec/tests.rs
+++ b/compiler/rustc_index/src/vec/tests.rs
@@ -3,7 +3,10 @@
 // Allows the macro invocation below to work
 use crate as rustc_index;
 
-rustc_macros::newtype_index!(struct MyIdx { MAX = 0xFFFF_FFFA });
+rustc_macros::newtype_index! {
+    #[max = 0xFFFF_FFFA]
+    struct MyIdx { }
+}
 
 #[test]
 fn index_size_is_optimized() {

--- a/compiler/rustc_index/src/vec/tests.rs
+++ b/compiler/rustc_index/src/vec/tests.rs
@@ -5,7 +5,7 @@ use crate as rustc_index;
 
 rustc_macros::newtype_index! {
     #[max = 0xFFFF_FFFA]
-    struct MyIdx { }
+    struct MyIdx {}
 }
 
 #[test]

--- a/compiler/rustc_infer/src/infer/region_constraints/leak_check.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/leak_check.rs
@@ -357,14 +357,14 @@ impl<'tcx> SccUniverse<'tcx> {
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "LeakCheckNode({})"]
     struct LeakCheckNode {
-        DEBUG_FORMAT = "LeakCheckNode({})"
     }
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "LeakCheckScc({})"]
     struct LeakCheckScc {
-        DEBUG_FORMAT = "LeakCheckScc({})"
     }
 }
 

--- a/compiler/rustc_infer/src/infer/region_constraints/leak_check.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/leak_check.rs
@@ -358,14 +358,12 @@ impl<'tcx> SccUniverse<'tcx> {
 
 rustc_index::newtype_index! {
     #[debug_format = "LeakCheckNode({})"]
-    struct LeakCheckNode {
-    }
+    struct LeakCheckNode {}
 }
 
 rustc_index::newtype_index! {
     #[debug_format = "LeakCheckScc({})"]
-    struct LeakCheckScc {
-    }
+    struct LeakCheckScc {}
 }
 
 /// Represents the graph of constraints. For each `R1: R2` constraint we create

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -41,7 +41,7 @@ struct LintLevelSets {
 rustc_index::newtype_index! {
     #[custom_encodable] // we don't need encoding
     struct LintStackIndex {
-        const COMMAND_LINE = 0,
+        const COMMAND_LINE = 0;
     }
 }
 

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -39,8 +39,8 @@ struct LintLevelSets {
 }
 
 rustc_index::newtype_index! {
+    #[custom_encodable] // we don't need encoding
     struct LintStackIndex {
-        ENCODABLE = custom, // we don't need encoding
         const COMMAND_LINE = 0,
     }
 }

--- a/compiler/rustc_macros/src/newtype.rs
+++ b/compiler/rustc_macros/src/newtype.rs
@@ -7,7 +7,6 @@ mod kw {
     syn::custom_keyword!(DEBUG_FORMAT);
     syn::custom_keyword!(MAX);
     syn::custom_keyword!(custom);
-    syn::custom_keyword!(ORD_IMPL);
 }
 
 #[derive(Debug)]
@@ -56,6 +55,10 @@ impl Parse for Newtype {
                     encodable = false;
                     false
                 }
+                "no_ord_impl" => {
+                    ord = false;
+                    false
+                }
                 _ => true,
             },
             _ => true,
@@ -89,13 +92,6 @@ impl Parse for Newtype {
                     if let Some(old) = max.replace(val) {
                         panic!("Specified multiple MAX: {:?}", old);
                     }
-                    continue;
-                }
-                if body.lookahead1().peek(kw::ORD_IMPL) {
-                    body.parse::<kw::ORD_IMPL>()?;
-                    body.parse::<Token![=]>()?;
-                    body.parse::<kw::custom>()?;
-                    ord = false;
                     continue;
                 }
 

--- a/compiler/rustc_macros/src/newtype.rs
+++ b/compiler/rustc_macros/src/newtype.rs
@@ -59,6 +59,17 @@ impl Parse for Newtype {
                     ord = false;
                     false
                 }
+                "max" => {
+                    let Ok(Meta::NameValue(literal) )= attr.parse_meta() else {
+                        panic!("#[max = NUMBER] attribute requires max value");
+                    };
+
+                    if let Some(old) = max.replace(literal.lit) {
+                        panic!("Specified multiple MAX: {:?}", old);
+                    }
+
+                    false
+                }
                 _ => true,
             },
             _ => true,
@@ -81,16 +92,6 @@ impl Parse for Newtype {
                     try_comma()?;
                     if let Some(old) = debug_format.replace(new_debug_format) {
                         panic!("Specified multiple debug format options: {:?}", old);
-                    }
-                    continue;
-                }
-                if body.lookahead1().peek(kw::MAX) {
-                    body.parse::<kw::MAX>()?;
-                    body.parse::<Token![=]>()?;
-                    let val: Lit = body.parse()?;
-                    try_comma()?;
-                    if let Some(old) = max.replace(val) {
-                        panic!("Specified multiple MAX: {:?}", old);
                     }
                     continue;
                 }

--- a/compiler/rustc_macros/src/newtype.rs
+++ b/compiler/rustc_macros/src/newtype.rs
@@ -1,11 +1,9 @@
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::parse::*;
-use syn::punctuated::Punctuated;
 use syn::*;
 
 mod kw {
-    syn::custom_keyword!(derive);
     syn::custom_keyword!(DEBUG_FORMAT);
     syn::custom_keyword!(MAX);
     syn::custom_keyword!(ENCODABLE);
@@ -57,16 +55,6 @@ impl Parse for Newtype {
             body.parse::<Token![..]>()?;
         } else {
             loop {
-                if body.lookahead1().peek(kw::derive) {
-                    body.parse::<kw::derive>()?;
-                    let derives;
-                    bracketed!(derives in body);
-                    let derives: Punctuated<Path, Token![,]> =
-                        derives.parse_terminated(Path::parse)?;
-                    try_comma()?;
-                    derive_paths.extend(derives);
-                    continue;
-                }
                 if body.lookahead1().peek(kw::DEBUG_FORMAT) {
                     body.parse::<kw::DEBUG_FORMAT>()?;
                     body.parse::<Token![=]>()?;

--- a/compiler/rustc_middle/src/middle/region.rs
+++ b/compiler/rustc_middle/src/middle/region.rs
@@ -148,8 +148,7 @@ rustc_index::newtype_index! {
     /// * The subscope with `first_statement_index == 1` is scope of `c`,
     ///   and thus does not include EXPR_2, but covers the `...`.
     #[derive(HashStable)]
-    pub struct FirstStatementIndex {
-    }
+    pub struct FirstStatementIndex {}
 }
 
 // compilation error if size of `ScopeData` is not the same as a `u32`

--- a/compiler/rustc_middle/src/middle/region.rs
+++ b/compiler/rustc_middle/src/middle/region.rs
@@ -147,8 +147,8 @@ rustc_index::newtype_index! {
     ///
     /// * The subscope with `first_statement_index == 1` is scope of `c`,
     ///   and thus does not include EXPR_2, but covers the `...`.
+    #[derive(HashStable)]
     pub struct FirstStatementIndex {
-        derive [HashStable]
     }
 }
 

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -12,8 +12,8 @@ rustc_index::newtype_index! {
     /// constant value of `0`.
     #[derive(HashStable)]
     #[max = 0xFFFF_FFFF]
+    #[debug_format = "ExpressionOperandId({})"]
     pub struct ExpressionOperandId {
-        DEBUG_FORMAT = "ExpressionOperandId({})",
     }
 }
 
@@ -34,8 +34,8 @@ impl ExpressionOperandId {
 rustc_index::newtype_index! {
     #[derive(HashStable)]
     #[max = 0xFFFF_FFFF]
+    #[debug_format = "CounterValueReference({})"]
     pub struct CounterValueReference {
-        DEBUG_FORMAT = "CounterValueReference({})",
     }
 }
 
@@ -58,8 +58,8 @@ rustc_index::newtype_index! {
     /// Values descend from u32::MAX.
     #[derive(HashStable)]
     #[max = 0xFFFF_FFFF]
+    #[debug_format = "InjectedExpressionId({})"]
     pub struct InjectedExpressionId {
-        DEBUG_FORMAT = "InjectedExpressionId({})",
     }
 }
 
@@ -69,8 +69,8 @@ rustc_index::newtype_index! {
     /// Values ascend from 0.
     #[derive(HashStable)]
     #[max = 0xFFFF_FFFF]
+    #[debug_format = "InjectedExpressionIndex({})"]
     pub struct InjectedExpressionIndex {
-        DEBUG_FORMAT = "InjectedExpressionIndex({})",
     }
 }
 
@@ -80,8 +80,8 @@ rustc_index::newtype_index! {
     /// "mapgen" process. They cannot be computed algorithmically, from the other `newtype_index`s.
     #[derive(HashStable)]
     #[max = 0xFFFF_FFFF]
+    #[debug_format = "MappedExpressionIndex({})"]
     pub struct MappedExpressionIndex {
-        DEBUG_FORMAT = "MappedExpressionIndex({})",
     }
 }
 

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -11,9 +11,9 @@ rustc_index::newtype_index! {
     /// (which _*descend*_ from u32::MAX). Id value `0` (zero) represents a virtual counter with a
     /// constant value of `0`.
     #[derive(HashStable)]
+    #[max = 0xFFFF_FFFF]
     pub struct ExpressionOperandId {
         DEBUG_FORMAT = "ExpressionOperandId({})",
-        MAX = 0xFFFF_FFFF,
     }
 }
 
@@ -33,9 +33,9 @@ impl ExpressionOperandId {
 
 rustc_index::newtype_index! {
     #[derive(HashStable)]
+    #[max = 0xFFFF_FFFF]
     pub struct CounterValueReference {
         DEBUG_FORMAT = "CounterValueReference({})",
-        MAX = 0xFFFF_FFFF,
     }
 }
 
@@ -57,9 +57,9 @@ rustc_index::newtype_index! {
     ///
     /// Values descend from u32::MAX.
     #[derive(HashStable)]
+    #[max = 0xFFFF_FFFF]
     pub struct InjectedExpressionId {
         DEBUG_FORMAT = "InjectedExpressionId({})",
-        MAX = 0xFFFF_FFFF,
     }
 }
 
@@ -68,9 +68,9 @@ rustc_index::newtype_index! {
     ///
     /// Values ascend from 0.
     #[derive(HashStable)]
+    #[max = 0xFFFF_FFFF]
     pub struct InjectedExpressionIndex {
         DEBUG_FORMAT = "InjectedExpressionIndex({})",
-        MAX = 0xFFFF_FFFF,
     }
 }
 
@@ -79,9 +79,9 @@ rustc_index::newtype_index! {
     /// array position in the LLVM coverage map "Expressions" array, which is assembled during the
     /// "mapgen" process. They cannot be computed algorithmically, from the other `newtype_index`s.
     #[derive(HashStable)]
+    #[max = 0xFFFF_FFFF]
     pub struct MappedExpressionIndex {
         DEBUG_FORMAT = "MappedExpressionIndex({})",
-        MAX = 0xFFFF_FFFF,
     }
 }
 

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -35,8 +35,7 @@ rustc_index::newtype_index! {
     #[derive(HashStable)]
     #[max = 0xFFFF_FFFF]
     #[debug_format = "CounterValueReference({})"]
-    pub struct CounterValueReference {
-    }
+    pub struct CounterValueReference {}
 }
 
 impl CounterValueReference {
@@ -59,8 +58,7 @@ rustc_index::newtype_index! {
     #[derive(HashStable)]
     #[max = 0xFFFF_FFFF]
     #[debug_format = "InjectedExpressionId({})"]
-    pub struct InjectedExpressionId {
-    }
+    pub struct InjectedExpressionId {}
 }
 
 rustc_index::newtype_index! {
@@ -70,8 +68,7 @@ rustc_index::newtype_index! {
     #[derive(HashStable)]
     #[max = 0xFFFF_FFFF]
     #[debug_format = "InjectedExpressionIndex({})"]
-    pub struct InjectedExpressionIndex {
-    }
+    pub struct InjectedExpressionIndex {}
 }
 
 rustc_index::newtype_index! {
@@ -81,8 +78,7 @@ rustc_index::newtype_index! {
     #[derive(HashStable)]
     #[max = 0xFFFF_FFFF]
     #[debug_format = "MappedExpressionIndex({})"]
-    pub struct MappedExpressionIndex {
-    }
+    pub struct MappedExpressionIndex {}
 }
 
 impl From<CounterValueReference> for ExpressionOperandId {

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -10,8 +10,8 @@ rustc_index::newtype_index! {
     /// CounterValueReference.as_u32() (which ascend from 1) or an ExpressionOperandId.as_u32()
     /// (which _*descend*_ from u32::MAX). Id value `0` (zero) represents a virtual counter with a
     /// constant value of `0`.
+    #[derive(HashStable)]
     pub struct ExpressionOperandId {
-        derive [HashStable]
         DEBUG_FORMAT = "ExpressionOperandId({})",
         MAX = 0xFFFF_FFFF,
     }
@@ -32,8 +32,8 @@ impl ExpressionOperandId {
 }
 
 rustc_index::newtype_index! {
+    #[derive(HashStable)]
     pub struct CounterValueReference {
-        derive [HashStable]
         DEBUG_FORMAT = "CounterValueReference({})",
         MAX = 0xFFFF_FFFF,
     }
@@ -56,8 +56,8 @@ rustc_index::newtype_index! {
     /// InjectedExpressionId.as_u32() converts to ExpressionOperandId.as_u32()
     ///
     /// Values descend from u32::MAX.
+    #[derive(HashStable)]
     pub struct InjectedExpressionId {
-        derive [HashStable]
         DEBUG_FORMAT = "InjectedExpressionId({})",
         MAX = 0xFFFF_FFFF,
     }
@@ -67,8 +67,8 @@ rustc_index::newtype_index! {
     /// InjectedExpressionIndex.as_u32() translates to u32::MAX - ExpressionOperandId.as_u32()
     ///
     /// Values ascend from 0.
+    #[derive(HashStable)]
     pub struct InjectedExpressionIndex {
-        derive [HashStable]
         DEBUG_FORMAT = "InjectedExpressionIndex({})",
         MAX = 0xFFFF_FFFF,
     }
@@ -78,8 +78,8 @@ rustc_index::newtype_index! {
     /// MappedExpressionIndex values ascend from zero, and are recalculated indexes based on their
     /// array position in the LLVM coverage map "Expressions" array, which is assembled during the
     /// "mapgen" process. They cannot be computed algorithmically, from the other `newtype_index`s.
+    #[derive(HashStable)]
     pub struct MappedExpressionIndex {
-        derive [HashStable]
         DEBUG_FORMAT = "MappedExpressionIndex({})",
         MAX = 0xFFFF_FFFF,
     }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -655,8 +655,8 @@ impl SourceInfo {
 
 rustc_index::newtype_index! {
     #[derive(HashStable)]
+    #[debug_format = "_{}"]
     pub struct Local {
-        DEBUG_FORMAT = "_{}",
         const RETURN_PLACE = 0,
     }
 }
@@ -1147,8 +1147,8 @@ rustc_index::newtype_index! {
     /// [`CriticalCallEdges`]: ../../rustc_const_eval/transform/add_call_guards/enum.AddCallGuards.html#variant.CriticalCallEdges
     /// [guide-mir]: https://rustc-dev-guide.rust-lang.org/mir/
     #[derive(HashStable)]
+    #[debug_format = "bb{}"]
     pub struct BasicBlock {
-        DEBUG_FORMAT = "bb{}",
         const START_BLOCK = 0,
     }
 }
@@ -1531,8 +1531,8 @@ rustc_index::newtype_index! {
     /// [CFG]: https://rustc-dev-guide.rust-lang.org/appendix/background.html#cfg
     /// [mir-datatypes]: https://rustc-dev-guide.rust-lang.org/mir/index.html#mir-data-types
     #[derive(HashStable)]
+    #[debug_format = "field[{}]"]
     pub struct Field {
-        DEBUG_FORMAT = "field[{}]"
     }
 }
 
@@ -1758,8 +1758,8 @@ impl Debug for Place<'_> {
 
 rustc_index::newtype_index! {
     #[derive(HashStable)]
+    #[debug_format = "scope[{}]"]
     pub struct SourceScope {
-        DEBUG_FORMAT = "scope[{}]",
         const OUTERMOST_SOURCE_SCOPE = 0,
     }
 }
@@ -2756,8 +2756,8 @@ impl<'tcx> TypeVisitable<'tcx> for UserTypeProjection {
 
 rustc_index::newtype_index! {
     #[derive(HashStable)]
+    #[debug_format = "promoted[{}]"]
     pub struct Promoted {
-        DEBUG_FORMAT = "promoted[{}]"
     }
 }
 

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -654,8 +654,8 @@ impl SourceInfo {
 // Variables and temps
 
 rustc_index::newtype_index! {
+    #[derive(HashStable)]
     pub struct Local {
-        derive [HashStable]
         DEBUG_FORMAT = "_{}",
         const RETURN_PLACE = 0,
     }
@@ -1146,8 +1146,8 @@ rustc_index::newtype_index! {
     ///     https://rustc-dev-guide.rust-lang.org/appendix/background.html#what-is-a-dataflow-analysis
     /// [`CriticalCallEdges`]: ../../rustc_const_eval/transform/add_call_guards/enum.AddCallGuards.html#variant.CriticalCallEdges
     /// [guide-mir]: https://rustc-dev-guide.rust-lang.org/mir/
+    #[derive(HashStable)]
     pub struct BasicBlock {
-        derive [HashStable]
         DEBUG_FORMAT = "bb{}",
         const START_BLOCK = 0,
     }
@@ -1530,8 +1530,8 @@ rustc_index::newtype_index! {
     /// [wrapper]: https://rustc-dev-guide.rust-lang.org/appendix/glossary.html#newtype
     /// [CFG]: https://rustc-dev-guide.rust-lang.org/appendix/background.html#cfg
     /// [mir-datatypes]: https://rustc-dev-guide.rust-lang.org/mir/index.html#mir-data-types
+    #[derive(HashStable)]
     pub struct Field {
-        derive [HashStable]
         DEBUG_FORMAT = "field[{}]"
     }
 }
@@ -1757,8 +1757,8 @@ impl Debug for Place<'_> {
 // Scopes
 
 rustc_index::newtype_index! {
+    #[derive(HashStable)]
     pub struct SourceScope {
-        derive [HashStable]
         DEBUG_FORMAT = "scope[{}]",
         const OUTERMOST_SOURCE_SCOPE = 0,
     }
@@ -2755,8 +2755,8 @@ impl<'tcx> TypeVisitable<'tcx> for UserTypeProjection {
 }
 
 rustc_index::newtype_index! {
+    #[derive(HashStable)]
     pub struct Promoted {
-        derive [HashStable]
         DEBUG_FORMAT = "promoted[{}]"
     }
 }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -657,7 +657,7 @@ rustc_index::newtype_index! {
     #[derive(HashStable)]
     #[debug_format = "_{}"]
     pub struct Local {
-        const RETURN_PLACE = 0,
+        const RETURN_PLACE = 0;
     }
 }
 
@@ -1149,7 +1149,7 @@ rustc_index::newtype_index! {
     #[derive(HashStable)]
     #[debug_format = "bb{}"]
     pub struct BasicBlock {
-        const START_BLOCK = 0,
+        const START_BLOCK = 0;
     }
 }
 
@@ -1532,8 +1532,7 @@ rustc_index::newtype_index! {
     /// [mir-datatypes]: https://rustc-dev-guide.rust-lang.org/mir/index.html#mir-data-types
     #[derive(HashStable)]
     #[debug_format = "field[{}]"]
-    pub struct Field {
-    }
+    pub struct Field {}
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -1760,7 +1759,7 @@ rustc_index::newtype_index! {
     #[derive(HashStable)]
     #[debug_format = "scope[{}]"]
     pub struct SourceScope {
-        const OUTERMOST_SOURCE_SCOPE = 0,
+        const OUTERMOST_SOURCE_SCOPE = 0;
     }
 }
 
@@ -2757,8 +2756,7 @@ impl<'tcx> TypeVisitable<'tcx> for UserTypeProjection {
 rustc_index::newtype_index! {
     #[derive(HashStable)]
     #[debug_format = "promoted[{}]"]
-    pub struct Promoted {
-    }
+    pub struct Promoted {}
 }
 
 impl<'tcx> Debug for Constant<'tcx> {

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -131,8 +131,8 @@ pub struct UnsafetyCheckResult {
 
 rustc_index::newtype_index! {
     #[derive(HashStable)]
+    #[debug_format = "_{}"]
     pub struct GeneratorSavedLocal {
-        DEBUG_FORMAT = "_{}",
     }
 }
 

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -132,8 +132,7 @@ pub struct UnsafetyCheckResult {
 rustc_index::newtype_index! {
     #[derive(HashStable)]
     #[debug_format = "_{}"]
-    pub struct GeneratorSavedLocal {
-    }
+    pub struct GeneratorSavedLocal {}
 }
 
 /// The layout of generator state.

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -130,8 +130,8 @@ pub struct UnsafetyCheckResult {
 }
 
 rustc_index::newtype_index! {
+    #[derive(HashStable)]
     pub struct GeneratorSavedLocal {
-        derive [HashStable]
         DEBUG_FORMAT = "_{}",
     }
 }

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -35,8 +35,8 @@ macro_rules! thir_with_elements {
         $(
             newtype_index! {
                 #[derive(HashStable)]
+                #[debug_format = $format]
                 pub struct $id {
-                    DEBUG_FORMAT = $format
                 }
             }
         )*

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -36,8 +36,7 @@ macro_rules! thir_with_elements {
             newtype_index! {
                 #[derive(HashStable)]
                 #[debug_format = $format]
-                pub struct $id {
-                }
+                pub struct $id {}
             }
         )*
 

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -99,12 +99,6 @@ impl<'tcx> fmt::Debug for ty::ConstVid<'tcx> {
     }
 }
 
-impl fmt::Debug for ty::RegionVid {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "'_#{}r", self.index())
-    }
-}
-
 impl<'tcx> fmt::Debug for ty::TraitRef<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         with_no_trimmed_paths!(fmt::Display::fmt(self, f))

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1379,8 +1379,7 @@ rustc_index::newtype_index! {
     /// A **region** (lifetime) **v**ariable **ID**.
     #[derive(HashStable)]
     #[debug_format = "'_#{}r"]
-    pub struct RegionVid {
-    }
+    pub struct RegionVid {}
 }
 
 impl Atom for RegionVid {
@@ -1391,7 +1390,7 @@ impl Atom for RegionVid {
 
 rustc_index::newtype_index! {
     #[derive(HashStable)]
-    pub struct BoundVar { .. }
+    pub struct BoundVar {}
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, TyEncodable, TyDecodable)]

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1378,8 +1378,8 @@ pub struct ConstVid<'tcx> {
 rustc_index::newtype_index! {
     /// A **region** (lifetime) **v**ariable **ID**.
     #[derive(HashStable)]
+    #[debug_format = "'_#{}r"]
     pub struct RegionVid {
-        DEBUG_FORMAT = custom,
     }
 }
 

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -608,8 +608,8 @@ impl<'a, V> LocalTableInContextMut<'a, V> {
 }
 
 rustc_index::newtype_index! {
+    #[derive(HashStable)]
     pub struct UserTypeAnnotationIndex {
-        derive [HashStable]
         DEBUG_FORMAT = "UserType({})",
         const START_INDEX = 0,
     }

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -611,7 +611,7 @@ rustc_index::newtype_index! {
     #[derive(HashStable)]
     #[debug_format = "UserType({})"]
     pub struct UserTypeAnnotationIndex {
-        const START_INDEX = 0,
+        const START_INDEX = 0;
     }
 }
 

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -609,8 +609,8 @@ impl<'a, V> LocalTableInContextMut<'a, V> {
 
 rustc_index::newtype_index! {
     #[derive(HashStable)]
+    #[debug_format = "UserType({})"]
     pub struct UserTypeAnnotationIndex {
-        DEBUG_FORMAT = "UserType({})",
         const START_INDEX = 0,
     }
 }

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -372,7 +372,7 @@ struct CFG<'tcx> {
 }
 
 rustc_index::newtype_index! {
-    struct ScopeId { .. }
+    struct ScopeId {}
 }
 
 #[derive(Debug)]

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -185,7 +185,7 @@ pub(crate) enum BreakableTarget {
 }
 
 rustc_index::newtype_index! {
-    struct DropIdx { .. }
+    struct DropIdx {}
 }
 
 const ROOT_NODE: DropIdx = DropIdx::from_u32(0);

--- a/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
@@ -14,8 +14,8 @@ use self::abs_domain::{AbstractElem, Lift};
 mod abs_domain;
 
 rustc_index::newtype_index! {
+    #[debug_format = "mp{}"]
     pub struct MovePathIndex {
-        DEBUG_FORMAT = "mp{}"
     }
 }
 
@@ -26,14 +26,14 @@ impl polonius_engine::Atom for MovePathIndex {
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "mo{}"]
     pub struct MoveOutIndex {
-        DEBUG_FORMAT = "mo{}"
     }
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "in{}"]
     pub struct InitIndex {
-        DEBUG_FORMAT = "in{}"
     }
 }
 

--- a/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
@@ -15,8 +15,7 @@ mod abs_domain;
 
 rustc_index::newtype_index! {
     #[debug_format = "mp{}"]
-    pub struct MovePathIndex {
-    }
+    pub struct MovePathIndex {}
 }
 
 impl polonius_engine::Atom for MovePathIndex {
@@ -27,14 +26,12 @@ impl polonius_engine::Atom for MovePathIndex {
 
 rustc_index::newtype_index! {
     #[debug_format = "mo{}"]
-    pub struct MoveOutIndex {
-    }
+    pub struct MoveOutIndex {}
 }
 
 rustc_index::newtype_index! {
     #[debug_format = "in{}"]
-    pub struct InitIndex {
-    }
+    pub struct InitIndex {}
 }
 
 impl MoveOutIndex {

--- a/compiler/rustc_mir_transform/src/coverage/graph.rs
+++ b/compiler/rustc_mir_transform/src/coverage/graph.rs
@@ -282,8 +282,8 @@ impl graph::WithPredecessors for CoverageGraph {
 
 rustc_index::newtype_index! {
     /// A node in the control-flow graph of CoverageGraph.
+    #[debug_format = "bcb{}"]
     pub(super) struct BasicCoverageBlock {
-        DEBUG_FORMAT = "bcb{}",
         const START_BCB = 0,
     }
 }

--- a/compiler/rustc_mir_transform/src/coverage/graph.rs
+++ b/compiler/rustc_mir_transform/src/coverage/graph.rs
@@ -284,7 +284,7 @@ rustc_index::newtype_index! {
     /// A node in the control-flow graph of CoverageGraph.
     #[debug_format = "bcb{}"]
     pub(super) struct BasicCoverageBlock {
-        const START_BCB = 0,
+        const START_BCB = 0;
     }
 }
 

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -108,14 +108,14 @@ use std::rc::Rc;
 mod rwu_table;
 
 rustc_index::newtype_index! {
+    #[debug_format = "v({})"]
     pub struct Variable {
-        DEBUG_FORMAT = "v({})",
     }
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "ln({})"]
     pub struct LiveNode {
-        DEBUG_FORMAT = "ln({})",
     }
 }
 

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -109,14 +109,12 @@ mod rwu_table;
 
 rustc_index::newtype_index! {
     #[debug_format = "v({})"]
-    pub struct Variable {
-    }
+    pub struct Variable {}
 }
 
 rustc_index::newtype_index! {
     #[debug_format = "ln({})"]
-    pub struct LiveNode {
-    }
+    pub struct LiveNode {}
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -37,7 +37,7 @@ pub struct DepGraph<K: DepKind> {
 }
 
 rustc_index::newtype_index! {
-    pub struct DepNodeIndex { .. }
+    pub struct DepNodeIndex {}
 }
 
 impl DepNodeIndex {
@@ -974,7 +974,7 @@ pub struct WorkProduct {
 
 // Index type for `DepNodeData`'s edges.
 rustc_index::newtype_index! {
-    struct EdgeIndex { .. }
+    struct EdgeIndex {}
 }
 
 /// `CurrentDepGraph` stores the dependency graph for the current session. It

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -28,8 +28,7 @@ use smallvec::SmallVec;
 // and use those bits to encode which index type it contains.
 rustc_index::newtype_index! {
     #[max = 0x7FFF_FFFF]
-    pub struct SerializedDepNodeIndex {
-    }
+    pub struct SerializedDepNodeIndex {}
 }
 
 /// Data for use when recompiling the **current crate**.

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -27,8 +27,8 @@ use smallvec::SmallVec;
 // unused so that we can store multiple index types in `CompressedHybridIndex`,
 // and use those bits to encode which index type it contains.
 rustc_index::newtype_index! {
+    #[max = 0x7FFF_FFFF]
     pub struct SerializedDepNodeIndex {
-        MAX = 0x7FFF_FFFF
     }
 }
 

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -10,8 +10,8 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 
 rustc_index::newtype_index! {
+    #[custom_encodable]
     pub struct CrateNum {
-        ENCODABLE = custom
         DEBUG_FORMAT = "crate{}"
     }
 }
@@ -194,9 +194,8 @@ rustc_index::newtype_index! {
     /// A DefIndex is an index into the hir-map for a crate, identifying a
     /// particular definition. It should really be considered an interned
     /// shorthand for a particular DefPath.
+    #[custom_encodable] // (only encodable in metadata)
     pub struct DefIndex {
-        ENCODABLE = custom // (only encodable in metadata)
-
         DEBUG_FORMAT = "DefIndex({})",
         /// The crate root is always assigned index 0 by the AST Map code,
         /// thanks to `NodeCollector::new`.

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -12,8 +12,7 @@ use std::hash::{Hash, Hasher};
 rustc_index::newtype_index! {
     #[custom_encodable]
     #[debug_format = "crate{}"]
-    pub struct CrateNum {
-    }
+    pub struct CrateNum {}
 }
 
 /// Item definitions in the currently-compiled crate would have the `CrateNum`
@@ -199,7 +198,7 @@ rustc_index::newtype_index! {
     pub struct DefIndex {
         /// The crate root is always assigned index 0 by the AST Map code,
         /// thanks to `NodeCollector::new`.
-        const CRATE_DEF_INDEX = 0,
+        const CRATE_DEF_INDEX = 0;
     }
 }
 

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -11,8 +11,8 @@ use std::hash::{Hash, Hasher};
 
 rustc_index::newtype_index! {
     #[custom_encodable]
+    #[debug_format = "crate{}"]
     pub struct CrateNum {
-        DEBUG_FORMAT = "crate{}"
     }
 }
 
@@ -195,8 +195,8 @@ rustc_index::newtype_index! {
     /// particular definition. It should really be considered an interned
     /// shorthand for a particular DefPath.
     #[custom_encodable] // (only encodable in metadata)
+    #[debug_format = "DefIndex({})"]
     pub struct DefIndex {
-        DEBUG_FORMAT = "DefIndex({})",
         /// The crate root is always assigned index 0 by the AST Map code,
         /// thanks to `NodeCollector::new`.
         const CRATE_DEF_INDEX = 0,

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -83,8 +83,8 @@ impl fmt::Debug for ExpnId {
 rustc_index::newtype_index! {
     /// A unique ID associated with a macro invocation and expansion.
     #[custom_encodable]
+    #[no_ord_impl]
     pub struct LocalExpnId {
-        ORD_IMPL = custom
         DEBUG_FORMAT = "expn{}"
     }
 }

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -84,8 +84,8 @@ rustc_index::newtype_index! {
     /// A unique ID associated with a macro invocation and expansion.
     #[custom_encodable]
     #[no_ord_impl]
+    #[debug_format = "expn{}"]
     pub struct LocalExpnId {
-        DEBUG_FORMAT = "expn{}"
     }
 }
 

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -61,8 +61,8 @@ pub struct SyntaxContextData {
 
 rustc_index::newtype_index! {
     /// A unique ID associated with a macro invocation and expansion.
+    #[custom_encodable]
     pub struct ExpnIndex {
-        ENCODABLE = custom
     }
 }
 
@@ -82,8 +82,8 @@ impl fmt::Debug for ExpnId {
 
 rustc_index::newtype_index! {
     /// A unique ID associated with a macro invocation and expansion.
+    #[custom_encodable]
     pub struct LocalExpnId {
-        ENCODABLE = custom
         ORD_IMPL = custom
         DEBUG_FORMAT = "expn{}"
     }

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -62,8 +62,7 @@ pub struct SyntaxContextData {
 rustc_index::newtype_index! {
     /// A unique ID associated with a macro invocation and expansion.
     #[custom_encodable]
-    pub struct ExpnIndex {
-    }
+    pub struct ExpnIndex {}
 }
 
 /// A unique ID associated with a macro invocation and expansion.
@@ -85,8 +84,7 @@ rustc_index::newtype_index! {
     #[custom_encodable]
     #[no_ord_impl]
     #[debug_format = "expn{}"]
-    pub struct LocalExpnId {
-    }
+    pub struct LocalExpnId {}
 }
 
 // To ensure correctness of incremental compilation,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1801,7 +1801,7 @@ impl fmt::Display for MacroRulesNormalizedIdent {
 pub struct Symbol(SymbolIndex);
 
 rustc_index::newtype_index! {
-    struct SymbolIndex { .. }
+    struct SymbolIndex {}
 }
 
 impl Symbol {

--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -20,8 +20,8 @@ impl ToJson for Endian {
 }
 
 rustc_index::newtype_index! {
+    #[derive(HashStable_Generic)]
     pub struct VariantIdx {
-        derive [HashStable_Generic]
     }
 }
 

--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -21,8 +21,7 @@ impl ToJson for Endian {
 
 rustc_index::newtype_index! {
     #[derive(HashStable_Generic)]
-    pub struct VariantIdx {
-    }
+    pub struct VariantIdx {}
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, HashStable_Generic)]

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -303,7 +303,7 @@ rustc_index::newtype_index! {
     #[derive(HashStable_Generic)]
     #[debug_format = "DebruijnIndex({})"]
     pub struct DebruijnIndex {
-        const INNERMOST = 0,
+        const INNERMOST = 0;
     }
 }
 
@@ -500,8 +500,7 @@ pub struct FloatVarValue(pub FloatTy);
 rustc_index::newtype_index! {
     /// A **ty**pe **v**ariable **ID**.
     #[debug_format = "_#{}t"]
-    pub struct TyVid {
-    }
+    pub struct TyVid {}
 }
 
 /// An **int**egral (`u32`, `i32`, `usize`, etc.) type **v**ariable **ID**.
@@ -789,8 +788,7 @@ rustc_index::newtype_index! {
     /// use for checking generic functions.
     #[derive(HashStable_Generic)]
     #[debug_format = "U{}"]
-    pub struct UniverseIndex {
-    }
+    pub struct UniverseIndex {}
 }
 
 impl UniverseIndex {

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -301,8 +301,8 @@ rustc_index::newtype_index! {
     ///
     /// [dbi]: https://en.wikipedia.org/wiki/De_Bruijn_index
     #[derive(HashStable_Generic)]
+    #[debug_format = "DebruijnIndex({})"]
     pub struct DebruijnIndex {
-        DEBUG_FORMAT = "DebruijnIndex({})",
         const INNERMOST = 0,
     }
 }
@@ -499,8 +499,8 @@ pub struct FloatVarValue(pub FloatTy);
 
 rustc_index::newtype_index! {
     /// A **ty**pe **v**ariable **ID**.
+    #[debug_format = "_#{}t"]
     pub struct TyVid {
-        DEBUG_FORMAT = "_#{}t"
     }
 }
 
@@ -788,8 +788,8 @@ rustc_index::newtype_index! {
     /// type -- an idealized representative of "types in general" that we
     /// use for checking generic functions.
     #[derive(HashStable_Generic)]
+    #[debug_format = "U{}"]
     pub struct UniverseIndex {
-        DEBUG_FORMAT = "U{}",
     }
 }
 

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -485,6 +485,16 @@ impl<P: Deref<Target: Unpin>> Pin<P> {
     ///
     /// Unlike `Pin::new_unchecked`, this method is safe because the pointer
     /// `P` dereferences to an [`Unpin`] type, which cancels the pinning guarantees.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::pin::Pin;
+    ///
+    /// let mut val: u8 = 5;
+    /// // We can pin the value, since it doesn't care about being moved
+    /// let mut pinned: Pin<&mut u8> = Pin::new(&mut val);
+    /// ```
     #[inline(always)]
     #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
     #[stable(feature = "pin", since = "1.33.0")]
@@ -496,8 +506,20 @@ impl<P: Deref<Target: Unpin>> Pin<P> {
 
     /// Unwraps this `Pin<P>` returning the underlying pointer.
     ///
-    /// This requires that the data inside this `Pin` is [`Unpin`] so that we
+    /// This requires that the data inside this `Pin` implements [`Unpin`] so that we
     /// can ignore the pinning invariants when unwrapping it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::pin::Pin;
+    ///
+    /// let mut val: u8 = 5;
+    /// let pinned: Pin<&mut u8> = Pin::new(&mut val);
+    /// // Unwrap the pin to get a reference to the value
+    /// let r = Pin::into_inner(pinned);
+    /// assert_eq!(*r, 5);
+    /// ```
     #[inline(always)]
     #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
     #[stable(feature = "pin_into_inner", since = "1.39.0")]
@@ -707,6 +729,18 @@ impl<P: DerefMut> Pin<P> {
     ///
     /// This overwrites pinned data, but that is okay: its destructor gets
     /// run before being overwritten, so no pinning guarantee is violated.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::pin::Pin;
+    ///
+    /// let mut val: u8 = 5;
+    /// let mut pinned: Pin<&mut u8> = Pin::new(&mut val);
+    /// println!("{}", pinned); // 5
+    /// pinned.as_mut().set(10);
+    /// println!("{}", pinned); // 10
+    /// ```
     #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
     pub fn set(&mut self, value: P::Target)

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -200,10 +200,14 @@ install!((self, builder, _config),
         install_sh(builder, "clippy", self.compiler.stage, Some(self.target), &tarball);
     };
     Miri, alias = "miri", Self::should_build(_config), only_hosts: true, {
-        let tarball = builder
-            .ensure(dist::Miri { compiler: self.compiler, target: self.target })
-            .expect("missing miri");
-        install_sh(builder, "miri", self.compiler.stage, Some(self.target), &tarball);
+        if let Some(tarball) = builder.ensure(dist::Miri { compiler: self.compiler, target: self.target }) {
+            install_sh(builder, "miri", self.compiler.stage, Some(self.target), &tarball);
+        } else {
+            // Miri is only available on nightly
+            builder.info(
+                &format!("skipping Install miri stage{} ({})", self.compiler.stage, self.target),
+            );
+        }
     };
     LlvmTools, alias = "llvm-tools", Self::should_build(_config), only_hosts: true, {
         let tarball = builder

--- a/src/test/ui-fulldeps/macro-crate-rlib.stderr
+++ b/src/test/ui-fulldeps/macro-crate-rlib.stderr
@@ -6,3 +6,4 @@ LL | #![plugin(rlib_crate_test)]
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0457`.

--- a/src/test/ui/svh/changing-crates.stderr
+++ b/src/test/ui/svh/changing-crates.stderr
@@ -11,3 +11,4 @@ LL | extern crate b;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0460`.

--- a/src/test/ui/svh/svh-change-lit.stderr
+++ b/src/test/ui/svh/svh-change-lit.stderr
@@ -11,3 +11,4 @@ LL | extern crate b;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0460`.

--- a/src/test/ui/svh/svh-change-significant-cfg.stderr
+++ b/src/test/ui/svh/svh-change-significant-cfg.stderr
@@ -11,3 +11,4 @@ LL | extern crate b;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0460`.

--- a/src/test/ui/svh/svh-change-trait-bound.stderr
+++ b/src/test/ui/svh/svh-change-trait-bound.stderr
@@ -11,3 +11,4 @@ LL | extern crate b;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0460`.

--- a/src/test/ui/svh/svh-change-type-arg.stderr
+++ b/src/test/ui/svh/svh-change-type-arg.stderr
@@ -11,3 +11,4 @@ LL | extern crate b;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0460`.

--- a/src/test/ui/svh/svh-change-type-ret.stderr
+++ b/src/test/ui/svh/svh-change-type-ret.stderr
@@ -11,3 +11,4 @@ LL | extern crate b;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0460`.

--- a/src/test/ui/svh/svh-change-type-static.stderr
+++ b/src/test/ui/svh/svh-change-type-static.stderr
@@ -11,3 +11,4 @@ LL | extern crate b;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0460`.

--- a/src/test/ui/svh/svh-use-trait.stderr
+++ b/src/test/ui/svh/svh-use-trait.stderr
@@ -11,3 +11,4 @@ LL | extern crate utb;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0460`.

--- a/src/test/ui/type-alias-impl-trait/auxiliary/coherence_cross_crate_trait_decl.rs
+++ b/src/test/ui/type-alias-impl-trait/auxiliary/coherence_cross_crate_trait_decl.rs
@@ -1,0 +1,9 @@
+pub trait SomeTrait {}
+
+impl SomeTrait for () {}
+
+// Adding this `impl` would cause errors in this crate's dependent,
+// so it would be a breaking change. We explicitly don't add this impl,
+// as the dependent crate already assumes this impl exists and thus already
+// does not compile.
+//impl SomeTrait for i32 {}

--- a/src/test/ui/type-alias-impl-trait/coherence_cross_crate.rs
+++ b/src/test/ui/type-alias-impl-trait/coherence_cross_crate.rs
@@ -1,0 +1,24 @@
+// aux-build: coherence_cross_crate_trait_decl.rs
+// This test ensures that adding an `impl SomeTrait for i32` within
+// `coherence_cross_crate_trait_decl` is not a breaking change, by
+// making sure that even without such an impl this test fails to compile.
+
+#![feature(type_alias_impl_trait)]
+
+extern crate coherence_cross_crate_trait_decl;
+
+use coherence_cross_crate_trait_decl::SomeTrait;
+
+trait OtherTrait {}
+
+type Alias = impl SomeTrait;
+
+fn constrain() -> Alias {
+    ()
+}
+
+impl OtherTrait for Alias {}
+impl OtherTrait for i32 {}
+//~^ ERROR: conflicting implementations of trait `OtherTrait` for type `Alias`
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/coherence_cross_crate.stderr
+++ b/src/test/ui/type-alias-impl-trait/coherence_cross_crate.stderr
@@ -1,0 +1,13 @@
+error[E0119]: conflicting implementations of trait `OtherTrait` for type `Alias`
+  --> $DIR/coherence_cross_crate.rs:21:1
+   |
+LL | impl OtherTrait for Alias {}
+   | ------------------------- first implementation here
+LL | impl OtherTrait for i32 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Alias`
+   |
+   = note: upstream crates may add a new impl of trait `coherence_cross_crate_trait_decl::SomeTrait` for type `i32` in future versions
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0119`.


### PR DESCRIPTION
Successful merges:

 - #105860 (Add long error docs for `E0460` and `E0457`)
 - #105880 (Improve syntax of `newtype_index`)
 - #105895 (Test that we don't add a new kind of breaking change with TAITs)
 - #105901 (Don't panic on stable since miri is not available there)
 - #105902 (docs: improve pin docs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=105860,105880,105895,105901,105902)
<!-- homu-ignore:end -->