### PR TITLE
rustdoc: remove unnecessary `.tooltip::after { text-align: center }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1109,7 +1109,6 @@ pre.rust .doccomment {
 }
 
 .example-wrap .tooltip:hover::after {
-	text-align: center;
 	padding: 5px 3px 3px 3px;
 	border-radius: 6px;
 	margin-left: 5px;

--- a/src/test/rustdoc-gui/codeblock-tooltip.goml
+++ b/src/test/rustdoc-gui/codeblock-tooltip.goml
@@ -34,7 +34,6 @@ define-function: (
             ".docblock .example-wrap.compile_fail .tooltip::after",
             {
                 "content": '"This example deliberately fails to compile"',
-                "text-align": "center",
                 "padding": "5px 3px 3px",
                 "background-color": |background|,
                 "color": |color|,
@@ -74,7 +73,6 @@ define-function: (
             ".docblock .example-wrap.should_panic .tooltip::after",
             {
                 "content": '"This example panics"',
-                "text-align": "center",
                 "padding": "5px 3px 3px",
                 "background-color": |background|,
                 "color": |color|,
@@ -114,7 +112,6 @@ define-function: (
             ".docblock .example-wrap.ignore .tooltip::after",
             {
                 "content": '"This example is not tested"',
-                "text-align": "center",
                 "padding": "5px 3px 3px",
                 "background-color": |background|,
                 "color": |color|,


### PR DESCRIPTION
This doesn't have an effect, since these tooltip are only one line anyway.