### PR TITLE
Cleanup `mingw-tidy` docker job

### DIFF
--- a/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
@@ -32,5 +32,4 @@ RUN pip3 install --no-deps --no-cache-dir --require-hashes -r /tmp/reuse-require
 COPY host-x86_64/mingw-check/validate-toolstate.sh /scripts/
 COPY host-x86_64/mingw-check/validate-error-codes.sh /scripts/
 
-ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
 ENV SCRIPT python3 ../x.py test --stage 0 src/tools/tidy tidyselftest

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -184,11 +184,11 @@ if [ "$RUN_CHECK_WITH_PARALLEL_QUERIES" != "" ]; then
   $SRC/configure --set rust.parallel-compiler
 
   # Save the build metrics before we wipe the directory
-  if [ $HAS_METRICS = 1 ]; then
+  if [ "$HAS_METRICS" = 1 ]; then
     mv build/metrics.json .
   fi
   rm -rf build
-  if [ $HAS_METRICS = 1 ]; then
+  if [ "$HAS_METRICS" = 1 ]; then
     mkdir build
     mv metrics.json build
   fi


### PR DESCRIPTION
Fixes a couple small regressions from https://github.com/rust-lang/rust/pull/106048 and https://github.com/rust-lang/rust/pull/105714.

- Avoid `/checkout/src/ci/run.sh: line 187: [: =: unary operator expected`: https://github.com/rust-lang/rust/actions/runs/3809902408/jobs/6481611301#step:26:1701
- Avoid running `x check` in the tidy test, to get faster feedback. It's already run on the normal `mingw-check` job.

r? @fee1-dead