### PR TITLE
Label `struct/enum constructor` instead of `fn item`, mention that it should be called on type mismatch

### DIFF
--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -2,10 +2,10 @@ use crate::traits::{ObligationCause, ObligationCauseCode};
 use crate::ty::diagnostics::suggest_constraining_type_param;
 use crate::ty::print::{with_forced_trimmed_paths, FmtPrinter, Printer};
 use crate::ty::{self, BoundRegionKind, Region, Ty, TyCtxt};
-use hir::def::DefKind;
 use rustc_errors::Applicability::{MachineApplicable, MaybeIncorrect};
 use rustc_errors::{pluralize, Diagnostic, MultiSpan};
 use rustc_hir as hir;
+use rustc_hir::def::{CtorOf, DefKind};
 use rustc_hir::def_id::DefId;
 use rustc_span::symbol::{sym, Symbol};
 use rustc_span::{BytePos, Span};
@@ -319,7 +319,11 @@ impl<'tcx> Ty<'tcx> {
                     .into()
                 }
             }
-            ty::FnDef(..) => "fn item".into(),
+            ty::FnDef(def_id, ..) => match tcx.def_kind(def_id) {
+                DefKind::Ctor(CtorOf::Struct, _) => "struct constructor".into(),
+                DefKind::Ctor(CtorOf::Variant, _) => "enum constructor".into(),
+                _ => "fn item".into(),
+            },
             ty::FnPtr(_) => "fn pointer".into(),
             ty::Dynamic(ref inner, ..) if let Some(principal) = inner.principal() => {
                 format!("trait object `dyn {}`", tcx.def_path_str(principal.def_id())).into()
@@ -366,7 +370,11 @@ impl<'tcx> Ty<'tcx> {
                 _ => "reference",
             }
             .into(),
-            ty::FnDef(..) => "fn item".into(),
+            ty::FnDef(def_id, ..) => match tcx.def_kind(def_id) {
+                DefKind::Ctor(CtorOf::Struct, _) => "struct constructor".into(),
+                DefKind::Ctor(CtorOf::Variant, _) => "enum constructor".into(),
+                _ => "fn item".into(),
+            },
             ty::FnPtr(_) => "fn pointer".into(),
             ty::Dynamic(..) => "trait object".into(),
             ty::Closure(..) => "closure".into(),

--- a/tests/ui/associated-types/substs-ppaux.normal.stderr
+++ b/tests/ui/associated-types/substs-ppaux.normal.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:16:17
    |
 LL |     fn bar<'a, T>() where T: 'a {}
-   |     --------------------------- fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>} defined here
+   |     --------------------------- associated function `bar` defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
    |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -20,7 +20,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:25:17
    |
 LL |     fn bar<'a, T>() where T: 'a {}
-   |     --------------------------- fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>} defined here
+   |     --------------------------- associated function `bar` defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
    |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:33:17
    |
 LL |     fn baz() {}
-   |     -------- fn() {<i8 as Foo<'static, 'static, u8>>::baz} defined here
+   |     -------- associated function `baz` defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
    |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -56,7 +56,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:41:17
    |
 LL | fn foo<'z>() where &'z (): Sized {
-   | -------------------------------- fn() {foo::<'static>} defined here
+   | -------------------------------- function `foo` defined here
 ...
 LL |     let x: () = foo::<'static>;
    |            --   ^^^^^^^^^^^^^^ expected `()`, found fn item

--- a/tests/ui/associated-types/substs-ppaux.verbose.stderr
+++ b/tests/ui/associated-types/substs-ppaux.verbose.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:16:17
    |
 LL |     fn bar<'a, T>() where T: 'a {}
-   |     --------------------------- fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>} defined here
+   |     --------------------------- associated function `bar` defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
    |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -20,7 +20,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:25:17
    |
 LL |     fn bar<'a, T>() where T: 'a {}
-   |     --------------------------- fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>} defined here
+   |     --------------------------- associated function `bar` defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
    |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:33:17
    |
 LL |     fn baz() {}
