### PR TITLE
rustdoc: Strip imports of items which are `#[doc(hidden)]`

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2494,6 +2494,17 @@ impl Import {
     pub(crate) fn new_glob(source: ImportSource, should_be_displayed: bool) -> Self {
         Self { kind: ImportKind::Glob, source, should_be_displayed }
     }
+
+    pub(crate) fn imported_item_is_doc_hidden(&self, tcx: TyCtxt<'_>) -> bool {
+        match self.source.did {
+            Some(did) => tcx
+                .get_attrs(did, sym::doc)
+                .filter_map(ast::Attribute::meta_item_list)
+                .flatten()
+                .has_word(sym::hidden),
+            None => false,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -248,6 +248,7 @@ pub(crate) struct ImportStripper<'tcx> {
 impl<'tcx> DocFolder for ImportStripper<'tcx> {
     fn fold_item(&mut self, i: Item) -> Option<Item> {
         match *i.kind {
+            clean::ImportItem(imp) if imp.imported_item_is_doc_hidden(self.tcx) => None,
             clean::ExternCrateItem { .. } | clean::ImportItem(..)
                 if i.visibility(self.tcx) != Some(Visibility::Public) =>
             {

--- a/src/test/rustdoc-json/doc_hidden_failure.rs
+++ b/src/test/rustdoc-json/doc_hidden_failure.rs
@@ -14,7 +14,8 @@ mod auto {
     }
 }
 
-// @count "$.index[*][?(@.name=='builders')]" 2
+// @count "$.index[*][?(@.name=='builders')]" 1
+// @has "$.index[*][?(@.name == 'ActionRowBuilder')"]
 pub use auto::*;
 
 pub mod builders {

--- a/src/test/rustdoc-json/reexport/pub_use_doc_hidden.rs
+++ b/src/test/rustdoc-json/reexport/pub_use_doc_hidden.rs
@@ -1,0 +1,15 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/106379>
+
+#![feature(no_core)]
+#![no_core]
+
+mod repeat_n {
+    #[doc(hidden)]
+    pub struct RepeatN {}
+}
+
+pub use repeat_n::RepeatN;
+
+// @count "$.index[*][?(@.name=='pub_use_doc_hidden')].inner.items[*]" 0
+// @!has "$.index[*][?(@.kind=='struct')]"
+// @!has "$.index[*][?(@.kind=='import')]"


### PR DESCRIPTION
Closes #106379
