### PR TITLE
Fix `unused_braces` on generic const expr macro call

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1105,6 +1105,7 @@ impl UnusedDelimLint for UnusedBraces {
                                 || matches!(expr.kind, ast::ExprKind::Lit(_)))
                             && !cx.sess().source_map().is_multiline(value.span)
                             && value.attrs.is_empty()
+                            && !expr.span.from_expansion()
                             && !value.span.from_expansion()
                             && !inner.span.from_expansion()
                         {

--- a/tests/ui/const-generics/unused_braces.fixed
+++ b/tests/ui/const-generics/unused_braces.fixed
@@ -2,10 +2,17 @@
 // run-rustfix
 #![warn(unused_braces)]
 
+macro_rules! make_1 {
+    () => {
+        1
+    }
+}
+
 struct A<const N: usize>;
 
 fn main() {
     let _: A<7>; // ok
     let _: A<7>; //~ WARN unnecessary braces
     let _: A<{ 3 + 5 }>; // ok
+    let _: A<{make_1!()}>; // ok
 }

--- a/tests/ui/const-generics/unused_braces.rs
+++ b/tests/ui/const-generics/unused_braces.rs
@@ -2,10 +2,17 @@
 // run-rustfix
 #![warn(unused_braces)]
 
+macro_rules! make_1 {
+    () => {
+        1
+    }
+}
+
 struct A<const N: usize>;
 
 fn main() {
     let _: A<7>; // ok
     let _: A<{ 7 }>; //~ WARN unnecessary braces
     let _: A<{ 3 + 5 }>; // ok
+    let _: A<{make_1!()}>; // ok
 }

--- a/tests/ui/const-generics/unused_braces.stderr
+++ b/tests/ui/const-generics/unused_braces.stderr
@@ -1,5 +1,5 @@
 warning: unnecessary braces around const expression
-  --> $DIR/unused_braces.rs:9:14
+  --> $DIR/unused_braces.rs:15:14
    |
 LL |     let _: A<{ 7 }>;
    |              ^^ ^^


### PR DESCRIPTION
Fixes #106545

@rustbot label +A-const-generics +A-lint