### PR TITLE
Fix doc comment parsing description in book

### DIFF
--- a/src/doc/rustdoc/src/write-documentation/the-doc-attribute.md
+++ b/src/doc/rustdoc/src/write-documentation/the-doc-attribute.md
@@ -9,11 +9,11 @@ are the same:
 
 ```rust,no_run
 /// This is a doc comment.
-#[doc = " This is a doc comment."]
+#[doc = r" This is a doc comment."]
 # fn f() {}
 ```
 
-(Note the leading space in the attribute version.)
+(Note the leading space and the raw string literal in the attribute version.)
 
 In most cases, `///` is easier to use than `#[doc]`. One case where the latter is easier is
 when generating documentation in macros; the `collapse-docs` pass will combine multiple


### PR DESCRIPTION
This can actually make a difference for the user if they rely on unicode formating.

Prompted by https://github.com/dtolnay/syn/issues/771