### PR TITLE
Fix error-index redirect to work with the back button.

### DIFF
--- a/src/tools/error_index_generator/book_config.toml
+++ b/src/tools/error_index_generator/book_config.toml
@@ -7,6 +7,7 @@ src = ""
 git-repository-url = "https://github.com/rust-lang/rust/"
 additional-css = ["error-index.css"]
 additional-js = ["error-index.js"]
+input-404 = ""
 
 [output.html.search]
 enable = true

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -171,9 +171,6 @@ This page lists all the error codes emitted by the Rust compiler.
 </html>"#,
     )?;
 
-    // No need for a 404 file, it's already handled by the server.
-    fs::remove_file(output_path.join("error_codes/404.html"))?;
-
     Ok(())
 }
 

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -98,8 +98,7 @@ fn add_rust_attribute_on_codeblock(explanation: &str) -> String {
 
 fn render_html(output_path: &Path) -> Result<(), Box<dyn Error>> {
     let mut introduction = format!(
-        "<script src='redirect.js'></script>
-# Rust error codes index
+        "# Rust error codes index
 
 This page lists all the error codes emitted by the Rust compiler.
 
@@ -149,7 +148,12 @@ This page lists all the error codes emitted by the Rust compiler.
     book.book.sections.push(BookItem::Chapter(chapter));
     book.build()?;
 
-    // We can't put this content into another file, otherwise `mbdbook` will also put it into the
+    // The error-index used to be generated manually (without mdbook), and the
+    // index was located at the top level. Now that it is generated with
+    // mdbook, error-index.html has moved to error_codes/error-index.html.
+    // This adds a redirect so that old links go to the new location.
+    //
+    // We can't put this content into another file, otherwise `mdbook` will also put it into the
     // output directory, making a duplicate.
     fs::write(
         output_path.join("error-index.html"),
@@ -163,7 +167,6 @@ This page lists all the error codes emitted by the Rust compiler.
     </head>
     <body>
         <div>If you are not automatically redirected to the error code index, please <a id="index-link" href="./error_codes/error-index.html">here</a>.
-        <script>document.getElementById("index-link").click()</script>
     </body>
 </html>"#,
     )?;

--- a/src/tools/error_index_generator/redirect.js
+++ b/src/tools/error_index_generator/redirect.js
@@ -3,14 +3,10 @@
         let code = window.location.hash.replace(/^#/, '');
         // We have to make sure this pattern matches to avoid inadvertently creating an
         // open redirect.
-        if (!/^E[0-9]+$/.test(code)) {
+        if (/^E[0-9]+$/.test(code)) {
+            window.location.replace('./error_codes/' + code + '.html');
             return;
         }
-        if (window.location.pathname.indexOf("/error_codes/") !== -1) {
-            // We're not at the top level, so we don't prepend with "./error_codes/".
-            window.location = './' + code + '.html';
-        } else {
-            window.location = './error_codes/' + code + '.html';
-        }
     }
+    window.location.replace('./error_codes/error-index.html');
 })()


### PR DESCRIPTION
This fixes the redirect page at https://doc.rust-lang.org/error-index.html so that it works with the browser's back-button. The solution is to use `window.location.replace()`, which avoids adding the page to the browser history stack.

This also cleans up the code a little bit, since it looks like it was written with different assumptions (maybe before f5857d5c5e1d2fde302f330d11c5cdea8005eb2a).  I don't think there is a need to have a redirect at https://doc.rust-lang.org/error_codes/error-index.html since I don't think fragment-based links were ever used there.

I have tested with Firefox, Chrome, and Safari. Going to `/error-index.html` redirects without adding to the stack, and can use the back button. Additionally, `/error-index.html#E0005` redirects correctly to the error page.

Finally, there is an unrelated commit to remove the 404 hack. There is an official way of avoiding the generation of the 404 page with setting input-404 to an empty value.

Fixes #106485
