### PR TITLE
rustdoc: reduce the size of `Function` from 80 to 40 bytes

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -240,7 +240,7 @@ pub(crate) fn build_external_trait(cx: &mut DocContext<'_>, did: DefId) -> clean
     clean::Trait { def_id: did, generics, items: trait_items, bounds: supertrait_bounds }
 }
 
-fn build_external_function<'tcx>(cx: &mut DocContext<'tcx>, did: DefId) -> Box<clean::Function> {
+fn build_external_function<'tcx>(cx: &mut DocContext<'tcx>, did: DefId) -> clean::Function {
     let sig = cx.tcx.fn_sig(did);
 
     let late_bound_regions = sig.bound_vars().into_iter().filter_map(|var| match var {
@@ -259,7 +259,7 @@ fn build_external_function<'tcx>(cx: &mut DocContext<'tcx>, did: DefId) -> Box<c
         let decl = clean_fn_decl_from_did_and_sig(cx, Some(did), sig);
         (generics, decl)
     });
-    Box::new(clean::Function { decl, generics })
+    clean::Function { decl, generics }
 }
 
 fn build_enum(cx: &mut DocContext<'_>, did: DefId) -> clean::Enum {

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1250,7 +1250,7 @@ impl clean::FnRetTy {
         cx: &'a Context<'tcx>,
     ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| match self {
-            clean::Return(clean::Tuple(tys)) if tys.is_empty() => Ok(()),
+            clean::Return(box clean::Tuple(tys)) if tys.is_empty() => Ok(()),
             clean::Return(ty) if f.alternate() => {
                 write!(f, " -> {:#}", ty.print(cx))
             }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -567,7 +567,7 @@ impl FromWithTcx<clean::FnDecl> for FnDecl {
                 .map(|arg| (arg.name.to_string(), arg.type_.into_tcx(tcx)))
                 .collect(),
             output: match output {
-                clean::FnRetTy::Return(t) => Some(t.into_tcx(tcx)),
+                clean::FnRetTy::Return(t) => Some((*t).into_tcx(tcx)),
                 clean::FnRetTy::DefaultReturn => None,
             },
             c_variadic,
@@ -632,12 +632,12 @@ impl FromWithTcx<clean::Impl> for Impl {
 }
 
 pub(crate) fn from_function(
-    function: Box<clean::Function>,
+    function: clean::Function,
     has_body: bool,
     header: rustc_hir::FnHeader,
     tcx: TyCtxt<'_>,
 ) -> Function {
-    let clean::Function { decl, generics } = *function;
+    let clean::Function { decl, generics } = function;
     Function {
         decl: decl.into_tcx(tcx),
         generics: generics.into_tcx(tcx),


### PR DESCRIPTION
This brings it low enough that ItemKind doesn't need to box it any more.