### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -569,8 +569,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             ty::ConstKind::Unevaluated(uv) => {
                 let instance = self.resolve(uv.def, uv.substs)?;
                 let cid = GlobalId { instance, promoted: None };
-                self.ctfe_query(span, |tcx| tcx.eval_to_valtree(self.param_env.and(cid)))?
-                    .unwrap_or_else(|| bug!("unable to create ValTree for {uv:?}"))
+                self.ctfe_query(span, |tcx| {
+                    tcx.eval_to_valtree(self.param_env.with_const().and(cid))
+                })?
+                .unwrap_or_else(|| bug!("unable to create ValTree for {uv:?}"))
             }
             ty::ConstKind::Bound(..) | ty::ConstKind::Infer(..) => {
                 span_bug!(self.cur_span(), "unexpected ConstKind in ctfe: {val:?}")

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -244,6 +244,7 @@ E0457: include_str!("./error_codes/E0457.md"),
 E0458: include_str!("./error_codes/E0458.md"),
 E0459: include_str!("./error_codes/E0459.md"),
 E0460: include_str!("./error_codes/E0460.md"),
+E0462: include_str!("./error_codes/E0462.md"),
 E0463: include_str!("./error_codes/E0463.md"),
 E0464: include_str!("./error_codes/E0464.md"),
 E0466: include_str!("./error_codes/E0466.md"),
@@ -594,7 +595,6 @@ E0791: include_str!("./error_codes/E0791.md"),
 //  E0427, // merged into 530
 //  E0456, // plugin `..` is not available for triple `..`
     E0461, // couldn't find crate `..` with expected target triple ..
-    E0462, // found staticlib `..` instead of rlib or dylib
     E0465, // multiple .. candidates for `..` found
 //  E0467, // removed
 //  E0470, // removed

--- a/compiler/rustc_error_codes/src/error_codes/E0462.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0462.md
@@ -1,0 +1,32 @@
+Found `staticlib` `..` instead of `rlib` or `dylib`.
+
+Consider the following two files:
+
+`a.rs`
+```ignore (cannot-link-with-other-tests)
+#![crate_type = "staticlib"]
+
+fn foo() {}
+```
+
+`main.rs`
+```ignore (cannot-link-with-other-tests)
+extern crate a;
+
+fn main() {
+    a::foo();
+}
+```
+
+Crate `a` is compiled as a `staticlib`. A `staticlib` is a system-dependant
+library only intended for linking with non-Rust applications (C programs). Note
+that `staticlib`s include all upstream dependencies (`core`, `std`, other user
+dependencies, etc) which makes them significantly larger than `dylib`s:
+prefer `staticlib` for linking with C programs. Learn more about different
+`crate_type`s in [this section of the Reference](../reference/linkage.html).
+
+This error can be fixed by:
+ * Using [Cargo](../cargo/index.html), the Rust package manager, automatically
+   fixing this issue.
+ * Recompiling the crate as a `rlib` or `dylib`; formats suitable for Rust
+   linking.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -130,7 +130,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     pub fn local_ty(&self, span: Span, nid: hir::HirId) -> LocalTy<'tcx> {
         self.locals.borrow().get(&nid).cloned().unwrap_or_else(|| {
-            span_bug!(span, "no type for local variable {}", self.tcx.hir().node_to_string(nid))
+            let err = self.tcx.ty_error_with_message(
+                span,
+                &format!("no type for local variable {}", self.tcx.hir().node_to_string(nid)),
+            );
+            LocalTy { decl_ty: err, revealed_ty: err }
         })
     }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3005,8 +3005,7 @@ fn render_call_locations(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Ite
                   </summary>\
                   <div class=\"hide-more\">Hide additional examples</div>\
                   <div class=\"more-scraped-examples\">\
-                    <div class=\"toggle-line\"><div class=\"toggle-line-inner\"></div></div>\
-                    <div class=\"more-scraped-examples-inner\">"
+                    <div class=\"toggle-line\"><div class=\"toggle-line-inner\"></div></div>"
         );
 
         // Only generate inline code for MAX_FULL_EXAMPLES number of examples. Otherwise we could
@@ -3030,7 +3029,7 @@ fn render_call_locations(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Ite
             write!(w, "</ul></div>");
         }
 
