### PR TITLE
rustdoc: remove redundant CSS `.source .content { overflow: visible }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -355,10 +355,6 @@ img {
 	max-width: 100%;
 }
 
-.source .content {
-	overflow: visible;
-}
-
 .sub-logo-container, .logo-container {
 	/* zero text boxes so that computed line height = image height exactly */
 	line-height: 0;


### PR DESCRIPTION
When added in 7669f04fb0ddc3d71a1fb44dc1c5c00a6564ae99 / #16066, the page itself was set to scroll. Now it's set so that the `example-wrap` is scrolling inside the page, so the overflow setting for the content is irrelevant.