### PR TITLE
rustdoc: remove no-op CSS from `.docblock-short`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -579,8 +579,6 @@ ul.block, .block li {
 .docblock-short {
 	overflow-wrap: break-word;
 	overflow-wrap: anywhere;
-	overflow: hidden;
-	text-overflow: ellipsis;
 }
 /* Wrap non-pre code blocks (`text`) but not (```text```). */
 .docblock :not(pre) > code,


### PR DESCRIPTION
The rules `overflow:hidden` and `text-overflow:ellipses` only have an effect if overflow occurs, which cannot happen because it will just line wrap instead.

These rules definitely became obsolete by https://github.com/rust-lang/rust/pull/77699, when the stylesheet was decidedly changed to have line wrapping in short docblocks, but given the bug it was fixing, this probably got broken earlier.