### PR TITLE
Miri: properly check return-position noalias

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1444,6 +1444,7 @@ impl Debug for Statement<'_> {
                 "Retag({}{:?})",
                 match kind {
                     RetagKind::FnEntry => "[fn entry] ",
+                    RetagKind::FnReturn => "[fn return] ",
                     RetagKind::TwoPhase => "[2phase] ",
                     RetagKind::Raw => "[raw] ",
                     RetagKind::Default => "",

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -323,7 +323,7 @@ pub enum StatementKind<'tcx> {
     /// For code that is not specific to stacked borrows, you should consider retags to read and
     /// modify the place in an opaque way.
     ///
-    /// Only `RetagKind::Default` and `RetagKind::FnEntry` are permitted.
+    /// Only `RetagKind::Default`, `RetagKind::FnEntry`, `RetagKind::FnReturn` are permitted.
     Retag(RetagKind, Box<Place<'tcx>>),
 
     /// Encodes a user's type ascription. These need to be preserved
@@ -412,6 +412,8 @@ impl std::fmt::Display for NonDivergingIntrinsic<'_> {
 pub enum RetagKind {
     /// The initial retag of arguments when entering a function.
     FnEntry,
+    /// The retag of a value that was just returned from another function.
+    FnReturn,
     /// Retag preparing for a two-phase borrow.
     TwoPhase,
     /// Retagging raw pointers.

--- a/compiler/rustc_mir_transform/src/add_retag.rs
+++ b/compiler/rustc_mir_transform/src/add_retag.rs
@@ -112,7 +112,7 @@ impl<'tcx> MirPass<'tcx> for AddRetag {
                 0,
                 Statement {
                     source_info,
-                    kind: StatementKind::Retag(RetagKind::Default, Box::new(dest_place)),
+                    kind: StatementKind::Retag(RetagKind::FnReturn, Box::new(dest_place)),
                 },
             );
         }

--- a/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
@@ -76,7 +76,7 @@ fn main() -> () {
     }
 
     bb1: {
-        Retag(_3);                       // scope 1 at $DIR/retag.rs:+3:17: +3:36
+        Retag([fn return] _3);           // scope 1 at $DIR/retag.rs:+3:17: +3:36
         StorageDead(_6);                 // scope 1 at $DIR/retag.rs:+3:35: +3:36
         StorageDead(_4);                 // scope 1 at $DIR/retag.rs:+3:35: +3:36
         StorageDead(_7);                 // scope 1 at $DIR/retag.rs:+3:36: +3:37
@@ -122,7 +122,7 @@ fn main() -> () {
     }
 
     bb3: {
-        Retag(_15);                      // scope 6 at $DIR/retag.rs:+15:14: +15:19
+        Retag([fn return] _15);          // scope 6 at $DIR/retag.rs:+15:14: +15:19
         StorageDead(_17);                // scope 6 at $DIR/retag.rs:+15:18: +15:19
         StorageDead(_16);                // scope 6 at $DIR/retag.rs:+15:18: +15:19
         StorageDead(_18);                // scope 6 at $DIR/retag.rs:+15:19: +15:20
@@ -148,7 +148,7 @@ fn main() -> () {
     }
 
     bb4: {
-        Retag(_19);                      // scope 7 at $DIR/retag.rs:+18:5: +18:24
+        Retag([fn return] _19);          // scope 7 at $DIR/retag.rs:+18:5: +18:24
         StorageDead(_22);                // scope 7 at $DIR/retag.rs:+18:23: +18:24
         StorageDead(_20);                // scope 7 at $DIR/retag.rs:+18:23: +18:24
         StorageDead(_23);                // scope 7 at $DIR/retag.rs:+18:24: +18:25

--- a/src/tools/miri/src/borrow_tracker/mod.rs
+++ b/src/tools/miri/src/borrow_tracker/mod.rs
@@ -87,7 +87,7 @@ pub struct GlobalStateInner {
     /// Table storing the "base" tag for each allocation.
     /// The base tag is the one used for the initial pointer.
     /// We need this in a separate table to handle cyclic statics.
-    pub base_ptr_tags: FxHashMap<AllocId, BorTag>,
+    base_ptr_tags: FxHashMap<AllocId, BorTag>,
     /// Next unused call ID (for protectors).
     pub next_call_id: CallId,
     /// All currently protected tags.

--- a/src/tools/miri/src/borrow_tracker/stacked_borrows/diagnostics.rs
+++ b/src/tools/miri/src/borrow_tracker/stacked_borrows/diagnostics.rs
@@ -193,7 +193,7 @@ struct RetagOp {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RetagCause {
     Normal,
-    FnReturn,
+    FnReturnPlace,
     FnEntry,
     TwoPhase,
 }
@@ -496,7 +496,7 @@ impl RetagCause {
         match self {
             RetagCause::Normal => "retag",
             RetagCause::FnEntry => "FnEntry retag",
-            RetagCause::FnReturn => "FnReturn retag",
+            RetagCause::FnReturnPlace => "return-place retag",
             RetagCause::TwoPhase => "two-phase retag",
         }
         .to_string()

--- a/src/tools/miri/src/borrow_tracker/stacked_borrows/diagnostics.rs
+++ b/src/tools/miri/src/borrow_tracker/stacked_borrows/diagnostics.rs
@@ -86,12 +86,7 @@ impl fmt::Display for InvalidationCause {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             InvalidationCause::Access(kind) => write!(f, "{kind}"),
-            InvalidationCause::Retag(perm, kind) =>
-                if *kind == RetagCause::FnEntry {
-                    write!(f, "{perm:?} FnEntry retag")
-                } else {
-                    write!(f, "{perm:?} retag")
-                },
+            InvalidationCause::Retag(perm, kind) => write!(f, "{perm:?} {retag}", retag = kind.summary()),
         }
     }
 }
@@ -192,6 +187,7 @@ struct RetagOp {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RetagCause {
     Normal,
+    Box,
     FnReturnPlace,
     FnEntry,
     TwoPhase,
@@ -490,6 +486,7 @@ impl RetagCause {
     fn summary(&self) -> String {
         match self {
             RetagCause::Normal => "retag",
+            RetagCause::Box => "Box retag",
             RetagCause::FnEntry => "FnEntry retag",
             RetagCause::FnReturnPlace => "return-place retag",
             RetagCause::TwoPhase => "two-phase retag",

--- a/src/tools/miri/src/borrow_tracker/stacked_borrows/diagnostics.rs
+++ b/src/tools/miri/src/borrow_tracker/stacked_borrows/diagnostics.rs
@@ -6,8 +6,7 @@ use rustc_span::{Span, SpanData};
 use rustc_target::abi::Size;
 
 use crate::borrow_tracker::{
-    stacked_borrows::{err_sb_ub, Permission},
-    AccessKind, GlobalStateInner, ProtectorKind,
+    stacked_borrows::{err_sb_ub, Permission}, AccessKind, GlobalStateInner,
 };
 use crate::*;
 
@@ -398,11 +397,7 @@ impl<'history, 'ecx, 'mir, 'tcx> DiagnosticCx<'history, 'ecx, 'mir, 'tcx> {
     }
 
     #[inline(never)] // This is only called on fatal code paths
-    pub(super) fn protector_error(&self, item: &Item, kind: ProtectorKind) -> InterpError<'tcx> {
-        let protected = match kind {
-            ProtectorKind::WeakProtector => "weakly protected",
-            ProtectorKind::StrongProtector => "strongly protected",
-        };
+    pub(super) fn protector_error(&self, item: &Item) -> InterpError<'tcx> {
         let call_id = self
             .machine
             .threads
@@ -417,7 +412,7 @@ impl<'history, 'ecx, 'mir, 'tcx> DiagnosticCx<'history, 'ecx, 'mir, 'tcx> {
         match self.operation {
             Operation::Dealloc(_) =>
                 err_sb_ub(
-                    format!("deallocating while item {item:?} is {protected} by call {call_id:?}",),
+                    format!("deallocating while item {item:?} is protected by call {call_id:?}",),
                     None,
                     None,
                 ),
@@ -425,7 +420,7 @@ impl<'history, 'ecx, 'mir, 'tcx> DiagnosticCx<'history, 'ecx, 'mir, 'tcx> {
             | Operation::Access(AccessOp { tag, .. }) =>
                 err_sb_ub(
                     format!(
-                        "not granting access to tag {tag:?} because that would remove {item:?} which is {protected} because it is an argument of call {call_id:?}",
+                        "not granting access to tag {tag:?} because that would remove {item:?} which is protected because it is an argument of call {call_id:?}",
                     ),
                     None,
                     tag.and_then(|tag| self.get_logs_relevant_to(tag, Some(item.tag()))),

--- a/src/tools/miri/src/borrow_tracker/stacked_borrows/mod.rs
+++ b/src/tools/miri/src/borrow_tracker/stacked_borrows/mod.rs
@@ -221,6 +221,7 @@ impl<'tcx> Stack {
         if !global.tracked_pointer_tags.is_empty() {
             dcx.check_tracked_tag_popped(item, global);
         }
+        dcx.log_invalidation(item.tag());
 
         if !item.protected() {
             return Ok(());
@@ -281,7 +282,6 @@ impl<'tcx> Stack {
             };
             self.pop_items_after(first_incompatible_idx, |item| {
                 Stack::item_invalidated(&item, global, dcx)?;
-                dcx.log_invalidation(item.tag());
                 Ok(())
             })?;
         } else {
@@ -302,7 +302,6 @@ impl<'tcx> Stack {
             };
             self.disable_uniques_starting_at(first_incompatible_idx, |item| {
                 Stack::item_invalidated(&item, global, dcx)?;
-                dcx.log_invalidation(item.tag());
                 Ok(())
             })?;
         }
@@ -928,7 +927,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                     access: Some(AccessKind::Write),
                     protector: false,
                 };
-                self.retag_ptr_inplace(place, new_perm, self.retag_cause)
+                self.retag_ptr_inplace(place, new_perm, RetagCause::Box)
             }
 
             fn visit_value(&mut self, place: &PlaceTy<'tcx, Provenance>) -> InterpResult<'tcx> {

--- a/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
   --> $DIR/aliasing_mut1.rs:LL:CC
    |
 LL | pub fn safe(_x: &mut i32, _y: &mut i32) {}
-   |                           ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+   |                           ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
   --> $DIR/aliasing_mut2.rs:LL:CC
    |
 LL | pub fn safe(_x: &i32, _y: &mut i32) {}
-   |                       ^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+   |                       ^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut4.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/aliasing_mut4.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
   --> $DIR/aliasing_mut4.rs:LL:CC
    |
 LL | pub fn safe(_x: &i32, _y: &mut Cell<i32>) {}
-   |                       ^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+   |                       ^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/box_noalias_violation.rs
+++ b/src/tools/miri/tests/fail/stacked_borrows/box_noalias_violation.rs
@@ -2,13 +2,15 @@ unsafe fn test(mut x: Box<i32>, y: *const i32) -> i32 {
     // We will call this in a way that x and y alias.
     *x = 5;
     std::mem::forget(x);
-    *y //~ERROR: weakly protected
+    *y //~ERROR: does not exist in the borrow stack
 }
 
 fn main() {
     unsafe {
         let mut v = 42;
         let ptr = &mut v as *mut i32;
-        test(Box::from_raw(ptr), ptr);
+        let b = Box::from_raw(ptr);
+        let ptr = &*b as *const i32;
+        test(b, ptr);
     }
 }

--- a/src/tools/miri/tests/fail/stacked_borrows/box_noalias_violation.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/box_noalias_violation.stderr
@@ -14,7 +14,7 @@ help: <TAG> was created by a SharedReadOnly retag at offsets [0x0..0x4]
    |
 LL |         let ptr = &*b as *const i32;
    |                   ^^^
-help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique retag
+help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique Box retag
   --> $DIR/box_noalias_violation.rs:LL:CC
    |
 LL |         test(b, ptr);

--- a/src/tools/miri/tests/fail/stacked_borrows/box_noalias_violation.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/box_noalias_violation.stderr
@@ -1,28 +1,31 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is weakly protected because it is an argument of call ID
+error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/box_noalias_violation.rs:LL:CC
    |
 LL |     *y
-   |     ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is weakly protected because it is an argument of call ID
+   |     ^^
+   |     |
+   |     attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |     this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-help: <TAG> was created by a SharedReadWrite retag at offsets [0x0..0x4]
+help: <TAG> was created by a SharedReadOnly retag at offsets [0x0..0x4]
   --> $DIR/box_noalias_violation.rs:LL:CC
    |
-LL |         let ptr = &mut v as *mut i32;
-   |                   ^^^^^^
-help: <TAG> is this argument
+LL |         let ptr = &*b as *const i32;
+   |                   ^^^
+help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique retag
   --> $DIR/box_noalias_violation.rs:LL:CC
    |
-LL | unsafe fn test(mut x: Box<i32>, y: *const i32) -> i32 {
-   |                ^^^^^
+LL |         test(b, ptr);
+   |              ^
    = note: BACKTRACE (of the first span):
    = note: inside `test` at $DIR/box_noalias_violation.rs:LL:CC
 note: inside `main`
   --> $DIR/box_noalias_violation.rs:LL:CC
    |
-LL |         test(Box::from_raw(ptr), ptr);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         test(b, ptr);
+   |         ^^^^^^^^^^^^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.rs
+++ b/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.rs
@@ -1,4 +1,5 @@
 //@error-pattern: /deallocating while item \[Unique for .*\] is strongly protected/
+use std::alloc::{dealloc, Layout};
 
 fn inner(x: &mut i32, f: fn(&mut i32)) {
     // `f` may mutate, but it may not deallocate!
@@ -7,7 +8,7 @@ fn inner(x: &mut i32, f: fn(&mut i32)) {
 
 fn main() {
     inner(Box::leak(Box::new(0)), |x| {
-        let raw = x as *mut _;
-        drop(unsafe { Box::from_raw(raw) });
+        let raw = x as *mut i32 as *mut u8;
+        drop(unsafe { dealloc(raw, Layout::new::<i32>()) });
     });
 }

--- a/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.rs
+++ b/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.rs
@@ -1,4 +1,4 @@
-//@error-pattern: /deallocating while item \[Unique for .*\] is strongly protected/
+//@error-pattern: /deallocating while item \[Unique for .*\] is protected/
 use std::alloc::{dealloc, Layout};
 
 fn inner(x: &mut i32, f: fn(&mut i32)) {

--- a/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
@@ -8,15 +8,11 @@ LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
    = note: BACKTRACE:
    = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `<std::alloc::Global as std::alloc::Allocator>::deallocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `alloc::alloc::box_free::<i32, std::alloc::Global>` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `std::ptr::drop_in_place::<std::boxed::Box<i32>> - shim(Some(std::boxed::Box<i32>))` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-   = note: inside `std::mem::drop::<std::boxed::Box<i32>>` at RUSTLIB/core/src/mem/mod.rs:LL:CC
 note: inside closure
   --> $DIR/deallocate_against_protector1.rs:LL:CC
    |
-LL |         drop(unsafe { Box::from_raw(raw) });
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         drop(unsafe { dealloc(raw, Layout::new::<i32>()) });
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: inside `<[closure@$DIR/deallocate_against_protector1.rs:LL:CC] as std::ops::FnOnce<(&mut i32,)>>::call_once - shim` at RUSTLIB/core/src/ops/function.rs:LL:CC
 note: inside `inner`
   --> $DIR/deallocate_against_protector1.rs:LL:CC
@@ -27,8 +23,8 @@ note: inside `main`
   --> $DIR/deallocate_against_protector1.rs:LL:CC
    |
 LL | /     inner(Box::leak(Box::new(0)), |x| {
-LL | |         let raw = x as *mut _;
-LL | |         drop(unsafe { Box::from_raw(raw) });
+LL | |         let raw = x as *mut i32 as *mut u8;
+LL | |         drop(unsafe { dealloc(raw, Layout::new::<i32>()) });
 LL | |     });
    | |______^
 

--- a/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: deallocating while item [Unique for <TAG>] is strongly protected by call ID
+error: Undefined Behavior: deallocating while item [Unique for <TAG>] is protected by call ID
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item [Unique for <TAG>] is strongly protected by call ID
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item [Unique for <TAG>] is protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector2.rs
+++ b/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector2.rs
@@ -1,4 +1,4 @@
-//@error-pattern: /deallocating while item \[SharedReadWrite for .*\] is strongly protected/
+//@error-pattern: /deallocating while item \[SharedReadWrite for .*\] is protected/
 use std::alloc::{dealloc, Layout};
 use std::marker::PhantomPinned;
 

--- a/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector2.rs
+++ b/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector2.rs
@@ -1,4 +1,5 @@
 //@error-pattern: /deallocating while item \[SharedReadWrite for .*\] is strongly protected/
+use std::alloc::{dealloc, Layout};
 use std::marker::PhantomPinned;
 
 pub struct NotUnpin(i32, PhantomPinned);
@@ -10,7 +11,7 @@ fn inner(x: &mut NotUnpin, f: fn(&mut NotUnpin)) {
 
 fn main() {
     inner(Box::leak(Box::new(NotUnpin(0, PhantomPinned))), |x| {
-        let raw = x as *mut _;
-        drop(unsafe { Box::from_raw(raw) });
+        let raw = x as *mut NotUnpin as *mut u8;
+        drop(unsafe { dealloc(raw, Layout::new::<NotUnpin>()) });
     });
 }

--- a/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector2.stderr
@@ -8,15 +8,11 @@ LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
    = note: BACKTRACE:
    = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `<std::alloc::Global as std::alloc::Allocator>::deallocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `alloc::alloc::box_free::<NotUnpin, std::alloc::Global>` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `std::ptr::drop_in_place::<std::boxed::Box<NotUnpin>> - shim(Some(std::boxed::Box<NotUnpin>))` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-   = note: inside `std::mem::drop::<std::boxed::Box<NotUnpin>>` at RUSTLIB/core/src/mem/mod.rs:LL:CC
 note: inside closure
   --> $DIR/deallocate_against_protector2.rs:LL:CC
    |
-LL |         drop(unsafe { Box::from_raw(raw) });
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         drop(unsafe { dealloc(raw, Layout::new::<NotUnpin>()) });
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: inside `<[closure@$DIR/deallocate_against_protector2.rs:LL:CC] as std::ops::FnOnce<(&mut NotUnpin,)>>::call_once - shim` at RUSTLIB/core/src/ops/function.rs:LL:CC
 note: inside `inner`
   --> $DIR/deallocate_against_protector2.rs:LL:CC
@@ -27,8 +23,8 @@ note: inside `main`
   --> $DIR/deallocate_against_protector2.rs:LL:CC
    |
 LL | /     inner(Box::leak(Box::new(NotUnpin(0, PhantomPinned))), |x| {
-LL | |         let raw = x as *mut _;
-LL | |         drop(unsafe { Box::from_raw(raw) });
+LL | |         let raw = x as *mut NotUnpin as *mut u8;
+LL | |         drop(unsafe { dealloc(raw, Layout::new::<NotUnpin>()) });
 LL | |     });
    | |______^
 

--- a/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: deallocating while item [SharedReadWrite for <TAG>] is strongly protected by call ID
+error: Undefined Behavior: deallocating while item [SharedReadWrite for <TAG>] is protected by call ID
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item [SharedReadWrite for <TAG>] is strongly protected by call ID
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item [SharedReadWrite for <TAG>] is protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/drop_in_place_protector.rs
+++ b/src/tools/miri/tests/fail/stacked_borrows/drop_in_place_protector.rs
@@ -10,7 +10,7 @@ impl Drop for HasDrop {
     fn drop(&mut self) {
         unsafe {
             let _val = *P;
-            //~^ ERROR: /not granting access .* because that would remove .* which is strongly protected/
+            //~^ ERROR: /not granting access .* because that would remove .* which is protected/
         }
     }
 }

--- a/src/tools/miri/tests/fail/stacked_borrows/drop_in_place_protector.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/drop_in_place_protector.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
   --> $DIR/drop_in_place_protector.rs:LL:CC
    |
 LL |             let _val = *P;
-   |                        ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+   |                        ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_write6.rs
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_write6.rs
@@ -7,6 +7,6 @@ fn main() {
 fn foo(a: &mut u32, y: *mut u32) -> u32 {
     *a = 1;
     let _b = &*a;
-    unsafe { *y = 2 }; //~ ERROR: /not granting access .* because that would remove .* which is strongly protected/
+    unsafe { *y = 2 }; //~ ERROR: /not granting access .* because that would remove .* which is protected/
     return *a;
 }

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_write6.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_write6.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
   --> $DIR/illegal_write6.rs:LL:CC
    |
 LL |     unsafe { *y = 2 };
-   |              ^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+   |              ^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/invalidate_against_protector1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/invalidate_against_protector1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
   --> $DIR/invalidate_against_protector1.rs:LL:CC
    |
 LL |     let _val = unsafe { *x };
-   |                         ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+   |                         ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/invalidate_against_protector2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/invalidate_against_protector2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
   --> $DIR/invalidate_against_protector2.rs:LL:CC
    |
 LL |     unsafe { *x = 0 };
-   |              ^^^^^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+   |              ^^^^^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/invalidate_against_protector3.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/invalidate_against_protector3.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
   --> $DIR/invalidate_against_protector3.rs:LL:CC
    |
 LL |     unsafe { *x = 0 };
-   |              ^^^^^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
+   |              ^^^^^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/newtype_pair_retagging.rs
+++ b/src/tools/miri/tests/fail/stacked_borrows/newtype_pair_retagging.rs
@@ -1,4 +1,4 @@
-//@error-pattern: which is strongly protected
+//@error-pattern: which is protected
 struct Newtype<'a>(&'a mut i32, i32);
 
 fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {

--- a/src/tools/miri/tests/fail/stacked_borrows/newtype_pair_retagging.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/newtype_pair_retagging.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
 LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/newtype_retagging.rs
+++ b/src/tools/miri/tests/fail/stacked_borrows/newtype_retagging.rs
@@ -1,4 +1,4 @@
-//@error-pattern: which is strongly protected
+//@error-pattern: which is protected
 struct Newtype<'a>(&'a mut i32);
 
 fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {

--- a/src/tools/miri/tests/fail/stacked_borrows/newtype_retagging.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/newtype_retagging.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
 LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/return-noalias.rs
+++ b/src/tools/miri/tests/fail/stacked_borrows/return-noalias.rs
@@ -1,0 +1,11 @@
+fn id<T>(x: Box<T>) -> Box<T> { x }
+
+fn main() {
+    let mut m = 0;
+    let b = unsafe { Box::from_raw(&mut m) };
+    let mut b2 = id(b);
+    // Since `id` returns a `Box`, this should invalidate all other pointers to this memory.
+    *b2 = 5;
+    std::mem::forget(b2);
+    println!("{}", m); //~ERROR: tag does not exist in the borrow stack
+}

--- a/src/tools/miri/tests/fail/stacked_borrows/return-noalias.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/return-noalias.stderr
@@ -1,0 +1,24 @@
+error: Undefined Behavior: trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+  --> $DIR/return-noalias.rs:LL:CC
+   |
+LL |     println!("{}", m);
+   |                    ^
+   |                    |
+   |                    trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    this error occurs as part of retag at ALLOC[0x0..0x4]
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
+   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
+help: <TAG> was created here, as the base tag for ALLOC
+  --> $DIR/return-noalias.rs:LL:CC
+   |
+LL |     let b = unsafe { Box::from_raw(&mut m) };
+   |                                    ^^^^^^
+   = note: BACKTRACE (of the first span):
+   = note: inside `main` at $DIR/return-noalias.rs:LL:CC
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+

--- a/src/tools/miri/tests/fail/stacked_borrows/return-noalias.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/return-noalias.stderr
@@ -14,6 +14,11 @@ help: <TAG> was created here, as the base tag for ALLOC
    |
 LL |     let b = unsafe { Box::from_raw(&mut m) };
    |                                    ^^^^^^
+help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique Box retag
+  --> $DIR/return-noalias.rs:LL:CC
+   |
+LL |     let b = unsafe { Box::from_raw(&mut m) };
+   |                      ^^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/return-noalias.rs:LL:CC
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/tools/miri/tests/pass/stacked-borrows/stack-printing.rs
+++ b/src/tools/miri/tests/pass/stacked-borrows/stack-printing.rs
@@ -29,7 +29,7 @@ fn main() {
     unsafe { *ptr = 42 };
     print_borrow_stacks(alloc_id);
 
-    let _b = unsafe { ManuallyDrop::new(Box::from_raw(ptr)) };
+    let _b = unsafe { &mut *ptr };
     print_borrow_stacks(alloc_id);
 
     let _ptr = unsafe { &*ptr };

--- a/src/tools/miri/tests/pass/stacked-borrows/stack-printing.stdout
+++ b/src/tools/miri/tests/pass/stacked-borrows/stack-printing.stdout
@@ -1,6 +1,6 @@
 0..1: [ SharedReadWrite<TAG> ]
 0..1: [ SharedReadWrite<TAG> ]
 0..1: [ SharedReadWrite<TAG> ]
-0..1: [ SharedReadWrite<TAG> Unique<TAG> Unique<TAG> Unique<TAG> Unique<TAG> Unique<TAG> Unique<TAG> Unique<TAG> ]
-0..1: [ SharedReadWrite<TAG> Disabled<TAG> Disabled<TAG> Disabled<TAG> Disabled<TAG> Disabled<TAG> Disabled<TAG> Disabled<TAG> SharedReadOnly<TAG> ]
+0..1: [ SharedReadWrite<TAG> Unique<TAG> Unique<TAG> ]
+0..1: [ SharedReadWrite<TAG> Disabled<TAG> Disabled<TAG> SharedReadOnly<TAG> ]
 0..1: [ unknown-bottom(..<TAG>) ]


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/unsafe-code-guidelines/issues/385, `Box`-returning functions get a `noalias` on their *return* value, which has a bunch of extra aliasing rules that Miri did not properly check.

We now do this by marking the post-return retags as `FnReturn`, and then when retagging a `Box` in that vein we *clear* the borrow stack of all the other tags. On its own this change is incompatible with the weak protectors on `Box` arguments that I [recently introduced](https://github.com/rust-lang/miri/pull/2684) to fix `Box` `noalias` enforcement, so we replace those protectors by also doing such a "clear" retagging in `FnEntry` for `Box`. Conveniently this means we can remove weak protectors entirely while still properly enforcing `noalias` (as far as I can tell).

Basically this means that `Box` cannot be reborrowed; when they are passed to and from a function, they always must be the only pointer used henceforth for this allocation. With `Box` not being a reference type, this kind of makes sense I guess. There is a chance that this might break even more unsafe code that uses `Box` in creative ways, though that seems unlikely -- when a `Box` is passed to a function, I would expect that function to either deallocate or return the `Box`; the new point now is that the caller must use the returned box rather than considering this a "reborrow" and sticking to some sneaky copy of the old box. Such code would be unsound with return-position `noalias` anyway.

@saethlin I hope this doesn't break the tag cache in subtle ways, though given that it can handle clearing the stack for the "unknown bottom" situation, I assume that will also work here.

One odd thing that can now happen is that the "base tag" of an allocation might cease to be valid for that allocation. But I don't think we ever assumed that it would always remain valid, and this does seem to match the semantics of return-position `noalias`, so I think this is fine.

r? @oli-obk @saethlin 