### PR TITLE
Don't monomorphize ty::tls closures in rustc_query_impl

### DIFF
--- a/compiler/rustc_middle/src/ty/context/tls.rs
+++ b/compiler/rustc_middle/src/ty/context/tls.rs
@@ -115,7 +115,7 @@ where
 }
 
 /// Allows access to the current `ImplicitCtxt` in a closure if one is available.
-#[inline(always)]
+#[inline]
 pub fn with_context_opt<F, R>(f: F) -> R
 where
     F: for<'a, 'tcx> FnOnce(Option<&ImplicitCtxt<'a, 'tcx>>) -> R,
@@ -134,7 +134,7 @@ where
 
 /// Allows access to the current `ImplicitCtxt`.
 /// Panics if there is no `ImplicitCtxt` available.
-#[inline(always)]
+#[inline]
 pub fn with_context<F, R>(f: F) -> R
 where
     F: for<'a, 'tcx> FnOnce(&ImplicitCtxt<'a, 'tcx>) -> R,
@@ -147,7 +147,7 @@ where
 /// as the `TyCtxt` passed in.
 /// This will panic if you pass it a `TyCtxt` which is different from the current
 /// `ImplicitCtxt`'s `tcx` field.
-#[inline(always)]
+#[inline]
 pub fn with_related_context<'tcx, F, R>(tcx: TyCtxt<'tcx>, f: F) -> R
 where
     F: FnOnce(&ImplicitCtxt<'_, 'tcx>) -> R,

--- a/compiler/rustc_middle/src/ty/context/tls.rs
+++ b/compiler/rustc_middle/src/ty/context/tls.rs
@@ -115,7 +115,7 @@ where
 }
 
 /// Allows access to the current `ImplicitCtxt` in a closure if one is available.
-#[inline]
+#[inline(always)]
 pub fn with_context_opt<F, R>(f: F) -> R
 where
     F: for<'a, 'tcx> FnOnce(Option<&ImplicitCtxt<'a, 'tcx>>) -> R,
@@ -134,7 +134,7 @@ where
 
 /// Allows access to the current `ImplicitCtxt`.
 /// Panics if there is no `ImplicitCtxt` available.
-#[inline]
+#[inline(always)]
 pub fn with_context<F, R>(f: F) -> R
 where
     F: for<'a, 'tcx> FnOnce(&ImplicitCtxt<'a, 'tcx>) -> R,
@@ -147,7 +147,7 @@ where
 /// as the `TyCtxt` passed in.
 /// This will panic if you pass it a `TyCtxt` which is different from the current
 /// `ImplicitCtxt`'s `tcx` field.
-#[inline]
+#[inline(always)]
 pub fn with_related_context<'tcx, F, R>(tcx: TyCtxt<'tcx>, f: F) -> R
 where
     F: FnOnce(&ImplicitCtxt<'_, 'tcx>) -> R,

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -104,7 +104,7 @@ impl QueryContext for QueryCtxt<'_> {
         token: QueryJobId,
         depth_limit: bool,
         diagnostics: Option<&Lock<ThinVec<Diagnostic>>>,
-        compute: impl FnOnce() -> R,
+        compute: &mut dyn FnMut() -> R,
     ) -> R {
         // The `TyCtxt` stored in TLS has the same global interner lifetime
         // as `self`, so we use `with_related_context` to relate the 'tcx lifetimes

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -104,7 +104,7 @@ impl QueryContext for QueryCtxt<'_> {
         token: QueryJobId,
         depth_limit: bool,
         diagnostics: Option<&Lock<ThinVec<Diagnostic>>>,
-        compute: &mut dyn FnMut() -> R,
+        compute: impl FnOnce() -> R,
     ) -> R {
         // The `TyCtxt` stored in TLS has the same global interner lifetime
         // as `self`, so we use `with_related_context` to relate the 'tcx lifetimes

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -128,7 +128,7 @@ pub trait QueryContext: HasDepContext {
         token: QueryJobId,
         depth_limit: bool,
         diagnostics: Option<&Lock<ThinVec<Diagnostic>>>,
-        compute: impl FnOnce() -> R,
+        compute: &mut dyn FnMut() -> R,
     ) -> R;
 
     fn depth_limit_error(self, job: QueryJobId);

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -128,7 +128,7 @@ pub trait QueryContext: HasDepContext {
         token: QueryJobId,
         depth_limit: bool,
         diagnostics: Option<&Lock<ThinVec<Diagnostic>>>,
-        compute: &mut dyn FnMut() -> R,
+        compute: impl FnOnce() -> R,
     ) -> R;
 
     fn depth_limit_error(self, job: QueryJobId);

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -421,7 +421,8 @@ where
         }
 
         let prof_timer = qcx.dep_context().profiler().query_provider();
