### PR TITLE
refactor: merge error code `E0465` into `E0464`

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -598,7 +598,7 @@ E0791: include_str!("./error_codes/E0791.md"),
 //  E0421, // merged into 531
 //  E0427, // merged into 530
 //  E0456, // plugin `..` is not available for triple `..`
-    E0465, // multiple .. candidates for `..` found
+//  E0465, // removed: merged with E0464
 //  E0467, // removed
 //  E0470, // removed
 //  E0471, // constant evaluation error (in pattern)

--- a/compiler/rustc_error_messages/locales/en-US/metadata.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/metadata.ftl
@@ -196,11 +196,7 @@ metadata_extern_location_not_file =
     extern location for {$crate_name} is not a file: {$location}
 
 metadata_multiple_candidates =
-    multiple {$flavor} candidates for `{$crate_name}` found
-
-metadata_multiple_matching_crates =
-    multiple matching crates for `{$crate_name}`
-    .note = candidates:{$candidates}
+    multiple candidates for `{$flavor}` dependency `{$crate_name}` found
 
 metadata_symbol_conflicts_current =
     the current crate is indistinguishable from one of its dependencies: it has the same crate-name `{$crate_name}` and was compiled with the same `-C metadata` arguments. This will result in symbol conflicts between the two.

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -486,23 +486,13 @@ impl IntoDiagnostic<'_> for MultipleCandidates {
         let mut diag = handler.struct_err(rustc_errors::fluent::metadata_multiple_candidates);
         diag.set_arg("crate_name", self.crate_name);
         diag.set_arg("flavor", self.flavor);
-        diag.code(error_code!(E0465));
+        diag.code(error_code!(E0464));
         diag.set_span(self.span);
         for (i, candidate) in self.candidates.iter().enumerate() {
-            diag.span_note(self.span, &format!("candidate #{}: {}", i + 1, candidate.display()));
+            diag.note(&format!("candidate #{}: {}", i + 1, candidate.display()));
         }
         diag
     }
