### PR TITLE
Implement a few trait goal candidates for the new solver

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1252,6 +1252,10 @@ impl<'tcx> InstantiatedPredicates<'tcx> {
     pub fn is_empty(&self) -> bool {
         self.predicates.is_empty()
     }
+
+    pub fn into_iter(self) -> impl Iterator<Item = (ty::Predicate<'tcx>, Span)> {
+        std::iter::zip(self.predicates, self.spans)
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, HashStable, TyEncodable, TyDecodable, Lift)]

--- a/compiler/rustc_trait_selection/src/solve/assembly.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly.rs
@@ -47,6 +47,11 @@ pub(super) trait GoalKind<'tcx>: TypeFoldable<'tcx> + Copy {
         impl_def_id: DefId,
     );
 
+    fn consider_trait_alias_candidate(
+        acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
+        goal: Goal<'tcx, Self>,
+    );
+
     fn consider_alias_bound_candidates(
         acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
         goal: Goal<'tcx, Self>,
@@ -105,6 +110,8 @@ impl<'a, 'tcx, G: GoalKind<'tcx>> AssemblyCtxt<'a, 'tcx, G> {
         acx.assemble_param_env_candidates(goal);
 
         acx.assemble_auto_trait_candidates(goal);
+
+        acx.assemble_trait_alias_candidates(goal);
 
         acx.assemble_fn_like_candidates(goal);
 
@@ -204,6 +211,12 @@ impl<'a, 'tcx, G: GoalKind<'tcx>> AssemblyCtxt<'a, 'tcx, G> {
     fn assemble_auto_trait_candidates(&mut self, goal: Goal<'tcx, G>) {
         if self.cx.tcx.trait_is_auto(goal.predicate.trait_def_id(self.cx.tcx)) {
             G::consider_auto_trait_candidate(self, goal);
+        }
+    }
+
+    fn assemble_trait_alias_candidates(&mut self, goal: Goal<'tcx, G>) {
+        if self.cx.tcx.is_trait_alias(goal.predicate.trait_def_id(self.cx.tcx)) {
+            G::consider_trait_alias_candidate(self, goal);
         }
     }
 

--- a/compiler/rustc_trait_selection/src/solve/assembly.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly.rs
@@ -80,6 +80,11 @@ pub(super) trait GoalKind<'tcx>: TypeFoldable<'tcx> + Copy {
         bound_sig: ty::PolyFnSig<'tcx>,
         tuple_arguments: TupleArgumentsFlag,
     );
+
+    fn consider_builtin_trait_candidates(
+        acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
+        goal: Goal<'tcx, Self>,
+    );
 }
 
 /// An abstraction which correctly deals with the canonical results for candidates.
@@ -114,6 +119,8 @@ impl<'a, 'tcx, G: GoalKind<'tcx>> AssemblyCtxt<'a, 'tcx, G> {
         acx.assemble_trait_alias_candidates(goal);
 
         acx.assemble_fn_like_candidates(goal);
+
+        G::consider_builtin_trait_candidates(&mut acx, goal);
 
         acx.candidates
     }

--- a/compiler/rustc_trait_selection/src/solve/assembly.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly.rs
@@ -157,7 +157,10 @@ impl<'a, 'tcx, G: GoalKind<'tcx>> AssemblyCtxt<'a, 'tcx, G> {
 
             // NOTE: Alternatively we could call `evaluate_goal` here and only have a `Normalized` candidate.
             // This doesn't work as long as we use `CandidateSource` in both winnowing and to resolve associated items.
-            let goal = goal.with(tcx, goal.predicate.with_self_ty(tcx, normalized_ty));
+            let goal = goal.with(
+                tcx,
+                goal.predicate.with_self_ty(tcx, self.infcx.shallow_resolve(normalized_ty)),
+            );
             let mut orig_values = OriginalQueryValues::default();
             let goal = self.infcx.canonicalize_query(goal, &mut orig_values);
             let normalized_candidates =

--- a/compiler/rustc_trait_selection/src/solve/assembly.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly.rs
@@ -56,6 +56,11 @@ pub(super) trait GoalKind<'tcx>: TypeFoldable<'tcx> + Copy {
         goal: Goal<'tcx, Self>,
         object_bounds: &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
     );
+
+    fn consider_param_env_candidates(
+        acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
+        goal: Goal<'tcx, Self>,
+    );
 }
 
 /// An abstraction which correctly deals with the canonical results for candidates.
@@ -82,6 +87,8 @@ impl<'a, 'tcx, G: GoalKind<'tcx>> AssemblyCtxt<'a, 'tcx, G> {
         acx.assemble_impl_candidates(goal);
 
         acx.assemble_bound_candidates(goal);
+
+        acx.assemble_param_env_candidates(goal);
 
         acx.candidates
     }
@@ -170,5 +177,9 @@ impl<'a, 'tcx, G: GoalKind<'tcx>> AssemblyCtxt<'a, 'tcx, G> {
             }
             _ => {}
         }
