### PR TITLE
Make `ObligationCtxt` deref to `InferCtxt`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -383,14 +383,14 @@ fn try_extract_error_from_fulfill_cx<'tcx>(
     // already run, but there's no point using `delay_span_bug`
     // when we're going to emit an error here anyway.
     let _errors = ocx.select_all_or_error();
-    let region_constraints = ocx.infcx.with_region_constraints(|r| r.clone());
+    let region_constraints = ocx.with_region_constraints(|r| r.clone());
     try_extract_error_from_region_constraints(
-        ocx.infcx,
+        ocx,
         placeholder_region,
         error_region,
         &region_constraints,
-        |vid| ocx.infcx.region_var_origin(vid),
-        |vid| ocx.infcx.universe_of_region(ocx.infcx.tcx.mk_region(ty::ReVar(vid))),
+        |vid| ocx.region_var_origin(vid),
+        |vid| ocx.universe_of_region(ocx.tcx.mk_region(ty::ReVar(vid))),
     )
 }
 

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -720,7 +720,7 @@ impl<'a, 'tcx> ImplTraitInTraitCollector<'a, 'tcx> {
 
 impl<'tcx> TypeFolder<'tcx> for ImplTraitInTraitCollector<'_, 'tcx> {
     fn tcx<'a>(&'a self) -> TyCtxt<'tcx> {
-        self.ocx.infcx.tcx
+        self.ocx.tcx
     }
 
     fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
@@ -735,7 +735,7 @@ impl<'tcx> TypeFolder<'tcx> for ImplTraitInTraitCollector<'_, 'tcx> {
                 bug!("FIXME(RPITIT): error here");
             }
             // Replace with infer var
-            let infer_ty = self.ocx.infcx.next_ty_var(TypeVariableOrigin {
+            let infer_ty = self.ocx.next_ty_var(TypeVariableOrigin {
                 span: self.span,
                 kind: TypeVariableOriginKind::MiscVariable,
             });

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -49,7 +49,7 @@ impl<'a, 'tcx> Deref for WfCheckingCtxt<'a, 'tcx> {
 
 impl<'tcx> WfCheckingCtxt<'_, 'tcx> {
     fn tcx(&self) -> TyCtxt<'tcx> {
-        self.ocx.infcx.tcx
+        self.ocx.tcx
     }
 
     // Convenience function to normalize during wfcheck. This performs
@@ -1894,7 +1894,7 @@ impl<'tcx> WfCheckingCtxt<'_, 'tcx> {
     /// aren't true.
     #[instrument(level = "debug", skip(self))]
     fn check_false_global_bounds(&mut self) {
-        let tcx = self.ocx.infcx.tcx;
+        let tcx = self.ocx.tcx;
         let mut span = self.span;
         let empty_env = ty::ParamEnv::empty();
 

--- a/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
@@ -175,7 +175,7 @@ fn get_impl_substs(
 
     let errors = ocx.select_all_or_error();
     if !errors.is_empty() {
-        ocx.infcx.err_ctxt().report_fulfillment_errors(&errors, None);
+        ocx.err_ctxt().report_fulfillment_errors(&errors, None);
         return None;
     }
 

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::fmt::Debug;
+use std::ops::Deref;
 
 use super::TraitEngine;
 use super::{ChalkFulfillmentContext, FulfillmentContext};
@@ -225,5 +226,13 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
             answer,
             &mut **self.engine.borrow_mut(),
         )
+    }
+}
+
+impl<'tcx> Deref for ObligationCtxt<'_, 'tcx> {
+    type Target = InferCtxt<'tcx>;
+
+    fn deref(&self) -> &InferCtxt<'tcx> {
+        self.infcx
     }
 }

