### PR TITLE
Support the remaining openwrt targets

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -981,15 +981,17 @@ impl fmt::Display for StackProtector {
 }
 
 macro_rules! supported_targets {
-    ( $(($triple:literal, $module:ident ),)+ ) => {
+    ( $(($triple:literal, $module:ident ),)+
+      $((alias $triple_alias:literal, $module_alias:ident ),)+ ) => {
         $(mod $module;)+
 
         /// List of supported targets
-        pub const TARGETS: &[&str] = &[$($triple),+];
+        pub const TARGETS: &[&str] = &[$($triple),+, $($triple_alias),+];
 
         fn load_builtin(target: &str) -> Option<Target> {
             let mut t = match target {
                 $( $triple => $module::target(), )+
+                $( $triple_alias => $module_alias::target(), )+
                 _ => return None,
             };
             t.is_builtin = true;
@@ -1252,6 +1254,13 @@ supported_targets! {
 
     ("aarch64-unknown-nto-qnx710", aarch64_unknown_nto_qnx_710),
     ("x86_64-pc-nto-qnx710", x86_64_pc_nto_qnx710),
+    (alias "mips-openwrt-linux-musl", mips_unknown_linux_musl),
+    (alias "mipsel-openwrt-linux-musl", mipsel_unknown_linux_musl),
+    (alias "aarch64-openwrt-linux-musl", aarch64_unknown_linux_musl),
+    (alias "armv7-openwrt-linux-musleabi", armv7_unknown_linux_musleabi),
+    (alias "armv7-openwrt-linux-musleabihf", armv7_unknown_linux_musleabihf),
+    (alias "powerpc64-openwrt-linux-musl", powerpc64_unknown_linux_musl),
+    (alias "x86_64-openwrt-linux-musl", x86_64_unknown_linux_musl),
 }
 
 /// Cow-Vec-Str: Cow<'static, [Cow<'static, str>]>

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -212,6 +212,7 @@ target | std | host | notes
 `aarch64-apple-tvos` | * |  | ARM64 tvOS
 [`aarch64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ |  | ARM64 Apple WatchOS Simulator
 [`aarch64-kmc-solid_asp3`](platform-support/kmc-solid.md) | ✓ |  | ARM64 SOLID with TOPPERS/ASP3
+`aarch64-openwrt-linux-musl` | ✓ | ✓ | OpenWRT Linux MUSL
 [`aarch64-nintendo-switch-freestanding`](platform-support/aarch64-nintendo-switch-freestanding.md) | * |  | ARM64 Nintendo Switch, Horizon
 [`aarch64-pc-windows-gnullvm`](platform-support/pc-windows-gnullvm.md) | ✓ | ✓ |
 [`aarch64-unknown-nto-qnx710`](platform-support/nto-qnx.md) | ? |  | ARM64 QNX Neutrino 7.1 RTOS |
@@ -235,6 +236,8 @@ target | std | host | notes
 `armv6-unknown-netbsd-eabihf` | ? |  |
 [`armv6k-nintendo-3ds`](platform-support/armv6k-nintendo-3ds.md) | ? |  | ARMv6K Nintendo 3DS, Horizon (Requires devkitARM toolchain)
 `armv7-apple-ios` | ✓ |  | ARMv7 iOS, Cortex-a8
+`armv7-openwrt-linux-musleabi` | ✓ | ✓ | ARMv7 OpenWRT Linux MUSL
+`armv7-openwrt-linux-musleabihf` | ✓ | ✓ | ARMv7 + hardfloat OpenWRT Linux MUSL
 [`armv7-sony-vita-newlibeabihf`](platform-support/armv7-sony-vita-newlibeabihf.md) | ? |  | ARM Cortex-A9 Sony PlayStation Vita (requires VITASDK toolchain)
 [`armv7-unknown-linux-uclibceabi`](platform-support/armv7-unknown-linux-uclibceabi.md) | ✓ | ✓ | ARMv7 Linux with uClibc, softfloat
 [`armv7-unknown-linux-uclibceabihf`](platform-support/armv7-unknown-linux-uclibceabihf.md) | ✓ | ? | ARMv7 Linux with uClibc, hardfloat
@@ -261,7 +264,9 @@ target | std | host | notes
 `i686-wrs-vxworks` | ? |  |
 [`m68k-unknown-linux-gnu`](platform-support/m68k-unknown-linux-gnu.md) | ? |  | Motorola 680x0 Linux
 `mips-unknown-linux-uclibc` | ✓ |  | MIPS Linux with uClibc
+`mips-openwrt-linux-musl` | ✓ | ✓ | OpenWRT Linux MUSL
 [`mips64-openwrt-linux-musl`](platform-support/mips64-openwrt-linux-musl.md) | ? |  | MIPS64 for OpenWrt Linux MUSL
+`mipsel-openwrt-linux-musl` | ✓ | ✓ | OpenWRT Linux MUSL
 `mipsel-sony-psp` | * |  | MIPS (LE) Sony PlayStation Portable (PSP)
 [`mipsel-sony-psx`](platform-support/mipsel-sony-psx.md) | * |  | MIPS (LE) Sony PlayStation 1 (PSX)
 `mipsel-unknown-linux-uclibc` | ✓ |  | MIPS (LE) Linux with uClibc
@@ -275,6 +280,7 @@ target | std | host | notes
 `powerpc-unknown-linux-musl` | ? |  |
 `powerpc-unknown-netbsd` | ✓ | ✓ |
 `powerpc-unknown-openbsd` | ? |  |
+`powerpc64-openwrt-linux-musl` | ✓ | ✓ | OpenWRT Linux MUSL
 `powerpc-wrs-vxworks-spe` | ? |  |
 `powerpc-wrs-vxworks` | ? |  |
 `powerpc64-unknown-freebsd` | ✓ | ✓ | PPC64 FreeBSD (ELFv1 and ELFv2)
@@ -306,6 +312,7 @@ target | std | host | notes
 `x86_64-apple-ios-macabi` | ✓ |  | Apple Catalyst on x86_64
 `x86_64-apple-tvos` | * | | x86 64-bit tvOS
 [`x86_64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ | | x86 64-bit Apple WatchOS simulator
+`x86_64-openwrt-linux-musl` | ✓ | ✓ | OpenWRT Linux MUSL
 [`x86_64-pc-nto-qnx710`](platform-support/nto-qnx.md) | ? |  | x86 64-bit QNX Neutrino 7.1 RTOS |
 [`x86_64-pc-windows-gnullvm`](platform-support/pc-windows-gnullvm.md) | ✓ | ✓ |
 `x86_64-pc-windows-msvc` | * |  | 64-bit Windows XP support


### PR DESCRIPTION
They are the same as the unknown-linux ones.

I'm currently maintaining this patch trying to have rust included in OpenWRT and ended up adding the alias support to the targets to keep the patch small enough.

Is it acceptable to add aliases this way?