### PR TITLE
Clarify that raw retags are not permitted in Mir

### DIFF
--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -671,8 +671,8 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                 // FIXME(JakobDegen) The validator should check that `self.mir_phase <
                 // DropsLowered`. However, this causes ICEs with generation of drop shims, which
                 // seem to fail to set their `MirPhase` correctly.
-                if *kind == RetagKind::Raw {
-                    self.fail(location, "explicit `RetagKind::Raw` is forbidden");
+                if *kind == RetagKind::Raw || *kind == RetagKind::TwoPhase {
+                    self.fail(location, format!("explicit `{:?}` is forbidden", kind));
                 }
             }
             StatementKind::StorageLive(..)

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -323,8 +323,7 @@ pub enum StatementKind<'tcx> {
     /// For code that is not specific to stacked borrows, you should consider retags to read and
     /// modify the place in an opaque way.
     ///
-    /// Explicit `RetagKind::Raw` is not permitted - it is implicit as a part of
-    /// `Rvalue::AddressOf`.
+    /// Only `RetagKind::Default` and `RetagKind::FnEntry` are permitted.
     Retag(RetagKind, Box<Place<'tcx>>),
 
     /// Encodes a user's type ascription. These need to be preserved

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -320,8 +320,11 @@ pub enum StatementKind<'tcx> {
     /// <https://internals.rust-lang.org/t/stacked-borrows-an-aliasing-model-for-rust/8153/> for
     /// more details.
     ///
-    /// For code that is not specific to stacked borrows, you should consider retags to read
-    /// and modify the place in an opaque way.
+    /// For code that is not specific to stacked borrows, you should consider retags to read and
+    /// modify the place in an opaque way.
+    ///
+    /// Explicit `RetagKind::Raw` is not permitted - it is implicit as a part of
+    /// `Rvalue::AddressOf`.
     Retag(RetagKind, Box<Place<'tcx>>),
 
     /// Encodes a user's type ascription. These need to be preserved

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -15,9 +15,6 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
             @call("mir_retag", args) => {
                 Ok(StatementKind::Retag(RetagKind::Default, Box::new(self.parse_place(args[0])?)))
             },
-            @call("mir_retag_raw", args) => {
-                Ok(StatementKind::Retag(RetagKind::Raw, Box::new(self.parse_place(args[0])?)))
-            },
             @call("mir_set_discriminant", args) => {
                 let place = self.parse_place(args[0])?;
                 let var = self.parse_integer_literal(args[1])? as u32;

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -259,7 +259,6 @@ define!("mir_drop", fn Drop<T>(place: T, goto: BasicBlock));
 define!("mir_drop_and_replace", fn DropAndReplace<T>(place: T, value: T, goto: BasicBlock));
 define!("mir_call", fn Call<T>(place: T, goto: BasicBlock, call: T));
 define!("mir_retag", fn Retag<T>(place: T));
-define!("mir_retag_raw", fn RetagRaw<T>(place: T));
 define!("mir_move", fn Move<T>(place: T) -> T);
 define!("mir_static", fn Static<T>(s: T) -> &'static T);
 define!("mir_static_mut", fn StaticMut<T>(s: T) -> *mut T);

--- a/src/test/mir-opt/building/custom/references.immut_ref.built.after.mir
+++ b/src/test/mir-opt/building/custom/references.immut_ref.built.after.mir
@@ -6,9 +6,8 @@ fn immut_ref(_1: &i32) -> &i32 {
 
     bb0: {
         _2 = &raw const (*_1);           // scope 0 at $DIR/references.rs:+5:13: +5:29
-        Retag([raw] _2);                 // scope 0 at $DIR/references.rs:+6:13: +6:24
-        _0 = &(*_2);                     // scope 0 at $DIR/references.rs:+7:13: +7:23
-        Retag(_0);                       // scope 0 at $DIR/references.rs:+8:13: +8:23
-        return;                          // scope 0 at $DIR/references.rs:+9:13: +9:21
+        _0 = &(*_2);                     // scope 0 at $DIR/references.rs:+6:13: +6:23
+        Retag(_0);                       // scope 0 at $DIR/references.rs:+7:13: +7:23
+        return;                          // scope 0 at $DIR/references.rs:+8:13: +8:21
     }
 }

--- a/src/test/mir-opt/building/custom/references.mut_ref.built.after.mir
+++ b/src/test/mir-opt/building/custom/references.mut_ref.built.after.mir
@@ -6,9 +6,8 @@ fn mut_ref(_1: &mut i32) -> &mut i32 {
 
     bb0: {
         _2 = &raw mut (*_1);             // scope 0 at $DIR/references.rs:+5:13: +5:33
-        Retag([raw] _2);                 // scope 0 at $DIR/references.rs:+6:13: +6:24
-        _0 = &mut (*_2);                 // scope 0 at $DIR/references.rs:+7:13: +7:26
-        Retag(_0);                       // scope 0 at $DIR/references.rs:+8:13: +8:23
-        return;                          // scope 0 at $DIR/references.rs:+9:13: +9:21
+        _0 = &mut (*_2);                 // scope 0 at $DIR/references.rs:+6:13: +6:26
+        Retag(_0);                       // scope 0 at $DIR/references.rs:+7:13: +7:23
+        return;                          // scope 0 at $DIR/references.rs:+8:13: +8:21
     }
 }

--- a/src/test/mir-opt/building/custom/references.rs
+++ b/src/test/mir-opt/building/custom/references.rs
@@ -12,7 +12,6 @@ pub fn mut_ref(x: &mut i32) -> &mut i32 {
 
         {
             t = addr_of_mut!(*x);
-            RetagRaw(t);
             RET = &mut *t;
             Retag(RET);
             Return()
@@ -28,7 +27,6 @@ pub fn immut_ref(x: &i32) -> &i32 {
 
         {
             t = addr_of!(*x);
-            RetagRaw(t);
             RET = & *t;
             Retag(RET);
             Return()


### PR DESCRIPTION
Not sure when this changed, but documentation and the validator needed to be updated. This also removes raw retags from custom mir.

cc rust-lang/miri#2735

r? @RalfJung 