### PR TITLE
Respect --set=target.platform when building rustbuild itself

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -753,6 +753,9 @@ class RustBuild(object):
             target_features += ["-crt-static"]
         if target_features:
             env["RUSTFLAGS"] += " -C target-feature=" + (",".join(target_features))
+        target_linker = self.get_toml("linker", build_section)
+        if target_linker is not None:
+            env["RUSTFLAGS"] += " -C linker=" + target_linker
         env["RUSTFLAGS"] += " -Wrust_2018_idioms -Wunused_lifetimes"
         env["RUSTFLAGS"] += " -Wsemicolon_in_expressions_from_macros"
         if self.get_toml("deny-warnings", "rust") != "false":

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -405,7 +405,9 @@ if 'target' in config:
         configured_targets.append(target)
 for target in configured_targets:
     targets[target] = sections['target'][:]
-    targets[target][0] = targets[target][0].replace("x86_64-unknown-linux-gnu", "'{}'".format(target))
+    # For `.` to be valid TOML, it needs to be quoted. But `bootstrap.py` doesn't use a proper TOML parser and fails to parse the target.
+    # Avoid using quotes unless it's necessary.
+    targets[target][0] = targets[target][0].replace("x86_64-unknown-linux-gnu", "'{}'".format(target) if "." in target else target)
 
 
 def is_number(value):


### PR DESCRIPTION
`--set=target.platform.cc` and `--set=target.platform.cxx` are ignored if target is quoted.

`--set=target.platform.linker` is ignored if RUSTFLAGS is not set.

Undo parts of
https://github.com/rust-lang/rust/commit/d1291dc8b4ac9a98ff1d286402559e4ba5d68488 and
https://github.com/rust-lang/rust/commit/1532fd8cd0db93f469e414f9da31ef083a44fcba