### PR TITLE
Render missing generics suggestion verbosely

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -167,7 +167,7 @@ impl<'a> Resolver<'a> {
                 );
                 err.emit();
             } else if let Some((span, msg, sugg, appl)) = suggestion {
-                err.span_suggestion(span, msg, sugg, appl);
+                err.span_suggestion_verbose(span, msg, sugg, appl);
                 err.emit();
             } else if let [segment] = path.as_slice() && is_call {
                 err.stash(segment.ident.span, rustc_errors::StashKey::CallIntoMethod);

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2065,7 +2065,11 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
         path: &[Segment],
     ) -> Option<(Span, &'static str, String, Applicability)> {
         let (ident, span) = match path {
-            [segment] if !segment.has_generic_args && segment.ident.name != kw::SelfUpper => {
+            [segment]
+                if !segment.has_generic_args
+                    && segment.ident.name != kw::SelfUpper
+                    && segment.ident.name != kw::Dyn =>
+            {
                 (segment.ident.to_string(), segment.ident.span)
             }
             _ => return None,

--- a/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
@@ -17,9 +17,12 @@ error[E0412]: cannot find type `VAL` in this scope
   --> $DIR/ice-6252.rs:10:63
    |
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
-   |          -                                                    ^^^ not found in this scope
-   |          |
-   |          help: you might be missing a type parameter: `, VAL`
+   |                                                               ^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | impl<N, M, VAL> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
+   |          +++++
 
 error[E0046]: not all trait items implemented, missing: `VAL`
   --> $DIR/ice-6252.rs:10:1

--- a/tests/ui/functions-closures/fn-help-with-err-generic-is-not-function.stderr
+++ b/tests/ui/functions-closures/fn-help-with-err-generic-is-not-function.stderr
@@ -2,9 +2,12 @@ error[E0412]: cannot find type `T` in this scope
   --> $DIR/fn-help-with-err-generic-is-not-function.rs:2:13
    |
 LL | impl Struct<T>
-   |     -       ^ not found in this scope
-   |     |
-   |     help: you might be missing a type parameter: `<T>`
+   |             ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | impl<T> Struct<T>
+   |     +++
 
 error[E0412]: cannot find type `T` in this scope
   --> $DIR/fn-help-with-err-generic-is-not-function.rs:7:5

--- a/tests/ui/issues/issue-58712.stderr
+++ b/tests/ui/issues/issue-58712.stderr
@@ -2,9 +2,12 @@ error[E0412]: cannot find type `DeviceId` in this scope
   --> $DIR/issue-58712.rs:6:20
    |
 LL | impl<H> AddrVec<H, DeviceId> {
-   |       -            ^^^^^^^^ not found in this scope
-   |       |
-   |       help: you might be missing a type parameter: `, DeviceId`
+   |                    ^^^^^^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | impl<H, DeviceId> AddrVec<H, DeviceId> {
+   |       ++++++++++
 
 error[E0412]: cannot find type `DeviceId` in this scope
   --> $DIR/issue-58712.rs:8:29

--- a/tests/ui/issues/issue-77919.stderr
+++ b/tests/ui/issues/issue-77919.stderr
@@ -13,9 +13,12 @@ error[E0412]: cannot find type `VAL` in this scope
   --> $DIR/issue-77919.rs:11:63
    |
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
-   |          -                                                    ^^^ not found in this scope
-   |          |
-   |          help: you might be missing a type parameter: `, VAL`
+   |                                                               ^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | impl<N, M, VAL> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
+   |          +++++
 
 error[E0046]: not all trait items implemented, missing: `VAL`
   --> $DIR/issue-77919.rs:11:1

--- a/tests/ui/issues/issue-86756.stderr
+++ b/tests/ui/issues/issue-86756.stderr
@@ -11,11 +11,6 @@ error[E0412]: cannot find type `dyn` in this scope
    |
 LL |     eq::<dyn, Foo>
    |          ^^^ not found in this scope
-   |
-help: you might be missing a type parameter
-   |
-LL | fn eq<A, B, dyn>() {
-   |           +++++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-86756.rs:5:15

--- a/tests/ui/issues/issue-86756.stderr
+++ b/tests/ui/issues/issue-86756.stderr
@@ -9,10 +9,13 @@ LL | trait Foo<T, T = T> {}
 error[E0412]: cannot find type `dyn` in this scope
   --> $DIR/issue-86756.rs:5:10
    |
-LL | fn eq<A, B>() {
-   |           - help: you might be missing a type parameter: `, dyn`
 LL |     eq::<dyn, Foo>
    |          ^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | fn eq<A, B, dyn>() {
+   |           +++++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-86756.rs:5:15

--- a/tests/ui/parser/dyn-trait-compatibility.stderr
+++ b/tests/ui/parser/dyn-trait-compatibility.stderr
@@ -26,17 +26,23 @@ error[E0412]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:5:15
    |
 LL | type A2 = dyn<dyn, dyn>;
-   |        -      ^^^ not found in this scope
-   |        |
-   |        help: you might be missing a type parameter: `<dyn>`
+   |               ^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | type A2<dyn> = dyn<dyn, dyn>;
+   |        +++++
 
 error[E0412]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:5:20
    |
 LL | type A2 = dyn<dyn, dyn>;
-   |        -           ^^^ not found in this scope
-   |        |
-   |        help: you might be missing a type parameter: `<dyn>`
+   |                    ^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | type A2<dyn> = dyn<dyn, dyn>;
+   |        +++++
 
 error[E0412]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:9:11
@@ -48,9 +54,12 @@ error[E0412]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:9:16
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
-   |        -       ^^^ not found in this scope
-   |        |
-   |        help: you might be missing a type parameter: `<dyn>`
+   |                ^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | type A3<dyn> = dyn<<dyn as dyn>::dyn>;
+   |        +++++
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/parser/dyn-trait-compatibility.stderr
+++ b/tests/ui/parser/dyn-trait-compatibility.stderr
@@ -27,22 +27,12 @@ error[E0412]: cannot find type `dyn` in this scope
    |
 LL | type A2 = dyn<dyn, dyn>;
    |               ^^^ not found in this scope
-   |
-help: you might be missing a type parameter
-   |
-LL | type A2<dyn> = dyn<dyn, dyn>;
-   |        +++++
 
 error[E0412]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:5:20
    |
 LL | type A2 = dyn<dyn, dyn>;
    |                    ^^^ not found in this scope
-   |
-help: you might be missing a type parameter
-   |
-LL | type A2<dyn> = dyn<dyn, dyn>;
-   |        +++++
 
 error[E0412]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:9:11
@@ -55,11 +45,6 @@ error[E0412]: cannot find type `dyn` in this scope
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |                ^^^ not found in this scope
-   |
-help: you might be missing a type parameter
-   |
-LL | type A3<dyn> = dyn<<dyn as dyn>::dyn>;
-   |        +++++
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/suggestions/type-not-found-in-adt-field.stderr
+++ b/tests/ui/suggestions/type-not-found-in-adt-field.stderr
@@ -7,10 +7,13 @@ LL |     m: Vec<Someunknownname<String, ()>>,
 error[E0412]: cannot find type `K` in this scope
   --> $DIR/type-not-found-in-adt-field.rs:6:8
    |
-LL | struct OtherStruct {
-   |                   - help: you might be missing a type parameter: `<K>`
 LL |     m: K,
    |        ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | struct OtherStruct<K> {
+   |                   +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/ignore-err-impls.stderr
+++ b/tests/ui/traits/ignore-err-impls.stderr
@@ -2,9 +2,12 @@ error[E0412]: cannot find type `Type` in this scope
   --> $DIR/ignore-err-impls.rs:6:14
    |
 LL | impl Generic<Type> for S {}
-   |     -        ^^^^ not found in this scope
-   |     |
-   |     help: you might be missing a type parameter: `<Type>`
+   |              ^^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | impl<Type> Generic<Type> for S {}
+   |     ++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/traits/issue-50480.stderr
+++ b/tests/ui/traits/issue-50480.stderr
@@ -2,9 +2,12 @@ error[E0412]: cannot find type `N` in this scope
   --> $DIR/issue-50480.rs:3:12
    |
 LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
-   |           -^ not found in this scope
-   |           |
-   |           help: you might be missing a type parameter: `<N>`
+   |            ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | struct Foo<N>(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
+   |           +++
 
 error[E0412]: cannot find type `NotDefined` in this scope
   --> $DIR/issue-50480.rs:3:15
@@ -16,17 +19,23 @@ error[E0412]: cannot find type `N` in this scope
   --> $DIR/issue-50480.rs:3:12
    |
 LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
-   |           -^ not found in this scope
-   |           |
-   |           help: you might be missing a type parameter: `<N>`
+   |            ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | struct Foo<N>(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
+   |           +++
 
 error[E0412]: cannot find type `NotDefined` in this scope
   --> $DIR/issue-50480.rs:3:15
    |
 LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
-   |           -   ^^^^^^^^^^ not found in this scope
-   |           |
-   |           help: you might be missing a type parameter: `<NotDefined>`
+   |               ^^^^^^^^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | struct Foo<NotDefined>(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
+   |           ++++++++++++
 
 error[E0412]: cannot find type `N` in this scope
   --> $DIR/issue-50480.rs:12:18

--- a/tests/ui/traits/issue-75627.stderr
+++ b/tests/ui/traits/issue-75627.stderr
@@ -2,9 +2,12 @@ error[E0412]: cannot find type `T` in this scope
   --> $DIR/issue-75627.rs:3:26
    |
 LL | unsafe impl Send for Foo<T> {}
-   |            -             ^ not found in this scope
-   |            |
-   |            help: you might be missing a type parameter: `<T>`
+   |                          ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | unsafe impl<T> Send for Foo<T> {}
+   |            +++
 
 error: aborting due to previous error
 

--- a/tests/ui/traits/issue-78372.stderr
+++ b/tests/ui/traits/issue-78372.stderr
@@ -30,9 +30,12 @@ error[E0412]: cannot find type `MISC` in this scope
   --> $DIR/issue-78372.rs:3:34
    |
 LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
-   |       -                          ^^^^ not found in this scope
-   |       |
-   |       help: you might be missing a type parameter: `, MISC`
+   |                                  ^^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | impl<T, MISC> DispatchFromDyn<Smaht<U, MISC>> for T {}
+   |       ++++++
 
 error[E0658]: use of unstable library feature 'dispatch_from_dyn'
   --> $DIR/issue-78372.rs:1:5

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst.stderr
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst.stderr
@@ -1,11 +1,13 @@
 error[E0412]: cannot find type `Dst` in this scope
   --> $DIR/unknown_dst.rs:20:36
    |
-LL | fn should_gracefully_handle_unknown_dst() {
-   |                                        - help: you might be missing a type parameter: `<Dst>`
-...
 LL |     assert::is_transmutable::<Src, Dst, Context>();
    |                                    ^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | fn should_gracefully_handle_unknown_dst<Dst>() {
+   |                                        +++++
 
 error: aborting due to previous error
 

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_src.stderr
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_src.stderr
@@ -1,11 +1,13 @@
 error[E0412]: cannot find type `Src` in this scope
   --> $DIR/unknown_src.rs:20:31
    |
-LL | fn should_gracefully_handle_unknown_src() {
-   |                                        - help: you might be missing a type parameter: `<Src>`
-...
 LL |     assert::is_transmutable::<Src, Dst, Context>();
    |                               ^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | fn should_gracefully_handle_unknown_src<Src>() {
+   |                                        +++++
 
 error: aborting due to previous error
 

--- a/tests/ui/typeck/autoderef-with-param-env-error.stderr
+++ b/tests/ui/typeck/autoderef-with-param-env-error.stderr
@@ -1,11 +1,13 @@
 error[E0412]: cannot find type `T` in this scope
   --> $DIR/autoderef-with-param-env-error.rs:3:5
    |
-LL | fn foo()
-   |       - help: you might be missing a type parameter: `<T>`
-LL | where
 LL |     T: Send,
    |     ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | fn foo<T>()
+   |       +++
 
 error: aborting due to previous error
 

--- a/tests/ui/typeck/issue-104513-ice.stderr
+++ b/tests/ui/typeck/issue-104513-ice.stderr
@@ -1,10 +1,13 @@
 error[E0405]: cannot find trait `Oops` in this scope
   --> $DIR/issue-104513-ice.rs:3:19
    |
-LL | fn f() {
-   |     - help: you might be missing a type parameter: `<Oops>`
 LL |     let _: S<impl Oops> = S;
    |                   ^^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | fn f<Oops>() {
+   |     ++++++
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
   --> $DIR/issue-104513-ice.rs:3:14


### PR DESCRIPTION
It's a bit easier to read like this, especially ones that are appending new generics onto an existing list, like ": `, T`" which render somewhat poorly inline.

Also don't suggest `dyn` as a type parameter to add, even if technically that's valid in edition 2015.