-        let result = qcx.start_query(job_id, query.depth_limit(), None, || query.compute(qcx, key));
+        let result =
+            qcx.start_query(job_id, query.depth_limit(), None, &mut || query.compute(qcx, key));
         let dep_node_index = dep_graph.next_virtual_depnode_index();
         prof_timer.finish_with_query_invocation_id(dep_node_index.into());
 
@@ -445,7 +446,7 @@ where
 
         // The diagnostics for this query will be promoted to the current session during
         // `try_mark_green()`, so we can ignore them here.
-        if let Some(ret) = qcx.start_query(job_id, false, None, || {
+        if let Some(ret) = qcx.start_query(job_id, false, None, &mut || {
             try_load_from_disk_and_cache_in_memory(query, qcx, &key, &dep_node)
         }) {
             return ret;
@@ -456,7 +457,7 @@ where
     let diagnostics = Lock::new(ThinVec::new());
 
     let (result, dep_node_index) =
-        qcx.start_query(job_id, query.depth_limit(), Some(&diagnostics), || {
+        qcx.start_query(job_id, query.depth_limit(), Some(&diagnostics), &mut || {
             if query.anon() {
                 return dep_graph.with_anon_task(*qcx.dep_context(), query.dep_kind(), || {
                     query.compute(qcx, key)

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -421,7 +421,7 @@ where
         }
 
         let prof_timer = qcx.dep_context().profiler().query_provider();
-        let result = qcx.start_query(job_id, query.depth_limit(), None, || query.compute(qcx, key));
+        let result = qcx.start_query(job_id, query.depth_limit(), None, &mut || query.compute(qcx, key));
         let dep_node_index = dep_graph.next_virtual_depnode_index();
         prof_timer.finish_with_query_invocation_id(dep_node_index.into());
 
@@ -445,7 +445,7 @@ where
 
         // The diagnostics for this query will be promoted to the current session during
         // `try_mark_green()`, so we can ignore them here.
-        if let Some(ret) = qcx.start_query(job_id, false, None, || {
+        if let Some(ret) = qcx.start_query(job_id, false, None, &mut || {
             try_load_from_disk_and_cache_in_memory(query, qcx, &key, &dep_node)
         }) {
             return ret;
@@ -456,7 +456,7 @@ where
     let diagnostics = Lock::new(ThinVec::new());
 
     let (result, dep_node_index) =
-        qcx.start_query(job_id, query.depth_limit(), Some(&diagnostics), || {
+        qcx.start_query(job_id, query.depth_limit(), Some(&diagnostics), &mut || {
             if query.anon() {
                 return dep_graph.with_anon_task(*qcx.dep_context(), query.dep_kind(), || {
                     query.compute(qcx, key)

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -421,7 +421,7 @@ where
         }
 
         let prof_timer = qcx.dep_context().profiler().query_provider();
-        let result = qcx.start_query(job_id, query.depth_limit(), None, &mut || query.compute(qcx, key));
+        let result = qcx.start_query(job_id, query.depth_limit(), None, || query.compute(qcx, key));
         let dep_node_index = dep_graph.next_virtual_depnode_index();
         prof_timer.finish_with_query_invocation_id(dep_node_index.into());
 
@@ -445,7 +445,7 @@ where
 
         // The diagnostics for this query will be promoted to the current session during
         // `try_mark_green()`, so we can ignore them here.
-        if let Some(ret) = qcx.start_query(job_id, false, None, &mut || {
+        if let Some(ret) = qcx.start_query(job_id, false, None, || {
             try_load_from_disk_and_cache_in_memory(query, qcx, &key, &dep_node)
         }) {
             return ret;
@@ -456,7 +456,7 @@ where
     let diagnostics = Lock::new(ThinVec::new());
 
     let (result, dep_node_index) =
-        qcx.start_query(job_id, query.depth_limit(), Some(&diagnostics), &mut || {
+        qcx.start_query(job_id, query.depth_limit(), Some(&diagnostics), || {
             if query.anon() {
                 return dep_graph.with_anon_task(*qcx.dep_context(), query.dep_kind(), || {
                     query.compute(qcx, key)


### PR DESCRIPTION
alternative to #106270; closes #106270. helps with https://github.com/rust-lang/rust/issues/65031

Best reviewed commit by commit.

r? @ghost