### PR TITLE
Update the documentation of `Vec` to use `extend(array)` instead of `extend(array.iter().copied())`

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -166,7 +166,7 @@ mod spec_extend;
 /// vec[0] = 7;
 /// assert_eq!(vec[0], 7);
 ///
-/// vec.extend([1, 2, 3].iter().copied());
+/// vec.extend([1, 2, 3]);
 ///
 /// for x in &vec {
 ///     println!("{x}");


### PR DESCRIPTION
Another option is to use `extend_from_slice()` (that may be faster), but I find this approach cleaner.