### PR TITLE
Mention "signature" rather than "fn pointer" when impl/trait methods are incompatible

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/infer.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/infer.ftl
@@ -253,8 +253,8 @@ infer_trait_placeholder_mismatch = implementation of `{$trait_def_id}` is not ge
 infer_trait_impl_diff = `impl` item signature doesn't match `trait` item signature
     .found = found `{$found}`
     .expected = expected `{$expected}`
-    .expected_found = expected `{$expected}`
-               {"   "}found `{$found}`
+    .expected_found = expected signature `{$expected}`
+               {"   "}found signature `{$found}`
 
 infer_tid_rel_help = verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
 infer_tid_consider_borrowing = consider borrowing this type parameter in the trait

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -270,8 +270,8 @@ fn compare_method_predicate_entailment<'tcx>(
     let unnormalized_impl_fty = tcx.mk_fn_ptr(ty::Binder::dummy(unnormalized_impl_sig));
 
     let norm_cause = ObligationCause::misc(impl_m_span, impl_m_hir_id);
-    let impl_fty = ocx.normalize(&norm_cause, param_env, unnormalized_impl_fty);
-    debug!("compare_impl_method: impl_fty={:?}", impl_fty);
+    let impl_sig = ocx.normalize(&norm_cause, param_env, unnormalized_impl_sig);
+    debug!("compare_impl_method: impl_fty={:?}", impl_sig);
 
     let trait_sig = tcx.bound_fn_sig(trait_m.def_id).subst(tcx, trait_to_placeholder_substs);
     let trait_sig = tcx.liberate_late_bound_regions(impl_m.def_id, trait_sig);
@@ -294,18 +294,17 @@ fn compare_method_predicate_entailment<'tcx>(
     // type would be more appropriate. In other places we have a `Vec<Span>`
     // corresponding to their `Vec<Predicate>`, but we don't have that here.
     // Fixing this would improve the output of test `issue-83765.rs`.
