### PR TITLE
Rename `glue` and refactor `push_tree`

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -710,7 +710,11 @@ impl Token {
         }
     }
 
-    pub fn glue(&self, joint: &Token) -> Option<Token> {
+    /// Checks if the current token is a multiple-character token (or glued like `==`, `<=`, `...`)
+    /// and returns the corresponding `TokenKind` if it is.
+    ///
+    /// if the current tokens is already complete, returns `None`.
+    pub fn check_is_multiple_char_token(&self, joint: &Token) -> Option<Token> {
         let kind = match self.kind {
             Eq => match joint.kind {
                 Eq => EqEq,

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -511,7 +511,7 @@ impl TokenStream {
     fn try_glue_to_last(vec: &mut Vec<TokenTree>, tt: &TokenTree) -> bool {
         if let Some(TokenTree::Token(last_tok, Spacing::Joint)) = vec.last()
             && let TokenTree::Token(tok, spacing) = tt
-            && let Some(glued_tok) = last_tok.glue(tok)
+            && let Some(glued_tok) = last_tok.check_is_multiple_char_token(tok)
         {
             // ...then overwrite the last token tree in `vec` with the
             // glued token, and skip the first token tree from `stream`.
@@ -527,9 +527,7 @@ impl TokenStream {
     pub fn push_tree(&mut self, tt: TokenTree) {
         let vec_mut = Lrc::make_mut(&mut self.0);
 
-        if Self::try_glue_to_last(vec_mut, &tt) {
-            // nothing else to do
-        } else {
+        if !Self::try_glue_to_last(vec_mut, &tt) {
             vec_mut.push(tt);
         }
     }

--- a/compiler/rustc_parse/src/lexer/tokentrees.rs
+++ b/compiler/rustc_parse/src/lexer/tokentrees.rs
@@ -71,7 +71,8 @@ impl<'a> TokenTreesReader<'a> {
                         let (next_tok, is_next_tok_preceded_by_whitespace) =
                             self.string_reader.next_token();
                         if !is_next_tok_preceded_by_whitespace {
-                            if let Some(glued) = self.token.check_is_multiple_char_token(&next_tok) {
+                            if let Some(glued) = self.token.check_is_multiple_char_token(&next_tok)
+                            {
                                 self.token = glued;
                             } else {
                                 let this_spacing =

--- a/compiler/rustc_parse/src/lexer/tokentrees.rs
+++ b/compiler/rustc_parse/src/lexer/tokentrees.rs
@@ -71,7 +71,7 @@ impl<'a> TokenTreesReader<'a> {
                         let (next_tok, is_next_tok_preceded_by_whitespace) =
                             self.string_reader.next_token();
                         if !is_next_tok_preceded_by_whitespace {
-                            if let Some(glued) = self.token.glue(&next_tok) {
+                            if let Some(glued) = self.token.check_is_multiple_char_token(&next_tok) {
                                 self.token = glued;
                             } else {
                                 let this_spacing =


### PR DESCRIPTION
Renamed the glue function to check_is_multiple_char_token and added some comments. 

And I think the `push_tree` function could only check the `!Self::try_glue_to_last` condition, so I refactored it.

thanks 