### PR TITLE
Reduce verbosity of errors involving builtin macros

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -858,6 +858,7 @@ impl SyntaxExtension {
         descr: Symbol,
         macro_def_id: Option<DefId>,
         parent_module: Option<DefId>,
+        builtin_name: Option<Symbol>,
     ) -> ExpnData {
         ExpnData::new(
             ExpnKind::Macro(self.macro_kind(), descr),
@@ -871,6 +872,7 @@ impl SyntaxExtension {
             self.allow_internal_unsafe,
             self.local_inner_macros,
             self.collapse_debuginfo,
+            builtin_name,
         )
     }
 }

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -292,6 +292,7 @@ impl<'a> ResolverExpand for Resolver<'a> {
                 fast_print_path(path),
                 def_id,
                 def_id.map(|def_id| self.macro_def_scope(def_id).nearest_parent_mod()),
+                ext.builtin_name,
             ),
             self.create_stable_hashing_context(),
         );

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -961,6 +961,9 @@ pub struct ExpnData {
     /// Should debuginfo for the macro be collapsed to the outermost expansion site (in other
     /// words, was the macro definition annotated with `#[collapse_debuginfo]`)?
     pub collapse_debuginfo: bool,
+    /// If this expansion comes from a builtin macro, this is the macro's name. Used when emitting
+    /// diagnostics to hide the line "this error originates in...".
+    pub builtin_name: Option<Symbol>,
 }
 
 impl !PartialEq for ExpnData {}
@@ -979,6 +982,7 @@ impl ExpnData {
         allow_internal_unsafe: bool,
         local_inner_macros: bool,
         collapse_debuginfo: bool,
+        builtin_name: Option<Symbol>,
     ) -> ExpnData {
         ExpnData {
             kind,
@@ -993,6 +997,7 @@ impl ExpnData {
             allow_internal_unsafe,
             local_inner_macros,
             collapse_debuginfo,
+            builtin_name,
         }
     }
 
@@ -1017,6 +1022,7 @@ impl ExpnData {
             allow_internal_unsafe: false,
             local_inner_macros: false,
             collapse_debuginfo: false,
+            builtin_name: None,
         }
     }
 

--- a/src/test/ui/allocator/not-an-allocator.stderr
+++ b/src/test/ui/allocator/not-an-allocator.stderr
@@ -7,7 +7,6 @@ LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = help: the trait `GlobalAlloc` is implemented for `System`
-   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:11
@@ -18,7 +17,6 @@ LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = help: the trait `GlobalAlloc` is implemented for `System`
-   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:11
@@ -29,7 +27,6 @@ LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = help: the trait `GlobalAlloc` is implemented for `System`
-   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:11
@@ -40,7 +37,6 @@ LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = help: the trait `GlobalAlloc` is implemented for `System`
-   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/allocator/two-allocators.stderr
+++ b/src/test/ui/allocator/two-allocators.stderr
@@ -7,8 +7,6 @@ LL | #[global_allocator]
    | ------------------- in this procedural macro expansion
 LL | static B: System = System;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot define a new global allocator
-   |
-   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/attributes/extented-attribute-macro-error.stderr
+++ b/src/test/ui/attributes/extented-attribute-macro-error.stderr
@@ -3,8 +3,6 @@ error: couldn't read the file
    |
 LL | #![doc = include_str!("../not_existing_file.md")]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-and-init.stderr
+++ b/src/test/ui/borrowck/borrowck-and-init.stderr
@@ -8,8 +8,6 @@ LL |     println!("{}", false && { i = 5; true });
    |                               ----- binding initialized here in some conditions
 LL |     println!("{}", i);
    |                    ^ `i` used here but it is possibly-uninitialized
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-break-uninit-2.stderr
+++ b/src/test/ui/borrowck/borrowck-break-uninit-2.stderr
@@ -7,7 +7,6 @@ LL |     let x: isize;
 LL |     println!("{}", x);
    |                    ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let x: isize = 0;

