### PR TITLE
Dont use `--merge-base` during bootstrap formatting subcommand

### DIFF
--- a/src/bootstrap/format.rs
+++ b/src/bootstrap/format.rs
@@ -79,24 +79,19 @@ fn update_rustfmt_version(build: &Builder<'_>) {
 ///
 /// Returns `None` if all files should be formatted.
 fn get_modified_rs_files(build: &Builder<'_>) -> Option<Vec<String>> {
-    let Ok(remote) = get_rust_lang_rust_remote() else {return None;};
+    let Ok(remote) = get_rust_lang_rust_remote() else { return None; };
     if !verify_rustfmt_version(build) {
         return None;
     }
+
+    let merge_base =
+        output(build.config.git().arg("merge-base").arg(&format!("{remote}/master")).arg("HEAD"));
     Some(
-        output(
-            build
-                .config
-                .git()
-                .arg("diff-index")
-                .arg("--name-only")
-                .arg("--merge-base")
-                .arg(&format!("{remote}/master")),
-        )
-        .lines()
-        .map(|s| s.trim().to_owned())
-        .filter(|f| Path::new(f).extension().map_or(false, |ext| ext == "rs"))
-        .collect(),
+        output(build.config.git().arg("diff-index").arg("--name-only").arg(merge_base.trim()))
+            .lines()
+            .map(|s| s.trim().to_owned())
+            .filter(|f| Path::new(f).extension().map_or(false, |ext| ext == "rs"))
+            .collect(),
     )
 }
 


### PR DESCRIPTION
I use a development image with Ubuntu 20.04 LTS, which has git 2.25.

Recently, `./x.py test tidy --bless` regressed in #105702 because it uses the `--merge-base` option on `diff-index`, which was only introduced in git 2.30 (git/git@0f5a1d449b9538c2765de9d6683abbb83a7fb4e2). Luckily, it can be replicated via two calls to `git merge-base` + `git diff-index`, so let's just use that.