### PR TITLE
Fix ICE due to `todo!()` in `rustdoc` for `Term`s

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1655,10 +1655,10 @@ impl clean::types::Term {
         &'a self,
         cx: &'a Context<'tcx>,
     ) -> impl fmt::Display + 'a + Captures<'tcx> {
-        match self {
-            clean::types::Term::Type(ty) => ty.print(cx),
-            _ => todo!(),
-        }
+        display_fn(move |f| match self {
+            clean::types::Term::Type(ty) => fmt::Display::fmt(&ty.print(cx), f),
+            clean::types::Term::Constant(ct) => fmt::Display::fmt(&ct.print(cx.tcx()), f),
+        })
     }
 }
 

--- a/src/test/rustdoc/issue-105952.rs
+++ b/src/test/rustdoc/issue-105952.rs
@@ -1,0 +1,14 @@
+#![crate_name = "foo"]
+
+#![feature(associated_const_equality)]
+pub enum ParseMode {
+    Raw,
+}
+pub trait Parse {
+    const PARSE_MODE: ParseMode;
+}
+pub trait RenderRaw {}
+
+// @hasraw foo/trait.RenderRaw.html 'impl'
+// @hasraw foo/trait.RenderRaw.html 'ParseMode::Raw'
+impl<T: Parse<PARSE_MODE = { ParseMode::Raw }>> RenderRaw for T {}


### PR DESCRIPTION
Left a todo awhile ago (I think), so fill it in to print a const for `Term`s.

Fixes #105952.

Should I add some annotations to the rustdoc test?