### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,22 +20,23 @@ Read ["Installation"] from [The Book].
 The Rust build system uses a Python script called `x.py` to build the compiler,
 which manages the bootstrapping process. It lives at the root of the project.
 
-The `x.py` command can be run directly on most systems in the following format:
+The `x.py` command can be run directly on most Unix systems in the following format:
 
 ```sh
 ./x.py <subcommand> [flags]
 ```
 
-This is how the documentation and examples assume you are running `x.py`.
-
-Systems such as Ubuntu 20.04 LTS do not create the necessary `python` command by default when Python is installed that allows `x.py` to be run directly. In that case, you can either create a symlink for `python` (Ubuntu provides the `python-is-python3` package for this), or run `x.py` using Python itself:
+This is how the documentation and examples assume you are running `x.py`. Some alternative ways are:
 
 ```sh
-# Python 3
-python3 x.py <subcommand> [flags]
+# On a Unix shell if you don't have the necessary `python3` command
+./x <subcommand> [flags]
 
-# Python 2.7
-python2.7 x.py <subcommand> [flags]
+# On the Windows Command Prompt (if .py files are configured to run Python)
+x.py <subcommand> [flags]
+
+# You can also run Python yourself, e.g.:
+python x.py <subcommand> [flags]
 ```
 
 More information about `x.py` can be found

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -392,7 +392,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ),
                     match &args[..] {
                         [] => (base.span.shrink_to_hi().with_hi(deref.span.hi()), ")".to_string()),
-                        [first, ..] => (base.span.until(first.span), String::new()),
+                        [first, ..] => (base.span.between(first.span), ", ".to_string()),
                     },
                 ]
             })

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -31,7 +31,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr_ty: Ty<'tcx>,
         expected: Ty<'tcx>,
         expected_ty_expr: Option<&'tcx hir::Expr<'tcx>>,
-        _error: Option<TypeError<'tcx>>,
+        error: Option<TypeError<'tcx>>,
     ) {
         if expr_ty == expected {
             return;

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -322,6 +322,38 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         )
     }
 
