### PR TITLE
Teach `rustc` to write the ICE backtrace and query stack to disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3952,6 +3952,7 @@ dependencies = [
  "libc",
  "rustc_ast",
  "rustc_ast_pretty",
+ "rustc_codegen_llvm",
  "rustc_codegen_ssa",
  "rustc_data_structures",
  "rustc_error_codes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
+dependencies = [
+ "num",
+ "time 0.1.43",
+]
+
+[[package]]
+name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
@@ -2535,7 +2545,7 @@ checksum = "23f3e133c6d515528745ffd3b9f0c7d975ae039f0b6abb099f2168daa2afb4f9"
 dependencies = [
  "ammonia",
  "anyhow",
- "chrono",
+ "chrono 0.4.19",
  "clap 3.2.20",
  "clap_complete",
  "elasticlunr-rs",
@@ -2704,12 +2714,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+dependencies = [
+ "num-integer",
+ "num-iter",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3916,6 +3948,7 @@ name = "rustc_driver"
 version = "0.0.0"
 dependencies = [
  "backtrace",
+ "chrono 0.2.25",
  "libc",
  "rustc_ast",
  "rustc_ast_pretty",
@@ -3942,7 +3975,6 @@ dependencies = [
  "rustc_span",
  "rustc_target",
  "serde_json",
- "time 0.3.17",
  "tracing",
  "winapi",
 ]
@@ -5252,7 +5284,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3c02f6eb7e7b4100c272f685a9ccaccaab302324e8c7ec3e2ee72340fb29ff3"
 dependencies = [
- "chrono",
+ "chrono 0.4.19",
  "log",
  "nom",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ci_info"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62a62f39080c8c83e899dff6abd46c4fac05c1cf8dafece96ad8238e79addbf8"
+dependencies = [
+ "envmnt",
+]
+
+[[package]]
 name = "clap"
 version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1434,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "envmnt"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73999a2b8871e74c8b8bc23759ee9f3d85011b24fafc91a4b3b5c8cc8185501"
+dependencies = [
+ "fsio",
+ "indexmap",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,6 +1647,15 @@ name = "fs_extra"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
+
+[[package]]
+name = "fsio"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad0ce30be0cc441b325c5d705c8b613a0ca0d92b6a8953d41bd236dc09a36d0"
+dependencies = [
+ "dunce",
+]
 
 [[package]]
 name = "futf"
@@ -3949,6 +3977,7 @@ version = "0.0.0"
 dependencies = [
  "backtrace",
  "chrono 0.2.25",
+ "ci_info",
  "libc",
  "rustc_ast",
  "rustc_ast_pretty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3976,6 +3976,7 @@ dependencies = [
  "rustc_target",
  "serde_json",
  "tracing",
+ "urlqstring",
  "winapi",
 ]
 
@@ -6089,6 +6090,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlqstring"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ef3473a06a065718d8ec7cd7acc6a35fc20f836dee7661ad3b64ea3cc2e0cc"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3915,6 +3915,7 @@ dependencies = [
 name = "rustc_driver"
 version = "0.0.0"
 dependencies = [
+ "backtrace",
  "libc",
  "rustc_ast",
  "rustc_ast_pretty",
@@ -3934,11 +3935,14 @@ dependencies = [
  "rustc_middle",
  "rustc_parse",
  "rustc_plugin_impl",
+ "rustc_query_impl",
+ "rustc_query_system",
  "rustc_save_analysis",
  "rustc_session",
  "rustc_span",
  "rustc_target",
  "serde_json",
+ "time 0.3.17",
  "tracing",
  "winapi",
 ]

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -23,7 +23,7 @@ extern crate tracing;
 use back::write::{create_informational_target_machine, create_target_machine};
 
 use errors::FailParsingTargetMachineConfigToTargetMachine;
-pub use llvm_util::target_features;
+pub use llvm_util::{get_version, target_features};
 use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_codegen_ssa::back::lto::{LtoModuleCodegen, SerializedModule, ThinModule};
 use rustc_codegen_ssa::back::write::{

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["dylib"]
 backtrace = "0.3.66"
 serde_json = "1.0.59"
 chrono = "0.2"
+ci_info = "0.14.9"
 urlqstring = "*"
 tracing = { version = "0.1.35" }
 rustc_log = { path = "../rustc_log" }

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["dylib"]
 [dependencies]
 backtrace = "0.3.66"
 serde_json = "1.0.59"
-time = { version = "0.3.17", features = ["std", "formatting"] }
+chrono = "0.2"
 tracing = { version = "0.1.35" }
 rustc_log = { path = "../rustc_log" }
 rustc_middle = { path = "../rustc_middle" }

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2021"
 crate-type = ["dylib"]
 
 [dependencies]
-tracing = { version = "0.1.35" }
+backtrace = "0.3.66"
 serde_json = "1.0.59"
+time = { version = "0.3.17", features = ["std", "formatting"] }
+tracing = { version = "0.1.35" }
 rustc_log = { path = "../rustc_log" }
 rustc_middle = { path = "../rustc_middle" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }
@@ -30,6 +32,8 @@ rustc_error_codes = { path = "../rustc_error_codes" }
 rustc_interface = { path = "../rustc_interface" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_span = { path = "../rustc_span" }
+rustc_query_system = { path = "../rustc_query_system" }
+rustc_query_impl = { path = "../rustc_query_impl" }
 rustc_hir_analysis = { path = "../rustc_hir_analysis" }
 
 [target.'cfg(unix)'.dependencies]

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["dylib"]
 backtrace = "0.3.66"
 serde_json = "1.0.59"
 chrono = "0.2"
+urlqstring = "*"
 tracing = { version = "0.1.35" }
 rustc_log = { path = "../rustc_log" }
 rustc_middle = { path = "../rustc_middle" }

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -28,6 +28,7 @@ rustc_parse = { path = "../rustc_parse" }
 rustc_plugin_impl = { path = "../rustc_plugin_impl" }
 rustc_save_analysis = { path = "../rustc_save_analysis" }
 rustc_codegen_ssa = { path = "../rustc_codegen_ssa" }
+rustc_codegen_llvm = { path = "../rustc_codegen_llvm" }
 rustc_session = { path = "../rustc_session" }
 rustc_error_codes = { path = "../rustc_error_codes" }
 rustc_interface = { path = "../rustc_interface" }

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1185,16 +1185,7 @@ pub fn catch_with_exit_code(f: impl FnOnce() -> interface::Result<()>) -> i32 {
 }
 
 struct IceError;
-impl From<time::error::InvalidFormatDescription> for IceError {
-    fn from(_: time::error::InvalidFormatDescription) -> IceError {
-        IceError
-    }
-}
-impl From<time::error::Format> for IceError {
-    fn from(_: time::error::Format) -> IceError {
-        IceError
-    }
-}
+
 impl From<std::io::Error> for IceError {
     fn from(_: std::io::Error) -> IceError {
         IceError
@@ -1203,11 +1194,9 @@ impl From<std::io::Error> for IceError {
 
 fn write_ice_to_disk(info: &panic::PanicInfo<'_>) -> Result<String, IceError> {
     let capture = backtrace::Backtrace::force_capture();
-    let now = time::OffsetDateTime::now_utc();
-    let format = time::format_description::parse("[year]-[month]-[day]_[hour]:[minute]:[second]")?;
-    let file_now = now.format(&format)?;
-    let format = time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]")?;
-    let now = now.format(&format)?;
+    let now = chrono::UTC::now();
+    let file_now = now.format("%Y-%m-%d_%H:%M:%S");
+    let now = now.format("%Y-%m-%d %H:%M:%S");
     let path = format!("rustc-ice-context-{file_now}.txt");
     let mut file = std::fs::File::create(&path)?;
     writeln!(

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -96,6 +96,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "arrayvec",
     "atty",
     "autocfg",
+    "backtrace",
     "bitflags",
     "block-buffer",
     "bumpalo", // Included in Cargo's dep graph but only activated on wasm32-*-unknown.

--- a/tests/ui/chalkify/bugs/async.rs
+++ b/tests/ui/chalkify/bugs/async.rs
@@ -6,7 +6,8 @@
 // failure-status:101
 // normalize-stderr-test "note: .*" -> ""
 // normalize-stderr-test "thread 'rustc' .*" -> ""
-// normalize-stderr-test "  .*\n" -> ""
+// normalize-stderr-test "  ? ?\d\d?\d?:.*\n" -> ""
+// normalize-stderr-test "       .*\n" -> ""
 // normalize-stderr-test "DefId([^)]*)" -> "..."
 
 fn main() -> () {}

--- a/tests/ui/chalkify/bugs/async.stderr
+++ b/tests/ui/chalkify/bugs/async.stderr
@@ -1,21 +1,39 @@
-error[E0277]: `[async fn body@$DIR/async.rs:14:29: 16:2]` is not a future
-LL |LL | |LL | | }
+error[E0277]: `[async fn body@$DIR/async.rs:15:29:  --> $DIR/async.rs:15:29
+   |
+LL |   async fn foo(x: u32) -> u32 {
+   |  _____________________________-
+LL | |     x
+LL | | }
+   | | ^
+   | | |
+   | |_`[async fn body@$DIR/async.rs:15:29:   |   required by a bound introduced by this call
+   |
+   = help: the trait `Future` is not implemented for `[async fn body@$DIR/async.rs:15:29:   = 
 
+  --> $SRC_DIR/core/src/future/mod.rs:LL:COL
 
-error[E0277]: the size for values of type `<[async fn body@$DIR/async.rs:14:29: 16:2] as Future>::Output` cannot be known at compilation time
-LL |LL | |LL | | }
+error[E0277]: the size for values of type `<[async fn body@$DIR/async.rs:15:29:  --> $DIR/async.rs:15:29
+   |
+LL |   async fn foo(x: u32) -> u32 {
+   |  _____________________________^
+LL | |     x
+LL | | }
+   | |_^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `<[async fn body@$DIR/async.rs:15:29:
+  --> $SRC_DIR/core/src/future/mod.rs:LL:COL
 
-
-error[E0277]: `[async fn body@$DIR/async.rs:14:29: 16:2]` is not a future
+error[E0277]: `[async fn body@$DIR/async.rs:15:29:  --> $DIR/async.rs:15:25
+   |
 LL | async fn foo(x: u32) -> u32 {
+   |   = help: the trait `Future` is not implemented for `[async fn body@$DIR/async.rs:15:29:   = 
 
-error: internal compiler error: compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs:1114:25: projection clauses should be implied from elsewhere. obligation: `Obligation(predicate=Binder(ProjectionPredicate(AliasTy { substs: [[async fn body@$DIR/async.rs:14:29: 16:2]], def_id: ...), _use_mk_alias_ty_instead: () }, Term::Ty(u32)), []), depth=0)`
+error: internal compiler error: compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs:1114:25: projection clauses should be implied from elsewhere. obligation: `Obligation(predicate=Binder(ProjectionPredicate(AliasTy { substs: [[async fn body@$DIR/async.rs:15:29:  --> $DIR/async.rs:15:25
+   |
 LL | async fn foo(x: u32) -> u32 {
-
+   |
 
 stack backtrace:
-
-
 
 
 

--- a/tests/ui/impl-trait/issues/issue-86800.stderr
+++ b/tests/ui/impl-trait/issues/issue-86800.stderr
@@ -9,9 +9,7 @@ LL | type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResu
 
 stack backtrace:
 
-error: internal compiler error: unexpected panic
-
-
+error: internal compiler error: the compiler unexpectedly panicked. this is a bug.
 
 
 

--- a/tests/ui/layout/valid_range_oob.stderr
+++ b/tests/ui/layout/valid_range_oob.stderr
@@ -1,4 +1,4 @@
-error: internal compiler error: unexpected panic
+error: internal compiler error: the compiler unexpectedly panicked. this is a bug.
 
 query stack during panic:
 #0 [layout_of] computing layout of `Foo`

--- a/tests/ui/panics/default-backtrace-ice.stderr
+++ b/tests/ui/panics/default-backtrace-ice.stderr
@@ -4,9 +4,7 @@ LL | fn main() { missing_ident; }
 
 stack backtrace:
 
-error: internal compiler error: unexpected panic
-
-
+error: internal compiler error: the compiler unexpectedly panicked. this is a bug.
 
 
 

--- a/tests/ui/treat-err-as-bug/delay_span_bug.stderr
+++ b/tests/ui/treat-err-as-bug/delay_span_bug.stderr
@@ -4,7 +4,7 @@ error: internal compiler error: delayed span bug triggered by #[rustc_error(dela
 LL | fn main() {}
    | ^^^^^^^^^
 
-error: internal compiler error: unexpected panic
+error: internal compiler error: the compiler unexpectedly panicked. this is a bug.
 
 query stack during panic:
 #0 [trigger_delay_span_bug] triggering a delay span bug

--- a/tests/ui/treat-err-as-bug/err.stderr
+++ b/tests/ui/treat-err-as-bug/err.stderr
@@ -4,7 +4,7 @@ error[E0080]: could not evaluate static initializer
 LL | pub static C: u32 = 0 - 1;
    |                     ^^^^^ attempt to compute `0_u32 - 1_u32`, which would overflow
 
-error: internal compiler error: unexpected panic
+error: internal compiler error: the compiler unexpectedly panicked. this is a bug.
 
 query stack during panic:
 #0 [eval_to_allocation_raw] const-evaluating + checking `C`


### PR DESCRIPTION
* On non-`-dev` builds, always hide the backtrace and query stack.
* Introduce `RUSTC_BACKTRACE_FORCE` where `1` will always print the backtrace and `0` will always hide it.