### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ members](https://rust-lang.zulipchat.com/#narrow/stream/122652-new-members)
 Zulip stream. We have lots of docs below of how to get started on your own, but
 the Zulip stream is the best place to *ask* for help.
 
-Documentation for contributing to Rust is located in the [Guide to Rustc Development](https://rustc-dev-guide.rust-lang.org/),
-commonly known as the [rustc-dev-guide]. Despite the name, this guide documents
-not just how to develop rustc (the Rust compiler), but also how to contribute to the standard library and rustdoc.
+Documentation for contributing to the compiler or tooling is located in the [Guide to Rustc
+Development][rustc-dev-guide], commonly known as the [rustc-dev-guide]. Documentation for the
+standard library in the [Standard library developers Guide][std-dev-guide], commonly known as the [std-dev-guide].
 
 ## About the [rustc-dev-guide]
 
@@ -35,6 +35,7 @@ refer to [this section][contributing-bug-reports] and [open an issue][issue temp
 
 [Contributing to Rust]: https://rustc-dev-guide.rust-lang.org/contributing.html#contributing-to-rust
 [rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/
+[std-dev-guide]: https://std-dev-guide.rust-lang.org/
 [contributing-bug-reports]: https://rustc-dev-guide.rust-lang.org/contributing.html#bug-reports
 [issue template]: https://github.com/rust-lang/rust/issues/new/choose
 [internals]: https://internals.rust-lang.org

--- a/README.md
+++ b/README.md
@@ -44,20 +44,37 @@ by running it with the `--help` flag or reading the [rustc dev guide][rustcguide
 [gettingstarted]: https://rustc-dev-guide.rust-lang.org/getting-started.html
 [rustcguidebuild]: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html
 
-### Building on a Unix-like system
-1. Make sure you have installed the dependencies:
+### Dependencies
 
-   * `g++` 5.1 or later or `clang++` 3.5 or later
+Make sure you have installed the dependencies:
+
    * `python` 3 or 2.7
-   * GNU `make` 3.81 or later
-   * `cmake` 3.13.4 or later
-   * `ninja`
-   * `curl`
    * `git`
-   * `ssl` which comes in `libssl-dev` or `openssl-devel`
+   * A C compiler (when building for the host, `cc` is enough; cross-compiling may need additional compilers)
+   * `curl` (not needed on Windows)
    * `pkg-config` if you are compiling on Linux and targeting Linux
+   * `libiconv` (already included with glibc on Debian-based distros)
 
-2. Clone the [source] with `git`:
+To build cargo, you'll also need OpenSSL (`libssl-dev` or `openssl-devel` on most Unix distros).
+
+If building LLVM from source, you'll need additional tools:
+
+* `g++`, `clang++`, or MSVC with versions listed on
+  [LLVM's documentation](https://llvm.org/docs/GettingStarted.html#host-c-toolchain-both-compiler-and-standard-library)
+* `ninja`, or GNU `make` 3.81 or later (ninja is recommended, especially on Windows)
+* `cmake` 3.13.4 or later
+* `libstdc++-static` may be required on some Linux distributions such as Fedora and Ubuntu
+
+On tier 1 or tier 2 with host tools platforms, you can also choose to download LLVM by setting `llvm.download-ci-llvm = true`.
+Otherwise, you'll need LLVM installed and `llvm-config` in your path.
+See [the rustc-dev-guide for more info][sysllvm].
+
+[sysllvm]: https://rustc-dev-guide.rust-lang.org/building/new-target.html#using-pre-built-llvm
+
+
+### Building on a Unix-like system
+
+1. Clone the [source] with `git`:
 
    ```sh
    git clone https://github.com/rust-lang/rust.git
@@ -66,7 +83,7 @@ by running it with the `--help` flag or reading the [rustc dev guide][rustcguide
 
 [source]: https://github.com/rust-lang/rust
 
-3. Configure the build settings:
+2. Configure the build settings:
 
     The Rust build system uses a file named `config.toml` in the root of the
     source tree to determine various configuration settings for the build.
@@ -79,9 +96,7 @@ by running it with the `--help` flag or reading the [rustc dev guide][rustcguide
     If you plan to use `x.py install` to create an installation, it is recommended
     that you set the `prefix` value in the `[install]` section to a directory.
 
-    Create an install directory if you are not installing in the default directory.
-
-4. Build and install:
+3. Build and install:
 
     ```sh
     ./x.py build && ./x.py install
@@ -97,6 +112,20 @@ by running it with the `--help` flag or reading the [rustc dev guide][rustcguide
 [Cargo]: https://github.com/rust-lang/cargo
 
 ### Building on Windows
+
+On Windows, we suggest using [winget] to install dependencies by running the following in a terminal:
+
+```powershell
+winget install -e Python.Python.3
+winget install -e Kitware.CMake
+winget install -e Git.Git
+```
+
+Then edit your system's `PATH` variable and add: `C:\Program Files\CMake\bin`. See
+[this guide on editing the system `PATH`](https://www.java.com/en/download/help/path.html) from the
+Java documentation.
+
+[winget]: https://github.com/microsoft/winget-cli
 
 There are two prominent ABIs in use on Windows: the native (MSVC) ABI used by
 Visual Studio and the GNU ABI used by the GCC toolchain. Which version of Rust

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ See [the rustc-dev-guide for more info][sysllvm].
 
     The Rust build system uses a file named `config.toml` in the root of the
     source tree to determine various configuration settings for the build.
-    Copy the default `config.toml.example` to `config.toml` to get started.
+    Set up the defaults intended for distros to get started. You can see a full list of options
+    in `config.toml.example`.
 
     ```sh
-    cp config.toml.example config.toml
+    printf 'profile = "user" \nchangelog-seen = 2 \n' > config.toml
     ```
 
     If you plan to use `x.py install` to create an installation, it is recommended
@@ -104,10 +105,8 @@ See [the rustc-dev-guide for more info][sysllvm].
 
     When complete, `./x.py install` will place several programs into
     `$PREFIX/bin`: `rustc`, the Rust compiler, and `rustdoc`, the
-    API-documentation tool. This install does not include [Cargo],
-    Rust's package manager. To build and install Cargo, you may
-    run `./x.py install cargo` or set the `build.extended` key in
-    `config.toml` to `true` to build and install all tools.
+    API-documentation tool. If you've set `profile = "user"` or `build.extended = true`, it will
+    also include [Cargo], Rust's package manager.
 
 [Cargo]: https://github.com/rust-lang/cargo
 
@@ -215,7 +214,7 @@ Windows build triples are:
     - `x86_64-pc-windows-msvc`
 
 The build triple can be specified by either specifying `--build=<triple>` when
-invoking `x.py` commands, or by copying the `config.toml` file (as described
+invoking `x.py` commands, or by creating a `config.toml` file (as described
 in [Installing From Source](#installing-from-source)), and modifying the
 `build` option under the `[build]` section.
 

--- a/README.md
+++ b/README.md
@@ -228,9 +228,7 @@ configure script and makefile (the latter of which just invokes `x.py`).
 make && sudo make install
 ```
 
-When using the configure script, the generated `config.mk` file may override the
-`config.toml` file. To go back to the `config.toml` file, delete the generated
-`config.mk` file.
+`configure` generates a `config.toml` which can also be used with normal `x.py` invocations.
 
 ## Building Documentation
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@ standard library, and documentation.
 [Rust]: https://www.rust-lang.org
 
 **Note: this README is for _users_ rather than _contributors_.
-If you wish to _contribute_ to the compiler, you should read the
-[Getting Started][gettingstarted] section of the rustc-dev-guide instead.
-You can ask for help in the [#new members Zulip stream][new-members].**
-
-[new-members]: https://rust-lang.zulipchat.com/#narrow/stream/122652-new-members
+If you wish to _contribute_ to the compiler, you should read [CONTRIBUTING.md](CONTRIBUTING.md) instead.
 
 ## Quick Start
 
@@ -227,41 +223,20 @@ precompiled "snapshot" version of itself (made in an earlier stage of
 development). As such, source builds require an Internet connection to
 fetch snapshots, and an OS that can execute the available snapshot binaries.
 
-Snapshot binaries are currently built and tested on several platforms:
-
-| Platform / Architecture                     | x86 | x86_64 |
-|---------------------------------------------|-----|--------|
-| Windows (7, 8, 10, ...)                     | ✓   | ✓      |
-| Linux (kernel 3.2, glibc 2.17 or later)     | ✓   | ✓      |
-| macOS (10.7 Lion or later)                  | (\*) | ✓      |
-
-(\*): Apple dropped support for running 32-bit binaries starting from macOS 10.15 and iOS 11.
-Due to this decision from Apple, the targets are no longer useful to our users.
-Please read [our blog post][macx32] for more info.
-
-[macx32]: https://blog.rust-lang.org/2020/01/03/reducing-support-for-32-bit-apple-targets.html
+See https://doc.rust-lang.org/nightly/rustc/platform-support.html for a list of supported platforms.
+Only "host tools" platforms have a pre-compiled snapshot binary available; to compile for a platform
+without host tools you must cross-compile.
 
 You may find that other platforms work, but these are our officially
 supported build environments that are most likely to work.
 
 ## Getting Help
 
-The Rust community congregates in a few places:
-
-* [Stack Overflow] - Direct questions about using the language.
-* [users.rust-lang.org] - General discussion and broader questions.
-* [/r/rust] - News and general discussion.
-
-[Stack Overflow]: https://stackoverflow.com/questions/tagged/rust
-[/r/rust]: https://reddit.com/r/rust
-[users.rust-lang.org]: https://users.rust-lang.org/
+See https://www.rust-lang.org/community for a list of chat platforms and forums.
 
 ## Contributing
 
-If you are interested in contributing to the Rust project, please take a look
-at the [Getting Started][gettingstarted] guide in the [rustc-dev-guide].
-
-[rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -38,6 +38,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Use `||` to give these suggestions a precedence
         let _ = self.suggest_missing_parentheses(err, expr)
+            || self.suggest_remove_last_method_call(err, expr, expected)
             || self.suggest_associated_const(err, expr, expected)
             || self.suggest_deref_ref_or_into(err, expr, expected, expr_ty, expected_ty_expr)
             || self.suggest_option_to_bool(err, expr, expr_ty, expected)

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -329,6 +329,26 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
+    pub fn suggest_remove_last_method_call(
+        &self,
+        err: &mut Diagnostic,
+        expr: &hir::Expr<'tcx>,
+        expected: Ty<'tcx>,
+    ) -> bool {
+        if let hir::ExprKind::MethodCall(hir::PathSegment { ident: method, .. }, recv_expr, &[], _) = expr.kind &&
+            let Some(recv_ty) = self.typeck_results.borrow().expr_ty_opt(recv_expr) &&
+            self.can_coerce(recv_ty, expected) {
+                err.span_suggestion_verbose(
+                    expr.span.with_lo(method.span.lo() - rustc_span::BytePos(1)),
+                    "try removing the method call",
+                    "",
+                    Applicability::MachineApplicable,
+                );
+                return true;
+            }
+        false
+    }
+
     pub fn suggest_deref_ref_or_into(
         &self,
         err: &mut Diagnostic,

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -1754,11 +1754,11 @@ mod remove_dir_impl {
     use crate::sys::{cvt, cvt_r};
 
     #[cfg(not(any(
-        target_os = "linux",
+        all(target_os = "linux", target_env = "gnu"),
         all(target_os = "macos", not(target_arch = "aarch64"))
     )))]
     use libc::{fdopendir, openat, unlinkat};
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     use libc::{fdopendir, openat64 as openat, unlinkat};
     #[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
     use macos_weak::{fdopendir, openat, unlinkat};

--- a/library/std/src/sys/unix/kernel_copy.rs
+++ b/library/std/src/sys/unix/kernel_copy.rs
@@ -61,9 +61,9 @@ use crate::ptr;
 use crate::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use crate::sys::cvt;
 use crate::sys::weak::syscall;
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
 use libc::sendfile as sendfile64;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 use libc::sendfile64;
 use libc::{EBADF, EINVAL, ENOSYS, EOPNOTSUPP, EOVERFLOW, EPERM, EXDEV};
 

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -95,9 +95,9 @@ pub unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
         )))]
         'poll: {
             use crate::sys::os::errno;
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
             use libc::open as open64;
-            #[cfg(target_os = "linux")]
+            #[cfg(all(target_os = "linux", target_env = "gnu"))]
             use libc::open64;
             let pfds: &mut [_] = &mut [
                 libc::pollfd { fd: 0, events: 0, revents: 0 },
@@ -143,9 +143,9 @@ pub unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
         )))]
         {
             use crate::sys::os::errno;
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
             use libc::open as open64;
-            #[cfg(target_os = "linux")]
+            #[cfg(all(target_os = "linux", target_env = "gnu"))]
             use libc::open64;
             for fd in 0..3 {
                 if libc::fcntl(fd, libc::F_GETFD) == -1 && errno() == libc::EBADF {

--- a/library/std/src/sys/unix/stack_overflow.rs
+++ b/library/std/src/sys/unix/stack_overflow.rs
@@ -45,9 +45,9 @@ mod imp {
     use crate::thread;
 
     use libc::MAP_FAILED;
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
     use libc::{mmap as mmap64, munmap};
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     use libc::{mmap64, munmap};
     use libc::{sigaction, sighandler_t, SA_ONSTACK, SA_SIGINFO, SIGBUS, SIG_DFL};
     use libc::{sigaltstack, SIGSTKSZ, SS_DISABLE};

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -653,9 +653,9 @@ pub mod guard {
 ))]
 #[cfg_attr(test, allow(dead_code))]
 pub mod guard {
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
     use libc::{mmap as mmap64, mprotect};
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     use libc::{mmap64, mprotect};
     use libc::{MAP_ANON, MAP_FAILED, MAP_FIXED, MAP_PRIVATE, PROT_NONE, PROT_READ, PROT_WRITE};
 

--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -80,18 +80,12 @@ The script accepts commands, flags, and arguments to determine what to do:
 
 ## Configuring rustbuild
 
-There are currently two methods for configuring the rustbuild build system.
-
-First, rustbuild offers a TOML-based configuration system with a `config.toml`
+rustbuild offers a TOML-based configuration system with a `config.toml`
 file. An example of this configuration can be found at `config.toml.example`,
 and the configuration file can also be passed as `--config path/to/config.toml`
 if the build system is being invoked manually (via the python script).
 
-Next, the `./configure` options serialized in `config.mk` will be
-parsed and read. That is, if any `./configure` options are passed, they'll be
-handled naturally. `./configure` should almost never be used for local
-installations, and is primarily useful for CI. Prefer to customize behavior
-using `config.toml`.
+You can generate a config.toml using `./configure` options if you want to automate creating the file without having to edit it.
 
 Finally, rustbuild makes use of the [cc-rs crate] which has [its own
 method][env-vars] of configuring C compilers and C flags via environment

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -46,10 +46,7 @@ pub enum DryRun {
 
 /// Global configuration for the entire build and/or bootstrap.
 ///
-/// This structure is derived from a combination of both `config.toml` and
-/// `config.mk`. As of the time of this writing it's unlikely that `config.toml`
-/// is used all that much, so this is primarily filled out by `config.mk` which
-/// is generated from `./configure`.
+/// This structure is parsed from `config.toml`, and some of the fields are inferred from `git` or build-time parameters.
 ///
 /// Note that this structure is not decoded directly into, but rather it is
 /// filled out from the decoded forms of the structs below. For documentation

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -347,6 +347,9 @@ pre {
 .source .content pre {
 	padding: 20px;
 }
+.rustdoc.source .example-wrap > pre.src-line-numbers  {
+	padding: 20px 0 20px 4px;
+}
 
 img {
 	max-width: 100%;
@@ -519,10 +522,6 @@ ul.block, .block li {
 	display: none;
 }
 
-.source .content pre.rust {
-	padding-left: 0;
-}
-
 .rustdoc .example-wrap {
 	display: flex;
 	position: relative;
@@ -550,23 +549,21 @@ ul.block, .block li {
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
+	padding: 14px 8px;
+	color: var(--src-line-numbers-span-color);
 }
 
-.example-line-numbers {
-	border: 1px solid;
-	padding: 13px 8px;
-	border-top-left-radius: 5px;
-	border-bottom-left-radius: 5px;
-	border-color: var(--example-line-numbers-border-color);
+.rustdoc .example-wrap > pre.src-line-numbers {
+	padding: 14px 0;
 }
-
 .src-line-numbers a, .src-line-numbers span {
 	color: var(--src-line-numbers-span-color);
+	padding: 0 8px;
 }
 .src-line-numbers :target {
 	background-color: transparent;
 	border-right: none;
-	padding-right: 0;
+	padding: 0 8px;
 }
 .src-line-numbers .line-highlighted {
 	background-color: var(--src-line-number-highlighted-background-color);
@@ -1956,15 +1953,6 @@ in storage.js
 }
 .scraped-example:not(.expanded) .code-wrapper:after {
 	bottom: 0;
-}
-
-.scraped-example .code-wrapper .src-line-numbers {
-	padding: 14px 0;
-}
-
-.scraped-example .code-wrapper .src-line-numbers a,
-.scraped-example .code-wrapper .src-line-numbers span {
-	padding: 0 14px;
 }
 
 .scraped-example .code-wrapper .example-wrap {

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -62,7 +62,6 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--code-highlight-question-mark-color: #ff9011;
 	--code-highlight-comment-color: #788797;
 	--code-highlight-doc-comment-color: #a1ac88;
-	--example-line-numbers-border-color: none;
 	--src-line-numbers-span-color: #5c6773;
 	--src-line-number-highlighted-background-color: rgba(255, 236, 164, 0.06);
 	--test-arrow-color: #788797;
@@ -132,7 +131,7 @@ pre, .rustdoc.source .example-wrap {
 
 .src-line-numbers .line-highlighted {
 	color: #708090;
-	padding-right: 4px;
+	padding-right: 7px;
 	border-right: 1px solid #ffb44c;
 }
 

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -57,7 +57,6 @@
 	--code-highlight-question-mark-color: #ff9011;
 	--code-highlight-comment-color: #8d8d8b;
 	--code-highlight-doc-comment-color: #8ca375;
-	--example-line-numbers-border-color: #4a4949;
 	--src-line-numbers-span-color: #3b91e2;
 	--src-line-number-highlighted-background-color: #0a042f;
 	--test-arrow-color: #dedede;

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -57,7 +57,6 @@
 	--code-highlight-question-mark-color: #ff9011;
 	--code-highlight-comment-color: #8e908c;
 	--code-highlight-doc-comment-color: #4d4d4c;
-	--example-line-numbers-border-color: #c7c7c7;
 	--src-line-numbers-span-color: #c67e2d;
 	--src-line-number-highlighted-background-color: #fdffd3;
 	--test-arrow-color: #f5f5f5;

--- a/src/test/codegen/comparison-operators-newtype.rs
+++ b/src/test/codegen/comparison-operators-newtype.rs
@@ -1,0 +1,49 @@
+// The `derive(PartialOrd)` for a newtype doesn't override `lt`/`le`/`gt`/`ge`.
+// This double-checks that the `Option<Ordering>` intermediate values used
+// in the operators for such a type all optimize away.
+
+// compile-flags: -C opt-level=1
+// min-llvm-version: 15.0
+
+#![crate_type = "lib"]
+
+use std::cmp::Ordering;
+
+#[derive(PartialOrd, PartialEq)]
+pub struct Foo(u16);
+
+// CHECK-LABEL: @check_lt
+// CHECK-SAME: (i16 %[[A:.+]], i16 %[[B:.+]])
+#[no_mangle]
+pub fn check_lt(a: Foo, b: Foo) -> bool {
+    // CHECK: %[[R:.+]] = icmp ult i16 %[[A]], %[[B]]
+    // CHECK-NEXT: ret i1 %[[R]]
+    a < b
+}
+
+// CHECK-LABEL: @check_le
+// CHECK-SAME: (i16 %[[A:.+]], i16 %[[B:.+]])
+#[no_mangle]
+pub fn check_le(a: Foo, b: Foo) -> bool {
+    // CHECK: %[[R:.+]] = icmp ule i16 %[[A]], %[[B]]
+    // CHECK-NEXT: ret i1 %[[R]]
+    a <= b
+}
+
+// CHECK-LABEL: @check_gt
+// CHECK-SAME: (i16 %[[A:.+]], i16 %[[B:.+]])
+#[no_mangle]
+pub fn check_gt(a: Foo, b: Foo) -> bool {
+    // CHECK: %[[R:.+]] = icmp ugt i16 %[[A]], %[[B]]
+    // CHECK-NEXT: ret i1 %[[R]]
+    a > b
+}
+
+// CHECK-LABEL: @check_ge
+// CHECK-SAME: (i16 %[[A:.+]], i16 %[[B:.+]])
+#[no_mangle]
+pub fn check_ge(a: Foo, b: Foo) -> bool {
+    // CHECK: %[[R:.+]] = icmp uge i16 %[[A]], %[[B]]
+    // CHECK-NEXT: ret i1 %[[R]]
+    a >= b
+}

--- a/src/test/rustdoc-gui/docblock-code-block-line-number.goml
+++ b/src/test/rustdoc-gui/docblock-code-block-line-number.goml
@@ -1,23 +1,53 @@
 // Checks that the setting "line numbers" is working as expected.
 goto: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
 
+// Otherwise, we can't check text color
+show-text: true
+
 // We check that without this setting, there is no line number displayed.
 assert-false: "pre.example-line-numbers"
 
-// We now set the setting to show the line numbers on code examples.
-local-storage: {"rustdoc-line-numbers": "true" }
-// We reload to make the line numbers appear.
-reload:
-
-// We wait for them to be added into the DOM by the JS...
-wait-for: "pre.example-line-numbers"
-// If the test didn't fail, it means that it was found!
 // Let's now check some CSS properties...
-assert-css: ("pre.example-line-numbers", {
-    "margin": "0px",
-    "padding": "13px 8px",
-    "text-align": "right",
+define-function: (
+    "check-colors",
+    (theme, color),
+    [
+        // We now set the setting to show the line numbers on code examples.
+        ("local-storage", {
+            "rustdoc-theme": |theme|,
+            "rustdoc-use-system-theme": "false",
+            "rustdoc-line-numbers": "true"
+        }),
+        // We reload to make the line numbers appear and change theme.
+        ("reload"),
+        // We wait for them to be added into the DOM by the JS...
+        ("wait-for", "pre.example-line-numbers"),
+        // If the test didn't fail, it means that it was found!
+        ("assert-css", (
+            "pre.example-line-numbers",
+            {
+                "color": |color|,
+                "margin": "0px",
+                "padding": "14px 8px",
+                "text-align": "right",
+            },
+            ALL,
+        )),
+    ],
+)
+call-function: ("check-colors", {
+    "theme": "ayu",
+    "color": "rgb(92, 103, 115)",
 })
+call-function: ("check-colors", {
+    "theme": "dark",
+    "color": "rgb(59, 145, 226)",
+})
+call-function: ("check-colors", {
+    "theme": "light",
+    "color": "rgb(198, 126, 45)",
+})
+
 // The first code block has two lines so let's check its `<pre>` elements lists both of them.
 assert-text: ("pre.example-line-numbers", "1\n2")
 

--- a/src/test/rustdoc-gui/source-code-page.goml
+++ b/src/test/rustdoc-gui/source-code-page.goml
@@ -89,9 +89,9 @@ assert-css: (".src-line-numbers", {"text-align": "right"})
 // do anything (and certainly not add a `#NaN` to the URL!).
 goto: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
 // We use this assert-position to know where we will click.
-assert-position: ("//*[@id='1']", {"x": 104, "y": 112})
+assert-position: ("//*[@id='1']", {"x": 88, "y": 112})
 // We click on the left of the "1" anchor but still in the "src-line-number" `<pre>`.
-click: (103, 103)
+click: (87, 103)
 assert-document-property: ({"URL": "/lib.rs.html"}, ENDS_WITH)
 
 // Checking the source code sidebar.

--- a/src/test/ui/suggestions/issue-105494.rs
+++ b/src/test/ui/suggestions/issue-105494.rs
@@ -1,0 +1,22 @@
+fn test1() {
+    let _v: i32 = (1 as i32).to_string(); //~ ERROR mismatched types
+
+    // won't suggestion
+    let _v: i32 = (1 as i128).to_string(); //~ ERROR mismatched types
+
+    let _v: &str = "foo".to_string(); //~ ERROR mismatched types
+}
+
+fn test2() {
+    let mut path: String = "/usr".to_string();
+    let folder: String = "lib".to_string();
+
+    path = format!("{}/{}", path, folder).as_str(); //~ ERROR mismatched types
+
+    println!("{}", &path);
+}
+
+fn main() {
+    test1();
+    test2();
+}

--- a/src/test/ui/suggestions/issue-105494.stderr
+++ b/src/test/ui/suggestions/issue-105494.stderr
@@ -1,0 +1,54 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-105494.rs:2:19
+   |
+LL |     let _v: i32 = (1 as i32).to_string();
+   |             ---   ^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found struct `String`
+   |             |
+   |             expected due to this
+   |
+help: try removing the method call
+   |
+LL -     let _v: i32 = (1 as i32).to_string();
+LL +     let _v: i32 = (1 as i32);
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/issue-105494.rs:5:19
+   |
+LL |     let _v: i32 = (1 as i128).to_string();
+   |             ---   ^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found struct `String`
+   |             |
+   |             expected due to this
+
+error[E0308]: mismatched types
+  --> $DIR/issue-105494.rs:7:20
+   |
+LL |     let _v: &str = "foo".to_string();
+   |             ----   ^^^^^^^^^^^^^^^^^ expected `&str`, found struct `String`
+   |             |
+   |             expected due to this
+   |
+help: try removing the method call
+   |
+LL -     let _v: &str = "foo".to_string();
+LL +     let _v: &str = "foo";
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/issue-105494.rs:14:12
+   |
+LL |     let mut path: String = "/usr".to_string();
+   |                   ------ expected due to this type
+...
+LL |     path = format!("{}/{}", path, folder).as_str();
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `String`, found `&str`
+   |
+help: try removing the method call
+   |
+LL -     path = format!("{}/{}", path, folder).as_str();
+LL +     path = format!("{}/{}", path, folder);
+   |
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2299,6 +2299,8 @@ impl<'test> TestCx<'test> {
         } else {
             filecheck.args(&["--check-prefixes", &prefixes]);
         }
+        // Provide more context on failures.
+        filecheck.args(&["--dump-input-context", "100"]);
         self.compose_and_run(filecheck, "", None, None)
     }
 


### PR DESCRIPTION
Successful merges:

 - #105465 (Improve top-level docs)
 - #105872 (Suggest remove last method call when type coerce with expected  type)
 - #106032 (std: only use LFS function on glibc)
 - #106078 (Provide more context on FileCheck failures)
 - #106100 (Codegen test for derived `<` on trivial newtype [TEST ONLY])
 - #106109 (rustdoc: make line number CSS for doc comment and scraped the same)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=105465,105872,106032,106078,106100,106109)
<!-- homu-ignore:end -->