-}
-
-#[derive(Diagnostic)]
-#[diag(metadata_multiple_matching_crates, code = "E0464")]
-#[note]
-pub struct MultipleMatchingCrates {
-    #[primary_span]
-    pub span: Span,
-    pub crate_name: Symbol,
-    pub candidates: String,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -216,9 +216,8 @@ use crate::creader::Library;
 use crate::errors::{
     CannotFindCrate, CrateLocationUnknownType, DlError, ExternLocationNotExist,
     ExternLocationNotFile, FoundStaticlib, IncompatibleRustc, InvalidMetadataFiles,
-    LibFilenameForm, MultipleCandidates, MultipleMatchingCrates, NewerCrateVersion,
-    NoCrateWithTriple, NoDylibPlugin, NonAsciiName, StableCrateIdCollision, SymbolConflictsCurrent,
-    SymbolConflictsOthers,
+    LibFilenameForm, MultipleCandidates, NewerCrateVersion, NoCrateWithTriple, NoDylibPlugin,
+    NonAsciiName, StableCrateIdCollision, SymbolConflictsCurrent, SymbolConflictsOthers,
 };
 use crate::rmeta::{rustc_version, MetadataBlob, METADATA_HEADER};
 
@@ -240,7 +239,6 @@ use rustc_target::spec::{Target, TargetTriple};
 
 use snap::read::FrameDecoder;
 use std::borrow::Cow;
-use std::fmt::Write as _;
 use std::io::{Read, Result as IoResult, Write};
 use std::path::{Path, PathBuf};
 use std::{cmp, fmt, fs};
@@ -482,7 +480,22 @@ impl<'a> CrateLocator<'a> {
         match libraries.len() {
             0 => Ok(None),
             1 => Ok(Some(libraries.into_iter().next().unwrap().1)),
-            _ => Err(CrateError::MultipleMatchingCrates(self.crate_name, libraries)),
+            _ => {
+                let mut libraries: Vec<_> = libraries.into_values().collect();
+
+                libraries.sort_by_cached_key(|lib| lib.source.paths().next().unwrap().clone());
+                let candidates = libraries
+                    .iter()
+                    .map(|lib| lib.source.paths().next().unwrap().clone())
+                    .collect::<Vec<_>>();
+
+                Err(CrateError::MultipleCandidates(
+                    self.crate_name,
+                    // these are the same for all candidates
+                    get_flavor_from_path(candidates.first().unwrap()),
+                    candidates,
+                ))
+            }
         }
     }
 
@@ -882,17 +895,22 @@ pub fn list_file_metadata(
     metadata_loader: &dyn MetadataLoader,
     out: &mut dyn Write,
 ) -> IoResult<()> {
+    let flavor = get_flavor_from_path(path);
+    match get_metadata_section(target, flavor, path, metadata_loader) {
+        Ok(metadata) => metadata.list_crate_metadata(out),
+        Err(msg) => write!(out, "{}\n", msg),
+    }
+}
+
+fn get_flavor_from_path(path: &Path) -> CrateFlavor {
     let filename = path.file_name().unwrap().to_str().unwrap();
-    let flavor = if filename.ends_with(".rlib") {
+
+    if filename.ends_with(".rlib") {
         CrateFlavor::Rlib
     } else if filename.ends_with(".rmeta") {
         CrateFlavor::Rmeta
     } else {
         CrateFlavor::Dylib
-    };
-    match get_metadata_section(target, flavor, path, metadata_loader) {
-        Ok(metadata) => metadata.list_crate_metadata(out),
-        Err(msg) => write!(out, "{}\n", msg),
     }
 }
 
@@ -931,7 +949,6 @@ pub(crate) enum CrateError {
     ExternLocationNotExist(Symbol, PathBuf),
     ExternLocationNotFile(Symbol, PathBuf),
     MultipleCandidates(Symbol, CrateFlavor, Vec<PathBuf>),
-    MultipleMatchingCrates(Symbol, FxHashMap<Svh, Library>),
     SymbolConflictsCurrent(Symbol),
     SymbolConflictsOthers(Symbol),
     StableCrateIdCollision(Symbol, Symbol),
@@ -972,37 +989,7 @@ impl CrateError {
                 sess.emit_err(ExternLocationNotFile { span, crate_name, location: &loc });
             }
             CrateError::MultipleCandidates(crate_name, flavor, candidates) => {
-                sess.emit_err(MultipleCandidates { span, flavor: flavor, crate_name, candidates });
-            }
-            CrateError::MultipleMatchingCrates(crate_name, libraries) => {
-                let mut libraries: Vec<_> = libraries.into_values().collect();
-                // Make ordering of candidates deterministic.
-                // This has to `clone()` to work around lifetime restrictions with `sort_by_key()`.
-                // `sort_by()` could be used instead, but this is in the error path,
-                // so the performance shouldn't matter.
-                libraries.sort_by_cached_key(|lib| lib.source.paths().next().unwrap().clone());
-                let candidates = libraries
-                    .iter()
-                    .map(|lib| {
-                        let crate_name = lib.metadata.get_root().name();
-                        let crate_name = crate_name.as_str();
-                        let mut paths = lib.source.paths();
-
-                        // This `unwrap()` should be okay because there has to be at least one
-                        // source file. `CrateSource`'s docs confirm that too.
-                        let mut s = format!(
-                            "\ncrate `{}`: {}",
-                            crate_name,
-                            paths.next().unwrap().display()
-                        );
-                        let padding = 8 + crate_name.len();
-                        for path in paths {
-                            write!(s, "\n{:>padding$}", path.display(), padding = padding).unwrap();
-                        }
-                        s
-                    })
-                    .collect::<String>();
-                sess.emit_err(MultipleMatchingCrates { span, crate_name, candidates });
+                sess.emit_err(MultipleCandidates { span, crate_name, flavor, candidates });
             }
             CrateError::SymbolConflictsCurrent(root_name) => {
                 sess.emit_err(SymbolConflictsCurrent { span, crate_name: root_name });

--- a/src/test/ui/crate-loading/auxiliary/crateresolve1-1.rs
+++ b/src/test/ui/crate-loading/auxiliary/crateresolve1-1.rs
@@ -1,4 +1,5 @@
 // compile-flags:-C extra-filename=-1
+// no-prefer-dynamic
 #![crate_name = "crateresolve1"]
 #![crate_type = "lib"]
 

--- a/src/test/ui/crate-loading/auxiliary/crateresolve1-2.rs
+++ b/src/test/ui/crate-loading/auxiliary/crateresolve1-2.rs
@@ -1,4 +1,5 @@
 // compile-flags:-C extra-filename=-2
+// no-prefer-dynamic
 #![crate_name = "crateresolve1"]
 #![crate_type = "lib"]
 

--- a/src/test/ui/crate-loading/auxiliary/crateresolve1-3.rs
+++ b/src/test/ui/crate-loading/auxiliary/crateresolve1-3.rs
@@ -1,4 +1,5 @@
 // compile-flags:-C extra-filename=-3
+// no-prefer-dynamic
 #![crate_name = "crateresolve1"]
 #![crate_type = "lib"]
 

--- a/src/test/ui/crate-loading/crateresolve1.rs
+++ b/src/test/ui/crate-loading/crateresolve1.rs
@@ -9,7 +9,6 @@
 // NOTE: This test is duplicated at `src/test/ui/error-codes/E0464.rs`.
 
 extern crate crateresolve1;
-//~^ ERROR multiple matching crates for `crateresolve1`
+//~^ ERROR multiple candidates for `rlib` dependency `crateresolve1` found
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/crate-loading/crateresolve1.stderr
+++ b/src/test/ui/crate-loading/crateresolve1.stderr
@@ -1,13 +1,12 @@
-error[E0464]: multiple matching crates for `crateresolve1`
+error[E0464]: multiple candidates for `rlib` dependency `crateresolve1` found
   --> $DIR/crateresolve1.rs:11:1
    |
 LL | extern crate crateresolve1;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: candidates:
-           crate `crateresolve1`: $TEST_BUILD_DIR/crate-loading/crateresolve1/auxiliary/libcrateresolve1-1.somelib
-           crate `crateresolve1`: $TEST_BUILD_DIR/crate-loading/crateresolve1/auxiliary/libcrateresolve1-2.somelib
-           crate `crateresolve1`: $TEST_BUILD_DIR/crate-loading/crateresolve1/auxiliary/libcrateresolve1-3.somelib
+   = note: candidate #1: $TEST_BUILD_DIR/crate-loading/crateresolve1/auxiliary/libcrateresolve1-1.somelib
+   = note: candidate #2: $TEST_BUILD_DIR/crate-loading/crateresolve1/auxiliary/libcrateresolve1-2.somelib
+   = note: candidate #3: $TEST_BUILD_DIR/crate-loading/crateresolve1/auxiliary/libcrateresolve1-3.somelib
 
 error: aborting due to previous error
 

--- a/src/test/ui/crate-loading/crateresolve2.rs
+++ b/src/test/ui/crate-loading/crateresolve2.rs
@@ -8,7 +8,6 @@
 // normalize-stderr-test: "\\\?\\" -> ""
 
 extern crate crateresolve2;
-//~^ ERROR multiple matching crates for `crateresolve2`
+//~^ ERROR multiple candidates for `rmeta` dependency `crateresolve2` found
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/crate-loading/crateresolve2.stderr
+++ b/src/test/ui/crate-loading/crateresolve2.stderr
@@ -1,13 +1,12 @@
-error[E0464]: multiple matching crates for `crateresolve2`
+error[E0464]: multiple candidates for `rmeta` dependency `crateresolve2` found
   --> $DIR/crateresolve2.rs:10:1
    |
 LL | extern crate crateresolve2;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: candidates:
-           crate `crateresolve2`: $TEST_BUILD_DIR/crate-loading/crateresolve2/auxiliary/libcrateresolve2-1.rmeta
-           crate `crateresolve2`: $TEST_BUILD_DIR/crate-loading/crateresolve2/auxiliary/libcrateresolve2-2.rmeta
-           crate `crateresolve2`: $TEST_BUILD_DIR/crate-loading/crateresolve2/auxiliary/libcrateresolve2-3.rmeta
+   = note: candidate #1: $TEST_BUILD_DIR/crate-loading/crateresolve2/auxiliary/libcrateresolve2-1.rmeta
+   = note: candidate #2: $TEST_BUILD_DIR/crate-loading/crateresolve2/auxiliary/libcrateresolve2-2.rmeta
+   = note: candidate #3: $TEST_BUILD_DIR/crate-loading/crateresolve2/auxiliary/libcrateresolve2-3.rmeta
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0464.rs
+++ b/src/test/ui/error-codes/E0464.rs
@@ -9,7 +9,6 @@
 // NOTE: This test is duplicated from `src/test/ui/crate-loading/crateresolve1.rs`.
 
 extern crate crateresolve1;
-//~^ ERROR multiple matching crates for `crateresolve1`
+//~^ ERROR multiple candidates for `rlib` dependency `crateresolve1` found
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/error-codes/E0464.stderr
+++ b/src/test/ui/error-codes/E0464.stderr
@@ -1,13 +1,12 @@
-error[E0464]: multiple matching crates for `crateresolve1`
+error[E0464]: multiple candidates for `rlib` dependency `crateresolve1` found
   --> $DIR/E0464.rs:11:1
    |
 LL | extern crate crateresolve1;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: candidates:
-           crate `crateresolve1`: $TEST_BUILD_DIR/error-codes/E0464/auxiliary/libcrateresolve1-1.somelib
-           crate `crateresolve1`: $TEST_BUILD_DIR/error-codes/E0464/auxiliary/libcrateresolve1-2.somelib
-           crate `crateresolve1`: $TEST_BUILD_DIR/error-codes/E0464/auxiliary/libcrateresolve1-3.somelib
+   = note: candidate #1: $TEST_BUILD_DIR/error-codes/E0464/auxiliary/libcrateresolve1-1.somelib
+   = note: candidate #2: $TEST_BUILD_DIR/error-codes/E0464/auxiliary/libcrateresolve1-2.somelib
+   = note: candidate #3: $TEST_BUILD_DIR/error-codes/E0464/auxiliary/libcrateresolve1-3.somelib
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/auxiliary/crateresolve1-1.rs
+++ b/src/test/ui/error-codes/auxiliary/crateresolve1-1.rs
@@ -1,4 +1,5 @@
 // compile-flags:-C extra-filename=-1
+// no-prefer-dynamic
 #![crate_name = "crateresolve1"]
 #![crate_type = "lib"]
 

--- a/src/test/ui/error-codes/auxiliary/crateresolve1-2.rs
+++ b/src/test/ui/error-codes/auxiliary/crateresolve1-2.rs
@@ -1,4 +1,5 @@
 // compile-flags:-C extra-filename=-2
+// no-prefer-dynamic
 #![crate_name = "crateresolve1"]
 #![crate_type = "lib"]
 

--- a/src/test/ui/error-codes/auxiliary/crateresolve1-3.rs
+++ b/src/test/ui/error-codes/auxiliary/crateresolve1-3.rs
@@ -1,4 +1,5 @@
 // compile-flags:-C extra-filename=-3
+// no-prefer-dynamic
 #![crate_name = "crateresolve1"]
 #![crate_type = "lib"]
 

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -11,8 +11,8 @@ use regex::Regex;
 
 // A few of those error codes can't be tested but all the others can and *should* be tested!
 const EXEMPTED_FROM_TEST: &[&str] = &[
-    "E0313", "E0461", "E0465", "E0476", "E0490", "E0514", "E0523", "E0554", "E0640", "E0717",
-    "E0729", "E0789",
+    "E0313", "E0461", "E0476", "E0490", "E0514", "E0523", "E0554", "E0640", "E0717", "E0729",
+    "E0789",
 ];
 
 // Some error codes don't have any tests apparently...


### PR DESCRIPTION
`E0465` is an undocumented and untested error code that is functionally identical to `E0464`. This PR merges `E0465` into `E0464`, thus documenting and testing another error code (#61137).

r? @GuillaumeGomez (not sure if you want to review this but it's relevant to my other PRs that you have reviewed)