### PR TITLE
error-code docs improvements (No. 2)

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -110,6 +110,7 @@ E0204: include_str!("./error_codes/E0204.md"),
 E0205: include_str!("./error_codes/E0205.md"),
 E0206: include_str!("./error_codes/E0206.md"),
 E0207: include_str!("./error_codes/E0207.md"),
+E0208: include_str!("./error_codes/E0208.md"),
 E0210: include_str!("./error_codes/E0210.md"),
 E0211: include_str!("./error_codes/E0211.md"),
 E0212: include_str!("./error_codes/E0212.md"),
@@ -387,6 +388,7 @@ E0636: include_str!("./error_codes/E0636.md"),
 E0637: include_str!("./error_codes/E0637.md"),
 E0638: include_str!("./error_codes/E0638.md"),
 E0639: include_str!("./error_codes/E0639.md"),
+E0640: include_str!("./error_codes/E0640.md"),
 E0641: include_str!("./error_codes/E0641.md"),
 E0642: include_str!("./error_codes/E0642.md"),
 E0643: include_str!("./error_codes/E0643.md"),
@@ -434,6 +436,7 @@ E0713: include_str!("./error_codes/E0713.md"),
 E0714: include_str!("./error_codes/E0714.md"),
 E0715: include_str!("./error_codes/E0715.md"),
 E0716: include_str!("./error_codes/E0716.md"),
+E0717: include_str!("./error_codes/E0717.md"),
 E0718: include_str!("./error_codes/E0718.md"),
 E0719: include_str!("./error_codes/E0719.md"),
 E0720: include_str!("./error_codes/E0720.md"),
@@ -540,7 +543,6 @@ E0791: include_str!("./error_codes/E0791.md"),
 //  E0190, // deprecated: can only cast a &-pointer to an &-object
 //  E0194, // merged into E0403
 //  E0196, // cannot determine a type for this closure
-    E0208, // internal error code
 //  E0209, // builtin traits can only be implemented on structs or enums
 //  E0213, // associated types are not accepted in this context
 //  E0215, // angle-bracket notation is not stable with `Fn`
@@ -633,14 +635,12 @@ E0791: include_str!("./error_codes/E0791.md"),
 //  E0629, // missing 'feature' (rustc_const_unstable)
 //  E0630, // rustc_const_unstable attribute must be paired with stable/unstable
            // attribute
-    E0640, // infer outlives requirements, internal error code
 //  E0645, // trait aliases not finished
 //  E0694, // an unknown tool name found in scoped attributes
 //  E0702, // replaced with a generic attribute input check
 //  E0707, // multiple elided lifetimes used in arguments of `async fn`
 //  E0709, // multiple different lifetimes used in arguments of `async fn`
     E0711, // a feature has been declared with conflicting stability attributes, internal error code
-    E0717, // rustc_promotable without stability attribute, internal error code
 //  E0721, // `await` keyword
 //  E0723, // unstable feature in `const` context
 //  E0738, // Removed; errored on `#[track_caller] fn`s in `extern "Rust" { ... }`.

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -436,6 +436,7 @@ E0713: include_str!("./error_codes/E0713.md"),
 E0714: include_str!("./error_codes/E0714.md"),
 E0715: include_str!("./error_codes/E0715.md"),
 E0716: include_str!("./error_codes/E0716.md"),
+E0711: include_str!("./error_codes/E0711.md"),
 E0717: include_str!("./error_codes/E0717.md"),
 E0718: include_str!("./error_codes/E0718.md"),
 E0719: include_str!("./error_codes/E0719.md"),
@@ -640,7 +641,6 @@ E0791: include_str!("./error_codes/E0791.md"),
 //  E0702, // replaced with a generic attribute input check
 //  E0707, // multiple elided lifetimes used in arguments of `async fn`
 //  E0709, // multiple different lifetimes used in arguments of `async fn`
-    E0711, // a feature has been declared with conflicting stability attributes, internal error code
 //  E0721, // `await` keyword
 //  E0723, // unstable feature in `const` context
 //  E0738, // Removed; errored on `#[track_caller] fn`s in `extern "Rust" { ... }`.

--- a/compiler/rustc_error_codes/src/error_codes/E0208.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0208.md
@@ -1,0 +1,1 @@
+#### This error code is internal to the compiler and will not be emitted with normal Rust code.

