### PR TITLE
Make `sess.bug` much less noisy

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1199,10 +1199,13 @@ static DEFAULT_HOOK: LazyLock<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 
             };
 
             // Invoke the default handler, which prints the actual panic message and optionally a backtrace
-            (*DEFAULT_HOOK)(info);
+            // Don't do this for `ExplicitBug`, which has an unhelpful message and backtrace.
+            if !info.payload().is::<rustc_errors::ExplicitBug>() {
+                (*DEFAULT_HOOK)(info);
 
-            // Separate the output with an empty line
-            eprintln!();
+                // Separate the output with an empty line
+                eprintln!();
+            }
 
             // Print the ICE message
             report_ice(info, BUG_REPORT_URL);


### PR DESCRIPTION
cc https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/ice.20debugging/near/315929150

Before:

<details>

```
   Compiling core v0.0.0 (C:\Users\Joshua Nelson\src\rust2\library\core)
error: internal compiler error: no warnings or errors encountered even though `delayed_good_path_bugs` issued

error: internal compiler error: oops
  |
  = note: delayed at    0: std::backtrace_rs::backtrace::trace_unsynchronized
             1: std::backtrace::Backtrace::disabled
             2: std::backtrace::Backtrace::force_capture
             3: <rustc_errors::Handler>::delay_good_path_bug::<&str>
             4: <rustc_interface::passes::QueryContext>::enter::<rustc_driver::run_compiler::{closure#1}::{closure#2}::{closure#2}, core::result::Result<(), rustc_errors::ErrorGuaranteed>>
             5: RINvMs2_NtCsiwHPejSviHg_15rustc_interface7queriesNtNtB8_9interface8Compiler5enterNCNCNvCs7PhwInflpyf_12rustc_driver12run_compilers_0s0_0INtNtCslM5znELOk5i_4core6result6ResultINtNtB2f_6option6OptionNtB6_6LinkerENtCshthk7JDUYGg_12rustc_errors15ErrorGuarante
             6: RINvCs6uSsza6NDuD_10rustc_span15with_source_mapINtNtCslM5znELOk5i_4core6result6ResultuNtCshthk7JDUYGg_12rustc_errors15ErrorGuaranteedENCNCINvNtCsiwHPejSviHg_15rustc_interface9interface12run_compilerBJ_NCNvCs7PhwInflpyf_12rustc_driver12run_compilers_0E00EB
             7: RINvMs_Cs9yvsqs6YnUZ_10scoped_tlsINtB5_9ScopedKeyNtCs6uSsza6NDuD_10rustc_span14SessionGlobalsE3setNCINvNtCsiwHPejSviHg_15rustc_interface9interface12run_compilerINtNtCslM5znELOk5i_4core6result6ResultuNtCshthk7JDUYGg_12rustc_errors15ErrorGuaranteedENCNvCs7P
             8: RINvNtNtCs5xszGlR5JQw_3std10sys_common9backtrace28___rust_begin_short_backtraceNCNCINvNtCsiwHPejSviHg_15rustc_interface4util31run_in_thread_pool_with_globalsNCINvNtB1o_9interface12run_compilerINtNtCslM5znELOk5i_4core6result6ResultuNtCshthk7JDUYGg_12rustc_
             9: RINvNtCs5xszGlR5JQw_3std9panicking3tryINtNtCslM5znELOk5i_4core6result6ResultuNtCshthk7JDUYGg_12rustc_errors15ErrorGuaranteedEINtNtNtBF_5panic11unwind_safe16AssertUnwindSafeNCNCINvMNtB4_6threadNtB2S_7Builder16spawn_unchecked_NCNCINvNtCsiwHPejSviHg_15rustc_
            10: <std::thread::Builder>::spawn_scoped::<rustc_interface::util::run_in_thread_pool_with_globals<rustc_interface::interface::run_compiler<(), rustc_driver::run_compiler::{closure#0}>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
            11: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
            12: std::sys::windows::thread::Thread::new
            13: BaseThreadInitThunk
            14: RtlUserThreadStart

thread 'rustc' panicked at 'Box<dyn Any>', compiler\rustc_errors\src\lib.rs:1610:13
stack backtrace:
   0:     0x7fffbe935a15 - std::backtrace_rs::backtrace::trace_unsynchronized::h2a29ea0a35c1f799
   1:     0x7fffbe968811 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h5e4ca8af47bfbcc0
   2:     0x7fffbe98aeab - core::fmt::write::h152a9de2569e7dc7
   3:     0x7fffbe961059 - std::io::Write::write_fmt::h2452e19093defac4
   4:     0x7fffbe96866b - std::sys_common::backtrace::print::h550d034f7b77d60a
   5:     0x7fffbe93be1b - std::panicking::default_hook::h3969ead74039b801
   6:     0x7fffbe93bbad - std::panicking::default_hook::h3969ead74039b801
   7:     0x7fffa5f0abe3 - rustc_driver[5b2ae43fbecaf219]::handle_options
   8:     0x7fffbe93c25b - std::panicking::rust_panic_with_hook::h32bbe3ce24999160
   9:     0x7fffa82baee5 - std[4086331e48bff2f6]::sys_common::backtrace::__rust_end_short_backtrace::<std[4086331e48bff2f6]::panicking::begin_panic<&str>::{closure#0}, !>
  10:     0x7fffa82bae89 - std[4086331e48bff2f6]::sys_common::backtrace::__rust_end_short_backtrace::<std[4086331e48bff2f6]::panicking::begin_panic<rustc_errors[cb829533098ec0fe]::ExplicitBug>::{closure#0}, !>
  11:     0x7fffa867ed89 - std[4086331e48bff2f6]::panicking::begin_panic::<rustc_errors[cb829533098ec0fe]::ExplicitBug>
  12:     0x7fffa8298de9 - <alloc[284c8fe3a98c29c4]::string::String as core[fda266aeadfb153a]::fmt::Write>::write_fmt
  13:     0x7fffa829b7e2 - <rustc_errors[cb829533098ec0fe]::HandlerInner>::flush_delayed::<core[fda266aeadfb153a]::iter::adapters::map::Map<alloc[284c8fe3a98c29c4]::vec::into_iter::IntoIter<rustc_errors[cb829533098ec0fe]::DelayedDiagnostic>, <rustc_errors[cb829533098ec0fe]::DelayedDiagnostic>::decorate>, &str>
  14:     0x7fffa8288638 - <rustc_errors[cb829533098ec0fe]::HandlerInner as core[fda266aeadfb153a]::ops::drop::Drop>::drop
  15:     0x7fffa5eb90e1 - core[fda266aeadfb153a]::ptr::drop_in_place::<rustc_errors[cb829533098ec0fe]::Handler>
  16:     0x7fffa5ebe9fd - core[fda266aeadfb153a]::ptr::drop_in_place::<rustc_session[e703468b2407e34a]::cgu_reuse_tracker::CguReuseTracker>
  17:     0x7fffa5ec0d7c - core[fda266aeadfb153a]::ptr::drop_in_place::<rustc_session[e703468b2407e34a]::session::Session>
  18:     0x7fffa5ebe41c - core[fda266aeadfb153a]::ptr::drop_in_place::<rustc_interface[d7cd35f07e7e6ecc]::interface::Compiler>
  19:     0x7fffa5eea05f - RINvCs6uSsza6NDuD_10rustc_span15with_source_mapINtNtCslM5znELOk5i_4core6result6ResultuNtCshthk7JDUYGg_12rustc_errors15ErrorGuaranteedENCNCINvNtCsiwHPejSviHg_15rustc_interface9interface12run_compilerBJ_NCNvCs7PhwInflpyf_12rustc_driver12run_compilers_0E00EB
  20:     0x7fffa5edbe3a - RINvMs_Cs9yvsqs6YnUZ_10scoped_tlsINtB5_9ScopedKeyNtCs6uSsza6NDuD_10rustc_span14SessionGlobalsE3setNCINvNtCsiwHPejSviHg_15rustc_interface9interface12run_compilerINtNtCslM5znELOk5i_4core6result6ResultuNtCshthk7JDUYGg_12rustc_errors15ErrorGuaranteedENCNvCs7P
  21:     0x7fffa5ef4ec9 - RINvNtNtCs5xszGlR5JQw_3std10sys_common9backtrace28___rust_begin_short_backtraceNCNCINvNtCsiwHPejSviHg_15rustc_interface4util31run_in_thread_pool_with_globalsNCINvNtB1o_9interface12run_compilerINtNtCslM5znELOk5i_4core6result6ResultuNtCshthk7JDUYGg_12rustc_
  22:     0x7fffa5ee9935 - RINvNtCs5xszGlR5JQw_3std9panicking3tryINtNtCslM5znELOk5i_4core6result6ResultuNtCshthk7JDUYGg_12rustc_errors15ErrorGuaranteedEINtNtNtBF_5panic11unwind_safe16AssertUnwindSafeNCNCINvMNtB4_6threadNtB2S_7Builder16spawn_unchecked_NCNCINvNtCsiwHPejSviHg_15rustc_
  23:     0x7fffa5f0d770 - <std[4086331e48bff2f6]::thread::Builder>::spawn_scoped::<rustc_interface[d7cd35f07e7e6ecc]::util::run_in_thread_pool_with_globals<rustc_interface[d7cd35f07e7e6ecc]::interface::run_compiler<(), rustc_driver[5b2ae43fbecaf219]::run_compiler::{closure#0}>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
  24:     0x7fffbe95b35b - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hfcd927f7aebafa45
  25:     0x7fffbe9331d3 - std::sys::windows::thread::Thread::new::hf8f4c920eaebd965
  26:     0x7ff815877614 - BaseThreadInitThunk
  27:     0x7ff8166e26a1 - RtlUserThreadStart

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.68.0-dev running on x86_64-pc-windows-msvc

note: compiler flags: --crate-type lib -C opt-level=3 -C embed-bitcode=no -C debuginfo=0 -Z unstable-options -C incremental=[REDACTED] -C symbol-mangling-version=legacy -Z unstable-options -Z unstable-options -Z macro-backtrace -C split-debuginfo=packed -C target-feature=+crt-static -C prefer-dynamic -C embed-bitcode=yes -Z crate-attr=doc(html_root_url="https://doc.rust-lang.org/nightly/") -Z binary-dep-depinfo -Z force-unstable-if-unmarked

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
end of query stack
error: could not compile `core`
```

