### PR TITLE
Correct a typo in fs::File::create documentation

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -360,7 +360,7 @@ impl File {
     /// Depending on the platform, this function may fail if the
     /// full directory path does not exist.
     ///
-    /// See the [`OpenOptions::open`] function for more details.
+    /// See the [`OpenOptions::create`] function for more details.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Hi, I think this is a typo, but feel free to close if it isn't.