### PR TITLE
Silence knock-down errors on `[type error]` bindings

### DIFF
--- a/src/test/ui/error-codes/E0033-teach.rs
+++ b/src/test/ui/error-codes/E0033-teach.rs
@@ -1,13 +1,13 @@
 // compile-flags: -Z teach
-
 trait SomeTrait {
-    fn foo(); //~ associated function `foo` has no `self` parameter
+    fn foo(&self);
 }
-
+struct S;
+impl SomeTrait for S {
+    fn foo(&self) {}
+}
 fn main() {
-    let trait_obj: &dyn SomeTrait = SomeTrait;
-    //~^ ERROR expected value, found trait `SomeTrait`
-    //~| ERROR E0038
+    let trait_obj: &dyn SomeTrait = &S;
 
     let &invalid = trait_obj;
     //~^ ERROR E0033

--- a/src/test/ui/error-codes/E0033-teach.stderr
+++ b/src/test/ui/error-codes/E0033-teach.stderr
@@ -1,31 +1,3 @@
-error[E0423]: expected value, found trait `SomeTrait`
-  --> $DIR/E0033-teach.rs:8:37
-   |
-LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
-   |                                     ^^^^^^^^^ not a value
-
-error[E0038]: the trait `SomeTrait` cannot be made into an object
-  --> $DIR/E0033-teach.rs:8:20
-   |
-LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
-   |                    ^^^^^^^^^^^^^^ `SomeTrait` cannot be made into an object
-   |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/E0033-teach.rs:4:8
-   |
-LL | trait SomeTrait {
-   |       --------- this trait cannot be made into an object...
-LL |     fn foo();
-   |        ^^^ ...because associated function `foo` has no `self` parameter
-help: consider turning `foo` into a method by giving it a `&self` argument
-   |
-LL |     fn foo(&self);
-   |            +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
-   |
-LL |     fn foo() where Self: Sized;
-   |              +++++++++++++++++
-
 error[E0033]: type `&dyn SomeTrait` cannot be dereferenced
   --> $DIR/E0033-teach.rs:12:9
    |
@@ -36,7 +8,6 @@ LL |     let &invalid = trait_obj;
            
            You can read more about trait objects in the Trait Objects section of the Reference: https://doc.rust-lang.org/reference/types.html#trait-objects
 
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0033, E0038, E0423.
-For more information about an error, try `rustc --explain E0033`.
+For more information about this error, try `rustc --explain E0033`.

--- a/src/test/ui/error-codes/E0033.rs
+++ b/src/test/ui/error-codes/E0033.rs
@@ -1,11 +1,12 @@
 trait SomeTrait {
-    fn foo(); //~ associated function `foo` has no `self` parameter
+    fn foo(&self);
 }
-
+struct S;
+impl SomeTrait for S {
+    fn foo(&self) {}
+}
 fn main() {
-    let trait_obj: &dyn SomeTrait = SomeTrait;
-    //~^ ERROR expected value, found trait `SomeTrait`
-    //~| ERROR E0038
+    let trait_obj: &dyn SomeTrait = &S;
 
     let &invalid = trait_obj;
     //~^ ERROR E0033

--- a/src/test/ui/error-codes/E0033.stderr
+++ b/src/test/ui/error-codes/E0033.stderr
@@ -1,38 +1,9 @@
-error[E0423]: expected value, found trait `SomeTrait`
-  --> $DIR/E0033.rs:6:37
-   |
-LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
-   |                                     ^^^^^^^^^ not a value
-
-error[E0038]: the trait `SomeTrait` cannot be made into an object
-  --> $DIR/E0033.rs:6:20
-   |
-LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
-   |                    ^^^^^^^^^^^^^^ `SomeTrait` cannot be made into an object
-   |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/E0033.rs:2:8
-   |
-LL | trait SomeTrait {
-   |       --------- this trait cannot be made into an object...
-LL |     fn foo();
-   |        ^^^ ...because associated function `foo` has no `self` parameter
-help: consider turning `foo` into a method by giving it a `&self` argument
-   |
-LL |     fn foo(&self);
-   |            +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
-   |
-LL |     fn foo() where Self: Sized;
-   |              +++++++++++++++++
-
 error[E0033]: type `&dyn SomeTrait` cannot be dereferenced
-  --> $DIR/E0033.rs:10:9
+  --> $DIR/E0033.rs:11:9
    |
 LL |     let &invalid = trait_obj;
    |         ^^^^^^^^ type `&dyn SomeTrait` cannot be dereferenced
 
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0033, E0038, E0423.
-For more information about an error, try `rustc --explain E0033`.
+For more information about this error, try `rustc --explain E0033`.

--- a/src/test/ui/lexer/lex-bad-char-literals-6.rs
+++ b/src/test/ui/lexer/lex-bad-char-literals-6.rs
@@ -7,10 +7,8 @@ fn main() {
     //~^ ERROR: character literal may only contain one codepoint
 
     if x == y {}
-    //~^ ERROR: can't compare `&str` with `char`
     if y == z {}  // no error here
     if x == z {}
-    //~^ ERROR: can't compare `&str` with `char`
 
     let a: usize = "";
     //~^ ERROR: mismatched types

--- a/src/test/ui/lexer/lex-bad-char-literals-6.stderr
+++ b/src/test/ui/lexer/lex-bad-char-literals-6.stderr
@@ -31,49 +31,14 @@ help: if you meant to write a `str` literal, use double quotes
 LL |     let z = "ef";
    |             ~~~~
 
-error[E0277]: can't compare `&str` with `char`
-  --> $DIR/lex-bad-char-literals-6.rs:9:10
-   |
-LL |     if x == y {}
-   |          ^^ no implementation for `&str == char`
-   |
-   = help: the trait `PartialEq<char>` is not implemented for `&str`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             <&'a str as PartialEq<OsString>>
-             <&'a str as PartialEq<String>>
-             <&'b str as PartialEq<Cow<'a, str>>>
-             <str as PartialEq<Cow<'a, str>>>
-             <str as PartialEq<OsStr>>
-             <str as PartialEq<OsString>>
-             <str as PartialEq<String>>
-             <str as PartialEq>
-
 error[E0308]: mismatched types
-  --> $DIR/lex-bad-char-literals-6.rs:15:20
+  --> $DIR/lex-bad-char-literals-6.rs:13:20
    |
 LL |     let a: usize = "";
    |            -----   ^^ expected `usize`, found `&str`
    |            |
    |            expected due to this
 
-error[E0277]: can't compare `&str` with `char`
-  --> $DIR/lex-bad-char-literals-6.rs:12:10
-   |
-LL |     if x == z {}
-   |          ^^ no implementation for `&str == char`
-   |
-   = help: the trait `PartialEq<char>` is not implemented for `&str`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             <&'a str as PartialEq<OsString>>
-             <&'a str as PartialEq<String>>
-             <&'b str as PartialEq<Cow<'a, str>>>
-             <str as PartialEq<Cow<'a, str>>>
-             <str as PartialEq<OsStr>>
-             <str as PartialEq<OsString>>
-             <str as PartialEq<String>>
-             <str as PartialEq>
+error: aborting due to 4 previous errors
 
-error: aborting due to 6 previous errors
-
-Some errors have detailed explanations: E0277, E0308.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/issue-104287.rs
+++ b/src/test/ui/suggestions/issue-104287.rs
@@ -1,9 +1,13 @@
 // The purpose of this test is not to validate the output of the compiler.
 // Instead, it ensures the suggestion is generated without performing an arithmetic overflow.
 
+struct S;
+impl S {
+    fn foo(&self) {}
+}
 fn main() {
-    let x = not_found; //~ ERROR cannot find value `not_found` in this scope
-    simd_gt::<()>(x);
+    let x = S;
+    foo::<()>(x);
     //~^ ERROR this associated function takes 0 generic arguments but 1 generic argument was supplied
-    //~| ERROR cannot find function `simd_gt` in this scope
+    //~| ERROR cannot find function `foo` in this scope
 }

--- a/src/test/ui/suggestions/issue-104287.stderr
+++ b/src/test/ui/suggestions/issue-104287.stderr
@@ -1,30 +1,30 @@
-error[E0425]: cannot find value `not_found` in this scope
-  --> $DIR/issue-104287.rs:5:13
-   |
-LL |     let x = not_found;
-   |             ^^^^^^^^^ not found in this scope
-
 error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/issue-104287.rs:6:5
+  --> $DIR/issue-104287.rs:10:5
    |
-LL |     simd_gt::<()>(x);
-   |     ^^^^^^^------ help: remove these generics
+LL |     foo::<()>(x);
+   |     ^^^------ help: remove these generics
    |     |
    |     expected 0 generic arguments
+   |
+note: associated function defined here, with 0 generic parameters
+  --> $DIR/issue-104287.rs:6:8
+   |
+LL |     fn foo(&self) {}
+   |        ^^^
 
-error[E0425]: cannot find function `simd_gt` in this scope
-  --> $DIR/issue-104287.rs:6:5
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/issue-104287.rs:10:5
    |
-LL |     simd_gt::<()>(x);
-   |     ^^^^^^^ not found in this scope
+LL |     foo::<()>(x);
+   |     ^^^ not found in this scope
    |
-help: use the `.` operator to call the method `SimdPartialOrd::simd_gt` on `[type error]`
+help: use the `.` operator to call the method `foo` on `&S`
    |
-LL -     simd_gt::<()>(x);
-LL +     x.simd_gt();
+LL -     foo::<()>(x);
+LL +     x.foo();
    |
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0107, E0425.
 For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/typeck/quiet-type-err-let-binding.rs
+++ b/src/test/ui/typeck/quiet-type-err-let-binding.rs
@@ -1,0 +1,17 @@
+// fn foo() -> String {
+//    String::new()
+// }
+
+fn test(s: &str) {
+    println!("{}", s);
+}
+
+fn test2(s: String) {
+    println!("{}", s);
+}
+
+fn main() {
+    let x = foo(); //~ERROR cannot find function `foo` in this scope
+    test(&x);
+    test2(x); // Does not complain about `x` being a `&str`.
+}

--- a/src/test/ui/typeck/quiet-type-err-let-binding.stderr
+++ b/src/test/ui/typeck/quiet-type-err-let-binding.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/quiet-type-err-let-binding.rs:14:13
+   |
+LL |     let x = foo();
+   |             ^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fix #56036, fix #76589.