### PR TITLE
Verify that spans point to char boundaries

### DIFF
--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -142,10 +142,11 @@ pub fn set_session_globals_then<R>(session_globals: &SessionGlobals, f: impl FnO
     SESSION_GLOBALS.set(session_globals, f)
 }
 
-pub fn create_session_if_not_set_then<R, F>(edition: Edition, f: F) -> R
-where
-    F: FnOnce(&SessionGlobals) -> R,
-{
+
+pub fn create_session_if_not_set_then<R>(
+    edition: Edition,
+    f: impl FnOnce(&SessionGlobals) -> R,
+) -> R {
     if !SESSION_GLOBALS.is_set() {
         let session_globals = SessionGlobals::new(edition);
         SESSION_GLOBALS.set(&session_globals, || SESSION_GLOBALS.with(f))
@@ -160,7 +161,14 @@ where
 {
     SESSION_GLOBALS.with(f)
 }
+pub struct NotSet;
 
+#[inline]
+pub fn try_with_session_globals<R>(f: impl FnOnce(&SessionGlobals) -> R) -> Result<R, NotSet> {
+    if SESSION_GLOBALS.is_set() { Ok(SESSION_GLOBALS.with(f)) } else { Err(NotSet) }
+}
+
+#[inline]
 pub fn create_default_session_globals_then<R>(f: impl FnOnce() -> R) -> R {
     create_session_globals_then(edition::DEFAULT_EDITION, f)
 }

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -142,7 +142,6 @@ pub fn set_session_globals_then<R>(session_globals: &SessionGlobals, f: impl FnO
     SESSION_GLOBALS.set(session_globals, f)
 }
 
-
 pub fn create_session_if_not_set_then<R>(
     edition: Edition,
     f: impl FnOnce(&SessionGlobals) -> R,

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -824,7 +824,12 @@ impl SourceMap {
     }
 
     /// Returns a new span representing just the first character of the given span.
+    /// When the span is empty, the same empty span is returned.
     pub fn start_point(&self, sp: Span) -> Span {
+        if sp.is_empty() {
+            return sp;
+        }
+
         let width = {
             let sp = sp.data();
             let local_begin = self.lookup_byte_offset(sp.lo);


### PR DESCRIPTION
This makes invalid spans a lot easier to debug. A quick and unscientific benchmarking test revealed that the performance impact of this is small at most.

I added this for debugging #106191

This PR also fixes a small bug that was found by the debug assertions.