-   |     -------- fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz} defined here
+   |     -------- associated function `baz` defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
    |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -56,7 +56,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:41:17
    |
 LL | fn foo<'z>() where &'z (): Sized {
-   | -------------------------------- fn() {foo::<ReStatic>} defined here
+   | -------------------------------- function `foo` defined here
 ...
 LL |     let x: () = foo::<'static>;
    |            --   ^^^^^^^^^^^^^^ expected `()`, found fn item

--- a/tests/ui/issues/issue-35241.stderr
+++ b/tests/ui/issues/issue-35241.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-35241.rs:3:20
    |
 LL | struct Foo(u32);
-   | ---------- fn(u32) -> Foo {Foo} defined here
+   | ---------- `Foo` defines a struct constructor here, which should be called
 LL |
 LL | fn test() -> Foo { Foo }
    |              ---   ^^^ expected struct `Foo`, found struct constructor

--- a/tests/ui/issues/issue-35241.stderr
+++ b/tests/ui/issues/issue-35241.stderr
@@ -5,12 +5,12 @@ LL | struct Foo(u32);
    | ---------- fn(u32) -> Foo {Foo} defined here
 LL |
 LL | fn test() -> Foo { Foo }
-   |              ---   ^^^ expected struct `Foo`, found fn item
+   |              ---   ^^^ expected struct `Foo`, found struct constructor
    |              |
    |              expected `Foo` because of return type
    |
-   = note: expected struct `Foo`
-             found fn item `fn(u32) -> Foo {Foo}`
+   = note:          expected struct `Foo`
+           found struct constructor `fn(u32) -> Foo {Foo}`
 help: use parentheses to construct this tuple struct
    |
 LL | fn test() -> Foo { Foo(/* u32 */) }

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -267,12 +267,12 @@ LL |             Fn(u8),
    |             -- fn(u8) -> Z {Z::Fn} defined here
 ...
 LL |         let _: Z = Z::Fn;
-   |                -   ^^^^^ expected enum `Z`, found fn item
+   |                -   ^^^^^ expected enum `Z`, found enum constructor
    |                |
    |                expected due to this
    |
-   = note: expected enum `Z`
-           found fn item `fn(u8) -> Z {Z::Fn}`
+   = note:          expected enum `Z`
+           found enum constructor `fn(u8) -> Z {Z::Fn}`
 help: use parentheses to construct this tuple variant
    |
 LL |         let _: Z = Z::Fn(/* u8 */);
@@ -308,12 +308,12 @@ LL |         Fn(u8),
    |         -- fn(u8) -> E {E::Fn} defined here
 ...
 LL |     let _: E = m::E::Fn;
-   |            -   ^^^^^^^^ expected enum `E`, found fn item
+   |            -   ^^^^^^^^ expected enum `E`, found enum constructor
    |            |
    |            expected due to this
    |
-   = note: expected enum `E`
-           found fn item `fn(u8) -> E {E::Fn}`
+   = note:          expected enum `E`
+           found enum constructor `fn(u8) -> E {E::Fn}`
 help: use parentheses to construct this tuple variant
    |
 LL |     let _: E = m::E::Fn(/* u8 */);
@@ -349,12 +349,12 @@ LL |         Fn(u8),
    |         -- fn(u8) -> E {E::Fn} defined here
 ...
 LL |     let _: E = E::Fn;
-   |            -   ^^^^^ expected enum `E`, found fn item
+   |            -   ^^^^^ expected enum `E`, found enum constructor
    |            |
    |            expected due to this
    |
-   = note: expected enum `E`
-           found fn item `fn(u8) -> E {E::Fn}`
+   = note:          expected enum `E`
+           found enum constructor `fn(u8) -> E {E::Fn}`
 help: use parentheses to construct this tuple variant
    |
 LL |     let _: E = E::Fn(/* u8 */);

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -264,7 +264,7 @@ error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:27:20
    |
 LL |             Fn(u8),
-   |             -- fn(u8) -> Z {Z::Fn} defined here
+   |             -- `Fn` defines an enum variant constructor here, which should be called
 ...
 LL |         let _: Z = Z::Fn;
    |                -   ^^^^^ expected enum `Z`, found enum constructor
@@ -305,7 +305,7 @@ error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:43:16
    |
 LL |         Fn(u8),
-   |         -- fn(u8) -> E {E::Fn} defined here
+   |         -- `Fn` defines an enum variant constructor here, which should be called
 ...
 LL |     let _: E = m::E::Fn;
    |            -   ^^^^^^^^ expected enum `E`, found enum constructor
@@ -346,7 +346,7 @@ error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:51:16
    |
 LL |         Fn(u8),
-   |         -- fn(u8) -> E {E::Fn} defined here
+   |         -- `Fn` defines an enum variant constructor here, which should be called
 ...
 LL |     let _: E = E::Fn;
    |            -   ^^^^^ expected enum `E`, found enum constructor

--- a/tests/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/tests/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:29:20
    |
 LL | fn foo(a: usize, b: usize) -> usize { a }
-   | ----------------------------------- fn(usize, usize) -> usize {foo} defined here
+   | ----------------------------------- function `foo` defined here
 ...
 LL |     let _: usize = foo;
    |            -----   ^^^ expected `usize`, found fn item
@@ -20,7 +20,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:30:16
    |
 LL | struct S(usize, usize);
-   | -------- fn(usize, usize) -> S {S} defined here
+   | -------- `S` defines a struct constructor here, which should be called
 ...
 LL |     let _: S = S;
    |            -   ^ expected struct `S`, found struct constructor
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:31:20
    |
 LL | fn bar() -> usize { 42 }
-   | ----------------- fn() -> usize {bar} defined here
+   | ----------------- function `bar` defined here
 ...
 LL |     let _: usize = bar;
    |            -----   ^^^ expected `usize`, found fn item
@@ -56,7 +56,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:32:16
    |
 LL | struct V();
-   | -------- fn() -> V {V} defined here
+   | -------- `V` defines a struct constructor here, which should be called
 ...
 LL |     let _: V = V;
    |            -   ^ expected struct `V`, found struct constructor
@@ -74,7 +74,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:33:20
    |
 LL |     fn baz(x: usize, y: usize) -> usize { x }
-   |     ----------------------------------- fn(usize, usize) -> usize {<_ as T>::baz} defined here
+   |     ----------------------------------- associated function `baz` defined here
 ...
 LL |     let _: usize = T::baz;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -92,7 +92,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:34:20
    |
 LL |     fn bat(x: usize) -> usize { 42 }
-   |     ------------------------- fn(usize) -> usize {<_ as T>::bat} defined here
+   |     ------------------------- associated function `bat` defined here
 ...
 LL |     let _: usize = T::bat;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -110,7 +110,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:35:16
    |
 LL |     A(usize),
-   |     - fn(usize) -> E {E::A} defined here
+   |     - `A` defines an enum variant constructor here, which should be called
 ...
 LL |     let _: E = E::A;
    |            -   ^^^^ expected enum `E`, found enum constructor
@@ -134,7 +134,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:37:20
    |
 LL |     fn baz(x: usize, y: usize) -> usize { x }
-   |     ----------------------------------- fn(usize, usize) -> usize {<X as T>::baz} defined here
+   |     ----------------------------------- associated function `baz` defined here
 ...
 LL |     let _: usize = X::baz;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -152,7 +152,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:38:20
    |
 LL |     fn bat(x: usize) -> usize { 42 }
-   |     ------------------------- fn(usize) -> usize {<X as T>::bat} defined here
+   |     ------------------------- associated function `bat` defined here
 ...
 LL |     let _: usize = X::bat;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -170,7 +170,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:39:20
    |
 LL |     fn bax(x: usize) -> usize { 42 }
-   |     ------------------------- fn(usize) -> usize {<X as T>::bax} defined here
+   |     ------------------------- associated function `bax` defined here
 ...
 LL |     let _: usize = X::bax;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -188,7 +188,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:40:20
    |
 LL |     fn bach(x: usize) -> usize;
-   |     --------------------------- fn(usize) -> usize {<X as T>::bach} defined here
+   |     --------------------------- associated function `bach` defined here
 ...
 LL |     let _: usize = X::bach;
    |            -----   ^^^^^^^ expected `usize`, found fn item
@@ -206,7 +206,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:41:20
    |
 LL |     fn ban(&self) -> usize { 42 }
-   |     ---------------------- for<'a> fn(&'a X) -> usize {<X as T>::ban} defined here
+   |     ---------------------- associated function `ban` defined here
 ...
 LL |     let _: usize = X::ban;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -224,7 +224,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:42:20
    |
 LL |     fn bal(&self) -> usize;
