### PR TITLE
Recover from where clauses placed before tuple struct bodies

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/parse.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parse.ftl
@@ -368,3 +368,9 @@ parse_maybe_fn_typo_with_impl = you might have meant to write `impl` instead of 
 
 parse_expected_fn_path_found_fn_keyword = expected identifier, found keyword `fn`
     .suggestion = use `Fn` to refer to the trait
+
+parse_where_clause_before_tuple_struct_body = where clauses are not allowed before tuple struct bodies
+    .label = unexpected where clause
+    .name_label = while parsing this tuple struct
+    .body_label = the struct body
+    .suggestion = move the body before the where clause

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1237,3 +1237,27 @@ pub(crate) struct ExpectedFnPathFoundFnKeyword {
     #[suggestion(applicability = "machine-applicable", code = "Fn", style = "verbose")]
     pub fn_token_span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(parse_where_clause_before_tuple_struct_body)]
+pub(crate) struct WhereClauseBeforeTupleStructBody {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    #[label(name_label)]
+    pub name: Span,
+    #[label(body_label)]
+    pub body: Span,
+    #[subdiagnostic]
+    pub sugg: Option<WhereClauseBeforeTupleStructBodySugg>,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(suggestion, applicability = "machine-applicable")]
+pub(crate) struct WhereClauseBeforeTupleStructBodySugg {
+    #[suggestion_part(code = "{snippet}")]
+    pub left: Span,
+    pub snippet: String,
+    #[suggestion_part(code = "")]
+    pub right: Span,
+}

--- a/tests/ui/parser/issues/issue-17904.rs
+++ b/tests/ui/parser/issues/issue-17904.rs
@@ -1,6 +1,8 @@
+// compile-flags: -Zparse-only
+
 struct Baz<U> where U: Eq(U); //This is parsed as the new Fn* style parenthesis syntax.
 struct Baz<U> where U: Eq(U) -> R; // Notice this parses as well.
 struct Baz<U>(U) where U: Eq; // This rightfully signals no error as well.
-struct Foo<T> where T: Copy, (T); //~ ERROR expected one of `:`, `==`, or `=`, found `;`
+struct Foo<T> where T: Copy, (T); //~ ERROR where clauses are not allowed before tuple struct bodies
 
 fn main() {}

--- a/tests/ui/parser/issues/issue-17904.stderr
+++ b/tests/ui/parser/issues/issue-17904.stderr
@@ -1,8 +1,17 @@
-error: expected one of `:`, `==`, or `=`, found `;`
-  --> $DIR/issue-17904.rs:4:33
+error: where clauses are not allowed before tuple struct bodies
+  --> $DIR/issue-17904.rs:6:15
    |
 LL | struct Foo<T> where T: Copy, (T);
-   |                                 ^ expected one of `:`, `==`, or `=`
+   |        ---    ^^^^^^^^^^^^^^ --- the struct body
+   |        |      |
+   |        |      unexpected where clause
+   |        while parsing this tuple struct
+   |
+help: move the body before the where clause
+   |
+LL - struct Foo<T> where T: Copy, (T);
+LL + struct Foo<T>(T) where T: Copy;
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/recover-where-clause-before-tuple-struct-body-0.fixed
+++ b/tests/ui/parser/recover-where-clause-before-tuple-struct-body-0.fixed
@@ -1,0 +1,15 @@
+// Regression test for issues #100790 and #106439.
+// run-rustfix
+
+pub struct Example(usize)
+where
+    (): Sized;
+//~^^^ ERROR where clauses are not allowed before tuple struct bodies
+
+struct _Demo(pub usize, usize)
+where
+    (): Sized,
+    String: Clone;
+//~^^^^ ERROR where clauses are not allowed before tuple struct bodies
+
+fn main() {}

--- a/tests/ui/parser/recover-where-clause-before-tuple-struct-body-0.rs
+++ b/tests/ui/parser/recover-where-clause-before-tuple-struct-body-0.rs
@@ -1,0 +1,17 @@
+// Regression test for issues #100790 and #106439.
+// run-rustfix
+
+pub struct Example
+where
+    (): Sized,
+(usize);
+//~^^^ ERROR where clauses are not allowed before tuple struct bodies
+
+struct _Demo
+where
+    (): Sized,
+    String: Clone,
+(pub usize, usize);
+//~^^^^ ERROR where clauses are not allowed before tuple struct bodies
+
+fn main() {}

--- a/tests/ui/parser/recover-where-clause-before-tuple-struct-body-0.stderr
+++ b/tests/ui/parser/recover-where-clause-before-tuple-struct-body-0.stderr
@@ -1,0 +1,40 @@
+error: where clauses are not allowed before tuple struct bodies
+  --> $DIR/recover-where-clause-before-tuple-struct-body-0.rs:5:1
+   |
+LL |   pub struct Example
+   |              ------- while parsing this tuple struct
+LL | / where
+LL | |     (): Sized,
+   | |______________^ unexpected where clause
+LL |   (usize);
+   |   ------- the struct body
+   |
+help: move the body before the where clause
+   |
+LL ~ pub struct Example(usize)
+LL | where
+LL ~     (): Sized;
+   |
+
+error: where clauses are not allowed before tuple struct bodies
+  --> $DIR/recover-where-clause-before-tuple-struct-body-0.rs:11:1
+   |
+LL |   struct _Demo
+   |          ----- while parsing this tuple struct
+LL | / where
+LL | |     (): Sized,
+LL | |     String: Clone,
+   | |__________________^ unexpected where clause
+LL |   (pub usize, usize);
+   |   ------------------ the struct body
+   |
+help: move the body before the where clause
+   |
+LL ~ struct _Demo(pub usize, usize)
+LL | where
+LL |     (): Sized,
+LL ~     String: Clone;
+   |
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/parser/recover-where-clause-before-tuple-struct-body-1.rs
+++ b/tests/ui/parser/recover-where-clause-before-tuple-struct-body-1.rs
@@ -1,0 +1,7 @@
+// Regression test for issues #100790 and #106439.
+
+// Make sure that we still show a helpful error message even if the trailing semicolon is missing.
+
+struct Foo<T> where T: MyTrait, (T)
+//~^ ERROR where clauses are not allowed before tuple struct bodies
+//~| ERROR expected `;`, found `<eof>`

--- a/tests/ui/parser/recover-where-clause-before-tuple-struct-body-1.stderr
+++ b/tests/ui/parser/recover-where-clause-before-tuple-struct-body-1.stderr
@@ -1,0 +1,23 @@
+error: where clauses are not allowed before tuple struct bodies
+  --> $DIR/recover-where-clause-before-tuple-struct-body-1.rs:5:15
+   |
+LL | struct Foo<T> where T: MyTrait, (T)
+   |        ---    ^^^^^^^^^^^^^^^^^ --- the struct body
+   |        |      |
+   |        |      unexpected where clause
+   |        while parsing this tuple struct
+   |
+help: move the body before the where clause
+   |
+LL - struct Foo<T> where T: MyTrait, (T)
+LL + struct Foo<T>(T) where T: MyTrait
+   |
+
+error: expected `;`, found `<eof>`
+  --> $DIR/recover-where-clause-before-tuple-struct-body-1.rs:5:35
+   |
+LL | struct Foo<T> where T: MyTrait, (T)
+   |                                   ^ expected `;`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Open to any suggestions regarding the phrasing of the diagnostic.

Fixes #100790.
@rustbot label A-diagnostics
r? diagnostics