### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -283,26 +283,26 @@ pub unsafe fn create_module<'ll>(
         if sess.target.arch == "aarch64" {
             llvm::LLVMRustAddModuleFlag(
                 llmod,
-                llvm::LLVMModFlagBehavior::Error,
+                llvm::LLVMModFlagBehavior::Min,
                 "branch-target-enforcement\0".as_ptr().cast(),
                 bti.into(),
             );
             llvm::LLVMRustAddModuleFlag(
                 llmod,
-                llvm::LLVMModFlagBehavior::Error,
+                llvm::LLVMModFlagBehavior::Min,
                 "sign-return-address\0".as_ptr().cast(),
                 pac_ret.is_some().into(),
             );
             let pac_opts = pac_ret.unwrap_or(PacRet { leaf: false, key: PAuthKey::A });
             llvm::LLVMRustAddModuleFlag(
                 llmod,
-                llvm::LLVMModFlagBehavior::Error,
+                llvm::LLVMModFlagBehavior::Min,
                 "sign-return-address-all\0".as_ptr().cast(),
                 pac_opts.leaf.into(),
             );
             llvm::LLVMRustAddModuleFlag(
                 llmod,
-                llvm::LLVMModFlagBehavior::Error,
+                llvm::LLVMModFlagBehavior::Min,
                 "sign-return-address-with-bkey\0".as_ptr().cast(),
                 u32::from(pac_opts.key == PAuthKey::B),
             );

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -79,6 +79,7 @@ pub enum LLVMModFlagBehavior {
     Append = 5,
     AppendUnique = 6,
     Max = 7,
+    Min = 8,
 }
 
 // Consts for the LLVM CallConv type, pre-cast to usize.

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -671,8 +671,8 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                 // FIXME(JakobDegen) The validator should check that `self.mir_phase <
                 // DropsLowered`. However, this causes ICEs with generation of drop shims, which
                 // seem to fail to set their `MirPhase` correctly.
-                if *kind == RetagKind::Raw {
-                    self.fail(location, "explicit `RetagKind::Raw` is forbidden");
+                if *kind == RetagKind::Raw || *kind == RetagKind::TwoPhase {
+                    self.fail(location, format!("explicit `{:?}` is forbidden", kind));
                 }
             }
             StatementKind::StorageLive(..)

--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -607,10 +607,7 @@ fn check_must_not_suspend_ty<'tcx>(
         ty::Tuple(fields) => {
             let mut has_emitted = false;
             let comps = match data.expr.map(|e| &e.kind) {
-                Some(hir::ExprKind::Tup(comps)) => {
-                    debug_assert_eq!(comps.len(), fields.len());
-                    Some(comps)
-                }
+                Some(hir::ExprKind::Tup(comps)) if comps.len() == fields.len() => Some(comps),
                 _ => None,
             };
             for (i, ty) in fields.iter().enumerate() {

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -408,7 +408,7 @@ impl<'hir> Map<'hir> {
     /// item (possibly associated), a closure, or a `hir::AnonConst`.
     pub fn body_owner(self, BodyId { hir_id }: BodyId) -> HirId {
         let parent = self.get_parent_node(hir_id);
-        assert!(self.find(parent).map_or(false, |n| is_body_owner(n, hir_id)));
+        assert!(self.find(parent).map_or(false, |n| is_body_owner(n, hir_id)), "{hir_id:?}");
         parent
     }
 
@@ -419,7 +419,7 @@ impl<'hir> Map<'hir> {
     /// Given a `LocalDefId`, returns the `BodyId` associated with it,
     /// if the node is a body owner, otherwise returns `None`.
     pub fn maybe_body_owned_by(self, id: LocalDefId) -> Option<BodyId> {
-        self.get_if_local(id.to_def_id()).map(associated_body).flatten()
+        self.find_by_def_id(id).and_then(associated_body)
     }
 
     /// Given a body owner's id, returns the `BodyId` associated with it.

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -170,6 +170,7 @@ impl<'hir> Map<'hir> {
     }
 
     #[inline]
+    #[track_caller]
     pub fn local_def_id(self, hir_id: HirId) -> LocalDefId {
         self.opt_local_def_id(hir_id).unwrap_or_else(|| {
             bug!(
@@ -310,6 +311,7 @@ impl<'hir> Map<'hir> {
         }
     }
 
+    #[track_caller]
     pub fn get_parent_node(self, hir_id: HirId) -> HirId {
         self.find_parent_node(hir_id)
             .unwrap_or_else(|| bug!("No parent for node {:?}", self.node_to_string(hir_id)))
@@ -334,12 +336,14 @@ impl<'hir> Map<'hir> {
     }
 
     /// Retrieves the `Node` corresponding to `id`, panicking if it cannot be found.
+    #[track_caller]
     pub fn get(self, id: HirId) -> Node<'hir> {
         self.find(id).unwrap_or_else(|| bug!("couldn't find hir id {} in the HIR map", id))
     }
 
     /// Retrieves the `Node` corresponding to `id`, panicking if it cannot be found.
     #[inline]
+    #[track_caller]
     pub fn get_by_def_id(self, id: LocalDefId) -> Node<'hir> {
         self.find_by_def_id(id).unwrap_or_else(|| bug!("couldn't find {:?} in the HIR map", id))
     }
@@ -377,6 +381,7 @@ impl<'hir> Map<'hir> {
         self.tcx.hir_owner_nodes(id.hir_id.owner).unwrap().bodies[&id.hir_id.local_id]
     }
 
+    #[track_caller]
     pub fn fn_decl_by_hir_id(self, hir_id: HirId) -> Option<&'hir FnDecl<'hir>> {
         if let Some(node) = self.find(hir_id) {
             node.fn_decl()
@@ -385,6 +390,7 @@ impl<'hir> Map<'hir> {
         }
     }
 
+    #[track_caller]
     pub fn fn_sig_by_hir_id(self, hir_id: HirId) -> Option<&'hir FnSig<'hir>> {
         if let Some(node) = self.find(hir_id) {
             node.fn_sig()
@@ -393,6 +399,7 @@ impl<'hir> Map<'hir> {
         }
     }
 
+    #[track_caller]
     pub fn enclosing_body_owner(self, hir_id: HirId) -> LocalDefId {
         for (_, node) in self.parent_iter(hir_id) {
             if let Some(body) = associated_body(node) {
@@ -423,6 +430,7 @@ impl<'hir> Map<'hir> {
     }
 
     /// Given a body owner's id, returns the `BodyId` associated with it.
+    #[track_caller]
     pub fn body_owned_by(self, id: LocalDefId) -> BodyId {
         self.maybe_body_owned_by(id).unwrap_or_else(|| {
             let hir_id = self.local_def_id_to_hir_id(id);

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -323,8 +323,7 @@ pub enum StatementKind<'tcx> {
     /// For code that is not specific to stacked borrows, you should consider retags to read and
     /// modify the place in an opaque way.
     ///
-    /// Explicit `RetagKind::Raw` is not permitted - it is implicit as a part of
-    /// `Rvalue::AddressOf`.
+    /// Only `RetagKind::Default` and `RetagKind::FnEntry` are permitted.
     Retag(RetagKind, Box<Place<'tcx>>),
 
     /// Encodes a user's type ascription. These need to be preserved

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -320,8 +320,11 @@ pub enum StatementKind<'tcx> {
     /// <https://internals.rust-lang.org/t/stacked-borrows-an-aliasing-model-for-rust/8153/> for
     /// more details.
     ///
-    /// For code that is not specific to stacked borrows, you should consider retags to read
-    /// and modify the place in an opaque way.
+    /// For code that is not specific to stacked borrows, you should consider retags to read and
+    /// modify the place in an opaque way.
+    ///
+    /// Explicit `RetagKind::Raw` is not permitted - it is implicit as a part of
+    /// `Rvalue::AddressOf`.
     Retag(RetagKind, Box<Place<'tcx>>),
 
     /// Encodes a user's type ascription. These need to be preserved

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -70,14 +70,6 @@ impl GenericParamDef {
         }
     }
 
-    pub fn has_default(&self) -> bool {
-        match self.kind {
-            GenericParamDefKind::Type { has_default, .. }
-            | GenericParamDefKind::Const { has_default } => has_default,
-            GenericParamDefKind::Lifetime => false,
-        }
-    }
-
     pub fn is_anonymous_lifetime(&self) -> bool {
         match self.kind {
             GenericParamDefKind::Lifetime => {

--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -348,7 +348,7 @@ impl<'tcx> InternalSubsts<'tcx> {
         substs.reserve(defs.params.len());
         for param in &defs.params {
             let kind = mk_kind(param, substs);
-            assert_eq!(param.index as usize, substs.len());
+            assert_eq!(param.index as usize, substs.len(), "{substs:#?}, {defs:#?}");
             substs.push(kind);
         }
     }

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -15,9 +15,6 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
             @call("mir_retag", args) => {
                 Ok(StatementKind::Retag(RetagKind::Default, Box::new(self.parse_place(args[0])?)))
             },
-            @call("mir_retag_raw", args) => {
-                Ok(StatementKind::Retag(RetagKind::Raw, Box::new(self.parse_place(args[0])?)))
-            },
             @call("mir_set_discriminant", args) => {
                 let place = self.parse_place(args[0])?;
                 let var = self.parse_integer_literal(args[1])? as u32;

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3185,14 +3185,8 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 && let predicates = self.tcx.predicates_of(def_id).instantiate_identity(self.tcx)
                 && let Some(pred) = predicates.predicates.get(*idx)
             {
-                if let Ok(trait_pred) = pred.kind().try_map_bound(|pred| match pred {
-                    ty::PredicateKind::Clause(ty::Clause::Trait(trait_pred)) => Ok(trait_pred),
-                    _ => Err(()),
-                })
-                    && let Ok(trait_predicate) = predicate.kind().try_map_bound(|pred| match pred {
-                        ty::PredicateKind::Clause(ty::Clause::Trait(trait_pred)) => Ok(trait_pred),
-                        _ => Err(()),
-                    })
+                if let Some(trait_pred) = pred.to_opt_poly_trait_pred()
+                    && let Some(trait_predicate) = predicate.to_opt_poly_trait_pred()
                 {
                     let mut c = CollectAllMismatches {
                         infcx: self.infcx,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3182,7 +3182,8 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             let mut type_diffs = vec![];
 
             if let ObligationCauseCode::ExprBindingObligation(def_id, _, _, idx) = parent_code.deref()
-                && let predicates = self.tcx.predicates_of(def_id).instantiate_identity(self.tcx)
+                && let Some(node_substs) = typeck_results.node_substs_opt(call_hir_id)
+                && let predicates = self.tcx.predicates_of(def_id).instantiate(self.tcx, node_substs)
                 && let Some(pred) = predicates.predicates.get(*idx)
             {
                 if let Some(trait_pred) = pred.to_opt_poly_trait_pred()

--- a/library/core/src/const_closure.rs
+++ b/library/core/src/const_closure.rs
@@ -51,7 +51,7 @@ macro_rules! impl_fn_mut_tuple {
         impl<'a, $($var,)* ClosureArguments, Function, ClosureReturnValue> const
             FnOnce<ClosureArguments> for ConstFnMutClosure<($(&'a mut $var),*), Function>
         where
-            Function: ~const Fn(($(&mut $var),*), ClosureArguments) -> ClosureReturnValue+ ~const Destruct,
+            Function: ~const Fn(($(&mut $var),*), ClosureArguments) -> ClosureReturnValue + ~const Destruct,
         {
             type Output = ClosureReturnValue;
 
@@ -64,7 +64,7 @@ macro_rules! impl_fn_mut_tuple {
         impl<'a, $($var,)* ClosureArguments, Function, ClosureReturnValue> const
             FnMut<ClosureArguments> for ConstFnMutClosure<($(&'a mut $var),*), Function>
         where
-            Function: ~const Fn(($(&mut $var),*), ClosureArguments)-> ClosureReturnValue,
+            Function: ~const Fn(($(&mut $var),*), ClosureArguments)-> ClosureReturnValue + ~const Destruct,
         {
             extern "rust-call" fn call_mut(&mut self, args: ClosureArguments) -> Self::Output {
                 #[allow(non_snake_case)]

--- a/library/core/src/hash/mod.rs
+++ b/library/core/src/hash/mod.rs
@@ -199,7 +199,7 @@ pub trait Hash {
     /// println!("Hash is {:x}!", hasher.finish());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn hash<H: Hasher>(&self, state: &mut H);
+    fn hash<H: ~const Hasher>(&self, state: &mut H);
 
     /// Feeds a slice of this type into the given [`Hasher`].
     ///
@@ -980,7 +980,7 @@ mod impls {
     #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     impl<T: ?Sized + ~const Hash> const Hash for &mut T {
         #[inline]
-        fn hash<H: Hasher>(&self, state: &mut H) {
+        fn hash<H: ~const Hasher>(&self, state: &mut H) {
             (**self).hash(state);
         }
     }

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -259,7 +259,6 @@ define!("mir_drop", fn Drop<T>(place: T, goto: BasicBlock));
 define!("mir_drop_and_replace", fn DropAndReplace<T>(place: T, value: T, goto: BasicBlock));
 define!("mir_call", fn Call<T>(place: T, goto: BasicBlock, call: T));
 define!("mir_retag", fn Retag<T>(place: T));
-define!("mir_retag_raw", fn RetagRaw<T>(place: T));
 define!("mir_move", fn Move<T>(place: T) -> T);
 define!("mir_static", fn Static<T>(s: T) -> &'static T);
 define!("mir_static_mut", fn StaticMut<T>(s: T) -> *mut T);

--- a/library/core/src/ops/index.rs
+++ b/library/core/src/ops/index.rs
@@ -165,7 +165,7 @@ see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#ind
 #[doc(alias = "]")]
 #[doc(alias = "[]")]
 #[const_trait]
-pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
+pub trait IndexMut<Idx: ?Sized>: ~const Index<Idx> {
     /// Performs the mutable indexing (`container[index]`) operation.
     ///
     /// # Panics

--- a/src/test/mir-opt/building/custom/references.immut_ref.built.after.mir
+++ b/src/test/mir-opt/building/custom/references.immut_ref.built.after.mir
@@ -6,9 +6,8 @@ fn immut_ref(_1: &i32) -> &i32 {
 
     bb0: {
         _2 = &raw const (*_1);           // scope 0 at $DIR/references.rs:+5:13: +5:29
-        Retag([raw] _2);                 // scope 0 at $DIR/references.rs:+6:13: +6:24
-        _0 = &(*_2);                     // scope 0 at $DIR/references.rs:+7:13: +7:23
-        Retag(_0);                       // scope 0 at $DIR/references.rs:+8:13: +8:23
-        return;                          // scope 0 at $DIR/references.rs:+9:13: +9:21
+        _0 = &(*_2);                     // scope 0 at $DIR/references.rs:+6:13: +6:23
+        Retag(_0);                       // scope 0 at $DIR/references.rs:+7:13: +7:23
+        return;                          // scope 0 at $DIR/references.rs:+8:13: +8:21
     }
 }

--- a/src/test/mir-opt/building/custom/references.mut_ref.built.after.mir
+++ b/src/test/mir-opt/building/custom/references.mut_ref.built.after.mir
@@ -6,9 +6,8 @@ fn mut_ref(_1: &mut i32) -> &mut i32 {
 
     bb0: {
         _2 = &raw mut (*_1);             // scope 0 at $DIR/references.rs:+5:13: +5:33
-        Retag([raw] _2);                 // scope 0 at $DIR/references.rs:+6:13: +6:24
-        _0 = &mut (*_2);                 // scope 0 at $DIR/references.rs:+7:13: +7:26
-        Retag(_0);                       // scope 0 at $DIR/references.rs:+8:13: +8:23
-        return;                          // scope 0 at $DIR/references.rs:+9:13: +9:21
+        _0 = &mut (*_2);                 // scope 0 at $DIR/references.rs:+6:13: +6:26
+        Retag(_0);                       // scope 0 at $DIR/references.rs:+7:13: +7:23
+        return;                          // scope 0 at $DIR/references.rs:+8:13: +8:21
     }
 }

--- a/src/test/mir-opt/building/custom/references.rs
+++ b/src/test/mir-opt/building/custom/references.rs
@@ -12,7 +12,6 @@ pub fn mut_ref(x: &mut i32) -> &mut i32 {
 
         {
             t = addr_of_mut!(*x);
-            RetagRaw(t);
             RET = &mut *t;
             Retag(RET);
             Return()
@@ -28,7 +27,6 @@ pub fn immut_ref(x: &i32) -> &i32 {
 
         {
             t = addr_of!(*x);
-            RetagRaw(t);
             RET = & *t;
             Retag(RET);
             Return()

--- a/src/test/ui/async-await/async-is-unwindsafe.rs
+++ b/src/test/ui/async-await/async-is-unwindsafe.rs
@@ -1,0 +1,30 @@
+// edition:2018
+
+fn is_unwindsafe(_: impl std::panic::UnwindSafe) {}
+
+fn main() {
+    // A normal future created by an async block takes a `&mut Context<'_>` argument.
+    // That should not leak through to the whole async block.
+    is_unwindsafe(async {
+        async {}.await; // this needs an inner await point
+    });
+
+    is_unwindsafe(async {
+        //~^ ERROR the type `&mut Context<'_>` may not be safely transferred across an unwind boundary
+        use std::ptr::null;
+        use std::task::{Context, RawWaker, RawWakerVTable, Waker};
+        let waker = unsafe {
+            Waker::from_raw(RawWaker::new(
+                null(),
+                &RawWakerVTable::new(|_| todo!(), |_| todo!(), |_| todo!(), |_| todo!()),
+            ))
+        };
+        let mut cx = Context::from_waker(&waker);
+        let cx_ref = &mut cx;
+
+        async {}.await; // this needs an inner await point
+
+        // in this case, `&mut Context<'_>` is *truly* alive across an await point
+        drop(cx_ref);
+    });
+}

--- a/src/test/ui/async-await/async-is-unwindsafe.stderr
+++ b/src/test/ui/async-await/async-is-unwindsafe.stderr
@@ -1,0 +1,38 @@
+error[E0277]: the type `&mut Context<'_>` may not be safely transferred across an unwind boundary
+  --> $DIR/async-is-unwindsafe.rs:12:19
+   |
+LL |       is_unwindsafe(async {
+   |  ___________________^
+LL | |
+LL | |         use std::ptr::null;
+LL | |         use std::task::{Context, RawWaker, RawWakerVTable, Waker};
+...  |
+LL | |         drop(cx_ref);
+LL | |     });
+   | |     ^
+   | |     |
+   | |_____`&mut Context<'_>` may not be safely transferred across an unwind boundary
+   |       within this `[async block@$DIR/async-is-unwindsafe.rs:12:19: 29:6]`
+   |
+   = help: within `[async block@$DIR/async-is-unwindsafe.rs:12:19: 29:6]`, the trait `UnwindSafe` is not implemented for `&mut Context<'_>`
+   = note: `UnwindSafe` is implemented for `&std::task::Context<'_>`, but not for `&mut std::task::Context<'_>`
+note: future does not implement `UnwindSafe` as this value is used across an await
+  --> $DIR/async-is-unwindsafe.rs:25:17
+   |
+LL |         let cx_ref = &mut cx;
+   |             ------ has type `&mut Context<'_>` which does not implement `UnwindSafe`
+LL |
+LL |         async {}.await; // this needs an inner await point
+   |                 ^^^^^^ await occurs here, with `cx_ref` maybe used later
+...
+LL |     });
+   |     - `cx_ref` is later dropped here
+note: required by a bound in `is_unwindsafe`
+  --> $DIR/async-is-unwindsafe.rs:3:26
+   |
+LL | fn is_unwindsafe(_: impl std::panic::UnwindSafe) {}
+   |                          ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_unwindsafe`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/iterators/invalid-iterator-chain.stderr
+++ b/src/test/ui/iterators/invalid-iterator-chain.stderr
@@ -52,14 +52,14 @@ LL |             .sum::<i32>(),
              <i32 as Sum<&'a i32>>
              <i32 as Sum>
 note: the method call chain might not have had the expected associated types
-  --> $DIR/invalid-iterator-chain.rs:20:14
+  --> $DIR/invalid-iterator-chain.rs:25:14
    |
 LL |         vec![0, 1]
    |         ---------- this expression has type `Vec<{integer}>`
 LL |             .iter()
    |              ------ `Iterator::Item` is `&{integer}` here
 LL |             .map(|x| x * 2)
-   |              ^^^^^^^^^^^^^^ `Iterator::Item` changed to `{integer}` here
+   |              -------------- `Iterator::Item` changed to `{integer}` here
 LL |             .map(|x| x as f64)
    |              ----------------- `Iterator::Item` changed to `f64` here
 LL |             .map(|x| x as i64)
@@ -84,14 +84,14 @@ LL |             .sum::<i32>(),
              <i32 as Sum<&'a i32>>
              <i32 as Sum>
 note: the method call chain might not have had the expected associated types
-  --> $DIR/invalid-iterator-chain.rs:32:14
+  --> $DIR/invalid-iterator-chain.rs:33:14
    |
 LL |         vec![0, 1]
    |         ---------- this expression has type `Vec<{integer}>`
 LL |             .iter()
    |              ------ `Iterator::Item` is `&{integer}` here
 LL |             .map(|x| x * 2)
-   |              ^^^^^^^^^^^^^^ `Iterator::Item` changed to `{integer}` here
+   |              -------------- `Iterator::Item` changed to `{integer}` here
 LL |             .map(|x| x as f64)
    |              ^^^^^^^^^^^^^^^^^ `Iterator::Item` changed to `f64` here
 LL |             .filter(|x| *x > 0.0)

--- a/src/test/ui/lint/must_not_suspend/tuple-mismatch.rs
+++ b/src/test/ui/lint/must_not_suspend/tuple-mismatch.rs
@@ -1,0 +1,9 @@
+#![feature(generators)]
+
+fn main() {
+    let _generator = || {
+        yield ((), ((), ()));
+        yield ((), ());
+        //~^ ERROR mismatched types
+    };
+}

--- a/src/test/ui/lint/must_not_suspend/tuple-mismatch.stderr
+++ b/src/test/ui/lint/must_not_suspend/tuple-mismatch.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/tuple-mismatch.rs:6:20
+   |
+LL |         yield ((), ());
+   |                    ^^ expected tuple, found `()`
+   |
+   = note:  expected tuple `((), ())`
+           found unit type `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #105837 (Don't ICE in `check_must_not_suspend_ty` for mismatched tuple arity)
 - #105932 (Correct branch-protection ModFlagBehavior for Aarch64 on LLVM-15)
 - #105960 (Various cleanups)
 - #105985 (Method chain nitpicks)
 - #105996 (Test that async blocks are `UnwindSafe`)
 - #106012 (Clarify that raw retags are not permitted in Mir)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=105837,105932,105960,105985,105996,106012)
<!-- homu-ignore:end -->