-        write!(w, "</div></div></details>");
+        write!(w, "</div></details>");
     }
 
     write!(w, "</div>");

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1287,6 +1287,7 @@ a.test-arrow:hover {
 #titles > button > div.count {
 	display: inline-block;
 	font-size: 1rem;
+	color: var(--search-tab-title-count-color);
 }
 
 #src-sidebar-toggle {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1991,20 +1991,15 @@ in storage.js
 }
 
 .more-scraped-examples {
-	margin-left: 5px;
-	display: flex;
-	flex-direction: row;
-}
-
-.more-scraped-examples-inner {
-	/* 20px is width of toggle-line + toggle-line-inner */
-	width: calc(100% - 20px);
+	margin-left: 25px;
+	position: relative;
 }
 
 .toggle-line {
-	align-self: stretch;
-	margin-right: 10px;
-	margin-top: 5px;
+	position: absolute;
+	top: 5px;
+	bottom: 0;
+	right: calc(100% + 10px);
 	padding: 0 4px;
 	cursor: pointer;
 }

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -45,6 +45,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--search-color: #fff;
 	--search-results-alias-color: #c5c5c5;
 	--search-results-grey-color: #999;
+	--search-tab-title-count-color: #888;
 	--stab-background-color: #314559;
 	--stab-code-color: #e6e1cf;
 	--code-highlight-kw-color: #ff7733;
@@ -173,10 +174,6 @@ pre, .rustdoc.source .example-wrap {
 
 #titles > button:hover {
 	border-bottom: 1px solid rgba(242, 151, 24, 0.3);
-}
-
-#titles > button > div.count {
-	color: #888;
 }
 
 /* rules that this theme does not need to set, here to satisfy the rule checker */

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -40,6 +40,7 @@
 	--search-color: #111;
 	--search-results-alias-color: #fff;
 	--search-results-grey-color: #ccc;
+	--search-tab-title-count-color: #888;
 	--stab-background-color: #314559;
 	--stab-code-color: #e6e1cf;
 	--code-highlight-kw-color: #ab8ac1;
@@ -94,10 +95,6 @@
 #titles > button:hover, #titles > button.selected {
 	border-top-color: #0089ff;
 	background-color: #353535;
