### PR TITLE
Don't trim path for `unsafe_op_in_unsafe_fn` lints

### DIFF
--- a/src/test/ui/unsafe/auxiliary/issue-106126.rs
+++ b/src/test/ui/unsafe/auxiliary/issue-106126.rs
@@ -1,0 +1,9 @@
+#[macro_export]
+macro_rules! foo {
+    () => {
+        unsafe fn __unsf() {}
+        unsafe fn __foo() {
+            __unsf();
+        }
+    };
+}

--- a/src/test/ui/unsafe/issue-106126-good-path-bug.rs
+++ b/src/test/ui/unsafe/issue-106126-good-path-bug.rs
@@ -1,0 +1,12 @@
+// Regression test for #106126.
+// check-pass
+// aux-build:issue-106126.rs
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
+#[macro_use]
+extern crate issue_106126;
+
+foo!();
+
+fn main() {}


### PR DESCRIPTION
Fixes #106126, alternative to #106127.
r? @ghost for now.