### PR TITLE
Added link from Targets to Platform Support in the book

### DIFF
--- a/src/doc/rustc/src/targets/index.md
+++ b/src/doc/rustc/src/targets/index.md
@@ -1,7 +1,10 @@
 # Targets
 
 `rustc` is a cross-compiler by default. This means that you can use any compiler to build for any
-architecture. The list of *targets* are the possible architectures that you can build for.
+architecture. The list of *targets* are the possible architectures that you can build for. See
+the [Platform Support](../platform-support.md) page for a detailed list of targets, or
+[Built-in Targets](built-in.md) for instructions on how to view what is available for your version
+of `rustc`.
 
 To see all the options that you can set with a target, see the docs
 [here](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_target/spec/struct.Target.html).


### PR DESCRIPTION
If you search the web for "rust targets", the first result is the [targets page](https://doc.rust-lang.org/nightly/rustc/targets/index.html). However, usually when searching for this I'm interested in seeing the available triples with host information, so I just added a link to the correct page.

The entire `Targets` chapter could probably be combined into one page, since its three subchapters each only have a tiny section (I'll do this if requested)