### PR TITLE
rustdoc: remove no-op CSS `.rustdoc.source .sidebar { width: 0 }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1598,12 +1598,8 @@ in storage.js
 
 	.sidebar.shown,
 	.source-sidebar-expanded .source .sidebar,
-	.sidebar:focus-within {
+	.rustdoc:not(.source) .sidebar:focus-within {
 		left: 0;
-	}
-
-	.rustdoc.source > .sidebar {
-		width: 0;
 	}
 
 	.mobile-topbar h2 {

--- a/src/test/rustdoc-gui/sidebar-source-code-display.goml
+++ b/src/test/rustdoc-gui/sidebar-source-code-display.goml
@@ -171,15 +171,15 @@ assert-css: (
 
 // We now check that the scroll position is kept when opening the sidebar.
 click: "#src-sidebar-toggle"
-wait-for-css: (".sidebar", {"width": "0px"})
+wait-for-css: (".sidebar", {"left": "-1000px"})
 // We scroll to line 117 to change the scroll position.
 scroll-to: '//*[@id="117"]'
 assert-window-property: {"pageYOffset": "2542"}
 // Expanding the sidebar...
 click: "#src-sidebar-toggle"
-wait-for-css: (".sidebar", {"width": "500px"})
+wait-for-css: (".sidebar", {"left": "0px"})
 click: "#src-sidebar-toggle"
-wait-for-css: (".sidebar", {"width": "0px"})
+wait-for-css: (".sidebar", {"left": "-1000px"})
 // The "scrollTop" property should be the same.
 assert-window-property: {"pageYOffset": "2542"}
 

--- a/src/test/rustdoc-gui/sidebar-source-code.goml
+++ b/src/test/rustdoc-gui/sidebar-source-code.goml
@@ -77,11 +77,11 @@ assert-count: ("//*[@id='source-sidebar']/details[not(text()='lib2') and not(@op
 
 // We now switch to mobile mode.
 size: (600, 600)
-wait-for-css: (".source-sidebar-expanded nav.sidebar", {"width": "600px"})
+wait-for-css: (".source-sidebar-expanded nav.sidebar", {"left": "0px"})
 // We collapse the sidebar.
 click: (10, 10)
-// We check that the sidebar has the expected width (0).
-assert-css: ("nav.sidebar", {"width": "0px"})
+// We check that the sidebar has been moved off-screen.
+assert-css: ("nav.sidebar", {"left": "-1000px"})
 // We ensure that the class has been removed.
 assert-false: ".source-sidebar-expanded"
 assert: "nav.sidebar"


### PR DESCRIPTION
This CSS was added in dc2c9723343c985740be09919236a6e96c4e4433, before 6a5f8b1aef1417d7dc85b5d0a229d2db1930eb7c when the sidebars were merged.

Now that they are merged, the source sidebar is being pushed off-screen anyway, so giving it zero width doesn't do much.