### PR TITLE
Suggest `Pin::as_mut` when encountering borrow error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,6 +3447,7 @@ dependencies = [
  "rustc_errors",
  "rustc_graphviz",
  "rustc_hir",
+ "rustc_hir_analysis",
  "rustc_index",
  "rustc_infer",
  "rustc_lexer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,6 @@ dependencies = [
  "rustc_errors",
  "rustc_graphviz",
  "rustc_hir",
- "rustc_hir_analysis",
  "rustc_index",
  "rustc_infer",
  "rustc_lexer",

--- a/compiler/rustc_borrowck/Cargo.toml
+++ b/compiler/rustc_borrowck/Cargo.toml
@@ -15,6 +15,7 @@ rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_graphviz = { path = "../rustc_graphviz" }
 rustc_hir = { path = "../rustc_hir" }
+rustc_hir_analysis = { path = "../rustc_hir_analysis" }
 rustc_index = { path = "../rustc_index" }
 rustc_infer = { path = "../rustc_infer" }
 rustc_lexer = { path = "../rustc_lexer" }

--- a/compiler/rustc_borrowck/Cargo.toml
+++ b/compiler/rustc_borrowck/Cargo.toml
@@ -15,7 +15,6 @@ rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_graphviz = { path = "../rustc_graphviz" }
 rustc_hir = { path = "../rustc_hir" }
-rustc_hir_analysis = { path = "../rustc_hir_analysis" }
 rustc_index = { path = "../rustc_index" }
 rustc_infer = { path = "../rustc_infer" }
 rustc_lexer = { path = "../rustc_lexer" }

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -1133,6 +1133,17 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                 place_name, partially_str, loop_message
                             ),
                         );
+                        if let ty::Adt(def, ..)
+                            = moved_place.ty(self.body, self.infcx.tcx).ty.kind()
+                            && Some(def.did()) == self.infcx.tcx.lang_items().pin_type()
+                        {
+                            err.span_suggestion_verbose(
+                                fn_call_span.shrink_to_lo(),
+                                "consider reborrowing the `Pin` instead of moving it",
+                                "as_mut().".to_string(),
+                                Applicability::MaybeIncorrect,
+                            );
+                        }
                     }
                     let tcx = self.infcx.tcx;
                     // Avoid pointing to the same function in multiple different

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -1135,16 +1135,14 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                             ),
                         );
                         let infcx = tcx.infer_ctxt().build();
-                        let ty = infcx.freshen(moved_place.ty(self.body, tcx).ty);
+                        let ty = tcx.erase_regions(moved_place.ty(self.body, tcx).ty);
                         if let ty::Adt(def, substs) = ty.kind()
                             && Some(def.did()) == tcx.lang_items().pin_type()
                             && let ty::Ref(_, _, hir::Mutability::Mut) = substs.type_at(0).kind()
