### PR TITLE
Fix --kbd-color variable name in rustdoc.css

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1374,7 +1374,7 @@ kbd {
 	vertical-align: middle;
 	border: solid 1px var(--border-color);
 	border-radius: 3px;
-	color: var(--kbd--color);
+	color: var(--kbd-color);
 	background-color: var(--kbd-background);
 	box-shadow: inset 0 -1px 0 var(--kbd-box-shadow-color);
 }

--- a/src/test/rustdoc-gui/help-page.goml
+++ b/src/test/rustdoc-gui/help-page.goml
@@ -39,7 +39,7 @@ call-function: ("check-colors", {
 })
 call-function: ("check-colors", {
     "theme": "dark",
-    "color": "rgb(221, 221, 221)",
+    "color": "rgb(0, 0, 0)",
     "background": "rgb(250, 251, 252)",
     "box_shadow": "rgb(198, 203, 209)",
 })


### PR DESCRIPTION
Interestingly enough, it only impacted the dark theme.

Before:

![Screenshot from 2023-01-05 11-03-17](https://user-images.githubusercontent.com/3050060/210754145-c3bb0f50-d35f-4543-bf73-010a4524a803.png)

After:

![Screenshot from 2023-01-05 11-03-05](https://user-images.githubusercontent.com/3050060/210754190-85c2f146-a774-4463-9cd3-9495b7c91bd7.png)

r? @notriddle 