### PR TITLE
Fix scrolling for item declaration block

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -337,6 +337,10 @@ pre {
 .item-decl pre {
 	overflow-x: auto;
 }
+/* This rule allows to have scrolling on the X axis. */
+.item-decl .type-contents-toggle {
+	contain: initial;
+}
 
 .source .content pre {
 	padding: 20px;

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -183,3 +183,161 @@ impl ItemInfoAlignmentTest {
     #[deprecated]
     pub fn bar() {}
 }
+
+pub mod scroll_traits {
+    use std::iter::*;
+
+    /// Shamelessly (partially) copied from `std::iter::Iterator`.
+    /// It allows us to check that the scroll is working as expected on "hidden" items.
+    pub trait Iterator {
+        type Item;
+
+        fn next(&mut self) -> Option<Self::Item>;
+        fn size_hint(&self) -> (usize, Option<usize>);
+        fn count(self) -> usize
+        where
+            Self: Sized;
+        fn last(self) -> Option<Self::Item>
+        where
+            Self: Sized;
+        fn advance_by(&mut self, n: usize) -> Result<(), usize>;
+        fn nth(&mut self, n: usize) -> Option<Self::Item>;
+        fn step_by(self, step: usize) -> StepBy<Self>
+        where
+            Self: Sized;
+        fn chain<U>(self, other: U) -> Chain<Self, U::IntoIter>
+        where
+            Self: Sized,
+            U: IntoIterator<Item = Self::Item>;
+        fn zip<U>(self, other: U) -> Zip<Self, U::IntoIter>
+        where
+            Self: Sized,
+            U: IntoIterator;
+        fn intersperse(self, separator: Self::Item) -> Intersperse<Self>
+        where
+            Self: Sized,
+            Self::Item: Clone;
+        fn intersperse_with<G>(self, separator: G) -> IntersperseWith<Self, G>
+        where
+            Self: Sized,
+            G: FnMut() -> Self::Item;
+        fn map<B, F>(self, f: F) -> Map<Self, F>
+        where
+            Self: Sized,
+            F: FnMut(Self::Item) -> B;
+        fn for_each<F>(self, f: F)
+        where
+            Self: Sized,
+            F: FnMut(Self::Item);
+        fn filter<P>(self, predicate: P) -> Filter<Self, P>
+        where
+            Self: Sized,
+            P: FnMut(&Self::Item) -> bool;
+        fn filter_map<B, F>(self, f: F) -> FilterMap<Self, F>
+        where
+            Self: Sized,
+            F: FnMut(Self::Item) -> Option<B>;
+        fn enumerate(self) -> Enumerate<Self>
+        where
+            Self: Sized;
+        fn peekable(self) -> Peekable<Self>
+        where
+            Self: Sized;
+        fn skip_while<P>(self, predicate: P) -> SkipWhile<Self, P>
+        where
+            Self: Sized,
+            P: FnMut(&Self::Item) -> bool;
+        fn take_while<P>(self, predicate: P) -> TakeWhile<Self, P>
+        where
+            Self: Sized,
+            P: FnMut(&Self::Item) -> bool;
+        fn map_while<B, P>(self, predicate: P) -> MapWhile<Self, P>
+        where
+            Self: Sized,
+            P: FnMut(Self::Item) -> Option<B>;
+        fn skip(self, n: usize) -> Skip<Self>
+        where
+            Self: Sized;
+        fn take(self, n: usize) -> Take<Self>
+        where
+            Self: Sized;
+        fn scan<St, B, F>(self, initial_state: St, f: F) -> Scan<Self, St, F>
+        where
+            Self: Sized,
+            F: FnMut(&mut St, Self::Item) -> Option<B>;
+        fn flat_map<U, F>(self, f: F) -> FlatMap<Self, U, F>
+        where
+            Self: Sized,
+            U: IntoIterator,
+            F: FnMut(Self::Item) -> U;
+        fn flatten(self) -> Flatten<Self>
+        where
+            Self: Sized,
+            Self::Item: IntoIterator;
+        fn fuse(self) -> Fuse<Self>
+        where
+            Self: Sized;
+        fn inspect<F>(self, f: F) -> Inspect<Self, F>
+        where
+            Self: Sized,
+            F: FnMut(&Self::Item);
+        fn by_ref(&mut self) -> &mut Self
+        where
+            Self: Sized;
+        fn collect<B: FromIterator<Self::Item>>(self) -> B
+        where
+            Self: Sized;
+        fn collect_into<E: Extend<Self::Item>>(self, collection: &mut E) -> &mut E
+        where
+            Self: Sized;
+        fn partition<B, F>(self, f: F) -> (B, B)
+        where
+            Self: Sized,
+            B: Default + Extend<Self::Item>,
+            F: FnMut(&Self::Item) -> bool;
+        fn partition_in_place<'a, T: 'a, P>(mut self, predicate: P) -> usize
+        where
+            Self: Sized + DoubleEndedIterator<Item = &'a mut T>,
+            P: FnMut(&T) -> bool;
+        fn is_partitioned<P>(mut self, mut predicate: P) -> bool
+        where
+            Self: Sized,
+            P: FnMut(Self::Item) -> bool;
+        fn fold<B, F>(mut self, init: B, mut f: F) -> B
+        where
+            Self: Sized,
+            F: FnMut(B, Self::Item) -> B;
+        fn reduce<F>(mut self, f: F) -> Option<Self::Item>
+        where
+            Self: Sized,
+            F: FnMut(Self::Item, Self::Item) -> Self::Item;
+        fn all<F>(&mut self, f: F) -> bool
+        where
+            Self: Sized,
+            F: FnMut(Self::Item) -> bool;
+        fn any<F>(&mut self, f: F) -> bool
+        where
+            Self: Sized,
+            F: FnMut(Self::Item) -> bool;
+        fn find<P>(&mut self, predicate: P) -> Option<Self::Item>
+        where
+            Self: Sized,
+            P: FnMut(&Self::Item) -> bool;
+        fn find_map<B, F>(&mut self, f: F) -> Option<B>
+        where
+            Self: Sized,
+            F: FnMut(Self::Item) -> Option<B>;
+        fn position<P>(&mut self, predicate: P) -> Option<usize>
+        where
+            Self: Sized,
+            P: FnMut(Self::Item) -> bool;
+        /// We will scroll to "string" to ensure it scrolls as expected.
+        fn this_is_a_method_with_a_long_name_returning_something() -> String;
+    }
+
+    /// This one doesn't have hidden items (because there are too many) so we can also confirm that it
+    /// scrolls as expected.
+    pub trait TraitWithLongItemsName {
+        fn this_is_a_method_with_a_long_name_returning_something() -> String;
+    }
+}

--- a/src/test/rustdoc-gui/type-declation-overflow.goml
+++ b/src/test/rustdoc-gui/type-declation-overflow.goml
@@ -59,3 +59,18 @@ goto: "file://" + |DOC_PATH| + "/lib2/too_long/struct.SuperIncrediblyLongLongLon
 compare-elements-position-false: (".main-heading h1", ".main-heading .out-of-band", ("y"))
 goto: "file://" + |DOC_PATH| + "/lib2/index.html"
 compare-elements-position-false: (".main-heading h1", ".main-heading .out-of-band", ("y"))
+
+// Now we will check that the scrolling is working.
+// First on an item with "hidden methods".
+goto: "file://" + |DOC_PATH| + "/lib2/scroll_traits/trait.Iterator.html"
+
+click: ".item-decl .type-contents-toggle"
+assert-property: (".item-decl > pre", {"scrollLeft": 0})
+scroll-to: "//*[@class='item-decl']//details/a[text()='String']"
+assert-property-false: (".item-decl > pre", {"scrollLeft": 0})
+
+// Then on an item without "hidden methods".
+goto: "file://" + |DOC_PATH| + "/lib2/scroll_traits/trait.TraitWithLongItemsName.html"
+assert-property: (".item-decl > pre", {"scrollLeft": 0})
+scroll-to: "//*[@class='item-decl']//code/a[text()='String']"
+assert-property-false: (".item-decl > pre", {"scrollLeft": 0})


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/105580.

The `contain: layout` was the issue here and the bug was actually on both mobile and desktop.

r? @notriddle 