</details>

After:

<details>

```
   Compiling core v0.0.0 (C:\Users\Joshua Nelson\src\rust2\library\core)
error: internal compiler error: no warnings or errors encountered even though `delayed_good_path_bugs` issued

error: internal compiler error: oops
  |
  = note: delayed at    0: std::backtrace_rs::backtrace::trace_unsynchronized
             1: std::backtrace::Backtrace::disabled
             2: std::backtrace::Backtrace::force_capture
             3: <rustc_errors::Handler>::delay_good_path_bug::<&str>
             4: <rustc_interface::passes::QueryContext>::enter::<rustc_driver::run_compiler::{closure#1}::{closure#2}::{closure#2}, core::result::Result<(), rustc_errors::ErrorGuaranteed>>
             5: RINvMs2_NtCsiwHPejSviHg_15rustc_interface7queriesNtNtB8_9interface8Compiler5enterNCNCNvCs7PhwInflpyf_12rustc_driver12run_compilers_0s0_0INtNtCslM5znELOk5i_4core6result6ResultINtNtB2f_6option6OptionNtB6_6LinkerENtCshthk7JDUYGg_12rustc_errors15ErrorGuarante
             6: RINvCs6uSsza6NDuD_10rustc_span15with_source_mapINtNtCslM5znELOk5i_4core6result6ResultuNtCshthk7JDUYGg_12rustc_errors15ErrorGuaranteedENCNCINvNtCsiwHPejSviHg_15rustc_interface9interface12run_compilerBJ_NCNvCs7PhwInflpyf_12rustc_driver12run_compilers_0E00EB
             7: RINvMs_Cs9yvsqs6YnUZ_10scoped_tlsINtB5_9ScopedKeyNtCs6uSsza6NDuD_10rustc_span14SessionGlobalsE3setNCINvNtCsiwHPejSviHg_15rustc_interface9interface12run_compilerINtNtCslM5znELOk5i_4core6result6ResultuNtCshthk7JDUYGg_12rustc_errors15ErrorGuaranteedENCNvCs7P
             8: RINvNtNtCs5xszGlR5JQw_3std10sys_common9backtrace28___rust_begin_short_backtraceNCNCINvNtCsiwHPejSviHg_15rustc_interface4util31run_in_thread_pool_with_globalsNCINvNtB1o_9interface12run_compilerINtNtCslM5znELOk5i_4core6result6ResultuNtCshthk7JDUYGg_12rustc_
             9: RINvNtCs5xszGlR5JQw_3std9panicking3tryINtNtCslM5znELOk5i_4core6result6ResultuNtCshthk7JDUYGg_12rustc_errors15ErrorGuaranteedEINtNtNtBF_5panic11unwind_safe16AssertUnwindSafeNCNCINvMNtB4_6threadNtB2S_7Builder16spawn_unchecked_NCNCINvNtCsiwHPejSviHg_15rustc_
            10: <std::thread::Builder>::spawn_scoped::<rustc_interface::util::run_in_thread_pool_with_globals<rustc_interface::interface::run_compiler<(), rustc_driver::run_compiler::{closure#0}>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
            11: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
            12: std::sys::windows::thread::Thread::new
            13: BaseThreadInitThunk
            14: RtlUserThreadStart

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.68.0-dev running on x86_64-pc-windows-msvc

note: compiler flags: --crate-type lib -C opt-level=3 -C embed-bitcode=no -C debuginfo=0 -Z unstable-options -C incremental=[REDACTED] -C symbol-mangling-version=legacy -Z unstable-options -Z unstable-options -Z macro-backtrace -C split-debuginfo=packed -C target-feature=+crt-static -C prefer-dynamic -C embed-bitcode=yes -Z crate-attr=doc(html_root_url="https://doc.rust-lang.org/nightly/") -Z binary-dep-depinfo -Z force-unstable-if-unmarked

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
end of query stack
error: could not compile `core`
```

</details>