### PR TITLE
Fix stack overflow in recursive AST walk in early lint

### DIFF
--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -19,6 +19,7 @@ use crate::passes::{EarlyLintPass, EarlyLintPassObject};
 use rustc_ast::ptr::P;
 use rustc_ast::visit::{self as ast_visit, Visitor};
 use rustc_ast::{self as ast, walk_list, HasAttrs};
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_middle::ty::RegisteredTools;
 use rustc_session::lint::{BufferedEarlyLint, LintBuffer, LintPass};
 use rustc_session::Session;
@@ -71,7 +72,7 @@ impl<'a, T: EarlyLintPass> EarlyContextAndPass<'a, T> {
         self.inlined_check_id(id);
         debug!("early context: enter_attrs({:?})", attrs);
         lint_callback!(self, enter_lint_attrs, attrs);
-        f(self);
+        ensure_sufficient_stack(|| f(self));
         debug!("early context: exit_attrs({:?})", attrs);
         lint_callback!(self, exit_lint_attrs, attrs);
         self.context.builder.pop(push);


### PR DESCRIPTION
The src/test/ui/issues/issue-74564-if-expr-stack-overflow.rs test case added to verify https://github.com/rust-lang/rust/issues/74564 still crashes with a stack overflow on s390x-ibm-linux.

Symptom is a very deep recursion in compiler/rustc_lint/src/early.rs:
    fn visit_expr(&mut self, e: &'a ast::Expr) {
        self.with_lint_attrs(e.id, &e.attrs, |cx| {
            lint_callback!(cx, check_expr, e);
            ast_visit::walk_expr(cx, e);
        })
    }
(where walk_expr recursively calls back into visit_expr).  The crash happens at a nesting depth of over 17000 stack frames when using the default 8 MB stack size on s390x.

This patch fixes the problem by adding a ensure_sufficient_stack call to the with_lint_attrs routine (which also should take care of all the other mutually recursive visitors here).

Fixes part of https://github.com/rust-lang/rust/issues/105383.