### PR TITLE
Account for multiple multiline spans with empty padding

### DIFF
--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.stderr
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.stderr
@@ -3,10 +3,7 @@ error[E0308]: mismatched types
    |
 LL |    #[alloc_error_handler]
    |    ---------------------- in this procedural macro expansion
-LL |    fn oom(
-   |  __^
-   | | _|
-   | ||
+LL | // fn oom(
 LL | ||     info: &Layout,
 LL | || ) -> ()
    | ||_______- arguments to this function are incorrect
@@ -29,10 +26,7 @@ error[E0308]: mismatched types
    |
 LL |    #[alloc_error_handler]
    |    ---------------------- in this procedural macro expansion
-LL |    fn oom(
-   |  __^
-   | | _|
-   | ||
+LL | // fn oom(
 LL | ||     info: &Layout,
 LL | || ) -> ()
    | ||_______^ expected `!`, found `()`

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.stderr
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.stderr
@@ -3,10 +3,7 @@ error[E0308]: mismatched types
    |
 LL |    #[alloc_error_handler]
    |    ---------------------- in this procedural macro expansion
-LL |    fn oom(
-   |  __^
-   | | _|
-   | ||
+LL | // fn oom(
 LL | ||     info: Layout,
 LL | || ) {
    | ||_- arguments to this function are incorrect
@@ -36,10 +33,7 @@ error[E0308]: mismatched types
    |
 LL |    #[alloc_error_handler]
    |    ---------------------- in this procedural macro expansion
-LL |    fn oom(
-   |  __^
-   | | _|
-   | ||
+LL | // fn oom(
 LL | ||     info: Layout,
 LL | || ) {
    | ||_^ expected `!`, found `()`

--- a/src/test/ui/asm/aarch64/interpolated-idents.stderr
+++ b/src/test/ui/asm/aarch64/interpolated-idents.stderr
@@ -30,12 +30,7 @@ error: asm outputs are not allowed with the `noreturn` option
 LL |               asm!("", $in(x) x, $out(x) x, $lateout(x) x, $inout(x) x, $inlateout(x) x,
    |                                  ^^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^^^^
 ...
-LL |       m!(in out lateout inout inlateout const sym
-   |  _____-
-   | |_____|
-   | |_____|
-   | |_____|
-   | |
+LL | /     m!(in out lateout inout inlateout const sym
 LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack options);
    | |                                -

--- a/src/test/ui/asm/x86_64/interpolated-idents.stderr
+++ b/src/test/ui/asm/x86_64/interpolated-idents.stderr
@@ -30,12 +30,7 @@ error: asm outputs are not allowed with the `noreturn` option
 LL |               asm!("", $in(x) x, $out(x) x, $lateout(x) x, $inout(x) x, $inlateout(x) x,
    |                                  ^^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^^^^
 ...
-LL |       m!(in out lateout inout inlateout const sym
-   |  _____-
-   | |_____|
-   | |_____|
-   | |_____|
-   | |
+LL | /     m!(in out lateout inout inlateout const sym
 LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack att_syntax options);
    | |                                           -

--- a/src/test/ui/issues/issue-13497-2.stderr
+++ b/src/test/ui/issues/issue-13497-2.stderr
@@ -1,10 +1,7 @@
 error[E0515]: cannot return value referencing local variable `rawLines`
   --> $DIR/issue-13497-2.rs:3:5
    |
-LL |        rawLines
-   |  ______^
-   | | _____|
-   | ||
+LL | //     rawLines
 LL | ||         .iter().map(|l| l.trim()).collect()
    | ||_______________-___________________________^ returns a value referencing data owned by the current function
    |  |_______________|

--- a/src/test/ui/suggestions/issue-99240-2.stderr
+++ b/src/test/ui/suggestions/issue-99240-2.stderr
@@ -4,10 +4,7 @@ error[E0618]: expected function, found enum variant `Alias::Unit`
 LL |        Unit,
    |        ---- enum variant `Alias::Unit` defined here
 ...
-LL |        Alias::
-   |  ______^
-   | | _____|
-   | ||
+LL | //     Alias::
 LL | ||     Unit();
    | ||________^_- call expression requires function
    |  |________|

--- a/src/tools/clippy/tests/ui/async_yields_async.stderr
+++ b/src/tools/clippy/tests/ui/async_yields_async.stderr
@@ -3,8 +3,7 @@ error: an async construct yields a type which is itself awaitable
    |
 LL |        let _h = async {
    |  _____________________-
-LL | |          async {
-   | | _________^
+LL | |/         async {
 LL | ||             3
 LL | ||         }
    | ||_________^ awaitable value not awaited
@@ -37,8 +36,7 @@ error: an async construct yields a type which is itself awaitable
    |
 LL |        let _j = async || {
    |  ________________________-
-LL | |          async {
-   | | _________^
+LL | |/         async {
 LL | ||             3
 LL | ||         }
    | ||_________^ awaitable value not awaited

--- a/src/tools/clippy/tests/ui/result_map_unit_fn_unfixable.stderr
+++ b/src/tools/clippy/tests/ui/result_map_unit_fn_unfixable.stderr
@@ -19,10 +19,7 @@ LL |     x.field.map(|value| if value > 0 { do_nothing(value); do_nothing(value)
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_unfixable.rs:29:5
    |
-LL |        x.field.map(|value| {
-   |  ______^
-   | | _____|
-   | ||
+LL | //     x.field.map(|value| {
 LL | ||         do_nothing(value);
 LL | ||         do_nothing(value)
 LL | ||     });


### PR DESCRIPTION
Instead of

```
LL |    fn oom(
   |  __^
   | | _|
   | ||
LL | || ) {
   | ||_-
LL | |  }
   | |__^
```

emit

```
LL | // fn oom(
LL | || ) {
   | ||_-
LL | |  }
   | |__^
   ```