### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -244,6 +244,7 @@ E0457: include_str!("./error_codes/E0457.md"),
 E0458: include_str!("./error_codes/E0458.md"),
 E0459: include_str!("./error_codes/E0459.md"),
 E0460: include_str!("./error_codes/E0460.md"),
+E0461: include_str!("./error_codes/E0461.md"),
 E0462: include_str!("./error_codes/E0462.md"),
 E0463: include_str!("./error_codes/E0463.md"),
 E0464: include_str!("./error_codes/E0464.md"),
@@ -595,7 +596,6 @@ E0791: include_str!("./error_codes/E0791.md"),
 //  E0421, // merged into 531
 //  E0427, // merged into 530
 //  E0456, // plugin `..` is not available for triple `..`
-    E0461, // couldn't find crate `..` with expected target triple ..
     E0465, // multiple .. candidates for `..` found
 //  E0467, // removed
 //  E0470, // removed

--- a/compiler/rustc_error_codes/src/error_codes/E0461.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0461.md
@@ -1,0 +1,30 @@
+Couldn't find crate `..` with expected target triple `..`.
+
+Example of erroneous code:
+
+`a.rs`
+```ignore (cannot-link-with-other-tests)
+#![crate_type = "lib"]
+
+fn foo() {}
+```
+
+`main.rs`
+```ignore (cannot-link-with-other-tests)
+extern crate a;
+
+fn main() {
+    a::foo();
+}
+```
+
+`a.rs` is then compiled with `--target powerpc-unknown-linux-gnu` and `b.rs`
+with `--target x86_64-unknown-linux-gnu`. `a.rs` is compiled into a binary
+format incompatible with `b.rs`; PowerPC and x86 are totally different
+architectures. This issue also extends to any difference in target triples, as
+`std` is operating-system specific.
+
+This error can be fixed by:
+ * Using [Cargo](../cargo/index.html), the Rust package manager, automatically
+   fixing this issue.
+ * Recompiling either crate so that they target a consistent target triple.

--- a/compiler/rustc_error_messages/locales/en-US/parse.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parse.ftl
@@ -365,3 +365,6 @@ parse_invalid_identifier_with_leading_number = expected identifier, found number
 
 parse_maybe_fn_typo_with_impl = you might have meant to write `impl` instead of `fn`
     .suggestion = replace `fn` with `impl` here
+
+parse_expected_fn_path_found_fn_keyword = expected identifier, found keyword `fn`
+    .suggestion = use `Fn` to refer to the trait

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -626,7 +626,7 @@ impl<'a> ExtCtxt<'a> {
 
     // Builds `#[name = val]`.
     //
-    // Note: `span` is used for both the identifer and the value.
+    // Note: `span` is used for both the identifier and the value.
     pub fn attr_name_value_str(&self, name: Symbol, val: Symbol, span: Span) -> ast::Attribute {
         let g = &self.sess.parse_sess.attr_id_generator;
         attr::mk_attr_name_value_str(g, ast::AttrStyle::Outer, name, val, span)

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -29,9 +29,7 @@ use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::util::{Discr, IntTypeExt};
-use rustc_middle::ty::{
-    self, AdtKind, Const, IsSuggestable, ToPredicate, Ty, TyCtxt, TypeVisitable,
-};
+use rustc_middle::ty::{self, AdtKind, Const, IsSuggestable, ToPredicate, Ty, TyCtxt};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::Span;
 use rustc_target::spec::abi;
@@ -1270,7 +1268,7 @@ fn suggest_impl_iterator<'tcx>(
     if !tcx
         .infer_ctxt()
         .build()
-        .type_implements_trait(iter_trait, [ret_ty], tcx.param_env(iter_trait))
+        .type_implements_trait(iter_trait, [ret_ty], tcx.param_env(def_id))
         .must_apply_modulo_regions()
     {
         return None;
@@ -1296,8 +1294,7 @@ fn suggest_impl_iterator<'tcx>(
     ));
     if ocx.select_where_possible().is_empty()
         && let item_ty = infcx.resolve_vars_if_possible(ty_var)
-        && !item_ty.references_error()
-        && !item_ty.has_placeholders()
+        && item_ty.is_suggestable(tcx, false)
     {
         return Some(item_ty);
     }

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -5,6 +5,7 @@ use rustc_hir::intravisit;
 use rustc_hir::intravisit::Visitor;
 use rustc_hir::{HirId, Node};
 use rustc_middle::hir::nested_filter;
+use rustc_middle::ty::print::with_forced_trimmed_paths;
 use rustc_middle::ty::subst::InternalSubsts;
 use rustc_middle::ty::util::IntTypeExt;
 use rustc_middle::ty::{self, DefIdTree, Ty, TyCtxt, TypeFolder, TypeSuperFoldable, TypeVisitable};
@@ -907,10 +908,10 @@ fn infer_placeholder_type<'a>(
                         Applicability::MachineApplicable,
                     );
                 } else {
-                    err.span_note(
+                    with_forced_trimmed_paths!(err.span_note(
                         tcx.hir().body(body_id).value.span,
-                        &format!("however, the inferred type `{}` cannot be named", ty),
-                    );
+                        &format!("however, the inferred type `{ty}` cannot be named"),
+                    ));
                 }
             }
 
