### PR TITLE
Remove unused `check-stage2-T-arm-linux-androideabi-H-x86_64-unknown-linux-gnu` make rule

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -57,11 +57,6 @@ tidy:
 prepare:
 	$(Q)$(BOOTSTRAP) build --stage 2 nonexistent/path/to/trigger/cargo/metadata
 
-check-stage2-T-arm-linux-androideabi-H-x86_64-unknown-linux-gnu:
-	$(Q)$(BOOTSTRAP) test --stage 2 --target arm-linux-androideabi
-check-stage2-T-x86_64-unknown-linux-musl-H-x86_64-unknown-linux-gnu:
-	$(Q)$(BOOTSTRAP) test --stage 2 --target x86_64-unknown-linux-musl
-
 TESTS_IN_2 := \
 	src/test/ui \
 	src/tools/linkchecker


### PR DESCRIPTION
It's not used anywhere in CI, and it seems of questionable use. It was first added in 0e272de69f4a9c889e5f1a024a88b3e1f60cb6c5, which looks like it's just intended for CI, not as a user-facing feature.