### PR TITLE
Re-enable `Fn` trait call notation error for non-tuple argument

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -214,7 +214,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         "cannot use call notation; the first type parameter \
                          for the function trait is neither a tuple nor unit"
                     )
-                    .delay_as_bug();
+                    .emit();
                     (self.err_args(provided_args.len()), None)
                 }
             }

--- a/src/test/ui/unboxed-closures/non-tupled-call.rs
+++ b/src/test/ui/unboxed-closures/non-tupled-call.rs
@@ -1,0 +1,17 @@
+#![feature(fn_traits, unboxed_closures, tuple_trait)]
+
+use std::default::Default;
+use std::marker::Tuple;
+
+fn wrap<P: Tuple + Default, T>(func: impl Fn<P, Output = T>) {
+    let x: P = Default::default();
+    // Should be: `func.call(x);`
+    func(x);
+    //~^ ERROR cannot use call notation; the first type parameter for the function trait is neither a tuple nor unit
+}
+
+fn foo() {}
+
+fn main() {
+    wrap(foo);
+}

--- a/src/test/ui/unboxed-closures/non-tupled-call.stderr
+++ b/src/test/ui/unboxed-closures/non-tupled-call.stderr
@@ -1,0 +1,9 @@
+error[E0059]: cannot use call notation; the first type parameter for the function trait is neither a tuple nor unit
+  --> $DIR/non-tupled-call.rs:9:5
+   |
+LL |     func(x);
+   |     ^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0059`.


### PR DESCRIPTION
I have no idea why I delayed this bug... but also there doesn't seem to be a UI test that actually shows a change, so maybe that's why.

Fixes #105936