### PR TITLE
codegen tests: adapt patterns to also work with v0 symbol mangling

### DIFF
--- a/src/test/codegen/unwind-abis/c-unwind-abi-panic-abort.rs
+++ b/src/test/codegen/unwind-abis/c-unwind-abi-panic-abort.rs
@@ -9,7 +9,8 @@
 // CHECK: @rust_item_that_can_unwind() unnamed_addr [[ATTR0:#[0-9]+]]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn rust_item_that_can_unwind() {
-    // CHECK: call void @_ZN4core9panicking15panic_no_unwind
+    // Handle both legacy and v0 symbol mangling.
+    // CHECK: call void @{{.*core9panicking15panic_no_unwind}}
     may_unwind();
 }
 

--- a/src/test/codegen/unwind-and-panic-abort.rs
+++ b/src/test/codegen/unwind-and-panic-abort.rs
@@ -9,7 +9,8 @@ extern "C-unwind" {
 
 // CHECK: Function Attrs:{{.*}}nounwind
 // CHECK-NEXT: define{{.*}}void @foo
-// CHECK: call void @_ZN4core9panicking15panic_no_unwind
+// Handle both legacy and v0 symbol mangling.
+// CHECK: call void @{{.*core9panicking15panic_no_unwind}}
 #[no_mangle]
 pub unsafe extern "C" fn foo() {
     bar();


### PR DESCRIPTION
No functional changes intended.

These tests were failing under `new-symbol-mangling = true`, cf. https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/a.20few.20panic-abort.20tests.20fail.20under.20.60new-symbol-mangling.60.
This adapts the patterns to work in this case.