--- a/compiler/rustc_traits/src/dropck_outlives.rs
+++ b/compiler/rustc_traits/src/dropck_outlives.rs
@@ -26,7 +26,7 @@ fn dropck_outlives<'tcx>(
     debug!("dropck_outlives(goal={:#?})", canonical_goal);
 
     tcx.infer_ctxt().enter_canonical_trait_query(&canonical_goal, |ocx, goal| {
-        let tcx = ocx.infcx.tcx;
+        let tcx = ocx.tcx;
         let ParamEnvAnd { param_env, value: for_ty } = goal;
 
         let mut result = DropckOutlivesResult { kinds: vec![], overflows: vec![] };
@@ -100,7 +100,7 @@ fn dropck_outlives<'tcx>(
             // to push them onto the stack to be expanded.
             for ty in constraints.dtorck_types.drain(..) {
                 let Normalized { value: ty, obligations } =
-                    ocx.infcx.at(&cause, param_env).query_normalize(ty)?;
+                    ocx.at(&cause, param_env).query_normalize(ty)?;
                 ocx.register_obligations(obligations);
 
                 debug!("dropck_outlives: ty from dtorck_types = {:?}", ty);

--- a/compiler/rustc_traits/src/implied_outlives_bounds.rs
+++ b/compiler/rustc_traits/src/implied_outlives_bounds.rs
@@ -38,7 +38,7 @@ fn compute_implied_outlives_bounds<'tcx>(
     param_env: ty::ParamEnv<'tcx>,
     ty: Ty<'tcx>,
 ) -> Fallible<Vec<OutlivesBound<'tcx>>> {
-    let tcx = ocx.infcx.tcx;
+    let tcx = ocx.tcx;
 
     // Sometimes when we ask what it takes for T: WF, we get back that
     // U: WF is required; in that case, we push U onto this stack and
@@ -67,9 +67,8 @@ fn compute_implied_outlives_bounds<'tcx>(
         // FIXME(@lcnr): It's not really "always fine", having fewer implied
         // bounds can be backward incompatible, e.g. #101951 was caused by
         // us not dealing with inference vars in `TypeOutlives` predicates.
-        let obligations =
-            wf::obligations(ocx.infcx, param_env, hir::CRATE_HIR_ID, 0, arg, DUMMY_SP)
-                .unwrap_or_default();
+        let obligations = wf::obligations(ocx, param_env, hir::CRATE_HIR_ID, 0, arg, DUMMY_SP)
+            .unwrap_or_default();
 
         // While these predicates should all be implied by other parts of
         // the program, they are still relevant as they may constrain
@@ -128,7 +127,7 @@ fn compute_implied_outlives_bounds<'tcx>(
         .flat_map(|ty::OutlivesPredicate(a, r_b)| match a.unpack() {
             ty::GenericArgKind::Lifetime(r_a) => vec![OutlivesBound::RegionSubRegion(r_b, r_a)],
             ty::GenericArgKind::Type(ty_a) => {
-                let ty_a = ocx.infcx.resolve_vars_if_possible(ty_a);
+                let ty_a = ocx.resolve_vars_if_possible(ty_a);
                 let mut components = smallvec![];
                 push_outlives_components(tcx, ty_a, &mut components);
                 implied_bounds_from_components(r_b, components)

--- a/compiler/rustc_traits/src/normalize_projection_ty.rs
+++ b/compiler/rustc_traits/src/normalize_projection_ty.rs
@@ -23,7 +23,7 @@ fn normalize_projection_ty<'tcx>(
     tcx.infer_ctxt().enter_canonical_trait_query(
         &goal,
         |ocx, ParamEnvAnd { param_env, value: goal }| {
-            let selcx = &mut SelectionContext::new(ocx.infcx);
+            let selcx = &mut SelectionContext::new(ocx);
             let cause = ObligationCause::dummy();
             let mut obligations = vec![];
             let answer = traits::normalize_projection_type(

--- a/compiler/rustc_traits/src/type_op.rs
+++ b/compiler/rustc_traits/src/type_op.rs
@@ -58,7 +58,7 @@ pub fn type_op_ascribe_user_type_with_span<'tcx>(
     let span = span.unwrap_or(DUMMY_SP);
 
     let UserSubsts { user_self_ty, substs } = user_substs;
-    let tcx = ocx.infcx.tcx;
+    let tcx = ocx.tcx;
     let cause = ObligationCause::dummy_with_span(span);
 
     let ty = tcx.bound_type_of(def_id).subst(tcx, substs);
@@ -137,7 +137,7 @@ where
 {
     let (param_env, Normalize { value }) = key.into_parts();
     let Normalized { value, obligations } =
-        ocx.infcx.at(&ObligationCause::dummy(), param_env).query_normalize(value)?;
+        ocx.at(&ObligationCause::dummy(), param_env).query_normalize(value)?;
     ocx.register_obligations(obligations);
     Ok(value)
 }
@@ -204,5 +204,5 @@ pub fn type_op_prove_predicate_with_cause<'tcx>(
     cause: ObligationCause<'tcx>,
 ) {
     let (param_env, ProvePredicate { predicate }) = key.into_parts();
-    ocx.register_obligation(Obligation::new(ocx.infcx.tcx, cause, param_env, predicate));
+    ocx.register_obligation(Obligation::new(ocx.tcx, cause, param_env, predicate));
 }


### PR DESCRIPTION
Slightly less chaining of `self.ocx.infcx.tcx`, etc.