### PR TITLE
Revert "bootstrap: Get rid of `tail_args` in `stream_cargo`"

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -99,13 +99,20 @@ impl Step for Std {
             cargo_subcommand(builder.kind),
         );
         std_cargo(builder, target, compiler.stage, &mut cargo);
-        cargo.args(args(builder));
 
         builder.info(&format!(
             "Checking stage{} library artifacts ({} -> {})",
             builder.top_stage, &compiler.host, target
         ));
-        run_cargo(builder, cargo, &libstd_stamp(builder, compiler, target), vec![], true, false);
+        run_cargo(
+            builder,
+            cargo,
+            args(builder),
+            &libstd_stamp(builder, compiler, target),
+            vec![],
+            true,
+            false,
+        );
 
         // We skip populating the sysroot in non-zero stage because that'll lead
         // to rlib/rmeta conflicts if std gets built during this session.
@@ -149,7 +156,6 @@ impl Step for Std {
         for krate in builder.in_tree_crates("test", Some(target)) {
             cargo.arg("-p").arg(krate.name);
         }
-        cargo.args(args(builder));
 
         builder.info(&format!(
             "Checking stage{} library test/bench/example targets ({} -> {})",
@@ -158,6 +164,7 @@ impl Step for Std {
         run_cargo(
             builder,
             cargo,
+            args(builder),
             &libstd_test_stamp(builder, compiler, target),
             vec![],
             true,
@@ -226,13 +233,20 @@ impl Step for Rustc {
         for krate in builder.in_tree_crates("rustc-main", Some(target)) {
             cargo.arg("-p").arg(krate.name);
         }
-        cargo.args(args(builder));
 
         builder.info(&format!(
             "Checking stage{} compiler artifacts ({} -> {})",
             builder.top_stage, &compiler.host, target
         ));
-        run_cargo(builder, cargo, &librustc_stamp(builder, compiler, target), vec![], true, false);
+        run_cargo(
+            builder,
+            cargo,
+            args(builder),
+            &librustc_stamp(builder, compiler, target),
+            vec![],
+            true,
+            false,
+        );
 
         let libdir = builder.sysroot_libdir(compiler, target);
         let hostdir = builder.sysroot_libdir(compiler, compiler.host);
@@ -279,7 +293,6 @@ impl Step for CodegenBackend {
             .arg("--manifest-path")
             .arg(builder.src.join(format!("compiler/rustc_codegen_{}/Cargo.toml", backend)));
         rustc_cargo_env(builder, &mut cargo, target);
-        cargo.args(args(builder));
 
         builder.info(&format!(
             "Checking stage{} {} artifacts ({} -> {})",
@@ -289,6 +302,7 @@ impl Step for CodegenBackend {
         run_cargo(
             builder,
             cargo,
+            args(builder),
             &codegen_backend_stamp(builder, compiler, target, backend),
             vec![],
             true,
@@ -345,13 +359,19 @@ impl Step for RustAnalyzer {
             cargo.arg("--benches");
         }
 
-        cargo.args(args(builder));
-
         builder.info(&format!(
             "Checking stage{} {} artifacts ({} -> {})",
             compiler.stage, "rust-analyzer", &compiler.host.triple, target.triple
         ));
-        run_cargo(builder, cargo, &stamp(builder, compiler, target), vec![], true, false);
+        run_cargo(
+            builder,
+            cargo,
+            args(builder),
+            &stamp(builder, compiler, target),
+            vec![],
+            true,
+            false,
+        );
 
         /// Cargo's output path in a given stage, compiled by a particular
         /// compiler for the specified target.
@@ -405,8 +425,6 @@ macro_rules! tool_check_step {
                     cargo.arg("--all-targets");
                 }
 
-                cargo.args(args(builder));
-
                 // Enable internal lints for clippy and rustdoc
                 // NOTE: this doesn't enable lints for any other tools unless they explicitly add `#![warn(rustc::internal)]`
                 // See https://github.com/rust-lang/rust/pull/80573#issuecomment-754010776
@@ -422,6 +440,7 @@ macro_rules! tool_check_step {
                 run_cargo(
                     builder,
                     cargo,
+                    args(builder),
                     &stamp(builder, compiler, target),
                     vec![],
                     true,

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -144,6 +144,7 @@ impl Step for Std {
         run_cargo(
             builder,
             cargo,
+            vec![],
             &libstd_stamp(builder, compiler, target),
             target_deps,
             false,
@@ -738,6 +739,7 @@ impl Step for Rustc {
         run_cargo(
             builder,
             cargo,
+            vec![],
             &librustc_stamp(builder, compiler, target),
             vec![],
             false,
@@ -998,7 +1000,7 @@ impl Step for CodegenBackend {
             "Building stage{} codegen backend {} ({} -> {})",
             compiler.stage, backend, &compiler.host, target
         ));
-        let files = run_cargo(builder, cargo, &tmp_stamp, vec![], false, false);
+        let files = run_cargo(builder, cargo, vec![], &tmp_stamp, vec![], false, false);
         if builder.config.dry_run() {
             return;
         }
@@ -1422,6 +1424,7 @@ pub fn add_to_sysroot(
 pub fn run_cargo(
     builder: &Builder<'_>,
     cargo: Cargo,
+    tail_args: Vec<String>,
     stamp: &Path,
     additional_target_deps: Vec<(PathBuf, DependencyType)>,
     is_check: bool,
@@ -1448,7 +1451,7 @@ pub fn run_cargo(
     // files we need to probe for later.
     let mut deps = Vec::new();
     let mut toplevel = Vec::new();
-    let ok = stream_cargo(builder, cargo, &mut |msg| {
+    let ok = stream_cargo(builder, cargo, tail_args, &mut |msg| {
         let (filenames, crate_types) = match msg {
             CargoMessage::CompilerArtifact {
                 filenames,
@@ -1585,6 +1588,7 @@ pub fn run_cargo(
 pub fn stream_cargo(
     builder: &Builder<'_>,
     cargo: Cargo,
+    tail_args: Vec<String>,
     cb: &mut dyn FnMut(CargoMessage<'_>),
 ) -> bool {
     let mut cargo = Command::from(cargo);
@@ -1603,6 +1607,10 @@ pub fn stream_cargo(
         message_format.push_str(s);
     }
     cargo.arg("--message-format").arg(message_format).stdout(Stdio::piped());
+
+    for arg in tail_args {
+        cargo.arg(arg);
+    }
 
     builder.verbose(&format!("running: {:?}", cargo));
     let mut child = match cargo.spawn() {

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -72,7 +72,7 @@ impl Step for ToolBuild {
 
         builder.info(&format!("Building stage{} tool {} ({})", compiler.stage, tool, target));
         let mut duplicates = Vec::new();
-        let is_expected = compile::stream_cargo(builder, cargo, &mut |msg| {
+        let is_expected = compile::stream_cargo(builder, cargo, vec![], &mut |msg| {
             // Only care about big things like the RLS/Cargo for now
             match tool {
                 "rls" | "cargo" | "clippy-driver" | "miri" | "rustfmt" => {}


### PR DESCRIPTION
This reverts commit 9dfe50440e6d48bd2fd40a4b7b3992998e55eace. (Note: that merged as part of https://github.com/rust-lang/rust/pull/106305, but https://github.com/rust-lang/rust/pull/106305/ contains more commits than just 9dfe50440e6d48bd2fd40a4b7b3992998e55eace.)

Fixes `x clippy`. It turns out `clippy` was the only one using `tail_args` 🤦 sorry for not testing this earlier.

r? @Mark-Simulacrum