### PR TITLE
rustdoc: remove legacy user-select CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -538,8 +538,6 @@ ul.block, .block li {
 	overflow: initial;
 	text-align: right;
 	-webkit-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
 	user-select: none;
 	padding: 14px 8px;
 	color: var(--src-line-numbers-span-color);


### PR DESCRIPTION
According to [caniuse], the only supported browser that requires the vendor prefix, as defined in [RFC 1985], is Safari.

* The last version of Chrome that required a vendor prefix was version 53. The current version is 108.
* Firefox 68 is the last version that required a vendor prefix. The [current Firefox ESR] is version 102.
* The current version of Safari for Mac and iOS still requires a prefix.
* The last version of Edge that required a vendor frefix was 18. The current version of Edge is 108.
* UCAndroid support is unknown, but if it still requires a vendor prefix, it's more likely to be `-webkit-` than `-moz-` or `-ms-`, since they would want to emulate iOS for compatibility.

[caniuse]: https://caniuse.com/?search=user-select
[RFC 1985]: https://rust-lang.github.io/rfcs/1985-tiered-browser-support.html
[current Firefox ESR]: https://wiki.mozilla.org/Releases