### PR TITLE
Bump `cfg-if` to `1.0` in rustc crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3590,7 +3590,7 @@ version = "0.0.0"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "ena",
  "indexmap",
  "jobserver",
@@ -4374,7 +4374,7 @@ dependencies = [
 name = "rustc_span"
 version = "0.0.0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "md-5",
  "rustc_arena",
  "rustc_data_structures",

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 bitflags = "1.2.1"
-cfg-if = "0.1.2"
+cfg-if = "1.0"
 ena = "0.14"
 indexmap = { version = "1.9.1" }
 jobserver_crate = { version = "0.1.13", package = "jobserver" }
@@ -21,7 +21,11 @@ rustc-hash = "1.1.0"
 rustc_index = { path = "../rustc_index", package = "rustc_index" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_serialize = { path = "../rustc_serialize" }
-smallvec = { version = "1.8.1", features = ["const_generics", "union", "may_dangle"] }
+smallvec = { version = "1.8.1", features = [
+    "const_generics",
+    "union",
+    "may_dangle",
+] }
 stable_deref_trait = "1.0.0"
 stacker = "0.1.15"
 tempfile = "3.2"

--- a/compiler/rustc_span/Cargo.toml
+++ b/compiler/rustc_span/Cargo.toml
@@ -13,7 +13,7 @@ rustc_index = { path = "../rustc_index" }
 rustc_arena = { path = "../rustc_arena" }
 scoped-tls = "1.0"
 unicode-width = "0.1.4"
-cfg-if = "0.1.2"
+cfg-if = "1.0"
 tracing = "0.1"
 sha1 = { package = "sha-1", version = "0.10.0" }
 sha2 = "0.10.1"


### PR DESCRIPTION
When `packed_simd_2` and `getrandom` are updated to newer versions, we will no longer have a dependency on old `cfg_if` versions.