### PR TITLE
Remove CraftSpider from review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -496,7 +496,6 @@ infra-ci = [
 rustdoc = [
     "@jsha",
     "@GuillaumeGomez",
-    "@CraftSpider",
     "@notriddle",
 ]
 docs = [


### PR DESCRIPTION
CraftSpider was removed from the rustdoc team in https://github.com/rust-lang/team/pull/897 and can no longer be assigned.