### PR TITLE
fix [type error] for error E0029 and E0277

### DIFF
--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -553,6 +553,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             (lhs, Some((true, rhs_ty, rhs_sp))) => one_side_err(rhs_sp, rhs_ty, lhs),
             _ => span_bug!(span, "Impossible, verified above."),
         }
+        if (lhs, rhs).references_error() {
+            err.downgrade_to_delayed_bug();
+        }
         if self.tcx.sess.teach(&err.get_code().unwrap()) {
             err.note(
                 "In a match expression, only numbers and characters can be matched \

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1387,7 +1387,6 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
         self.note_obligation_cause(&mut err, &obligation);
         self.point_at_returns_when_relevant(&mut err, &obligation);
-
         err.emit();
     }
 }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -248,7 +248,7 @@ pub trait TypeErrCtxtExt<'tcx> {
 
     fn point_at_returns_when_relevant(
         &self,
-        err: &mut Diagnostic,
+        err: &mut DiagnosticBuilder<'tcx, ErrorGuaranteed>,
         obligation: &PredicateObligation<'tcx>,
     );
 
@@ -1686,7 +1686,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
     fn point_at_returns_when_relevant(
         &self,
-        err: &mut Diagnostic,
+        err: &mut DiagnosticBuilder<'tcx, ErrorGuaranteed>,
         obligation: &PredicateObligation<'tcx>,
     ) {
         match obligation.cause.code().peel_derives() {
@@ -1708,7 +1708,15 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             for expr in &visitor.returns {
                 if let Some(returned_ty) = typeck_results.node_type_opt(expr.hir_id) {
                     let ty = self.resolve_vars_if_possible(returned_ty);
-                    err.span_label(expr.span, &format!("this returned value is of type `{}`", ty));
+                    if ty.references_error() {
+                        // don't print out the [type error] here
+                        err.delay_as_bug();
+                    } else {
+                        err.span_label(
+                            expr.span,
+                            &format!("this returned value is of type `{}`", ty),
+                        );
+                    }
                 }
             }
         }

--- a/src/test/ui/typeck/issue-105946.rs
+++ b/src/test/ui/typeck/issue-105946.rs
@@ -1,0 +1,12 @@
+fn digit() -> str {
+  return {};
+  //~^ ERROR: mismatched types [E0308]
+}
+fn main() {
+    let [_y..] = [box 1, box 2];
+    //~^ ERROR: cannot find value `_y` in this scope [E0425]
+    //~| ERROR: `X..` patterns in slices are experimental [E0658]
+    //~| ERROR: box expression syntax is experimental; you can call `Box::new` instead [E0658]
+    //~| ERROR: box expression syntax is experimental; you can call `Box::new` instead [E0658]
+    //~| ERROR: pattern requires 1 element but array has 2 [E0527]
+}

--- a/src/test/ui/typeck/issue-105946.stderr
+++ b/src/test/ui/typeck/issue-105946.stderr
@@ -1,0 +1,49 @@
+error[E0425]: cannot find value `_y` in this scope
+  --> $DIR/issue-105946.rs:6:10
+   |
+LL |     let [_y..] = [box 1, box 2];
+   |          ^^ not found in this scope
+
+error[E0658]: `X..` patterns in slices are experimental
+  --> $DIR/issue-105946.rs:6:10
+   |
+LL |     let [_y..] = [box 1, box 2];
+   |          ^^^^
+   |
+   = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
+   = help: add `#![feature(half_open_range_patterns_in_slices)]` to the crate attributes to enable
+
+error[E0658]: box expression syntax is experimental; you can call `Box::new` instead
+  --> $DIR/issue-105946.rs:6:19
+   |
+LL |     let [_y..] = [box 1, box 2];
+   |                   ^^^^^
+   |
+   = note: see issue #49733 <https://github.com/rust-lang/rust/issues/49733> for more information
+   = help: add `#![feature(box_syntax)]` to the crate attributes to enable
+
+error[E0658]: box expression syntax is experimental; you can call `Box::new` instead
+  --> $DIR/issue-105946.rs:6:26
+   |
+LL |     let [_y..] = [box 1, box 2];
+   |                          ^^^^^
+   |
+   = note: see issue #49733 <https://github.com/rust-lang/rust/issues/49733> for more information
+   = help: add `#![feature(box_syntax)]` to the crate attributes to enable
+
+error[E0308]: mismatched types
+  --> $DIR/issue-105946.rs:2:10
+   |
+LL |   return {};
+   |          ^^ expected `str`, found `()`
+
+error[E0527]: pattern requires 1 element but array has 2
+  --> $DIR/issue-105946.rs:6:9
+   |
+LL |     let [_y..] = [box 1, box 2];
+   |         ^^^^^^ expected 2 elements
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0308, E0425, E0527, E0658.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
check explicitly for the type references error
if ty.references_error() is true change the error to be err.delay_as_bug() and prevent the error E0029 and E0277 from emitting out this fix #105946