--- a/src/test/ui/borrowck/borrowck-break-uninit.stderr
+++ b/src/test/ui/borrowck/borrowck-break-uninit.stderr
@@ -7,7 +7,6 @@ LL |     let x: isize;
 LL |     println!("{}", x);
    |                    ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let x: isize = 0;

--- a/src/test/ui/borrowck/borrowck-or-init.stderr
+++ b/src/test/ui/borrowck/borrowck-or-init.stderr
@@ -8,8 +8,6 @@ LL |     println!("{}", false || { i = 5; true });
    |                               ----- binding initialized here in some conditions
 LL |     println!("{}", i);
    |                    ^ `i` used here but it is possibly-uninitialized
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-while-break.stderr
+++ b/src/test/ui/borrowck/borrowck-while-break.stderr
@@ -8,8 +8,6 @@ LL |     while cond {
 ...
 LL |     println!("{}", v);
    |                    ^ `v` used here but it is possibly-uninitialized
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/issue-24267-flow-exit.stderr
+++ b/src/test/ui/borrowck/issue-24267-flow-exit.stderr
@@ -7,7 +7,6 @@ LL |     loop { x = break; }
 LL |     println!("{}", x);
    |                    ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let x: i32 = 0;
@@ -22,7 +21,6 @@ LL |     for _ in 0..10 { x = continue; }
 LL |     println!("{}", x);
    |                    ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let x: i32 = 0;

--- a/src/test/ui/borrowck/issue-64453.stderr
+++ b/src/test/ui/borrowck/issue-64453.stderr
@@ -5,7 +5,6 @@ LL | static settings_dir: String = format!("");
    |                               ^^^^^^^^^^^
    |
    = help: add `#![feature(const_fmt_arguments_new)]` to the crate attributes to enable
-   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const fn `format` in statics
   --> $DIR/issue-64453.rs:4:31

--- a/src/test/ui/borrowck/suggest-assign-rvalue.stderr
+++ b/src/test/ui/borrowck/suggest-assign-rvalue.stderr
@@ -19,7 +19,6 @@ LL |     let my_float: f32;
 LL |     println!("my_float: {}", my_float);
    |                              ^^^^^^^^ `my_float` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let my_float: f32 = 0.0;
@@ -33,7 +32,6 @@ LL |     let demo: Demo;
 LL |     println!("demo: {:?}", demo);
    |                            ^^^^ `demo` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let demo: Demo = Default::default();
@@ -47,7 +45,6 @@ LL |     let demo_no: DemoNoDef;
 LL |     println!("demo_no: {:?}", demo_no);
    |                               ^^^^^^^ `demo_no` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let demo_no: DemoNoDef = todo!();
@@ -61,7 +58,6 @@ LL |     let arr: [i32; 5];
 LL |     println!("arr: {:?}", arr);
    |                           ^^^ `arr` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let arr: [i32; 5] = todo!();
@@ -75,7 +71,6 @@ LL |     let foo: Vec<&str>;
 LL |     println!("foo: {:?}", foo);
    |                           ^^^ `foo` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let foo: Vec<&str> = vec![];
@@ -89,7 +84,6 @@ LL |     let my_string: String;
 LL |     println!("my_string: {}", my_string);
    |                               ^^^^^^^^^ `my_string` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let my_string: String = Default::default();
@@ -103,7 +97,6 @@ LL |     let my_int: &i32;
 LL |     println!("my_int: {}", *my_int);
    |                            ^^^^^^^ `*my_int` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let my_int: &i32 = todo!();
@@ -117,7 +110,6 @@ LL |     let hello: &str;
 LL |     println!("hello: {}", hello);
    |                           ^^^^^ `hello` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let hello: &str = todo!();
@@ -130,8 +122,6 @@ LL |     let never: !;
    |         ----- binding declared here but left uninitialized
 LL |     println!("never: {}", never);
    |                           ^^^^^ `never` used here but it isn't initialized
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/arrays.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/arrays.stderr
@@ -81,8 +81,6 @@ LL |     println!("{}", arr[3]);
 ...
 LL |     c();
    |     - mutable borrow later used here
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0502]: cannot borrow `arr` as immutable because it is also borrowed as mutable
   --> $DIR/arrays.rs:73:24

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/box.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/box.stderr
@@ -25,8 +25,6 @@ LL |     println!("{}", e.0.0.m.x);
 LL |
 LL |     c();
    |     - mutable borrow later used here
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0506]: cannot assign to `e.0.0.m.x` because it is borrowed
   --> $DIR/box.rs:55:5

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
@@ -9,7 +9,6 @@ LL |         println!("{}", foo.x);
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
    = note: `#[deny(unaligned_references)]` on by default
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 
@@ -25,5 +24,4 @@ LL |         println!("{}", foo.x);
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
    = note: `#[deny(unaligned_references)]` on by default
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/simple-struct-min-capture.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/simple-struct-min-capture.stderr
@@ -13,8 +13,6 @@ LL |     println!("{:?}", p);
 LL |
 LL |     c();
    |     - mutable borrow later used here
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/bad-format-args.stderr
+++ b/src/test/ui/codemap_tests/bad-format-args.stderr
@@ -3,8 +3,6 @@ error: requires at least a format string argument
    |
 LL |     format!();
    |     ^^^^^^^^^
