### PR TITLE
Powershell: Use `WaitForExit` instead of `-Wait`

### DIFF
--- a/x.ps1
+++ b/x.ps1
@@ -23,7 +23,8 @@ foreach ($python in "py", "python3", "python", "python2") {
             # Use python3, not python2
             $xpy_args = @("-3") + $xpy_args
         }
-        $process = Start-Process -NoNewWindow -Wait -PassThru $python $xpy_args
+        $process = Start-Process -NoNewWindow -PassThru $python $xpy_args
+        $process.WaitForExit()
         Exit $process.ExitCode
     }
 }


### PR DESCRIPTION
Using the method `WaitForExit` instead of the parameter `-Wait` results in a notable speed up of the `x.ps1` script (~350ms, fairly consistently).

Results:
```
milliseconds before: 1127.7576
milliseconds after:   779.0467
```

I think there are opportunities for further speed up by calling `Get-Command` only once with the pattern `py*` then filtering the returned list.

But I'll leave that for another time (or someone else).

r? @jyn514 