### PR TITLE
Add a regression test for argument copies with DestinationPropagation

### DIFF
--- a/tests/codegen/move-operands.rs
+++ b/tests/codegen/move-operands.rs
@@ -1,0 +1,12 @@
+// compile-flags: -C no-prepopulate-passes -Zmir-enable-passes=+DestinationPropagation
+
+#![crate_type = "lib"]
+
+type T = [u8; 256];
+
+#[no_mangle]
+pub fn f(a: T, b: fn(_: T, _: T)) {
+    // CHECK: call void @llvm.memcpy.{{.*}}({{i8\*|ptr}} align 1 %{{.*}}, {{i8\*|ptr}} align 1 %{{.*}}, {{.*}} 256, i1 false)
+    // CHECK-NOT: call void @llvm.memcpy.{{.*}}({{i8\*|ptr}} align 1 %{{.*}}, {{i8\*|ptr}} align 1 %{{.*}}, {{.*}} 256, i1 false)
+    b(a, a)
+}


### PR DESCRIPTION
This example, as a codegen test: https://github.com/rust-lang/rust/pull/105813#issuecomment-1367947793

r? @tmiasko 