### PR TITLE
rustdoc: Simplify CSS for scraped code examples code blocks

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1976,10 +1976,7 @@ in storage.js
 }
 
 .scraped-example .code-wrapper .example-wrap {
-	display: grid;
-	grid-template-columns: max-content auto;
 	width: 100%;
-	overflow-x: auto;
 	overflow-y: hidden;
 	margin-bottom: 0;
 }
@@ -1987,13 +1984,6 @@ in storage.js
 .scraped-example:not(.expanded) .code-wrapper .example-wrap {
 	overflow-x: hidden;
 }
-
-.scraped-example .code-wrapper .example-wrap pre.rust {
-	overflow-x: inherit;
-	width: inherit;
-	overflow-y: hidden;
-}
-
 
 .more-examples-toggle {
 	max-width: calc(100% + 25px);


### PR DESCRIPTION
It's another approach than https://github.com/rust-lang/rust/pull/105894 for https://github.com/rust-lang/rust/pull/105823.

I simply removed the extra style added for the scraped code blocks which appears to be unneeded.

r? @notriddle 