+    #[instrument(level = "debug", skip(self))]
+    pub fn probe_for_name_many(
+        &self,
+        mode: Mode,
+        item_name: Ident,
+        is_suggestion: IsSuggestion,
+        self_ty: Ty<'tcx>,
+        scope_expr_id: hir::HirId,
+        scope: ProbeScope,
+    ) -> Vec<ty::AssocItem> {
+        self.probe_op(
+            item_name.span,
+            mode,
+            Some(item_name),
+            None,
+            is_suggestion,
+            self_ty,
+            scope_expr_id,
+            scope,
+            |probe_cx| {
+                Ok(probe_cx
+                    .inherent_candidates
+                    .iter()
+                    .chain(&probe_cx.extension_candidates)
+                    // .filter(|candidate| candidate_filter(&candidate.item))
+                    .map(|candidate| candidate.item)
+                    .collect())
+            },
+        )
+        .unwrap()
+    }
+
     fn probe_op<OP, R>(
         &'a self,
         span: Span,

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1138,6 +1138,7 @@ impl UnusedDelimLint for UnusedBraces {
                             && !cx.sess().source_map().is_multiline(value.span)
                             && value.attrs.is_empty()
                             && !value.span.from_expansion()
+                            && !inner.span.from_expansion()
                         {
                             self.emit_unused_delims_expr(cx, value, ctx, left_pos, right_pos)
                         }

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -45,14 +45,6 @@ fi
 ci_dir=`cd $(dirname $0) && pwd`
 source "$ci_dir/shared.sh"
 
-if command -v python > /dev/null; then
-    PYTHON="python"
-elif command -v python3 > /dev/null; then
-    PYTHON="python3"
-else
-    PYTHON="python2"
-fi
-
 if ! isCI || isCiBranch auto || isCiBranch beta || isCiBranch try || isCiBranch try-perf; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.print-step-timings --enable-verbose-tests"
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.metrics"
@@ -201,7 +193,7 @@ if [ "$RUN_CHECK_WITH_PARALLEL_QUERIES" != "" ]; then
     mv metrics.json build
   fi
 
-  CARGO_INCREMENTAL=0 $PYTHON ../x.py check
+  CARGO_INCREMENTAL=0 ../x check
 fi
 
 sccache --show-stats || true

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -183,11 +183,7 @@ individually rather than as a group) */
 /* FIXME: these rules should be at the bottom of the file but currently must be
 above the `@media (max-width: 700px)` rules due to a bug in the css checker */
 /* see https://github.com/rust-lang/rust/pull/71237#issuecomment-618170143 */
-pre.rust .lifetime {}
-pre.rust .kw {}
 #search-tabs > button:hover, #search-tabs > button.selected {}
-pre.rust .self, pre.rust .bool-val, pre.rust .prelude-val, pre.rust .attribute {}
-pre.rust .kw-2, pre.rust .prelude-ty {}
 
 #settings-menu > a img {
 	filter: invert(100);

--- a/src/test/ui/lint/unused_braces_macro.rs
+++ b/src/test/ui/lint/unused_braces_macro.rs
@@ -1,0 +1,6 @@
+// build-pass
+pub fn foo<const BAR: bool> () {}
+
+fn main() {
+    foo::<{cfg!(feature = "foo")}>();
+}

--- a/src/test/ui/suggestions/shadowed-lplace-method-2.rs
+++ b/src/test/ui/suggestions/shadowed-lplace-method-2.rs
@@ -1,0 +1,23 @@
+#![allow(unused)]
+
+struct X {
+    x: (),
+}
+pub trait A {
+    fn foo(&mut self, _: usize) -> &mut ();
+}
+impl A for X {
+    fn foo(&mut self, _: usize) -> &mut () {
+        &mut self.x
+    }
+}
+impl X {
+    fn foo(&mut self, _: usize) -> &mut Self {
+        self
+    }
+}
+
+fn main() {
+    let mut x = X { x: () };
+    *x.foo(0) = (); //~ ERROR E0308
+}

--- a/src/test/ui/suggestions/shadowed-lplace-method-2.stderr
+++ b/src/test/ui/suggestions/shadowed-lplace-method-2.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/shadowed-lplace-method-2.rs:22:17
+   |
+LL |     *x.foo(0) = ();
+   |     ---------   ^^ expected struct `X`, found `()`
+   |     |
+   |     expected due to the type of this binding
+   |
+note: the `foo` call is resolved to the method in `X`, shadowing the method of the same name on trait `A`
+  --> $DIR/shadowed-lplace-method-2.rs:22:8
+   |
+LL |     *x.foo(0) = ();
+   |        ^^^ refers to `X::foo`
+help: you might have meant to call the other method; you can use the fully-qualified path to call it explicitly
+   |
+LL |     *<_ as A>::foo(&mut x, 0) = ();
+   |      ++++++++++++++++++  ~
+help: try wrapping the expression in `X`
+   |
+LL |     *x.foo(0) = X { x: () };
+   |                 ++++++    +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/shadowed-lplace-method.fixed
+++ b/src/test/ui/suggestions/shadowed-lplace-method.fixed
@@ -1,0 +1,10 @@
+// run-rustfix
+#![allow(unused_imports)]
+use std::borrow::BorrowMut;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+fn main() {
+    let rc = Rc::new(RefCell::new(true));
+    *std::cell::RefCell::<_>::borrow_mut(&rc) = false; //~ ERROR E0308
+}

--- a/src/test/ui/suggestions/shadowed-lplace-method.rs
+++ b/src/test/ui/suggestions/shadowed-lplace-method.rs
@@ -1,0 +1,10 @@
+// run-rustfix
+#![allow(unused_imports)]
+use std::borrow::BorrowMut;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+fn main() {
+    let rc = Rc::new(RefCell::new(true));
+    *rc.borrow_mut() = false; //~ ERROR E0308
+}

--- a/src/test/ui/suggestions/shadowed-lplace-method.stderr
+++ b/src/test/ui/suggestions/shadowed-lplace-method.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/shadowed-lplace-method.rs:9:24
+   |
+LL |     *rc.borrow_mut() = false;
+   |     ----------------   ^^^^^ expected struct `Rc`, found `bool`
+   |     |
+   |     expected due to the type of this binding
+   |
+   = note: expected struct `Rc<RefCell<bool>>`
+                found type `bool`
+note: there are multiple methods with the same name, `borrow_mut` refers to `std::borrow::BorrowMut::borrow_mut` in the method call
+  --> $DIR/shadowed-lplace-method.rs:9:9
+   |
+LL |     *rc.borrow_mut() = false;
+   |         ^^^^^^^^^^ refers to `std::borrow::BorrowMut::borrow_mut`
+help: you might have meant to invoke a different method, you can use the fully-qualified path
+   |
+LL |     *std::cell::RefCell::<_>::borrow_mut(&rc) = false;
+   |      +++++++++++++++++++++++++++++++++++++  ~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/shadowed-lplace-method.stderr
+++ b/src/test/ui/suggestions/shadowed-lplace-method.stderr
@@ -8,12 +8,15 @@ LL |     *rc.borrow_mut() = false;
    |
    = note: expected struct `Rc<RefCell<bool>>`
                 found type `bool`
-note: there are multiple methods with the same name, `borrow_mut` refers to `std::borrow::BorrowMut::borrow_mut` in the method call
+note: the `borrow_mut` call is resolved to the method in `std::borrow::BorrowMut`, shadowing the method of the same name on the inherent impl for `std::cell::RefCell<T>`
   --> $DIR/shadowed-lplace-method.rs:9:9
    |
+LL | use std::borrow::BorrowMut;
+   |     ---------------------- `std::borrow::BorrowMut` imported here
+...
 LL |     *rc.borrow_mut() = false;
    |         ^^^^^^^^^^ refers to `std::borrow::BorrowMut::borrow_mut`
-help: you might have meant to invoke a different method, you can use the fully-qualified path
+help: you might have meant to call the other method; you can use the fully-qualified path to call it explicitly
    |
 LL |     *std::cell::RefCell::<_>::borrow_mut(&rc) = false;
    |      +++++++++++++++++++++++++++++++++++++  ~


### PR DESCRIPTION
Successful merges:

 - #105515 (Account for macros in const generics)
 - #106146 (Readme: update section on how to run `x.py`)
 - #106150 (Detect when method call on LHS might be shadowed)
 - #106174 (Remove unused empty CSS rules in ayu theme)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=105515,106146,106150,106174)
<!-- homu-ignore:end -->