### PR TITLE
Fix a formatting error in Iterator::for_each docs

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -803,7 +803,7 @@ pub trait Iterator {
     /// (0..5).map(|x| x * 2 + 1)
     ///       .for_each(move |x| tx.send(x).unwrap());
     ///
-    /// let v: Vec<_> =  rx.iter().collect();
+    /// let v: Vec<_> = rx.iter().collect();
     /// assert_eq!(v, vec![1, 3, 5, 7, 9]);
     /// ```
     ///


### PR DESCRIPTION
There is a formatting error (extra space in an assignment) in the documentation of `core::iter::Iterator::for_each`, which I have fixed in this pull request.