### PR TITLE
Remove unneeded ItemId::Primitive variant

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -600,7 +600,9 @@ fn build_module_items(
                 items.push(clean::Item {
                     name: None,
                     attrs: Box::new(clean::Attributes::default()),
-                    item_id: ItemId::Primitive(prim_ty, did.krate),
+                    // We can use the item's `DefId` directly since the only information ever used
+                    // from it is `DefId.krate`.
+                    item_id: ItemId::DefId(did),
                     kind: Box::new(clean::ImportItem(clean::Import::new_simple(
                         item.ident.name,
                         clean::ImportSource {

--- a/src/librustdoc/formats/mod.rs
+++ b/src/librustdoc/formats/mod.rs
@@ -53,12 +53,6 @@ impl Impl {
             ItemId::Blanket { impl_id, .. } => impl_id,
             ItemId::Auto { trait_, .. } => trait_,
             ItemId::DefId(def_id) => def_id,
-            ItemId::Primitive(_, _) => {
-                panic!(
-                    "Unexpected ItemId::Primitive in expect_def_id: {:?}",
-                    self.impl_item.item_id
-                )
-            }
         }
     }
 

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -252,7 +252,6 @@ pub(crate) fn from_item_id_with_name(item_id: ItemId, tcx: TyCtxt<'_>, name: Opt
         ItemId::Auto { for_, trait_ } => {
             Id(format!("a:{}-{}", DisplayDefId(trait_, tcx, None), DisplayDefId(for_, tcx, name)))
         }
-        ItemId::Primitive(_, _) => unreachable!(),
     }
 }
 


### PR DESCRIPTION
As I mentioned [here](https://github.com/rust-lang/rust/pull/106412#issuecomment-1371405115), I wondered if `ItemId::Primitive` was actually used for anything. Apparently, it seems so because removing it led to no changes as far as I and tests could see.

r? @notriddle 