### PR TITLE
rustdoc: clean up src sidebar toggle position CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -364,6 +364,10 @@ img {
 	line-height: 0;
 }
 
+.sub-logo-container {
+	margin-right: 32px;
+}
+
 .sub-logo-container > img {
 	height: 60px;
 	width: 60px;
@@ -670,9 +674,6 @@ nav.sub {
 }
 .source nav.sub {
 	margin: 0 0 15px 0;
-}
-.source .search-form {
-	margin-left: 32px;
 }
 
 a {
@@ -1832,13 +1833,6 @@ in storage.js
 	.sub-logo-container > img {
 		height: 35px;
 		width: 35px;
-	}
-
-	#src-sidebar-toggle {
-		top: 10px;
-	}
-	.source-sidebar-expanded #src-sidebar-toggle {
-		top: unset;
 	}
 }
 


### PR DESCRIPTION
This PR makes the `464px` version of `#src-sidebar-toggle` the same as the `700px` version, with the button lower on the page so that it doesn't cover up the search form, and removes the left margin to make space for it.

## Before

![image](https://user-images.githubusercontent.com/1593513/209507474-0463e4b2-0bd4-497b-958c-ec4fdbb524fb.png)

## After

![image](https://user-images.githubusercontent.com/1593513/209507499-a32c1728-d4c9-46d9-821d-ba6f8d4d94d4.png)