+    }
+
+    fn assemble_param_env_candidates(&mut self, goal: Goal<'tcx, G>) {
+        G::consider_param_env_candidates(self, goal);
     }
 }

--- a/compiler/rustc_trait_selection/src/solve/assembly.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly.rs
@@ -61,6 +61,11 @@ pub(super) trait GoalKind<'tcx>: TypeFoldable<'tcx> + Copy {
         acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
         goal: Goal<'tcx, Self>,
     );
+
+    fn consider_auto_trait_candidate(
+        acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
+        goal: Goal<'tcx, Self>,
+    );
 }
 
 /// An abstraction which correctly deals with the canonical results for candidates.
@@ -89,6 +94,8 @@ impl<'a, 'tcx, G: GoalKind<'tcx>> AssemblyCtxt<'a, 'tcx, G> {
         acx.assemble_bound_candidates(goal);
 
         acx.assemble_param_env_candidates(goal);
+
+        acx.assemble_auto_trait_candidates(goal);
 
         acx.candidates
     }
@@ -181,5 +188,11 @@ impl<'a, 'tcx, G: GoalKind<'tcx>> AssemblyCtxt<'a, 'tcx, G> {
 
     fn assemble_param_env_candidates(&mut self, goal: Goal<'tcx, G>) {
         G::consider_param_env_candidates(self, goal);
+    }
+
+    fn assemble_auto_trait_candidates(&mut self, goal: Goal<'tcx, G>) {
+        if self.cx.tcx.trait_is_auto(goal.predicate.trait_def_id(self.cx.tcx)) {
+            G::consider_auto_trait_candidate(self, goal);
+        }
     }
 }

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -234,6 +234,13 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
     ) {
         todo!()
     }
+
+    fn consider_auto_trait_candidate(
+        _acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
+        _goal: Goal<'tcx, Self>,
+    ) {
+        // Auto traits never have associated types
+    }
 }
 
 /// This behavior is also implemented in `rustc_ty_utils` and in the old `project` code.

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -211,6 +211,22 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
             acx.try_insert_candidate(CandidateSource::Impl(impl_def_id), certainty);
         })
     }
+
+    fn consider_alias_bound_candidates(
+        _acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
+        _goal: Goal<'tcx, ProjectionPredicate<'tcx>>,
+        _alias_ty: ty::AliasTy<'tcx>,
+    ) {
+        todo!()
+    }
+
+    fn consider_object_bound_candidates(
+        _acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
+        _goal: Goal<'tcx, Self>,
+        _object_bounds: &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
+    ) {
+        todo!()
+    }
 }
 
 /// This behavior is also implemented in `rustc_ty_utils` and in the old `project` code.

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -212,6 +212,13 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
         })
     }
 
+    fn consider_trait_alias_candidate(
+        _acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
+        _goal: Goal<'tcx, Self>,
+    ) {
+        // Trait aliases never have (their own) associated types
+    }
+
     fn consider_alias_bound_candidates(
         _acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
         _goal: Goal<'tcx, ProjectionPredicate<'tcx>>,

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -257,6 +257,13 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
     ) {
         todo!()
     }
+
+    fn consider_builtin_trait_candidates(
+        _acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
+        _goal: Goal<'tcx, Self>,
+    ) {
+        todo!();
+    }
 }
 
 /// This behavior is also implemented in `rustc_ty_utils` and in the old `project` code.

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -227,6 +227,13 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
     ) {
         todo!()
     }
+
+    fn consider_param_env_candidates(
+        _acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
+        _goal: Goal<'tcx, Self>,
+    ) {
+        todo!()
+    }
 }
 
 /// This behavior is also implemented in `rustc_ty_utils` and in the old `project` code.

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -241,6 +241,15 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
     ) {
         // Auto traits never have associated types
     }
+
+    fn consider_fn_candidate(
+        _acx: &mut AssemblyCtxt<'_, 'tcx, Self>,
+        _goal: Goal<'tcx, Self>,
+        _bound_sig: ty::PolyFnSig<'tcx>,
+        _tuple_arguments: crate::traits::TupleArgumentsFlag,
+    ) {
+        todo!()
+    }
 }
 
 /// This behavior is also implemented in `rustc_ty_utils` and in the old `project` code.

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -60,6 +60,7 @@ pub use self::specialize::{specialization_graph, translate_substs, OverlapError}
 pub use self::structural_match::{
     search_for_adt_const_param_violation, search_for_structural_match_violation,
 };
+pub use self::util::TupleArgumentsFlag;
 pub use self::util::{
     elaborate_obligations, elaborate_predicates, elaborate_predicates_with_span,
     elaborate_trait_ref, elaborate_trait_refs,


### PR DESCRIPTION
Not sure this is *exactly* the right structure for how to assemble these, but it's a first pass.

Since lcnr is gone for a bit for holiday, I'll update this PR in the mean time:
- [x] closures
- [x] fn ptrs
- [ ] generators (Future + Generator, depending on the kind)
- [x] trait aliases
- [x] flesh out some structure to handle built-in traits like Copy/Clone

r? @lcnr