### PR TITLE
Use smaller spans for missing lifetime/generic args

### DIFF
--- a/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
@@ -597,11 +597,15 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 let span = self.path_segment.ident.span;
 
                 // insert a suggestion of the form "Y<'a, 'b>"
-                let ident = self.path_segment.ident.name.to_ident_string();
-                let sugg = format!("{}<{}>", ident, suggested_args);
+                let sugg = format!("<{}>", suggested_args);
                 debug!("sugg: {:?}", sugg);
 
-                err.span_suggestion_verbose(span, &msg, sugg, Applicability::HasPlaceholders);
+                err.span_suggestion_verbose(
+                    span.shrink_to_hi(),
+                    &msg,
+                    sugg,
+                    Applicability::HasPlaceholders,
+                );
             }
 
             AngleBrackets::Available => {
@@ -643,11 +647,15 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 let span = self.path_segment.ident.span;
 
                 // insert a suggestion of the form "Y<T, U>"
-                let ident = self.path_segment.ident.name.to_ident_string();
-                let sugg = format!("{}<{}>", ident, suggested_args);
+                let sugg = format!("<{}>", suggested_args);
                 debug!("sugg: {:?}", sugg);
 
-                err.span_suggestion_verbose(span, &msg, sugg, Applicability::HasPlaceholders);
+                err.span_suggestion_verbose(
+                    span.shrink_to_hi(),
+                    &msg,
+                    sugg,
+                    Applicability::HasPlaceholders,
+                );
             }
             AngleBrackets::Available => {
                 let gen_args_span = self.gen_args.span().unwrap();

--- a/src/test/rustdoc-ui/issue-105742.stderr
+++ b/src/test/rustdoc-ui/issue-105742.stderr
@@ -12,7 +12,7 @@ LL |     type Item<'a, T>;
 help: add missing lifetime argument
    |
 LL |     <Self as SVec>::Item<'a>,
-   |                     ~~~~~~~~
+   |                         ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:13:21
@@ -28,7 +28,7 @@ LL |     type Item<'a, T>;
 help: add missing generic argument
    |
 LL |     <Self as SVec>::Item<T>,
-   |                     ~~~~~~~
+   |                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:18:37
@@ -44,7 +44,7 @@ LL |     type Item<'a, T>;
 help: add missing lifetime argument
    |
 LL |     Output = <Index<<Self as SVec>::Item<'a>,
-   |                                     ~~~~~~~~
+   |                                         ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:18:37
@@ -60,7 +60,7 @@ LL |     type Item<'a, T>;
 help: add missing generic argument
    |
 LL |     Output = <Index<<Self as SVec>::Item<T>,
-   |                                     ~~~~~~~
+   |                                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:23:30
@@ -76,7 +76,7 @@ LL |     type Item<'a, T>;
 help: add missing lifetime argument
    |
 LL |     Output = <Self as SVec>::Item<'a>> as SVec>::Item,
-   |                              ~~~~~~~~
+   |                                  ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:23:30
@@ -92,7 +92,7 @@ LL |     type Item<'a, T>;
 help: add missing generic argument
    |
 LL |     Output = <Self as SVec>::Item<T>> as SVec>::Item,
-   |                              ~~~~~~~
+   |                                  +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:23:46
@@ -108,7 +108,7 @@ LL |     type Item<'a, T>;
 help: add missing lifetime argument
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item<'a>,
-   |                                              ~~~~~~~~
+   |                                                  ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:23:46
@@ -124,7 +124,7 @@ LL |     type Item<'a, T>;
 help: add missing generic argument
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item<T>,
-   |                                              ~~~~~~~
+   |                                                  +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:5:40
@@ -140,7 +140,7 @@ LL |     type Item<'a, T>;
 help: add missing lifetime argument
    |
 LL | pub fn next<'a, T>(s: &'a mut dyn SVec<Item<'_> = T, Output = T>) {
-   |                                        ~~~~~~~~
+   |                                            ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:5:40
@@ -156,7 +156,7 @@ LL |     type Item<'a, T>;
 help: add missing generic argument
    |
 LL | pub fn next<'a, T>(s: &'a mut dyn SVec<Item<T> = T, Output = T>) {
-   |                                        ~~~~~~~
+   |                                            +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:13:21
@@ -172,7 +172,7 @@ LL |     type Item<'a, T>;
 help: add missing lifetime argument
    |
 LL |     <Self as SVec>::Item<'a>,
-   |                     ~~~~~~~~
+   |                         ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:13:21
@@ -188,7 +188,7 @@ LL |     type Item<'a, T>;
 help: add missing generic argument
    |
 LL |     <Self as SVec>::Item<T>,
-   |                     ~~~~~~~
+   |                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:18:37
@@ -204,7 +204,7 @@ LL |     type Item<'a, T>;
 help: add missing lifetime argument
    |
 LL |     Output = <Index<<Self as SVec>::Item<'a>,
-   |                                     ~~~~~~~~
+   |                                         ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:18:37
@@ -220,7 +220,7 @@ LL |     type Item<'a, T>;
 help: add missing generic argument
    |
 LL |     Output = <Index<<Self as SVec>::Item<T>,
-   |                                     ~~~~~~~
+   |                                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:23:30
@@ -236,7 +236,7 @@ LL |     type Item<'a, T>;
 help: add missing lifetime argument
    |
 LL |     Output = <Self as SVec>::Item<'a>> as SVec>::Item,
-   |                              ~~~~~~~~
+   |                                  ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:23:30
@@ -252,7 +252,7 @@ LL |     type Item<'a, T>;
 help: add missing generic argument
    |
 LL |     Output = <Self as SVec>::Item<T>> as SVec>::Item,
-   |                              ~~~~~~~
+   |                                  +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:23:46
@@ -268,7 +268,7 @@ LL |     type Item<'a, T>;
 help: add missing lifetime argument
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item<'a>,
-   |                                              ~~~~~~~~
+   |                                                  ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:23:46
@@ -284,7 +284,7 @@ LL |     type Item<'a, T>;
 help: add missing generic argument
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item<T>,
-   |                                              ~~~~~~~
+   |                                                  +++
 
 error[E0038]: the trait `SVec` cannot be made into an object
   --> $DIR/issue-105742.rs:5:31
@@ -329,7 +329,7 @@ LL |     type Item<'a, T>;
 help: add missing lifetime argument
    |
 LL |     fn len(&self) -> <Self as SVec>::Item<'_>;
-   |                                      ~~~~~~~~
+   |                                          ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:35:38
@@ -345,7 +345,7 @@ LL |     type Item<'a, T>;
 help: add missing generic argument
    |
 LL |     fn len(&self) -> <Self as SVec>::Item<T>;
-   |                                      ~~~~~~~
+   |                                          +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:35:38
@@ -361,7 +361,7 @@ LL |     type Item<'a, T>;
 help: add missing lifetime argument
    |
 LL |     fn len(&self) -> <Self as SVec>::Item<'_>;
-   |                                      ~~~~~~~~
+   |                                          ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:35:38
@@ -377,7 +377,7 @@ LL |     type Item<'a, T>;
 help: add missing generic argument
    |
 LL |     fn len(&self) -> <Self as SVec>::Item<T>;
-   |                                      ~~~~~~~
+   |                                          +++
 
 error: aborting due to 23 previous errors
 

--- a/src/test/ui/consts/issue-103790.stderr
+++ b/src/test/ui/consts/issue-103790.stderr
@@ -20,7 +20,7 @@ LL | struct S<const S: (), const S: S = { S }>;
 help: add missing generic argument
    |
 LL | struct S<const S: (), const S: S<S> = { S }>;
-   |                                ~~~~
+   |                                 +++
 
 error[E0391]: cycle detected when computing type of `S::S`
   --> $DIR/issue-103790.rs:4:32

--- a/src/test/ui/generic-associated-types/elided-in-expr-position.stderr
+++ b/src/test/ui/generic-associated-types/elided-in-expr-position.stderr
@@ -12,7 +12,7 @@ LL |     type Assoc<'a> where Self: 'a;
 help: add missing lifetime argument
    |
 LL |     fn g(&self) -> Self::Assoc<'_>;
-   |                          ~~~~~~~~~
+   |                               ++++
 
 error[E0107]: missing generics for associated type `Trait::Assoc`
   --> $DIR/elided-in-expr-position.rs:31:26
@@ -28,7 +28,7 @@ LL |     type Assoc<'a> where Self: 'a;
 help: add missing lifetime argument
    |
 LL |     fn g(&self) -> Self::Assoc<'_> {
-   |                          ~~~~~~~~~
+   |                               ++++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
+++ b/src/test/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
@@ -12,7 +12,7 @@ LL |   type Y<'a>;
 help: add missing lifetime argument
    |
 LL |   fn foo<'a, T1: X<Y<'a> = T1>>(t : T1) -> T1::Y<'a> {
-   |                    ~~~~~
+   |                     ++++
 
 error[E0107]: missing generics for associated type `X::Y`
   --> $DIR/gat-trait-path-missing-lifetime.rs:8:20
@@ -28,7 +28,7 @@ LL |   type Y<'a>;
 help: add missing lifetime argument
    |
 LL |   fn foo<'a, T1: X<Y<'a> = T1>>(t : T1) -> T1::Y<'a> {
-   |                    ~~~~~
+   |                     ++++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generic-associated-types/issue-71176.stderr
+++ b/src/test/ui/generic-associated-types/issue-71176.stderr
@@ -12,7 +12,7 @@ LL |     type A<'a>;
 help: add missing lifetime argument
    |
 LL |   inner: Box<dyn Provider<A<'a> = B>>,
-   |                           ~~~~~
+   |                            ++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-76535.base.stderr
+++ b/src/test/ui/generic-associated-types/issue-76535.base.stderr
@@ -12,7 +12,7 @@ LL |     type SubType<'a>: SubTrait where Self: 'a;
 help: add missing lifetime argument
    |
 LL |     let sub: Box<dyn SuperTrait<SubType<'a> = SubStruct>> = Box::new(SuperStruct::new(0));
-   |                                 ~~~~~~~~~~~
+   |                                        ++++
 
 error[E0038]: the trait `SuperTrait` cannot be made into an object
   --> $DIR/issue-76535.rs:39:14

--- a/src/test/ui/generic-associated-types/issue-76535.extended.stderr
+++ b/src/test/ui/generic-associated-types/issue-76535.extended.stderr
@@ -12,7 +12,7 @@ LL |     type SubType<'a>: SubTrait where Self: 'a;
 help: add missing lifetime argument
    |
 LL |     let sub: Box<dyn SuperTrait<SubType<'a> = SubStruct>> = Box::new(SuperStruct::new(0));
-   |                                 ~~~~~~~~~~~
+   |                                        ++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-78671.base.stderr
+++ b/src/test/ui/generic-associated-types/issue-78671.base.stderr
@@ -12,7 +12,7 @@ LL |     type Member<T>;
 help: add missing generic argument
    |
 LL |     Box::new(Family) as &dyn CollectionFamily<Member<T>=usize>
-   |                                               ~~~~~~~~~
+   |                                                     +++
 
 error[E0038]: the trait `CollectionFamily` cannot be made into an object
   --> $DIR/issue-78671.rs:10:25

--- a/src/test/ui/generic-associated-types/issue-78671.extended.stderr
+++ b/src/test/ui/generic-associated-types/issue-78671.extended.stderr
@@ -12,7 +12,7 @@ LL |     type Member<T>;
 help: add missing generic argument
    |
 LL |     Box::new(Family) as &dyn CollectionFamily<Member<T>=usize>
-   |                                               ~~~~~~~~~
+   |                                                     +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-79422.base.stderr
+++ b/src/test/ui/generic-associated-types/issue-79422.base.stderr
@@ -12,7 +12,7 @@ LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
 help: add missing lifetime argument
    |
 LL |         as Box<dyn MapLike<u8, u8, VRefCont<'a> = dyn RefCont<'_, u8>>>;
-   |                                    ~~~~~~~~~~~~
+   |                                            ++++
 
 error[E0038]: the trait `MapLike` cannot be made into an object
   --> $DIR/issue-79422.rs:47:12

--- a/src/test/ui/generic-associated-types/issue-79422.extended.stderr
+++ b/src/test/ui/generic-associated-types/issue-79422.extended.stderr
@@ -12,7 +12,7 @@ LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
 help: add missing lifetime argument
    |
 LL |         as Box<dyn MapLike<u8, u8, VRefCont<'a> = dyn RefCont<'_, u8>>>;
-   |                                    ~~~~~~~~~~~~
+   |                                            ++++
 
 error[E0271]: type mismatch resolving `<BTreeMap<u8, u8> as MapLike<u8, u8>>::VRefCont<'_> == (dyn RefCont<'_, u8> + 'static)`
   --> $DIR/issue-79422.rs:44:13

--- a/src/test/ui/generic-associated-types/issue-79636-1.stderr
+++ b/src/test/ui/generic-associated-types/issue-79636-1.stderr
@@ -12,7 +12,7 @@ LL |     type Wrapped<B>;
 help: add missing generic argument
    |
 LL |     MInner: Monad<Unwrapped = A, Wrapped<B> = MOuter::Wrapped<A>>,
-   |                                  ~~~~~~~~~~
+   |                                         +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-79636-2.stderr
+++ b/src/test/ui/generic-associated-types/issue-79636-2.stderr
@@ -12,7 +12,7 @@ LL |     type Wrapped<A>: SomeTrait;
 help: add missing generic argument
    |
 LL |     W: SomeTrait<Wrapped<A> = W>,
-   |                  ~~~~~~~~~~
+   |                         +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-80433.stderr
+++ b/src/test/ui/generic-associated-types/issue-80433.stderr
@@ -12,7 +12,7 @@ LL |     type Output<'a>;
 help: add missing lifetime argument
    |
 LL | fn test_simpler<'a>(dst: &'a mut impl TestMut<Output<'a> = &'a mut f32>)