--- a/compiler/rustc_error_codes/src/error_codes/E0640.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0640.md
@@ -1,0 +1,1 @@
+#### This error code is internal to the compiler and will not be emitted with normal Rust code.

--- a/compiler/rustc_error_codes/src/error_codes/E0711.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0711.md
@@ -1,0 +1,30 @@
+#### This error code is internal to the compiler and will not be emitted with normal Rust code.
+
+Feature declared with conflicting stability requirements.
+
+```compile_fail,E0711
+// NOTE: this attribute is perma-unstable and should *never* be used outside of
+//       stdlib and the compiler.
+#![feature(staged_api)]
+
+#![stable(feature = "...", since = "1.0.0")]
+
+#[stable(feature = "foo", since = "1.0.0")]
+fn foo_stable_1_0_0() {}
+
+// error: feature `foo` is declared stable since 1.29.0
+#[stable(feature = "foo", since = "1.29.0")]
+fn foo_stable_1_29_0() {}
+
+// error: feature `foo` is declared unstable
+#[unstable(feature = "foo", issue = "none")]
+fn foo_unstable() {}
+```
+
+In the above example, the `foo` feature is first defined to be stable since
+1.0.0, but is then re-declared stable since 1.29.0. This discrepancy in
+versions causes an error. Furthermore, `foo` is then re-declared as unstable,
+again the conflict causes an error.
+
+This error can be fixed by splitting the feature, this allows any
+stability requirements and removes any possibility of conflict.

--- a/compiler/rustc_error_codes/src/error_codes/E0717.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0717.md
@@ -1,0 +1,1 @@
+#### This error code is internal to the compiler and will not be emitted with normal Rust code.

--- a/src/test/ui/error-codes/E0711.rs
+++ b/src/test/ui/error-codes/E0711.rs
@@ -1,0 +1,18 @@
+// copied from: src/test/ui/feature-gates/stability-attribute-consistency.rs
+
+#![feature(staged_api)]
+
+#![stable(feature = "stable_test_feature", since = "1.0.0")]
+
+#[stable(feature = "foo", since = "1.0.0")]
+fn foo_stable_1_0_0() {}
+
+#[stable(feature = "foo", since = "1.29.0")]
+//~^ ERROR feature `foo` is declared stable since 1.29.0
+fn foo_stable_1_29_0() {}
+
+#[unstable(feature = "foo", issue = "none")]
+//~^ ERROR feature `foo` is declared unstable
+fn foo_unstable() {}
+
+fn main() {}

--- a/src/test/ui/error-codes/E0711.stderr
+++ b/src/test/ui/error-codes/E0711.stderr
@@ -1,0 +1,15 @@
+error[E0711]: feature `foo` is declared stable since 1.29.0, but was previously declared stable since 1.0.0
+  --> $DIR/E0711.rs:10:1
+   |
+LL | #[stable(feature = "foo", since = "1.29.0")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0711]: feature `foo` is declared unstable, but was previously declared stable
+  --> $DIR/E0711.rs:14:1
+   |
+LL | #[unstable(feature = "foo", issue = "none")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0711`.

--- a/src/test/ui/feature-gates/stability-attribute-consistency.stderr
+++ b/src/test/ui/feature-gates/stability-attribute-consistency.stderr
@@ -12,3 +12,4 @@ LL | #[unstable(feature = "foo", issue = "none")]
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0711`.

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
@@ -132,5 +132,5 @@ LL | #[stable(feature = "a", since = "1.0.0")]
 
 error: aborting due to 20 previous errors
 
-Some errors have detailed explanations: E0539, E0541, E0542, E0543, E0544, E0546, E0547, E0549.
+Some errors have detailed explanations: E0539, E0541, E0542, E0543, E0544, E0546, E0547, E0549, E0711.
 For more information about an error, try `rustc --explain E0539`.

--- a/src/test/ui/variance/variance-associated-consts.stderr
+++ b/src/test/ui/variance/variance-associated-consts.stderr
@@ -6,3 +6,4 @@ LL | struct Foo<T: Trait> {
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0208`.