-   |
-   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected `,`, found `1`
   --> $DIR/bad-format-args.rs:3:16

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -3,8 +3,6 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
    |
 LL |     assert!("foo");
    |     ^^^^^^^^^^^^^^ cannot apply unary operator `!`
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/tab_3.stderr
+++ b/src/test/ui/codemap_tests/tab_3.stderr
@@ -11,7 +11,6 @@ LL |         println!("{:?}", some_vec);
    |
 note: `into_iter` takes ownership of the receiver `self`, which moves `some_vec`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     some_vec.clone().into_iter();

--- a/src/test/ui/const-ptr/forbidden_slices.32bit.stderr
+++ b/src/test/ui/const-ptr/forbidden_slices.32bit.stderr
@@ -124,7 +124,6 @@ note: inside `R1`
    |
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL

--- a/src/test/ui/const-ptr/forbidden_slices.64bit.stderr
+++ b/src/test/ui/const-ptr/forbidden_slices.64bit.stderr
@@ -124,7 +124,6 @@ note: inside `R1`
    |
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL

--- a/src/test/ui/consts/const-eval/format.stderr
+++ b/src/test/ui/consts/const-eval/format.stderr
@@ -14,7 +14,6 @@ LL |     println!("{:?}", 0);
    |                      ^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `Arguments::<'a>::new_v1` is not yet stable as a const fn
   --> $DIR/format.rs:7:5
