### PR TITLE
Suppress type errors that come from private fields

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2217,7 +2217,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.tcx.check_stability(field.did, Some(expr.hir_id), expr.span, None);
                             return field_ty;
                         }
-                        private_candidate = Some((adjustments, base_def.did(), field_ty));
+                        private_candidate = Some((adjustments, base_def.did()));
                     }
                 }
                 ty::Tuple(tys) => {
@@ -2240,12 +2240,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
         self.structurally_resolved_type(autoderef.span(), autoderef.final_ty(false));
 
-        if let Some((adjustments, did, field_ty)) = private_candidate {
+        if let Some((adjustments, did)) = private_candidate {
             // (#90483) apply adjustments to avoid ExprUseVisitor from
             // creating erroneous projection.
             self.apply_adjustments(base, adjustments);
             self.ban_private_field_access(expr, base_ty, field, did);
-            return field_ty;
+            return self.tcx().ty_error();
         }
 
         if field.name == kw::Empty {

--- a/src/test/ui/issues/issue-25386.rs
+++ b/src/test/ui/issues/issue-25386.rs
@@ -24,5 +24,4 @@ macro_rules! check_ptr_exist {
 fn main() {
     let item = stuff::Item::new();
     println!("{}", check_ptr_exist!(item, name));
-    //~^ ERROR field `name` of struct `CObj` is private
 }

--- a/src/test/ui/issues/issue-25386.stderr
+++ b/src/test/ui/issues/issue-25386.stderr
@@ -9,12 +9,6 @@ LL |     println!("{}", check_ptr_exist!(item, name));
    |
    = note: this error originates in the macro `check_ptr_exist` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0616]: field `name` of struct `CObj` is private
-  --> $DIR/issue-25386.rs:26:43
-   |
-LL |     println!("{}", check_ptr_exist!(item, name));
-   |                                           ^^^^ private field
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0616`.

--- a/src/test/ui/privacy/private-field-ty-err.rs
+++ b/src/test/ui/privacy/private-field-ty-err.rs
@@ -1,0 +1,20 @@
+fn main() {
+    let x = foo::Foo::default();
+    if x.len {
+        //~^ ERROR field `len` of struct `Foo` is private
+        println!("foo");
+    }
+}
+
+mod foo {
+    #[derive(Default)]
+    pub struct Foo {
+        len: String,
+    }
+
+    impl Foo {
+        pub fn len(&self) -> usize {
+            42
+        }
+    }
+}

--- a/src/test/ui/privacy/private-field-ty-err.stderr
+++ b/src/test/ui/privacy/private-field-ty-err.stderr
@@ -1,0 +1,14 @@
+error[E0616]: field `len` of struct `Foo` is private
+  --> $DIR/private-field-ty-err.rs:3:10
+   |
+LL |     if x.len {
+   |          ^^^ private field
+   |
+help: a method `len` also exists, call it with parentheses
+   |
+LL |     if x.len() {
+   |             ++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0616`.


### PR DESCRIPTION
Fixes #57320

There was some discussion here (https://github.com/rust-lang/rust/issues/57320#issuecomment-451308420), but I honestly think the second error is worth suppressing regardless. 

I would be open to feedback though -- perhaps we can suppress the `.len()` suggestion if there's type error (since we have access to [`Expectation`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_typeck/enum.Expectation.html), we can determine that).

r? @estebank