### PR TITLE
Mark ZST as FFI-safe if all its fields are PhantomData

### DIFF
--- a/tests/ui/lint/lint-ffi-safety-all-phantom.rs
+++ b/tests/ui/lint/lint-ffi-safety-all-phantom.rs
@@ -1,0 +1,22 @@
+// This is a regression test for issue https://github.com/rust-lang/rust/issues/106629.
+// It ensures that transparent types where all fields are PhantomData are marked as
+// FFI-safe.
+
+// check-pass
+
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+struct MyPhantom(core::marker::PhantomData<u8>);
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Bar {
+    pub x: i32,
+    _marker: MyPhantom,
+}
+
+extern "C" {
+    pub fn foo(bar: *mut Bar);
+}
+
+fn main() {}


### PR DESCRIPTION
This presents one possible solution to issue: #106629.

This is my first (tentative) contribution to the compiler itself.

I'm looking forward for comments and feedback

Closes: #106629