### PR TITLE
Implement `PartialOrd` and `Ord` for `Discriminant`

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -700,7 +700,17 @@ pub trait DiscriminantKind {
     /// The type of the discriminant, which must satisfy the trait
     /// bounds required by `mem::Discriminant`.
     #[lang = "discriminant_type"]
-    type Discriminant: Clone + Copy + Debug + Eq + PartialEq + Hash + Send + Sync + Unpin;
+    type Discriminant: Clone
+        + Copy
+        + Debug
+        + Eq
+        + Hash
+        + Ord
+        + PartialEq
+        + PartialOrd
+        + Send
+        + Sync
+        + Unpin;
 }
 
 /// Compiler-internal trait used to determine whether a type contains

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1127,7 +1127,7 @@ impl<T> cmp::Ord for Discriminant<T> {
 ///
 /// # Stability
 ///
-/// `Discriminant` is an opaque wrapper around the enum discriminant, therefore it's value will
+/// `Discriminant` is an opaque wrapper around the enum discriminant, therefore its value will
 /// change when the enum definition changes. See the [Reference] for more information.
 ///
 /// [Reference]: ../../reference/items/enumerations.html#custom-discriminant-values-for-fieldless-enumerations

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1127,11 +1127,10 @@ impl<T> cmp::Ord for Discriminant<T> {
 ///
 /// # Stability
 ///
-/// The discriminant of an enum variant may change if the enum definition changes. A discriminant
-/// of some variant will not change between compilations with the same compiler. See the [Reference]
-/// for more information.
+/// `Discriminant` is an opaque wrapper around the enum discriminant, therefore it's value will
+/// change when the enum definition changes. See the [Reference] for more information.
 ///
-/// [Reference]: ../../reference/items/enumerations.html#custom-discriminant-values-for-fieldless-enumerations
+/// [Reference]: ../../reference/items/enumerations.html#discriminants
 ///
 /// # Examples
 ///

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1106,14 +1106,14 @@ impl<T> fmt::Debug for Discriminant<T> {
     }
 }
 
-#[stable(feature = "discriminant_value", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "discriminant_ord", since = "CURRENT_RUSTC_VERSION")]
 impl<T> cmp::PartialOrd for Discriminant<T> {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         self.0.partial_cmp(&other.0)
     }
 }
 
-#[stable(feature = "discriminant_value", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "discriminant_ord", since = "CURRENT_RUSTC_VERSION")]
 impl<T> cmp::Ord for Discriminant<T> {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         self.0.cmp(&other.0)

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1113,7 +1113,7 @@ impl<T> cmp::PartialOrd for Discriminant<T> {
     }
 }
 
-#[stable(feature = "discriminant_value", since = "1.21.0")]
+#[stable(feature = "discriminant_value", since = "CURRENT_RUSTC_VERSION")]
 impl<T> cmp::Ord for Discriminant<T> {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         self.0.cmp(&other.0)

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1130,7 +1130,7 @@ impl<T> cmp::Ord for Discriminant<T> {
 /// `Discriminant` is an opaque wrapper around the enum discriminant, therefore it's value will
 /// change when the enum definition changes. See the [Reference] for more information.
 ///
-/// [Reference]: ../../reference/items/enumerations.html#discriminants
+/// [Reference]: ../../reference/items/enumerations.html#custom-discriminant-values-for-fieldless-enumerations
 ///
 /// # Examples
 ///

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1106,7 +1106,7 @@ impl<T> fmt::Debug for Discriminant<T> {
     }
 }
 
-#[stable(feature = "discriminant_value", since = "1.21.0")]
+#[stable(feature = "discriminant_value", since = "CURRENT_RUSTC_VERSION")]
 impl<T> cmp::PartialOrd for Discriminant<T> {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         self.0.partial_cmp(&other.0)

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1106,6 +1106,20 @@ impl<T> fmt::Debug for Discriminant<T> {
     }
 }
 
+#[stable(feature = "discriminant_value", since = "1.21.0")]
+impl<T> cmp::PartialOrd for Discriminant<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+#[stable(feature = "discriminant_value", since = "1.21.0")]
+impl<T> cmp::Ord for Discriminant<T> {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
 /// Returns a value uniquely identifying the enum variant in `v`.
 ///
 /// If `T` is not an enum, calling this function will not result in undefined behavior, but the


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/106418)*
<!-- homu-ignore:end -->

I found it difficult to implement `PartialOrd` or `Ord` for enums without the ability to compare two `Discriminant` values. Is it OK to implement `PartialOrd` and `Ord` for `Discriminant`?