### PR TITLE
Always enable MultipleReturnTerminators

### DIFF
--- a/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
@@ -13,17 +13,13 @@
   
       bb1: {
           _0 = move _1;                    // scope 0 at $DIR/76803_regression.rs:+3:14: +3:15
-          goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:+3:14: +3:15
+          return;                          // scope 0 at $DIR/76803_regression.rs:+3:14: +3:15
       }
   
       bb2: {
           Deinit(_0);                      // scope 0 at $DIR/76803_regression.rs:+2:20: +2:27
           discriminant(_0) = 1;            // scope 0 at $DIR/76803_regression.rs:+2:20: +2:27
-          goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:+2:20: +2:27
-      }
-  
-      bb3: {
-          return;                          // scope 0 at $DIR/76803_regression.rs:+5:2: +5:2
+          return;                          // scope 0 at $DIR/76803_regression.rs:+2:20: +2:27
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -98,7 +98,7 @@
           StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:27: +10:28
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+11:6: +11:7
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:1: +12:2
-          goto -> bb11;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:2: +12:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:2: +12:2
       }
   
       bb3: {
@@ -221,10 +221,6 @@
           discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+11:6: +11:7
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:1: +12:2
-          goto -> bb11;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:2: +12:2
-      }
-  
-      bb11: {
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:2: +12:2
       }
   }

--- a/src/test/mir-opt/early_otherwise_branch_soundness.no_deref_ptr.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_soundness.no_deref_ptr.EarlyOtherwiseBranch.diff
@@ -19,7 +19,7 @@
   
       bb1: {
           _0 = const 0_i32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+7:14: +7:15
-          goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+7:14: +7:15
+          return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+7:14: +7:15
       }
   
       bb2: {
@@ -29,7 +29,7 @@
   
       bb3: {
           _0 = const 0_i32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+5:18: +5:19
-          goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+5:18: +5:19
+          return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+5:18: +5:19
       }
   
       bb4: {
@@ -37,11 +37,7 @@
           _5 = (((*_2) as Some).0: i32);   // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:18: +4:19
           _0 = _5;                         // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+4:24: +4:25
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:24: +4:25
-          goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:24: +4:25
-      }
-  
-      bb5: {
-          return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+9:2: +9:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:24: +4:25
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
@@ -23,16 +23,12 @@
   
       bb2: {
           _0 = const 1_u32;                // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:38: +1:39
-          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:5: +1:52
+          return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:5: +1:52
       }
   
       bb3: {
           _0 = const 2_u32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:49: +1:50
-          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:5: +1:52
-      }
-  
-      bb4: {
-          return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+2:2: +2:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:5: +1:52
       }
   }
   

--- a/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -31,7 +31,7 @@ fn num_to_digit(_1: char) -> u32 {
         StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         _6 = _1;                         // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        _5 = char::methods::<impl char>::to_digit(move _6, const 8_u32) -> bb5; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        _5 = char::methods::<impl char>::to_digit(move _6, const 8_u32) -> bb4; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // + literal: Const { ty: fn(char, u32) -> Option<u32> {char::methods::<impl char>::to_digit}, val: Value(<ZST>) }
@@ -47,19 +47,15 @@ fn num_to_digit(_1: char) -> u32 {
 
     bb2: {
         _7 = discriminant(_2);           // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        switchInt(move _7) -> [0: bb6, 1: bb8, otherwise: bb7]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(move _7) -> [0: bb5, 1: bb7, otherwise: bb6]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
     bb3: {
         _0 = const 0_u32;                // scope 0 at $DIR/issue_59352.rs:+2:60: +2:61
-        goto -> bb4;                     // scope 0 at $DIR/issue_59352.rs:+2:5: +2:63
+        return;                          // scope 0 at $DIR/issue_59352.rs:+2:5: +2:63
     }
 
     bb4: {
-        return;                          // scope 0 at $DIR/issue_59352.rs:+3:2: +3:2
-    }
-
-    bb5: {
         _4 = &_5;                        // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         _9 = discriminant((*_4));        // scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
@@ -69,7 +65,7 @@ fn num_to_digit(_1: char) -> u32 {
         switchInt(move _9) -> [1: bb1, otherwise: bb3]; // scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
     }
 
-    bb6: {
+    bb5: {
         StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         _8 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
                                          // mir::Constant
@@ -80,13 +76,13 @@ fn num_to_digit(_1: char) -> u32 {
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
     }
 
-    bb7: {
+    bb6: {
         unreachable;                     // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
-    bb8: {
+    bb7: {
         _0 = move ((_2 as Some).0: u32); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         StorageDead(_2);                 // scope 0 at $DIR/issue_59352.rs:+2:49: +2:50
-        goto -> bb4;                     // scope 0 at $DIR/issue_59352.rs:+2:5: +2:63
+        return;                          // scope 0 at $DIR/issue_59352.rs:+2:5: +2:63
     }
 }

--- a/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -115,7 +115,7 @@
           discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
--         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+-         goto -> bb1;                     // scope 0 at $SRC_DIR/core/src/result.rs:LL:COL
 +         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
 +         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
 +         switchInt(move _5) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
@@ -137,7 +137,7 @@
           discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
--         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+-         goto -> bb1;                     // scope 0 at $SRC_DIR/core/src/result.rs:LL:COL
 +         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
 +         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
 +         switchInt(move _5) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10


### PR DESCRIPTION
When this pass was created, LLVM experts said that LLVM prefers a single return. But for example, this pass produces a lot of simplification of `Option::unwrap_or` (and thus possibly other matches?). Let's see what comes out of a perf run...

r? @ghost