### PR TITLE
create helper function for `rustc_lint_defs::Level` and remove it's duplicated code

### DIFF
--- a/compiler/rustc_errors/src/diagnostic_impls.rs
+++ b/compiler/rustc_errors/src/diagnostic_impls.rs
@@ -179,16 +179,7 @@ impl IntoDiagnosticArg for type_ir::FloatTy {
 
 impl IntoDiagnosticArg for Level {
     fn into_diagnostic_arg(self) -> DiagnosticArgValue<'static> {
-        DiagnosticArgValue::Str(Cow::Borrowed(match self {
-            Level::Allow => "-A",
-            Level::Warn => "-W",
-            Level::ForceWarn(_) => "--force-warn",
-            Level::Deny => "-D",
-            Level::Forbid => "-F",
-            Level::Expect(_) => {
-                unreachable!("lints with the level of `expect` should not run this code");
-            }
-        }))
+        DiagnosticArgValue::Str(Cow::Borrowed(self.to_cmd_flag()))
     }
 }
 

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -253,6 +253,19 @@ impl Level {
         }
     }
 
+    pub fn to_cmd_flag(self) -> &'static str {
+        match self {
+            Level::Warn => "-W",
+            Level::Deny => "-D",
+            Level::Forbid => "-F",
+            Level::Allow => "-A",
+            Level::ForceWarn(_) => "--force-warn",
+            Level::Expect(_) => {
+                unreachable!("the expect level does not have a commandline flag")
+            }
+        }
+    }
+
     pub fn is_error(self) -> bool {
         match self {
             Level::Allow | Level::Expect(_) | Level::Warn | Level::ForceWarn(_) => false,

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -234,16 +234,7 @@ pub fn explain_lint_level_source(
             err.note_once(&format!("`#[{}({})]` on by default", level.as_str(), name));
         }
         LintLevelSource::CommandLine(lint_flag_val, orig_level) => {
-            let flag = match orig_level {
-                Level::Warn => "-W",
-                Level::Deny => "-D",
-                Level::Forbid => "-F",
-                Level::Allow => "-A",
-                Level::ForceWarn(_) => "--force-warn",
-                Level::Expect(_) => {
-                    unreachable!("the expect level does not have a commandline flag")
-                }
-            };
+            let flag = orig_level.to_cmd_flag();
             let hyphen_case_lint_name = name.replace('_', "-");
             if lint_flag_val.as_str() == name {
                 err.note_once(&format!(


### PR DESCRIPTION
Signed-off-by: ozkanonur <work@onurozkan.dev>