-   |                                               ~~~~~~~~~~
+   |                                                     ++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-81712-cyclic-traits.stderr
+++ b/src/test/ui/generic-associated-types/issue-81712-cyclic-traits.stderr
@@ -12,7 +12,7 @@ LL |     type DType<T>: D<T, CType = Self>;
 help: add missing generic argument
    |
 LL |     type CType: C<DType<T> = Self>;
-   |                   ~~~~~~~~
+   |                        +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-81862.stderr
+++ b/src/test/ui/generic-associated-types/issue-81862.stderr
@@ -12,7 +12,7 @@ LL |     type Item<'a>;
 help: add missing lifetime argument
    |
 LL |     fn next(&mut self) -> Option<Self::Item<'_>>;
-   |                                        ~~~~~~~~
+   |                                            ++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/missing_lifetime_args.stderr
+++ b/src/test/ui/generic-associated-types/missing_lifetime_args.stderr
@@ -12,7 +12,7 @@ LL |     type Y<'a, 'b>;
 help: add missing lifetime arguments
    |
 LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
-   |                                ~~~~~~~~~
+   |                                 ++++++++
 
 error[E0107]: this struct takes 3 lifetime arguments but 2 lifetime arguments were supplied
   --> $DIR/missing_lifetime_args.rs:14:26

