### PR TITLE
rustdoc: fix buggy JS check for absolute URL

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -563,7 +563,7 @@ function loadCss(cssUrl) {
                 onEachLazy(code.getElementsByTagName("a"), elem => {
                     const href = elem.getAttribute("href");
 
-                    if (href && href.indexOf("http") !== 0) {
+                    if (href && !/^(?:[a-z+]+:)?\/\//.test(href)) {
                         elem.setAttribute("href", window.rootPath + href);
                     }
                 });

--- a/src/test/rustdoc-gui/implementors.goml
+++ b/src/test/rustdoc-gui/implementors.goml
@@ -33,3 +33,9 @@ goto: "file://" + |DOC_PATH| + "/lib2/trait.TraitToReexport.html"
 assert-count: ("#implementors-list .impl", 1)
 goto: "file://" + |DOC_PATH| + "/implementors/trait.TraitToReexport.html"
 assert-count: ("#implementors-list .impl", 1)
+
+// Now check that the link is properly rewritten for a crate called `http`.
+// An older version of rustdoc had a buggy check for absolute links.
+goto: "file://" + |DOC_PATH| + "/http/trait.HttpTrait.html"
+assert-count: ("#implementors-list .impl", 1)
+assert-attribute: ("#implementors-list .impl a.trait", {"href": "../http/trait.HttpTrait.html"})

--- a/src/test/rustdoc-gui/search-filter.goml
+++ b/src/test/rustdoc-gui/search-filter.goml
@@ -15,6 +15,7 @@ click: "#crate-search"
 press-key: "ArrowDown"
 press-key: "ArrowDown"
 press-key: "ArrowDown"
+press-key: "ArrowDown"
 press-key: "Enter"
 // Waiting for the search results to appear...
 wait-for: "#search-tabs"
@@ -36,6 +37,7 @@ assert-property: ("#crate-search", {"value": "lib2"})
 
 // Selecting back "All crates"
 click: "#crate-search"
+press-key: "ArrowUp"
 press-key: "ArrowUp"
 press-key: "ArrowUp"
 press-key: "ArrowUp"

--- a/src/test/rustdoc-gui/sidebar-source-code.goml
+++ b/src/test/rustdoc-gui/sidebar-source-code.goml
@@ -73,7 +73,7 @@ assert: "//*[@class='dir-entry' and @open]/*[text()='sub_mod']"
 // Only "another_folder" should be "open" in "lib2".
 assert: "//*[@class='dir-entry' and not(@open)]/*[text()='another_mod']"
 // All other trees should be collapsed.
-assert-count: ("//*[@id='source-sidebar']/details[not(text()='lib2') and not(@open)]", 7)
+assert-count: ("//*[@id='source-sidebar']/details[not(text()='lib2') and not(@open)]", 8)
 
 // We now switch to mobile mode.
 size: (600, 600)

--- a/src/test/rustdoc-gui/source-code-page.goml
+++ b/src/test/rustdoc-gui/source-code-page.goml
@@ -102,7 +102,7 @@ assert: ".source-sidebar-expanded"
 
 // We check that the first entry of the sidebar is collapsed
 assert-property: ("#source-sidebar details:first-of-type", {"open": "false"})
-assert-text: ("#source-sidebar details:first-of-type > summary", "huge_logo")
+assert-text: ("#source-sidebar details:first-of-type > summary", "http")
 // We now click on it.
 click: "#source-sidebar details:first-of-type > summary"
 assert-property: ("#source-sidebar details:first-of-type", {"open": "true"})

--- a/src/test/rustdoc-gui/src/lib2/Cargo.lock
+++ b/src/test/rustdoc-gui/src/lib2/Cargo.lock
@@ -3,12 +3,20 @@
 version = 3
 
 [[package]]
+name = "http"
+version = "0.1.0"
+
+[[package]]
 name = "implementors"
 version = "0.1.0"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "lib2"
 version = "0.1.0"
 dependencies = [
+ "http",
  "implementors",
 ]

--- a/src/test/rustdoc-gui/src/lib2/Cargo.toml
+++ b/src/test/rustdoc-gui/src/lib2/Cargo.toml
@@ -8,3 +8,4 @@ path = "lib.rs"
 
 [dependencies]
 implementors = { path = "./implementors" }
+http = { path = "./http" }

--- a/src/test/rustdoc-gui/src/lib2/http/Cargo.toml
+++ b/src/test/rustdoc-gui/src/lib2/http/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
-name = "implementors"
+name = "http"
 version = "0.1.0"
 edition = "2018"
 
 [lib]
 path = "lib.rs"
-
-[dependencies]
-http = { path = "../http/" }

--- a/src/test/rustdoc-gui/src/lib2/http/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/http/lib.rs
@@ -1,0 +1,1 @@
+pub trait HttpTrait {}

--- a/src/test/rustdoc-gui/src/lib2/implementors/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/implementors/lib.rs
@@ -10,6 +10,8 @@ impl Whatever for Struct {
     type Foo = u8;
 }
 
+impl http::HttpTrait for Struct {}
+
 mod traits {
     pub trait TraitToReexport {
         fn method() {}


### PR DESCRIPTION
The old code did the wrong thing when faced with a crate named "http".