### PR TITLE
Disable fast submodule checkout due to spurious ci failures

### DIFF
--- a/src/ci/scripts/checkout-submodules.sh
+++ b/src/ci/scripts/checkout-submodules.sh
@@ -36,7 +36,8 @@ function fetch_github_commit_archive {
     rm $cached
 }
 
-included="src/llvm-project src/doc/book src/doc/rust-by-example"
+#included="src/llvm-project src/doc/book src/doc/rust-by-example"
+included=""
 modules="$(git config --file .gitmodules --get-regexp '\.path$' | cut -d' ' -f2)"
 modules=($modules)
 use_git=""
@@ -60,9 +61,9 @@ done
 retry sh -c "git submodule deinit -f $use_git && \
     git submodule sync && \
     git submodule update -j 16 --init --recursive --depth 1 $use_git"
-STATUS=0
-for pid in ${bg_pids[*]}
-do
-    wait $pid || STATUS=1
-done
-exit ${STATUS}
+#STATUS=0
+#for pid in ${bg_pids[*]}
+#do
+#    wait $pid || STATUS=1
+#done
+#exit ${STATUS}


### PR DESCRIPTION
Same fix we included in https://github.com/rust-lang/rust/pull/98423.