### PR TITLE
Always permit ConstProp to exploit arithmetic identities

### DIFF
--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -655,11 +655,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             return None;
         }
 
-        if self.tcx.sess.mir_opt_level() >= 4 {
-            self.eval_rvalue_with_identities(rvalue, place)
-        } else {
-            self.use_ecx(|this| this.ecx.eval_rvalue_into_place(rvalue, place))
-        }
+        self.eval_rvalue_with_identities(rvalue, place)
     }
 
     // Attempt to use algebraic identities to eliminate constant expressions

--- a/src/test/mir-opt/div_overflow.const_dividend.PreCodegen.after.mir
+++ b/src/test/mir-opt/div_overflow.const_dividend.PreCodegen.after.mir
@@ -1,0 +1,17 @@
+// MIR for `const_dividend` after PreCodegen
+
+fn const_dividend(_1: i32) -> i32 {
+    debug a => _1;                       // in scope 0 at $DIR/div_overflow.rs:+0:23: +0:24
+    let mut _0: i32;                     // return place in scope 0 at $DIR/div_overflow.rs:+0:34: +0:37
+    let mut _2: bool;                    // in scope 0 at $DIR/div_overflow.rs:+1:5: +1:12
+
+    bb0: {
+        _2 = Eq(_1, const 0_i32);        // scope 0 at $DIR/div_overflow.rs:+1:5: +1:12
+        assert(!move _2, "attempt to divide `{}` by zero", const 256_i32) -> bb1; // scope 0 at $DIR/div_overflow.rs:+1:5: +1:12
+    }
+
+    bb1: {
+        _0 = Div(const 256_i32, move _1); // scope 0 at $DIR/div_overflow.rs:+1:5: +1:12
+        return;                          // scope 0 at $DIR/div_overflow.rs:+2:2: +2:2
+    }
+}

--- a/src/test/mir-opt/div_overflow.const_divisor.PreCodegen.after.mir
+++ b/src/test/mir-opt/div_overflow.const_divisor.PreCodegen.after.mir
@@ -1,0 +1,11 @@
+// MIR for `const_divisor` after PreCodegen
+
+fn const_divisor(_1: i32) -> i32 {
+    debug a => _1;                       // in scope 0 at $DIR/div_overflow.rs:+0:22: +0:23
+    let mut _0: i32;                     // return place in scope 0 at $DIR/div_overflow.rs:+0:33: +0:36
+
+    bb0: {
+        _0 = Div(move _1, const 256_i32); // scope 0 at $DIR/div_overflow.rs:+1:5: +1:12
+        return;                          // scope 0 at $DIR/div_overflow.rs:+2:2: +2:2
+    }
+}

--- a/src/test/mir-opt/div_overflow.rs
+++ b/src/test/mir-opt/div_overflow.rs
@@ -1,0 +1,18 @@
+// compile-flags: -Copt-level=0 -Coverflow-checks=yes
+
+// Tests that division with a const does not emit a panicking branch for overflow
+
+// EMIT_MIR div_overflow.const_divisor.PreCodegen.after.mir
+pub fn const_divisor(a: i32) -> i32 {
+    a / 256
+}
+
+// EMIT_MIR div_overflow.const_dividend.PreCodegen.after.mir
+pub fn const_dividend(a: i32) -> i32 {
+    256 / a
+}
+
+fn main() {
+    const_divisor(123);
+    const_dividend(123);
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/72751

Initially, I thought I would need to enable operand propagation then do something else, but actually https://github.com/rust-lang/rust/pull/74491 already has the fix for the issue in question! It looks like this optimization was put under MIR opt level 3 due to possible soundness/stability implications, then demoted further to MIR opt level 4 when MIR opt level 2 became associated with `--release`.

Perhaps in the past we were doing CTFE on optimized MIR? We aren't anymore, so this optimization has no stability implications.

r? @oli-obk