### PR TITLE
Use the correct tracking issue for `dyn_star`

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -383,7 +383,7 @@ declare_features! (
     /// Allows `#[doc(masked)]`.
     (active, doc_masked, "1.21.0", Some(44027), None),
     /// Allows `dyn* Trait` objects.
-    (incomplete, dyn_star, "1.65.0", Some(91611), None),
+    (incomplete, dyn_star, "1.65.0", Some(102425), None),
     /// Allows `X..Y` patterns.
     (active, exclusive_range_pattern, "1.11.0", Some(37854), None),
     /// Allows exhaustive pattern matching on types that contain uninhabited types.

--- a/src/test/ui/dyn-star/align.normal.stderr
+++ b/src/test/ui/dyn-star/align.normal.stderr
@@ -4,7 +4,7 @@ warning: the feature `dyn_star` is incomplete and may not be safe to use and/or 
 LL | #![feature(dyn_star)]
    |            ^^^^^^^^
    |
-   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 warning: 1 warning emitted

--- a/src/test/ui/dyn-star/align.over_aligned.stderr
+++ b/src/test/ui/dyn-star/align.over_aligned.stderr
@@ -4,7 +4,7 @@ warning: the feature `dyn_star` is incomplete and may not be safe to use and/or 
 LL | #![feature(dyn_star)]
    |            ^^^^^^^^
    |
-   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0277]: `AlignedUsize` needs to be a pointer-sized type

--- a/src/test/ui/dyn-star/dispatch-on-pin-mut.stderr
+++ b/src/test/ui/dyn-star/dispatch-on-pin-mut.stderr
@@ -4,7 +4,7 @@ warning: the feature `dyn_star` is incomplete and may not be safe to use and/or 
 LL | #![feature(dyn_star)]
    |            ^^^^^^^^
    |
-   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 warning: 1 warning emitted

--- a/src/test/ui/dyn-star/dont-unsize-coerce-dyn-star.stderr
+++ b/src/test/ui/dyn-star/dont-unsize-coerce-dyn-star.stderr
@@ -4,7 +4,7 @@ warning: the feature `dyn_star` is incomplete and may not be safe to use and/or 
 LL | #![feature(dyn_star)]
    |            ^^^^^^^^
    |
-   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 warning: 1 warning emitted

--- a/src/test/ui/dyn-star/feature-gate-dyn_star.stderr
+++ b/src/test/ui/dyn-star/feature-gate-dyn_star.stderr
@@ -4,7 +4,7 @@ error[E0658]: dyn* trait objects are unstable
 LL | pub fn dyn_star_parameter(_: &dyn* Send) {
    |                               ^^^^^^^^^
    |
-   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = help: add `#![feature(dyn_star)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/dyn-star/no-explicit-dyn-star-cast.stderr
+++ b/src/test/ui/dyn-star/no-explicit-dyn-star-cast.stderr
@@ -4,7 +4,7 @@ error[E0658]: dyn* trait objects are unstable
 LL |     let dyn_i: dyn* Debug = i as dyn* Debug;
    |                ^^^^^^^^^^
    |
-   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = help: add `#![feature(dyn_star)]` to the crate attributes to enable
 
 error[E0658]: dyn* trait objects are unstable
@@ -13,7 +13,7 @@ error[E0658]: dyn* trait objects are unstable
 LL |     let dyn_i: dyn* Debug = i as dyn* Debug;
    |                                  ^^^^^^^^^^
    |
-   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = help: add `#![feature(dyn_star)]` to the crate attributes to enable
 
 error[E0606]: casting `usize` as `dyn* Debug` is invalid

--- a/src/test/ui/dyn-star/no-unsize-coerce-dyn-trait.stderr
+++ b/src/test/ui/dyn-star/no-unsize-coerce-dyn-trait.stderr
@@ -4,7 +4,7 @@ warning: the feature `dyn_star` is incomplete and may not be safe to use and/or 
 LL | #![feature(dyn_star, trait_upcasting)]
    |            ^^^^^^^^
    |
-   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0308]: mismatched types

--- a/src/test/ui/dyn-star/return.stderr
+++ b/src/test/ui/dyn-star/return.stderr
@@ -4,7 +4,7 @@ warning: the feature `dyn_star` is incomplete and may not be safe to use and/or 
 LL | #![feature(dyn_star)]
    |            ^^^^^^^^
    |
-   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 warning: 1 warning emitted

--- a/src/test/ui/dyn-star/upcast.stderr
+++ b/src/test/ui/dyn-star/upcast.stderr
@@ -4,7 +4,7 @@ warning: the feature `dyn_star` is incomplete and may not be safe to use and/or 
 LL | #![feature(dyn_star, trait_upcasting)]
    |            ^^^^^^^^
    |
-   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0277]: `dyn* Foo` needs to be a pointer-sized type


### PR DESCRIPTION
`#![feature(dyn_star)]` now has its own tracking issue, #102425.