@@ -931,10 +932,10 @@ fn infer_placeholder_type<'a>(
                         Applicability::MaybeIncorrect,
                     );
                 } else {
-                    diag.span_note(
+                    with_forced_trimmed_paths!(diag.span_note(
                         tcx.hir().body(body_id).value.span,
-                        &format!("however, the inferred type `{}` cannot be named", ty),
-                    );
+                        &format!("however, the inferred type `{ty}` cannot be named"),
+                    ));
                 }
             }
 

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -241,7 +241,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             });
 
             if let Some(ok) = self.lookup_method_in_trait(
-                call_expr.span,
+                self.misc(call_expr.span),
                 method_name,
                 trait_def_id,
                 adjusted_ty,

--- a/compiler/rustc_hir_typeck/src/place_op.rs
+++ b/compiler/rustc_hir_typeck/src/place_op.rs
@@ -225,7 +225,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         imm_tr.and_then(|trait_did| {
             self.lookup_method_in_trait(
-                span,
+                self.misc(span),
                 Ident::with_dummy_span(imm_op),
                 trait_did,
                 base_ty,
@@ -264,7 +264,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         mut_tr.and_then(|trait_did| {
             self.lookup_method_in_trait(
-                span,
+                self.misc(span),
                 Ident::with_dummy_span(mut_op),
                 trait_did,
                 base_ty,

--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -851,7 +851,7 @@ impl Cursor<'_> {
     }
 
     // Eats the identifier. Note: succeeds on `_`, which isn't a valid
-    // identifer.
+    // identifier.
     fn eat_identifier(&mut self) {
         if !is_id_start(self.first()) {
             return;

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1229,3 +1229,11 @@ pub(crate) struct FnTypoWithImpl {
     #[suggestion(applicability = "maybe-incorrect", code = "impl", style = "verbose")]
     pub fn_span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(parse_expected_fn_path_found_fn_keyword)]
+pub(crate) struct ExpectedFnPathFoundFnKeyword {
+    #[primary_span]
+    #[suggestion(applicability = "machine-applicable", code = "Fn", style = "verbose")]
+    pub fn_token_span: Span,
+}

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -213,6 +213,7 @@ symbols! {
         Is,
         ItemContext,
         Iterator,
+        IteratorItem,
         Layout,
         Left,
         LinkedList,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -66,6 +66,7 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item = ()>) {}
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub trait Iterator {
     /// The type of the elements being iterated over.
+    #[rustc_diagnostic_item = "IteratorItem"]
     #[stable(feature = "rust1", since = "1.0.0")]
     type Item;
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -378,10 +378,6 @@ img {
 	filter: var(--rust-logo-filter);
 }
 
-.sidebar, .mobile-topbar, .sidebar-menu-toggle {
-	background-color: var(--sidebar-background-color);
-}
-
 .sidebar {
 	font-size: 0.875rem;
 	flex: 0 0 200px;
@@ -400,7 +396,8 @@ img {
 	overflow-y: hidden;
 }
 
-.source .sidebar, #src-sidebar-toggle, #source-sidebar {
+.sidebar, .mobile-topbar, .sidebar-menu-toggle,
+#src-sidebar-toggle, #source-sidebar {
 	background-color: var(--sidebar-background-color);
 }
 

--- a/src/test/rustdoc-gui/sidebar-source-code.goml
+++ b/src/test/rustdoc-gui/sidebar-source-code.goml
@@ -1,7 +1,52 @@
 // The goal of this test is to ensure that the sidebar is working as expected in the source
 // code pages.
 goto: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
-// First: desktop mode.
+show-text: true
+
+// First, check the sidebar colors.
+define-function: (
+    "check-colors",
+    (theme, color, background_color),
+    [
+        ("local-storage", {
+            "rustdoc-theme": |theme|,
+            "rustdoc-use-system-theme": "false",
+        }),
+        ("reload"),
+        // Checking results colors.
+        ("assert-css", (".source .sidebar", {
+        	"color": |color|,
+        	"background-color": |background_color|
+        }, ALL)),
+    ],
+)
+
+call-function: (
+	"check-colors",
+	{
+		"theme": "ayu",
+		"color": "rgb(197, 197, 197)",
+		"background_color": "rgb(20, 25, 31)",
+	}
+)
+call-function: (
+	"check-colors",
+	{
+		"theme": "dark",
+		"color": "rgb(221, 221, 221)",
+		"background_color": "rgb(80, 80, 80)",
+	}
+)
+call-function: (
+	"check-colors",
+	{
+		"theme": "light",
+		"color": "rgb(0, 0, 0)",
+		"background_color": "rgb(245, 245, 245)",
+	}
+)
+
+// Next, desktop mode layout.
 size: (1100, 800)
 // We check that the sidebar isn't expanded and has the expected width.
 assert-css: ("nav.sidebar", {"width": "50px"})

--- a/src/test/rustdoc-gui/sidebar.goml
+++ b/src/test/rustdoc-gui/sidebar.goml
@@ -2,6 +2,50 @@
 goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
 assert-property: (".sidebar", {"clientWidth": "200"})
 show-text: true
+
+// First, check the sidebar colors.
+define-function: (
+    "check-colors",
+    (theme, color, background_color),
+    [
+        ("local-storage", {
+            "rustdoc-theme": |theme|,
+            "rustdoc-use-system-theme": "false",
+        }),
+        ("reload"),
+        // Checking results colors.
+        ("assert-css", (".sidebar", {
+        	"color": |color|,
+        	"background-color": |background_color|
+        }, ALL)),
+    ],
+)
+
+call-function: (
+	"check-colors",
+	{
+		"theme": "ayu",
+		"color": "rgb(197, 197, 197)",
+		"background_color": "rgb(20, 25, 31)",
+	}
+)
+call-function: (
+	"check-colors",
+	{
+		"theme": "dark",
+		"color": "rgb(221, 221, 221)",
+		"background_color": "rgb(80, 80, 80)",
+	}
+)
+call-function: (
+	"check-colors",
+	{
+		"theme": "light",
+		"color": "rgb(0, 0, 0)",
+		"background_color": "rgb(245, 245, 245)",
+	}
+)
+
 local-storage: {"rustdoc-theme": "light"}
 // We reload the page so the local storage settings are being used.
 reload:

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.stderr
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.stderr
@@ -3,10 +3,7 @@ error[E0308]: mismatched types
    |
 LL |    #[alloc_error_handler]
    |    ---------------------- in this procedural macro expansion
-LL |    fn oom(
-   |  __^
-   | | _|
-   | ||
+LL | // fn oom(
 LL | ||     info: &Layout,
 LL | || ) -> ()
    | ||_______- arguments to this function are incorrect
@@ -29,10 +26,7 @@ error[E0308]: mismatched types
    |
 LL |    #[alloc_error_handler]
    |    ---------------------- in this procedural macro expansion
-LL |    fn oom(
-   |  __^
-   | | _|
-   | ||
+LL | // fn oom(
 LL | ||     info: &Layout,
 LL | || ) -> ()
    | ||_______^ expected `!`, found `()`

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.stderr
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.stderr
@@ -3,10 +3,7 @@ error[E0308]: mismatched types
    |
 LL |    #[alloc_error_handler]
    |    ---------------------- in this procedural macro expansion
-LL |    fn oom(
-   |  __^
-   | | _|
-   | ||
+LL | // fn oom(
 LL | ||     info: Layout,
 LL | || ) {
    | ||_- arguments to this function are incorrect
@@ -36,10 +33,7 @@ error[E0308]: mismatched types
    |
 LL |    #[alloc_error_handler]
    |    ---------------------- in this procedural macro expansion
-LL |    fn oom(
-   |  __^
-   | | _|
-   | ||
+LL | // fn oom(
 LL | ||     info: Layout,
 LL | || ) {
    | ||_^ expected `!`, found `()`

--- a/src/test/ui/asm/x86_64/interpolated-idents.stderr
+++ b/src/test/ui/asm/x86_64/interpolated-idents.stderr
@@ -30,12 +30,7 @@ error: asm outputs are not allowed with the `noreturn` option
 LL |               asm!("", $in(x) x, $out(x) x, $lateout(x) x, $inout(x) x, $inlateout(x) x,
    |                                  ^^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^^^^
 ...
-LL |       m!(in out lateout inout inlateout const sym
-   |  _____-
-   | |_____|
-   | |_____|
-   | |_____|
-   | |
+LL | /     m!(in out lateout inout inlateout const sym
 LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack att_syntax options);
    | |                                           -

--- a/src/test/ui/error-codes/E0033-teach.rs
+++ b/src/test/ui/error-codes/E0033-teach.rs
@@ -1,13 +1,13 @@
 // compile-flags: -Z teach
-
 trait SomeTrait {
-    fn foo(); //~ associated function `foo` has no `self` parameter
+    fn foo(&self);
 }
-
+struct S;
+impl SomeTrait for S {
+    fn foo(&self) {}
+}
 fn main() {
-    let trait_obj: &dyn SomeTrait = SomeTrait;
-    //~^ ERROR expected value, found trait `SomeTrait`
-    //~| ERROR E0038
+    let trait_obj: &dyn SomeTrait = &S;
 
     let &invalid = trait_obj;
     //~^ ERROR E0033

--- a/src/test/ui/error-codes/E0033-teach.stderr
+++ b/src/test/ui/error-codes/E0033-teach.stderr
@@ -1,31 +1,3 @@
-error[E0423]: expected value, found trait `SomeTrait`
-  --> $DIR/E0033-teach.rs:8:37
-   |
-LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
-   |                                     ^^^^^^^^^ not a value
-
-error[E0038]: the trait `SomeTrait` cannot be made into an object
-  --> $DIR/E0033-teach.rs:8:20
-   |
-LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
-   |                    ^^^^^^^^^^^^^^ `SomeTrait` cannot be made into an object
-   |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/E0033-teach.rs:4:8
-   |
-LL | trait SomeTrait {
-   |       --------- this trait cannot be made into an object...
-LL |     fn foo();
-   |        ^^^ ...because associated function `foo` has no `self` parameter
-help: consider turning `foo` into a method by giving it a `&self` argument
-   |
-LL |     fn foo(&self);
-   |            +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
-   |
-LL |     fn foo() where Self: Sized;
-   |              +++++++++++++++++
-
 error[E0033]: type `&dyn SomeTrait` cannot be dereferenced
   --> $DIR/E0033-teach.rs:12:9
    |
@@ -36,7 +8,6 @@ LL |     let &invalid = trait_obj;
            
            You can read more about trait objects in the Trait Objects section of the Reference: https://doc.rust-lang.org/reference/types.html#trait-objects
 
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0033, E0038, E0423.
-For more information about an error, try `rustc --explain E0033`.
+For more information about this error, try `rustc --explain E0033`.

--- a/src/test/ui/error-codes/E0033.rs
+++ b/src/test/ui/error-codes/E0033.rs
@@ -1,11 +1,12 @@
 trait SomeTrait {
-    fn foo(); //~ associated function `foo` has no `self` parameter
+    fn foo(&self);
 }
-
+struct S;
+impl SomeTrait for S {
+    fn foo(&self) {}
+}
 fn main() {
-    let trait_obj: &dyn SomeTrait = SomeTrait;
-    //~^ ERROR expected value, found trait `SomeTrait`
-    //~| ERROR E0038
+    let trait_obj: &dyn SomeTrait = &S;
 
     let &invalid = trait_obj;
     //~^ ERROR E0033

--- a/src/test/ui/error-codes/E0033.stderr
+++ b/src/test/ui/error-codes/E0033.stderr
@@ -1,38 +1,9 @@
-error[E0423]: expected value, found trait `SomeTrait`
-  --> $DIR/E0033.rs:6:37
-   |
-LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
-   |                                     ^^^^^^^^^ not a value
-
-error[E0038]: the trait `SomeTrait` cannot be made into an object
-  --> $DIR/E0033.rs:6:20
-   |
-LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
-   |                    ^^^^^^^^^^^^^^ `SomeTrait` cannot be made into an object
-   |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/E0033.rs:2:8
-   |
-LL | trait SomeTrait {
-   |       --------- this trait cannot be made into an object...
-LL |     fn foo();
-   |        ^^^ ...because associated function `foo` has no `self` parameter
-help: consider turning `foo` into a method by giving it a `&self` argument
-   |
-LL |     fn foo(&self);
-   |            +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
-   |
-LL |     fn foo() where Self: Sized;
-   |              +++++++++++++++++
-
 error[E0033]: type `&dyn SomeTrait` cannot be dereferenced
-  --> $DIR/E0033.rs:10:9
+  --> $DIR/E0033.rs:11:9
    |
 LL |     let &invalid = trait_obj;
    |         ^^^^^^^^ type `&dyn SomeTrait` cannot be dereferenced
 
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0033, E0038, E0423.
-For more information about an error, try `rustc --explain E0033`.
+For more information about this error, try `rustc --explain E0033`.

--- a/src/test/ui/issues/issue-13497-2.stderr
+++ b/src/test/ui/issues/issue-13497-2.stderr
@@ -1,10 +1,7 @@
 error[E0515]: cannot return value referencing local variable `rawLines`
   --> $DIR/issue-13497-2.rs:3:5
    |
-LL |        rawLines
-   |  ______^
-   | | _____|
-   | ||
+LL | //     rawLines
 LL | ||         .iter().map(|l| l.trim()).collect()
    | ||_______________-___________________________^ returns a value referencing data owned by the current function
    |  |_______________|

--- a/src/test/ui/lexer/lex-bad-char-literals-6.rs
+++ b/src/test/ui/lexer/lex-bad-char-literals-6.rs
@@ -7,10 +7,8 @@ fn main() {
     //~^ ERROR: character literal may only contain one codepoint
 
     if x == y {}
-    //~^ ERROR: can't compare `&str` with `char`
     if y == z {}  // no error here
     if x == z {}
-    //~^ ERROR: can't compare `&str` with `char`
 
     let a: usize = "";
     //~^ ERROR: mismatched types

--- a/src/test/ui/lexer/lex-bad-char-literals-6.stderr
+++ b/src/test/ui/lexer/lex-bad-char-literals-6.stderr
@@ -31,49 +31,14 @@ help: if you meant to write a `str` literal, use double quotes
 LL |     let z = "ef";
    |             ~~~~
 
-error[E0277]: can't compare `&str` with `char`
-  --> $DIR/lex-bad-char-literals-6.rs:9:10
-   |
-LL |     if x == y {}
-   |          ^^ no implementation for `&str == char`
-   |
-   = help: the trait `PartialEq<char>` is not implemented for `&str`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             <&'a str as PartialEq<OsString>>
-             <&'a str as PartialEq<String>>
-             <&'b str as PartialEq<Cow<'a, str>>>
-             <str as PartialEq<Cow<'a, str>>>
-             <str as PartialEq<OsStr>>
-             <str as PartialEq<OsString>>
-             <str as PartialEq<String>>
-             <str as PartialEq>
-
 error[E0308]: mismatched types
-  --> $DIR/lex-bad-char-literals-6.rs:15:20
+  --> $DIR/lex-bad-char-literals-6.rs:13:20
    |
 LL |     let a: usize = "";
    |            -----   ^^ expected `usize`, found `&str`
    |            |
    |            expected due to this
 
-error[E0277]: can't compare `&str` with `char`
-  --> $DIR/lex-bad-char-literals-6.rs:12:10
-   |
-LL |     if x == z {}
-   |          ^^ no implementation for `&str == char`
-   |
-   = help: the trait `PartialEq<char>` is not implemented for `&str`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             <&'a str as PartialEq<OsString>>
-             <&'a str as PartialEq<String>>
-             <&'b str as PartialEq<Cow<'a, str>>>
-             <str as PartialEq<Cow<'a, str>>>
-             <str as PartialEq<OsStr>>
-             <str as PartialEq<OsString>>
-             <str as PartialEq<String>>
-             <str as PartialEq>
+error: aborting due to 4 previous errors
 
-error: aborting due to 6 previous errors
-
-Some errors have detailed explanations: E0277, E0308.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/kw-in-trait-bounds.rs
+++ b/src/test/ui/parser/kw-in-trait-bounds.rs
@@ -4,21 +4,13 @@ fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
 //~^ ERROR expected identifier, found keyword `fn`
 //~| ERROR expected identifier, found keyword `fn`
 //~| ERROR expected identifier, found keyword `fn`
-//~| ERROR cannot find trait `r#fn` in this scope
-//~| ERROR cannot find trait `r#fn` in this scope
-//~| ERROR cannot find trait `r#fn` in this scope
-//~| HELP  a trait with a similar name exists
-//~| HELP  a trait with a similar name exists
-//~| HELP  a trait with a similar name exists
-//~| HELP  escape `fn` to use it as an identifier
-//~| HELP  escape `fn` to use it as an identifier
-//~| HELP  escape `fn` to use it as an identifier
+//~| HELP use `Fn` to refer to the trait
+//~| HELP use `Fn` to refer to the trait
+//~| HELP use `Fn` to refer to the trait
 where
 G: fn(),
     //~^ ERROR expected identifier, found keyword `fn`
-    //~| ERROR cannot find trait `r#fn` in this scope
-    //~| HELP  a trait with a similar name exists
-    //~| HELP  escape `fn` to use it as an identifier
+    //~| HELP use `Fn` to refer to the trait
 {}
 
 fn _g<A: struct, B>(_: impl struct, _: &dyn struct)

--- a/src/test/ui/parser/kw-in-trait-bounds.stderr
+++ b/src/test/ui/parser/kw-in-trait-bounds.stderr
@@ -2,48 +2,48 @@ error: expected identifier, found keyword `fn`
   --> $DIR/kw-in-trait-bounds.rs:3:10
    |
 LL | fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
-   |          ^^ expected identifier, found keyword
+   |          ^^
    |
-help: escape `fn` to use it as an identifier
+help: use `Fn` to refer to the trait
    |
-LL | fn _f<F: r#fn(), G>(_: impl fn(), _: &dyn fn())
-   |          ++
+LL | fn _f<F: Fn(), G>(_: impl fn(), _: &dyn fn())
+   |          ~~
 
 error: expected identifier, found keyword `fn`
   --> $DIR/kw-in-trait-bounds.rs:3:27
    |
 LL | fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
-   |                           ^^ expected identifier, found keyword
+   |                           ^^
    |
-help: escape `fn` to use it as an identifier
+help: use `Fn` to refer to the trait
    |
-LL | fn _f<F: fn(), G>(_: impl r#fn(), _: &dyn fn())
-   |                           ++
+LL | fn _f<F: fn(), G>(_: impl Fn(), _: &dyn fn())
+   |                           ~~
 
 error: expected identifier, found keyword `fn`
   --> $DIR/kw-in-trait-bounds.rs:3:41
    |
 LL | fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
-   |                                         ^^ expected identifier, found keyword
+   |                                         ^^
    |
-help: escape `fn` to use it as an identifier
+help: use `Fn` to refer to the trait
    |
-LL | fn _f<F: fn(), G>(_: impl fn(), _: &dyn r#fn())
-   |                                         ++
+LL | fn _f<F: fn(), G>(_: impl fn(), _: &dyn Fn())
+   |                                         ~~
 
 error: expected identifier, found keyword `fn`
-  --> $DIR/kw-in-trait-bounds.rs:17:4
+  --> $DIR/kw-in-trait-bounds.rs:11:4
    |
 LL | G: fn(),
-   |    ^^ expected identifier, found keyword
+   |    ^^
    |
-help: escape `fn` to use it as an identifier
+help: use `Fn` to refer to the trait
    |
-LL | G: r#fn(),
-   |    ++
+LL | G: Fn(),
+   |    ~~
 
 error: expected identifier, found keyword `struct`
-  --> $DIR/kw-in-trait-bounds.rs:24:10
+  --> $DIR/kw-in-trait-bounds.rs:16:10
    |
 LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
    |          ^^^^^^ expected identifier, found keyword
@@ -54,7 +54,7 @@ LL | fn _g<A: r#struct, B>(_: impl struct, _: &dyn struct)
    |          ++
 
 error: expected identifier, found keyword `struct`
-  --> $DIR/kw-in-trait-bounds.rs:24:29
+  --> $DIR/kw-in-trait-bounds.rs:16:29
    |
 LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
    |                             ^^^^^^ expected identifier, found keyword
@@ -65,7 +65,7 @@ LL | fn _g<A: struct, B>(_: impl r#struct, _: &dyn struct)
    |                             ++
 
 error: expected identifier, found keyword `struct`
-  --> $DIR/kw-in-trait-bounds.rs:24:45
+  --> $DIR/kw-in-trait-bounds.rs:16:45
    |
 LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
    |                                             ^^^^^^ expected identifier, found keyword
@@ -76,7 +76,7 @@ LL | fn _g<A: struct, B>(_: impl struct, _: &dyn r#struct)
    |                                             ++
 
 error: expected identifier, found keyword `struct`
-  --> $DIR/kw-in-trait-bounds.rs:38:8
+  --> $DIR/kw-in-trait-bounds.rs:30:8
    |
 LL |     B: struct,
    |        ^^^^^^ expected identifier, found keyword
@@ -86,44 +86,8 @@ help: escape `struct` to use it as an identifier
 LL |     B: r#struct,
    |        ++
 
-error[E0405]: cannot find trait `r#fn` in this scope
-  --> $DIR/kw-in-trait-bounds.rs:3:10
-   |
-LL | fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
-   |          ^^ help: a trait with a similar name exists (notice the capitalization): `Fn`
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
-
-error[E0405]: cannot find trait `r#fn` in this scope
-  --> $DIR/kw-in-trait-bounds.rs:17:4
-   |
-LL | G: fn(),
-   |    ^^ help: a trait with a similar name exists (notice the capitalization): `Fn`
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
-
-error[E0405]: cannot find trait `r#fn` in this scope
-  --> $DIR/kw-in-trait-bounds.rs:3:27
-   |
-LL | fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
-   |                           ^^ help: a trait with a similar name exists (notice the capitalization): `Fn`
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
-
-error[E0405]: cannot find trait `r#fn` in this scope
-  --> $DIR/kw-in-trait-bounds.rs:3:41
-   |
-LL | fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
-   |                                         ^^ help: a trait with a similar name exists (notice the capitalization): `Fn`
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
-
 error[E0405]: cannot find trait `r#struct` in this scope
-  --> $DIR/kw-in-trait-bounds.rs:24:10
+  --> $DIR/kw-in-trait-bounds.rs:16:10
    |
 LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
    |          ^^^^^^ help: a trait with a similar name exists (notice the capitalization): `Struct`
@@ -132,7 +96,7 @@ LL | trait Struct {}
    | ------------ similarly named trait `Struct` defined here
 
 error[E0405]: cannot find trait `r#struct` in this scope
-  --> $DIR/kw-in-trait-bounds.rs:38:8
+  --> $DIR/kw-in-trait-bounds.rs:30:8
    |
 LL |     B: struct,
    |        ^^^^^^ help: a trait with a similar name exists (notice the capitalization): `Struct`
@@ -141,7 +105,7 @@ LL | trait Struct {}
    | ------------ similarly named trait `Struct` defined here
 
 error[E0405]: cannot find trait `r#struct` in this scope
-  --> $DIR/kw-in-trait-bounds.rs:24:29
+  --> $DIR/kw-in-trait-bounds.rs:16:29
    |
 LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
    |                             ^^^^^^ help: a trait with a similar name exists (notice the capitalization): `Struct`
@@ -150,7 +114,7 @@ LL | trait Struct {}
    | ------------ similarly named trait `Struct` defined here
 
 error[E0405]: cannot find trait `r#struct` in this scope
-  --> $DIR/kw-in-trait-bounds.rs:24:45
+  --> $DIR/kw-in-trait-bounds.rs:16:45
    |
 LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
    |                                             ^^^^^^ help: a trait with a similar name exists (notice the capitalization): `Struct`
@@ -158,6 +122,6 @@ LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
 LL | trait Struct {}
    | ------------ similarly named trait `Struct` defined here
 
-error: aborting due to 16 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0405`.

--- a/src/test/ui/parser/recover-fn-trait-from-fn-kw.rs
+++ b/src/test/ui/parser/recover-fn-trait-from-fn-kw.rs
@@ -1,0 +1,12 @@
+fn foo(_: impl fn() -> i32) {}
+//~^ ERROR expected identifier, found keyword `fn`
+
+fn foo2<T: fn(i32)>(_: T) {}
+//~^ ERROR expected identifier, found keyword `fn`
+
+fn main() {
+    foo(|| ());
+    //~^ mismatched types
+    foo2(|_: ()| {});
+    //~^ type mismatch in closure arguments
+}

--- a/src/test/ui/parser/recover-fn-trait-from-fn-kw.stderr
+++ b/src/test/ui/parser/recover-fn-trait-from-fn-kw.stderr
@@ -1,0 +1,48 @@
+error: expected identifier, found keyword `fn`
+  --> $DIR/recover-fn-trait-from-fn-kw.rs:1:16
+   |
+LL | fn foo(_: impl fn() -> i32) {}
+   |                ^^
+   |
+help: use `Fn` to refer to the trait
+   |
+LL | fn foo(_: impl Fn() -> i32) {}
+   |                ~~
+
+error: expected identifier, found keyword `fn`
+  --> $DIR/recover-fn-trait-from-fn-kw.rs:4:12
+   |
+LL | fn foo2<T: fn(i32)>(_: T) {}
+   |            ^^
+   |
+help: use `Fn` to refer to the trait
+   |
+LL | fn foo2<T: Fn(i32)>(_: T) {}
+   |            ~~
+
+error[E0308]: mismatched types
+  --> $DIR/recover-fn-trait-from-fn-kw.rs:8:12
+   |
+LL |     foo(|| ());
+   |            ^^ expected `i32`, found `()`
+
+error[E0631]: type mismatch in closure arguments
+  --> $DIR/recover-fn-trait-from-fn-kw.rs:10:5
+   |
+LL |     foo2(|_: ()| {});
+   |     ^^^^ ------- found signature defined here
+   |     |
+   |     expected due to this
+   |
+   = note: expected closure signature `fn(i32) -> _`
+              found closure signature `fn(()) -> _`
+note: required by a bound in `foo2`
+  --> $DIR/recover-fn-trait-from-fn-kw.rs:4:12
+   |
+LL | fn foo2<T: fn(i32)>(_: T) {}
+   |            ^^^^^^^ required by this bound in `foo2`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0308, E0631.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/issue-104287.rs
+++ b/src/test/ui/suggestions/issue-104287.rs
@@ -1,9 +1,13 @@
 // The purpose of this test is not to validate the output of the compiler.
 // Instead, it ensures the suggestion is generated without performing an arithmetic overflow.
 
+struct S;
+impl S {
+    fn foo(&self) {}
+}
 fn main() {
-    let x = not_found; //~ ERROR cannot find value `not_found` in this scope
-    simd_gt::<()>(x);
+    let x = S;
+    foo::<()>(x);
     //~^ ERROR this associated function takes 0 generic arguments but 1 generic argument was supplied
-    //~| ERROR cannot find function `simd_gt` in this scope
+    //~| ERROR cannot find function `foo` in this scope
 }

--- a/src/test/ui/suggestions/issue-104287.stderr
+++ b/src/test/ui/suggestions/issue-104287.stderr
@@ -1,30 +1,30 @@
-error[E0425]: cannot find value `not_found` in this scope
-  --> $DIR/issue-104287.rs:5:13
-   |
-LL |     let x = not_found;
-   |             ^^^^^^^^^ not found in this scope
-
 error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/issue-104287.rs:6:5
+  --> $DIR/issue-104287.rs:10:5
    |
-LL |     simd_gt::<()>(x);
-   |     ^^^^^^^------ help: remove these generics
+LL |     foo::<()>(x);
+   |     ^^^------ help: remove these generics
    |     |
    |     expected 0 generic arguments
+   |
+note: associated function defined here, with 0 generic parameters
+  --> $DIR/issue-104287.rs:6:8
+   |
+LL |     fn foo(&self) {}
+   |        ^^^
 
-error[E0425]: cannot find function `simd_gt` in this scope
-  --> $DIR/issue-104287.rs:6:5
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/issue-104287.rs:10:5
    |
-LL |     simd_gt::<()>(x);
-   |     ^^^^^^^ not found in this scope
+LL |     foo::<()>(x);
+   |     ^^^ not found in this scope
    |
-help: use the `.` operator to call the method `SimdPartialOrd::simd_gt` on `[type error]`
+help: use the `.` operator to call the method `foo` on `&S`
    |
-LL -     simd_gt::<()>(x);
-LL +     x.simd_gt();
+LL -     foo::<()>(x);
+LL +     x.foo();
    |
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0107, E0425.
 For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/suggestions/issue-99240-2.stderr
+++ b/src/test/ui/suggestions/issue-99240-2.stderr
@@ -4,10 +4,7 @@ error[E0618]: expected function, found enum variant `Alias::Unit`
 LL |        Unit,
    |        ---- enum variant `Alias::Unit` defined here
 ...
-LL |        Alias::
-   |  ______^
-   | | _____|
-   | ||
+LL | //     Alias::
 LL | ||     Unit();
    | ||________^_- call expression requires function
    |  |________|

--- a/src/test/ui/suggestions/unnamable-types.stderr
+++ b/src/test/ui/suggestions/unnamable-types.stderr
@@ -19,7 +19,7 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL | const C: _ = || 42;
    |          ^ not allowed in type signatures
    |
-note: however, the inferred type `[closure@$DIR/unnamable-types.rs:17:14: 17:16]` cannot be named
+note: however, the inferred type `[closure@unnamable-types.rs:17:14]` cannot be named
   --> $DIR/unnamable-types.rs:17:14
    |
 LL | const C: _ = || 42;
@@ -31,7 +31,7 @@ error: missing type for `const` item
 LL | const D = S { t: { let i = 0; move || -> i32 { i } } };
    |        ^
    |
-note: however, the inferred type `S<[closure@$DIR/unnamable-types.rs:23:31: 23:45]>` cannot be named
+note: however, the inferred type `S<[closure@unnamable-types.rs:23:31]>` cannot be named
   --> $DIR/unnamable-types.rs:23:11
    |
 LL | const D = S { t: { let i = 0; move || -> i32 { i } } };

--- a/src/test/ui/typeck/quiet-type-err-let-binding.rs
+++ b/src/test/ui/typeck/quiet-type-err-let-binding.rs
@@ -1,0 +1,17 @@
+// fn foo() -> String {
+//    String::new()
+// }
+
+fn test(s: &str) {
+    println!("{}", s);
+}
+
+fn test2(s: String) {
+    println!("{}", s);
+}
+
+fn main() {
+    let x = foo(); //~ERROR cannot find function `foo` in this scope
+    test(&x);
+    test2(x); // Does not complain about `x` being a `&str`.
+}

--- a/src/test/ui/typeck/quiet-type-err-let-binding.stderr
+++ b/src/test/ui/typeck/quiet-type-err-let-binding.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/quiet-type-err-let-binding.rs:14:13
+   |
+LL |     let x = foo();
+   |             ^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/typeck/typeck_type_placeholder_item.rs
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.rs
@@ -220,3 +220,11 @@ fn value() -> Option<&'static _> {
 
 const _: Option<_> = map(value);
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+
+fn evens_squared(n: usize) -> _ {
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    (1..n).filter(|x| x % 2 == 0).map(|x| x * x)
+}
+
+const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants

--- a/src/test/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.stderr
@@ -443,7 +443,7 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |          ^ not allowed in type signatures
    |
-note: however, the inferred type `Map<Filter<std::ops::Range<i32>, [closure@$DIR/typeck_type_placeholder_item.rs:229:29: 229:32]>, [closure@$DIR/typeck_type_placeholder_item.rs:229:49: 229:52]>` cannot be named
+note: however, the inferred type `Map<Filter<Range<i32>, [closure@typeck_type_placeholder_item.rs:229:29]>, [closure@typeck_type_placeholder_item.rs:229:49]>` cannot be named
   --> $DIR/typeck_type_placeholder_item.rs:229:14
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);

--- a/src/test/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.stderr
@@ -428,6 +428,27 @@ LL | const _: Option<_> = map(value);
    |          not allowed in type signatures
    |          help: replace with the correct type: `Option<u8>`
 
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:224:31
+   |
+LL | fn evens_squared(n: usize) -> _ {
+   |                               ^
+   |                               |
+   |                               not allowed in type signatures
+   |                               help: replace with an appropriate return type: `impl Iterator<Item = usize>`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:229:10
+   |
+LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
+   |          ^ not allowed in type signatures
+   |
+note: however, the inferred type `Map<Filter<std::ops::Range<i32>, [closure@$DIR/typeck_type_placeholder_item.rs:229:29: 229:32]>, [closure@$DIR/typeck_type_placeholder_item.rs:229:49: 229:52]>` cannot be named
+  --> $DIR/typeck_type_placeholder_item.rs:229:14
+   |
+LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:140:31
    |
@@ -636,7 +657,7 @@ LL |     const D: _ = 42;
    |              not allowed in type signatures
    |              help: replace with the correct type: `i32`
 
-error: aborting due to 69 previous errors
+error: aborting due to 71 previous errors
 
 Some errors have detailed explanations: E0121, E0282, E0403.
 For more information about an error, try `rustc --explain E0121`.


### PR DESCRIPTION
Successful merges:

 - #106028 (docs/test: add UI test and long-form error docs for `E0461`)
 - #106172 (Suggest `impl Iterator` when possible for `_` return type)
 - #106173 (Deduplicate `op` methods)
 - #106176 (Recover `fn` keyword as `Fn` trait in bounds)
 - #106190 (Account for multiple multiline spans with empty padding)
 - #106194 (rustdoc: combine common sidebar background color CSS rules)
 - #106199 (Silence knock-down errors on `[type error]` bindings)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=106028,106172,106173,106176,106190,106194,106199)
<!-- homu-ignore:end -->