### PR TITLE
Enable Shadow Call Stack for Fuchsia on AArch64

### DIFF
--- a/compiler/rustc_target/src/spec/aarch64_unknown_fuchsia.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_fuchsia.rs
@@ -8,7 +8,9 @@ pub fn target() -> Target {
         arch: "aarch64".into(),
         options: TargetOptions {
             max_atomic_width: Some(128),
-            supported_sanitizers: SanitizerSet::ADDRESS | SanitizerSet::CFI,
+            supported_sanitizers: SanitizerSet::ADDRESS
+                | SanitizerSet::CFI
+                | SanitizerSet::SHADOWCALLSTACK,
             ..super::fuchsia_base::opts()
         },
     }


### PR DESCRIPTION
Fuchsia already uses SCS by default for C/C++ code on ARM hardware. This patch allows SCS to be used for Rust code as well.