### PR TITLE
Always inline `PredicateKind::try_fold_with`

### DIFF
--- a/compiler/rustc_macros/src/type_foldable.rs
+++ b/compiler/rustc_macros/src/type_foldable.rs
@@ -1,5 +1,5 @@
 use quote::quote;
-use syn::parse_quote;
+use syn::{parse_quote, Meta, NestedMeta};
 
 pub fn type_foldable_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
     if let syn::Data::Union(_) = s.ast().data {
@@ -22,9 +22,32 @@ pub fn type_foldable_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::
         })
     });
 
+    let is_inline_always = s.ast().attrs.iter().any(|attr| {
+        let Ok(Meta::List(list)) = attr.parse_meta() else { return false; };
+
+        if list.path.get_ident().map_or(true, |ident| ident.to_string() != "type_foldable") {
+            return false;
+        }
+
+        let is_inline_always = list.nested.iter().any(|nested| match nested {
+            NestedMeta::Meta(Meta::Path(path)) => {
+                path.get_ident().map_or(false, |ident| ident.to_string() == "inline_always")
+            }
+            _ => false,
+        });
+        is_inline_always
+    });
+
+    let inline_attr = if is_inline_always {
+        quote! { #[inline(always)] }
+    } else {
+        quote! {}
+    };
+
     s.bound_impl(
         quote!(::rustc_middle::ty::fold::TypeFoldable<'tcx>),
         quote! {
+            #inline_attr
             fn try_fold_with<__F: ::rustc_middle::ty::fold::FallibleTypeFolder<'tcx>>(
                 self,
                 __folder: &mut __F

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -589,6 +589,7 @@ pub enum Clause<'tcx> {
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 #[derive(HashStable, TypeFoldable, TypeVisitable, Lift)]
+#[type_foldable(inline_always)]
 pub enum PredicateKind<'tcx> {
     /// Prove a clause
     Clause(Clause<'tcx>),


### PR DESCRIPTION
rustc spends some time spilling the predicate kind onto the stack before calling the function, inlining it should reduce this.

Maybe the PGO build already exploits this inlining opportunity, let's see (even if it doesn't, this can still be useful for non-PGO builds).

r? @ghost