### PR TITLE
Default relax_elf_relocations to true

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -821,7 +821,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(profile_emit, Some(PathBuf::from("abc")));
     tracked!(profile_sample_use, Some(PathBuf::from("abc")));
     tracked!(profiler_runtime, "abc".to_string());
-    tracked!(relax_elf_relocations, Some(true));
+    tracked!(relax_elf_relocations, Some(false));
     tracked!(relro_level, Some(RelroLevel::Full));
     tracked!(remap_cwd_prefix, Some(PathBuf::from("abc")));
     tracked!(report_delayed_bugs, true);

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2216,7 +2216,7 @@ impl Default for TargetOptions {
             mcount: "mcount".into(),
             llvm_mcount_intrinsic: None,
             llvm_abiname: "".into(),
-            relax_elf_relocations: false,
+            relax_elf_relocations: true,
             llvm_args: cvs![],
             use_ctors_section: false,
             eh_frame_header: true,

--- a/compiler/rustc_target/src/spec/x86_64_fortanix_unknown_sgx.rs
+++ b/compiler/rustc_target/src/spec/x86_64_fortanix_unknown_sgx.rs
@@ -69,7 +69,6 @@ pub fn target() -> Target {
         position_independent_executables: true,
         pre_link_args,
         override_export_symbols: Some(EXPORT_SYMBOLS.iter().cloned().map(Cow::from).collect()),
-        relax_elf_relocations: true,
         ..Default::default()
     };
     Target {


### PR DESCRIPTION
This option tells LLVM to emit relaxable relocation types R_X86_64_GOTPCRELX/R_X86_64_REX_GOTPCRELX/R_386_GOT32X in applicable cases. True matches Clang's CMake default since 2020-08 [1] and latest LLVM default[2].

This also works around a GNU ld<2.41 issue[2] when using general-dynamic/local-dynamic TLS models in `-Z plt=no` mode with latest LLVM.

[1]: https://github.com/llvm/llvm-project/commit/c41a18cf61790fc898dcda1055c3efbf442c14c0
[2]: https://github.com/llvm/llvm-project/commit/2aedfdd9b82e6c72a28576d0e8ea854f1300ff4e
[3]: https://sourceware.org/bugzilla/show_bug.cgi?id=24784