### PR TITLE
[experiment] Get rid of `pending_obligations`

### DIFF
--- a/compiler/rustc_hir_typeck/src/fallback.rs
+++ b/compiler/rustc_hir_typeck/src/fallback.rs
@@ -281,7 +281,6 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
             roots_reachable_from_non_diverging,
         );
 
-        debug!("inherited: {:#?}", self.inh.fulfillment_cx.borrow().pending_obligations());
         debug!("obligations: {:#?}", self.fulfillment_cx.borrow().pending_obligations());
         debug!("relationships: {:#?}", relationships);
 

--- a/compiler/rustc_hir_typeck/src/fallback.rs
+++ b/compiler/rustc_hir_typeck/src/fallback.rs
@@ -12,7 +12,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
     pub(super) fn type_inference_fallback(&self) {
         debug!(
             "type-inference-fallback start obligations: {:#?}",
-            self.fulfillment_cx.borrow_mut().pending_obligations()
+            self.fulfillment_cx.borrow().pending_obligations()
         );
 
         // All type checking constraints were added, try to fallback unsolved variables.
@@ -20,7 +20,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
 
         debug!(
             "type-inference-fallback post selection obligations: {:#?}",
-            self.fulfillment_cx.borrow_mut().pending_obligations()
+            self.fulfillment_cx.borrow().pending_obligations()
         );
 
         // Check if we have any unsolved variables. If not, no need for fallback.
@@ -281,8 +281,8 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
             roots_reachable_from_non_diverging,
         );
 
-        debug!("inherited: {:#?}", self.inh.fulfillment_cx.borrow_mut().pending_obligations());
-        debug!("obligations: {:#?}", self.fulfillment_cx.borrow_mut().pending_obligations());
+        debug!("inherited: {:#?}", self.inh.fulfillment_cx.borrow().pending_obligations());
+        debug!("obligations: {:#?}", self.fulfillment_cx.borrow().pending_obligations());
         debug!("relationships: {:#?}", relationships);
 
         // For each diverging variable, figure out whether it can
@@ -348,7 +348,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
     /// Returns a graph whose nodes are (unresolved) inference variables and where
     /// an edge `?A -> ?B` indicates that the variable `?A` is coerced to `?B`.
     fn create_coercion_graph(&self) -> VecGraph<ty::TyVid> {
-        let pending_obligations = self.fulfillment_cx.borrow_mut().pending_obligations();
+        let pending_obligations = self.fulfillment_cx.borrow().pending_obligations();
         debug!("create_coercion_graph: pending_obligations={:?}", pending_obligations);
         let coercion_edges: Vec<(ty::TyVid, ty::TyVid)> = pending_obligations
             .into_iter()

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -611,10 +611,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // FIXME: consider using `sub_root_var` here so we
         // can see through subtyping.
         let ty_var_root = self.root_var(self_ty);
-        trace!("pending_obligations = {:#?}", self.fulfillment_cx.borrow().pending_obligations());
+        trace!("root_obligations = {:#?}", self.root_obligations.borrow());
 
-        self.fulfillment_cx.borrow().pending_obligations().into_iter().filter_map(
-            move |obligation| match &obligation.predicate.kind().skip_binder() {
+        self.root_obligations.borrow().clone().into_iter().filter_map(move |obligation| {
+            match &obligation.predicate.kind().skip_binder() {
                 ty::PredicateKind::Clause(ty::Clause::Projection(data))
                     if self.self_type_matches_expected_vid(
                         data.projection_ty.self_ty(),
@@ -650,8 +650,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 | ty::PredicateKind::ClosureKind(..)
                 | ty::PredicateKind::Ambiguous
                 | ty::PredicateKind::TypeWellFormedFromEnv(..) => None,
-            },
-        )
+            }
+        })
     }
 
     pub(in super::super) fn type_var_is_sized(&self, self_ty: ty::TyVid) -> bool {

--- a/compiler/rustc_infer/src/traits/engine.rs
+++ b/compiler/rustc_infer/src/traits/engine.rs
@@ -41,8 +41,6 @@ pub trait TraitEngine<'tcx>: 'tcx {
 
     fn select_where_possible(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>>;
 
-    fn pending_obligations(&self) -> Vec<PredicateObligation<'tcx>>;
-
     fn relationships(&mut self) -> &mut FxHashMap<ty::TyVid, ty::FoundRelationships>;
 }
 

--- a/compiler/rustc_trait_selection/src/traits/chalk_fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/chalk_fulfill.rs
@@ -151,10 +151,6 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentContext<'tcx> {
         errors
     }
 
-    fn pending_obligations(&self) -> Vec<PredicateObligation<'tcx>> {
-        self.obligations.iter().cloned().collect()
-    }
-
     fn relationships(&mut self) -> &mut FxHashMap<ty::TyVid, ty::FoundRelationships> {
         &mut self.relationships
     }

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -161,10 +161,6 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentContext<'tcx> {
         self.select(selcx)
     }
 
