### PR TITLE
[LSDA] Take ttype_index into account when taking unwind action

### DIFF
--- a/library/std/src/personality/dwarf/eh.rs
+++ b/library/std/src/personality/dwarf/eh.rs
@@ -84,7 +84,7 @@ pub unsafe fn find_eh_action(lsda: *const u8, context: &EHContext<'_>) -> Result
             let cs_start = read_encoded_pointer(&mut reader, context, call_site_encoding)?;
             let cs_len = read_encoded_pointer(&mut reader, context, call_site_encoding)?;
             let cs_lpad = read_encoded_pointer(&mut reader, context, call_site_encoding)?;
-            let cs_action = reader.read_uleb128();
+            let cs_action_entry = reader.read_uleb128();
             // Callsite table is sorted by cs_start, so if we've passed the ip, we
             // may stop searching.
             if ip < func_start + cs_start {
@@ -95,7 +95,15 @@ pub unsafe fn find_eh_action(lsda: *const u8, context: &EHContext<'_>) -> Result
                     return Ok(EHAction::None);
                 } else {
                     let lpad = lpad_base + cs_lpad;
-                    return Ok(interpret_cs_action(cs_action, lpad));
+                    if cs_action_entry == 0 {
+                        return Ok(interpret_cs_action(0, lpad));
+                    } else {
+                        let action_record =
+                            (action_table as *mut u8).offset(cs_action_entry as isize - 1);
+                        let mut action_reader = DwarfReader::new(action_record);
+                        let ttype_index = action_reader.read_sleb128();
+                        return Ok(interpret_cs_action(ttype_index as u64, lpad));
+                    }
                 }
             }
         }

--- a/library/std/src/personality/dwarf/eh.rs
+++ b/library/std/src/personality/dwarf/eh.rs
@@ -131,10 +131,12 @@ unsafe fn interpret_cs_action(
     lpad: usize,
 ) -> EHAction {
     if cs_action_entry == 0 {
-        // If cs_action is 0 then this is a cleanup (Drop::drop). We run these
+        // If cs_action_entry is 0 then this is a cleanup (Drop::drop). We run these
         // for both Rust panics and foreign exceptions.
         EHAction::Cleanup(lpad)
     } else {
+        // If lpad != 0 and cs_action_entry != 0, we have to check ttype_index.
+        // If ttype_index == 0 under the condition, we take cleanup action.
         let action_record = (action_table as *mut u8).offset(cs_action_entry as isize - 1);
         let mut action_reader = DwarfReader::new(action_record);
         let ttype_index = action_reader.read_sleb128();

--- a/library/std/src/personality/dwarf/eh.rs
+++ b/library/std/src/personality/dwarf/eh.rs
@@ -102,6 +102,8 @@ pub unsafe fn find_eh_action(lsda: *const u8, context: &EHContext<'_>) -> Result
                             (action_table as *mut u8).offset(cs_action_entry as isize - 1);
                         let mut action_reader = DwarfReader::new(action_record);
                         let ttype_index = action_reader.read_sleb128();
+                        // Normally, if ttype_index < 0, meaning the catch type is exception specification.
+                        // Since we only care about if ttype_index is zero, so casting ttype_index to u64 makes sense.
                         return Ok(interpret_cs_action(ttype_index as u64, lpad));
                     }
                 }


### PR DESCRIPTION
If `cs_action != 0`, we should check the `ttype_index` field in action record. If `ttype_index == 0`, a clean up action is taken; otherwise catch action is taken.

This can fix unwind failure on AIX which uses LLVM's libunwind by default. IIUC, rust's LSDA is borrowed from c++ and I'm assuming itanium-cxx-abi https://itanium-cxx-abi.github.io/cxx-abi/exceptions.pdf should be followed, so the fix follows what libcxxabi does. See https://github.com/llvm/llvm-project/blob/ec48682ce9f61d056361c5095f21e930b8365661/libcxxabi/src/cxa_personality.cpp#L152 for use of `ttype_index`.
