### PR TITLE
fix vec::IntoIter::drop on high-alignment ZST

### DIFF
--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -251,7 +251,7 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
                 return Err(unsafe { array::IntoIter::new_unchecked(raw_ary, 0..len) });
             }
 
-            self.ptr = self.ptr.wrapping_byte_add(N);
+            self.end = self.end.wrapping_byte_sub(N);
             // Safety: ditto
             return Ok(unsafe { raw_ary.transpose().assume_init() });
         }

--- a/src/tools/miri/README.md
+++ b/src/tools/miri/README.md
@@ -639,6 +639,7 @@ Definite bugs found:
 * [Data race in `thread::scope`](https://github.com/rust-lang/rust/issues/98498)
 * [`regex` incorrectly handling unaligned `Vec<u8>` buffers](https://www.reddit.com/r/rust/comments/vq3mmu/comment/ienc7t0?context=3)
 * [Incorrect use of `compare_exchange_weak` in `once_cell`](https://github.com/matklad/once_cell/issues/186)
+* [Dropping with unaligned pointers in `vec::IntoIter`](https://github.com/rust-lang/rust/pull/106084)
 
 Violations of [Stacked Borrows] found that are likely bugs (but Stacked Borrows is currently just an experiment):
 

--- a/src/tools/miri/tests/pass/vec.rs
+++ b/src/tools/miri/tests/pass/vec.rs
@@ -1,4 +1,6 @@
 //@compile-flags: -Zmiri-strict-provenance
+#![feature(iter_advance_by, iter_next_chunk)]
+
 // Gather all references from a mutable iterator and make sure Miri notices if
 // using them is dangerous.
 fn test_all_refs<'a, T: 'a>(dummy: &mut T, iter: impl Iterator<Item = &'a mut T>) {
@@ -44,6 +46,18 @@ fn vec_into_iter_zst() {
     for _ in vec![[0u64; 0]].into_iter() {}
     let v = vec![[0u64; 0], [0u64; 0]].into_iter().map(|x| x.len()).sum::<usize>();
     assert_eq!(v, 0);
+
+    let mut it = vec![[0u64; 0], [0u64; 0]].into_iter();
+    it.advance_by(1);
+    drop(it);
+
+    let mut it = vec![[0u64; 0], [0u64; 0]].into_iter();
+    it.next_chunk::<1>().unwrap();
+    drop(it);
+
+    let mut it = vec![[0u64; 0], [0u64; 0]].into_iter();
+    it.next_chunk::<4>().unwrap_err();
+    drop(it);
 }
 
 fn vec_into_iter_rev_zst() {

--- a/src/tools/miri/tests/pass/vec.rs
+++ b/src/tools/miri/tests/pass/vec.rs
@@ -37,15 +37,19 @@ fn vec_into_iter() -> u8 {
 }
 
 fn vec_into_iter_rev() -> u8 {
-    vec![1, 2, 3, 4].into_iter().map(|x| x * x).fold(0, |x, y| x + y)
+    vec![1, 2, 3, 4].into_iter().rev().map(|x| x * x).fold(0, |x, y| x + y)
 }
 
-fn vec_into_iter_zst() -> usize {
-    vec![[0u64; 0], [0u64; 0]].into_iter().rev().map(|x| x.len()).sum()
+fn vec_into_iter_zst() {
+    for _ in vec![[0u64; 0]].into_iter() {}
+    let v = vec![[0u64; 0], [0u64; 0]].into_iter().map(|x| x.len()).sum::<usize>();
+    assert_eq!(v, 0);
 }
 
-fn vec_into_iter_rev_zst() -> usize {
-    vec![[0u64; 0], [0u64; 0]].into_iter().rev().map(|x| x.len()).sum()
+fn vec_into_iter_rev_zst() {
+    for _ in vec![[0u64; 0]; 5].into_iter().rev() {}
+    let v = vec![[0u64; 0], [0u64; 0]].into_iter().rev().map(|x| x.len()).sum::<usize>();
+    assert_eq!(v, 0);
 }
 
 fn vec_iter_and_mut() {
@@ -150,8 +154,8 @@ fn main() {
     assert_eq!(vec_into_iter(), 30);
     assert_eq!(vec_into_iter_rev(), 30);
     vec_iter_and_mut();
-    assert_eq!(vec_into_iter_zst(), 0);
-    assert_eq!(vec_into_iter_rev_zst(), 0);
+    vec_into_iter_zst();
+    vec_into_iter_rev_zst();
     vec_iter_and_mut_rev();
 
     assert_eq!(make_vec().capacity(), 4);


### PR DESCRIPTION
This fixes a soundness bug: IntoIter would call `drop_in_place` on an insufficiently aligned pointer. So if a ZST with alignment greater 1 had drop glue, that would be called with an unaligned reference. Since https://github.com/rust-lang/rust/pull/103957, Miri checks alignment even if the type does not have drop glue, which is how this bug was found.

r? @thomcc 