### PR TITLE
Fix help docs for -Zallow-features

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1241,7 +1241,7 @@ options! {
 
     // tidy-alphabetical-start
     allow_features: Option<Vec<String>> = (None, parse_opt_comma_list, [TRACKED],
-        "only allow the listed language features to be enabled in code (space separated)"),
+        "only allow the listed language features to be enabled in code (comma separated)"),
     always_encode_mir: bool = (false, parse_bool, [TRACKED],
         "encode MIR of all functions into the crate metadata (default: no)"),
     asm_comments: bool = (false, parse_bool, [TRACKED],

--- a/src/test/rustdoc-ui/z-help.stdout
+++ b/src/test/rustdoc-ui/z-help.stdout
@@ -1,4 +1,4 @@
-    -Z                          allow-features=val -- only allow the listed language features to be enabled in code (space separated)
+    -Z                          allow-features=val -- only allow the listed language features to be enabled in code (comma separated)
     -Z                       always-encode-mir=val -- encode MIR of all functions into the crate metadata (default: no)
     -Z                            asm-comments=val -- generate comments into the assembly (may change behavior) (default: no)
     -Z                       assert-incr-state=val -- assert that the incremental cache is in given state: either `loaded` or `not-loaded`.


### PR DESCRIPTION
The arguments for -Zallow-features are comma-separated (`parse_opt_comma_list`), not space separated (`parse_list`).
