### PR TITLE
Let unsafe traits and autotraits be used as bound in dyn-safe trait

### DIFF
--- a/tests/ui/where-clauses/auxiliary/autotrait.rs
+++ b/tests/ui/where-clauses/auxiliary/autotrait.rs
@@ -1,0 +1,3 @@
+#![feature(auto_traits)]
+
+pub auto trait AutoTrait {}

--- a/tests/ui/where-clauses/self-in-where-clause-allowed.rs
+++ b/tests/ui/where-clauses/self-in-where-clause-allowed.rs
@@ -1,0 +1,30 @@
+// check-fail
+// aux-build: autotrait.rs
+
+#![deny(where_clauses_object_safety)]
+
+extern crate autotrait;
+
+use autotrait::AutoTrait as NonlocalAutoTrait;
+
+unsafe trait UnsafeTrait {}
+
+trait Trait {
+    fn static_lifetime_bound(&self) where Self: 'static {}
+
+    fn arg_lifetime_bound<'a>(&self, _arg: &'a ()) where Self: 'a {}
+
+    fn unsafe_trait_bound(&self) where Self: UnsafeTrait {}
+
+    fn nonlocal_autotrait_bound(&self) where Self: NonlocalAutoTrait {}
+}
+
+impl Trait for () {}
+
+fn main() {
+    let trait_object = &() as &dyn Trait;
+    trait_object.static_lifetime_bound();
+    trait_object.arg_lifetime_bound(&());
+    trait_object.unsafe_trait_bound(); //~ ERROR: the trait bound `dyn Trait: UnsafeTrait` is not satisfied
+    trait_object.nonlocal_autotrait_bound(); //~ ERROR: the trait bound `dyn Trait: AutoTrait` is not satisfied
+}

--- a/tests/ui/where-clauses/self-in-where-clause-allowed.stderr
+++ b/tests/ui/where-clauses/self-in-where-clause-allowed.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the trait bound `dyn Trait: UnsafeTrait` is not satisfied
+  --> $DIR/self-in-where-clause-allowed.rs:28:18
+   |
+LL |     trait_object.unsafe_trait_bound();
+   |                  ^^^^^^^^^^^^^^^^^^ the trait `UnsafeTrait` is not implemented for `dyn Trait`
+   |
+note: required by a bound in `Trait::unsafe_trait_bound`
+  --> $DIR/self-in-where-clause-allowed.rs:17:46
+   |
+LL |     fn unsafe_trait_bound(&self) where Self: UnsafeTrait {}
+   |                                              ^^^^^^^^^^^ required by this bound in `Trait::unsafe_trait_bound`
+
+error[E0277]: the trait bound `dyn Trait: AutoTrait` is not satisfied
+  --> $DIR/self-in-where-clause-allowed.rs:29:18
+   |
+LL |     trait_object.nonlocal_autotrait_bound();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AutoTrait` is not implemented for `dyn Trait`
+   |
+note: required by a bound in `Trait::nonlocal_autotrait_bound`
+  --> $DIR/self-in-where-clause-allowed.rs:19:52
+   |
+LL |     fn nonlocal_autotrait_bound(&self) where Self: NonlocalAutoTrait {}
+   |                                                    ^^^^^^^^^^^^^^^^^ required by this bound in `Trait::nonlocal_autotrait_bound`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/where-clauses/self-in-where-clause-future-compat.rs
+++ b/tests/ui/where-clauses/self-in-where-clause-future-compat.rs
@@ -1,0 +1,14 @@
+// check-fail
+
+#![deny(where_clauses_object_safety)]
+
+unsafe trait UnsafeTrait<T: ?Sized> {}
+
+trait Trait {
+    fn unsafe_trait_bound(&self) where (): UnsafeTrait<Self> {} //~ ERROR: the trait `Trait` cannot be made into an object
+    //~^ WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+}
+
+fn main() {
+    let _: &dyn Trait;
+}

--- a/tests/ui/where-clauses/self-in-where-clause-future-compat.stderr
+++ b/tests/ui/where-clauses/self-in-where-clause-future-compat.stderr
@@ -1,0 +1,24 @@
+error: the trait `Trait` cannot be made into an object
+  --> $DIR/self-in-where-clause-future-compat.rs:8:8
+   |
+LL |     fn unsafe_trait_bound(&self) where (): UnsafeTrait<Self> {}
+   |        ^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/self-in-where-clause-future-compat.rs:8:8
+   |
+LL | trait Trait {
+   |       ----- this trait cannot be made into an object...
+LL |     fn unsafe_trait_bound(&self) where (): UnsafeTrait<Self> {}
+   |        ^^^^^^^^^^^^^^^^^^ ...because method `unsafe_trait_bound` references the `Self` type in its `where` clause
+   = help: consider moving `unsafe_trait_bound` to another trait
+note: the lint level is defined here
+  --> $DIR/self-in-where-clause-future-compat.rs:3:9
+   |
+LL | #![deny(where_clauses_object_safety)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This PR implements the observation from https://github.com/rust-lang/rust/issues/51443#issuecomment-1374847313 that the `where_clauses_object_safety` future compatibility lint is unnecessarily restrictive in the case of `where Self: Sync` bounds for 2 reasons:

1. As an unsafe trait, writing `unsafe impl Sync for dyn Trait + '_ {}` in order to make `Trait`'s `where Self: Sync` methods callable on `dyn Trait` is something that the user would have brought upon themselves. That impl is wrong.

2. As an autotrait, they can't even write such an impl in the first place.

Fixes https://github.com/dtolnay/async-trait/issues/228.