### PR TITLE
rustdoc: remove legacy box-sizing CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -76,8 +76,6 @@
 }
 
 * {
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 


### PR DESCRIPTION
According to [caniuse], these vendor prefixes aren't needed in any supported web browsers as defined in [RFC 1985]

* The last version of Chrome that required a vendor prefix was version 9. The current version is 108.
* Firefox 28 is the last version that required a vendor prefix. The [current Firefox ESR] is version 102.
* The last version of Safari that required a vendor prefix was version 5. The current version is 16.
* The last version of Safari/iOS that required a vendor prefix was version 4. The current version is 16.
* Edge never required vendor prefixes.
* UCAndroid never required vendor prefixes.

[caniuse]: https://caniuse.com/?search=box-sizing
[RFC 1985]: https://rust-lang.github.io/rfcs/1985-tiered-browser-support.html
[current Firefox ESR]: https://wiki.mozilla.org/Releases