-   |     ----------------------- for<'a> fn(&'a X) -> usize {<X as T>::bal} defined here
+   |     ----------------------- associated function `bal` defined here
 ...
 LL |     let _: usize = X::bal;
    |            -----   ^^^^^^ expected `usize`, found fn item

--- a/tests/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/tests/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -23,12 +23,12 @@ LL | struct S(usize, usize);
    | -------- fn(usize, usize) -> S {S} defined here
 ...
 LL |     let _: S = S;
-   |            -   ^ expected struct `S`, found fn item
+   |            -   ^ expected struct `S`, found struct constructor
    |            |
    |            expected due to this
    |
-   = note: expected struct `S`
-             found fn item `fn(usize, usize) -> S {S}`
+   = note:          expected struct `S`
+           found struct constructor `fn(usize, usize) -> S {S}`
 help: use parentheses to construct this tuple struct
    |
 LL |     let _: S = S(/* usize */, /* usize */);
@@ -59,12 +59,12 @@ LL | struct V();
    | -------- fn() -> V {V} defined here
 ...
 LL |     let _: V = V;
-   |            -   ^ expected struct `V`, found fn item
+   |            -   ^ expected struct `V`, found struct constructor
    |            |
    |            expected due to this
    |
-   = note: expected struct `V`
-             found fn item `fn() -> V {V}`
+   = note:          expected struct `V`
+           found struct constructor `fn() -> V {V}`
 help: use parentheses to construct this tuple struct
    |
 LL |     let _: V = V();