@@ -23,7 +22,6 @@ LL |     println!("{:?}", 0);
    |     ^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(const_fmt_arguments_new)]` to the crate attributes to enable
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const fn `_print` in constant functions
   --> $DIR/format.rs:7:5
@@ -79,16 +77,12 @@ note: erroneous constant used
    |
 LL |     println!("{:?}", 0);
    |                      ^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant used
   --> $DIR/format.rs:7:22
    |
 LL |     println!("{:?}", 0);
    |                      ^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/const-eval/issue-44578.stderr
+++ b/src/test/ui/consts/const-eval/issue-44578.stderr
@@ -15,24 +15,18 @@ note: erroneous constant used
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant used
   --> $DIR/issue-44578.rs:25:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant used
   --> $DIR/issue-44578.rs:25:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/control-flow/assert.stderr
+++ b/src/test/ui/consts/control-flow/assert.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of constant value failed
    |
 LL | const _: () = assert!(false);
    |               ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/assert.rs:5:15
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/cross/cross-crate-macro-backtrace/main.stderr
+++ b/src/test/ui/cross/cross-crate-macro-backtrace/main.stderr
@@ -3,8 +3,6 @@ error: 1 positional argument in format string, but no arguments were given
    |
 LL |     myprintln!("{}");
    |     ^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `concat` which comes from the expansion of the macro `myprintln` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/custom_test_frameworks/mismatch.stderr
+++ b/src/test/ui/custom_test_frameworks/mismatch.stderr
@@ -7,7 +7,6 @@ LL | fn wrong_kind(){}
    | ^^^^^^^^^^^^^^^^^ the trait `Testable` is not implemented for `TestDescAndFn`
    |
    = note: required for the cast from `TestDescAndFn` to the object type `dyn Testable`
-   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/extenv/extenv-not-defined-custom.stderr
+++ b/src/test/ui/extenv/extenv-not-defined-custom.stderr
@@ -3,8 +3,6 @@ error: my error message
    |
 LL | fn main() { env!("__HOPEFULLY_NOT_DEFINED__", "my error message"); }
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/extenv/extenv-not-defined-default.stderr
+++ b/src/test/ui/extenv/extenv-not-defined-default.stderr
@@ -3,8 +3,6 @@ error: environment variable `__HOPEFULLY_NOT_DEFINED__` not defined
    |
 LL |     env!("__HOPEFULLY_NOT_DEFINED__");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/extenv/issue-55897.stderr
+++ b/src/test/ui/extenv/issue-55897.stderr
@@ -3,8 +3,6 @@ error: environment variable `NON_EXISTENT` not defined
    |
 LL |     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
    |                      ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: suffixes on string literals are invalid
   --> $DIR/issue-55897.rs:16:22

--- a/src/test/ui/feature-gates/feature-gate-concat_idents2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-concat_idents2.stderr
@@ -12,8 +12,6 @@ error[E0425]: cannot find value `ab` in this scope
    |
 LL |     concat_idents!(a, b);
    |     ^^^^^^^^^^^^^^^^^^^^ not found in this scope
-   |
-   = note: this error originates in the macro `concat_idents` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/fmt/format-args-capture-macro-hygiene.stderr
+++ b/src/test/ui/fmt/format-args-capture-macro-hygiene.stderr
@@ -6,7 +6,6 @@ LL |     format!(concat!("{foo}"));
    |
    = note: did you intend to capture a variable `foo` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: there is no argument named `bar`
   --> $DIR/format-args-capture-macro-hygiene.rs:16:13
@@ -16,7 +15,6 @@ LL |     format!(concat!("{ba", "r} {}"), 1);
    |
    = note: did you intend to capture a variable `bar` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: there is no argument named `foo`
   --> $DIR/format-args-capture-macro-hygiene.rs:7:13

--- a/src/test/ui/fmt/format-expanded-string.stderr
+++ b/src/test/ui/fmt/format-expanded-string.stderr
@@ -5,7 +5,6 @@ LL |     format!(concat!("abc}"));
    |             ^^^^^^^^^^^^^^^ unmatched `}` in format string
    |
    = note: if you intended to print `}`, you can escape it using `}}`
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: invalid format string: unmatched `}` found
   --> $DIR/format-expanded-string.rs:22:34

--- a/src/test/ui/fmt/ifmt-bad-arg.stderr
+++ b/src/test/ui/fmt/ifmt-bad-arg.stderr
@@ -309,7 +309,6 @@ LL |     println!("{} {:.*} {}", 1, 3.2, 4);
               found reference `&{float}`
 note: associated function defined here
   --> $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/ifmt-bad-arg.rs:81:35
@@ -324,7 +323,6 @@ LL |     println!("{} {:07$.*} {}", 1, 3.2, 4);
               found reference `&{float}`
 note: associated function defined here
   --> $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 38 previous errors
 

--- a/src/test/ui/fmt/ifmt-bad-format-args.stderr
+++ b/src/test/ui/fmt/ifmt-bad-format-args.stderr
@@ -3,8 +3,6 @@ error: requires at least a format string argument
    |
 LL |     format_args!();
    |     ^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: format argument must be a string literal
   --> $DIR/ifmt-bad-format-args.rs:3:18

--- a/src/test/ui/fmt/ifmt-unimpl.stderr
+++ b/src/test/ui/fmt/ifmt-unimpl.stderr
@@ -17,7 +17,6 @@ LL |     format!("{:X}", "3");
    = note: required for `&str` to implement `UpperHex`
 note: required by a bound in `ArgumentV1::<'a>::new_upper_hex`
   --> $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `arg_new` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/fmt/issue-86085.stderr
