### PR TITLE
Run `tidy` in its own job in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,16 +41,24 @@ jobs:
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
       CACHE_DOMAIN: ci-caches.rust-lang.org
     if: "github.event_name == 'pull_request'"
+    continue-on-error: "${{ matrix.tidy }}"
     strategy:
       matrix:
         include:
           - name: mingw-check
+            tidy: false
+            os: ubuntu-20.04-xl
+            env: {}
+          - name: mingw-check-tidy
+            tidy: true
             os: ubuntu-20.04-xl
             env: {}
           - name: x86_64-gnu-llvm-13
+            tidy: false
             os: ubuntu-20.04-xl
             env: {}
           - name: x86_64-gnu-tools
+            tidy: false
             env:
               CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
             os: ubuntu-20.04-xl

--- a/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:18.04
+# FIXME: when bumping the version, remove the Python 3.6-specific changes in
+# the reuse-requirements.in file, regenerate reuse-requirements.txt and remove
+# this comment.
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  ninja-build \
+  file \
+  curl \
+  ca-certificates \
+  python3 \
+  python3-pip \
+  python3-pkg-resources \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  xz-utils \
+  libssl-dev \
+  pkg-config \
+  mingw-w64 \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+COPY host-x86_64/mingw-check/reuse-requirements.txt /tmp/
+RUN pip3 install --no-deps --no-cache-dir --require-hashes -r /tmp/reuse-requirements.txt
+
+COPY host-x86_64/mingw-check/validate-toolstate.sh /scripts/
+COPY host-x86_64/mingw-check/validate-error-codes.sh /scripts/
+
+ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
+ENV SCRIPT python3 ../x.py test --stage 0 src/tools/tidy

--- a/src/ci/docker/host-x86_64/mingw-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check/Dockerfile
@@ -40,7 +40,6 @@ COPY host-x86_64/mingw-check/validate-error-codes.sh /scripts/
 
 ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
 ENV SCRIPT python3 ../x.py --stage 2 test src/tools/expand-yaml-anchors && \
-           python3 ../x.py test --stage 0 src/tools/tidy && \
            python3 ../x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu --all-targets && \
            python3 ../x.py build --stage 0 src/tools/build-manifest && \
            python3 ../x.py test --stage 0 src/tools/compiletest && \

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -287,19 +287,27 @@ jobs:
     env:
       <<: [*shared-ci-variables, *public-variables]
     if: github.event_name == 'pull_request'
+    continue-on-error: ${{ matrix.tidy }}
     strategy:
       matrix:
         include:
           - name: mingw-check
             <<: *job-linux-xl
+            tidy: false
+
+          - name: mingw-check-tidy
+            <<: *job-linux-xl
+            tidy: true
 
           - name: x86_64-gnu-llvm-13
             <<: *job-linux-xl
+            tidy: false
 
           - name: x86_64-gnu-tools
+            <<: *job-linux-xl
+            tidy: false
             env:
               CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
-            <<: *job-linux-xl
 
   auto:
     permissions:


### PR DESCRIPTION
This duplicates mingw-check into two jobs where one job runs `tidy` only while the other job does not. The tidy job will not cancel other jobs on failure.