### PR TITLE
Correct `std::prelude` comment

### DIFF
--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -91,10 +91,10 @@ pub use core::prelude::v1::cfg_eval;
 )]
 pub use core::prelude::v1::type_ascribe;
 
-// The file so far is equivalent to src/libcore/prelude/v1.rs,
-// and below to src/liballoc/prelude.rs.
-// Those files are duplicated rather than using glob imports
-// because we want docs to show these re-exports as pointing to within `std`.
+// The file so far is equivalent to core/src/prelude/v1.rs. It is duplicated
+// rather than glob imported because we want docs to show these re-exports as
+// pointing to within `std`.
+// Below are the items from the alloc crate.
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]


### PR DESCRIPTION
(Read the changed file first for context.)

First, `alloc` has no prelude.

Second, the docs for `v1` don't matter since the [prelude module] already has all the doc links. The `rust_2021` module for instance also doesnt have a convenient doc page. However as I understand glob imports still cant be used because the items dont have the same stabilisation versions.

[prelude module]: https://doc.rust-lang.org/std/prelude/index.html