+++ b/src/test/ui/fmt/issue-86085.stderr
@@ -5,7 +5,6 @@ LL | format ! ( concat ! ( r#"lJ𐏿Æ�.𐏿�"# , "r} {}" )     ) ;
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unmatched `}` in format string
    |
    = note: if you intended to print `}`, you can escape it using `}}`
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/fmt/issue-91556.stderr
+++ b/src/test/ui/fmt/issue-91556.stderr
@@ -5,7 +5,6 @@ LL |   let _ = format!(concat!("{0}𝖳𝖾𝗌𝗍{"), i);
    |                   ^^^^^^^^^^^^^^^^^^^ expected `'}'` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/fmt/respanned-literal-issue-106191.stderr
+++ b/src/test/ui/fmt/respanned-literal-issue-106191.stderr
@@ -13,7 +13,6 @@ LL |     format_args!(r#concat!("¡        {"));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ expected `'}'` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/yield-while-ref-reborrowed.stderr
+++ b/src/test/ui/generator/yield-while-ref-reborrowed.stderr
@@ -10,8 +10,6 @@ LL |     println!("{}", x);
    |                    ^ second borrow occurs here
 LL |     Pin::new(&mut b).resume(());
    |              ------ first borrow later used here
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/generics/post_monomorphization_error_backtrace.stderr
+++ b/src/test/ui/generics/post_monomorphization_error_backtrace.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `assert_zst::F::<u32>::V` failed
    |
 LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/post_monomorphization_error_backtrace.rs:6:23
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: the above error was encountered while instantiating `fn assert_zst::<u32>`
   --> $DIR/post_monomorphization_error_backtrace.rs:18:5
@@ -17,8 +15,6 @@ error[E0080]: evaluation of `assert_zst::F::<i32>::V` failed
    |
 LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/post_monomorphization_error_backtrace.rs:6:23
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: the above error was encountered while instantiating `fn assert_zst::<i32>`
   --> $DIR/post_monomorphization_error_backtrace.rs:18:5

--- a/src/test/ui/include-macros/mismatched-types.stderr
+++ b/src/test/ui/include-macros/mismatched-types.stderr
@@ -8,7 +8,6 @@ LL |     let b: &[u8] = include_str!("file.txt");
    |
    = note: expected reference `&[u8]`
               found reference `&'static str`
-   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/mismatched-types.rs:3:19

--- a/src/test/ui/inline-const/const-expr-generic-err.stderr
+++ b/src/test/ui/inline-const/const-expr-generic-err.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `foo::<i32>::{constant#0}` failed
    |
 LL |     const { assert!(std::mem::size_of::<T>() == 0); }
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/const-expr-generic-err.rs:5:13
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: the above error was encountered while instantiating `fn foo::<i32>`
   --> $DIR/const-expr-generic-err.rs:13:5

--- a/src/test/ui/issues/issue-12997-2.stderr
+++ b/src/test/ui/issues/issue-12997-2.stderr
@@ -14,7 +14,6 @@ note: function defined here
    |
 LL | fn bar(x: isize) { }
    |    ^^^ --------
-   = note: this error originates in the attribute macro `bench` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-14091-2.stderr
+++ b/src/test/ui/issues/issue-14091-2.stderr
@@ -11,7 +11,6 @@ LL | pub struct BytePos(pub u32);
    | ^^^^^^^^^^^^^^^^^^ must implement `Not`
 note: the trait `Not` must be implemented
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-27592.stderr
+++ b/src/test/ui/issues/issue-27592.stderr
@@ -6,16 +6,12 @@ LL |     write(|| format_args!("{}", String::from("Hello world")));
    |              |                  |
    |              |                  temporary value created here
    |              returns a value referencing data owned by the current function
-   |
-   = note: this error originates in the macro `format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0515]: cannot return reference to temporary value
   --> $DIR/issue-27592.rs:16:14
    |
 LL |     write(|| format_args!("{}", String::from("Hello world")));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returns a reference to data owned by the current function
-   |
-   = note: this error originates in the macro `format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-32950.stderr
+++ b/src/test/ui/issues/issue-32950.stderr
@@ -9,8 +9,6 @@ error[E0412]: cannot find type `FooBar` in this scope
    |
 LL |     concat_idents!(Foo, Bar)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
-   |
-   = note: this error originates in the macro `concat_idents` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-42796.stderr
+++ b/src/test/ui/issues/issue-42796.stderr
@@ -9,7 +9,6 @@ LL |     let mut s_copy = s;
 LL |     println!("{}", s);
    |                    ^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |     let mut s_copy = s.clone();

--- a/src/test/ui/issues/issue-47646.stderr
+++ b/src/test/ui/issues/issue-47646.stderr
@@ -12,8 +12,6 @@ LL |             println!("{:?}", heap);
 ...
 LL |     };
    |      - ... and the mutable borrow might be used here, when that temporary is dropped and runs the destructor for type `(Option<PeekMut<'_, i32>>, ())`
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-69455.stderr
+++ b/src/test/ui/issues/issue-69455.stderr
@@ -4,7 +4,6 @@ error[E0282]: type annotations needed
 LL |     println!("{}", 23u64.test(xs.iter().sum()));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the associated function `new_display`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider specifying the generic argument
    |
 LL |     println!("{}", 23u64.test(xs.iter().sum())::<T>);

--- a/src/test/ui/limits/issue-55878.stderr
+++ b/src/test/ui/limits/issue-55878.stderr
@@ -14,24 +14,18 @@ note: erroneous constant used
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant used
   --> $DIR/issue-55878.rs:7:26
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant used
   --> $DIR/issue-55878.rs:7:26
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/test-inner-fn.stderr
+++ b/src/test/ui/lint/test-inner-fn.stderr
@@ -5,15 +5,12 @@ LL |     #[test]
    |     ^^^^^^^
    |
    = note: requested on the command line with `-D unnameable-test-items`
-   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot test inner items
   --> $DIR/test-inner-fn.rs:13:9
    |
 LL |         #[test]
    |         ^^^^^^^
-   |
-   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/liveness/liveness-move-in-while.stderr
+++ b/src/test/ui/liveness/liveness-move-in-while.stderr
@@ -35,7 +35,6 @@ LL |         while true { while true { while true { x = y; x.clone(); } } }
    |         |            inside of this loop
    |         inside of this loop
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |         while true { while true { while true { x = y.clone(); x.clone(); } } }

--- a/src/test/ui/liveness/liveness-use-after-move.stderr
+++ b/src/test/ui/liveness/liveness-use-after-move.stderr
@@ -9,7 +9,6 @@ LL |
 LL |     println!("{}", *x);
    |                    ^^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |     let y = x.clone();

--- a/src/test/ui/liveness/liveness-use-after-send.stderr
+++ b/src/test/ui/liveness/liveness-use-after-send.stderr
@@ -13,7 +13,6 @@ note: consider changing this parameter type in function `send` to borrow instead
    |
 LL | fn send<T:Send + std::fmt::Debug>(ch: Chan<T>, data: T) {
    |    ---- in this function                             ^ this parameter takes ownership of the value
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |     send(ch, message.clone());

--- a/src/test/ui/loops/loop-proper-liveness.stderr
+++ b/src/test/ui/loops/loop-proper-liveness.stderr
@@ -7,7 +7,6 @@ LL |     let x: i32;
 LL |     println!("{:?}", x);
    |                      ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let x: i32 = 0;

--- a/src/test/ui/macros/cfg.stderr
+++ b/src/test/ui/macros/cfg.stderr
@@ -3,8 +3,6 @@ error: macro requires a cfg-pattern as an argument
    |
 LL |     cfg!();
    |     ^^^^^^ cfg-pattern required
-   |
-   = note: this error originates in the macro `cfg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected identifier, found `123`
   --> $DIR/cfg.rs:3:10
@@ -23,8 +21,6 @@ error: expected 1 cfg-pattern
    |
 LL |     cfg!(foo, bar);
    |     ^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `cfg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/macros/format-parse-errors.stderr
+++ b/src/test/ui/macros/format-parse-errors.stderr
@@ -3,8 +3,6 @@ error: requires at least a format string argument
    |
 LL |     format!();
    |     ^^^^^^^^^
-   |
-   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found keyword `struct`
   --> $DIR/format-parse-errors.rs:5:13

--- a/src/test/ui/macros/macro-backtrace-println.stderr
+++ b/src/test/ui/macros/macro-backtrace-println.stderr
@@ -6,8 +6,6 @@ LL |     ($fmt:expr) => (myprint!(concat!($fmt, "\n")));
 ...
 LL |     myprintln!("{}");
    |     ---------------- in this macro invocation
-   |
-   = note: this error originates in the macro `concat` which comes from the expansion of the macro `myprintln` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macros-nonfatal-errors.stderr
+++ b/src/test/ui/macros/macros-nonfatal-errors.stderr
@@ -161,8 +161,6 @@ error: environment variable `RUST_HOPEFULLY_THIS_DOESNT_EXIST` not defined
    |
 LL |     env!("RUST_HOPEFULLY_THIS_DOESNT_EXIST");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: format argument must be a string literal
   --> $DIR/macros-nonfatal-errors.rs:108:13
@@ -192,8 +190,6 @@ error: couldn't read $DIR/i'd be quite surprised if a file with this name existe
    |
 LL |     include_str!("i'd be quite surprised if a file with this name existed");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: argument must be a string literal
   --> $DIR/macros-nonfatal-errors.rs:114:20

--- a/src/test/ui/macros/unreachable-format-args.edition_2015.stderr
+++ b/src/test/ui/macros/unreachable-format-args.edition_2015.stderr
@@ -6,7 +6,6 @@ LL |     unreachable!("x is {x} and y is {y}", y = 0);
    |
    = note: did you intend to capture a variable `x` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
-   = note: this error originates in the macro `$crate::concat` which comes from the expansion of the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/moves-based-on-type-capture-clause-bad.stderr
+++ b/src/test/ui/moves/moves-based-on-type-capture-clause-bad.stderr
@@ -10,8 +10,6 @@ LL |         println!("{}", x);
 LL |     });
 LL |     println!("{}", x);
    |                    ^ value borrowed here after move
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/on-unimplemented/no-debug.stderr
+++ b/src/test/ui/on-unimplemented/no-debug.stderr
@@ -6,7 +6,6 @@ LL |     println!("{:?} {:?}", Foo, Bar);
    |
    = help: the trait `Debug` is not implemented for `Foo`
    = note: add `#[derive(Debug)]` to `Foo` or manually `impl Debug for Foo`
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Foo` with `#[derive(Debug)]`
    |
 LL | #[derive(Debug)]
@@ -19,7 +18,6 @@ LL |     println!("{:?} {:?}", Foo, Bar);
    |                                ^^^ `Bar` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `Bar`
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Foo` doesn't implement `std::fmt::Display`
   --> $DIR/no-debug.rs:11:23
@@ -29,7 +27,6 @@ LL |     println!("{} {}", Foo, Bar);
    |
    = help: the trait `std::fmt::Display` is not implemented for `Foo`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Bar` doesn't implement `std::fmt::Display`
   --> $DIR/no-debug.rs:11:28
@@ -39,7 +36,6 @@ LL |     println!("{} {}", Foo, Bar);
    |
    = help: the trait `std::fmt::Display` is not implemented for `Bar`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -9,7 +9,6 @@ LL | fn can_parse_zero_as_f32() -> Result<f32, ParseFloatError> {
    = note: required for `Result<f32, ParseFloatError>` to implement `Termination`
 note: required by a bound in `assert_test_result`
   --> $SRC_DIR/test/src/lib.rs:LL:COL
-   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
+++ b/src/test/ui/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
@@ -6,7 +6,6 @@ LL |     let _: NotDebug = dbg!(NotDebug);
    |
    = help: the trait `Debug` is not implemented for `NotDebug`
    = note: add `#[derive(Debug)]` to `NotDebug` or manually `impl Debug for NotDebug`
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NotDebug` with `#[derive(Debug)]`
    |
 LL | #[derive(Debug)]

--- a/src/test/ui/suggestions/bound-suggestions.stderr
+++ b/src/test/ui/suggestions/bound-suggestions.stderr
@@ -4,7 +4,6 @@ error[E0277]: `impl Sized` doesn't implement `Debug`
 LL |     println!("{:?}", t);
    |                      ^ `impl Sized` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
 LL | fn test_impl(t: impl Sized + std::fmt::Debug) {
@@ -16,7 +15,6 @@ error[E0277]: `T` doesn't implement `Debug`
 LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
 LL | fn test_no_bounds<T: std::fmt::Debug>(t: T) {
@@ -28,7 +26,6 @@ error[E0277]: `T` doesn't implement `Debug`
 LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
 LL | fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
@@ -40,7 +37,6 @@ error[E0277]: `Y` doesn't implement `Debug`
 LL |     println!("{:?} {:?}", x, y);
    |                              ^ `Y` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `Y`
    |
 LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
@@ -52,7 +48,6 @@ error[E0277]: `X` doesn't implement `Debug`
 LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
 LL | fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
@@ -64,7 +59,6 @@ error[E0277]: `X` doesn't implement `Debug`
 LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
 LL | fn test_many_bounds_where<X>(x: X) where X: Sized + std::fmt::Debug, X: Sized {

--- a/src/test/ui/suggestions/issue-97760.stderr
+++ b/src/test/ui/suggestions/issue-97760.stderr
@@ -6,7 +6,6 @@ LL |         println!("{x}");
    |
    = help: the trait `std::fmt::Display` is not implemented for `<impl IntoIterator as IntoIterator>::Item`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
 LL ~ pub fn print_values<I: IntoIterator>(values: &I)

--- a/src/test/ui/suggestions/path-display.stderr
+++ b/src/test/ui/suggestions/path-display.stderr
@@ -6,7 +6,6 @@ LL |     println!("{}", path);
    |
    = help: the trait `std::fmt::Display` is not implemented for `Path`
    = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `PathBuf` doesn't implement `std::fmt::Display`
   --> $DIR/path-display.rs:9:20
@@ -16,7 +15,6 @@ LL |     println!("{}", path);
    |
    = help: the trait `std::fmt::Display` is not implemented for `PathBuf`
    = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/try-block/try-block-maybe-bad-lifetime.stderr
+++ b/src/test/ui/try-block/try-block-maybe-bad-lifetime.stderr
@@ -22,7 +22,6 @@ LL |         };
 LL |         println!("{}", x);
    |                        ^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |             ::std::mem::drop(x.clone());

--- a/src/test/ui/type-alias-impl-trait/nested.stderr
+++ b/src/test/ui/type-alias-impl-trait/nested.stderr
@@ -5,7 +5,6 @@ LL |     println!("{:?}", bar());
    |                      ^^^^^ `Bar` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `Bar`
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/use/use-after-move-based-on-type.stderr
+++ b/src/test/ui/use/use-after-move-based-on-type.stderr
@@ -8,7 +8,6 @@ LL |     let _y = x;
 LL |     println!("{}", x);
    |                    ^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |     let _y = x.clone();

--- a/src/test/ui/walk-struct-literal-with.stderr
+++ b/src/test/ui/walk-struct-literal-with.stderr
@@ -13,7 +13,6 @@ note: `Mine::make_string_bar` takes ownership of the receiver `self`, which move
    |
 LL |     fn make_string_bar(mut self) -> Mine{
    |                            ^^^^
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Do not show note "this error originates in" when it is caused by one in an explicit block list of builtin macros. Most notably, `println!` and friends will stop doing so.