### PR TITLE
Fix `vec_deque::Drain` FIXME

### DIFF
--- a/library/alloc/src/collections/vec_deque/drain.rs
+++ b/library/alloc/src/collections/vec_deque/drain.rs
@@ -62,11 +62,10 @@ impl<'a, T, A: Allocator> Drain<'a, T, A> {
             // We know that `self.idx + self.remaining <= deque.len <= usize::MAX`, so this won't overflow.
             let end = start + self.remaining;
 
-            // SAFETY: the range `start..end` lies strictly inside
-            // the range `0..deque.original_len`. Because of this, and because
-            // we haven't touched the elements inside this range yet,
-            // it's guaranteed that `a_range` and `b_range` represent valid ranges into
-            // the deques buffer.
+            // SAFETY: `start..end` represents the range of elements that
+            // haven't been drained yet, so they're all initialized,
+            // and `slice::range(start..end, end) == start..end`,
+            // so the preconditions for `slice_ranges` are met.
             let (a_range, b_range) = deque.slice_ranges(start..end, end);
             (deque.buffer_range(a_range), deque.buffer_range(b_range))
         }

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -1230,10 +1230,9 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// # Safety
     ///
     /// This function is always safe to call. For the resulting ranges to be valid
-    /// ranges into the physical buffer, the caller must ensure that for all possible
-    /// values of `range` and `len`, the result of calling `slice::range(range, ..len)`
-    /// represents a valid range into the logical buffer, and that all elements
-    /// in that range are initialized.
+    /// ranges into the physical buffer, the caller must ensure that the result of
+    /// calling `slice::range(range, ..len)` represents a valid range into the
+    /// logical buffer, and that all elements in that range are initialized.
     fn slice_ranges<R>(&self, range: R, len: usize) -> (Range<usize>, Range<usize>)
     where
         R: RangeBounds<usize>,
@@ -1244,7 +1243,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
         if len == 0 {
             (0..0, 0..0)
         } else {
-            // `slice::range` guarantees that `start <= end <= self.len`.
+            // `slice::range` guarantees that `start <= end <= len`.
             // because `len != 0`, we know that `start < end`, so `start < len`
             // and the indexing is valid.
             let wrapped_start = self.to_physical_idx(start);

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -1226,6 +1226,14 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// the given range. The `len` parameter should usually just be `self.len`;
     /// the reason it's passed explicitly is that if the deque is wrapped in
     /// a `Drain`, then `self.len` is not actually the length of the deque.
+    ///
+    /// # Safety
+    ///
+    /// This function is always safe to call. For the resulting ranges to be valid
+    /// ranges into the physical buffer, the caller must ensure that for all possible
+    /// values of `range` and `len`, the result of calling `slice::range(range, ..len)`
+    /// represents a valid range into the logical buffer, and that all elements
+    /// in that range are initialized.
     fn slice_ranges<R>(&self, range: R, len: usize) -> (Range<usize>, Range<usize>)
     where
         R: RangeBounds<usize>,


### PR DESCRIPTION
In my original `VecDeque` rewrite, I didn't use `VecDeque::slice_ranges` in `Drain::as_slices`, even though that's basically the exact use case for `slice_ranges`. The reason for this was that a `VecDeque` wrapped in a `Drain` actually has its length set to `drain_start`, so that there's no potential use after free if you `mem::forget` the `Drain`. I modified `slice_ranges` to accept an explicit `len` parameter instead, which it now uses to bounds check the given range. This way, `Drain::as_slices` can use `slice_ranges` internally instead of having to basically just copy paste the `slice_ranges` code. Since `slice_ranges` is just an internal helper function, this shouldn't change the user facing behavior in any way.