### PR TITLE
rustdoc: remove redundant CSS `.code-wrapper { position: relative }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1871,12 +1871,11 @@ in storage.js
 }
 
 .scraped-example {
-	/* So .scraped-example-title can be positioned absolutely */
+	/* So .scraped-example-title, .prev, .next, and .expand can be positioned absolutely */
 	position: relative;
 }
 
 .scraped-example .code-wrapper {
-	position: relative;
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;


### PR DESCRIPTION
This line, added in 4b3f82ad0321b8f2e2630b74bbc526ffb8fa5bda, was part of how the expand/prev/next buttons were aligned.

Now that 6ccd14a782420d27aef9d9fcd9196949a3276427 made the outer wrapper has relative position, though, it doesn't matter any more, because those buttons will get the same position when they're made relative to that.