--- a/src/test/ui/variance/variance-associated-types.stderr
+++ b/src/test/ui/variance/variance-associated-types.stderr
@@ -12,3 +12,4 @@ LL | struct Bar<'a, T : Trait<'a>> {
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0208`.

--- a/src/test/ui/variance/variance-object-types.stderr
+++ b/src/test/ui/variance/variance-object-types.stderr
@@ -6,3 +6,4 @@ LL | struct Foo<'a> {
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0208`.

--- a/src/test/ui/variance/variance-regions-direct.stderr
+++ b/src/test/ui/variance/variance-regions-direct.stderr
@@ -42,3 +42,4 @@ LL | enum Test8<'a, 'b, 'c:'b> {
 
 error: aborting due to 7 previous errors
 
+For more information about this error, try `rustc --explain E0208`.

--- a/src/test/ui/variance/variance-regions-indirect.stderr
+++ b/src/test/ui/variance/variance-regions-indirect.stderr
@@ -30,3 +30,4 @@ LL | struct Derived4<'a, 'b, 'c:'b> {
 
 error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0208`.

--- a/src/test/ui/variance/variance-trait-bounds.stderr
+++ b/src/test/ui/variance/variance-trait-bounds.stderr
@@ -24,3 +24,4 @@ LL | struct TestBox<U,T:Getter<U>+Setter<U>> {
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0208`.

--- a/src/test/ui/variance/variance-trait-object-bound.stderr
+++ b/src/test/ui/variance/variance-trait-object-bound.stderr
@@ -6,3 +6,4 @@ LL | struct TOption<'a> {
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0208`.

--- a/src/test/ui/variance/variance-types-bounds.stderr
+++ b/src/test/ui/variance/variance-types-bounds.stderr
@@ -30,3 +30,4 @@ LL | struct TestObject<A, R> {
 
 error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0208`.

--- a/src/test/ui/variance/variance-types.stderr
+++ b/src/test/ui/variance/variance-types.stderr
@@ -36,3 +36,4 @@ LL | enum Enum<A,B,C> {
 
 error: aborting due to 6 previous errors
 
+For more information about this error, try `rustc --explain E0208`.

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -27,7 +27,8 @@ const ERROR_DOCS_PATH: &str = "compiler/rustc_error_codes/src/error_codes/";
 const ERROR_TESTS_PATH: &str = "src/test/ui/error-codes/";
 
 // Error codes that (for some reason) can't have a doctest in their explanation. Error codes are still expected to provide a code example, even if untested.
-const IGNORE_DOCTEST_CHECK: &[&str] = &["E0464", "E0570", "E0601", "E0602"];
+const IGNORE_DOCTEST_CHECK: &[&str] =
+    &["E0208", "E0464", "E0570", "E0601", "E0602", "E0640", "E0717"];
 
 // Error codes that don't yet have a UI test. This list will eventually be removed.
 const IGNORE_UI_TEST_CHECK: &[&str] = &[
@@ -193,6 +194,7 @@ fn check_error_codes_docs(
                 "warning: Error code `{err_code}` doesn't have a code example, all error codes are expected to have one \
                 (even if untested)."
             );
+            return;
         }
 
         let test_ignored = IGNORE_DOCTEST_CHECK.contains(&&err_code);

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -64,6 +64,8 @@ const PROBLEMATIC_CONSTS: &[u32] = &[
     3735927486, 3735932941, 4027431614, 4276992702,
 ];
 
+const INTERNAL_COMPILER_DOCS_LINE: &str = "#### This error code is internal to the compiler and will not be emitted with normal Rust code.";
+
 /// Parser states for `line_is_url`.
 #[derive(Clone, Copy, PartialEq)]
 #[allow(non_camel_case_types)]
@@ -132,6 +134,8 @@ fn long_line_is_ok(extension: &str, is_error_code: bool, max_columns: usize, lin
         "ftl" => true,
         // non-error code markdown is allowed to be any length
         "md" if !is_error_code => true,
+        // HACK(Ezrashaw): there is no way to split a markdown header over multiple lines
+        "md" if line == INTERNAL_COMPILER_DOCS_LINE => true,
         _ => line_is_url(is_error_code, max_columns, line) || should_ignore(line),
     }
 }


### PR DESCRIPTION
- Added empty error-code docs for `E0208`, `E0640` and `E0717` with the "internal" header as discussed on Discord.
- Wrote docs and UI test for `E0711`, again with the header.
- `tidy` changes are common-sense and make everything pass, `style.rs` hack is annoying though.

r? @GuillaumeGomez 