### PR TITLE
Prefer non-`[type error]` candidates during selection

### DIFF
--- a/compiler/rustc_middle/src/ty/_match.rs
+++ b/compiler/rustc_middle/src/ty/_match.rs
@@ -89,7 +89,9 @@ impl<'tcx> TypeRelation<'tcx> for Match<'tcx> {
                 Err(TypeError::Sorts(relate::expected_found(self, a, b)))
             }
 
-            (&ty::Error(_), _) | (_, &ty::Error(_)) => Ok(self.tcx().ty_error()),
+            (&ty::Error(guar), _) | (_, &ty::Error(guar)) => {
+                Ok(self.tcx().ty_error_with_guaranteed(guar))
+            }
 
             _ => relate::super_relate_tys(self, a, b),
         }

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -414,7 +414,7 @@ pub fn super_relate_tys<'tcx, R: TypeRelation<'tcx>>(
             bug!("bound types encountered in super_relate_tys")
         }
 
-        (&ty::Error(_), _) | (_, &ty::Error(_)) => Ok(tcx.ty_error()),
+        (&ty::Error(guar), _) | (_, &ty::Error(guar)) => Ok(tcx.ty_error_with_guaranteed(guar)),
 
         (&ty::Never, _)
         | (&ty::Char, _)

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -174,7 +174,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             .param_env
             .caller_bounds()
             .iter()
-            .filter_map(|o| o.to_opt_poly_trait_pred());
+            .filter_map(|p| p.to_opt_poly_trait_pred())
+            .filter(|p| !p.references_error());
 
         // Micro-optimization: filter out predicates relating to different traits.
         let matching_bounds =

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2377,6 +2377,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let impl_substs = self.infcx.fresh_substs_for_item(obligation.cause.span, impl_def_id);
 
         let impl_trait_ref = impl_trait_ref.subst(self.tcx(), impl_substs);
+        if impl_trait_ref.references_error() {
+            return Err(());
+        }
 
         debug!(?impl_trait_ref);
 

--- a/tests/ui/c-variadic/issue-86053-1.rs
+++ b/tests/ui/c-variadic/issue-86053-1.rs
@@ -2,7 +2,7 @@
 // error-pattern:unexpected `self` parameter in function
 // error-pattern:`...` must be the last argument of a C-variadic function
 // error-pattern:cannot find type `F` in this scope
-// error-pattern:in type `&'a &'b usize`, reference has a longer lifetime than the data it references
+
 
 #![feature(c_variadic)]
 #![crate_type="lib"]

