### PR TITLE
Document read_line gotchas

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2153,10 +2153,11 @@ pub trait BufRead: Read {
     ///
     /// This function is blocking and should be used carefully: it is possible for
     /// an attacker to continuously send bytes without ever sending a newline
-    /// or EOF.
+    /// or EOF. You can use [`take`] to limit the maximum number of bytes read.
     ///
     /// [`Ok(0)`]: Ok
-    /// [`clear`]: String:::clear
+    /// [`clear`]: String::clear
+    /// [`take`]: crate::io::Read::take
     ///
     /// # Errors
     ///

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2137,8 +2137,10 @@ pub trait BufRead: Read {
     }
 
     /// Read all bytes until a newline (the `0xA` byte) is reached, and append
-    /// them to the provided buffer. You do not need to clear the buffer before
-    /// appending.
+    /// them to the provided `String` buffer.
+    ///
+    /// Previous content of the buffer will be preserved. To avoid appending to
+    /// the buffer, you need to [`clear`] it first.
     ///
     /// This function will read bytes from the underlying stream until the
     /// newline delimiter (the `0xA` byte) or EOF is found. Once found, all bytes
@@ -2154,6 +2156,7 @@ pub trait BufRead: Read {
     /// or EOF.
     ///
     /// [`Ok(0)`]: Ok
+    /// [`clear`]: String:::clear
     ///
     /// # Errors
     ///


### PR DESCRIPTION
1. The "You do not need to clear the buffer before appending" advice is ambiguous, because it depends what you use this function for. For a rather common case of reading individual lines in a loop, it _is_ necessary to clear the buffer.

2. The docs warn about a DoS risk. I've added a hint how to mitigate unbounded memory growth.
