### PR TITLE
Fix handling of dead unwinds in backward analyses

### DIFF
--- a/compiler/rustc_mir_dataflow/src/framework/direction.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/direction.rs
@@ -287,7 +287,7 @@ impl Direction for Backward {
                 | mir::TerminatorKind::InlineAsm { cleanup: Some(unwind), .. }
                     if unwind == bb =>
                 {
-                    if dead_unwinds.map_or(true, |dead| !dead.contains(bb)) {
+                    if dead_unwinds.map_or(true, |dead| !dead.contains(pred)) {
                         propagate(pred, exit_state);
                     }
                 }


### PR DESCRIPTION
Dead unwinds set contains a head of an unreachable unwind edge.