### PR TITLE
docs/test: add docs and a UI test for `E0514` and `E0519`

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -280,6 +280,7 @@ E0515: include_str!("./error_codes/E0515.md"),
 E0516: include_str!("./error_codes/E0516.md"),
 E0517: include_str!("./error_codes/E0517.md"),
 E0518: include_str!("./error_codes/E0518.md"),
+E0519: include_str!("./error_codes/E0519.md"),
 E0520: include_str!("./error_codes/E0520.md"),
 E0521: include_str!("./error_codes/E0521.md"),
 E0522: include_str!("./error_codes/E0522.md"),
@@ -616,7 +617,6 @@ E0791: include_str!("./error_codes/E0791.md"),
 //  E0489, // type/lifetime parameter not in scope here
     E0490, // a value of type `..` is borrowed for too long
     E0514, // metadata version mismatch
-    E0519, // local crate and dependency have same (crate-name, disambiguator)
     E0523, // two dependencies have same (crate-name, disambiguator) but different SVH
 //  E0526, // shuffle indices are not constant
 //  E0540, // multiple rustc_deprecated attributes

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -276,6 +276,7 @@ E0509: include_str!("./error_codes/E0509.md"),
 E0510: include_str!("./error_codes/E0510.md"),
 E0511: include_str!("./error_codes/E0511.md"),
 E0512: include_str!("./error_codes/E0512.md"),
+E0514: include_str!("./error_codes/E0514.md"),
 E0515: include_str!("./error_codes/E0515.md"),
 E0516: include_str!("./error_codes/E0516.md"),
 E0517: include_str!("./error_codes/E0517.md"),
@@ -616,7 +617,6 @@ E0791: include_str!("./error_codes/E0791.md"),
 //  E0488, // lifetime of variable does not enclose its declaration
 //  E0489, // type/lifetime parameter not in scope here
     E0490, // a value of type `..` is borrowed for too long
-    E0514, // metadata version mismatch
     E0523, // two dependencies have same (crate-name, disambiguator) but different SVH
 //  E0526, // shuffle indices are not constant
 //  E0540, // multiple rustc_deprecated attributes

--- a/compiler/rustc_error_codes/src/error_codes/E0514.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0514.md
@@ -1,0 +1,33 @@
+Dependency compiled with different version of `rustc`.
+
+Example of erroneous code:
+
+`a.rs`
+```ignore (cannot-link-with-other-tests)
+// compiled with stable `rustc`
+
+#[crate_type = "lib"]
+```
+
+`b.rs`
+```ignore (cannot-link-with-other-tests)
+// compiled with nightly `rustc`
+
+#[crate_type = "lib"]
+
+extern crate a; // error: found crate `a` compiled by an incompatible version
+                //        of rustc
+```
+
+This error is caused when the version of `rustc` used to compile a crate, as
+stored in the binary's metadata, differs from the version of one of its
+dependencies. Many parts of Rust binaries are considered unstable. For
+instance, the Rust ABI is not stable between compiler versions. This means that
+the compiler cannot be sure about *how* to call a function between compiler
+versions, and therefore this error occurs.
+
+This error can be fixed by:
+ * Using [Cargo](../cargo/index.html), the Rust package manager and
+   [Rustup](https://rust-lang.github.io/rustup/), the Rust toolchain installer,
+   automatically fixing this issue.
+ * Recompiling the crates with a uniform `rustc` version.

--- a/compiler/rustc_error_codes/src/error_codes/E0519.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0519.md
@@ -1,0 +1,40 @@
+The current crate is indistinguishable from one of its dependencies, in terms
+of metadata.
+
+Example of erroneous code:
+
+`a.rs`
+```ignore (cannot-link-with-other-tests)
+#![crate_name = "a"]
+#![crate_type = "lib"]
+
+pub fn foo() {}
+```
+
+`b.rs`
+```ignore (cannot-link-with-other-tests)
+#![crate_name = "a"]
+#![crate_type = "lib"]
+
+// error: the current crate is indistinguishable from one of its dependencies:
+//        it has the same crate-name `a` and was compiled with the same
+//        `-C metadata` arguments. This will result in symbol conflicts between
+//        the two.
+extern crate a;
+
+pub fn foo() {}
+
+fn bar() {
+    a::foo(); // is this calling the local crate or the dependency?
+}
+```
+
+The above example compiles two crates with exactly the same name and
+`crate_type` (plus any other metadata). This causes an error because it becomes
+impossible for the compiler to distinguish between symbols (`pub` item names).
+
+This error can be fixed by:
+ * Using [Cargo](../cargo/index.html), the Rust package manager, automatically
+   fixing this issue.
+ * Recompiling the crate with different metadata (different name/
+   `crate_type`).

--- a/src/test/ui/error-codes/E0519.rs
+++ b/src/test/ui/error-codes/E0519.rs
@@ -1,0 +1,8 @@
+// no need to create a new aux file, we can use an existing.
+// aux-build: crateresolve1-1.rs
+
+// set same metadata as `crateresolve1`
+#![crate_name = "crateresolve1"]
+#![crate_type = "lib"]
+
+extern crate crateresolve1; //~ ERROR E0519

--- a/src/test/ui/error-codes/E0519.stderr
+++ b/src/test/ui/error-codes/E0519.stderr
@@ -1,0 +1,9 @@
+error[E0519]: the current crate is indistinguishable from one of its dependencies: it has the same crate-name `crateresolve1` and was compiled with the same `-C metadata` arguments. This will result in symbol conflicts between the two.
+  --> $DIR/E0519.rs:8:1
+   |
+LL | extern crate crateresolve1;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0519`.

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -11,8 +11,8 @@ use regex::Regex;
 
 // A few of those error codes can't be tested but all the others can and *should* be tested!
 const EXEMPTED_FROM_TEST: &[&str] = &[
-    "E0313", "E0461", "E0465", "E0476", "E0490", "E0514", "E0519", "E0523", "E0554", "E0640",
-    "E0717", "E0729", "E0789",
+    "E0313", "E0461", "E0465", "E0476", "E0490", "E0514", "E0523", "E0554", "E0640", "E0717",
+    "E0729", "E0789",
 ];
 
 // Some error codes don't have any tests apparently...


### PR DESCRIPTION
No UI test on `E0514`, it would need to compile with a different `rustc` version. 

r? @GuillaumeGomez