### PR TITLE
Permit the MIR inliner to inline diverging functions

### DIFF
--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -424,13 +424,6 @@ impl<'tcx> Inliner<'tcx> {
         debug!("    final inline threshold = {}", threshold);
 
         // FIXME: Give a bonus to functions with only a single caller
-        let diverges = matches!(
-            callee_body.basic_blocks[START_BLOCK].terminator().kind,
-            TerminatorKind::Unreachable | TerminatorKind::Call { target: None, .. }
-        );
-        if diverges && !matches!(callee_attrs.inline, InlineAttr::Always) {
-            return Err("callee diverges unconditionally");
-        }
 
         let mut checker = CostChecker {
             tcx: self.tcx,

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -28,7 +28,7 @@
 //! return.
 
 use crate::MirPass;
-use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_middle::mir::coverage::*;
 use rustc_middle::mir::visit::{MutVisitor, MutatingUseContext, PlaceContext, Visitor};
@@ -48,6 +48,7 @@ impl SimplifyCfg {
 
 pub fn simplify_cfg<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
     CfgSimplifier::new(body).simplify();
+    remove_duplicate_unreachable_blocks(tcx, body);
     remove_dead_blocks(tcx, body);
 
     // FIXME: Should probably be moved into some kind of pass manager
@@ -256,6 +257,47 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
         for blk in self.basic_blocks.iter_mut() {
             blk.statements.retain(|stmt| !matches!(stmt.kind, StatementKind::Nop))
         }
+    }
+}
+
+pub fn remove_duplicate_unreachable_blocks<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+    struct OptApplier<'tcx> {
+        tcx: TyCtxt<'tcx>,
+        duplicates: FxIndexSet<BasicBlock>,
+    }
+
+    impl<'tcx> MutVisitor<'tcx> for OptApplier<'tcx> {
+        fn tcx(&self) -> TyCtxt<'tcx> {
+            self.tcx
+        }
+
+        fn visit_terminator(&mut self, terminator: &mut Terminator<'tcx>, location: Location) {
+            for target in terminator.successors_mut() {
+                if self.duplicates.contains(target) {
+                    *target = self.duplicates[0];
+                }
+            }
+
+            self.super_terminator(terminator, location);
+        }
+    }
+
+    let unreachable_blocks = body
+        .basic_blocks
+        .iter_enumerated()
+        .filter(|(_, bb)| {
+            // CfgSimplifier::simplify leaves behind some unreachable basic blocks without a
+            // terminator. Those blocks will be deleted by remove_dead_blocks, but we run just
+            // before then so we need to handle missing terminators.
+            // We also need to prevent confusing cleanup and non-cleanup blocks. In practice we
+            // don't emit empty unreachable cleanup blocks, so this simple check suffices.
+            bb.terminator.is_some() && bb.is_empty_unreachable() && !bb.is_cleanup
+        })
+        .map(|(block, _)| block)
+        .collect::<FxIndexSet<_>>();
+
+    if unreachable_blocks.len() > 1 {
+        OptApplier { tcx, duplicates: unreachable_blocks }.visit_body(body);
     }
 }
 

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -273,6 +273,8 @@ pub fn remove_duplicate_unreachable_blocks<'tcx>(tcx: TyCtxt<'tcx>, body: &mut B
 
         fn visit_terminator(&mut self, terminator: &mut Terminator<'tcx>, location: Location) {
             for target in terminator.successors_mut() {
+                // We don't have to check whether `target` is a cleanup block, because have
+                // entirely excluded cleanup blocks in building the set of duplicates.
                 if self.duplicates.contains(target) {
                     *target = self.duplicates[0];
                 }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1933,6 +1933,12 @@ impl<'a> Builder<'a> {
                 rustflags.arg("-Zvalidate-mir");
                 rustflags.arg(&format!("-Zmir-opt-level={}", mir_opt_level));
             }
+            // Always enable inlining MIR when building the standard library.
+            // Without this flag, MIR inlining is disabled when incremental compilation is enabled.
+            // That causes some mir-opt tests which inline functions from the standard library to
+            // break when incremental compilation is enabled. So this overrides the "no inlining
+            // during incremental builds" heuristic for the standard library.
+            rustflags.arg("-Zinline-mir");
         }
 
         Cargo { command: cargo, rustflags, rustdocflags, allow_features }

--- a/tests/mir-opt/building/async_await.b-{closure#0}.generator_resume.0.mir
+++ b/tests/mir-opt/building/async_await.b-{closure#0}.generator_resume.0.mir
@@ -90,7 +90,7 @@ fn b::{closure#0}(_1: Pin<&mut [async fn body@$DIR/async_await.rs:14:18: 17:2]>,
 
     bb0: {
         _39 = discriminant((*(_1.0: &mut [async fn body@$DIR/async_await.rs:14:18: 17:2]))); // scope 0 at $DIR/async_await.rs:+0:18: +3:2
-        switchInt(move _39) -> [0: bb1, 1: bb29, 3: bb27, 4: bb28, otherwise: bb30]; // scope 0 at $DIR/async_await.rs:+0:18: +3:2
+        switchInt(move _39) -> [0: bb1, 1: bb28, 3: bb26, 4: bb27, otherwise: bb29]; // scope 0 at $DIR/async_await.rs:+0:18: +3:2
     }
 
     bb1: {
@@ -263,7 +263,7 @@ fn b::{closure#0}(_1: Pin<&mut [async fn body@$DIR/async_await.rs:14:18: 17:2]>,
         StorageDead(_29);                // scope 5 at $DIR/async_await.rs:+2:13: +2:14
         StorageDead(_26);                // scope 5 at $DIR/async_await.rs:+2:13: +2:14
         _32 = discriminant(_25);         // scope 4 at $DIR/async_await.rs:+2:8: +2:14
-        switchInt(move _32) -> [0: bb22, 1: bb20, otherwise: bb21]; // scope 4 at $DIR/async_await.rs:+2:8: +2:14
+        switchInt(move _32) -> [0: bb21, 1: bb20, otherwise: bb9]; // scope 4 at $DIR/async_await.rs:+2:8: +2:14
     }
 
     bb20: {
@@ -281,10 +281,6 @@ fn b::{closure#0}(_1: Pin<&mut [async fn body@$DIR/async_await.rs:14:18: 17:2]>,
     }
 
     bb21: {
-        unreachable;                     // scope 4 at $DIR/async_await.rs:+2:8: +2:14
-    }
-
-    bb22: {
         StorageLive(_33);                // scope 4 at $DIR/async_await.rs:+2:5: +2:14
         _33 = ((_25 as Ready).0: ());    // scope 4 at $DIR/async_await.rs:+2:5: +2:14
         _37 = _33;                       // scope 6 at $DIR/async_await.rs:+2:5: +2:14
@@ -293,10 +289,10 @@ fn b::{closure#0}(_1: Pin<&mut [async fn body@$DIR/async_await.rs:14:18: 17:2]>,
         StorageDead(_28);                // scope 4 at $DIR/async_await.rs:+2:13: +2:14
         StorageDead(_25);                // scope 4 at $DIR/async_await.rs:+2:13: +2:14
         StorageDead(_24);                // scope 4 at $DIR/async_await.rs:+2:13: +2:14
-        goto -> bb24;                    // scope 0 at $DIR/async_await.rs:+2:13: +2:14
+        goto -> bb23;                    // scope 0 at $DIR/async_await.rs:+2:13: +2:14
     }
 
-    bb23: {
+    bb22: {
         StorageDead(_36);                // scope 4 at $DIR/async_await.rs:+2:13: +2:14
         _38 = move _35;                  // scope 4 at $DIR/async_await.rs:+2:8: +2:14
         StorageDead(_35);                // scope 4 at $DIR/async_await.rs:+2:13: +2:14
@@ -304,23 +300,23 @@ fn b::{closure#0}(_1: Pin<&mut [async fn body@$DIR/async_await.rs:14:18: 17:2]>,
         goto -> bb16;                    // scope 4 at $DIR/async_await.rs:+2:8: +2:14
     }
 
-    bb24: {
+    bb23: {
         nop;                             // scope 0 at $DIR/async_await.rs:+2:13: +2:14
+        goto -> bb24;                    // scope 0 at $DIR/async_await.rs:+3:1: +3:2
+    }
+
+    bb24: {
+        StorageDead(_21);                // scope 0 at $DIR/async_await.rs:+3:1: +3:2
         goto -> bb25;                    // scope 0 at $DIR/async_await.rs:+3:1: +3:2
     }
 
     bb25: {
-        StorageDead(_21);                // scope 0 at $DIR/async_await.rs:+3:1: +3:2
-        goto -> bb26;                    // scope 0 at $DIR/async_await.rs:+3:1: +3:2
-    }
-
-    bb26: {
         _0 = Poll::<()>::Ready(move _37); // scope 0 at $DIR/async_await.rs:+3:2: +3:2
         discriminant((*(_1.0: &mut [async fn body@$DIR/async_await.rs:14:18: 17:2]))) = 1; // scope 0 at $DIR/async_await.rs:+3:2: +3:2
         return;                          // scope 0 at $DIR/async_await.rs:+3:2: +3:2
     }
 
-    bb27: {
+    bb26: {
         StorageLive(_3);                 // scope 0 at $DIR/async_await.rs:+0:18: +3:2
         StorageLive(_4);                 // scope 0 at $DIR/async_await.rs:+0:18: +3:2
         StorageLive(_19);                // scope 0 at $DIR/async_await.rs:+0:18: +3:2
@@ -329,19 +325,19 @@ fn b::{closure#0}(_1: Pin<&mut [async fn body@$DIR/async_await.rs:14:18: 17:2]>,
         goto -> bb11;                    // scope 0 at $DIR/async_await.rs:+0:18: +3:2
     }
 
-    bb28: {
+    bb27: {
         StorageLive(_21);                // scope 0 at $DIR/async_await.rs:+0:18: +3:2
         StorageLive(_35);                // scope 0 at $DIR/async_await.rs:+0:18: +3:2
         StorageLive(_36);                // scope 0 at $DIR/async_await.rs:+0:18: +3:2
         _35 = move _2;                   // scope 0 at $DIR/async_await.rs:+0:18: +3:2
-        goto -> bb23;                    // scope 0 at $DIR/async_await.rs:+0:18: +3:2
+        goto -> bb22;                    // scope 0 at $DIR/async_await.rs:+0:18: +3:2
+    }
+
+    bb28: {
+        assert(const false, "`async fn` resumed after completion") -> bb28; // scope 0 at $DIR/async_await.rs:+0:18: +3:2
     }
 
     bb29: {
-        assert(const false, "`async fn` resumed after completion") -> bb29; // scope 0 at $DIR/async_await.rs:+0:18: +3:2
-    }
-
-    bb30: {
         unreachable;                     // scope 0 at $DIR/async_await.rs:+0:18: +3:2
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.rs
+++ b/tests/mir-opt/inline/unchecked_shifts.rs
@@ -1,0 +1,17 @@
+#![crate_type = "lib"]
+#![feature(unchecked_math)]
+
+// ignore-debug: the debug assertions prevent the inlining we are testing for
+// compile-flags: -Zmir-opt-level=2 -Zinline-mir
+
+// EMIT_MIR unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.diff
+// EMIT_MIR unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.mir
+pub unsafe fn unchecked_shl_unsigned_smaller(a: u16, b: u32) -> u16 {
+    a.unchecked_shl(b)
+}
+
+// EMIT_MIR unchecked_shifts.unchecked_shr_signed_smaller.Inline.diff
+// EMIT_MIR unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.mir
+pub unsafe fn unchecked_shr_signed_smaller(a: i16, b: u32) -> i16 {
+    a.unchecked_shr(b)
+}

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.diff
@@ -1,0 +1,115 @@
+- // MIR for `unchecked_shl_unsigned_smaller` before Inline
++ // MIR for `unchecked_shl_unsigned_smaller` after Inline
+  
+  fn unchecked_shl_unsigned_smaller(_1: u16, _2: u32) -> u16 {
+      debug a => _1;                       // in scope 0 at $DIR/unchecked_shifts.rs:+0:46: +0:47
+      debug b => _2;                       // in scope 0 at $DIR/unchecked_shifts.rs:+0:54: +0:55
+      let mut _0: u16;                     // return place in scope 0 at $DIR/unchecked_shifts.rs:+0:65: +0:68
+      let mut _3: u16;                     // in scope 0 at $DIR/unchecked_shifts.rs:+1:5: +1:6
+      let mut _4: u32;                     // in scope 0 at $DIR/unchecked_shifts.rs:+1:21: +1:22
++     scope 1 (inlined core::num::<impl u16>::unchecked_shl) { // at $DIR/unchecked_shifts.rs:10:7: 10:23
++         debug self => _3;                // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         debug rhs => _4;                 // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         let mut _5: u16;                 // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         let mut _6: std::option::Option<u16>; // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         let mut _7: std::result::Result<u16, std::num::TryFromIntError>; // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         scope 2 {
++             scope 3 (inlined Result::<u16, TryFromIntError>::ok) { // at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++                 debug self => _7;        // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++                 let mut _8: isize;       // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++                 let _9: u16;             // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++                 scope 4 {
++                     debug x => _9;       // in scope 4 at $SRC_DIR/core/src/result.rs:LL:COL
++                 }
++                 scope 5 {
++                     scope 6 {
++                         debug x => const TryFromIntError(()); // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
++                     }
++                 }
++             }
++             scope 7 (inlined #[track_caller] Option::<u16>::unwrap_unchecked) { // at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++                 debug self => _6;        // in scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
++                 let mut _10: &std::option::Option<u16>; // in scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
++                 let mut _11: isize;      // in scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
++                 scope 8 {
++                     debug val => _5;     // in scope 8 at $SRC_DIR/core/src/option.rs:LL:COL
++                 }
++                 scope 9 {
++                     scope 11 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
++                         scope 12 {
++                             scope 13 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
++                             }
++                         }
++                     }
++                 }
++                 scope 10 (inlined Option::<u16>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
++                     debug self => _10;   // in scope 10 at $SRC_DIR/core/src/option.rs:LL:COL
++                 }
++             }
++         }
++     }
+  
+      bb0: {
+          StorageLive(_3);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:5: +1:6
+          _3 = _1;                         // scope 0 at $DIR/unchecked_shifts.rs:+1:5: +1:6
+          StorageLive(_4);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:21: +1:22
+          _4 = _2;                         // scope 0 at $DIR/unchecked_shifts.rs:+1:21: +1:22
+-         _0 = core::num::<impl u16>::unchecked_shl(move _3, move _4) -> bb1; // scope 0 at $DIR/unchecked_shifts.rs:+1:5: +1:23
++         StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         StorageLive(_7);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         _7 = <u32 as TryInto<u16>>::try_into(_4) -> bb1; // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+                                           // mir::Constant
+-                                          // + span: $DIR/unchecked_shifts.rs:10:7: 10:20
+-                                          // + literal: Const { ty: unsafe fn(u16, u32) -> u16 {core::num::<impl u16>::unchecked_shl}, val: Value(<ZST>) }
++                                          // + span: $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++                                          // + literal: Const { ty: fn(u32) -> Result<u16, <u32 as TryInto<u16>>::Error> {<u32 as TryInto<u16>>::try_into}, val: Value(<ZST>) }
+      }
+  
+      bb1: {
++         StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         _8 = discriminant(_7);           // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++         switchInt(move _8) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++     }
++ 
++     bb2: {
++         StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         StorageLive(_10);                // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         _11 = discriminant(_6);          // scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
++         switchInt(move _11) -> [1: bb7, otherwise: bb5]; // scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
++     }
++ 
++     bb3: {
++         StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+          StorageDead(_4);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:22: +1:23
+          StorageDead(_3);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:22: +1:23
+          return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
++     }
++ 
++     bb4: {
++         _6 = Option::<u16>::None;        // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
++         goto -> bb2;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
++     }
++ 
++     bb5: {
++         unreachable;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++     }
++ 
++     bb6: {
++         _9 = move ((_7 as Ok).0: u16);   // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++         _6 = Option::<u16>::Some(move _9); // scope 4 at $SRC_DIR/core/src/result.rs:LL:COL
++         goto -> bb2;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++     }
++ 
++     bb7: {
++         _5 = move ((_6 as Some).0: u16); // scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
++         StorageDead(_10);                // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         _0 = unchecked_shl::<u16>(_3, move _5) -> bb3; // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++                                          // mir::Constant
++                                          // + span: $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(u16, u16) -> u16 {unchecked_shl::<u16>}, val: Value(<ZST>) }
+      }
+  }
+  

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.mir
@@ -1,0 +1,102 @@
+// MIR for `unchecked_shl_unsigned_smaller` after PreCodegen
+
+fn unchecked_shl_unsigned_smaller(_1: u16, _2: u32) -> u16 {
+    debug a => _1;                       // in scope 0 at $DIR/unchecked_shifts.rs:+0:46: +0:47
+    debug b => _2;                       // in scope 0 at $DIR/unchecked_shifts.rs:+0:54: +0:55
+    let mut _0: u16;                     // return place in scope 0 at $DIR/unchecked_shifts.rs:+0:65: +0:68
+    scope 1 (inlined core::num::<impl u16>::unchecked_shl) { // at $DIR/unchecked_shifts.rs:10:7: 10:23
+        debug self => _1;                // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        debug rhs => _2;                 // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        let mut _3: u16;                 // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        let mut _4: std::option::Option<u16>; // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        let mut _5: std::result::Result<u16, std::num::TryFromIntError>; // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        scope 2 {
+            scope 3 (inlined Result::<u16, TryFromIntError>::ok) { // at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+                debug self => _5;        // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+                let mut _6: isize;       // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+                let _7: u16;             // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+                scope 4 {
+                    debug x => _7;       // in scope 4 at $SRC_DIR/core/src/result.rs:LL:COL
+                }
+                scope 5 {
+                    scope 6 {
+                        debug x => const TryFromIntError(()); // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+                    }
+                }
+            }
+            scope 7 (inlined #[track_caller] Option::<u16>::unwrap_unchecked) { // at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+                debug self => _4;        // in scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
+                let mut _8: &std::option::Option<u16>; // in scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
+                let mut _9: isize;       // in scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
+                scope 8 {
+                    debug val => _3;     // in scope 8 at $SRC_DIR/core/src/option.rs:LL:COL
+                }
+                scope 9 {
+                    scope 11 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
+                        scope 12 {
+                            scope 13 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            }
+                        }
+                    }
+                }
+                scope 10 (inlined Option::<u16>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
+                    debug self => _8;    // in scope 10 at $SRC_DIR/core/src/option.rs:LL:COL
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        _5 = <u32 as TryInto<u16>>::try_into(_2) -> bb1; // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+                                         // + literal: Const { ty: fn(u32) -> Result<u16, <u32 as TryInto<u16>>::Error> {<u32 as TryInto<u16>>::try_into}, val: Value(<ZST>) }
+    }
+
+    bb1: {
+        StorageLive(_7);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        _6 = discriminant(_5);           // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+        switchInt(move _6) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb2: {
+        StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        StorageLive(_8);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        _9 = discriminant(_4);           // scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(move _9) -> [1: bb7, otherwise: bb5]; // scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
+    }
+
+    bb3: {
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
+    }
+
+    bb4: {
+        _4 = Option::<u16>::None;        // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        goto -> bb2;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb5: {
+        unreachable;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb6: {
+        _7 = move ((_5 as Ok).0: u16);   // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+        _4 = Option::<u16>::Some(move _7); // scope 4 at $SRC_DIR/core/src/result.rs:LL:COL
+        goto -> bb2;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb7: {
+        _3 = move ((_4 as Some).0: u16); // scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageDead(_8);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        _0 = unchecked_shl::<u16>(_1, move _3) -> bb3; // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(u16, u16) -> u16 {unchecked_shl::<u16>}, val: Value(<ZST>) }
+    }
+}

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.diff
@@ -1,0 +1,115 @@
+- // MIR for `unchecked_shr_signed_smaller` before Inline
++ // MIR for `unchecked_shr_signed_smaller` after Inline
+  
+  fn unchecked_shr_signed_smaller(_1: i16, _2: u32) -> i16 {
+      debug a => _1;                       // in scope 0 at $DIR/unchecked_shifts.rs:+0:44: +0:45
+      debug b => _2;                       // in scope 0 at $DIR/unchecked_shifts.rs:+0:52: +0:53
+      let mut _0: i16;                     // return place in scope 0 at $DIR/unchecked_shifts.rs:+0:63: +0:66
+      let mut _3: i16;                     // in scope 0 at $DIR/unchecked_shifts.rs:+1:5: +1:6
+      let mut _4: u32;                     // in scope 0 at $DIR/unchecked_shifts.rs:+1:21: +1:22
++     scope 1 (inlined core::num::<impl i16>::unchecked_shr) { // at $DIR/unchecked_shifts.rs:16:7: 16:23
++         debug self => _3;                // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         debug rhs => _4;                 // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         let mut _5: i16;                 // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         let mut _6: std::option::Option<i16>; // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         let mut _7: std::result::Result<i16, std::num::TryFromIntError>; // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         scope 2 {
++             scope 3 (inlined Result::<i16, TryFromIntError>::ok) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++                 debug self => _7;        // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++                 let mut _8: isize;       // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++                 let _9: i16;             // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++                 scope 4 {
++                     debug x => _9;       // in scope 4 at $SRC_DIR/core/src/result.rs:LL:COL
++                 }
++                 scope 5 {
++                     scope 6 {
++                         debug x => const TryFromIntError(()); // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
++                     }
++                 }
++             }
++             scope 7 (inlined #[track_caller] Option::<i16>::unwrap_unchecked) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++                 debug self => _6;        // in scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
++                 let mut _10: &std::option::Option<i16>; // in scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
++                 let mut _11: isize;      // in scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
++                 scope 8 {
++                     debug val => _5;     // in scope 8 at $SRC_DIR/core/src/option.rs:LL:COL
++                 }
++                 scope 9 {
++                     scope 11 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
++                         scope 12 {
++                             scope 13 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
++                             }
++                         }
++                     }
++                 }
++                 scope 10 (inlined Option::<i16>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
++                     debug self => _10;   // in scope 10 at $SRC_DIR/core/src/option.rs:LL:COL
++                 }
++             }
++         }
++     }
+  
+      bb0: {
+          StorageLive(_3);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:5: +1:6
+          _3 = _1;                         // scope 0 at $DIR/unchecked_shifts.rs:+1:5: +1:6
+          StorageLive(_4);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:21: +1:22
+          _4 = _2;                         // scope 0 at $DIR/unchecked_shifts.rs:+1:21: +1:22
+-         _0 = core::num::<impl i16>::unchecked_shr(move _3, move _4) -> bb1; // scope 0 at $DIR/unchecked_shifts.rs:+1:5: +1:23
++         StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         StorageLive(_7);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         _7 = <u32 as TryInto<i16>>::try_into(_4) -> bb1; // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                           // mir::Constant
+-                                          // + span: $DIR/unchecked_shifts.rs:16:7: 16:20
+-                                          // + literal: Const { ty: unsafe fn(i16, u32) -> i16 {core::num::<impl i16>::unchecked_shr}, val: Value(<ZST>) }
++                                          // + span: $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++                                          // + literal: Const { ty: fn(u32) -> Result<i16, <u32 as TryInto<i16>>::Error> {<u32 as TryInto<i16>>::try_into}, val: Value(<ZST>) }
+      }
+  
+      bb1: {
++         StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         _8 = discriminant(_7);           // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++         switchInt(move _8) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++     }
++ 
++     bb2: {
++         StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         StorageLive(_10);                // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         _11 = discriminant(_6);          // scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
++         switchInt(move _11) -> [1: bb7, otherwise: bb5]; // scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
++     }
++ 
++     bb3: {
++         StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+          StorageDead(_4);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:22: +1:23
+          StorageDead(_3);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:22: +1:23
+          return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
++     }
++ 
++     bb4: {
++         _6 = Option::<i16>::None;        // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
++         goto -> bb2;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
++     }
++ 
++     bb5: {
++         unreachable;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++     }
++ 
++     bb6: {
++         _9 = move ((_7 as Ok).0: i16);   // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++         _6 = Option::<i16>::Some(move _9); // scope 4 at $SRC_DIR/core/src/result.rs:LL:COL
++         goto -> bb2;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
++     }
++ 
++     bb7: {
++         _5 = move ((_6 as Some).0: i16); // scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
++         StorageDead(_10);                // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         _0 = unchecked_shr::<i16>(_3, move _5) -> bb3; // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++                                          // mir::Constant
++                                          // + span: $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(i16, i16) -> i16 {unchecked_shr::<i16>}, val: Value(<ZST>) }
+      }
+  }
+  

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.mir
@@ -1,0 +1,102 @@
+// MIR for `unchecked_shr_signed_smaller` after PreCodegen
+
+fn unchecked_shr_signed_smaller(_1: i16, _2: u32) -> i16 {
+    debug a => _1;                       // in scope 0 at $DIR/unchecked_shifts.rs:+0:44: +0:45
+    debug b => _2;                       // in scope 0 at $DIR/unchecked_shifts.rs:+0:52: +0:53
+    let mut _0: i16;                     // return place in scope 0 at $DIR/unchecked_shifts.rs:+0:63: +0:66
+    scope 1 (inlined core::num::<impl i16>::unchecked_shr) { // at $DIR/unchecked_shifts.rs:16:7: 16:23
+        debug self => _1;                // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        debug rhs => _2;                 // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        let mut _3: i16;                 // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        let mut _4: std::option::Option<i16>; // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        let mut _5: std::result::Result<i16, std::num::TryFromIntError>; // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        scope 2 {
+            scope 3 (inlined Result::<i16, TryFromIntError>::ok) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                debug self => _5;        // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+                let mut _6: isize;       // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+                let _7: i16;             // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+                scope 4 {
+                    debug x => _7;       // in scope 4 at $SRC_DIR/core/src/result.rs:LL:COL
+                }
+                scope 5 {
+                    scope 6 {
+                        debug x => const TryFromIntError(()); // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+                    }
+                }
+            }
+            scope 7 (inlined #[track_caller] Option::<i16>::unwrap_unchecked) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                debug self => _4;        // in scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
+                let mut _8: &std::option::Option<i16>; // in scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
+                let mut _9: isize;       // in scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
+                scope 8 {
+                    debug val => _3;     // in scope 8 at $SRC_DIR/core/src/option.rs:LL:COL
+                }
+                scope 9 {
+                    scope 11 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
+                        scope 12 {
+                            scope 13 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            }
+                        }
+                    }
+                }
+                scope 10 (inlined Option::<i16>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
+                    debug self => _8;    // in scope 10 at $SRC_DIR/core/src/option.rs:LL:COL
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        _5 = <u32 as TryInto<i16>>::try_into(_2) -> bb1; // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                         // + literal: Const { ty: fn(u32) -> Result<i16, <u32 as TryInto<i16>>::Error> {<u32 as TryInto<i16>>::try_into}, val: Value(<ZST>) }
+    }
+
+    bb1: {
+        StorageLive(_7);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        _6 = discriminant(_5);           // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+        switchInt(move _6) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb2: {
+        StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageLive(_8);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        _9 = discriminant(_4);           // scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(move _9) -> [1: bb7, otherwise: bb5]; // scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
+    }
+
+    bb3: {
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
+    }
+
+    bb4: {
+        _4 = Option::<i16>::None;        // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        goto -> bb2;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb5: {
+        unreachable;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb6: {
+        _7 = move ((_5 as Ok).0: i16);   // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+        _4 = Option::<i16>::Some(move _7); // scope 4 at $SRC_DIR/core/src/result.rs:LL:COL
+        goto -> bb2;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb7: {
+        _3 = move ((_4 as Some).0: i16); // scope 7 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageDead(_8);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        _0 = unchecked_shr::<i16>(_1, move _3) -> bb3; // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(i16, i16) -> i16 {unchecked_shr::<i16>}, val: Value(<ZST>) }
+    }
+}

--- a/tests/mir-opt/inline/unwrap_unchecked.rs
+++ b/tests/mir-opt/inline/unwrap_unchecked.rs
@@ -1,5 +1,6 @@
 #![crate_type = "lib"]
 
+// ignore-wasm32-bare compiled with panic=abort by default
 // ignore-debug: the debug assertions prevent the inlining we are testing for
 // compile-flags: -Zmir-opt-level=2 -Zinline-mir
 

--- a/tests/mir-opt/inline/unwrap_unchecked.rs
+++ b/tests/mir-opt/inline/unwrap_unchecked.rs
@@ -1,0 +1,10 @@
+#![crate_type = "lib"]
+
+// ignore-debug: the debug assertions prevent the inlining we are testing for
+// compile-flags: -Zmir-opt-level=2 -Zinline-mir
+
+// EMIT_MIR unwrap_unchecked.unwrap_unchecked.Inline.diff
+// EMIT_MIR unwrap_unchecked.unwrap_unchecked.PreCodegen.after.mir
+pub unsafe fn unwrap_unchecked<T>(slf: Option<T>) -> T {
+    slf.unwrap_unchecked()
+}

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.diff
@@ -1,0 +1,55 @@
+- // MIR for `unwrap_unchecked` before Inline
++ // MIR for `unwrap_unchecked` after Inline
+  
+  fn unwrap_unchecked(_1: Option<T>) -> T {
+      debug slf => _1;                     // in scope 0 at $DIR/unwrap_unchecked.rs:+0:35: +0:38
+      let mut _0: T;                       // return place in scope 0 at $DIR/unwrap_unchecked.rs:+0:54: +0:55
+      let mut _2: std::option::Option<T>;  // in scope 0 at $DIR/unwrap_unchecked.rs:+1:5: +1:8
++     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) { // at $DIR/unwrap_unchecked.rs:9:9: 9:27
++         debug self => _2;                // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
++         let mut _3: &std::option::Option<T>; // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
++         let mut _4: isize;               // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
++         scope 2 {
++             debug val => _0;             // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
++         }
++         scope 3 {
++             scope 5 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
++                 scope 6 {
++                     scope 7 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
++                     }
++                 }
++             }
++         }
++         scope 4 (inlined Option::<T>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
++             debug self => _3;            // in scope 4 at $SRC_DIR/core/src/option.rs:LL:COL
++         }
++     }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:5: +1:8
+          _2 = move _1;                    // scope 0 at $DIR/unwrap_unchecked.rs:+1:5: +1:8
+-         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/unwrap_unchecked.rs:+1:5: +1:27
+-                                          // mir::Constant
+-                                          // + span: $DIR/unwrap_unchecked.rs:9:9: 9:25
+-                                          // + literal: Const { ty: unsafe fn(Option<T>) -> T {Option::<T>::unwrap_unchecked}, val: Value(<ZST>) }
++         StorageLive(_3);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:9: +1:27
++         _4 = discriminant(_2);           // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
++         switchInt(move _4) -> [0: bb1, 1: bb2, otherwise: bb1]; // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
+      }
+  
+      bb1: {
+-         StorageDead(_2);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:26: +1:27
+-         return;                          // scope 0 at $DIR/unwrap_unchecked.rs:+2:2: +2:2
++         unreachable;                     // scope 6 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+      }
+  
+-     bb2 (cleanup): {
+-         resume;                          // scope 0 at $DIR/unwrap_unchecked.rs:+0:1: +2:2
++     bb2: {
++         _0 = move ((_2 as Some).0: T);   // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
++         StorageDead(_3);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:9: +1:27
++         StorageDead(_2);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:26: +1:27
++         return;                          // scope 0 at $DIR/unwrap_unchecked.rs:+2:2: +2:2
+      }
+  }
+  

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.diff
@@ -5,7 +5,7 @@
       debug slf => _1;                     // in scope 0 at $DIR/unwrap_unchecked.rs:+0:35: +0:38
       let mut _0: T;                       // return place in scope 0 at $DIR/unwrap_unchecked.rs:+0:54: +0:55
       let mut _2: std::option::Option<T>;  // in scope 0 at $DIR/unwrap_unchecked.rs:+1:5: +1:8
-+     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) { // at $DIR/unwrap_unchecked.rs:9:9: 9:27
++     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) { // at $DIR/unwrap_unchecked.rs:10:9: 10:27
 +         debug self => _2;                // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
 +         let mut _3: &std::option::Option<T>; // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
 +         let mut _4: isize;               // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
@@ -30,7 +30,7 @@
           _2 = move _1;                    // scope 0 at $DIR/unwrap_unchecked.rs:+1:5: +1:8
 -         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/unwrap_unchecked.rs:+1:5: +1:27
 -                                          // mir::Constant
--                                          // + span: $DIR/unwrap_unchecked.rs:9:9: 9:25
+-                                          // + span: $DIR/unwrap_unchecked.rs:10:9: 10:25
 -                                          // + literal: Const { ty: unsafe fn(Option<T>) -> T {Option::<T>::unwrap_unchecked}, val: Value(<ZST>) }
 +         StorageLive(_3);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:9: +1:27
 +         _4 = discriminant(_2);           // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.mir
@@ -3,7 +3,7 @@
 fn unwrap_unchecked(_1: Option<T>) -> T {
     debug slf => _1;                     // in scope 0 at $DIR/unwrap_unchecked.rs:+0:35: +0:38
     let mut _0: T;                       // return place in scope 0 at $DIR/unwrap_unchecked.rs:+0:54: +0:55
-    scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) { // at $DIR/unwrap_unchecked.rs:9:9: 9:27
+    scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) { // at $DIR/unwrap_unchecked.rs:10:9: 10:27
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
         let mut _2: &std::option::Option<T>; // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
         let mut _3: isize;               // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.mir
@@ -1,0 +1,41 @@
+// MIR for `unwrap_unchecked` after PreCodegen
+
+fn unwrap_unchecked(_1: Option<T>) -> T {
+    debug slf => _1;                     // in scope 0 at $DIR/unwrap_unchecked.rs:+0:35: +0:38
+    let mut _0: T;                       // return place in scope 0 at $DIR/unwrap_unchecked.rs:+0:54: +0:55
+    scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) { // at $DIR/unwrap_unchecked.rs:9:9: 9:27
+        debug self => _1;                // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
+        let mut _2: &std::option::Option<T>; // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
+        let mut _3: isize;               // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
+        scope 2 {
+            debug val => _0;             // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+        }
+        scope 3 {
+            scope 5 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
+                scope 6 {
+                    scope 7 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                    }
+                }
+            }
+        }
+        scope 4 (inlined Option::<T>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
+            debug self => _2;            // in scope 4 at $SRC_DIR/core/src/option.rs:LL:COL
+        }
+    }
+
+    bb0: {
+        StorageLive(_2);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:9: +1:27
+        _3 = discriminant(_1);           // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(move _3) -> [1: bb2, otherwise: bb1]; // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
+    }
+
+    bb1: {
+        unreachable;                     // scope 6 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+    }
+
+    bb2: {
+        _0 = move ((_1 as Some).0: T);   // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageDead(_2);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:9: +1:27
+        return;                          // scope 0 at $DIR/unwrap_unchecked.rs:+2:2: +2:2
+    }
+}

--- a/tests/mir-opt/instcombine_duplicate_switch_targets.assert_zero.InstCombine.diff
+++ b/tests/mir-opt/instcombine_duplicate_switch_targets.assert_zero.InstCombine.diff
@@ -1,0 +1,21 @@
+- // MIR for `assert_zero` before InstCombine
++ // MIR for `assert_zero` after InstCombine
+  
+  fn assert_zero(_1: u8) -> u8 {
+      let mut _0: u8;                      // return place in scope 0 at $DIR/instcombine_duplicate_switch_targets.rs:+0:37: +0:39
+  
+      bb0: {
+-         switchInt(_1) -> [0: bb2, 1: bb1, otherwise: bb1]; // scope 0 at $DIR/instcombine_duplicate_switch_targets.rs:+3:13: +7:14
++         switchInt(_1) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/instcombine_duplicate_switch_targets.rs:+3:13: +7:14
+      }
+  
+      bb1: {
+          unreachable;                     // scope 0 at $DIR/instcombine_duplicate_switch_targets.rs:+10:13: +10:26
+      }
+  
+      bb2: {
+          _0 = _1;                         // scope 0 at $DIR/instcombine_duplicate_switch_targets.rs:+13:13: +13:20
+          return;                          // scope 0 at $DIR/instcombine_duplicate_switch_targets.rs:+14:13: +14:21
+      }
+  }
+  

--- a/tests/mir-opt/instcombine_duplicate_switch_targets.rs
+++ b/tests/mir-opt/instcombine_duplicate_switch_targets.rs
@@ -1,0 +1,27 @@
+#![feature(custom_mir, core_intrinsics)]
+#![crate_type = "lib"]
+
+use std::intrinsics::mir::*;
+
+// unit-test: InstCombine
+
+// EMIT_MIR instcombine_duplicate_switch_targets.assert_zero.InstCombine.diff
+#[custom_mir(dialect = "runtime", phase = "post-cleanup")]
+pub unsafe fn assert_zero(x: u8) -> u8 {
+    mir!(
+        {
+            match x {
+                0 => retblock,
+                1 => unreachable,
+                _ => unreachable,
+            }
+        }
+        unreachable = {
+            Unreachable()
+        }
+        retblock = {
+            RET = x;
+            Return()
+        }
+    )
+}

--- a/tests/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
+++ b/tests/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
@@ -61,7 +61,7 @@
   
       bb4: {
           _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
-          switchInt(move _8) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
+          switchInt(move _8) -> [0: bb6, 1: bb5, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
       bb5: {
@@ -69,14 +69,10 @@
           _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
           _0 = Option::<i32>::None;        // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
           StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
-          goto -> bb8;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
+          goto -> bb7;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
       }
   
       bb6: {
-          unreachable;                     // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
-      }
-  
-      bb7: {
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
           _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
           StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
@@ -84,10 +80,10 @@
           _0 = Option::<i32>::Some(move _10); // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
           StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:43: +11:44
           StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
-          goto -> bb8;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
+          goto -> bb7;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
       }
   
-      bb8: {
+      bb7: {
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+14:1: +14:2
           return;                          // scope 0 at $DIR/separate_const_switch.rs:+14:2: +14:2
       }

--- a/tests/mir-opt/simplify_duplicate_unreachable_blocks.assert_nonzero_nonmax.SimplifyCfg-after-uninhabited-enum-branching.diff
+++ b/tests/mir-opt/simplify_duplicate_unreachable_blocks.assert_nonzero_nonmax.SimplifyCfg-after-uninhabited-enum-branching.diff
@@ -1,0 +1,25 @@
+- // MIR for `assert_nonzero_nonmax` before SimplifyCfg-after-uninhabited-enum-branching
++ // MIR for `assert_nonzero_nonmax` after SimplifyCfg-after-uninhabited-enum-branching
+  
+  fn assert_nonzero_nonmax(_1: u8) -> u8 {
+      let mut _0: u8;                      // return place in scope 0 at $DIR/simplify_duplicate_unreachable_blocks.rs:+0:47: +0:49
+  
+      bb0: {
+-         switchInt(_1) -> [0: bb1, 255: bb2, otherwise: bb3]; // scope 0 at $DIR/simplify_duplicate_unreachable_blocks.rs:+3:13: +7:14
++         switchInt(_1) -> [0: bb1, 255: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_duplicate_unreachable_blocks.rs:+3:13: +7:14
+      }
+  
+      bb1: {
+          unreachable;                     // scope 0 at $DIR/simplify_duplicate_unreachable_blocks.rs:+10:13: +10:26
+      }
+  
+      bb2: {
+-         unreachable;                     // scope 0 at $DIR/simplify_duplicate_unreachable_blocks.rs:+13:13: +13:26
+-     }
+- 
+-     bb3: {
+          _0 = _1;                         // scope 0 at $DIR/simplify_duplicate_unreachable_blocks.rs:+16:13: +16:20
+          return;                          // scope 0 at $DIR/simplify_duplicate_unreachable_blocks.rs:+17:13: +17:21
+      }
+  }
+  

--- a/tests/mir-opt/simplify_duplicate_unreachable_blocks.rs
+++ b/tests/mir-opt/simplify_duplicate_unreachable_blocks.rs
@@ -1,0 +1,30 @@
+#![feature(custom_mir, core_intrinsics)]
+#![crate_type = "lib"]
+
+use std::intrinsics::mir::*;
+
+// unit-test: SimplifyCfg-after-uninhabited-enum-branching
+
+// EMIT_MIR simplify_duplicate_unreachable_blocks.assert_nonzero_nonmax.SimplifyCfg-after-uninhabited-enum-branching.diff
+#[custom_mir(dialect = "runtime", phase = "post-cleanup")]
+pub unsafe fn assert_nonzero_nonmax(x: u8) -> u8 {
+    mir!(
+        {
+            match x {
+                0 => unreachable1,
+                u8::MAX => unreachable2,
+                _ => retblock,
+            }
+        }
+        unreachable1 = {
+            Unreachable()
+        }
+        unreachable2 = {
+            Unreachable()
+        }
+        retblock = {
+            RET = x;
+            Return()
+        }
+    )
+}

--- a/tests/mir-opt/try_identity_e2e.new.PreCodegen.after.mir
+++ b/tests/mir-opt/try_identity_e2e.new.PreCodegen.after.mir
@@ -26,35 +26,35 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/try_identity_e2e.rs:+2:15: +7:10
         _3 = discriminant(_1);           // scope 0 at $DIR/try_identity_e2e.rs:+3:19: +3:20
-        switchInt(move _3) -> [0: bb2, 1: bb1, otherwise: bb5]; // scope 0 at $DIR/try_identity_e2e.rs:+3:13: +3:20
+        switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/try_identity_e2e.rs:+3:13: +3:20
     }
 
     bb1: {
         _5 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity_e2e.rs:+5:21: +5:22
         _2 = ControlFlow::<E, T>::Break(move _5); // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
-        goto -> bb3;                     // scope 0 at $DIR/try_identity_e2e.rs:+5:47: +5:48
+        goto -> bb4;                     // scope 0 at $DIR/try_identity_e2e.rs:+5:47: +5:48
     }
 
     bb2: {
-        _4 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity_e2e.rs:+4:20: +4:21
-        _2 = ControlFlow::<E, T>::Continue(move _4); // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
-        goto -> bb3;                     // scope 0 at $DIR/try_identity_e2e.rs:+4:49: +4:50
+        unreachable;                     // scope 0 at $DIR/try_identity_e2e.rs:+3:19: +3:20
     }
 
     bb3: {
-        _6 = discriminant(_2);           // scope 0 at $DIR/try_identity_e2e.rs:+2:15: +7:10
-        switchInt(move _6) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 0 at $DIR/try_identity_e2e.rs:+2:9: +7:10
+        _4 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity_e2e.rs:+4:20: +4:21
+        _2 = ControlFlow::<E, T>::Continue(move _4); // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
+        goto -> bb4;                     // scope 0 at $DIR/try_identity_e2e.rs:+4:49: +4:50
     }
 
     bb4: {
+        _6 = discriminant(_2);           // scope 0 at $DIR/try_identity_e2e.rs:+2:15: +7:10
+        switchInt(move _6) -> [0: bb6, 1: bb5, otherwise: bb2]; // scope 0 at $DIR/try_identity_e2e.rs:+2:9: +7:10
+    }
+
+    bb5: {
         _8 = move ((_2 as Break).0: E);  // scope 0 at $DIR/try_identity_e2e.rs:+9:32: +9:33
         _0 = Result::<T, E>::Err(move _8); // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
         StorageDead(_2);                 // scope 0 at $DIR/try_identity_e2e.rs:+12:1: +12:2
         return;                          // scope 0 at $DIR/try_identity_e2e.rs:+12:1: +12:2
-    }
-
-    bb5: {
-        unreachable;                     // scope 0 at $DIR/try_identity_e2e.rs:+2:15: +7:10
     }
 
     bb6: {

--- a/tests/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/tests/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -34,7 +34,7 @@ fn main() -> () {
         StorageLive(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
         _7 = Test2::D;                   // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
         _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
-        switchInt(move _8) -> [4: bb5, 5: bb3, otherwise: bb4]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +7:19
+        switchInt(move _8) -> [4: bb4, 5: bb3, otherwise: bb2]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +7:19
     }
 
     bb2: {
@@ -49,22 +49,18 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _6 = &(*_9);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
         StorageDead(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
-        goto -> bb6;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
+        goto -> bb5;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
     }
 
     bb4: {
-        unreachable;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
-    }
-
-    bb5: {
         _6 = const "D";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching.rs:27:21: 27:24
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        goto -> bb6;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
+        goto -> bb5;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
     }
 
-    bb6: {
+    bb5: {
         StorageDead(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+10:6: +10:7
         StorageDead(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+10:6: +10:7
         _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching.rs:+0:11: +11:2

--- a/tests/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
+++ b/tests/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
@@ -63,7 +63,7 @@
           StorageLive(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
           _7 = Test2::D;                   // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
           _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
-          switchInt(move _8) -> [4: bb8, 5: bb6, otherwise: bb7]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +7:19
+          switchInt(move _8) -> [4: bb7, 5: bb6, otherwise: bb2]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +7:19
       }
   
       bb6: {
@@ -74,22 +74,18 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _6 = &(*_9);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
           StorageDead(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
-          goto -> bb9;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
+          goto -> bb8;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
       }
   
       bb7: {
-          unreachable;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
-      }
-  
-      bb8: {
           _6 = const "D";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:27:21: 27:24
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          goto -> bb9;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
+          goto -> bb8;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
       }
   
-      bb9: {
+      bb8: {
           StorageDead(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+10:6: +10:7
           StorageDead(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+10:6: +10:7
           _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching.rs:+0:11: +11:2

--- a/tests/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/tests/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -63,7 +63,7 @@ fn main() -> () {
         StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
         StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +15:6
         _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
-        switchInt(move _10) -> [2: bb7, 3: bb5, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
+        switchInt(move _10) -> [2: bb6, 3: bb5, otherwise: bb2]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
     }
 
     bb5: {
@@ -74,14 +74,10 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _9 = &(*_13);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
         StorageDead(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
-        goto -> bb8;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
+        goto -> bb7;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
     }
 
     bb6: {
-        unreachable;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
-    }
-
-    bb7: {
         StorageLive(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
         _12 = const "C";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
                                          // mir::Constant
@@ -89,10 +85,10 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _9 = &(*_12);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
         StorageDead(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
-        goto -> bb8;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
+        goto -> bb7;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
     }
 
-    bb8: {
+    bb7: {
         StorageDead(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+15:6: +15:7
         _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching2.rs:+0:11: +16:2
         StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+16:1: +16:2

--- a/tests/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
+++ b/tests/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
@@ -84,8 +84,8 @@
           StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
           StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +15:6
           _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
--         switchInt(move _10) -> [0: bb9, 1: bb10, 2: bb11, 3: bb7, otherwise: bb8]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
-+         switchInt(move _10) -> [2: bb11, 3: bb7, otherwise: bb8]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
+-         switchInt(move _10) -> [0: bb8, 1: bb9, 2: bb10, 3: bb7, otherwise: bb2]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
++         switchInt(move _10) -> [2: bb10, 3: bb7, otherwise: bb2]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
       }
   
       bb7: {
@@ -96,22 +96,18 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _9 = &(*_13);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
           StorageDead(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
-          goto -> bb12;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
+          goto -> bb11;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
       }
   
       bb8: {
-          unreachable;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
-      }
-  
-      bb9: {
           _9 = const "A(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:+11:24: +11:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:29:24: 29:34
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          goto -> bb12;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+11:24: +11:34
+          goto -> bb11;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+11:24: +11:34
       }
   
-      bb10: {
+      bb9: {
           StorageLive(_11);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:24: +12:34
           _11 = const "B(Empty)";          // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:24: +12:34
                                            // mir::Constant
@@ -119,10 +115,10 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _9 = &(*_11);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:24: +12:34
           StorageDead(_11);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:33: +12:34
-          goto -> bb12;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:33: +12:34
+          goto -> bb11;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:33: +12:34
       }
   
-      bb11: {
+      bb10: {
           StorageLive(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
           _12 = const "C";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
                                            // mir::Constant
@@ -130,10 +126,10 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _9 = &(*_12);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
           StorageDead(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
-          goto -> bb12;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
+          goto -> bb11;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
       }
   
-      bb12: {
+      bb11: {
           StorageDead(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+15:6: +15:7
           _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching2.rs:+0:11: +16:2
           StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+16:1: +16:2


### PR DESCRIPTION
This heuristic prevents inlining of `hint::unreachable_unchecked`, which in turn makes `Option/Result::unwrap_unchecked` a bad inlining candidate. I looked through the changes to `core`, `alloc`, `std`, and `hashbrown` by hand and they all seem reasonable. Let's see how this looks in perf...

---

Based on rustc-perf it looks like this regresses ctfe-stress, and the cachegrind diff indicates that this regression is in `InterpCx::statement`. I don't know how to do any deeper analysis because that function is _enormous_ in the try toolchain, which has no debuginfo in it. And a local build produces significantly different codegen for that function, even with LTO.