### PR TITLE
remove E0280

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -574,7 +574,7 @@ E0791: include_str!("./error_codes/E0791.md"),
 //  E0274, // on_unimplemented #2
 //  E0278, // requirement is not satisfied
 //  E0279,
-    E0280, // requirement is not satisfied
+//  E0280, // changed to ICE
 //  E0285, // overflow evaluation builtin bounds
 //  E0296, // replaced with a generic attribute input check
 //  E0298, // cannot compare constants

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1102,15 +1102,19 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     }
 
                     ty::PredicateKind::Clause(ty::Clause::RegionOutlives(..))
-                    | ty::PredicateKind::Clause(ty::Clause::Projection(..))
                     | ty::PredicateKind::Clause(ty::Clause::TypeOutlives(..)) => {
-                        let predicate = self.resolve_vars_if_possible(obligation.predicate);
-                        struct_span_err!(
-                            self.tcx.sess,
+                        span_bug!(
                             span,
-                            E0280,
-                            "the requirement `{}` is not satisfied",
-                            predicate
+                            "outlives clauses should not error outside borrowck. obligation: `{:?}`",
+                            obligation
+                        )
+                    }
+
+                    ty::PredicateKind::Clause(ty::Clause::Projection(..)) => {
+                        span_bug!(
+                            span,
+                            "projection clauses should be implied from elsewhere. obligation: `{:?}`",
+                            obligation
                         )
                     }
 

--- a/src/test/ui/chalkify/bugs/async.rs
+++ b/src/test/ui/chalkify/bugs/async.rs
@@ -1,6 +1,13 @@
 // check-fail
-// known-bug: unknown
-// compile-flags: -Z trait-solver=chalk --edition=2021
+// known-bug
+// unset-rustc-env:RUST_BACKTRACE
+// compile-flags:-Z trait-solver=chalk --edition=2021
+// error-pattern:stack backtrace:
+// failure-status:101
+// normalize-stderr-test "note: .*" -> ""
+// normalize-stderr-test "thread 'rustc' .*" -> ""
+// normalize-stderr-test "  .*\n" -> ""
+// normalize-stderr-test "DefId([^)]*)" -> "..."
 
 fn main() -> () {}
 

--- a/src/test/ui/chalkify/bugs/async.stderr
+++ b/src/test/ui/chalkify/bugs/async.stderr
@@ -1,48 +1,40 @@
-error[E0277]: `[async fn body@$DIR/async.rs:7:29: 9:2]` is not a future
-  --> $DIR/async.rs:7:29
-   |
-LL |   async fn foo(x: u32) -> u32 {
-   |  _____________________________-
-LL | |     x
-LL | | }
-   | | ^
-   | | |
-   | |_`[async fn body@$DIR/async.rs:7:29: 9:2]` is not a future
-   |   required by a bound introduced by this call
-   |
-   = help: the trait `Future` is not implemented for `[async fn body@$DIR/async.rs:7:29: 9:2]`
-   = note: [async fn body@$DIR/async.rs:7:29: 9:2] must be a future or must implement `IntoFuture` to be awaited
-note: required by a bound in `identity_future`
-  --> $SRC_DIR/core/src/future/mod.rs:LL:COL
+error[E0277]: `[async fn body@$DIR/async.rs:14:29: 16:2]` is not a future
+LL |LL | |LL | | }
 
-error[E0277]: the size for values of type `<[async fn body@$DIR/async.rs:7:29: 9:2] as Future>::Output` cannot be known at compilation time
-  --> $DIR/async.rs:7:29
-   |
-LL |   async fn foo(x: u32) -> u32 {
-   |  _____________________________^
-LL | |     x
-LL | | }
-   | |_^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `<[async fn body@$DIR/async.rs:7:29: 9:2] as Future>::Output`
-note: required by a bound in `identity_future`
-  --> $SRC_DIR/core/src/future/mod.rs:LL:COL
 
-error[E0277]: `[async fn body@$DIR/async.rs:7:29: 9:2]` is not a future
-  --> $DIR/async.rs:7:25
-   |
+error[E0277]: the size for values of type `<[async fn body@$DIR/async.rs:14:29: 16:2] as Future>::Output` cannot be known at compilation time
+LL |LL | |LL | | }
+
+
+error[E0277]: `[async fn body@$DIR/async.rs:14:29: 16:2]` is not a future
 LL | async fn foo(x: u32) -> u32 {
-   |                         ^^^ `[async fn body@$DIR/async.rs:7:29: 9:2]` is not a future
-   |
-   = help: the trait `Future` is not implemented for `[async fn body@$DIR/async.rs:7:29: 9:2]`
-   = note: [async fn body@$DIR/async.rs:7:29: 9:2] must be a future or must implement `IntoFuture` to be awaited
 
-error[E0280]: the requirement `<[async fn body@$DIR/async.rs:7:29: 9:2] as Future>::Output == u32` is not satisfied
-  --> $DIR/async.rs:7:25
-   |
+error: internal compiler error: compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs:1114:25: projection clauses should be implied from elsewhere. obligation: `Obligation(predicate=Binder(ProjectionPredicate(AliasTy { substs: [[async fn body@$DIR/async.rs:14:29: 16:2]], def_id: ...), _use_mk_alias_ty_instead: () }, Term::Ty(u32)), []), depth=0)`
 LL | async fn foo(x: u32) -> u32 {
-   |                         ^^^
 
+
+stack backtrace:
+
+
+
+
+
+
+
+
+
+query stack during panic:
+#0 [typeck] type-checking `foo`
+#1 [thir_body] building THIR for `foo`
+#2 [mir_built] building MIR for `foo`
+#3 [unsafety_check_result] unsafety-checking `foo`
+#4 [mir_const] preparing `foo` for borrow checking
+#5 [mir_promoted] processing MIR for `foo`
+#6 [mir_borrowck] borrow-checking `foo`
+#7 [type_of] computing type of `foo::{opaque#0}`
+#8 [check_mod_item_types] checking item types in top-level module
+#9 [analysis] running analysis passes on this crate
+end of query stack
 error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
After looking at #61137 I tried my hand at E0280. I'm unable to find a reasonable example that emits the error. There are a couple of old examples that compile with the current compiler ([#26217](https://github.com/rust-lang/rust/issues/26217), [#42114](https://github.com/rust-lang/rust/issues/42114), [#27113](https://github.com/rust-lang/rust/issues/27113)) and there is a [bug with chalk](https://github.com/rust-lang/rust/blob/b7cdb635c4b973572307ad288466fba64533369c/src/test/ui/chalkify/bugs/async.rs) that makes it emit the error, with a couple more chalk bugs on zulip.

It seems like the error is supposed to be emitted from unfulfilled where bounds, of which two are related to borrow checking (error in where T: 'a or where 'a: 'b) and thus tend to emit errors like "lifetime may not live long enough" from borrow checking instead. The final case is with type equality constraints (where <T as Iterator>::Item == u32), which is unimplemented ([#20041](https://github.com/rust-lang/rust/issues/20041)). That such different problems are supposed to have the same error code also seems strange to me.

Since the error seems to only be emitted when using chalk I propose to remove it and replace it with an ICE instead. A crater run might be warranted.

Pinging @jackh726 due to removal of chalk test that now ICEs.