### PR TITLE
Fix rustdoc source code rendering for `#[path = "../path/to/mod.rs"]` links

### DIFF
--- a/src/test/rustdoc/src-links.rs
+++ b/src/test/rustdoc/src-links.rs
@@ -7,6 +7,11 @@
 #[path = "src-links/mod.rs"]
 pub mod qux;
 
+// @has src/foo/src-links.rs.html
+// @has foo/fizz/index.html '//a/@href' '../src/foo/src-links/fizz.rs.html'
+#[path = "src-links/../src-links/fizz.rs"]
+pub mod fizz;
+
 // @has foo/bar/index.html '//a/@href' '../../src/foo/src-links.rs.html'
 pub mod bar {
 

--- a/src/test/rustdoc/src-links/fizz.rs
+++ b/src/test/rustdoc/src-links/fizz.rs
@@ -1,0 +1,1 @@
+pub struct Buzz;


### PR DESCRIPTION
Fixes #103517

While generating the location for modules source HTML to be saved at, a `..` path component appeared to be translated to `/up/`.
Additionally, while generating the navigation sidebar, `..` path components were ignored. This means that (as in the issue above), a *real* directory structure of:
```
sys/
  unix/
    mod.rs  <-- contains #![path = "../unix/mod.rs]
    cmath.rs
```
was rendered as:
```
sys/
  unix/
    mod.rs
    unix/
      cmath.rs  <-- links to sys/unix/unix/cmath.rs.html, 404
```
While the *files* were stored as
```
sys/
  unix/
    mod.rs.html
    up/
      unix/
        cmath.rs.html
```