### PR TITLE
Provide more context on FileCheck failures

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2299,6 +2299,8 @@ impl<'test> TestCx<'test> {
         } else {
             filecheck.args(&["--check-prefixes", &prefixes]);
         }
+        // Provide more context on failures.
+        filecheck.args(&["--dump-input-context", "100"]);
         self.compose_and_run(filecheck, "", None, None)
     }
 


### PR DESCRIPTION
FileCheck provides 5 lines of context by default. This is often insufficient to analyze failures that happen in CI. Increase the amount of context to 100 lines.