-                            && let self_ty = infcx.freshen(
-                                infcx.replace_bound_vars_with_fresh_vars(
-                                    fn_call_span,
-                                    LateBoundRegionConversionTime::FnCall,
-                                    tcx.fn_sig(method_did).input(0),
-                                )
+                            && let self_ty = infcx.replace_bound_vars_with_fresh_vars(
+                                fn_call_span,
+                                LateBoundRegionConversionTime::FnCall,
+                                tcx.fn_sig(method_did).input(0),
                             )
                             && infcx.can_eq(self.param_env, ty, self_ty).is_ok()
                         {

--- a/src/test/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.stderr
@@ -9,6 +9,10 @@ LL |     let _x = Rc::new(vec![1, 2]).into_iter();
    |
 note: `into_iter` takes ownership of the receiver `self`, which moves value
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |     let _x = Rc::new(vec![1, 2]).clone().into_iter();
+   |                                  ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.fixed
+++ b/src/test/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.fixed
@@ -9,7 +9,7 @@ fn call<F>(f: F) where F : Fn() {
 fn main() {
     let y = vec![format!("World")];
     call(|| {
-        y.into_iter();
+        y.clone().into_iter();
         //~^ ERROR cannot move out of `y`, a captured variable in an `Fn` closure
     });
 }

--- a/src/test/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.stderr
+++ b/src/test/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of `y`, a captured variable in an `Fn` closure
-  --> $DIR/unboxed-closures-move-upvar-from-non-once-ref-closure.rs:11:9
+  --> $DIR/unboxed-closures-move-upvar-from-non-once-ref-closure.rs:12:9
    |
 LL |     let y = vec![format!("World")];
    |         - captured outer variable
@@ -12,6 +12,10 @@ LL |         y.into_iter();
    |
 note: `into_iter` takes ownership of the receiver `self`, which moves `y`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |         y.clone().into_iter();
+   |           ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/tab_3.stderr
+++ b/src/test/ui/codemap_tests/tab_3.stderr
@@ -12,10 +12,6 @@ LL |         println!("{:?}", some_vec);
 note: `into_iter` takes ownership of the receiver `self`, which moves `some_vec`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider cloning the value if the performance cost is acceptable
-   |
-LL |     some_vec.clone().into_iter();
-   |             ++++++++
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     some_vec.clone().into_iter();

--- a/src/test/ui/codemap_tests/tab_3.stderr
+++ b/src/test/ui/codemap_tests/tab_3.stderr
@@ -16,6 +16,10 @@ help: consider cloning the value if the performance cost is acceptable
    |
 LL |     some_vec.clone().into_iter();
    |             ++++++++
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |     some_vec.clone().into_iter();
+   |              ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/move-fn-self-receiver.stderr
+++ b/src/test/ui/moves/move-fn-self-receiver.stderr
@@ -97,10 +97,6 @@ note: `Foo::use_rc_self` takes ownership of the receiver `self`, which moves `rc
    |
 LL |     fn use_rc_self(self: Rc<Self>) {}
    |                    ^^^^
-help: consider cloning the value if the performance cost is acceptable
-   |
-LL |     rc_foo.clone().use_rc_self();
-   |           ++++++++
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     rc_foo.clone().use_rc_self();
@@ -144,10 +140,6 @@ LL |     for _val in explicit_into_iter.into_iter() {}
 LL |     explicit_into_iter;
    |     ^^^^^^^^^^^^^^^^^^ value used here after move
    |
-help: consider cloning the value if the performance cost is acceptable
-   |
-LL |     for _val in explicit_into_iter.clone().into_iter() {}
-   |                                   ++++++++
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     for _val in explicit_into_iter.clone().into_iter() {}

--- a/src/test/ui/moves/move-fn-self-receiver.stderr
+++ b/src/test/ui/moves/move-fn-self-receiver.stderr
@@ -9,6 +9,10 @@ LL |     val.0;
 note: `into_iter` takes ownership of the receiver `self`, which moves `val.0`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
    = note: move occurs because `val.0` has type `Vec<bool>`, which does not implement the `Copy` trait
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |     val.0.clone().into_iter().next();
+   |           ++++++++
 
 error[E0382]: use of moved value: `foo`
   --> $DIR/move-fn-self-receiver.rs:34:5
@@ -97,6 +101,10 @@ help: consider cloning the value if the performance cost is acceptable
    |
 LL |     rc_foo.clone().use_rc_self();
    |           ++++++++
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |     rc_foo.clone().use_rc_self();
+   |            ++++++++
 
 error[E0382]: use of moved value: `foo_add`
   --> $DIR/move-fn-self-receiver.rs:59:5
@@ -140,6 +148,10 @@ help: consider cloning the value if the performance cost is acceptable
    |
 LL |     for _val in explicit_into_iter.clone().into_iter() {}
    |                                   ++++++++
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |     for _val in explicit_into_iter.clone().into_iter() {}
+   |                                    ++++++++
 
 error[E0382]: use of moved value: `container`
   --> $DIR/move-fn-self-receiver.rs:71:5

--- a/src/test/ui/moves/move-fn-self-receiver.stderr
+++ b/src/test/ui/moves/move-fn-self-receiver.stderr
@@ -67,6 +67,10 @@ note: `Foo::use_pin_box_self` takes ownership of the receiver `self`, which move
    |
 LL |     fn use_pin_box_self(self: Pin<Box<Self>>) {}
    |                         ^^^^
+help: consider reborrowing the `Pin` instead of moving it
+   |
+LL |     pin_box_foo.as_mut().use_pin_box_self();
+   |                 +++++++++
 
 error[E0505]: cannot move out of `mut_foo` because it is borrowed
   --> $DIR/move-fn-self-receiver.rs:50:5

--- a/src/test/ui/moves/move-fn-self-receiver.stderr
+++ b/src/test/ui/moves/move-fn-self-receiver.stderr
@@ -67,10 +67,6 @@ note: `Foo::use_pin_box_self` takes ownership of the receiver `self`, which move
    |
 LL |     fn use_pin_box_self(self: Pin<Box<Self>>) {}
    |                         ^^^^
-help: consider reborrowing the `Pin` instead of moving it
-   |
-LL |     pin_box_foo.as_mut().use_pin_box_self();
-   |                 +++++++++
 
 error[E0505]: cannot move out of `mut_foo` because it is borrowed
   --> $DIR/move-fn-self-receiver.rs:50:5

--- a/src/test/ui/moves/moves-based-on-type-access-to-field.stderr
+++ b/src/test/ui/moves/moves-based-on-type-access-to-field.stderr
@@ -10,10 +10,6 @@ LL |     touch(&x[0]);
    |
 note: `into_iter` takes ownership of the receiver `self`, which moves `x`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
-help: consider cloning the value if the performance cost is acceptable
-   |
-LL |     consume(x.clone().into_iter().next().unwrap());
-   |              ++++++++
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     consume(x.clone().into_iter().next().unwrap());

--- a/src/test/ui/moves/moves-based-on-type-access-to-field.stderr
+++ b/src/test/ui/moves/moves-based-on-type-access-to-field.stderr
@@ -14,6 +14,10 @@ help: consider cloning the value if the performance cost is acceptable
    |
 LL |     consume(x.clone().into_iter().next().unwrap());
    |              ++++++++
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |     consume(x.clone().into_iter().next().unwrap());
+   |               ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/moves-based-on-type-exprs.stderr
+++ b/src/test/ui/moves/moves-based-on-type-exprs.stderr
@@ -162,10 +162,6 @@ LL |     touch(&x);
    |
 note: `into_iter` takes ownership of the receiver `self`, which moves `x`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
-help: consider cloning the value if the performance cost is acceptable
-   |
-LL |     let _y = x.clone().into_iter().next().unwrap();
-   |               ++++++++
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     let _y = x.clone().into_iter().next().unwrap();
@@ -183,10 +179,6 @@ LL |     touch(&x);
    |
 note: `into_iter` takes ownership of the receiver `self`, which moves `x`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
-help: consider cloning the value if the performance cost is acceptable
-   |
-LL |     let _y = [x.clone().into_iter().next().unwrap(); 1];
-   |                ++++++++
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     let _y = [x.clone().into_iter().next().unwrap(); 1];

--- a/src/test/ui/moves/moves-based-on-type-exprs.stderr
+++ b/src/test/ui/moves/moves-based-on-type-exprs.stderr
@@ -166,6 +166,10 @@ help: consider cloning the value if the performance cost is acceptable
    |
 LL |     let _y = x.clone().into_iter().next().unwrap();
    |               ++++++++
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |     let _y = x.clone().into_iter().next().unwrap();
+   |                ++++++++
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:83:11
@@ -183,6 +187,10 @@ help: consider cloning the value if the performance cost is acceptable
    |
 LL |     let _y = [x.clone().into_iter().next().unwrap(); 1];
    |                ++++++++
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |     let _y = [x.clone().into_iter().next().unwrap(); 1];
+   |                 ++++++++
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/moves/pin-mut-reborrow.fixed
+++ b/src/test/ui/moves/pin-mut-reborrow.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+use std::pin::Pin;
+
+struct Foo;
+
+impl Foo {
+    fn foo(self: Pin<&mut Self>) {}
+}
+
+fn main() {
+    let mut foo = Foo;
+    let mut foo = Pin::new(&mut foo);
+    foo.as_mut().foo();
+    foo.foo(); //~ ERROR use of moved value
+}

--- a/src/test/ui/moves/pin-mut-reborrow.rs
+++ b/src/test/ui/moves/pin-mut-reborrow.rs
@@ -1,0 +1,15 @@
+// run-rustfix
+use std::pin::Pin;
+
+struct Foo;
+
+impl Foo {
+    fn foo(self: Pin<&mut Self>) {}
+}
+
+fn main() {
+    let mut foo = Foo;
+    let mut foo = Pin::new(&mut foo);
+    foo.foo();
+    foo.foo(); //~ ERROR use of moved value
+}

--- a/src/test/ui/moves/pin-mut-reborrow.stderr
+++ b/src/test/ui/moves/pin-mut-reborrow.stderr
@@ -1,0 +1,23 @@
+error[E0382]: use of moved value: `foo`
+  --> $DIR/pin-mut-reborrow.rs:14:5
+   |
+LL |     let mut foo = Pin::new(&mut foo);
+   |         ------- move occurs because `foo` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
+LL |     foo.foo();
+   |         ----- `foo` moved due to this method call
+LL |     foo.foo();
+   |     ^^^ value used here after move
+   |
+note: `Foo::foo` takes ownership of the receiver `self`, which moves `foo`
+  --> $DIR/pin-mut-reborrow.rs:7:12
+   |
+LL |     fn foo(self: Pin<&mut Self>) {}
+   |            ^^^^
+help: consider reborrowing the `Pin` instead of moving it
+   |
+LL |     foo.as_mut().foo();
+   |         +++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/moves/suggest-clone.fixed
+++ b/src/test/ui/moves/suggest-clone.fixed
@@ -1,0 +1,11 @@
+// run-rustfix
+
+#[derive(Clone)]
+struct Foo;
+impl Foo {
+    fn foo(self) {}
+}
+fn main() {
+    let foo = &Foo;
+    foo.clone().foo(); //~ ERROR cannot move out
+}

--- a/src/test/ui/moves/suggest-clone.rs
+++ b/src/test/ui/moves/suggest-clone.rs
@@ -1,0 +1,11 @@
+// run-rustfix
+
+#[derive(Clone)]
+struct Foo;
+impl Foo {
+    fn foo(self) {}
+}
+fn main() {
+    let foo = &Foo;
+    foo.foo(); //~ ERROR cannot move out
+}

--- a/src/test/ui/moves/suggest-clone.stderr
+++ b/src/test/ui/moves/suggest-clone.stderr
@@ -1,0 +1,22 @@
+error[E0507]: cannot move out of `*foo` which is behind a shared reference
+  --> $DIR/suggest-clone.rs:10:5
+   |
+LL |     foo.foo();
+   |     ^^^^-----
+   |     |   |
+   |     |   `*foo` moved due to this method call
+   |     move occurs because `*foo` has type `Foo`, which does not implement the `Copy` trait
+   |
+note: `Foo::foo` takes ownership of the receiver `self`, which moves `*foo`
+  --> $DIR/suggest-clone.rs:6:12
+   |
+LL |     fn foo(self) {}
+   |            ^^^^
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |     foo.clone().foo();
+   |         ++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/suggestions/option-content-move.stderr
+++ b/src/test/ui/suggestions/option-content-move.stderr
@@ -9,6 +9,10 @@ LL |                 if selection.1.unwrap().contains(selection.0) {
    |
 note: `Option::<T>::unwrap` takes ownership of the receiver `self`, which moves `selection.1`
   --> $SRC_DIR/core/src/option.rs:LL:COL
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |                 if selection.1.clone().unwrap().contains(selection.0) {
+   |                                ++++++++
 
 error[E0507]: cannot move out of `selection.1` which is behind a shared reference
   --> $DIR/option-content-move.rs:27:20
@@ -21,6 +25,10 @@ LL |                 if selection.1.unwrap().contains(selection.0) {
    |
 note: `Result::<T, E>::unwrap` takes ownership of the receiver `self`, which moves `selection.1`
   --> $SRC_DIR/core/src/result.rs:LL:COL
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |                 if selection.1.clone().unwrap().contains(selection.0) {
+   |                                ++++++++
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fix #65409 for `Pin<&mut T>`.