### PR TITLE
Check `impl`'s `where` clauses in `consider_impl_candidate` in experimental solver

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -131,8 +131,14 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
             else {
                 return
             };
+            let where_clause_bounds = tcx
+                .predicates_of(impl_def_id)
+                .instantiate(tcx, impl_substs)
+                .predicates
+                .into_iter()
+                .map(|pred| goal.with(tcx, pred));
 
-            let nested_goals = obligations.into_iter().map(|o| o.into()).collect();
+            let nested_goals = obligations.into_iter().map(|o| o.into()).chain(where_clause_bounds).collect();
             let Ok(trait_ref_certainty) = acx.cx.evaluate_all(acx.infcx, nested_goals) else { return };
 
             let Some(assoc_def) = fetch_eligible_assoc_item_def(


### PR DESCRIPTION
Check impl's nested predicates as part of the recursive evaluate in `consider_impl_candidate`.

<sub>Unless, for some reason, these are intentionally **not** checked here -- in which case, I really don't understand where they're being checked...<sub>

r? @lcnr