-}
-
-#titles > button > div.count {
-	color: #888;
 }
 
 .scraped-example-list .scrape-help {

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -40,6 +40,7 @@
 	--search-color: #000;
 	--search-results-alias-color: #000;
 	--search-results-grey-color: #999;
+	--search-tab-title-count-color: #888;
 	--stab-background-color: #fff5d6;
 	--stab-code-color: #000;
 	--code-highlight-kw-color: #8959a8;
@@ -91,10 +92,6 @@
 #titles > button:hover, #titles > button.selected {
 	background-color: #ffffff;
 	border-top-color: #0089ff;
-}
-
-#titles > button > div.count {
-	color: #888;
 }
 
 .scraped-example-list .scrape-help {

--- a/src/test/codegen/sanitizer-kcfi-emit-kcfi-operand-bundle-itanium-cxx-abi.rs
+++ b/src/test/codegen/sanitizer-kcfi-emit-kcfi-operand-bundle-itanium-cxx-abi.rs
@@ -20,24 +20,21 @@ impl Copy for i32 {}
 
 pub fn foo(f: fn(i32) -> i32, arg: i32) -> i32 {
     // CHECK-LABEL: define{{.*}}foo
-    // FIXME(rcvalle): Change <unknown kind #36> to !kcfi_type when Rust is updated to LLVM 16
-    // CHECK-SAME: {{.*}}!<unknown kind #36> ![[TYPE1:[0-9]+]]
+    // CHECK-SAME: {{.*}}!{{<unknown kind #36>|kcfi_type}} ![[TYPE1:[0-9]+]]
     // CHECK: call i32 %f(i32 %arg){{.*}}[ "kcfi"(i32 -1666898348) ]
     f(arg)
 }
 
 pub fn bar(f: fn(i32, i32) -> i32, arg1: i32, arg2: i32) -> i32 {
     // CHECK-LABEL: define{{.*}}bar
-    // FIXME(rcvalle): Change <unknown kind #36> to !kcfi_type when Rust is updated to LLVM 16
-    // CHECK-SAME: {{.*}}!<unknown kind #36> ![[TYPE2:[0-9]+]]
+    // CHECK-SAME: {{.*}}!{{<unknown kind #36>|kcfi_type}} ![[TYPE2:[0-9]+]]
     // CHECK: call i32 %f(i32 %arg1, i32 %arg2){{.*}}[ "kcfi"(i32 -1789026986) ]
     f(arg1, arg2)
 }
 
 pub fn baz(f: fn(i32, i32, i32) -> i32, arg1: i32, arg2: i32, arg3: i32) -> i32 {
     // CHECK-LABEL: define{{.*}}baz
-    // FIXME(rcvalle): Change <unknown kind #36> to !kcfi_type when Rust is updated to LLVM 16
-    // CHECK-SAME: {{.*}}!<unknown kind #36> ![[TYPE3:[0-9]+]]
+    // CHECK-SAME: {{.*}}!{{<unknown kind #36>|kcfi_type}} ![[TYPE3:[0-9]+]]
     // CHECK: call i32 %f(i32 %arg1, i32 %arg2, i32 %arg3){{.*}}[ "kcfi"(i32 1248878270) ]
     f(arg1, arg2, arg3)
 }

--- a/src/test/rustdoc-gui/scrape-examples-layout.goml
+++ b/src/test/rustdoc-gui/scrape-examples-layout.goml
@@ -10,13 +10,8 @@ assert-property-false: (
 // Check that examples with very long lines have the same width as ones that don't.
 store-property: (
     clientWidth,
-    ".more-scraped-examples .scraped-example:nth-child(1) .code-wrapper .src-line-numbers",
-    "clientWidth"
-)
-
-assert-property: (
     ".more-scraped-examples .scraped-example:nth-child(2) .code-wrapper .src-line-numbers",
-    {"clientWidth": |clientWidth|}
+    "clientWidth"
 )
 
 assert-property: (
@@ -31,5 +26,10 @@ assert-property: (
 
 assert-property: (
     ".more-scraped-examples .scraped-example:nth-child(5) .code-wrapper .src-line-numbers",
+    {"clientWidth": |clientWidth|}
+)
+
+assert-property: (
+    ".more-scraped-examples .scraped-example:nth-child(6) .code-wrapper .src-line-numbers",
     {"clientWidth": |clientWidth|}
 )

--- a/src/test/rustdoc-gui/search-result-color.goml
+++ b/src/test/rustdoc-gui/search-result-color.goml
@@ -67,6 +67,11 @@ reload:
 // Waiting for the search results to appear...
 wait-for: "#titles"
 assert-css: (
+    "#titles > button > div.count",
+    {"color": "rgb(136, 136, 136)"},
+    ALL,
+)
+assert-css: (
     "//*[@class='desc'][text()='Just a normal struct.']",
     {"color": "rgb(197, 197, 197)"},
 )
@@ -179,6 +184,11 @@ reload:
 // Waiting for the search results to appear...
 wait-for: "#titles"
 assert-css: (
+    "#titles > button > div.count",
+    {"color": "rgb(136, 136, 136)"},
+    ALL,
+)
+assert-css: (
     "//*[@class='desc'][text()='Just a normal struct.']",
     {"color": "rgb(221, 221, 221)"},
 )
@@ -275,6 +285,11 @@ reload:
 
 // Waiting for the search results to appear...
 wait-for: "#titles"
+assert-css: (
+    "#titles > button > div.count",
+    {"color": "rgb(136, 136, 136)"},
+    ALL,
+)
 assert-css: (
     "//*[@class='desc'][text()='Just a normal struct.']",
     {"color": "rgb(0, 0, 0)"},

--- a/src/test/ui/const-generics/generic_const_exprs/issue-94293.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-94293.rs
@@ -1,0 +1,31 @@
+// check-pass
+
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+#![deny(const_evaluatable_unchecked)]
+
+pub struct If<const CONDITION: bool>;
+pub trait True {}
+impl True for If<true> {}
+
+pub struct FixedI8<const FRAC: u32> {
+    pub bits: i8,
+}
+
+impl<const FRAC_LHS: u32, const FRAC_RHS: u32> PartialEq<FixedI8<FRAC_RHS>> for FixedI8<FRAC_LHS>
+where
+    If<{ FRAC_RHS <= 8 }>: True,
+{
+    fn eq(&self, _rhs: &FixedI8<FRAC_RHS>) -> bool {
+        unimplemented!()
+    }
+}
+
+impl<const FRAC: u32> PartialEq<i8> for FixedI8<FRAC> {
+    fn eq(&self, rhs: &i8) -> bool {
+        let rhs_as_fixed = FixedI8::<0> { bits: *rhs };
+        PartialEq::eq(self, &rhs_as_fixed)
+    }
+}
+
+fn main() {}

--- a/src/test/ui/consts/issue-104396.rs
+++ b/src/test/ui/consts/issue-104396.rs
@@ -1,0 +1,36 @@
+// compile-flags: -Zmir-opt-level=3
+// check-pass
+
+#![feature(generic_const_exprs)]
+//~^ WARN the feature `generic_const_exprs` is incomplete
+
+#[inline(always)]
+fn from_fn_1<const N: usize, F: FnMut(usize) -> f32>(mut f: F) -> [f32; N] {
+    let mut result = [0.0; N];
+    let mut i = 0;
+    while i < N {
+        result[i] = f(i);
+        i += 1;
+    }
+    result
+}
+
+pub struct TestArray<const N: usize>
+where
+    [(); N / 2]:,
+{
+    array: [f32; N / 2],
+}
+
+impl<const N: usize> TestArray<N>
+where
+    [(); N / 2]:,
+{
+    fn from_fn_2<F: FnMut(usize) -> f32>(f: F) -> Self {
+        Self { array: from_fn_1(f) }
+    }
+}
+
+fn main() {
+    TestArray::<4>::from_fn_2(|i| 0.0);
+}

--- a/src/test/ui/consts/issue-104396.stderr
+++ b/src/test/ui/consts/issue-104396.stderr
@@ -1,0 +1,11 @@
+warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-104396.rs:4:12
+   |
+LL | #![feature(generic_const_exprs)]
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/src/test/ui/error-codes/E0462.rs
+++ b/src/test/ui/error-codes/E0462.rs
@@ -1,0 +1,7 @@
+// aux-build:found-staticlib.rs
+
+extern crate found_staticlib; //~ ERROR E0462
+
+fn main() {
+    found_staticlib::foo();
+}

--- a/src/test/ui/error-codes/E0462.stderr
+++ b/src/test/ui/error-codes/E0462.stderr
@@ -1,0 +1,13 @@
+error[E0462]: found staticlib `found_staticlib` instead of rlib or dylib
+  --> $DIR/E0462.rs:3:1
+   |
+LL | extern crate found_staticlib;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the following crate versions were found:
+           crate `found_staticlib`: $TEST_BUILD_DIR/error-codes/E0462/auxiliary/libfound_staticlib.a
+   = help: please recompile that crate using --crate-type lib
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0462`.

--- a/src/test/ui/error-codes/auxiliary/found-staticlib.rs
+++ b/src/test/ui/error-codes/auxiliary/found-staticlib.rs
@@ -1,0 +1,4 @@
+// no-prefer-dynamic
+#![crate_type = "staticlib"]
+
+pub fn foo() {}

--- a/src/test/ui/typeck/issue-106030.rs
+++ b/src/test/ui/typeck/issue-106030.rs
@@ -1,0 +1,5 @@
+fn main() {
+    unknown(1, |glyf| { //~ ERROR: cannot find function `unknown` in this scope
+        let actual = glyf;
+    });
+}

--- a/src/test/ui/typeck/issue-106030.stderr
+++ b/src/test/ui/typeck/issue-106030.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find function `unknown` in this scope
+  --> $DIR/issue-106030.rs:2:5
+   |
+LL |     unknown(1, |glyf| {
+   |     ^^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -11,8 +11,8 @@ use regex::Regex;
 
 // A few of those error codes can't be tested but all the others can and *should* be tested!
 const EXEMPTED_FROM_TEST: &[&str] = &[
-    "E0313", "E0461", "E0462", "E0465", "E0476", "E0490", "E0514", "E0519", "E0523", "E0554",
-    "E0640", "E0717", "E0729", "E0789",
+    "E0313", "E0461", "E0465", "E0476", "E0490", "E0514", "E0519", "E0523", "E0554", "E0640",
+    "E0717", "E0729", "E0789",
 ];
 
 // Some error codes don't have any tests apparently...


### PR DESCRIPTION
Successful merges:

 - #105567 (KCFI test: Also support LLVM 16 output)
 - #105847 (Ensure param-env is const before calling `eval_to_valtree`)
 - #105970 (docs/test: add UI test and long-form error docs for E0462)
 - #106027 (rustdoc: simplify CSS and DOM for more-scraped-examples)
 - #106035 (Migrate search tab title color to CSS variable)
 - #106037 (Add regression test for #94293)
 - #106039 (Return `TyKind::Error` instead of `span_bug!`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=105567,105847,105970,106027,106035,106037,106039)
<!-- homu-ignore:end -->