### PR TITLE
Add default support for arrays of all sizes

### DIFF
--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -306,6 +306,18 @@ fn empty_array_is_always_default() {
 }
 
 #[test]
+fn all_arrays_are_generic_also_default() {
+    let _arr = <[u8; 1]>::default();
+    let _arr = <[u8; 2]>::default();
+    let _arr = <[u8; 4]>::default();
+    let _arr = <[u8; 8]>::default();
+    let _arr = <[u8; 16]>::default();
+    let _arr = <[u8; 32]>::default();
+    let _arr = <[u8; 64]>::default();
+    let _arr = <[u8; 1337]>::default();
+}
+
+#[test]
 fn array_map() {
     let a = [1, 2, 3];
     let b = a.map(|v| v + 1);


### PR DESCRIPTION
Currently only arrays of up to size 32 support `Default`.
This expands `Default` to be allowed for arrays of all sizes.

https://github.com/rust-lang/libs-team/issues/153