### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -259,8 +259,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         body.as_deref(),
                     );
 
-                    let mut itctx = ImplTraitContext::Universal;
-                    let (generics, decl) = this.lower_generics(generics, id, &mut itctx, |this| {
+                    let itctx = ImplTraitContext::Universal;
+                    let (generics, decl) = this.lower_generics(generics, id, &itctx, |this| {
                         let ret_id = asyncness.opt_return_id();
                         this.lower_fn_decl(&decl, id, *fn_sig_span, FnDeclKind::Fn, ret_id)
                     });
@@ -369,9 +369,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 // method, it will not be considered an in-band
                 // lifetime to be added, but rather a reference to a
                 // parent lifetime.
-                let mut itctx = ImplTraitContext::Universal;
+                let itctx = ImplTraitContext::Universal;
                 let (generics, (trait_ref, lowered_ty)) =
-                    self.lower_generics(ast_generics, id, &mut itctx, |this| {
+                    self.lower_generics(ast_generics, id, &itctx, |this| {
                         let trait_ref = trait_ref.as_ref().map(|trait_ref| {
                             this.lower_trait_ref(
                                 trait_ref,
@@ -590,9 +590,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
             kind: match &i.kind {
                 ForeignItemKind::Fn(box Fn { sig, generics, .. }) => {
                     let fdec = &sig.decl;
-                    let mut itctx = ImplTraitContext::Universal;
+                    let itctx = ImplTraitContext::Universal;
                     let (generics, (fn_dec, fn_args)) =
-                        self.lower_generics(generics, i.id, &mut itctx, |this| {
+                        self.lower_generics(generics, i.id, &itctx, |this| {
                             (
                                 // Disallow `impl Trait` in foreign items.
                                 this.lower_fn_decl(
@@ -1184,8 +1184,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
         is_async: Option<(NodeId, Span)>,
     ) -> (&'hir hir::Generics<'hir>, hir::FnSig<'hir>) {
         let header = self.lower_fn_header(sig.header);
-        let mut itctx = ImplTraitContext::Universal;
-        let (generics, decl) = self.lower_generics(generics, id, &mut itctx, |this| {
+        let itctx = ImplTraitContext::Universal;
+        let (generics, decl) = self.lower_generics(generics, id, &itctx, |this| {
             this.lower_fn_decl(&sig.decl, id, sig.span, kind, is_async)
         });
         (generics, hir::FnSig { header, decl, span: self.lower_span(sig.span) })

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1670,9 +1670,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     // Lowers a function declaration.
     //
     // `decl`: the unlowered (AST) function declaration.
-    // `fn_def_id`: if `Some`, impl Trait arguments are lowered into generic parameters on the
-    //      given DefId, otherwise impl Trait is disallowed. Must be `Some` if
-    //      `make_ret_async` is also `Some`.
+    // `fn_node_id`: `impl Trait` arguments are lowered into generic parameters on the given `NodeId`.
     // `make_ret_async`: if `Some`, converts `-> T` into `-> impl Future<Output = T>` in the
     //      return type. This is used for `async fn` declarations. The `NodeId` is the ID of the
     //      return type `impl Trait` item, and the `Span` points to the `async` keyword.
@@ -1796,7 +1794,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     //     type OpaqueTy<generics_from_parent_fn> = impl Future<Output = T>;
     //
     // `output`: unlowered output type (`T` in `-> T`)
-    // `fn_def_id`: `DefId` of the parent function (used to create child impl trait definition)
+    // `fn_node_id`: `NodeId` of the parent function (used to create child impl trait definition)
     // `opaque_ty_node_id`: `NodeId` of the opaque `impl Trait` type that should be created
     #[instrument(level = "debug", skip(self))]
     fn lower_async_fn_ret_ty(

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2031,7 +2031,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         &mut self,
         output: &FnRetTy,
         span: Span,
-        mut nested_impl_trait_context: ImplTraitContext,
+        nested_impl_trait_context: ImplTraitContext,
     ) -> hir::GenericBound<'hir> {
         // Compute the `T` in `Future<Output = T>` from the return type.
         let output_ty = match output {
@@ -2039,7 +2039,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 // Not `OpaqueTyOrigin::AsyncFn`: that's only used for the
                 // `impl Future` opaque type that `async fn` implicitly
                 // generates.
-                self.lower_ty(ty, &mut nested_impl_trait_context)
+                self.lower_ty(ty, &nested_impl_trait_context)
             }
             FnRetTy::Default(ret_ty_span) => self.arena.alloc(self.ty_tup(*ret_ty_span, &[])),
         };

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -37,7 +37,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             qself,
                             path,
                             ParamMode::Optional,
-                            &mut ImplTraitContext::Disallowed(ImplTraitPosition::Path),
+                            &ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                         );
                         let (pats, ddpos) = self.lower_pat_tuple(pats, "tuple struct");
                         break hir::PatKind::TupleStruct(qpath, pats, ddpos);
@@ -53,7 +53,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             qself,
                             path,
                             ParamMode::Optional,
-                            &mut ImplTraitContext::Disallowed(ImplTraitPosition::Path),
+                            &ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                         );
                         break hir::PatKind::Path(qpath);
                     }
@@ -63,7 +63,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             qself,
                             path,
                             ParamMode::Optional,
-                            &mut ImplTraitContext::Disallowed(ImplTraitPosition::Path),
+                            &ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                         );
 
                         let fs = self.arena.alloc_from_iter(fields.iter().map(|f| {

--- a/compiler/rustc_borrowck/src/type_check/input_output.rs
+++ b/compiler/rustc_borrowck/src/type_check/input_output.rs
@@ -37,31 +37,30 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         // those.
         //
         // e.g., `|x: FxHashMap<_, &'static u32>| ...`
-        let user_provided_sig;
-        if !self.tcx().is_closure(mir_def_id.to_def_id()) {
-            user_provided_sig = None;
+        let user_provided_sig = if !self.tcx().is_closure(mir_def_id.to_def_id()) {
+            None
         } else {
             let typeck_results = self.tcx().typeck(mir_def_id);
-            user_provided_sig =
-                typeck_results.user_provided_sigs.get(&mir_def_id).map(|user_provided_poly_sig| {
-                    // Instantiate the canonicalized variables from
-                    // user-provided signature (e.g., the `_` in the code
-                    // above) with fresh variables.
-                    let poly_sig = self.instantiate_canonical_with_fresh_inference_vars(
-                        body.span,
-                        &user_provided_poly_sig,
-                    );
 
-                    // Replace the bound items in the fn sig with fresh
-                    // variables, so that they represent the view from
-                    // "inside" the closure.
-                    self.infcx.replace_bound_vars_with_fresh_vars(
-                        body.span,
-                        LateBoundRegionConversionTime::FnCall,
-                        poly_sig,
-                    )
-                });
-        }
+            typeck_results.user_provided_sigs.get(&mir_def_id).map(|user_provided_poly_sig| {
+                // Instantiate the canonicalized variables from
+                // user-provided signature (e.g., the `_` in the code
+                // above) with fresh variables.
+                let poly_sig = self.instantiate_canonical_with_fresh_inference_vars(
+                    body.span,
+                    &user_provided_poly_sig,
+                );
+
+                // Replace the bound items in the fn sig with fresh
+                // variables, so that they represent the view from
+                // "inside" the closure.
+                self.infcx.replace_bound_vars_with_fresh_vars(
+                    body.span,
+                    LateBoundRegionConversionTime::FnCall,
+                    poly_sig,
+                )
+            })
+        };
 
         debug!(?normalized_input_tys, ?body.local_decls);
 

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -102,10 +102,10 @@ pub fn uwtable_attr(llcx: &llvm::Context) -> &Attribute {
 
 pub fn frame_pointer_type_attr<'ll>(cx: &CodegenCx<'ll, '_>) -> Option<&'ll Attribute> {
     let mut fp = cx.sess().target.frame_pointer;
+    let opts = &cx.sess().opts;
     // "mcount" function relies on stack pointer.
     // See <https://sourceware.org/binutils/docs/gprof/Implementation.html>.
-    if cx.sess().instrument_mcount() || matches!(cx.sess().opts.cg.force_frame_pointers, Some(true))
-    {
+    if opts.unstable_opts.instrument_mcount || matches!(opts.cg.force_frame_pointers, Some(true)) {
         fp = FramePointer::Always;
     }
     let attr_value = match fp {
@@ -119,7 +119,7 @@ pub fn frame_pointer_type_attr<'ll>(cx: &CodegenCx<'ll, '_>) -> Option<&'ll Attr
 /// Tell LLVM what instrument function to insert.
 #[inline]
 fn instrument_function_attr<'ll>(cx: &CodegenCx<'ll, '_>) -> Option<&'ll Attribute> {
-    if cx.sess().instrument_mcount() {
+    if cx.sess().opts.unstable_opts.instrument_mcount {
         // Similar to `clang -pg` behavior. Handled by the
         // `post-inline-ee-instrument` LLVM pass.
 

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -203,7 +203,7 @@ pub fn target_machine_factory(
         sess.opts.unstable_opts.trap_unreachable.unwrap_or(sess.target.trap_unreachable);
     let emit_stack_size_section = sess.opts.unstable_opts.emit_stack_sizes;
 
-    let asm_comments = sess.asm_comments();
+    let asm_comments = sess.opts.unstable_opts.asm_comments;
     let relax_elf_relocations =
         sess.opts.unstable_opts.relax_elf_relocations.unwrap_or(sess.target.relax_elf_relocations);
 

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -81,10 +81,10 @@ unsafe fn configure_llvm(sess: &Session) {
         };
         // Set the llvm "program name" to make usage and invalid argument messages more clear.
         add("rustc -Cllvm-args=\"...\" with", true);
-        if sess.time_llvm_passes() {
+        if sess.opts.unstable_opts.time_llvm_passes {
             add("-time-passes", false);
         }
-        if sess.print_llvm_passes() {
+        if sess.opts.unstable_opts.print_llvm_passes {
             add("-debug-pass=Structure", false);
         }
         if sess.target.generate_arange_section

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1899,7 +1899,7 @@ impl<B: ExtraBackendMethods> OngoingCodegen<B> {
 
         // FIXME: time_llvm_passes support - does this use a global context or
         // something?
-        if sess.codegen_units() == 1 && sess.time_llvm_passes() {
+        if sess.codegen_units() == 1 && sess.opts.unstable_opts.time_llvm_passes {
             self.backend.print_pass_timings()
         }
 

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -681,7 +681,7 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
     });
 
     let mut total_codegen_time = Duration::new(0, 0);
-    let start_rss = tcx.sess.time_passes().then(|| get_resident_set_size());
+    let start_rss = tcx.sess.opts.unstable_opts.time_passes.then(|| get_resident_set_size());
 
     // The non-parallel compiler can only translate codegen units to LLVM IR
     // on a single thread, leading to a staircase effect where the N LLVM
@@ -781,7 +781,7 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
 
     // Since the main thread is sometimes blocked during codegen, we keep track
     // -Ztime-passes output manually.
-    if tcx.sess.time_passes() {
+    if tcx.sess.opts.unstable_opts.time_passes {
         let end_rss = get_resident_set_size();
 
         print_time_passes_entry(

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -509,7 +509,7 @@ pub fn compute_debuginfo_vtable_name<'tcx>(
         visited.clear();
         push_generic_params_internal(tcx, trait_ref.substs, &mut vtable_name, &mut visited);
     } else {
-        vtable_name.push_str("_");
+        vtable_name.push('_');
     }
 
     push_close_angle_bracket(cpp_like_debuginfo, &mut vtable_name);

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -653,7 +653,7 @@ fn print_crate_info(
     for req in &sess.opts.prints {
         match *req {
             TargetList => {
-                let mut targets = rustc_target::spec::TARGETS.iter().copied().collect::<Vec<_>>();
+                let mut targets = rustc_target::spec::TARGETS.to_vec();
                 targets.sort_unstable();
                 println!("{}", targets.join("\n"));
             }

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1212,8 +1212,8 @@ impl HandlerInner {
         self.taught_diagnostics.insert(code.clone())
     }
 
-    fn force_print_diagnostic(&mut self, mut db: Diagnostic) {
-        self.emitter.emit_diagnostic(&mut db);
+    fn force_print_diagnostic(&mut self, db: Diagnostic) {
+        self.emitter.emit_diagnostic(&db);
     }
 
     /// Emit all stashed diagnostics.

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -1166,11 +1166,7 @@ fn check_matcher_core<'tt>(
                                     err.note(&format!(
                                         "{}{} or {}",
                                         msg,
-                                        ts[..ts.len() - 1]
-                                            .iter()
-                                            .copied()
-                                            .collect::<Vec<_>>()
-                                            .join(", "),
+                                        ts[..ts.len() - 1].to_vec().join(", "),
                                         ts[ts.len() - 1],
                                     ));
                                 }

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -410,10 +410,7 @@ fn check_gat_where_clauses(tcx: TyCtxt<'_>, associated_items: &[hir::TraitItemRe
                             tcx,
                             param_env,
                             item_hir_id,
-                            tcx.explicit_item_bounds(item_def_id)
-                                .iter()
-                                .copied()
-                                .collect::<Vec<_>>(),
+                            tcx.explicit_item_bounds(item_def_id).to_vec(),
                             &FxIndexSet::default(),
                             gat_def_id.def_id,
                             gat_generics,

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -355,14 +355,12 @@ impl LintStore {
                     sub: RequestedLevel { level, lint_name },
                 });
             }
-            CheckLintNameResult::Tool(result) => {
-                if let Err((Some(_), new_name)) = result {
-                    sess.emit_warning(CheckNameDeprecated {
-                        lint_name: lint_name.clone(),
-                        new_name,
-                        sub: RequestedLevel { level, lint_name },
-                    });
-                }
+            CheckLintNameResult::Tool(Err((Some(_), new_name))) => {
+                sess.emit_warning(CheckNameDeprecated {
+                    lint_name: lint_name.clone(),
+                    new_name,
+                    sub: RequestedLevel { level, lint_name },
+                });
             }
             CheckLintNameResult::NoTool => {
                 sess.emit_err(CheckNameUnknownTool {

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1564,7 +1564,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 let trait_ref = self.tcx.impl_trait_ref(def_id);
                 if let Some(trait_ref) = trait_ref {
                     let trait_def = self.tcx.trait_def(trait_ref.def_id);
-                    if let Some(mut an) = trait_def.ancestors(self.tcx, def_id).ok() {
+                    if let Ok(mut an) = trait_def.ancestors(self.tcx, def_id) {
                         if let Some(specialization_graph::Node::Impl(parent)) = an.nth(1) {
                             self.tables.impl_parent.set(def_id.index, parent.into());
                         }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -713,7 +713,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         let computed_total_bytes: usize = stats.iter().map(|(_, size)| size).sum();
         assert_eq!(total_bytes, computed_total_bytes);
 
-        if tcx.sess.meta_stats() {
+        if tcx.sess.opts.unstable_opts.meta_stats {
             self.opaque.flush();
 
             // Rewind and re-read all the metadata to count the zero bytes we wrote.

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -704,12 +704,10 @@ impl<'hir> Map<'hir> {
     pub fn get_return_block(self, id: HirId) -> Option<HirId> {
         let mut iter = self.parent_iter(id).peekable();
         let mut ignore_tail = false;
-        if let Some(node) = self.find(id) {
-            if let Node::Expr(Expr { kind: ExprKind::Ret(_), .. }) = node {
-                // When dealing with `return` statements, we don't care about climbing only tail
-                // expressions.
-                ignore_tail = true;
-            }
+        if let Some(Node::Expr(Expr { kind: ExprKind::Ret(_), .. })) = self.find(id) {
+            // When dealing with `return` statements, we don't care about climbing only tail
+            // expressions.
+            ignore_tail = true;
         }
         while let Some((hir_id, node)) = iter.next() {
             if let (Some((_, next_node)), false) = (iter.peek(), ignore_tail) {

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2894,7 +2894,7 @@ fn pretty_print_const_value<'tcx>(
                 if let Some(contents) = tcx.try_destructure_mir_constant(
                     ty::ParamEnv::reveal_all().and(ConstantKind::Val(ct, ty)),
                 ) {
-                    let fields = contents.fields.iter().copied().collect::<Vec<_>>();
+                    let fields = contents.fields.to_vec();
                     match *ty.kind() {
                         ty::Array(..) => {
                             fmt.write_str("[")?;

--- a/compiler/rustc_monomorphize/src/partitioning/mod.rs
+++ b/compiler/rustc_monomorphize/src/partitioning/mod.rs
@@ -305,7 +305,7 @@ where
                 );
             }
 
-            let _ = writeln!(s, "");
+            let _ = writeln!(s);
         }
 
         std::mem::take(s)

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1090,9 +1090,7 @@ impl CheckAttrVisitor<'_> {
                                     errors::DocTestUnknownInclude {
                                         path,
                                         value: value.to_string(),
-                                        inner: (attr.style == AttrStyle::Inner)
-                                            .then_some("!")
-                                            .unwrap_or(""),
+                                        inner: if attr.style == AttrStyle::Inner { "!" } else { "" },
                                         sugg: (attr.meta().unwrap().span, applicability),
                                     }
                                 );

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1214,7 +1214,6 @@ options! {
         "only allow the listed language features to be enabled in code (space separated)"),
     always_encode_mir: bool = (false, parse_bool, [TRACKED],
         "encode MIR of all functions into the crate metadata (default: no)"),
-    #[rustc_lint_opt_deny_field_access("use `Session::asm_comments` instead of this field")]
     asm_comments: bool = (false, parse_bool, [TRACKED],
         "generate comments into the assembly (may change behavior) (default: no)"),
     assert_incr_state: Option<String> = (None, parse_opt_string, [UNTRACKED],
@@ -1363,7 +1362,6 @@ options! {
         `=except-unused-generics`
         `=except-unused-functions`
         `=off` (default)"),
-    #[rustc_lint_opt_deny_field_access("use `Session::instrument_mcount` instead of this field")]
     instrument_mcount: bool = (false, parse_bool, [TRACKED],
         "insert function instrument code for mcount-based tracing (default: no)"),
     keep_hygiene_data: bool = (false, parse_bool, [UNTRACKED],
@@ -1392,7 +1390,6 @@ options! {
     merge_functions: Option<MergeFunctions> = (None, parse_merge_functions, [TRACKED],
         "control the operation of the MergeFunctions LLVM pass, taking \
         the same values as the target option of the same name"),
-    #[rustc_lint_opt_deny_field_access("use `Session::meta_stats` instead of this field")]
     meta_stats: bool = (false, parse_bool, [UNTRACKED],
         "gather metadata statistics (default: no)"),
     mir_emit_retag: bool = (false, parse_bool, [TRACKED],
@@ -1467,7 +1464,6 @@ options! {
         See #77382 and #74551."),
     print_fuel: Option<String> = (None, parse_opt_string, [TRACKED],
         "make rustc print the total optimization fuel used by a crate"),
-    #[rustc_lint_opt_deny_field_access("use `Session::print_llvm_passes` instead of this field")]
     print_llvm_passes: bool = (false, parse_bool, [UNTRACKED],
         "print the LLVM optimization passes being run (default: no)"),
     print_mono_items: Option<String> = (None, parse_opt_string, [UNTRACKED],
@@ -1581,10 +1577,8 @@ options! {
     #[rustc_lint_opt_deny_field_access("use `Session::threads` instead of this field")]
     threads: usize = (1, parse_threads, [UNTRACKED],
         "use a thread pool with N threads"),
-    #[rustc_lint_opt_deny_field_access("use `Session::time_llvm_passes` instead of this field")]
     time_llvm_passes: bool = (false, parse_bool, [UNTRACKED],
         "measure time of each LLVM pass (default: no)"),
-    #[rustc_lint_opt_deny_field_access("use `Session::time_passes` instead of this field")]
     time_passes: bool = (false, parse_bool, [UNTRACKED],
         "measure time of each rustc pass (default: no)"),
     #[rustc_lint_opt_deny_field_access("use `Session::tls_model` instead of this field")]

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -976,32 +976,8 @@ impl Session {
         self.opts.unstable_opts.verbose
     }
 
-    pub fn instrument_mcount(&self) -> bool {
-        self.opts.unstable_opts.instrument_mcount
-    }
-
-    pub fn time_passes(&self) -> bool {
-        self.opts.unstable_opts.time_passes
-    }
-
-    pub fn time_llvm_passes(&self) -> bool {
-        self.opts.unstable_opts.time_llvm_passes
-    }
-
-    pub fn meta_stats(&self) -> bool {
-        self.opts.unstable_opts.meta_stats
-    }
-
-    pub fn asm_comments(&self) -> bool {
-        self.opts.unstable_opts.asm_comments
-    }
-
     pub fn verify_llvm_ir(&self) -> bool {
         self.opts.unstable_opts.verify_llvm_ir || option_env!("RUSTC_VERIFY_LLVM_IR").is_some()
-    }
-
-    pub fn print_llvm_passes(&self) -> bool {
-        self.opts.unstable_opts.print_llvm_passes
     }
 
     pub fn binary_dep_depinfo(&self) -> bool {

--- a/src/test/rustdoc-gui/links-color.goml
+++ b/src/test/rustdoc-gui/links-color.goml
@@ -4,82 +4,95 @@ goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
 // This is needed so that the text color is computed.
 show-text: true
 
-// Ayu theme
-local-storage: {
-    "rustdoc-theme": "ayu",
-    "rustdoc-use-system-theme": "false",
-}
-reload:
-
-assert-css: (".item-table .mod", {"color": "rgb(57, 175, 215)"}, ALL)
-assert-css: (".item-table .macro", {"color": "rgb(163, 122, 204)"}, ALL)
-assert-css: (".item-table .struct", {"color": "rgb(255, 160, 165)"}, ALL)
-assert-css: (".item-table .enum", {"color": "rgb(255, 160, 165)"}, ALL)
-assert-css: (".item-table .trait", {"color": "rgb(57, 175, 215)"}, ALL)
-assert-css: (".item-table .fn", {"color": "rgb(253, 214, 135)"}, ALL)
-assert-css: (".item-table .type", {"color": "rgb(255, 160, 165)"}, ALL)
-assert-css: (".item-table .union", {"color": "rgb(255, 160, 165)"}, ALL)
-assert-css: (".item-table .keyword", {"color": "rgb(57, 175, 215)"}, ALL)
-
-assert-css: (
-    ".sidebar-elems a:not(.current)",
-    {"color": "rgb(83, 177, 219)", "background-color": "rgba(0, 0, 0, 0)", "font-weight": "400"},
-    ALL,
-)
-assert-css: (
-    ".sidebar-elems a.current",
-    {"color": "rgb(255, 180, 76)", "background-color": "rgba(0, 0, 0, 0)", "font-weight": "500"},
-    ALL,
-)
-
-
-// Dark theme
-local-storage: {"rustdoc-theme": "dark"}
-reload:
-
-assert-css: (".item-table .mod", {"color": "rgb(210, 153, 29)"}, ALL)
-assert-css: (".item-table .macro", {"color": "rgb(9, 189, 0)"}, ALL)
-assert-css: (".item-table .struct", {"color": "rgb(45, 191, 184)"}, ALL)
-assert-css: (".item-table .enum", {"color": "rgb(45, 191, 184)"}, ALL)
-assert-css: (".item-table .trait", {"color": "rgb(183, 140, 242)"}, ALL)
-assert-css: (".item-table .fn", {"color": "rgb(43, 171, 99)"}, ALL)
-assert-css: (".item-table .type", {"color": "rgb(45, 191, 184)"}, ALL)
-assert-css: (".item-table .union", {"color": "rgb(45, 191, 184)"}, ALL)
-assert-css: (".item-table .keyword", {"color": "rgb(210, 153, 29)"}, ALL)
-
-assert-css: (
-    ".sidebar-elems a:not(.current)",
-    {"color": "rgb(253, 191, 53)", "background-color": "rgba(0, 0, 0, 0)", "font-weight": "400"},
-    ALL,
-)
-assert-css: (
-    ".sidebar-elems a.current",
-    {"color": "rgb(253, 191, 53)", "background-color": "rgb(68, 68, 68)", "font-weight": "500"},
-    ALL,
+define-function: (
+    "check-colors",
+    (theme, mod, macro, struct, enum, trait, fn, type, union, keyword,
+     sidebar, sidebar_current, sidebar_current_background),
+    [
+        ("local-storage", {
+            "rustdoc-theme": |theme|,
+            "rustdoc-use-system-theme": "false",
+        }),
+        ("reload"),
+        // Checking results colors.
+        ("assert-css", (".item-table .mod", {"color": |mod|}, ALL)),
+        ("assert-css", (".item-table .macro", {"color": |macro|}, ALL)),
+        ("assert-css", (".item-table .struct", {"color": |struct|}, ALL)),
+        ("assert-css", (".item-table .enum", {"color": |enum|}, ALL)),
+        ("assert-css", (".item-table .trait", {"color": |trait|}, ALL)),
+        ("assert-css", (".item-table .fn", {"color": |fn|}, ALL)),
+        ("assert-css", (".item-table .type", {"color": |type|}, ALL)),
+        ("assert-css", (".item-table .union", {"color": |union|}, ALL)),
+        ("assert-css", (".item-table .keyword", {"color": |keyword|}, ALL)),
+        // Checking sidebar elements.
+        ("assert-css", (
+            ".sidebar-elems a:not(.current)",
+            {"color": |sidebar|, "background-color": "rgba(0, 0, 0, 0)", "font-weight": "400"},
+            ALL,
+        )),
+        ("assert-css", (
+            ".sidebar-elems a.current",
+            {
+                "color": |sidebar_current|,
+                "background-color": |sidebar_current_background|,
+                "font-weight": "500",
+            },
+            ALL,
+        )),
+    ],
 )
 
-
-// Light theme
-local-storage: {"rustdoc-theme": "light"}
-reload:
-
-assert-css: (".item-table .mod", {"color": "rgb(56, 115, 173)"}, ALL)
-assert-css: (".item-table .macro", {"color": "rgb(6, 128, 0)"}, ALL)
-assert-css: (".item-table .struct", {"color": "rgb(173, 55, 138)"}, ALL)
-assert-css: (".item-table .enum", {"color": "rgb(173, 55, 138)"}, ALL)
-assert-css: (".item-table .trait", {"color": "rgb(110, 79, 201)"}, ALL)
-assert-css: (".item-table .fn", {"color": "rgb(173, 124, 55)"}, ALL)
-assert-css: (".item-table .type", {"color": "rgb(173, 55, 138)"}, ALL)
-assert-css: (".item-table .union", {"color": "rgb(173, 55, 138)"}, ALL)
-assert-css: (".item-table .keyword", {"color": "rgb(56, 115, 173)"}, ALL)
-
-assert-css: (
-    ".sidebar-elems a:not(.current)",
-    {"color": "rgb(53, 109, 164)", "background-color": "rgba(0, 0, 0, 0)", "font-weight": "400"},
-    ALL,
+call-function: (
+    "check-colors",
+    {
+        "theme": "ayu",
+        "mod": "rgb(57, 175, 215)",
+        "macro": "rgb(163, 122, 204)",
+        "struct": "rgb(255, 160, 165)",
+        "enum": "rgb(255, 160, 165)",
+        "trait": "rgb(57, 175, 215)",
+        "fn": "rgb(253, 214, 135)",
+        "type": "rgb(255, 160, 165)",
+        "union": "rgb(255, 160, 165)",
+        "keyword": "rgb(57, 175, 215)",
+        "sidebar": "rgb(83, 177, 219)",
+        "sidebar_current": "rgb(255, 180, 76)",
+        "sidebar_current_background": "rgba(0, 0, 0, 0)",
+    },
 )
-assert-css: (
-    ".sidebar-elems a.current",
-    {"color": "rgb(53, 109, 164)", "background-color": "rgb(255, 255, 255)", "font-weight": "500"},
-    ALL,
+call-function: (
+    "check-colors",
+    {
+        "theme": "dark",
+        "mod": "rgb(210, 153, 29)",
+        "macro": "rgb(9, 189, 0)",
+        "struct": "rgb(45, 191, 184)",
+        "enum": "rgb(45, 191, 184)",
+        "trait": "rgb(183, 140, 242)",
+        "fn": "rgb(43, 171, 99)",
+        "type": "rgb(45, 191, 184)",
+        "union": "rgb(45, 191, 184)",
+        "keyword": "rgb(210, 153, 29)",
+        "sidebar": "rgb(253, 191, 53)",
+        "sidebar_current": "rgb(253, 191, 53)",
+        "sidebar_current_background": "rgb(68, 68, 68)",
+    },
+)
+call-function: (
+    "check-colors",
+    {
+        "theme": "light",
+        "mod": "rgb(56, 115, 173)",
+        "macro": "rgb(6, 128, 0)",
+        "struct": "rgb(173, 55, 138)",
+        "enum": "rgb(173, 55, 138)",
+        "trait": "rgb(110, 79, 201)",
+        "fn": "rgb(173, 124, 55)",
+        "type": "rgb(173, 55, 138)",
+        "union": "rgb(173, 55, 138)",
+        "keyword": "rgb(56, 115, 173)",
+        "sidebar": "rgb(53, 109, 164)",
+        "sidebar_current": "rgb(53, 109, 164)",
+        "sidebar_current_background": "rgb(255, 255, 255)",
+    },
 )


### PR DESCRIPTION
Successful merges:

 - #105375 (Fix an outdated comment mentioning parameter that doesn't exist anymore)
 - #105955 (Remove wrapper functions for some unstable options)
 - #106137 (fix more clippy::style findings)
 - #106140 (Migrate links-color.goml to functions)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=105375,105955,106137,106140)
<!-- homu-ignore:end -->