### PR TITLE
specialize impl of `ToString` on `bool`

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2549,6 +2549,15 @@ impl ToString for char {
 }
 
 #[cfg(not(no_global_oom_handling))]
+#[stable(feature = "bool_to_string_specialization", since = "CURRENT_RUSTC_VERSION")]
+impl ToString for bool {
+    #[inline]
+    fn to_string(&self) -> String {
+        String::from(if *self { "true" } else { "false" })
+    }
+}
+
+#[cfg(not(no_global_oom_handling))]
 #[stable(feature = "u8_to_string_specialization", since = "1.54.0")]
 impl ToString for u8 {
     #[inline]


### PR DESCRIPTION
Fixes #106611

Specialize `bool`s `ToString` impl by copying it from `Display`. This is a significant optimization as we avoid lots of dynamic dispatch. AFAIK, this doesn't require a API Change Proposal as this doesn't regress existing code and can be undone without regressing code.