### PR TITLE
Allow passing a specific date to `bump-stage0`

### DIFF
--- a/src/bootstrap/run.rs
+++ b/src/bootstrap/run.rs
@@ -105,6 +105,7 @@ impl Step for BumpStage0 {
 
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let mut cmd = builder.tool_cmd(Tool::BumpStage0);
+        cmd.args(builder.config.cmd.args());
         builder.run(&mut cmd);
     }
 }


### PR DESCRIPTION
This allows regenerating `src/stage0.json` on changes to the tool, without needing to hard-code the date in the source. It was useful for https://github.com/rust-lang/rust/pull/106394, which added clippy to the list of required components.

r? @pietroalbini