### PR TITLE
Emit fewer errors on invalid `#[repr(transparent)]` on `enum`

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1060,10 +1060,8 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
 
     if adt.variants().len() != 1 {
         bad_variant_count(tcx, adt, tcx.def_span(adt.did()), adt.did());
-        if adt.variants().is_empty() {
-            // Don't bother checking the fields. No variants (and thus no fields) exist.
-            return;
-        }
+        // Don't bother checking the fields.
+        return;
     }
 
     // For each field, figure out if it's known to be a ZST and align(1), with "known"

--- a/src/test/ui/repr/transparent-enum-too-many-variants.rs
+++ b/src/test/ui/repr/transparent-enum-too-many-variants.rs
@@ -1,0 +1,10 @@
+use std::mem::size_of;
+
+#[repr(transparent)]
+enum Foo { //~ ERROR E0731
+    A(u8), B(u8),
+}
+
+fn main() {
+    println!("Foo: {}", size_of::<Foo>());
+}

--- a/src/test/ui/repr/transparent-enum-too-many-variants.stderr
+++ b/src/test/ui/repr/transparent-enum-too-many-variants.stderr
@@ -1,0 +1,11 @@
+error[E0731]: transparent enum needs exactly one variant, but has 2
+  --> $DIR/transparent-enum-too-many-variants.rs:4:1
+   |
+LL | enum Foo {
+   | ^^^^^^^^ needs exactly one variant, but has 2
+LL |     A(u8), B(u8),
+   |     -      - too many variants in `Foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0731`.


### PR DESCRIPTION
Fix #68420.