### PR TITLE
rustdoc: remove legacy font-feature-settings CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -110,11 +110,7 @@ body {
 	/* Then override it with `anywhere`, which is required to make non-Safari browsers break
 	   more aggressively when we want them to. */
 	overflow-wrap: anywhere;
-
-	-webkit-font-feature-settings: "kern", "liga";
-	-moz-font-feature-settings: "kern", "liga";
 	font-feature-settings: "kern", "liga";
-
 	background-color: var(--main-background-color);
 	color: var(--main-color);
 }


### PR DESCRIPTION
According to [caniuse], these vendor prefixes aren't needed in any supported web browsers as defined in [RFC 1985].

* The last version of Chrome that required a vendor prefix was version 47. The current version is 108.
* Firefox 33 is the last version that required a vendor prefix. The [current Firefox ESR] is version 102.
* The last version of Safari that required a vendor prefix was version 9.1. The current version is 16.
* The last version of Safari/iOS that required a vendor prefix was version 9.3. The current version is 16.
* Edge never required vendor prefixes.
* UCAndroid never required vendor prefixes.

[caniuse]: https://caniuse.com/?search=font-feature-settings
[RFC 1985]: https://rust-lang.github.io/rfcs/1985-tiered-browser-support.html
[current Firefox ESR]: https://wiki.mozilla.org/Releases