--- a/src/test/ui/generics/generic-type-less-params-with-defaults.stderr
+++ b/src/test/ui/generics/generic-type-less-params-with-defaults.stderr
@@ -12,7 +12,7 @@ LL | struct Vec<T, A = Heap>(
 help: add missing generic argument
    |
 LL |     let _: Vec<T>;
-   |            ~~~~~~
+   |               +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generics/wrong-number-of-args.stderr
+++ b/src/test/ui/generics/wrong-number-of-args.stderr
@@ -251,7 +251,7 @@ LL |     struct Ty<A, B>;
 help: add missing generic arguments
    |
 LL |     type A = Ty<A, B>;
-   |              ~~~~~~~~
+   |                ++++++
 
 error[E0107]: this struct takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:30:14
@@ -315,7 +315,7 @@ LL |     struct Ty<'a, T>;
 help: add missing generic argument
    |
 LL |     type A = Ty<T>;
-   |              ~~~~~
+   |                +++
 
 error[E0107]: this struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:54:14
@@ -391,7 +391,7 @@ LL |     struct Ty<A, B, C = &'static str>;
 help: add missing generic arguments
    |
 LL |     type A = Ty<A, B>;
-   |              ~~~~~~~~
+   |                ++++++
 
 error[E0107]: this struct takes at least 2 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:84:14
@@ -483,7 +483,7 @@ LL |     trait GenericType<A> {
 help: add missing generic argument
    |
 LL |     type D = Box<dyn GenericType<A>>;
-   |                      ~~~~~~~~~~~~~~
+   |                                 +++
 
 error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:133:22
@@ -892,7 +892,7 @@ LL |         type A = HashMap;
 help: add missing generic arguments
    |
 LL |         type A = HashMap<K, V>;
-   |                  ~~~~~~~~~~~~~
+   |                         ++++++
 
 error[E0107]: this struct takes at least 2 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:314:18
@@ -954,7 +954,7 @@ LL |         type A = Result;
 help: add missing generic arguments
    |
 LL |         type A = Result<T, E>;
-   |                  ~~~~~~~~~~~~
+   |                        ++++++
 
 error[E0107]: this enum takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:338:18

--- a/src/test/ui/impl-trait/issues/issue-92305.stderr
+++ b/src/test/ui/impl-trait/issues/issue-92305.stderr
@@ -7,7 +7,7 @@ LL | fn f<T>(data: &[T]) -> impl Iterator<Item = Vec> {
 help: add missing generic argument
    |
 LL | fn f<T>(data: &[T]) -> impl Iterator<Item = Vec<T>> {
-   |                                             ~~~~~~
+   |                                                +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-14092.stderr
+++ b/src/test/ui/issues/issue-14092.stderr
@@ -7,7 +7,7 @@ LL | fn fn1(0: Box) {}
 help: add missing generic argument
    |
 LL | fn fn1(0: Box<T>) {}
-   |           ~~~~~~
+   |              +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23024.stderr
+++ b/src/test/ui/issues/issue-23024.stderr
@@ -16,7 +16,7 @@ LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
 help: add missing generic argument
    |
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn<Args>)(3));
-   |                                       ~~~~~~~~
+   |                                         ++++++
 
 error[E0191]: the value of the associated type `Output` (from trait `FnOnce`) must be specified
   --> $DIR/issue-23024.rs:8:39

--- a/src/test/ui/issues/issue-86756.stderr
+++ b/src/test/ui/issues/issue-86756.stderr
@@ -42,7 +42,7 @@ LL | trait Foo<T, T = T> {}
 help: add missing generic argument
    |
 LL |     eq::<dyn, Foo<T>>
-   |               ~~~~~~
+   |                  +++
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/src/test/ui/lifetimes/missing-lifetime-in-alias.stderr
+++ b/src/test/ui/lifetimes/missing-lifetime-in-alias.stderr
@@ -39,7 +39,7 @@ LL |     type Bar<'b>
 help: add missing lifetime argument
    |
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar<'a>;
-   |                                    ~~~~~~~
+   |                                       ++++
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/tag-type-args.stderr
+++ b/src/test/ui/tag-type-args.stderr
@@ -12,7 +12,7 @@ LL | enum Quux<T> { Bar }
 help: add missing generic argument
    |
 LL | fn foo(c: Quux<T>) { assert!((false)); }
-   |           ~~~~~~~
+   |               +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/ascription/issue-34255-1.stderr
+++ b/src/test/ui/type/ascription/issue-34255-1.stderr
@@ -28,7 +28,7 @@ LL |         input_cells: Vec::new()
 help: add missing generic argument
    |
 LL |         input_cells: Vec<T>::new()
-   |                      ~~~~~~
+   |                         +++
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/ufcs/ufcs-qpath-missing-params.stderr
+++ b/src/test/ui/ufcs/ufcs-qpath-missing-params.stderr
@@ -12,7 +12,7 @@ LL | pub trait IntoCow<'a, B: ?Sized> where B: ToOwned {
 help: add missing generic argument
    |
 LL |     <String as IntoCow<B>>::into_cow("foo".to_string());
-   |                ~~~~~~~~~~
+   |                       +++
 
 error[E0107]: missing generics for trait `IntoCow`
   --> $DIR/ufcs-qpath-missing-params.rs:17:16
@@ -28,7 +28,7 @@ LL | pub trait IntoCow<'a, B: ?Sized> where B: ToOwned {
 help: add missing generic argument
    |
 LL |     <String as IntoCow<B>>::into_cow::<str>("foo".to_string());
-   |                ~~~~~~~~~~
+   |                       +++
 
 error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/ufcs-qpath-missing-params.rs:17:26


### PR DESCRIPTION
We can remove ident from suggestions.