-    let result = ocx.sup(&cause, param_env, trait_fty, impl_fty);
+    let result = ocx.sup(&cause, param_env, trait_sig, impl_sig);
 
     if let Err(terr) = result {
-        debug!(?terr, "sub_types failed: impl ty {:?}, trait ty {:?}", impl_fty, trait_fty);
+        debug!(?impl_sig, ?trait_sig, ?terr, "sub_types failed");
 
         let emitted = report_trait_method_mismatch(
             &infcx,
             cause,
             terr,
-            (trait_m, trait_fty),
-            (impl_m, impl_fty),
-            trait_sig,
+            (trait_m, trait_sig),
+            (impl_m, impl_sig),
             impl_trait_ref,
         );
         return Err(emitted);
@@ -484,7 +483,8 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
     let impl_trait_ref = tcx.impl_trait_ref(impl_m.impl_container(tcx).unwrap()).unwrap();
     let param_env = tcx.param_env(def_id);
 
-    // First, check a few of the same thing as `compare_impl_method`, just so we don't ICE during substitutions later.
+    // First, check a few of the same things as `compare_impl_method`,
+    // just so we don't ICE during substitution later.
     compare_number_of_generics(tcx, impl_m, trait_m, tcx.hir().span_if_local(impl_m.def_id), true)?;
     compare_generic_param_kinds(tcx, impl_m, trait_m, true)?;
     check_region_bounds_on_impl_item(tcx, impl_m, trait_m, true)?;
@@ -577,14 +577,11 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
 
     debug!(?trait_sig, ?impl_sig, "equating function signatures");
 
-    let trait_fty = tcx.mk_fn_ptr(ty::Binder::dummy(trait_sig));
-    let impl_fty = tcx.mk_fn_ptr(ty::Binder::dummy(impl_sig));
-
     // Unify the whole function signature. We need to do this to fully infer
     // the lifetimes of the return type, but do this after unifying just the
     // return types, since we want to avoid duplicating errors from
     // `compare_method_predicate_entailment`.
-    match ocx.eq(&cause, param_env, trait_fty, impl_fty) {
+    match ocx.eq(&cause, param_env, trait_sig, impl_sig) {
         Ok(()) => {}
         Err(terr) => {
             // This function gets called during `compare_method_predicate_entailment` when normalizing a
@@ -595,9 +592,8 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
                 infcx,
                 cause,
                 terr,
-                (trait_m, trait_fty),
-                (impl_m, impl_fty),
-                trait_sig,
+                (trait_m, trait_sig),
+                (impl_m, impl_sig),
                 impl_trait_ref,
             );
             return Err(emitted);
@@ -771,9 +767,8 @@ fn report_trait_method_mismatch<'tcx>(
     infcx: &InferCtxt<'tcx>,
     mut cause: ObligationCause<'tcx>,
     terr: TypeError<'tcx>,
-    (trait_m, trait_fty): (&ty::AssocItem, Ty<'tcx>),
-    (impl_m, impl_fty): (&ty::AssocItem, Ty<'tcx>),
-    trait_sig: ty::FnSig<'tcx>,
+    (trait_m, trait_sig): (&ty::AssocItem, ty::FnSig<'tcx>),
+    (impl_m, impl_sig): (&ty::AssocItem, ty::FnSig<'tcx>),
     impl_trait_ref: ty::TraitRef<'tcx>,
 ) -> ErrorGuaranteed {
     let tcx = infcx.tcx;
@@ -858,10 +853,7 @@ fn report_trait_method_mismatch<'tcx>(
         &mut diag,
         &cause,
         trait_err_span.map(|sp| (sp, "type in trait".to_owned())),
-        Some(infer::ValuePairs::Terms(ExpectedFound {
-            expected: trait_fty.into(),
-            found: impl_fty.into(),
-        })),
+        Some(infer::ValuePairs::Sigs(ExpectedFound { expected: trait_sig, found: impl_sig })),
         terr,
         false,
         false,

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -427,3 +427,15 @@ impl<'tcx> ToTrace<'tcx> for ty::AliasTy<'tcx> {
         }
     }
 }
+
+impl<'tcx> ToTrace<'tcx> for ty::FnSig<'tcx> {
+    fn to_trace(
+        _: TyCtxt<'tcx>,
+        cause: &ObligationCause<'tcx>,
+        a_is_expected: bool,
+        a: Self,
+        b: Self,
+    ) -> TypeTrace<'tcx> {
+        TypeTrace { cause: cause.clone(), values: Sigs(ExpectedFound::new(a_is_expected, a, b)) }
+    }
+}

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1429,8 +1429,8 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         impl<'tcx> OpaqueTypesVisitor<'tcx> {
             fn visit_expected_found(
                 tcx: TyCtxt<'tcx>,
-                expected: Ty<'tcx>,
-                found: Ty<'tcx>,
+                expected: impl TypeVisitable<'tcx>,
+                found: impl TypeVisitable<'tcx>,
                 ignore_span: Span,
             ) -> Self {
                 let mut types_visitor = OpaqueTypesVisitor {
@@ -1569,6 +1569,11 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             }
                             _ => (false, Mismatch::Fixed("type")),
                         }
+                    }
+                    ValuePairs::Sigs(infer::ExpectedFound { expected, found }) => {
+                        OpaqueTypesVisitor::visit_expected_found(self.tcx, expected, found, span)
+                            .report(diag);
+                        (false, Mismatch::Fixed("signature"))
                     }
                     ValuePairs::TraitRefs(_) | ValuePairs::PolyTraitRefs(_) => {
                         (false, Mismatch::Fixed("trait"))
@@ -2040,6 +2045,17 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     }
                     ret => ret,
                 }
+            }
+            infer::Sigs(exp_found) => {
+                let exp_found = self.resolve_vars_if_possible(exp_found);
+                if exp_found.references_error() {
+                    return None;
+                }
+                let (exp, fnd) = self.cmp_fn_sig(
+                    &ty::Binder::dummy(exp_found.expected),
+                    &ty::Binder::dummy(exp_found.found),
+                );
+                Some((exp, fnd, None, None))
             }
         }
     }

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -361,6 +361,7 @@ pub enum ValuePairs<'tcx> {
     Terms(ExpectedFound<ty::Term<'tcx>>),
     TraitRefs(ExpectedFound<ty::TraitRef<'tcx>>),
     PolyTraitRefs(ExpectedFound<ty::PolyTraitRef<'tcx>>),
+    Sigs(ExpectedFound<ty::FnSig<'tcx>>),
 }
 
 impl<'tcx> ValuePairs<'tcx> {

--- a/src/test/ui/associated-types/defaults-specialization.stderr
+++ b/src/test/ui/associated-types/defaults-specialization.stderr
@@ -22,8 +22,8 @@ note: type in trait
    |
 LL |     fn make() -> Self::Ty {
    |                  ^^^^^^^^
-   = note: expected fn pointer `fn() -> <A<T> as Tr>::Ty`
-              found fn pointer `fn() -> u8`
+   = note: expected signature `fn() -> <A<T> as Tr>::Ty`
+              found signature `fn() -> u8`
 
 error[E0053]: method `make` has an incompatible type for trait
   --> $DIR/defaults-specialization.rs:35:18
@@ -42,8 +42,8 @@ note: type in trait
    |
 LL |     fn make() -> Self::Ty {
    |                  ^^^^^^^^
-   = note: expected fn pointer `fn() -> <B<T> as Tr>::Ty`
-              found fn pointer `fn() -> bool`
+   = note: expected signature `fn() -> <B<T> as Tr>::Ty`
+              found signature `fn() -> bool`
 
 error[E0308]: mismatched types
   --> $DIR/defaults-specialization.rs:10:9

--- a/src/test/ui/async-await/in-trait/async-example-desugared-boxed-in-trait.stderr
+++ b/src/test/ui/async-await/in-trait/async-example-desugared-boxed-in-trait.stderr
@@ -9,8 +9,8 @@ note: type in trait
    |
 LL |     fn foo(&self) -> Pin<Box<dyn Future<Output = i32> + '_>>;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected fn pointer `fn(&i32) -> Pin<Box<dyn Future<Output = i32>>>`
-              found fn pointer `fn(&i32) -> impl Future<Output = i32>`
+   = note: expected signature `fn(&i32) -> Pin<Box<dyn Future<Output = i32>>>`
+              found signature `fn(&i32) -> impl Future<Output = i32>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
+++ b/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
@@ -22,8 +22,8 @@ error[E0308]: method not compatible with trait
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected fn pointer `fn(&'a isize, Inv<'c>, Inv<'c>, Inv<'_>)`
-              found fn pointer `fn(&'a isize, Inv<'_>, Inv<'c>, Inv<'_>)`
+   = note: expected signature `fn(&'a isize, Inv<'c>, Inv<'c>, Inv<'_>)`
+              found signature `fn(&'a isize, Inv<'_>, Inv<'c>, Inv<'_>)`
 note: the lifetime `'c` as defined here...
   --> $DIR/regions-bound-missing-bound-in-impl.rs:27:24
    |
@@ -41,8 +41,8 @@ error[E0308]: method not compatible with trait
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected fn pointer `fn(&'a isize, Inv<'c>, Inv<'c>, Inv<'_>)`
-              found fn pointer `fn(&'a isize, Inv<'_>, Inv<'c>, Inv<'_>)`
+   = note: expected signature `fn(&'a isize, Inv<'c>, Inv<'c>, Inv<'_>)`
+              found signature `fn(&'a isize, Inv<'_>, Inv<'c>, Inv<'_>)`
 note: the lifetime `'c` as defined here...
   --> $DIR/regions-bound-missing-bound-in-impl.rs:27:24
    |

--- a/src/test/ui/compare-method/bad-self-type.stderr
+++ b/src/test/ui/compare-method/bad-self-type.stderr
@@ -7,8 +7,8 @@ LL |     fn poll(self, _: &mut Context<'_>) -> Poll<()> {
    |             expected struct `Pin`, found struct `MyFuture`
    |             help: change the self-receiver type to match the trait: `self: Pin<&mut MyFuture>`
    |
-   = note: expected fn pointer `fn(Pin<&mut MyFuture>, &mut Context<'_>) -> Poll<_>`
-              found fn pointer `fn(MyFuture, &mut Context<'_>) -> Poll<_>`
+   = note: expected signature `fn(Pin<&mut MyFuture>, &mut Context<'_>) -> Poll<_>`
+              found signature `fn(MyFuture, &mut Context<'_>) -> Poll<_>`
 
 error[E0053]: method `foo` has an incompatible type for trait
   --> $DIR/bad-self-type.rs:22:18
@@ -24,8 +24,8 @@ note: type in trait
    |
 LL |     fn foo(self);
    |            ^^^^
-   = note: expected fn pointer `fn(MyFuture)`
-              found fn pointer `fn(Box<MyFuture>)`
+   = note: expected signature `fn(MyFuture)`
+              found signature `fn(Box<MyFuture>)`
 
 error[E0053]: method `bar` has an incompatible type for trait
   --> $DIR/bad-self-type.rs:24:18
@@ -38,8 +38,8 @@ note: type in trait
    |
 LL |     fn bar(self) -> Option<()>;
    |                     ^^^^^^^^^^
-   = note: expected fn pointer `fn(MyFuture) -> Option<()>`
-              found fn pointer `fn(MyFuture)`
+   = note: expected signature `fn(MyFuture) -> Option<()>`
+              found signature `fn(MyFuture)`
 help: change the output type to match the trait
    |
 LL |     fn bar(self) -> Option<()> {}

--- a/src/test/ui/compare-method/issue-90444.stderr
+++ b/src/test/ui/compare-method/issue-90444.stderr
@@ -7,8 +7,8 @@ LL |     fn from(_: fn((), (), &mut ())) -> Self {
    |                types differ in mutability
    |                help: change the parameter type to match the trait: `for<'a> fn((), (), &'a ())`
    |
-   = note: expected fn pointer `fn(for<'a> fn((), (), &'a ())) -> A`
-              found fn pointer `fn(for<'a> fn((), (), &'a mut ())) -> A`
+   = note: expected signature `fn(for<'a> fn((), (), &'a ())) -> A`
+              found signature `fn(for<'a> fn((), (), &'a mut ())) -> A`
 
 error[E0053]: method `from` has an incompatible type for trait
   --> $DIR/issue-90444.rs:11:16
@@ -19,8 +19,8 @@ LL |     fn from(_: fn((), (), u64)) -> Self {
    |                expected `u32`, found `u64`
    |                help: change the parameter type to match the trait: `fn((), (), u32)`
    |
-   = note: expected fn pointer `fn(fn((), (), u32)) -> B`
-              found fn pointer `fn(fn((), (), u64)) -> B`
+   = note: expected signature `fn(fn((), (), u32)) -> B`
+              found signature `fn(fn((), (), u64)) -> B`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/compare-method/reordered-type-param.stderr
+++ b/src/test/ui/compare-method/reordered-type-param.stderr
@@ -14,8 +14,8 @@ note: type in trait
    |
 LL |   fn b<C:Clone,D>(&self, x: C) -> C;
    |                             ^
-   = note: expected fn pointer `fn(&E, F) -> F`
-              found fn pointer `fn(&E, G) -> G`
+   = note: expected signature `fn(&E, F) -> F`
+              found signature `fn(&E, G) -> G`
    = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
    = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
 

--- a/src/test/ui/impl-trait/impl-generic-mismatch-ab.stderr
+++ b/src/test/ui/impl-trait/impl-generic-mismatch-ab.stderr
@@ -13,8 +13,8 @@ note: type in trait
    |
 LL |     fn foo<A: Debug>(&self, a: &A, b: &impl Debug);
    |                                ^^
-   = note: expected fn pointer `fn(&(), &B, &impl Debug)`
-              found fn pointer `fn(&(), &impl Debug, &B)`
+   = note: expected signature `fn(&(), &B, &impl Debug)`
+              found signature `fn(&(), &impl Debug, &B)`
    = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
    = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
 

--- a/src/test/ui/impl-trait/in-trait/method-signature-matches.stderr
+++ b/src/test/ui/impl-trait/in-trait/method-signature-matches.stderr
@@ -12,8 +12,8 @@ note: type in trait
    |
 LL |     fn owo(x: ()) -> impl Sized;
    |               ^^
-   = note: expected fn pointer `fn(())`
-              found fn pointer `fn(u8)`
+   = note: expected signature `fn(())`
+              found signature `fn(u8)`
 
 error[E0053]: method `owo` has an incompatible type for trait
   --> $DIR/method-signature-matches.rs:20:21
@@ -39,8 +39,8 @@ note: type in trait
    |
 LL |     async fn owo(x: ()) {}
    |                     ^^
-   = note: expected fn pointer `fn(()) -> _`
-              found fn pointer `fn(u8) -> _`
+   = note: expected signature `fn(()) -> _`
+              found signature `fn(u8) -> _`
 
 error[E0050]: method `calm_down_please` has 3 parameters but the declaration in trait `TooMuch::calm_down_please` has 0
   --> $DIR/method-signature-matches.rs:29:28
@@ -75,8 +75,8 @@ note: type in trait
    |
 LL |     fn early<'early, T>(x: &'early T) -> impl Sized;
    |                            ^^^^^^^^^
-   = note: expected fn pointer `fn(&'early T)`
-              found fn pointer `fn(&())`
+   = note: expected signature `fn(&'early T)`
+              found signature `fn(&())`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/impl-trait/in-trait/signature-mismatch.stderr
+++ b/src/test/ui/impl-trait/in-trait/signature-mismatch.stderr
@@ -7,8 +7,8 @@ LL |     fn async_fn(&self, buff: &[u8]) -> impl Future<Output = Vec<u8>>;
 LL |     fn async_fn<'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + '2`
    |
-   = note: expected `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + 'static`
-              found `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + '2`
+   = note: expected signature `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + 'static`
+              found signature `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + '2`
    = help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
    = help: verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
 

--- a/src/test/ui/impl-trait/in-trait/specialization-broken.stderr
+++ b/src/test/ui/impl-trait/in-trait/specialization-broken.stderr
@@ -15,8 +15,8 @@ note: type in trait
    |
 LL |     fn bar(&self) -> impl Sized;
    |                      ^^^^^^^^^^
-   = note: expected fn pointer `fn(&U) -> impl Sized`
-              found fn pointer `fn(&U) -> U`
+   = note: expected signature `fn(&U) -> impl Sized`
+              found signature `fn(&U) -> U`
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
+++ b/src/test/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
@@ -18,8 +18,8 @@ LL |         fn eq(&self, _other: &(Foo, i32)) -> bool {
    |                              expected struct `Bar`, found opaque type
    |                              help: change the parameter type to match the trait: `&(a::Bar, i32)`
    |
-   = note: expected fn pointer `fn(&a::Bar, &(a::Bar, i32)) -> _`
-              found fn pointer `fn(&a::Bar, &(a::Foo, i32)) -> _`
+   = note: expected signature `fn(&a::Bar, &(a::Bar, i32)) -> _`
+              found signature `fn(&a::Bar, &(a::Foo, i32)) -> _`
 
 error: unconstrained opaque type
   --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:18:16
@@ -41,8 +41,8 @@ LL |         fn eq(&self, _other: &(Bar, i32)) -> bool {
    |                              expected opaque type, found struct `Bar`
    |                              help: change the parameter type to match the trait: `&(b::Foo, i32)`
    |
-   = note: expected fn pointer `fn(&b::Bar, &(b::Foo, i32)) -> _`
-              found fn pointer `fn(&b::Bar, &(b::Bar, i32)) -> _`
+   = note: expected signature `fn(&b::Bar, &(b::Foo, i32)) -> _`
+              found signature `fn(&b::Bar, &(b::Bar, i32)) -> _`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/impl-trait/trait_type.stderr
+++ b/src/test/ui/impl-trait/trait_type.stderr
@@ -7,8 +7,8 @@ LL |    fn fmt(&self, x: &str) -> () { }
    |                     types differ in mutability
    |                     help: change the parameter type to match the trait: `&mut Formatter<'_>`
    |
-   = note: expected fn pointer `fn(&MyType, &mut Formatter<'_>) -> Result<(), std::fmt::Error>`
-              found fn pointer `fn(&MyType, &str)`
+   = note: expected signature `fn(&MyType, &mut Formatter<'_>) -> Result<(), std::fmt::Error>`
+              found signature `fn(&MyType, &str)`
 
 error[E0050]: method `fmt` has 1 parameter but the declaration in trait `std::fmt::Display::fmt` has 2
   --> $DIR/trait_type.rs:12:11

--- a/src/test/ui/issues/issue-13033.rs
+++ b/src/test/ui/issues/issue-13033.rs
@@ -7,8 +7,8 @@ struct Baz;
 impl Foo for Baz {
     fn bar(&mut self, other: &dyn Foo) {}
     //~^ ERROR method `bar` has an incompatible type for trait
-    //~| expected fn pointer `fn(&mut Baz, &mut dyn Foo)`
-    //~| found fn pointer `fn(&mut Baz, &dyn Foo)`
+    //~| expected signature `fn(&mut Baz, &mut dyn Foo)`
+    //~| found signature `fn(&mut Baz, &dyn Foo)`
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-13033.stderr
+++ b/src/test/ui/issues/issue-13033.stderr
@@ -12,8 +12,8 @@ note: type in trait
    |
 LL |     fn bar(&mut self, other: &mut dyn Foo);
    |                              ^^^^^^^^^^^^
-   = note: expected fn pointer `fn(&mut Baz, &mut dyn Foo)`
-              found fn pointer `fn(&mut Baz, &dyn Foo)`
+   = note: expected signature `fn(&mut Baz, &mut dyn Foo)`
+              found signature `fn(&mut Baz, &dyn Foo)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-15094.rs
+++ b/src/test/ui/issues/issue-15094.rs
@@ -10,8 +10,8 @@ impl<T: fmt::Debug> ops::FnOnce<(),> for Debuger<T> {
     type Output = ();
     fn call_once(self, _args: ()) {
     //~^ ERROR `call_once` has an incompatible type for trait
-    //~| expected fn pointer `extern "rust-call" fn
-    //~| found fn pointer `fn
+    //~| expected signature `extern "rust-call" fn
+    //~| found signature `fn
         println!("{:?}", self.x);
     }
 }

--- a/src/test/ui/issues/issue-15094.stderr
+++ b/src/test/ui/issues/issue-15094.stderr
@@ -4,8 +4,8 @@ error[E0053]: method `call_once` has an incompatible type for trait
 LL |     fn call_once(self, _args: ()) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "rust-call" fn, found "Rust" fn
    |
-   = note: expected fn pointer `extern "rust-call" fn(Debuger<_>, ())`
-              found fn pointer `fn(Debuger<_>, ())`
+   = note: expected signature `extern "rust-call" fn(Debuger<_>, ())`
+              found signature `fn(Debuger<_>, ())`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20225.stderr
+++ b/src/test/ui/issues/issue-20225.stderr
@@ -9,8 +9,8 @@ LL |   extern "rust-call" fn call(&self, (_,): (T,)) {}
    |                                           expected `&T`, found type parameter `T`
    |                                           help: change the parameter type to match the trait: `(&'a T,)`
    |
-   = note: expected fn pointer `extern "rust-call" fn(&Foo, (&'a T,))`
-              found fn pointer `extern "rust-call" fn(&Foo, (T,))`
+   = note: expected signature `extern "rust-call" fn(&Foo, (&'a T,))`
+              found signature `extern "rust-call" fn(&Foo, (T,))`
 
 error[E0053]: method `call_mut` has an incompatible type for trait
   --> $DIR/issue-20225.rs:11:51
@@ -23,8 +23,8 @@ LL |   extern "rust-call" fn call_mut(&mut self, (_,): (T,)) {}
    |                                                   expected `&T`, found type parameter `T`
    |                                                   help: change the parameter type to match the trait: `(&'a T,)`
    |
-   = note: expected fn pointer `extern "rust-call" fn(&mut Foo, (&'a T,))`
-              found fn pointer `extern "rust-call" fn(&mut Foo, (T,))`
+   = note: expected signature `extern "rust-call" fn(&mut Foo, (&'a T,))`
+              found signature `extern "rust-call" fn(&mut Foo, (T,))`
 
 error[E0053]: method `call_once` has an incompatible type for trait
   --> $DIR/issue-20225.rs:18:47
@@ -38,8 +38,8 @@ LL |   extern "rust-call" fn call_once(self, (_,): (T,)) {}
    |                                               expected `&T`, found type parameter `T`
    |                                               help: change the parameter type to match the trait: `(&'a T,)`
    |
-   = note: expected fn pointer `extern "rust-call" fn(Foo, (&'a T,))`
-              found fn pointer `extern "rust-call" fn(Foo, (T,))`
+   = note: expected signature `extern "rust-call" fn(Foo, (&'a T,))`
+              found signature `extern "rust-call" fn(Foo, (T,))`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-21332.stderr
+++ b/src/test/ui/issues/issue-21332.stderr
@@ -7,8 +7,8 @@ LL |     fn next(&mut self) -> Result<i32, i32> { Ok(7) }
    |                           expected enum `Option`, found enum `Result`
    |                           help: change the output type to match the trait: `Option<i32>`
    |
-   = note: expected fn pointer `fn(&mut S) -> Option<i32>`
-              found fn pointer `fn(&mut S) -> Result<i32, i32>`
+   = note: expected signature `fn(&mut S) -> Option<i32>`
+              found signature `fn(&mut S) -> Result<i32, i32>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-37884.stderr
+++ b/src/test/ui/issues/issue-37884.stderr
@@ -4,8 +4,8 @@ error[E0308]: method not compatible with trait
 LL |     fn next(&'a mut self) -> Option<Self::Item>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected fn pointer `fn(&mut RepeatMut<'a, T>) -> Option<_>`
-              found fn pointer `fn(&'a mut RepeatMut<'a, T>) -> Option<_>`
+   = note: expected signature `fn(&mut RepeatMut<'a, T>) -> Option<_>`
+              found signature `fn(&'a mut RepeatMut<'a, T>) -> Option<_>`
 note: the anonymous lifetime as defined here...
   --> $DIR/issue-37884.rs:6:5
    |

--- a/src/test/ui/lifetimes/lifetime-mismatch-between-trait-and-impl.stderr
+++ b/src/test/ui/lifetimes/lifetime-mismatch-between-trait-and-impl.stderr
@@ -7,8 +7,8 @@ LL |     fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32;
 LL |     fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(&'1 i32, &'1 i32) -> &'1 i32`
    |
-   = note: expected `fn(&'1 i32, &'a i32) -> &'a i32`
-              found `fn(&'1 i32, &'1 i32) -> &'1 i32`
+   = note: expected signature `fn(&'1 i32, &'a i32) -> &'a i32`
+              found signature `fn(&'1 i32, &'1 i32) -> &'1 i32`
    = help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
    = help: verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
 

--- a/src/test/ui/mismatched_types/E0053.stderr
+++ b/src/test/ui/mismatched_types/E0053.stderr
@@ -12,8 +12,8 @@ note: type in trait
    |
 LL |     fn foo(x: u16);
    |               ^^^
-   = note: expected fn pointer `fn(u16)`
-              found fn pointer `fn(i16)`
+   = note: expected signature `fn(u16)`
+              found signature `fn(i16)`
 
 error[E0053]: method `bar` has an incompatible type for trait
   --> $DIR/E0053.rs:11:12
@@ -29,8 +29,8 @@ note: type in trait
    |
 LL |     fn bar(&self);
    |            ^^^^^
-   = note: expected fn pointer `fn(&Bar)`
-              found fn pointer `fn(&mut Bar)`
+   = note: expected signature `fn(&Bar)`
+              found signature `fn(&mut Bar)`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/issue-74918-missing-lifetime.stderr
+++ b/src/test/ui/mismatched_types/issue-74918-missing-lifetime.stderr
@@ -18,8 +18,8 @@ LL |     fn next(&mut self) -> Option<IteratorChunk<T, S>> {
    |
    = note: expected `fn(&'1 mut ChunkingIterator<T, S>) -> Option<IteratorChunk<'static, T, S>>`
    |
-   = note: expected `fn(&'1 mut ChunkingIterator<T, S>) -> Option<IteratorChunk<'static, T, S>>`
-              found `fn(&'1 mut ChunkingIterator<T, S>) -> Option<IteratorChunk<'1, T, S>>`
+   = note: expected signature `fn(&'1 mut ChunkingIterator<T, S>) -> Option<IteratorChunk<'static, T, S>>`
+              found signature `fn(&'1 mut ChunkingIterator<T, S>) -> Option<IteratorChunk<'1, T, S>>`
    = help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
    = help: verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
 

--- a/src/test/ui/mismatched_types/issue-75361-mismatched-impl.stderr
+++ b/src/test/ui/mismatched_types/issue-75361-mismatched-impl.stderr
@@ -7,8 +7,8 @@ LL |   fn adjacent_edges(&self) -> Box<dyn MyTrait<Item = &Self::EdgeType>>;
 LL |   fn adjacent_edges(&self) -> Box<dyn MyTrait<Item = &Self::EdgeType> + '_> {
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(&'1 T) -> Box<(dyn MyTrait<Item = &'1 T> + '1)>`
    |
-   = note: expected `fn(&'1 T) -> Box<(dyn MyTrait<Item = &'1 T> + 'static)>`
-              found `fn(&'1 T) -> Box<(dyn MyTrait<Item = &'1 T> + '1)>`
+   = note: expected signature `fn(&'1 T) -> Box<(dyn MyTrait<Item = &'1 T> + 'static)>`
+              found signature `fn(&'1 T) -> Box<(dyn MyTrait<Item = &'1 T> + '1)>`
 help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
   --> $DIR/issue-75361-mismatched-impl.rs:12:55
    |

--- a/src/test/ui/mismatched_types/trait-impl-fn-incompatibility.stderr
+++ b/src/test/ui/mismatched_types/trait-impl-fn-incompatibility.stderr
@@ -12,8 +12,8 @@ note: type in trait
    |
 LL |     fn foo(x: u16);
    |               ^^^
-   = note: expected fn pointer `fn(u16)`
-              found fn pointer `fn(i16)`
+   = note: expected signature `fn(u16)`
+              found signature `fn(i16)`
 
 error[E0053]: method `bar` has an incompatible type for trait
   --> $DIR/trait-impl-fn-incompatibility.rs:10:28
@@ -29,8 +29,8 @@ note: type in trait
    |
 LL |     fn bar(&mut self, bar: &mut Bar);
    |                            ^^^^^^^^
-   = note: expected fn pointer `fn(&mut Bar, &mut Bar)`
-              found fn pointer `fn(&mut Bar, &Bar)`
+   = note: expected signature `fn(&mut Bar, &mut Bar)`
+              found signature `fn(&mut Bar, &Bar)`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/impl-method-mismatch.rs
+++ b/src/test/ui/traits/impl-method-mismatch.rs
@@ -6,8 +6,8 @@ impl Mumbo for usize {
     // Cannot have a larger effect than the trait:
     unsafe fn jumbo(&self, x: &usize) { *self + *x; }
     //~^ ERROR method `jumbo` has an incompatible type for trait
-    //~| expected fn pointer `fn
-    //~| found fn pointer `unsafe fn
+    //~| expected signature `fn
+    //~| found signature `unsafe fn
 }
 
 fn main() {}

--- a/src/test/ui/traits/impl-method-mismatch.stderr
+++ b/src/test/ui/traits/impl-method-mismatch.stderr
@@ -9,8 +9,8 @@ note: type in trait
    |
 LL |     fn jumbo(&self, x: &usize) -> usize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected fn pointer `fn(&usize, &usize) -> usize`
-              found fn pointer `unsafe fn(&usize, &usize)`
+   = note: expected signature `fn(&usize, &usize) -> usize`
+              found signature `unsafe fn(&usize, &usize)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/issue-35869.stderr
+++ b/src/test/ui/traits/issue-35869.stderr
@@ -12,8 +12,8 @@ note: type in trait
    |
 LL |     fn foo(_: fn(u8) -> ());
    |               ^^^^^^^^^^^^
-   = note: expected fn pointer `fn(fn(u8))`
-              found fn pointer `fn(fn(u16))`
+   = note: expected signature `fn(fn(u8))`
+              found signature `fn(fn(u16))`
 
 error[E0053]: method `bar` has an incompatible type for trait
   --> $DIR/issue-35869.rs:13:15
@@ -29,8 +29,8 @@ note: type in trait
    |
 LL |     fn bar(_: Option<u8>);
    |               ^^^^^^^^^^
-   = note: expected fn pointer `fn(Option<u8>)`
-              found fn pointer `fn(Option<u16>)`
+   = note: expected signature `fn(Option<u8>)`
+              found signature `fn(Option<u16>)`
 
 error[E0053]: method `baz` has an incompatible type for trait
   --> $DIR/issue-35869.rs:15:15
@@ -46,8 +46,8 @@ note: type in trait
    |
 LL |     fn baz(_: (u8, u16));
    |               ^^^^^^^^^
-   = note: expected fn pointer `fn((u8, _))`
-              found fn pointer `fn((u16, _))`
+   = note: expected signature `fn((u8, _))`
+              found signature `fn((u16, _))`
 
 error[E0053]: method `qux` has an incompatible type for trait
   --> $DIR/issue-35869.rs:17:17
@@ -63,8 +63,8 @@ note: type in trait
    |
 LL |     fn qux() -> u8;
    |                 ^^
-   = note: expected fn pointer `fn() -> u8`
-              found fn pointer `fn() -> u16`
+   = note: expected signature `fn() -> u8`
+              found signature `fn() -> u16`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/traits/matching-lifetimes.stderr
+++ b/src/test/ui/traits/matching-lifetimes.stderr
@@ -4,8 +4,8 @@ error[E0308]: method not compatible with trait
 LL |     fn foo(x: Foo<'b,'a>) {
    |     ^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected fn pointer `fn(Foo<'a, 'b>)`
-              found fn pointer `fn(Foo<'b, 'a>)`
+   = note: expected signature `fn(Foo<'a, 'b>)`
+              found signature `fn(Foo<'b, 'a>)`
 note: the lifetime `'b` as defined here...
   --> $DIR/matching-lifetimes.rs:13:9
    |
@@ -23,8 +23,8 @@ error[E0308]: method not compatible with trait
 LL |     fn foo(x: Foo<'b,'a>) {
    |     ^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected fn pointer `fn(Foo<'a, 'b>)`
-              found fn pointer `fn(Foo<'b, 'a>)`
+   = note: expected signature `fn(Foo<'a, 'b>)`
+              found signature `fn(Foo<'b, 'a>)`
 note: the lifetime `'a` as defined here...
   --> $DIR/matching-lifetimes.rs:13:6
    |

--- a/src/test/ui/traits/param-without-lifetime-constraint.stderr
+++ b/src/test/ui/traits/param-without-lifetime-constraint.stderr
@@ -7,8 +7,8 @@ LL |     fn get_relation(&self) -> To;
 LL |     fn get_relation(&self) -> &ProofReader {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(&'1 Article) -> &'1 ProofReader`
    |
-   = note: expected `fn(&'1 Article) -> &'2 ProofReader`
-              found `fn(&'1 Article) -> &'1 ProofReader`
+   = note: expected signature `fn(&'1 Article) -> &'2 ProofReader`
+              found signature `fn(&'1 Article) -> &'1 ProofReader`
 help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
   --> $DIR/param-without-lifetime-constraint.rs:10:31
    |

--- a/src/test/ui/traits/self-without-lifetime-constraint.stderr
+++ b/src/test/ui/traits/self-without-lifetime-constraint.stderr
@@ -7,8 +7,8 @@ LL |     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self, &Self>;
 LL |     fn column_result(value: ValueRef<'_>) -> FromSqlResult<&str, &&str> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(ValueRef<'1>) -> Result<(&'1 str, &'1 &'1 str), FromSqlError>`
    |
-   = note: expected `fn(ValueRef<'1>) -> Result<(&'2 str, &'1 &'2 str), FromSqlError>`
-              found `fn(ValueRef<'1>) -> Result<(&'1 str, &'1 &'1 str), FromSqlError>`
+   = note: expected signature `fn(ValueRef<'1>) -> Result<(&'2 str, &'1 &'2 str), FromSqlError>`
+              found signature `fn(ValueRef<'1>) -> Result<(&'1 str, &'1 &'1 str), FromSqlError>`
 help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
   --> $DIR/self-without-lifetime-constraint.rs:41:60
    |

--- a/src/test/ui/unsafe/unsafe-trait-impl.rs
+++ b/src/test/ui/unsafe/unsafe-trait-impl.rs
@@ -7,8 +7,8 @@ trait Foo {
 impl Foo for u32 {
     fn len(&self) -> u32 { *self }
     //~^ ERROR method `len` has an incompatible type for trait
-    //~| expected fn pointer `unsafe fn(&u32) -> _`
-    //~| found fn pointer `fn(&u32) -> _`
+    //~| expected signature `unsafe fn(&u32) -> _`
+    //~| found signature `fn(&u32) -> _`
 }
 
 fn main() { }

--- a/src/test/ui/unsafe/unsafe-trait-impl.stderr
+++ b/src/test/ui/unsafe/unsafe-trait-impl.stderr
@@ -9,8 +9,8 @@ note: type in trait
    |
 LL |     unsafe fn len(&self) -> u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected fn pointer `unsafe fn(&u32) -> _`
-              found fn pointer `fn(&u32) -> _`
+   = note: expected signature `unsafe fn(&u32) -> _`
+              found signature `fn(&u32) -> _`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wrong-mul-method-signature.stderr
+++ b/src/test/ui/wrong-mul-method-signature.stderr
@@ -7,8 +7,8 @@ LL |     fn mul(self, s: &f64) -> Vec1 {
    |                     expected `f64`, found `&f64`
    |                     help: change the parameter type to match the trait: `f64`
    |
-   = note: expected fn pointer `fn(Vec1, f64) -> Vec1`
-              found fn pointer `fn(Vec1, &f64) -> Vec1`
+   = note: expected signature `fn(Vec1, f64) -> Vec1`
+              found signature `fn(Vec1, &f64) -> Vec1`
 
 error[E0053]: method `mul` has an incompatible type for trait
   --> $DIR/wrong-mul-method-signature.rs:33:21
@@ -19,8 +19,8 @@ LL |     fn mul(self, s: f64) -> Vec2 {
    |                     expected struct `Vec2`, found `f64`
    |                     help: change the parameter type to match the trait: `Vec2`
    |
-   = note: expected fn pointer `fn(Vec2, Vec2) -> f64`
-              found fn pointer `fn(Vec2, f64) -> Vec2`
+   = note: expected signature `fn(Vec2, Vec2) -> f64`
+              found signature `fn(Vec2, f64) -> Vec2`
 
 error[E0053]: method `mul` has an incompatible type for trait
   --> $DIR/wrong-mul-method-signature.rs:52:29
@@ -31,8 +31,8 @@ LL |     fn mul(self, s: f64) -> f64 {
    |                             expected `i32`, found `f64`
    |                             help: change the output type to match the trait: `i32`
    |
-   = note: expected fn pointer `fn(Vec3, _) -> i32`
-              found fn pointer `fn(Vec3, _) -> f64`
+   = note: expected signature `fn(Vec3, _) -> i32`
+              found signature `fn(Vec3, _) -> f64`
 
 error[E0308]: mismatched types
   --> $DIR/wrong-mul-method-signature.rs:63:45


### PR DESCRIPTION
Fixes #80929
Fixes #67296