### PR TITLE
Fix bad import suggestion with nested `use` tree

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -161,6 +161,7 @@ impl<'a> Resolver<'a> {
                     found_use,
                     DiagnosticMode::Normal,
                     path,
+                    None,
                 );
                 err.emit();
             } else if let Some((span, msg, sugg, appl)) = suggestion {
@@ -690,6 +691,7 @@ impl<'a> Resolver<'a> {
                         FoundUse::Yes,
                         DiagnosticMode::Pattern,
                         vec![],
+                        None,
                     );
                 }
                 err
@@ -1344,6 +1346,7 @@ impl<'a> Resolver<'a> {
             FoundUse::Yes,
             DiagnosticMode::Normal,
             vec![],
+            None,
         );
 
         if macro_kind == MacroKind::Derive && (ident.name == sym::Send || ident.name == sym::Sync) {
@@ -2325,6 +2328,7 @@ pub(crate) fn import_candidates(
     use_placement_span: Option<Span>,
     candidates: &[ImportSuggestion],
     mode: DiagnosticMode,
+    append: Option<&str>,
 ) {
     show_candidates(
         session,
@@ -2336,6 +2340,7 @@ pub(crate) fn import_candidates(
         FoundUse::Yes,
         mode,
         vec![],
+        append,
     );
 }
 
@@ -2353,10 +2358,12 @@ fn show_candidates(
     found_use: FoundUse,
     mode: DiagnosticMode,
     path: Vec<Segment>,
+    append: Option<&str>,
 ) {
     if candidates.is_empty() {
         return;
     }
+    let append = append.unwrap_or("");
 
     let mut accessible_path_strings: Vec<(String, &str, Option<DefId>, &Option<String>)> =
         Vec::new();
@@ -2417,7 +2424,7 @@ fn show_candidates(
                 // produce an additional newline to separate the new use statement
                 // from the directly following item.
                 let additional_newline = if let FoundUse::Yes = found_use { "" } else { "\n" };
-                candidate.0 = format!("{}{};\n{}", add_use, &candidate.0, additional_newline);
+                candidate.0 = format!("{add_use}{}{append};\n{additional_newline}", &candidate.0);
             }
 
             err.span_suggestions(

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2309,7 +2309,7 @@ enum FoundUse {
 }
 
 /// Whether a binding is part of a pattern or a use statement. Used for diagnostics.
-enum DiagnosticMode {
+pub(crate) enum DiagnosticMode {
     Normal,
     /// The binding is part of a pattern
     Pattern,
@@ -2324,6 +2324,7 @@ pub(crate) fn import_candidates(
     // This is `None` if all placement locations are inside expansions
     use_placement_span: Option<Span>,
     candidates: &[ImportSuggestion],
+    mode: DiagnosticMode,
 ) {
     show_candidates(
         session,
@@ -2333,7 +2334,7 @@ pub(crate) fn import_candidates(
         candidates,
         Instead::Yes,
         FoundUse::Yes,
-        DiagnosticMode::Import,
+        mode,
         vec![],
     );
 }

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -161,7 +161,7 @@ impl<'a> Resolver<'a> {
                     found_use,
                     DiagnosticMode::Normal,
                     path,
-                    None,
+                    "",
                 );
                 err.emit();
             } else if let Some((span, msg, sugg, appl)) = suggestion {
@@ -691,7 +691,7 @@ impl<'a> Resolver<'a> {
                         FoundUse::Yes,
                         DiagnosticMode::Pattern,
                         vec![],
-                        None,
+                        "",
                     );
                 }
                 err
@@ -1346,7 +1346,7 @@ impl<'a> Resolver<'a> {
             FoundUse::Yes,
             DiagnosticMode::Normal,
             vec![],
-            None,
+            "",
         );
 
         if macro_kind == MacroKind::Derive && (ident.name == sym::Send || ident.name == sym::Sync) {
@@ -2328,7 +2328,7 @@ pub(crate) fn import_candidates(
     use_placement_span: Option<Span>,
     candidates: &[ImportSuggestion],
     mode: DiagnosticMode,
-    append: Option<&str>,
+    append: &str,
 ) {
     show_candidates(
         session,
@@ -2358,12 +2358,11 @@ fn show_candidates(
     found_use: FoundUse,
     mode: DiagnosticMode,
     path: Vec<Segment>,
-    append: Option<&str>,
+    append: &str,
 ) {
     if candidates.is_empty() {
         return;
     }
-    let append = append.unwrap_or("");
 
     let mut accessible_path_strings: Vec<(String, &str, Option<DefId>, &Option<String>)> =
         Vec::new();

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -547,15 +547,16 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
 
             if let Some(candidates) = &err.candidates {
                 match &import.kind {
-                    ImportKind::Single { nested: false, .. } => import_candidates(
+                    ImportKind::Single { nested: false, source, target, .. } => import_candidates(
                         self.r.session,
                         &self.r.untracked.source_span,
                         &mut diag,
                         Some(err.span),
                         &candidates,
                         DiagnosticMode::Import,
+                        (source != target).then(|| format!(" as {target}")).as_deref(),
                     ),
-                    ImportKind::Single { nested: true, .. } => {
+                    ImportKind::Single { nested: true, source, target, .. } => {
                         import_candidates(
                             self.r.session,
                             &self.r.untracked.source_span,
@@ -563,6 +564,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                             None,
                             &candidates,
                             DiagnosticMode::Normal,
+                            (source != target).then(|| format!(" as {target}")).as_deref(),
                         );
                     }
                     _ => {}

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -896,7 +896,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                 let resolutions = resolutions.as_ref().into_iter().flat_map(|r| r.iter());
                 let names = resolutions
                     .filter_map(|(BindingKey { ident: i, .. }, resolution)| {
-                        if *i == ident {
+                        if i.name == ident.name {
                             return None;
                         } // Never suggest the same name
                         match *resolution.borrow() {

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -554,7 +554,10 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                         Some(err.span),
                         &candidates,
                         DiagnosticMode::Import,
-                        (source != target).then(|| format!(" as {target}")).as_deref(),
+                        (source != target)
+                            .then(|| format!(" as {target}"))
+                            .as_deref()
+                            .unwrap_or(""),
                     ),
                     ImportKind::Single { nested: true, source, target, .. } => {
                         import_candidates(
@@ -564,7 +567,10 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                             None,
                             &candidates,
                             DiagnosticMode::Normal,
-                            (source != target).then(|| format!(" as {target}")).as_deref(),
+                            (source != target)
+                                .then(|| format!(" as {target}"))
+                                .as_deref()
+                                .unwrap_or(""),
                         );
                     }
                     _ => {}

--- a/src/test/ui/hygiene/extern-prelude-from-opaque-fail.stderr
+++ b/src/test/ui/hygiene/extern-prelude-from-opaque-fail.stderr
@@ -2,10 +2,7 @@ error[E0432]: unresolved import `my_core`
   --> $DIR/extern-prelude-from-opaque-fail.rs:20:9
    |
 LL |     use my_core;
-   |         ^^^^^^^
-   |         |
-   |         no `my_core` in the root
-   |         help: a similar name exists in the module: `my_core`
+   |         ^^^^^^^ no `my_core` in the root
 
 error[E0432]: unresolved import `my_core`
   --> $DIR/extern-prelude-from-opaque-fail.rs:7:13

--- a/src/test/ui/imports/bad-import-in-nested.rs
+++ b/src/test/ui/imports/bad-import-in-nested.rs
@@ -1,14 +1,27 @@
+// edition: 2021
+
 #![allow(unused)]
 
 mod A {
     pub(crate) type AA = ();
+    pub(crate) type BB = ();
+
+    mod A2 {
+        use super::{super::C::D::AA, AA as _};
+        //~^ ERROR unresolved import
+    }
 }
 
-mod C {}
+mod C {
+    pub mod D {}
+}
 
 mod B {
     use crate::C::{self, AA};
-    //~^ ERROR unresolved import `crate::C::AA`
+    //~^ ERROR unresolved import
+
+    use crate::{A, C::BB};
+    //~^ ERROR unresolved import
 }
 
 fn main() {}

--- a/src/test/ui/imports/bad-import-in-nested.rs
+++ b/src/test/ui/imports/bad-import-in-nested.rs
@@ -1,0 +1,14 @@
+#![allow(unused)]
+
+mod A {
+    pub(crate) type AA = ();
+}
+
+mod C {}
+
+mod B {
+    use crate::C::{self, AA};
+    //~^ ERROR unresolved import `crate::C::AA`
+}
+
+fn main() {}

--- a/src/test/ui/imports/bad-import-in-nested.stderr
+++ b/src/test/ui/imports/bad-import-in-nested.stderr
@@ -1,9 +1,30 @@
+error[E0432]: unresolved import `super::super::C::D::AA`
+  --> $DIR/bad-import-in-nested.rs:10:21
+   |
+LL |         use super::{super::C::D::AA, AA as _};
+   |                     ^^^^^^^^^^^^^^^ no `AA` in `C::D`
+   |
+   = note: consider importing this type alias instead:
+           crate::A::AA
+
 error[E0432]: unresolved import `crate::C::AA`
-  --> $DIR/bad-import-in-nested.rs:10:26
+  --> $DIR/bad-import-in-nested.rs:20:26
    |
 LL |     use crate::C::{self, AA};
    |                          ^^ no `AA` in `C`
+   |
+   = note: consider importing this type alias instead:
+           crate::A::AA
 
-error: aborting due to previous error
+error[E0432]: unresolved import `crate::C::BB`
+  --> $DIR/bad-import-in-nested.rs:23:20
+   |
+LL |     use crate::{A, C::BB};
+   |                    ^^^^^ no `BB` in `C`
+   |
+   = note: consider importing this type alias instead:
+           crate::A::BB
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0432`.

--- a/src/test/ui/imports/bad-import-in-nested.stderr
+++ b/src/test/ui/imports/bad-import-in-nested.stderr
@@ -1,0 +1,9 @@
+error[E0432]: unresolved import `crate::C::AA`
+  --> $DIR/bad-import-in-nested.rs:10:26
+   |
+LL |     use crate::C::{self, AA};
+   |                          ^^ no `AA` in `C`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0432`.

--- a/src/test/ui/imports/bad-import-with-rename.rs
+++ b/src/test/ui/imports/bad-import-with-rename.rs
@@ -1,0 +1,16 @@
+mod A {
+    pub type B = ();
+    pub type B2 = ();
+}
+
+mod C {
+    use crate::D::B as _;
+    //~^ ERROR unresolved import `crate::D::B`
+
+    use crate::D::B2;
+    //~^ ERROR unresolved import `crate::D::B2`
+}
+
+mod D {}
+
+fn main() {}

--- a/src/test/ui/imports/bad-import-with-rename.stderr
+++ b/src/test/ui/imports/bad-import-with-rename.stderr
@@ -1,0 +1,25 @@
+error[E0432]: unresolved import `crate::D::B`
+  --> $DIR/bad-import-with-rename.rs:7:9
+   |
+LL |     use crate::D::B as _;
+   |         ^^^^^^^^^^^^^^^^ no `B` in `D`
+   |
+help: consider importing this type alias instead
+   |
+LL |     use A::B as _;
+   |         ~~~~~~~~~~
+
+error[E0432]: unresolved import `crate::D::B2`
+  --> $DIR/bad-import-with-rename.rs:10:9
+   |
+LL |     use crate::D::B2;
+   |         ^^^^^^^^^^^^ no `B2` in `D`
+   |
+help: consider importing this type alias instead
+   |
+LL |     use A::B2;
+   |         ~~~~~~
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0432`.

--- a/src/test/ui/test-attrs/inaccessible-test-modules.stderr
+++ b/src/test/ui/test-attrs/inaccessible-test-modules.stderr
@@ -2,10 +2,7 @@ error[E0432]: unresolved import `main`
   --> $DIR/inaccessible-test-modules.rs:5:5
    |
 LL | use main as x;
-   |     ----^^^^^
-   |     |
-   |     no `main` in the root
-   |     help: a similar name exists in the module: `main`
+   |     ^^^^^^^^^ no `main` in the root
 
 error[E0432]: unresolved import `test`
   --> $DIR/inaccessible-test-modules.rs:6:5
@@ -13,10 +10,6 @@ error[E0432]: unresolved import `test`
 LL | use test as y;
    |     ^^^^^^^^^ no `test` in the root
    |
-help: a similar name exists in the module
-   |
-LL | use test as y;
-   |     ~~~~
 help: consider importing this module instead
    |
 LL | use test::test as y;

--- a/src/test/ui/test-attrs/inaccessible-test-modules.stderr
+++ b/src/test/ui/test-attrs/inaccessible-test-modules.stderr
@@ -19,8 +19,8 @@ LL | use test as y;
    |     ~~~~
 help: consider importing this module instead
    |
-LL | use test::test;
-   |     ~~~~~~~~~~~
+LL | use test::test as y;
+   |     ~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes #105566
Fixes #105373

Ideally, we'd find some way to turn these into structured suggestions -- perhaps on a separate line as a different `use` statement, but I have no idea how to access the span for the whole `use` from this point in the import resolution code.