@@ -113,12 +113,12 @@ LL |     A(usize),
    |     - fn(usize) -> E {E::A} defined here
 ...
 LL |     let _: E = E::A;
-   |            -   ^^^^ expected enum `E`, found fn item
+   |            -   ^^^^ expected enum `E`, found enum constructor
    |            |
    |            expected due to this
    |
-   = note: expected enum `E`
-           found fn item `fn(usize) -> E {E::A}`
+   = note:          expected enum `E`
+           found enum constructor `fn(usize) -> E {E::A}`
 help: use parentheses to construct this tuple variant
    |
 LL |     let _: E = E::A(/* usize */);

--- a/tests/ui/typeck/issue-87181/empty-tuple-method.rs
+++ b/tests/ui/typeck/issue-87181/empty-tuple-method.rs
@@ -10,5 +10,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo };
     thing.bar.foo();
-    //~^ ERROR no method named `foo` found for fn item `fn() -> Foo {Foo}` in the current scope [E0599]
+    //~^ ERROR no method named `foo` found for struct constructor `fn() -> Foo {Foo}` in the current scope [E0599]
 }

--- a/tests/ui/typeck/issue-87181/empty-tuple-method.stderr
+++ b/tests/ui/typeck/issue-87181/empty-tuple-method.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `foo` found for fn item `fn() -> Foo {Foo}` in the current scope
+error[E0599]: no method named `foo` found for struct constructor `fn() -> Foo {Foo}` in the current scope
   --> $DIR/empty-tuple-method.rs:12:15
    |
 LL |     thing.bar.foo();

--- a/tests/ui/typeck/issue-87181/enum-variant.rs
+++ b/tests/ui/typeck/issue-87181/enum-variant.rs
@@ -12,5 +12,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo::Tup };
     thing.bar.foo();
-    //~^ ERROR no method named `foo` found for fn item `fn() -> Foo {Foo::Tup}` in the current scope [E0599]
+    //~^ ERROR no method named `foo` found for enum constructor `fn() -> Foo {Foo::Tup}` in the current scope [E0599]
 }

--- a/tests/ui/typeck/issue-87181/enum-variant.stderr
+++ b/tests/ui/typeck/issue-87181/enum-variant.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `foo` found for fn item `fn() -> Foo {Foo::Tup}` in the current scope
+error[E0599]: no method named `foo` found for enum constructor `fn() -> Foo {Foo::Tup}` in the current scope
   --> $DIR/enum-variant.rs:14:15
    |
 LL |     thing.bar.foo();

--- a/tests/ui/typeck/issue-87181/tuple-method.rs
+++ b/tests/ui/typeck/issue-87181/tuple-method.rs
@@ -10,5 +10,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo };
     thing.bar.foo();
-    //~^ ERROR no method named `foo` found for fn item `fn(u8, i32) -> Foo {Foo}` in the current scope [E0599]
+    //~^ ERROR no method named `foo` found for struct constructor `fn(u8, i32) -> Foo {Foo}` in the current scope [E0599]
 }

--- a/tests/ui/typeck/issue-87181/tuple-method.stderr
+++ b/tests/ui/typeck/issue-87181/tuple-method.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `foo` found for fn item `fn(u8, i32) -> Foo {Foo}` in the current scope
+error[E0599]: no method named `foo` found for struct constructor `fn(u8, i32) -> Foo {Foo}` in the current scope
   --> $DIR/tuple-method.rs:12:15
    |
 LL |     thing.bar.foo();

--- a/tests/ui/typeck/issue-96738.stderr
+++ b/tests/ui/typeck/issue-96738.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `nonexistent_method` found for fn item `fn(_) -> Option<_> {Option::<_>::Some}` in the current scope
+error[E0599]: no method named `nonexistent_method` found for enum constructor `fn(_) -> Option<_> {Option::<_>::Some}` in the current scope
   --> $DIR/issue-96738.rs:2:10
    |
 LL |     Some.nonexistent_method();


### PR DESCRIPTION
Fixes #106516