### PR TITLE
Mark `proc_macro_decls_static` as always used

### DIFF
--- a/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
+++ b/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
@@ -262,6 +262,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
 //          use proc_macro::bridge::client::ProcMacro;
 //
 //          #[rustc_proc_macro_decls]
+//          #[used]
 //          #[allow(deprecated)]
 //          static DECLS: &[ProcMacro] = &[
 //              ProcMacro::custom_derive($name_trait1, &[], ::$name1);
@@ -364,6 +365,7 @@ fn mk_decls(cx: &mut ExtCtxt<'_>, macros: &[ProcMacro]) -> P<ast::Item> {
         )
         .map(|mut i| {
             i.attrs.push(cx.attr_word(sym::rustc_proc_macro_decls, span));
+            i.attrs.push(cx.attr_word(sym::used, span));
             i.attrs.push(cx.attr_nested_word(sym::allow, sym::deprecated, span));
             i
         });

--- a/src/test/ui/proc-macro/quote-debug.stdout
+++ b/src/test/ui/proc-macro/quote-debug.stdout
@@ -42,6 +42,7 @@ const _: () =
     {
         extern crate proc_macro;
         #[rustc_proc_macro_decls]
+        #[used]
         #[allow(deprecated)]
         static _DECLS: &[proc_macro::bridge::client::ProcMacro] = &[];
     };


### PR DESCRIPTION
This would have avoided a bug in https://github.com/rust-lang/rust/pull/104860.

In practice this shouldn't matter since nothing uses the query other than the `dead_code` lint, but this isn't documented as an internal-only query so it seems nice for it to be accurate. I think for `dead_code` it doesn't matter because the relevant code is generated by `rustc_builtin_macros` and isn't linted.

I think @tmiasko or @bjorn3 would be a good reviewer?

r? @tmiasko