### PR TITLE
Extend scraped examples layout GUI test for position of buttons

### DIFF
--- a/src/test/rustdoc-gui/scrape-examples-layout.goml
+++ b/src/test/rustdoc-gui/scrape-examples-layout.goml
@@ -33,3 +33,17 @@ assert-property: (
     ".more-scraped-examples .scraped-example:nth-child(6) .code-wrapper .src-line-numbers",
     {"clientWidth": |clientWidth|}
 )
+
+// Check that for both mobile and desktop sizes, the buttons in scraped examples are displayed
+// correctly.
+
+store-value: (offset_y, 4)
+
+// First with desktop
+assert-position: (".scraped-example .code-wrapper", {"y": 255})
+assert-position: (".scraped-example .code-wrapper .prev", {"y": 255 + |offset_y|})
+
+// Then with mobile
+size: (600, 600)
+assert-position: (".scraped-example .code-wrapper", {"y": 314})
+assert-position: (".scraped-example .code-wrapper .prev", {"y": 314 + |offset_y|})


### PR DESCRIPTION
This is a regression test for https://github.com/rust-lang/rust/pull/106279.

r? @notriddle 