### PR TITLE
Readme: update section on how to run `x.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,22 +20,23 @@ Read ["Installation"] from [The Book].
 The Rust build system uses a Python script called `x.py` to build the compiler,
 which manages the bootstrapping process. It lives at the root of the project.
 
-The `x.py` command can be run directly on most systems in the following format:
+The `x.py` command can be run directly on most Unix systems in the following format:
 
 ```sh
 ./x.py <subcommand> [flags]
 ```
 
-This is how the documentation and examples assume you are running `x.py`.
-
-Systems such as Ubuntu 20.04 LTS do not create the necessary `python` command by default when Python is installed that allows `x.py` to be run directly. In that case, you can either create a symlink for `python` (Ubuntu provides the `python-is-python3` package for this), or run `x.py` using Python itself:
+This is how the documentation and examples assume you are running `x.py`. Some alternative ways are:
 
 ```sh
-# Python 3
-python3 x.py <subcommand> [flags]
+# On a Unix shell if you don't have the necessary `python3` command
+./x <subcommand> [flags]
 
-# Python 2.7
-python2.7 x.py <subcommand> [flags]
+# On the Windows Command Prompt (if .py files are configured to run Python)
+x.py <subcommand> [flags]
+
+# You can also run Python yourself, e.g.:
+python x.py <subcommand> [flags]
 ```
 
 More information about `x.py` can be found

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -45,14 +45,6 @@ fi
 ci_dir=`cd $(dirname $0) && pwd`
 source "$ci_dir/shared.sh"
 
-if command -v python > /dev/null; then
-    PYTHON="python"
-elif command -v python3 > /dev/null; then
-    PYTHON="python3"
-else
-    PYTHON="python2"
-fi
-
 if ! isCI || isCiBranch auto || isCiBranch beta || isCiBranch try || isCiBranch try-perf; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.print-step-timings --enable-verbose-tests"
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.metrics"
@@ -201,7 +193,7 @@ if [ "$RUN_CHECK_WITH_PARALLEL_QUERIES" != "" ]; then
     mv metrics.json build
   fi
 
-  CARGO_INCREMENTAL=0 $PYTHON ../x.py check
+  CARGO_INCREMENTAL=0 ../x check
 fi
 
 sccache --show-stats || true


### PR DESCRIPTION
`./x.py` currently looks for `python3` (not `python`) in the `PATH`. I updated that in the readme and also mentioned a convenient way to run `x.py` on Windows. The PowerShell script is actually quite inconvenient to use (and not really necessary on the `cmd.exe` prompt) so I left it out.

In addition I adapted `./x` in one of the CI scripts.