### PR TITLE
Only include stable lints in `rustdoc::all` group

### DIFF
--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -194,7 +194,11 @@ pub(crate) fn register_lints(_sess: &Session, lint_store: &mut LintStore) {
         true,
         "rustdoc::all",
         Some("rustdoc"),
-        RUSTDOC_LINTS.iter().map(|&lint| LintId::of(lint)).collect(),
+        RUSTDOC_LINTS
+            .iter()
+            .filter(|lint| lint.feature_gate.is_none()) // only include stable lints
+            .map(|&lint| LintId::of(lint))
+            .collect(),
     );
     for lint in &*RUSTDOC_LINTS {
         let name = lint.name_lower();

--- a/tests/rustdoc-ui/check-fail.rs
+++ b/tests/rustdoc-ui/check-fail.rs
@@ -2,6 +2,7 @@
 
 #![feature(rustdoc_missing_doc_code_examples)]
 #![deny(missing_docs)]
+#![deny(rustdoc::missing_doc_code_examples)]
 #![deny(rustdoc::all)]
 
 //! ```rust,testharness

--- a/tests/rustdoc-ui/check-fail.stderr
+++ b/tests/rustdoc-ui/check-fail.stderr
@@ -1,5 +1,5 @@
 error: missing documentation for a function
-  --> $DIR/check-fail.rs:12:1
+  --> $DIR/check-fail.rs:13:1
    |
 LL | pub fn foo() {}
    | ^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL | #![deny(missing_docs)]
    |         ^^^^^^^^^^^^
 
 error: missing code example in this documentation
-  --> $DIR/check-fail.rs:12:1
+  --> $DIR/check-fail.rs:13:1
    |
 LL | pub fn foo() {}
    | ^^^^^^^^^^^^^^^
@@ -19,12 +19,11 @@ LL | pub fn foo() {}
 note: the lint level is defined here
   --> $DIR/check-fail.rs:5:9
    |
-LL | #![deny(rustdoc::all)]
-   |         ^^^^^^^^^^^^
-   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc::all)]`
+LL | #![deny(rustdoc::missing_doc_code_examples)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unknown attribute `testharness`. Did you mean `test_harness`?
-  --> $DIR/check-fail.rs:7:1
+  --> $DIR/check-fail.rs:8:1
    |
 LL | / //! ```rust,testharness
 LL | |
@@ -33,10 +32,15 @@ LL | | //! ```
    | |_______^
    |
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
+note: the lint level is defined here
+  --> $DIR/check-fail.rs:6:9
+   |
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
    = note: `#[deny(rustdoc::invalid_codeblock_attributes)]` implied by `#[deny(rustdoc::all)]`
 
 error: unknown attribute `testharness`. Did you mean `test_harness`?
-  --> $DIR/check-fail.rs:16:1
+  --> $DIR/check-fail.rs:17:1
    |
 LL | / /// hello
 LL | |

--- a/tests/rustdoc-ui/check.rs
+++ b/tests/rustdoc-ui/check.rs
@@ -7,6 +7,7 @@
 //~^^ WARN
 
 #![warn(missing_docs)]
+#![warn(rustdoc::missing_doc_code_examples)]
 #![warn(rustdoc::all)]
 
 pub fn foo() {}

--- a/tests/rustdoc-ui/check.stderr
+++ b/tests/rustdoc-ui/check.stderr
@@ -17,7 +17,7 @@ LL | #![warn(missing_docs)]
    |         ^^^^^^^^^^^^
 
 warning: missing documentation for a function
-  --> $DIR/check.rs:12:1
+  --> $DIR/check.rs:13:1
    |
 LL | pub fn foo() {}
    | ^^^^^^^^^^^^
@@ -27,7 +27,7 @@ warning: no documentation found for this crate's top-level module
    = help: The following guide may be of use:
            https://doc.rust-lang.org/$CHANNEL/rustdoc/how-to-write-documentation.html
 note: the lint level is defined here
-  --> $DIR/check.rs:10:9
+  --> $DIR/check.rs:11:9
    |
 LL | #![warn(rustdoc::all)]
    |         ^^^^^^^^^^^^
