### PR TITLE
Update Fuchsia walkthrough with new configs

### DIFF
--- a/src/doc/rustc/src/platform-support/fuchsia.md
+++ b/src/doc/rustc/src/platform-support/fuchsia.md
@@ -198,6 +198,9 @@ target = ["<host_platform>", "aarch64-fuchsia", "x86_64-fuchsia"]
 [rust]
 lld = true
 
+[llvm]
+download-ci-llvm = false
+
 [target.x86_64-fuchsia]
 cc = "clang"
 cxx = "clang++"


### PR DESCRIPTION
The new `download-ci-llvm` configuration option dosn't work with `lld = true` (see #100853). The Fuchsia walkthrough should recommend setting it to `false`.

r? @tmandry