-    fn pending_obligations(&self) -> Vec<PredicateObligation<'tcx>> {
-        self.predicates.map_pending_obligations(|o| o.obligation.clone())
-    }
-
     fn relationships(&mut self) -> &mut FxHashMap<ty::TyVid, ty::FoundRelationships> {
         &mut self.relationships
     }

--- a/src/test/ui/higher-rank-trait-bounds/issue-30786.rs
+++ b/src/test/ui/higher-rank-trait-bounds/issue-30786.rs
@@ -116,7 +116,6 @@ fn variant1() {
     // guess.
     let map = source.mapx(|x: &_| x);
     let filter = map.filterx(|x: &_| true);
-    //~^ ERROR the method
 }
 
 fn variant2() {

--- a/src/test/ui/higher-rank-trait-bounds/issue-30786.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/issue-30786.stderr
@@ -1,26 +1,5 @@
-error[E0599]: the method `filterx` exists for struct `Map<Repeat, [closure@issue-30786.rs:117:27]>`, but its trait bounds were not satisfied
-  --> $DIR/issue-30786.rs:118:22
-   |
-LL | pub struct Map<S, F> {
-   | --------------------
-   | |
-   | method `filterx` not found for this struct
-   | doesn't satisfy `_: StreamExt`
-...
-LL |     let filter = map.filterx(|x: &_| true);
-   |                      ^^^^^^^ method cannot be called on `Map<Repeat, [closure@issue-30786.rs:117:27]>` due to unsatisfied trait bounds
-   |
-note: the following trait bounds were not satisfied:
-      `&'a mut &Map<Repeat, [closure@$DIR/issue-30786.rs:117:27: 117:34]>: Stream`
-      `&'a mut &mut Map<Repeat, [closure@$DIR/issue-30786.rs:117:27: 117:34]>: Stream`
-      `&'a mut Map<Repeat, [closure@$DIR/issue-30786.rs:117:27: 117:34]>: Stream`
-  --> $DIR/issue-30786.rs:96:50
-   |
-LL | impl<T> StreamExt for T where for<'a> &'a mut T: Stream {}
-   |         ---------     -                          ^^^^^^ unsatisfied trait bound introduced here
-
-error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, [closure@issue-30786.rs:129:30]>`, but its trait bounds were not satisfied
-  --> $DIR/issue-30786.rs:130:24
+error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, [closure@issue-30786.rs:128:30]>`, but its trait bounds were not satisfied
+  --> $DIR/issue-30786.rs:129:24
    |
 LL | pub struct Filter<S, F> {
    | -----------------------
@@ -32,14 +11,14 @@ LL |     let count = filter.countx();
    |                        ^^^^^^ method cannot be called due to unsatisfied trait bounds
    |
 note: the following trait bounds were not satisfied:
-      `&'a mut &Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>: Stream`
-      `&'a mut &mut Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>: Stream`
-      `&'a mut Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>: Stream`
+      `&'a mut &Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:128:30: 128:37]>: Stream`
+      `&'a mut &mut Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:128:30: 128:37]>: Stream`
+      `&'a mut Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:128:30: 128:37]>: Stream`
   --> $DIR/issue-30786.rs:96:50
    |
 LL | impl<T> StreamExt for T where for<'a> &'a mut T: Stream {}
    |         ---------     -                          ^^^^^^ unsatisfied trait bound introduced here
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/impl-trait/in-trait/default-body-with-rpit.rs
+++ b/src/test/ui/impl-trait/in-trait/default-body-with-rpit.rs
@@ -1,5 +1,8 @@
-// check-pass
 // edition:2021
+
+// known-bug: unknown
+// This is broken bc we don't normalize the obligations we get back from InferOk...
+// I'll have to think how best to do that later.
 
 #![feature(async_fn_in_trait, return_position_impl_trait_in_trait)]
 #![allow(incomplete_features)]

--- a/src/test/ui/impl-trait/in-trait/default-body-with-rpit.stderr
+++ b/src/test/ui/impl-trait/in-trait/default-body-with-rpit.stderr
@@ -1,0 +1,33 @@
+error: non-defining opaque type use in defining scope
+  --> $DIR/default-body-with-rpit.rs:13:39
+   |
+LL |       async fn baz(&self) -> impl Debug {
+   |  _______________________________________^
+LL | |         ""
+LL | |     }
+   | |_____^ lifetime `'_` is part of concrete type but not used in parameter list of the `impl Trait` type alias
+
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/default-body-with-rpit.rs:14:9
+   |
+LL |         ""
+   |         ^^ expected `impl Debug`, got `&'static str`
+   |
+note: previous use here
+  --> $DIR/default-body-with-rpit.rs:13:39
+   |
+LL |       async fn baz(&self) -> impl Debug {
+   |  _______________________________________^
+LL | |         ""
+LL | |     }
+   | |_____^
+
+error[E0720]: cannot resolve opaque type
+  --> $DIR/default-body-with-rpit.rs:13:28
+   |
+LL |     async fn baz(&self) -> impl Debug {
+   |                            ^^^^^^^^^^ cannot resolve opaque type
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0720`.

--- a/src/test/ui/impl-trait/issue-72911.rs
+++ b/src/test/ui/impl-trait/issue-72911.rs
@@ -5,7 +5,6 @@ pub struct Lint {}
 impl Lint {}
 
 pub fn gather_all() -> impl Iterator<Item = Lint> {
-    //~^ ERROR type annotations needed
     lint_files().flat_map(|f| gather_from_file(&f))
 }
 

--- a/src/test/ui/impl-trait/issue-72911.stderr
+++ b/src/test/ui/impl-trait/issue-72911.stderr
@@ -1,22 +1,15 @@
 error[E0433]: failed to resolve: use of undeclared crate or module `foo`
-  --> $DIR/issue-72911.rs:12:33
+  --> $DIR/issue-72911.rs:11:33
    |
 LL | fn gather_from_file(dir_entry: &foo::MissingItem) -> impl Iterator<Item = Lint> {
    |                                 ^^^ use of undeclared crate or module `foo`
 
 error[E0433]: failed to resolve: use of undeclared crate or module `foo`
-  --> $DIR/issue-72911.rs:17:41
+  --> $DIR/issue-72911.rs:16:41
    |
 LL | fn lint_files() -> impl Iterator<Item = foo::MissingItem> {
    |                                         ^^^ use of undeclared crate or module `foo`
 
-error[E0282]: type annotations needed
-  --> $DIR/issue-72911.rs:7:24
-   |
-LL | pub fn gather_all() -> impl Iterator<Item = Lint> {
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0282, E0433.
-For more information about an error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Currently has some issues:
- [ ] Autoderef still needs to do some fulfillment, to make sure that the autoderef chain doesn't stall on an inference variable
    - We may be able to move the fulfillment in `method_autoderef_steps` or somewhere else where this particularly matters...
- [ ] The `explicit_item_bounds` of an RPITIT need to be normalized before being registered
    - Probably all bounds could be normalized here, there are likely ways of making this break in RPIT too... 

r? @ghost