@@ -45,10 +45,14 @@ LL | |
 LL | | pub fn foo() {}
    | |_______________^
    |
-   = note: `#[warn(rustdoc::missing_doc_code_examples)]` implied by `#[warn(rustdoc::all)]`
+note: the lint level is defined here
+  --> $DIR/check.rs:10:9
+   |
+LL | #![warn(rustdoc::missing_doc_code_examples)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: missing code example in this documentation
-  --> $DIR/check.rs:12:1
+  --> $DIR/check.rs:13:1
    |
 LL | pub fn foo() {}
    | ^^^^^^^^^^^^^^^

--- a/tests/rustdoc-ui/lint-group.rs
+++ b/tests/rustdoc-ui/lint-group.rs
@@ -6,6 +6,7 @@
 //! println!("sup");
 //! ```
 
+#![deny(rustdoc::missing_doc_code_examples)]
 #![deny(rustdoc::all)]
 
 /// what up, let's make an [error]

--- a/tests/rustdoc-ui/lint-group.stderr
+++ b/tests/rustdoc-ui/lint-group.stderr
@@ -1,5 +1,5 @@
 error: missing code example in this documentation
-  --> $DIR/lint-group.rs:18:1
+  --> $DIR/lint-group.rs:19:1
    |
 LL | /// wait, this doesn't have a doctest?
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,12 +7,11 @@ LL | /// wait, this doesn't have a doctest?
 note: the lint level is defined here
   --> $DIR/lint-group.rs:9:9
    |
-LL | #![deny(rustdoc::all)]
-   |         ^^^^^^^^^^^^
-   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc::all)]`
+LL | #![deny(rustdoc::missing_doc_code_examples)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: documentation test in private item
-  --> $DIR/lint-group.rs:21:1
+  --> $DIR/lint-group.rs:22:1
    |
 LL | / /// wait, this *does* have a doctest?
 LL | | ///
@@ -21,16 +20,21 @@ LL | | /// println!("sup");
 LL | | /// ```
    | |_______^
    |
+note: the lint level is defined here
+  --> $DIR/lint-group.rs:10:9
+   |
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
    = note: `#[deny(rustdoc::private_doc_tests)]` implied by `#[deny(rustdoc::all)]`
 
 error: missing code example in this documentation
-  --> $DIR/lint-group.rs:28:1
+  --> $DIR/lint-group.rs:29:1
    |
 LL | /// <unknown>
    | ^^^^^^^^^^^^^
 
 error: unresolved link to `error`
-  --> $DIR/lint-group.rs:11:29
+  --> $DIR/lint-group.rs:12:29
    |
 LL | /// what up, let's make an [error]
    |                             ^^^^^ no item named `error` in scope
@@ -39,7 +43,7 @@ LL | /// what up, let's make an [error]
    = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(rustdoc::all)]`
 
 error: unclosed HTML tag `unknown`
-  --> $DIR/lint-group.rs:28:5
+  --> $DIR/lint-group.rs:29:5
    |
 LL | /// <unknown>
    |     ^^^^^^^^^

--- a/tests/rustdoc-ui/rustdoc-all-only-stable-lints.rs
+++ b/tests/rustdoc-ui/rustdoc-all-only-stable-lints.rs
@@ -1,0 +1,6 @@
+// check-pass
+
+// Ensure `rustdoc::all` only affects stable lints. See #106289.
+
+#![deny(unknown_lints)]
+#![allow(rustdoc::all)]


### PR DESCRIPTION
Fixes #106289.

Including unstable lints in the lint group produces unintuitive behavior
on stable (see #106289). Meanwhile, if we only included unstable lints
on nightly and not on stable, we could end up with confusing bugs that
were hard to compare across versions of Rust that lacked code changes.

I think that only including stable lints in `rustdoc::all`, no matter
the release channel, is the most intuitive option. Users can then
control unstable lints individually, which is reasonable since they have
to enable the feature gates individually anyway.

r? @GuillaumeGomez
