### PR TITLE
Enable doctests for rustc_query_impl

### DIFF
--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [lib]
-doctest = false
+
 
 [dependencies]
 measureme = "10.0.0"


### PR DESCRIPTION
doctests worked out of the box for query_impl on my local machine. Working towards #99144