### PR TITLE
rustdoc: simplify section anchor CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -689,13 +689,9 @@ a {
 	position: relative;
 }
 
-.small-section-header:hover > .anchor {
+.small-section-header:hover > .anchor, .impl:hover > .anchor,
+.trait-impl:hover > .anchor, .variant:hover > .anchor {
 	display: initial;
-}
-
-.impl:hover > .anchor, .trait-impl:hover > .anchor, .variant:hover > .anchor {
-	display: inline-block;
-	position: absolute;
 }
 .anchor {
 	display: none;


### PR DESCRIPTION
Since f50bf8636e3b0296db82e631fe95c84324a46ccc changed anchors to be always positioned absolute, specifying it on hover as well is redundant.