--- a/tests/ui/c-variadic/issue-86053-1.stderr
+++ b/tests/ui/c-variadic/issue-86053-1.stderr
@@ -76,24 +76,6 @@ help: you might be missing a type parameter
 LL | fn ordering4 < 'a , 'b, F     > ( a :            ,   self , self ,   self ,
    |                       +++
 
-error[E0491]: in type `&'a &'b usize`, reference has a longer lifetime than the data it references
-  --> $DIR/issue-86053-1.rs:11:52
-   |
-LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize ) {
-   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: the pointer is valid for the lifetime `'a` as defined here
-  --> $DIR/issue-86053-1.rs:10:16
-   |
-LL | fn ordering4 < 'a , 'b     > ( a :            ,   self , self ,   self ,
-   |                ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined here
-  --> $DIR/issue-86053-1.rs:10:21
-   |
-LL | fn ordering4 < 'a , 'b     > ( a :            ,   self , self ,   self ,
-   |                     ^^
+error: aborting due to 11 previous errors
 
-error: aborting due to 12 previous errors
-
-Some errors have detailed explanations: E0412, E0491.
-For more information about an error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
@@ -17,7 +17,7 @@ LL |     Condition<{ LHS <= RHS }>: True
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/issue-72787.rs:25:25
+  --> $DIR/issue-72787.rs:23:25
    |
 LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    |                         ^ cannot perform const operation using `I`
@@ -26,7 +26,7 @@ LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/issue-72787.rs:25:36
+  --> $DIR/issue-72787.rs:23:36
    |
 LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    |                                    ^ cannot perform const operation using `J`
@@ -34,42 +34,5 @@ LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    = help: const parameters may only be used as standalone arguments, i.e. `J`
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error[E0283]: type annotations needed: cannot satisfy `IsLessOrEqual<I, 8>: True`
-  --> $DIR/issue-72787.rs:21:26
-   |
-LL |     IsLessOrEqual<I, 8>: True,
-   |                          ^^^^
-   |
-note: multiple `impl`s or `where` clauses satisfying `IsLessOrEqual<I, 8>: True` found
-  --> $DIR/issue-72787.rs:10:1
-   |
-LL | impl<const LHS: u32, const RHS: u32> True for IsLessOrEqual<LHS, RHS> where
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL |     IsLessOrEqual<I, 8>: True,
-   |                          ^^^^
-...
-LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
-   |                                          ^^^^
+error: aborting due to 4 previous errors
 
-error[E0283]: type annotations needed: cannot satisfy `IsLessOrEqual<I, 8>: True`
-  --> $DIR/issue-72787.rs:21:26
-   |
-LL |     IsLessOrEqual<I, 8>: True,
-   |                          ^^^^
-   |
-note: multiple `impl`s or `where` clauses satisfying `IsLessOrEqual<I, 8>: True` found
-  --> $DIR/issue-72787.rs:10:1
-   |
-LL | impl<const LHS: u32, const RHS: u32> True for IsLessOrEqual<LHS, RHS> where
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL |     IsLessOrEqual<I, 8>: True,
-   |                          ^^^^
-...
-LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
-   |                                          ^^^^
-
-error: aborting due to 6 previous errors
-
-For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-72787.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72787.rs
@@ -19,8 +19,6 @@ struct S<const I: u32, const J: u32>;
 impl<const I: u32, const J: u32> S<I, J>
 where
     IsLessOrEqual<I, 8>: True,
-//[min]~^ Error type annotations needed
-//[min]~| Error type annotations needed
     IsLessOrEqual<J, 8>: True,
     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
 //[min]~^ Error generic parameters may not be used in const operations

--- a/tests/ui/traits/ignore-err-impls.rs
+++ b/tests/ui/traits/ignore-err-impls.rs
@@ -1,0 +1,9 @@
+pub struct S;
+
+trait Generic<T> {}
+
+impl<'a, T> Generic<&'a T> for S {}
+impl Generic<Type> for S {}
+//~^ ERROR cannot find type `Type` in this scope
+
+fn main() {}

--- a/tests/ui/traits/ignore-err-impls.stderr
+++ b/tests/ui/traits/ignore-err-impls.stderr
@@ -1,0 +1,11 @@
+error[E0412]: cannot find type `Type` in this scope
+  --> $DIR/ignore-err-impls.rs:6:14
+   |
+LL | impl Generic<Type> for S {}
+   |     -        ^^^^ not found in this scope
+   |     |
+   |     help: you might be missing a type parameter: `<Type>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/where-clauses/ignore-err-clauses.rs
+++ b/tests/ui/where-clauses/ignore-err-clauses.rs
@@ -1,0 +1,14 @@
+use std::ops::Add;
+
+fn dbl<T>(x: T) -> <T as Add>::Output
+where
+    T: Copy + Add,
+    UUU: Copy,
+    //~^ ERROR cannot find type `UUU` in this scope
+{
+    x + x
+}
+
+fn main() {
+    println!("{}", dbl(3));
+}

--- a/tests/ui/where-clauses/ignore-err-clauses.stderr
+++ b/tests/ui/where-clauses/ignore-err-clauses.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `UUU` in this scope
+  --> $DIR/ignore-err-clauses.rs:6:5
+   |
+LL |     UUU: Copy,
+   |     ^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fixes #102130
Fixes #106351

r? types

note: Alternatively we could filter out error where-clauses during param-env construction? But we still need to filter out impls with errors during `match_impl`, I think.