### PR TITLE
fix infinite recursion on complex traits

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -59,6 +59,7 @@ use rustc_middle::ty::print::with_no_trimmed_paths;
 
 mod candidate_assembly;
 mod confirmation;
+mod only_fresh_differ;
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum IntercrateAmbiguityCause {
@@ -1135,7 +1136,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // precise still.
         if stack.iter().skip(1).any(|prev| {
             stack.obligation.param_env == prev.obligation.param_env
-                && self.match_fresh_trait_refs(
+                && self.only_typevars_differ(
                     stack.fresh_trait_pred,
                     prev.fresh_trait_pred,
                     prev.obligation.param_env,
@@ -2452,13 +2453,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     ///////////////////////////////////////////////////////////////////////////
     // Miscellany
 
-    fn match_fresh_trait_refs(
+    fn only_typevars_differ(
         &self,
         previous: ty::PolyTraitPredicate<'tcx>,
         current: ty::PolyTraitPredicate<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
     ) -> bool {
-        let mut matcher = ty::_match::Match::new(self.tcx(), param_env);
+        let mut matcher = only_fresh_differ::FreshDiffer::new(self.tcx(), param_env);
         matcher.relate(previous, current).is_ok()
     }
 

--- a/compiler/rustc_trait_selection/src/traits/select/only_fresh_differ.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/only_fresh_differ.rs
@@ -1,0 +1,116 @@
+use rustc_middle::ty::error::TypeError;
+use rustc_middle::ty::relate::{self, Relate, RelateResult, TypeRelation};
+use rustc_middle::ty::{self, InferConst, Ty, TyCtxt};
+
+/// Requires that the types can be unified by substituting fresh variables
+/// for fresh variable only.
+pub struct FreshDiffer<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+}
+
+impl<'tcx> FreshDiffer<'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>, param_env: ty::ParamEnv<'tcx>) -> Self {
+        Self { tcx, param_env }
+    }
+}
+
+impl<'tcx> TypeRelation<'tcx> for FreshDiffer<'tcx> {
+    fn tag(&self) -> &'static str {
+        "FreshDiffer"
+    }
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
+    fn intercrate(&self) -> bool {
+        false
+    }
+
+    fn param_env(&self) -> ty::ParamEnv<'tcx> {
+        self.param_env
+    }
+    fn a_is_expected(&self) -> bool {
+        true
+    } // irrelevant
+
+    fn mark_ambiguous(&mut self) {
+        bug!()
+    }
+
+    fn relate_with_variance<T: Relate<'tcx>>(
+        &mut self,
+        _: ty::Variance,
+        _: ty::VarianceDiagInfo<'tcx>,
+        a: T,
+        b: T,
+    ) -> RelateResult<'tcx, T> {
+        self.relate(a, b)
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    fn regions(
+        &mut self,
+        a: ty::Region<'tcx>,
+        b: ty::Region<'tcx>,
+    ) -> RelateResult<'tcx, ty::Region<'tcx>> {
+        Ok(a)
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    fn tys(&mut self, a: Ty<'tcx>, b: Ty<'tcx>) -> RelateResult<'tcx, Ty<'tcx>> {
+        if a == b {
+            return Ok(a);
+        }
+
+        match (a.kind(), b.kind()) {
+            (&ty::Infer(ty::FreshTy(_)), &ty::Infer(ty::FreshTy(_)))
+            | (&ty::Infer(ty::FreshIntTy(_)), &ty::Infer(ty::FreshIntTy(_)))
+            | (&ty::Infer(ty::FreshFloatTy(_)), &ty::Infer(ty::FreshFloatTy(_))) => Ok(a),
+
+            (&ty::Infer(_), _) | (_, &ty::Infer(_)) => {
+                Err(TypeError::Sorts(relate::expected_found(self, a, b)))
+            }
+
+            (&ty::Error(_), _) | (_, &ty::Error(_)) => Ok(self.tcx().ty_error()),
+
+            _ => relate::super_relate_tys(self, a, b),
+        }
+    }
+
+    fn consts(
+        &mut self,
+        a: ty::Const<'tcx>,
+        b: ty::Const<'tcx>,
+    ) -> RelateResult<'tcx, ty::Const<'tcx>> {
+        debug!("{}.consts({:?}, {:?})", self.tag(), a, b);
+        if a == b {
+            return Ok(a);
+        }
+
+        match (a.kind(), b.kind()) {
+            (_, ty::ConstKind::Infer(InferConst::Fresh(_))) => {
+                return Ok(a);
+            }
+
+            (ty::ConstKind::Infer(_), _) | (_, ty::ConstKind::Infer(_)) => {
+                return Err(TypeError::ConstMismatch(relate::expected_found(self, a, b)));
+            }
+
+            _ => {}
+        }
+
+        relate::super_relate_consts(self, a, b)
+    }
+
+    fn binders<T>(
+        &mut self,
+        a: ty::Binder<'tcx, T>,
+        b: ty::Binder<'tcx, T>,
+    ) -> RelateResult<'tcx, ty::Binder<'tcx, T>>
+    where
+        T: Relate<'tcx>,
+    {
+        Ok(a.rebind(self.relate(a.skip_binder(), b.skip_binder())?))
+    }
+}


### PR DESCRIPTION
Fixes #39959.

As I explained in the issue, evaluate_stack in rustc_trait_selection::traits::select attempts to prevent infinite recursion when inferring types that satisfy traits but fails to do so. I got the details wrong, though.

The code previously only checked for cases like $0: Eq, $1: Eq, etc. Now it also works in cases where the type variables are buried in some
data structure, like Union<$0, $1>: Eq.

This should fix all the errors reported in the issue. It fixes my instance of the problem, at least.

There is another class of problem it does not fix: infinite recursion that never repeats the same pattern. Avoiding that one would require exploring the options in a BFS manner or using bounded DFS. I haven't heard of this happening in practice but it could be that people who would have run into it were too discouraged by this bug.

I should probably add some test for this. Where would I do that?