### PR TITLE
Allow only implementing `Read::read_buf`

### DIFF
--- a/library/alloc/src/io/read.rs
+++ b/library/alloc/src/io/read.rs
@@ -84,6 +84,7 @@ use crate::vec::Vec;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(notable_trait)]
 #[cfg_attr(not(test), rustc_diagnostic_item = "IoRead")]
+#[rustc_must_implement_one_of(read, read_buf)]
 pub trait Read {
     /// Pull some bytes from this source into the specified buffer, returning
     /// how many bytes were read.
@@ -164,7 +165,10 @@ pub trait Read {
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let mut buf = BorrowedBuf::from(buf);
+        self.read_buf(buf.unfilled()).map(|()| buf.len())
+    }
 
     /// Like `read`, except that it reads into a slice of buffers.
     ///

--- a/library/core/src/io/util.rs
+++ b/library/core/src/io/util.rs
@@ -130,7 +130,7 @@ impl Seek for Empty {
 /// [`Ok(0)`]: Ok
 ///
 /// [`write`]: crate::io::Write::write
-/// [`read`]: ../../std/io/trait.Read.html#tymethod.read
+/// [`read`]: ../../std/io/trait.Read.html#method.read
 ///
 /// # Examples
 ///

--- a/tests/rustdoc-html/jump-to-def/non-local-method.rs
+++ b/tests/rustdoc-html/jump-to-def/non-local-method.rs
@@ -16,7 +16,7 @@ use std::cmp::Ordering;
 use std::marker::PhantomData;
 
 pub fn bar2<T: Read>(readable: T) {
-    //@ has - '//a[@href="{{channel}}/alloc/io/read/trait.Read.html#tymethod.read"]' 'read'
+    //@ has - '//a[@href="{{channel}}/alloc/io/read/trait.Read.html#method.read"]' 'read'
     let _ = readable.read(&mut []);
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/106643)*
<!-- homu-ignore:end -->

This PR allows users to only implement `Read::read_buf`, without the need for implementing `Read::read`. `rustc_must_implement_one_of` annotation ensures that **at least** one of the methods is implemented, so that the default impls don't create infinite recursion.

Note that `Read::read_buf` is unstable, so this doesn't change anything on stable, there you still need to implement `Read::read`, since you can't implement `Read::read_buf`. Thus, we don't expose `rustc_must_implement_one_of` to stable.

r? @thomcc