### PR TITLE
Remove proc-macro back-compat hack for rental

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1424,7 +1424,7 @@ fn pretty_printing_compatibility_hack(item: &Item, sess: &ParseSess) -> bool {
                 if variant.ident.name == sym::Input {
                     let filename = sess.source_map().span_to_filename(item.ident.span);
                     if let FileName::Real(real) = filename {
-                        if let real
+                        if real
                             .local_path()
                             .unwrap_or(Path::new(""))
                             .components()
@@ -1436,10 +1436,10 @@ fn pretty_printing_compatibility_hack(item: &Item, sess: &ParseSess) -> bool {
                                     &PROC_MACRO_BACK_COMPAT,
                                     item.ident.span,
                                     ast::CRATE_NODE_ID,
-                                    "using an old version of `rental`",
+                                    "using `allsorts-rental`",
                                     BuiltinLintDiagnostics::ProcMacroBackCompat(
-                                    "older versions of the `rental` crate will stop compiling in future versions of Rust; \
-                                    please update to `rental` v0.5.6, or switch to one of the `rental` alternatives".to_string()
+                                    "the `allsorts-rental` crate will stop compiling in future versions of Rust; \
+                                    please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`".to_string()
                                     )
                                 );
                             return true;

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1424,38 +1424,25 @@ fn pretty_printing_compatibility_hack(item: &Item, sess: &ParseSess) -> bool {
                 if variant.ident.name == sym::Input {
                     let filename = sess.source_map().span_to_filename(item.ident.span);
                     if let FileName::Real(real) = filename {
-                        if let Some(c) = real
+                        if let real
                             .local_path()
                             .unwrap_or(Path::new(""))
                             .components()
                             .flat_map(|c| c.as_os_str().to_str())
-                            .find(|c| c.starts_with("rental") || c.starts_with("allsorts-rental"))
+                            .find(|c| c.starts_with("allsorts-rental"))
+                            .is_some()
                         {
-                            let crate_matches = if c.starts_with("allsorts-rental") {
-                                true
-                            } else {
-                                let mut version = c.trim_start_matches("rental-").split('.');
-                                version.next() == Some("0")
-                                    && version.next() == Some("5")
-                                    && version
-                                        .next()
-                                        .and_then(|c| c.parse::<u32>().ok())
-                                        .map_or(false, |v| v < 6)
-                            };
-
-                            if crate_matches {
-                                sess.buffer_lint_with_diagnostic(
-                                        &PROC_MACRO_BACK_COMPAT,
-                                        item.ident.span,
-                                        ast::CRATE_NODE_ID,
-                                        "using an old version of `rental`",
-                                        BuiltinLintDiagnostics::ProcMacroBackCompat(
-                                        "older versions of the `rental` crate will stop compiling in future versions of Rust; \
-                                        please update to `rental` v0.5.6, or switch to one of the `rental` alternatives".to_string()
-                                        )
-                                    );
-                                return true;
-                            }
+                            sess.buffer_lint_with_diagnostic(
+                                    &PROC_MACRO_BACK_COMPAT,
+                                    item.ident.span,
+                                    ast::CRATE_NODE_ID,
+                                    "using an old version of `rental`",
+                                    BuiltinLintDiagnostics::ProcMacroBackCompat(
+                                    "older versions of the `rental` crate will stop compiling in future versions of Rust; \
+                                    please update to `rental` v0.5.6, or switch to one of the `rental` alternatives".to_string()
+                                    )
+                                );
+                            return true;
                         }
                     }
                 }

--- a/tests/ui/proc-macro/pretty-print-hack-show.local.stderr
+++ b/tests/ui/proc-macro/pretty-print-hack-show.local.stderr
@@ -1,4 +1,4 @@
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -6,10 +6,10 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
    = note: `#[deny(proc_macro_back_compat)]` on by default
 
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -17,9 +17,9 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
 
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -27,9 +27,9 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
 
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -37,12 +37,12 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
 
 error: aborting due to 4 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -50,11 +50,11 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
    = note: `#[deny(proc_macro_back_compat)]` on by default
 
 Future breakage diagnostic:
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -62,11 +62,11 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
    = note: `#[deny(proc_macro_back_compat)]` on by default
 
 Future breakage diagnostic:
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -74,11 +74,11 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
    = note: `#[deny(proc_macro_back_compat)]` on by default
 
 Future breakage diagnostic:
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -86,6 +86,6 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
    = note: `#[deny(proc_macro_back_compat)]` on by default
 

--- a/tests/ui/proc-macro/pretty-print-hack-show.local.stderr
+++ b/tests/ui/proc-macro/pretty-print-hack-show.local.stderr
@@ -39,47 +39,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
 
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-
-error: aborting due to 8 previous errors
+error: aborting due to 4 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
 error: using an old version of `rental`
@@ -120,54 +80,6 @@ LL | enum ProceduralMasqueradeDummyType {
 Future breakage diagnostic:
 error: using an old version of `rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-   = note: `#[deny(proc_macro_back_compat)]` on by default
-
-Future breakage diagnostic:
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-   = note: `#[deny(proc_macro_back_compat)]` on by default
-
-Future breakage diagnostic:
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-   = note: `#[deny(proc_macro_back_compat)]` on by default
-
-Future breakage diagnostic:
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-   = note: `#[deny(proc_macro_back_compat)]` on by default
-
-Future breakage diagnostic:
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/proc-macro/pretty-print-hack-show.local.stdout
+++ b/tests/ui/proc-macro/pretty-print-hack-show.local.stdout
@@ -20,8 +20,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:36: 14:2 (#0),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum ProceduralMasqueradeDummyType { Input, }
-PRINT-DERIVE RE-COLLECTED (DISPLAY): enum ProceduralMasqueradeDummyType { Input }
+PRINT-DERIVE INPUT (DISPLAY): enum ProceduralMasqueradeDummyType { Input }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",

--- a/tests/ui/proc-macro/pretty-print-hack-show.remapped.stderr
+++ b/tests/ui/proc-macro/pretty-print-hack-show.remapped.stderr
@@ -1,4 +1,4 @@
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -6,10 +6,10 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
    = note: `#[deny(proc_macro_back_compat)]` on by default
 
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -17,9 +17,9 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
 
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -27,9 +27,9 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
 
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -37,52 +37,12 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
 
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-
-error: aborting due to 8 previous errors
+error: aborting due to 4 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -90,11 +50,11 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
    = note: `#[deny(proc_macro_back_compat)]` on by default
 
 Future breakage diagnostic:
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -102,11 +62,11 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
    = note: `#[deny(proc_macro_back_compat)]` on by default
 
 Future breakage diagnostic:
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -114,11 +74,11 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
    = note: `#[deny(proc_macro_back_compat)]` on by default
 
 Future breakage diagnostic:
-error: using an old version of `rental`
+error: using `allsorts-rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
    |
 LL | enum ProceduralMasqueradeDummyType {
@@ -126,54 +86,6 @@ LL | enum ProceduralMasqueradeDummyType {
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-   = note: `#[deny(proc_macro_back_compat)]` on by default
-
-Future breakage diagnostic:
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-   = note: `#[deny(proc_macro_back_compat)]` on by default
-
-Future breakage diagnostic:
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-   = note: `#[deny(proc_macro_back_compat)]` on by default
-
-Future breakage diagnostic:
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
-   = note: `#[deny(proc_macro_back_compat)]` on by default
-
-Future breakage diagnostic:
-error: using an old version of `rental`
-  --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
-   |
-LL | enum ProceduralMasqueradeDummyType {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
-   = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: the `allsorts-rental` crate will stop compiling in future versions of Rust; please switch to `rental` v0.5.6, or switch to one of the `rental` alternatives like `ouroboros`
    = note: `#[deny(proc_macro_back_compat)]` on by default
 

--- a/tests/ui/proc-macro/pretty-print-hack-show.remapped.stdout
+++ b/tests/ui/proc-macro/pretty-print-hack-show.remapped.stdout
@@ -20,8 +20,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:36: 14:2 (#0),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum ProceduralMasqueradeDummyType { Input, }
-PRINT-DERIVE RE-COLLECTED (DISPLAY): enum ProceduralMasqueradeDummyType { Input }
+PRINT-DERIVE INPUT (DISPLAY): enum ProceduralMasqueradeDummyType { Input }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",


### PR DESCRIPTION
This leaves the hack in place for allsorts-rental - it still relies on this backc-ompat hack to compile, and some crates on crates.io are still using it.

We've been emitting future-incompat report warnings for rental for a while now, and fixing a broken build only requires bumping rental to the latest point release.

Background (in reverse chronological order):
 * the hack was restricted to the `rental` and `allsorts-rental` crates back in PR #94063
 * the `proc_macro_back_compat` was extended to any use of a `procedural-masquerade` crate in PR #83168
 * The `proc_macro_back_comat` lint was introduced in PR #83127 (rollup PR #83149)
