### PR TITLE
Fix invalid files array re-creation in rustdoc-gui tester

### DIFF
--- a/src/tools/rustdoc-gui/tester.js
+++ b/src/tools/rustdoc-gui/tester.js
@@ -278,7 +278,8 @@ async function main(argv) {
         await runTests(opts, framework_options, files, new_results, status_bar, it + 1 >= NB_RETRY);
         Array.prototype.push.apply(results.successful, new_results.successful);
         // We generate the new list of files with the previously failing tests.
-        files = Array.prototype.concat(new_results.failed, new_results.errored);
+        files = Array.prototype.concat(new_results.failed, new_results.errored).map(
+            f => f['file_name']);
         if (files.length > originalFilesLen / 2) {
             // If we have too many failing tests, it's very likely not flaky failures anymore so
             // no need to retry.


### PR DESCRIPTION
It fixes the error <code>expected `runTest` first argument to be a string</code>:

```
{
  file_name: {
    file_name: '/home/imperio/rust/rust/src/test/rustdoc-gui/type-declation-overflow.goml',
    output: 'type-declation-overflow... FAILED\n' +
      '...'
  },
  output: Error: expected `runTest` first argument to be a string
      at runTest (/home/imperio/rust/rust/node_modules/browser-ui-test/src/index.js:591:15)
      at runTests (/home/imperio/rust/rust/src/tools/rustdoc-gui/tester.js:144:26)
      at main (/home/imperio/rust/rust/src/tools/rustdoc-gui/tester.js:278:15)
} Error: expected `runTest` first argument to be a string
    at runTest (/home/imperio/rust/rust/node_modules/browser-ui-test/src/index.js:591:15)
    at runTests (/home/imperio/rust/rust/src/tools/rustdoc-gui/tester.js:144:26)
    at main (/home/imperio/rust/rust/src/tools/rustdoc-gui/tester.js:278:15)
```

The problem was that I concatenated two arrays of object whereas `files` is supposed to be an array of string.

r? @notriddle 