### PR TITLE
Run SimplifyCfg after SimplifyLocals

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -577,6 +577,7 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             &o1(simplify::SimplifyCfg::new("final")),
             &nrvo::RenameReturnPlace,
             &simplify::SimplifyLocals::new("final"),
+            &o1(simplify::SimplifyCfg::new("final")),
             &multiple_return_terminators::MultipleReturnTerminators,
             &deduplicate_blocks::DeduplicateBlocks,
             // Some cleanup necessary at least for LLVM and potentially other codegen backends.


### PR DESCRIPTION
SimplifyLocals can create goto chains by deleting all the statements in a block with a goto terminator. Moving the final SimplifyCfg after SimplifyLocals ensures these blocks are completely deleted.

As far as I can tell, this is the primary cause of the MIR changes in https://github.com/rust-lang/rust/pull/106550#issuecomment-1374407180, because I sloppily added a new SimplifyCfg around this position.

Locally, this fails an incremental compilation test, but I have no idea how that is possible. Let's see what CI and perf say...

r? @ghost