### PR TITLE
enable `rust_2018_idioms` lint group for doctests

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1474,6 +1474,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     /// Given a function definition like:
     ///
     /// ```rust
+    /// use std::fmt::Debug;
+    ///
     /// fn test<'a, T: Debug>(x: &'a T) -> impl Debug + 'a {
     ///     x
     /// }
@@ -1481,13 +1483,13 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     ///
     /// we will create a TAIT definition in the HIR like
     ///
-    /// ```
+    /// ```rust,ignore (pseudo-Rust)
     /// type TestReturn<'a, T, 'x> = impl Debug + 'x
     /// ```
     ///
     /// and return a type like `TestReturn<'static, T, 'a>`, so that the function looks like:
     ///
-    /// ```rust
+    /// ```rust,ignore (pseudo-Rust)
     /// fn test<'a, T: Debug>(x: &'a T) -> TestReturn<'static, T, 'a>
     /// ```
     ///

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -1038,7 +1038,7 @@ impl<'a> MethodDef<'a> {
     /// `&self.x` because that might cause an unaligned ref. So for any trait
     /// method that takes a reference, we use a local block to force a copy.
     /// This requires that the field impl `Copy`.
-    /// ```
+    /// ```rust,ignore (example)
     /// # struct A { x: u8, y: u8 }
     /// impl PartialEq for A {
     ///     fn eq(&self, other: &A) -> bool {

--- a/compiler/rustc_graphviz/src/lib.rs
+++ b/compiler/rustc_graphviz/src/lib.rs
@@ -167,7 +167,7 @@
 //!     fn node_label(&self, n: &Nd) -> dot::LabelText<'_> {
 //!         dot::LabelText::LabelStr(self.nodes[*n].into())
 //!     }
-//!     fn edge_label<'b>(&'b self, _: &Ed) -> dot::LabelText<'b> {
+//!     fn edge_label(&self, _: &Ed<'_>) -> dot::LabelText<'_> {
 //!         dot::LabelText::LabelStr("&sube;".into())
 //!     }
 //! }
@@ -177,8 +177,8 @@
 //!     type Edge = Ed<'a>;
 //!     fn nodes(&self) -> dot::Nodes<'a,Nd> { (0..self.nodes.len()).collect() }
 //!     fn edges(&'a self) -> dot::Edges<'a,Ed<'a>> { self.edges.iter().collect() }
-//!     fn source(&self, e: &Ed) -> Nd { let & &(s,_) = e; s }
-//!     fn target(&self, e: &Ed) -> Nd { let & &(_,t) = e; t }
+//!     fn source(&self, e: &Ed<'_>) -> Nd { let & &(s,_) = e; s }
+//!     fn target(&self, e: &Ed<'_>) -> Nd { let & &(_,t) = e; t }
 //! }
 //!
 //! # pub fn main() { render_to(&mut Vec::new()) }
@@ -226,11 +226,11 @@
 //!     fn node_id(&'a self, n: &Nd<'a>) -> dot::Id<'a> {
 //!         dot::Id::new(format!("N{}", n.0)).unwrap()
 //!     }
-//!     fn node_label<'b>(&'b self, n: &Nd<'b>) -> dot::LabelText<'b> {
+//!     fn node_label(&self, n: &Nd<'_>) -> dot::LabelText<'_> {
 //!         let &(i, _) = n;
 //!         dot::LabelText::LabelStr(self.nodes[i].into())
 //!     }
-//!     fn edge_label<'b>(&'b self, _: &Ed<'b>) -> dot::LabelText<'b> {
+//!     fn edge_label(&self, _: &Ed<'_>) -> dot::LabelText<'_> {
 //!         dot::LabelText::LabelStr("&sube;".into())
 //!     }
 //! }

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -1913,7 +1913,7 @@ fn is_late_bound_map(
     /// handles cycle detection as we go through the query system.
     ///
     /// This is necessary in the first place for the following case:
-    /// ```
+    /// ```rust,ignore (pseudo-Rust)
     /// type Alias<'a, T> = <T as Trait<'a>>::Assoc;
     /// fn foo<'a>(_: Alias<'a, ()>) -> Alias<'a, ()> { ... }
     /// ```

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -31,7 +31,7 @@ pub enum TypeAnnotationNeeded {
     /// ```
     E0282,
     /// An implementation cannot be chosen unambiguously because of lack of information.
-    /// ```compile_fail,E0283
+    /// ```compile_fail,E0790
     /// let _ = Default::default();
     /// ```
     E0283,

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/different_lifetimes.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/different_lifetimes.rs
@@ -21,7 +21,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
     ///
     /// Consider a case where we have
     ///
-    /// ```compile_fail,E0623
+    /// ```compile_fail
     /// fn foo(x: &mut Vec<&u8>, y: &u8) {
     ///     x.push(y);
     /// }

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -14,7 +14,7 @@ use rustc_middle::ty::{self, Region, TyCtxt};
 /// br - the bound region corresponding to the above region which is of type `BrAnon(_)`
 ///
 /// # Example
-/// ```compile_fail,E0623
+/// ```compile_fail
 /// fn foo(x: &mut Vec<&u8>, y: &u8)
 ///    { x.push(y); }
 /// ```

--- a/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
+++ b/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
@@ -13,9 +13,11 @@ use crate::infer::region_constraints::VerifyIfEq;
 
 /// Given a "verify-if-eq" type test like:
 ///
-///     exists<'a...> {
-///         verify_if_eq(some_type, bound_region)
-///     }
+/// ```rust,ignore (pseudo-Rust)
+/// exists<'a...> {
+///     verify_if_eq(some_type, bound_region)
+/// }
+/// ```
 ///
 /// and the type `test_ty` that the type test is being tested against,
 /// returns:

--- a/compiler/rustc_infer/src/infer/outlives/verify.rs
+++ b/compiler/rustc_infer/src/infer/outlives/verify.rs
@@ -277,7 +277,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
     ///
     /// It will not, however, work for higher-ranked bounds like:
     ///
-    /// ```compile_fail,E0311
+    /// ```ignore(this does compile today, previously was marked as `compile_fail,E0311`)
     /// trait Foo<'a, 'b>
     /// where for<'x> <Self as Foo<'x, 'b>>::Bar: 'x
     /// {

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -217,7 +217,7 @@ pub enum VerifyBound<'tcx> {
 /// and supplies a bound if it ended up being relevant. It's used in situations
 /// like this:
 ///
-/// ```rust
+/// ```rust,ignore (pseudo-Rust)
 /// fn foo<'a, 'b, T: SomeTrait<'a>>
 /// where
 ///    <T as SomeTrait<'a>>::Item: 'b
@@ -232,7 +232,7 @@ pub enum VerifyBound<'tcx> {
 /// In the [`VerifyBound`], this struct is enclosed in `Binder` to account
 /// for cases like
 ///
-/// ```rust
+/// ```rust,ignore (pseudo-Rust)
 /// where for<'a> <T as SomeTrait<'a>::Item: 'a
 /// ```
 ///

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -333,6 +333,7 @@ declare_lint! {
     ///
     /// ```rust,compile_fail
     /// #![deny(unused_extern_crates)]
+    /// #![deny(warnings)]
     /// extern crate proc_macro;
     /// ```
     ///
@@ -1667,6 +1668,7 @@ declare_lint! {
     ///
     /// ```rust,compile_fail
     /// #![deny(elided_lifetimes_in_paths)]
+    /// #![deny(warnings)]
     /// struct Foo<'a> {
     ///     x: &'a u32
     /// }
@@ -2158,6 +2160,7 @@ declare_lint! {
     /// ```rust,compile_fail
     /// # #![allow(unused)]
     /// #![deny(explicit_outlives_requirements)]
+    /// #![deny(warnings)]
     ///
     /// struct SharedRef<'a, T>
     /// where

--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -115,7 +115,7 @@ where
 /// ```
 /// use std::borrow::Cow;
 ///
-/// fn abs_all(input: &mut Cow<[i32]>) {
+/// fn abs_all(input: &mut Cow<'_, [i32]>) {
 ///     for i in 0..input.len() {
 ///         let v = input[i];
 ///         if v < 0 {
@@ -145,7 +145,7 @@ where
 /// ```
 /// use std::borrow::Cow;
 ///
-/// struct Items<'a, X: 'a> where [X]: ToOwned<Owned = Vec<X>> {
+/// struct Items<'a, X> where [X]: ToOwned<Owned = Vec<X>> {
 ///     values: Cow<'a, [X]>,
 /// }
 ///
@@ -267,7 +267,7 @@ impl<B: ?Sized + ToOwned> Cow<'_, B> {
     ///
     /// assert_eq!(
     ///   cow,
-    ///   Cow::Owned(String::from("FOO")) as Cow<str>
+    ///   Cow::Owned(String::from("FOO")) as Cow<'_, str>
     /// );
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -311,7 +311,7 @@ impl<B: ?Sized + ToOwned> Cow<'_, B> {
     /// use std::borrow::Cow;
     ///
     /// let s = "Hello world!";
-    /// let cow: Cow<str> = Cow::Owned(String::from(s));
+    /// let cow: Cow<'_, str> = Cow::Owned(String::from(s));
     ///
     /// assert_eq!(
     ///   cow.into_owned(),

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -363,7 +363,7 @@
 //! # use std::fmt;
 //! # struct Foo; // our custom type
 //! # impl fmt::Display for Foo {
-//! fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+//! fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 //! # write!(f, "testing, testing")
 //! # } }
 //! ```
@@ -399,7 +399,7 @@
 //! }
 //!
 //! impl fmt::Display for Vector2D {
-//!     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+//!     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 //!         // The `f` value implements the `Write` trait, which is what the
 //!         // write! macro is expecting. Note that this formatting ignores the
 //!         // various flags provided to format strings.
@@ -410,7 +410,7 @@
 //! // Different traits allow different forms of output of a type. The meaning
 //! // of this format is to print the magnitude of a vector.
 //! impl fmt::Binary for Vector2D {
-//!     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+//!     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 //!         let magnitude = (self.x * self.x + self.y * self.y) as f64;
 //!         let magnitude = magnitude.sqrt();
 //!
@@ -517,7 +517,7 @@
 //! let mut some_writer = io::stdout();
 //! write!(&mut some_writer, "{}", format_args!("print with a {}", "macro"));
 //!
-//! fn my_fmt_fn(args: fmt::Arguments) {
+//! fn my_fmt_fn(args: fmt::Arguments<'_>) {
 //!     write!(&mut io::stdout(), "{args}");
 //! }
 //! my_fmt_fn(format_args!(", or a {} too", "function"));

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2039,7 +2039,7 @@ where
     /// ```rust
     /// # use std::rc::Rc;
     /// # use std::borrow::Cow;
-    /// let cow: Cow<str> = Cow::Borrowed("eggplant");
+    /// let cow: Cow<'_, str> = Cow::Borrowed("eggplant");
     /// let shared: Rc<str> = Rc::from(cow);
     /// assert_eq!("eggplant", &shared[..]);
     /// ```

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2732,7 +2732,7 @@ impl<'a> From<Cow<'a, str>> for String {
     /// ```
     /// # use std::borrow::Cow;
     /// // If the string is not owned...
-    /// let cow: Cow<str> = Cow::Borrowed("eggplant");
+    /// let cow: Cow<'_, str> = Cow::Borrowed("eggplant");
     /// // It will allocate on the heap and copy the string.
     /// let owned: String = String::from(cow);
     /// assert_eq!(&owned[..], "eggplant");

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2768,7 +2768,7 @@ where
     /// ```rust
     /// # use std::sync::Arc;
     /// # use std::borrow::Cow;
-    /// let cow: Cow<str> = Cow::Borrowed("eggplant");
+    /// let cow: Cow<'_, str> = Cow::Borrowed("eggplant");
     /// let shared: Arc<str> = Arc::from(cow);
     /// assert_eq!("eggplant", &shared[..]);
     /// ```

--- a/library/alloc/src/vec/drain.rs
+++ b/library/alloc/src/vec/drain.rs
@@ -16,7 +16,7 @@ use super::Vec;
 ///
 /// ```
 /// let mut v = vec![0, 1, 2];
-/// let iter: std::vec::Drain<_> = v.drain(..);
+/// let iter: std::vec::Drain<'_, _> = v.drain(..);
 /// ```
 #[stable(feature = "drain", since = "1.6.0")]
 pub struct Drain<

--- a/library/alloc/src/vec/drain_filter.rs
+++ b/library/alloc/src/vec/drain_filter.rs
@@ -16,7 +16,7 @@ use super::Vec;
 /// #![feature(drain_filter)]
 ///
 /// let mut v = vec![0, 1, 2];
-/// let iter: std::vec::DrainFilter<_, _> = v.drain_filter(|x| *x % 2 == 0);
+/// let iter: std::vec::DrainFilter<'_, _, _> = v.drain_filter(|x| *x % 2 == 0);
 /// ```
 #[unstable(feature = "drain_filter", reason = "recently added", issue = "43244")]
 #[derive(Debug)]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3142,8 +3142,8 @@ where
     ///
     /// ```
     /// # use std::borrow::Cow;
-    /// let o: Cow<[i32]> = Cow::Owned(vec![1, 2, 3]);
-    /// let b: Cow<[i32]> = Cow::Borrowed(&[1, 2, 3]);
+    /// let o: Cow<'_, [i32]> = Cow::Owned(vec![1, 2, 3]);
+    /// let b: Cow<'_, [i32]> = Cow::Borrowed(&[1, 2, 3]);
     /// assert_eq!(Vec::from(o), Vec::from(b));
     /// ```
     fn from(s: Cow<'a, [T]>) -> Vec<T> {

--- a/library/alloc/src/vec/splice.rs
+++ b/library/alloc/src/vec/splice.rs
@@ -14,7 +14,7 @@ use super::{Drain, Vec};
 /// ```
 /// let mut v = vec![0, 1, 2];
 /// let new = [7, 8];
-/// let iter: std::vec::Splice<_> = v.splice(1.., new);
+/// let iter: std::vec::Splice<'_, _> = v.splice(1.., new);
 /// ```
 #[derive(Debug)]
 #[stable(feature = "vec_splice", since = "1.21.0")]

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -115,7 +115,7 @@
 //!     let shared_map: Rc<RefCell<_>> = Rc::new(RefCell::new(HashMap::new()));
 //!     // Create a new block to limit the scope of the dynamic borrow
 //!     {
-//!         let mut map: RefMut<_> = shared_map.borrow_mut();
+//!         let mut map: RefMut<'_, _> = shared_map.borrow_mut();
 //!         map.insert("africa", 92388);
 //!         map.insert("kyoto", 11837);
 //!         map.insert("piccadilly", 11826);
@@ -1435,8 +1435,8 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     /// use std::cell::{RefCell, Ref};
     ///
     /// let c = RefCell::new((5, 'b'));
-    /// let b1: Ref<(u32, char)> = c.borrow();
-    /// let b2: Ref<u32> = Ref::map(b1, |t| &t.0);
+    /// let b1: Ref<'_, (u32, char)> = c.borrow();
+    /// let b2: Ref<'_, u32> = Ref::map(b1, |t| &t.0);
     /// assert_eq!(*b2, 5)
     /// ```
     #[stable(feature = "cell_map", since = "1.8.0")]
@@ -1464,8 +1464,8 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     /// use std::cell::{RefCell, Ref};
     ///
     /// let c = RefCell::new(vec![1, 2, 3]);
-    /// let b1: Ref<Vec<u32>> = c.borrow();
-    /// let b2: Result<Ref<u32>, _> = Ref::filter_map(b1, |v| v.get(1));
+    /// let b1: Ref<'_, Vec<u32>> = c.borrow();
+    /// let b2: Result<Ref<'_, u32>, _> = Ref::filter_map(b1, |v| v.get(1));
     /// assert_eq!(*b2.unwrap(), 2);
     /// ```
     #[stable(feature = "cell_filter_map", since = "1.63.0")]
@@ -1577,8 +1577,8 @@ impl<'b, T: ?Sized> RefMut<'b, T> {
     ///
     /// let c = RefCell::new((5, 'b'));
     /// {
-    ///     let b1: RefMut<(u32, char)> = c.borrow_mut();
-    ///     let mut b2: RefMut<u32> = RefMut::map(b1, |t| &mut t.0);
+    ///     let b1: RefMut<'_, (u32, char)> = c.borrow_mut();
+    ///     let mut b2: RefMut<'_, u32> = RefMut::map(b1, |t| &mut t.0);
     ///     assert_eq!(*b2, 5);
     ///     *b2 = 42;
     /// }
@@ -1612,8 +1612,8 @@ impl<'b, T: ?Sized> RefMut<'b, T> {
     /// let c = RefCell::new(vec![1, 2, 3]);
     ///
     /// {
-    ///     let b1: RefMut<Vec<u32>> = c.borrow_mut();
-    ///     let mut b2: Result<RefMut<u32>, _> = RefMut::filter_map(b1, |v| v.get_mut(1));
+    ///     let b1: RefMut<'_, Vec<u32>> = c.borrow_mut();
+    ///     let mut b2: Result<RefMut<'_, u32>, _> = RefMut::filter_map(b1, |v| v.get_mut(1));
     ///
     ///     if let Ok(mut b2) = b2 {
     ///         *b2 += 2;

--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -60,7 +60,7 @@ impl fmt::Write for PadAdapter<'_, '_> {
 /// }
 ///
 /// impl fmt::Debug for Foo {
-///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         fmt.debug_struct("Foo")
 ///            .field("bar", &self.bar)
 ///            .field("baz", &self.baz)
@@ -249,7 +249,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
 /// struct Foo(i32, String);
 ///
 /// impl fmt::Debug for Foo {
-///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         fmt.debug_tuple("Foo")
 ///            .field(&self.0)
 ///            .field(&self.1)
@@ -418,7 +418,7 @@ impl<'a, 'b: 'a> DebugInner<'a, 'b> {
 /// struct Foo(Vec<i32>);
 ///
 /// impl fmt::Debug for Foo {
-///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         fmt.debug_set().entries(self.0.iter()).finish()
 ///     }
 /// }
@@ -548,7 +548,7 @@ impl<'a, 'b: 'a> DebugSet<'a, 'b> {
 /// struct Foo(Vec<i32>);
 ///
 /// impl fmt::Debug for Foo {
-///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         fmt.debug_list().entries(self.0.iter()).finish()
 ///     }
 /// }
@@ -678,7 +678,7 @@ impl<'a, 'b: 'a> DebugList<'a, 'b> {
 /// struct Foo(Vec<(String, i32)>);
 ///
 /// impl fmt::Debug for Foo {
-///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         fmt.debug_map().entries(self.0.iter().map(|&(ref k, ref v)| (k, v))).finish()
 ///     }
 /// }

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -534,7 +534,7 @@ impl<'a> Arguments<'a> {
     ///
     /// fn write_str(_: &str) { /* ... */ }
     ///
-    /// fn write_fmt(args: &Arguments) {
+    /// fn write_fmt(args: &Arguments<'_>) {
     ///     if let Some(s) = args.as_str() {
     ///         write_str(s)
     ///     } else {
@@ -1381,7 +1381,7 @@ impl<'a> Formatter<'a> {
     /// }
     ///
     /// impl fmt::Display for Foo {
-    ///     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         // We need to remove "-" from the number output.
     ///         let tmp = self.nb.abs().to_string();
     ///
@@ -1481,7 +1481,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo;
     ///
     /// impl fmt::Display for Foo {
-    ///     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         formatter.pad("Foo")
     ///     }
     /// }
@@ -1663,7 +1663,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo;
     ///
     /// impl fmt::Display for Foo {
-    ///     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         formatter.write_str("Foo")
     ///         // This is equivalent to:
     ///         // write!(formatter, "Foo")
@@ -1688,7 +1688,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo(i32);
     ///
     /// impl fmt::Display for Foo {
-    ///     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         formatter.write_fmt(format_args!("Foo {}", self.0))
     ///     }
     /// }
@@ -1723,7 +1723,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo;
     ///
     /// impl fmt::Display for Foo {
-    ///     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         let c = formatter.fill();
     ///         if let Some(width) = formatter.width() {
     ///             for _ in 0..width {
@@ -1751,14 +1751,12 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```
-    /// extern crate core;
-    ///
     /// use std::fmt::{self, Alignment};
     ///
     /// struct Foo;
     ///
     /// impl fmt::Display for Foo {
-    ///     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         let s = if let Some(s) = formatter.align() {
     ///             match s {
     ///                 Alignment::Left    => "left",
@@ -1798,7 +1796,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo(i32);
     ///
     /// impl fmt::Display for Foo {
-    ///     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         if let Some(width) = formatter.width() {
     ///             // If we received a width, we use it
     ///             write!(formatter, "{:width$}", format!("Foo({})", self.0), width = width)
@@ -1829,7 +1827,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo(f32);
     ///
     /// impl fmt::Display for Foo {
-    ///     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         if let Some(precision) = formatter.precision() {
     ///             // If we received a precision, we use it.
     ///             write!(formatter, "Foo({1:.*})", precision, self.0)
@@ -1859,7 +1857,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo(i32);
     ///
     /// impl fmt::Display for Foo {
-    ///     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         if formatter.sign_plus() {
     ///             write!(formatter,
     ///                    "Foo({}{})",
@@ -1891,7 +1889,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo(i32);
     ///
     /// impl fmt::Display for Foo {
-    ///     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         if formatter.sign_minus() {
     ///             // You want a minus sign? Have one!
     ///             write!(formatter, "-Foo({})", self.0)
@@ -1920,7 +1918,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo(i32);
     ///
     /// impl fmt::Display for Foo {
-    ///     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         if formatter.alternate() {
     ///             write!(formatter, "Foo({})", self.0)
     ///         } else {
@@ -1948,7 +1946,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo(i32);
     ///
     /// impl fmt::Display for Foo {
-    ///     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         assert!(formatter.sign_aware_zero_pad());
     ///         assert_eq!(formatter.width(), Some(4));
     ///         // We ignore the formatter's options.
@@ -1992,7 +1990,7 @@ impl<'a> Formatter<'a> {
     /// }
     ///
     /// impl fmt::Debug for Foo {
-    ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         fmt.debug_struct("Foo")
     ///             .field("bar", &self.bar)
     ///             .field("baz", &self.baz)
@@ -2150,7 +2148,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo<T>(i32, String, PhantomData<T>);
     ///
     /// impl<T> fmt::Debug for Foo<T> {
-    ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         fmt.debug_tuple("Foo")
     ///             .field(&self.0)
     ///             .field(&self.1)
@@ -2282,7 +2280,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo(Vec<i32>);
     ///
     /// impl fmt::Debug for Foo {
-    ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         fmt.debug_list().entries(self.0.iter()).finish()
     ///     }
     /// }
@@ -2305,7 +2303,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo(Vec<i32>);
     ///
     /// impl fmt::Debug for Foo {
-    ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         fmt.debug_set().entries(self.0.iter()).finish()
     ///     }
     /// }
@@ -2321,14 +2319,14 @@ impl<'a> Formatter<'a> {
     /// ```rust
     /// use std::fmt;
     ///
-    /// struct Arm<'a, L: 'a, R: 'a>(&'a (L, R));
-    /// struct Table<'a, K: 'a, V: 'a>(&'a [(K, V)], V);
+    /// struct Arm<'a, L, R>(&'a (L, R));
+    /// struct Table<'a, K, V>(&'a [(K, V)], V);
     ///
     /// impl<'a, L, R> fmt::Debug for Arm<'a, L, R>
     /// where
     ///     L: 'a + fmt::Debug, R: 'a + fmt::Debug
     /// {
-    ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         L::fmt(&(self.0).0, fmt)?;
     ///         fmt.write_str(" => ")?;
     ///         R::fmt(&(self.0).1, fmt)
@@ -2339,7 +2337,7 @@ impl<'a> Formatter<'a> {
     /// where
     ///     K: 'a + fmt::Debug, V: 'a + fmt::Debug
     /// {
-    ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         fmt.debug_set()
     ///         .entries(self.0.iter().map(Arm))
     ///         .entry(&Arm(&(format_args!("_"), &self.1)))
@@ -2363,7 +2361,7 @@ impl<'a> Formatter<'a> {
     /// struct Foo(Vec<(String, i32)>);
     ///
     /// impl fmt::Debug for Foo {
-    ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         fmt.debug_map().entries(self.0.iter().map(|&(ref k, ref v)| (k, v))).finish()
     ///     }
     /// }

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -15,7 +15,6 @@
 //! ```rust
 //! #![feature(core_intrinsics, custom_mir)]
 //!
-//! extern crate core;
 //! use core::intrinsics::mir::*;
 //!
 //! #[custom_mir(dialect = "built")]
@@ -65,7 +64,6 @@
 //! ```rust
 //! #![feature(core_intrinsics, custom_mir)]
 //!
-//! extern crate core;
 //! use core::intrinsics::mir::*;
 //!
 //! #[custom_mir(dialect = "built")]
@@ -317,7 +315,6 @@ define!(
     /// ```rust
     /// #![feature(custom_mir, core_intrinsics)]
     ///
-    /// extern crate core;
     /// use core::intrinsics::mir::*;
     ///
     /// #[custom_mir(dialect = "built")]

--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -15,7 +15,7 @@ use crate::ops::Try;
 ///
 /// let a1 = [1, 2, 3];
 /// let a2 = [4, 5, 6];
-/// let iter: Chain<Iter<_>, Iter<_>> = a1.iter().chain(a2.iter());
+/// let iter: Chain<Iter<'_, _>, Iter<'_, _>> = a1.iter().chain(a2.iter());
 /// ```
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -498,7 +498,6 @@ macro_rules! r#try {
 /// In a `no_std` setup you are responsible for the implementation details of the components.
 ///
 /// ```no_run
-/// # extern crate core;
 /// use core::fmt::Write;
 ///
 /// struct Example;

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -591,7 +591,7 @@ impl<T: ?Sized> !Sync for *mut T {}
 /// use std::marker::PhantomData;
 ///
 /// # #[allow(dead_code)]
-/// struct Slice<'a, T: 'a> {
+/// struct Slice<'a, T> {
 ///     start: *const T,
 ///     end: *const T,
 ///     phantom: PhantomData<&'a T>,
@@ -607,7 +607,7 @@ impl<T: ?Sized> !Sync for *mut T {}
 /// ```
 /// # #![allow(dead_code)]
 /// # use std::marker::PhantomData;
-/// # struct Slice<'a, T: 'a> {
+/// # struct Slice<'a, T> {
 /// #     start: *const T,
 /// #     end: *const T,
 /// #     phantom: PhantomData<&'a T>,

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -517,7 +517,7 @@ div_impl_float! { f32 f64 }
 /// use std::ops::Rem;
 ///
 /// #[derive(PartialEq, Debug)]
-/// struct SplitSlice<'a, T: 'a> {
+/// struct SplitSlice<'a, T> {
 ///     slice: &'a [T],
 /// }
 ///

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -555,6 +555,7 @@ impl Copy for () {
 ///
 /// ```
 /// # #![feature(rustc_private)]
+/// #[allow(unused_extern_crates)]
 /// extern crate libc;
 ///
 /// use std::mem;

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -2287,7 +2287,7 @@ mod use_keyword {}
 /// # #![allow(dead_code)]
 /// pub enum Cow<'a, B>
 /// where
-///     B: 'a + ToOwned + ?Sized,
+///     B: ToOwned + ?Sized,
 /// {
 ///     Borrowed(&'a B),
 ///     Owned(<B as ToOwned>::Owned),

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -368,7 +368,7 @@ pub trait OpenOptionsExt {
     ///
     /// ```no_run
     /// # #![feature(rustc_private)]
-    /// extern crate libc;
+    /// use libc;
     /// use std::fs::OpenOptions;
     /// use std::os::unix::fs::OpenOptionsExt;
     ///

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -117,7 +117,7 @@ use crate::sys::path::{is_sep_byte, is_verbatim_sep, parse_prefix, MAIN_SEP_STR}
 /// use std::path::Prefix::*;
 /// use std::ffi::OsStr;
 ///
-/// fn get_path_prefix(s: &str) -> Prefix {
+/// fn get_path_prefix(s: &str) -> Prefix<'_> {
 ///     let path = Path::new(s);
 ///     match path.components().next().unwrap() {
 ///         Component::Prefix(prefix_component) => prefix_component.kind(),

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -555,6 +555,7 @@ impl Copy for () {
 ///
 /// ```
 /// # #![feature(rustc_private)]
+/// #[allow(unused_extern_crates)]
 /// extern crate libc;
 ///
 /// use std::mem;

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1835,7 +1835,7 @@ impl ExitCode {
     /// # use std::fmt;
     /// # enum UhOhError { GenericProblem, Specific, WithCode { exit_code: ExitCode, _x: () } }
     /// # impl fmt::Display for UhOhError {
-    /// #     fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+    /// #     fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { unimplemented!() }
     /// # }
     /// // there's no way to gracefully recover from an UhOhError, so we just
     /// // print a message and exit

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -2146,6 +2146,10 @@ impl<'a> Builder<'a> {
 #[cfg(test)]
 mod tests;
 
+/// Represents flag values in `String` form with whitespace delimiter to pass it to the compiler later.
+///
+/// `-Z crate-attr` flags will be applied recursively on the target code using the `rustc_parse::parser::Parser`.
+/// See `rustc_builtin_macros::cmdline_attrs::inject` for more information.
 #[derive(Debug, Clone)]
 struct Rustflags(String, TargetSelection);
 

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -412,6 +412,8 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, stage: u32, car
         format!("-Zcrate-attr=doc(html_root_url=\"{}/\")", builder.doc_rust_lang_org_channel(),);
     cargo.rustflag(&html_root);
     cargo.rustdocflag(&html_root);
+
+    cargo.rustdocflag("-Zcrate-attr=warn(rust_2018_idioms)");
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -810,6 +812,9 @@ pub fn rustc_cargo(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetSelec
         .arg(builder.rustc_features(builder.kind))
         .arg("--manifest-path")
         .arg(builder.src.join("compiler/rustc/Cargo.toml"));
+
+    cargo.rustdocflag("-Zcrate-attr=warn(rust_2018_idioms)");
+
     rustc_cargo_env(builder, cargo, target, stage);
 }
 


### PR DESCRIPTION
With this change, `rust_2018_idioms` lint group will be enabled for compiler/libstd doctests.

Resolves #106086 
Resolves #99144

Signed-off-by: ozkanonur <work@onurozkan.dev>