### PR TITLE
Only deduplicate stack traces for good path bugs

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1199,8 +1199,8 @@ static DEFAULT_HOOK: LazyLock<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 
             };
 
             // Invoke the default handler, which prints the actual panic message and optionally a backtrace
-            // Don't do this for `ExplicitBug`, which has an unhelpful message and backtrace.
-            if !info.payload().is::<rustc_errors::ExplicitBug>() {
+            // Don't do this for `GoodPathBug`, which already emits its own more useful backtrace.
+            if !info.payload().is::<rustc_errors::GoodPathBug>() {
                 (*DEFAULT_HOOK)(info);
 
                 // Separate the output with an empty line
@@ -1237,7 +1237,9 @@ pub fn report_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
 
     // a .span_bug or .bug call has already printed what
     // it wants to print.
-    if !info.payload().is::<rustc_errors::ExplicitBug>() {
+    if !info.payload().is::<rustc_errors::ExplicitBug>()
+        && !info.payload().is::<rustc_errors::GoodPathBug>()
+    {
         let mut d = rustc_errors::Diagnostic::new(rustc_errors::Level::Bug, "unexpected panic");
         handler.emit_diagnostic(&mut d);
     }


### PR DESCRIPTION
Fixes #106267

Restores backtraces for `bug!` and `delay_span_bug` after #106056. Only `delay_good_path_bug` needed its backtraces to be deduplicated, since it spits out the backtrace where it was created when it's being emitted.

Before:

```
error: internal compiler error: /home/ubuntu/rust2/compiler/rustc_middle/src/ty/relate.rs:638:13: var types encountered in super_relate_consts: Const { ty: usize, kind: Infer(Var(_#0c)) } Const { ty: usize, kind: Param(N/#1) }

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.68.0-dev running on x86_64-unknown-linux-gnu

query stack during panic:
#0 [typeck] type-checking `<impl at /home/ubuntu/test.rs:7:1: 7:34>::trigger`
#1 [typeck_item_bodies] type-checking all item bodies
#2 [analysis] running analysis passes on this crate
end of query stack
error: aborting due to 2 previous errors
```

Hmm... that's a little bare.

After:

```
error: internal compiler error: /home/ubuntu/rust2/compiler/rustc_middle/src/ty/relate.rs:638:13: var types encountered in super_relate_consts: Const { ty: usize, kind: Infer(Var(_#0c)) } Const { ty: usize, kind: Param(N/#1) }

thread 'rustc' panicked at 'Box<dyn Any>', /home/ubuntu/rust2/compiler/rustc_errors/src/lib.rs:1599:9
stack backtrace:
   0:     0x7ffb5b41bdd1 - std::backtrace_rs::backtrace::libunwind::trace::h26056f81198c6594
                               at /home/ubuntu/rust2/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x7ffb5b41bdd1 - std::backtrace_rs::backtrace::trace_unsynchronized::hacfb345a0c6d5bb1
                               at /home/ubuntu/rust2/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x7ffb5b41bdd1 - std::sys_common::backtrace::_print_fmt::h18ea6016ac8030f3
                               at /home/ubuntu/rust2/library/std/src/sys_common/backtrace.rs:65:5
   3:     0x7ffb5b41bdd1 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::he35dde201d0c2d09
                               at /home/ubuntu/rust2/library/std/src/sys_common/backtrace.rs:44:22
   4:     0x7ffb5b4a0308 - core::fmt::write::h094ad263467a053c
                               at /home/ubuntu/rust2/library/core/src/fmt/mod.rs:1208:17
   5:     0x7ffb5b43caf1 - std::io::Write::write_fmt::hd47b4e2324b4d9b7
                               at /home/ubuntu/rust2/library/std/src/io/mod.rs:1682:15
   6:     0x7ffb5b41bbfa - std::sys_common::backtrace::_print::h43044162653a17fc
                               at /home/ubuntu/rust2/library/std/src/sys_common/backtrace.rs:47:5
   7:     0x7ffb5b41bbfa - std::sys_common::backtrace::print::hc8605da258fa5aeb
                               at /home/ubuntu/rust2/library/std/src/sys_common/backtrace.rs:34:9
   8:     0x7ffb5b3ffb87 - std::panicking::default_hook::{{closure}}::h9e37f23f75122a15
   9:     0x7ffb5b3ff97b - std::panicking::default_hook::h602873a063f84da2
                               at /home/ubuntu/rust2/library/std/src/panicking.rs:286:9
  10:     0x7ffb5be192b2 - <alloc[48d7b30605060536]::boxed::Box<dyn for<'a, 'b> core[672e3947e150d6c6]::ops::function::Fn<(&'a core[672e3947e150d6c6]::panic::panic_info::PanicInfo<'b>,), Output = ()> + core[672e3947e150d6c6]::marker::Send + core[672e3947e150d6c6]::marker::Sync> as core[672e3947e150d6c6]::ops::function::Fn<(&core[672e3947e150d6c6]::panic::panic_info::PanicInfo,)>>::call
                               at /home/ubuntu/rust2/library/alloc/src/boxed.rs:2002:9
  11:     0x7ffb5be192b2 - rustc_driver[f5b6d32d8905ecdd]::DEFAULT_HOOK::{closure#0}::{closure#0}
                               at /home/ubuntu/rust2/compiler/rustc_driver/src/lib.rs:1204:17
  12:     0x7ffb5b4000d3 - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::hfd13333ca953ae8e
                               at /home/ubuntu/rust2/library/alloc/src/boxed.rs:2002:9
  13:     0x7ffb5b4000d3 - std::panicking::rust_panic_with_hook::h45753e10264ebe7e
                               at /home/ubuntu/rust2/library/std/src/panicking.rs:692:13
  14:     0x7ffb5e8b3a63 - std[3330b4673efabfce]::panicking::begin_panic::<rustc_errors[1b15f4e7e49d1fd5]::ExplicitBug>::{closure#0}

[... FRAMES INTENTIONALLY OMITTED BECAUSE GITHUB GOT ANGRY ...]

 186:     0x7ffb5bea5554 - <std[3330b4673efabfce]::thread::Builder>::spawn_unchecked_::<rustc_interface[947706ead88047d0]::util::run_in_thread_pool_with_globals<rustc_interface[947706ead88047d0]::interface::run_compiler<core[672e3947e150d6c6]::result::Result<(), rustc_errors[1b15f4e7e49d1fd5]::ErrorGuaranteed>, rustc_driver[f5b6d32d8905ecdd]::run_compiler::{closure#1}>::{closure#0}, core[672e3947e150d6c6]::result::Result<(), rustc_errors[1b15f4e7e49d1fd5]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[672e3947e150d6c6]::result::Result<(), rustc_errors[1b15f4e7e49d1fd5]::ErrorGuaranteed>>::{closure#1}
                               at /home/ubuntu/rust2/library/std/src/thread/mod.rs:549:30
 187:     0x7ffb5bea5554 - <<std[3330b4673efabfce]::thread::Builder>::spawn_unchecked_<rustc_interface[947706ead88047d0]::util::run_in_thread_pool_with_globals<rustc_interface[947706ead88047d0]::interface::run_compiler<core[672e3947e150d6c6]::result::Result<(), rustc_errors[1b15f4e7e49d1fd5]::ErrorGuaranteed>, rustc_driver[f5b6d32d8905ecdd]::run_compiler::{closure#1}>::{closure#0}, core[672e3947e150d6c6]::result::Result<(), rustc_errors[1b15f4e7e49d1fd5]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[672e3947e150d6c6]::result::Result<(), rustc_errors[1b15f4e7e49d1fd5]::ErrorGuaranteed>>::{closure#1} as core[672e3947e150d6c6]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
                               at /home/ubuntu/rust2/library/core/src/ops/function.rs:250:5
 188:     0x7ffb5b433968 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::he8b26fc22c6f51ec
                               at /home/ubuntu/rust2/library/alloc/src/boxed.rs:1988:9
 189:     0x7ffb5b433968 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h5cf9cbe75a8c3ddc
                               at /home/ubuntu/rust2/library/alloc/src/boxed.rs:1988:9
 190:     0x7ffb5b41199c - std::sys::unix::thread::Thread::new::thread_start::h2d6dd4455e97d031
                               at /home/ubuntu/rust2/library/std/src/sys/unix/thread.rs:108:17
 191:     0x7ffb5441b609 - start_thread
 192:     0x7ffb5b282133 - clone
 193:                0x0 - <unknown>

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.68.0-dev running on x86_64-unknown-linux-gnu

query stack during panic:
#0 [typeck] type-checking `<impl at /home/ubuntu/test.rs:7:1: 7:34>::trigger`
#1 [typeck_item_bodies] type-checking all item bodies
#2 [analysis] running analysis passes on this crate
end of query stack
error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0601`.
```