### PR TITLE
Remove u8 slice output of `simd_bitmask`

### DIFF
--- a/src/test/ui/simd/intrinsic/generic-bitmask.stderr
+++ b/src/test/ui/simd/intrinsic/generic-bitmask.stderr
@@ -1,28 +1,28 @@
-error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u16`, expected `u8` or `[u8; 1]`
+error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u16`, expected `u8`
   --> $DIR/generic-bitmask.rs:53:22
    |
 LL |         let _: u16 = simd_bitmask(m2);
    |                      ^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u16`, expected `u8` or `[u8; 1]`
+error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u16`, expected `u8`
   --> $DIR/generic-bitmask.rs:56:22
    |
 LL |         let _: u16 = simd_bitmask(m8);
    |                      ^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u32`, expected `u16` or `[u8; 2]`
+error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u32`, expected `u16`
   --> $DIR/generic-bitmask.rs:59:22
    |
 LL |         let _: u32 = simd_bitmask(m16);
    |                      ^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u64`, expected `u32` or `[u8; 4]`
+error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u64`, expected `u32`
   --> $DIR/generic-bitmask.rs:62:22
    |
 LL |         let _: u64 = simd_bitmask(m32);
    |                      ^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u128`, expected `u64` or `[u8; 8]`
+error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u128`, expected `u64`
   --> $DIR/generic-bitmask.rs:65:23
    |
 LL |         let _: u128 = simd_bitmask(m64);

--- a/src/test/ui/simd/simd-bitmask.rs
+++ b/src/test/ui/simd/simd-bitmask.rs
@@ -15,17 +15,13 @@ fn main() {
     unsafe {
         let v = Simd::<i8, 4>([-1, 0, -1, 0]);
         let i: u8 = simd_bitmask(v);
-        let a: [u8; 1] = simd_bitmask(v);
 
         assert_eq!(i, 0b0101);
-        assert_eq!(a, [0b0101]);
 
         let v = Simd::<i8, 16>([0, 0, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, -1, 0]);
         let i: u16 = simd_bitmask(v);
-        let a: [u8; 2] = simd_bitmask(v);
 
         assert_eq!(i, 0b0101000000001100);
-        assert_eq!(a, [0b1100, 0b01010000]);
     }
 
     unsafe {


### PR DESCRIPTION
related: https://github.com/rust-lang/miri/issues/2734

this seems to be unused and trivially replaced by https://doc.rust-lang.org/std/primitive.i64.html#method.to_be_bytes or similar

r? @Amanieu @matthiaskrgr 