### PR TITLE
std tests: use __OsLocalKeyInner from realstd

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -177,18 +177,18 @@ use crate::sys_common::thread_parking::Parker;
 use crate::sys_common::{AsInner, IntoInner};
 use crate::time::Duration;
 
+#[stable(feature = "scoped_threads", since = "1.63.0")]
+mod scoped;
+
+#[stable(feature = "scoped_threads", since = "1.63.0")]
+pub use scoped::{scope, Scope, ScopedJoinHandle};
+
 ////////////////////////////////////////////////////////////////////////////////
 // Thread-local storage
 ////////////////////////////////////////////////////////////////////////////////
 
 #[macro_use]
 mod local;
-
-#[stable(feature = "scoped_threads", since = "1.63.0")]
-mod scoped;
-
-#[stable(feature = "scoped_threads", since = "1.63.0")]
-pub use scoped::{scope, Scope, ScopedJoinHandle};
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::local::{AccessError, LocalKey};
@@ -209,7 +209,6 @@ pub use self::local::{AccessError, LocalKey};
 ))]
 #[doc(hidden)]
 pub use self::local::fast::Key as __FastLocalKeyInner;
-
 // when building for tests, use real std's type
 #[unstable(feature = "libstd_thread_internals", issue = "none")]
 #[cfg(test)]
@@ -220,12 +219,21 @@ pub use self::local::fast::Key as __FastLocalKeyInner;
 pub use realstd::thread::__FastLocalKeyInner;
 
 #[unstable(feature = "libstd_thread_internals", issue = "none")]
+#[cfg(not(test))]
 #[cfg(all(
     not(target_thread_local),
     not(all(target_family = "wasm", not(target_feature = "atomics"))),
 ))]
 #[doc(hidden)]
 pub use self::local::os::Key as __OsLocalKeyInner;
+// when building for tests, use real std's type
+#[unstable(feature = "libstd_thread_internals", issue = "none")]
+#[cfg(test)]
+#[cfg(all(
+    not(target_thread_local),
+    not(all(target_family = "wasm", not(target_feature = "atomics"))),
+))]
+pub use realstd::thread::__OsLocalKeyInner;
 
 #[unstable(feature = "libstd_thread_internals", issue = "none")]
 #[cfg(all(target_family = "wasm", not(target_feature = "atomics")))]


### PR DESCRIPTION
This is basically the same as https://github.com/rust-lang/rust/pull/100201, but for __OsLocalKeyInner:

Some std tests are failing in Miri on Windows because [this static](https://github.com/rust-lang/rust/blob/a377893da2cd7124e5a18c7116cbb70e16dd5541/library/std/src/sys/windows/thread_local_key.rs#L234-L239) is getting duplicated, and Miri does not handle that properly -- Miri does not support this magic `.CRT$XLB` linker section, but instead just looks up this particular hard-coded static in the standard library. This PR lets the test suite use the std static instead of having its own copy.

Fixes https://github.com/rust-lang/miri/issues/2754
r? @thomcc