### PR TITLE
Make trait/impl `where` clause mismatch on region error a bit more actionable

### DIFF
--- a/src/test/ui/compare-method/region-extra-2.stderr
+++ b/src/test/ui/compare-method/region-extra-2.stderr
@@ -6,6 +6,11 @@ LL |     fn renew<'b: 'a>(self) -> &'b mut [T];
 ...
 LL |     fn renew<'b: 'a>(self) -> &'b mut [T] where 'a: 'b {
    |                                                     ^^ impl has extra requirement `'a: 'b`
+   |
+help: copy the `where` clause predicates from the trait
+   |
+LL |     fn renew<'b: 'a>(self) -> &'b mut [T] where 'b: 'a {
+   |                                           ~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/compare-method/region-extra.stderr
+++ b/src/test/ui/compare-method/region-extra.stderr
@@ -6,6 +6,12 @@ LL |     fn foo();
 ...
 LL |     fn foo() where 'a: 'b { }
    |                        ^^ impl has extra requirement `'a: 'b`
+   |
+help: remove the `where` clause
+   |
+LL -     fn foo() where 'a: 'b { }
+LL +     fn foo()  { }
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/impl_bounds.stderr
+++ b/src/test/ui/generic-associated-types/impl_bounds.stderr
@@ -15,6 +15,11 @@ LL |     type B<'a, 'b> where 'a: 'b;
 ...
 LL |     type B<'a, 'b> = (&'a(), &'b ()) where 'b: 'a;
    |                                                ^^ impl has extra requirement `'b: 'a`
+   |
+help: copy the `where` clause predicates from the trait
+   |
+LL |     type B<'a, 'b> = (&'a(), &'b ()) where 'a: 'b;
+   |                                      ~~~~~~~~~~~~
 
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/impl_bounds.rs:18:33

--- a/src/test/ui/generic-associated-types/issue-90014.stderr
+++ b/src/test/ui/generic-associated-types/issue-90014.stderr
@@ -5,13 +5,17 @@ LL |     type Fut<'a> where Self: 'a;
    |     ------------ definition of `Fut` from trait
 ...
 LL |     type Fut<'a> = impl Future<Output = ()>;
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^- help: try copying this clause from the trait: `where Self: 'a`
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: type must outlive the lifetime `'a` as defined here
   --> $DIR/issue-90014.rs:13:14
    |
 LL |     type Fut<'a> = impl Future<Output = ()>;
    |              ^^
+help: copy the `where` clause predicates from the trait
+   |
+LL |     type Fut<'a> = impl Future<Output = ()> where Self: 'a;
+   |                                             ++++++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-91883.stderr
+++ b/src/test/ui/generic-associated-types/issue-91883.stderr
@@ -5,7 +5,7 @@ LL |     type Cursor<'tx>: Cursor<'tx>
    |     ----------------------------- definition of `Cursor` from trait
 ...
 LL |     type Cursor<'tx> = CursorImpl<'tx>;
-   |                        ^^^^^^^^^^^^^^^- help: try copying these clauses from the trait: `where 'db: 'tx, Self: 'tx`
+   |                        ^^^^^^^^^^^^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'db` as defined here
   --> $DIR/issue-91883.rs:29:6
@@ -17,6 +17,10 @@ note: but lifetime parameter must outlive the lifetime `'tx` as defined here
    |
 LL |     type Cursor<'tx> = CursorImpl<'tx>;
    |                 ^^^
+help: copy the `where` clause predicates from the trait
+   |
+LL |     type Cursor<'tx> = CursorImpl<'tx> where 'db: 'tx, Self: 'tx;
+   |                                        +++++++++++++++++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-92033.stderr
+++ b/src/test/ui/generic-associated-types/issue-92033.stderr
@@ -5,13 +5,17 @@ LL |     type TextureIter<'a>: Iterator<Item = &'a Texture>
    |     -------------------------------------------------- definition of `TextureIter` from trait
 ...
 LL |     type TextureIter<'a> = std::option::IntoIter<&'a Texture>;
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- help: try copying this clause from the trait: `where Self: 'a`
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: type must outlive the lifetime `'a` as defined here
   --> $DIR/issue-92033.rs:20:22
    |
 LL |     type TextureIter<'a> = std::option::IntoIter<&'a Texture>;
    |                      ^^
+help: copy the `where` clause predicates from the trait
+   |
+LL |     type TextureIter<'a> = std::option::IntoIter<&'a Texture> where Self: 'a;
+   |                                                               ++++++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/mismatched-where-clause-regions.rs
+++ b/src/test/ui/generic-associated-types/mismatched-where-clause-regions.rs
@@ -1,0 +1,12 @@
+trait Foo {
+    type T<'a1, 'b1>
+    where
+        'a1: 'b1;
+}
+
+impl Foo for () {
+    type T<'a2, 'b2> = () where 'b2: 'a2;
+    //~^ ERROR impl has stricter requirements than trait
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/mismatched-where-clause-regions.stderr
+++ b/src/test/ui/generic-associated-types/mismatched-where-clause-regions.stderr
@@ -1,0 +1,17 @@
+error[E0276]: impl has stricter requirements than trait
+  --> $DIR/mismatched-where-clause-regions.rs:8:38
+   |
+LL |     type T<'a1, 'b1>
+   |     ---------------- definition of `T` from trait
+...
+LL |     type T<'a2, 'b2> = () where 'b2: 'a2;
+   |                                      ^^^ impl has extra requirement `'b2: 'a2`
+   |
+help: copy the `where` clause predicates from the trait
+   |
+LL |     type T<'a2, 'b2> = () where 'a2: 'b2;
+   |                           ~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0276`.

--- a/src/test/ui/generic-associated-types/missing-where-clause-on-trait.stderr
+++ b/src/test/ui/generic-associated-types/missing-where-clause-on-trait.stderr
@@ -6,6 +6,12 @@ LL |     type Assoc<'a, 'b>;
 ...
 LL |     type Assoc<'a, 'b> = () where 'a: 'b;
    |                                       ^^ impl has extra requirement `'a: 'b`
+   |
+help: remove the `where` clause
+   |
+LL -     type Assoc<'a, 'b> = () where 'a: 'b;
+LL +     type Assoc<'a, 'b> = () ;
+   |
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Improve `where` clause suggestions for GATs/methods that have incompatible region predicates in their `where` clauses.

Also addresses this diagnostic that went away https://github.com/rust-lang/rust/pull/106129#discussion_r1056875772