### PR TITLE
Use try_fold and try_rfold in default implementations of fold and rfold

### DIFF
--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -1,5 +1,5 @@
 use crate::marker::Destruct;
-use crate::ops::{ControlFlow, Try};
+use crate::ops::{ControlFlow, NeverShortCircuit, Try};
 
 /// An iterator able to yield elements from both ends.
 ///
@@ -297,16 +297,12 @@ pub trait DoubleEndedIterator: Iterator {
     #[inline]
     #[stable(feature = "iter_rfold", since = "1.27.0")]
     #[rustc_do_not_const_check]
-    fn rfold<B, F>(mut self, init: B, mut f: F) -> B
+    fn rfold<B, F>(mut self, init: B, f: F) -> B
     where
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        let mut accum = init;
-        while let Some(x) = self.next_back() {
-            accum = f(accum, x);
-        }
-        accum
+        self.try_rfold(init, NeverShortCircuit::wrap_mut_2(f)).0
     }
 
     /// Searches for an element of an iterator from the back that satisfies a predicate.


### PR DESCRIPTION
This means that specialised versions will only need to implement the try variant and will get a specialised non-try variant for free. That is, once the `Try` trait and co. are stable.

This can't add any extra branches due to the use of `NeverShortCircuit`, but the actual perf implications are still unclear.