### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1246,6 +1246,9 @@ impl PathBuf {
     ///   and `path` is not empty, the new path is normalized: all references
     ///   to `.` and `..` are removed.
     ///
+    /// Consider using [`Path::join`] if you need a new `PathBuf` instead of
+    /// using this function on a cloned `PathBuf`.
+    ///
     /// # Examples
     ///
     /// Pushing a relative path extends the existing path:

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -662,6 +662,7 @@ impl<'a> Builder<'a> {
                 crate::toolstate::ToolStateCheck,
                 test::ExpandYamlAnchors,
                 test::Tidy,
+                test::TidySelfTest,
                 test::Ui,
                 test::RunPassValgrind,
                 test::MirOpt,

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1143,6 +1143,40 @@ help: to skip test's attempt to check tidiness, pass `--exclude src/tools/tidy` 
     }
 }
 
+/// Runs tidy's own tests.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct TidySelfTest;
+
+impl Step for TidySelfTest {
+    type Output = ();
+    const DEFAULT: bool = true;
+    const ONLY_HOSTS: bool = true;
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        run.alias("tidyselftest")
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        run.builder.ensure(TidySelfTest);
+    }
+
+    fn run(self, builder: &Builder<'_>) {
+        let bootstrap_host = builder.config.build;
+        let compiler = builder.compiler(0, bootstrap_host);
+        let cargo = tool::prepare_tool_cargo(
+            builder,
+            compiler,
+            Mode::ToolBootstrap,
+            bootstrap_host,
+            "test",
+            "src/tools/tidy",
+            SourceType::InTree,
+            &[],
+        );
+        try_run(builder, &mut cargo.into());
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct ExpandYamlAnchors;
 

--- a/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
@@ -33,4 +33,4 @@ COPY host-x86_64/mingw-check/validate-toolstate.sh /scripts/
 COPY host-x86_64/mingw-check/validate-error-codes.sh /scripts/
 
 ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
-ENV SCRIPT python3 ../x.py test --stage 0 src/tools/tidy
+ENV SCRIPT python3 ../x.py test --stage 0 src/tools/tidy tidyselftest

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1865,9 +1865,13 @@ in storage.js
 	font-size: 12px;
 	position: relative;
 	bottom: 1px;
-	border-width: 1px;
-	border-style: solid;
+	border: 1px solid var(--scrape-example-help-border-color);
 	border-radius: 50px;
+	color: var(--scrape-example-help-color);
+}
+.scraped-example-list .scrape-help:hover {
+	border-color: var(--scrape-example-help-hover-border-color);
+	color: var(--scrape-example-help-hover-color);
 }
 
 .scraped-example {
@@ -1958,14 +1962,6 @@ in storage.js
 }
 .scraped-example .example-wrap .rust span.highlight.focus {
 	background: var(--scrape-example-code-line-highlight-focus);
-}
-.scraped-example-list .scrape-help {
-	border-color: var(--scrape-example-help-border-color);
-	color: var(--scrape-example-help-color);
-}
-.scraped-example-list .scrape-help:hover {
-	border-color: var(--scrape-example-help-hover-border-color);
-	color: var(--scrape-example-help-hover-color);
 }
 
 .more-examples-toggle {

--- a/src/test/rustdoc-gui/scrape-examples-fonts.goml
+++ b/src/test/rustdoc-gui/scrape-examples-fonts.goml
@@ -1,3 +1,4 @@
+// This test ensures that the correct font is used in scraped examples.
 goto: "file://" + |DOC_PATH| + "/scrape_examples/fn.test_many.html"
 
 store-value: (font, '"Fira Sans", Arial, NanumBarunGothic, sans-serif')

--- a/src/tools/tidy/src/features/version/tests.rs
+++ b/src/tools/tidy/src/features/version/tests.rs
@@ -12,8 +12,8 @@ fn test_try_from_invalid_version() {
 
 #[test]
 fn test_try_from_single() {
-    assert_eq!("1.32.0".parse(), Ok(Version { parts: [1, 32, 0] }));
-    assert_eq!("1.0.0".parse(), Ok(Version { parts: [1, 0, 0] }));
+    assert_eq!("1.32.0".parse(), Ok(Version::Explicit { parts: [1, 32, 0] }));
+    assert_eq!("1.0.0".parse(), Ok(Version::Explicit { parts: [1, 0, 0] }));
 }
 
 #[test]


### PR DESCRIPTION
Successful merges:

 - #106280 (docs: add link to `Path::join` in `PathBuf::push`)
 - #106297 (rustdoc: merge scrape-help CSS)
 - #106328 (Add comment explaining what the GUI scrape-examples-fonts test is about)
 - #106334 (Fix tidy unittest.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=106280,106297,106328,106334)
<!-- homu-ignore:end -->