### PR TITLE
Add help diag. for `const = Enum` missing braces around `Enum`

### DIFF
--- a/src/test/ui/const-generics/assoc_const_eq_diagnostic.rs
+++ b/src/test/ui/const-generics/assoc_const_eq_diagnostic.rs
@@ -1,0 +1,18 @@
+#![feature(associated_const_equality)]
+
+pub enum Mode {
+    Cool,
+}
+
+pub trait Parse {
+    const MODE: Mode;
+}
+
+pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
+//~^ ERROR expected associated constant bound
+//~| ERROR expected type
+
+fn no_help() -> Mode::Cool {}
+//~^ ERROR expected type, found variant
+
+fn main() {}

--- a/src/test/ui/const-generics/assoc_const_eq_diagnostic.stderr
+++ b/src/test/ui/const-generics/assoc_const_eq_diagnostic.stderr
@@ -1,0 +1,33 @@
+error[E0573]: expected type, found variant `Mode::Cool`
+  --> $DIR/assoc_const_eq_diagnostic.rs:11:35
+   |
+LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
+   |                                   ^^^^^^^^^^
+   |                                   |
+   |                                   not a type
+   |                                   help: try using the variant's enum: `Mode`
+
+error[E0573]: expected type, found variant `Mode::Cool`
+  --> $DIR/assoc_const_eq_diagnostic.rs:15:17
+   |
+LL | fn no_help() -> Mode::Cool {}
+   |                 ^^^^^^^^^^
+   |                 |
+   |                 not a type
+   |                 help: try using the variant's enum: `Mode`
+
+error: expected associated constant bound, found type
+  --> $DIR/assoc_const_eq_diagnostic.rs:11:28
+   |
+LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
+   |                            ^^^^^^^^^^^^^^^^^ help: if equating a const, try wrapping with braces: `MODE = { const }`
+   |
+note: associated constant defined here
+  --> $DIR/assoc_const_eq_diagnostic.rs:8:5
+   |
+LL |     const MODE: Mode;
+   |     ^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0573`.


### PR DESCRIPTION
Previously it was not clear why this errored or if it was even supported, as there was no diagnostic that suggested wrapping it in braces.

Thus, add a simple diagnostic that suggests wrapping enum variants in braces.

Fixes #105927