### PR TITLE
Use CI LLVM in `test-various` builder

### DIFF
--- a/src/ci/docker/host-x86_64/test-various/Dockerfile
+++ b/src/ci/docker/host-x86_64/test-various/Dockerfile
@@ -41,10 +41,6 @@ WORKDIR /
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# We are disabling CI LLVM since this builder needs to build LLD, which is
-# currently unsupported when downloading pre-built LLVM.
-ENV NO_DOWNLOAD_CI_LLVM 1
-
 ENV RUST_CONFIGURE_ARGS \
   --musl-root-x86_64=/usr/local/x86_64-linux-musl \
   --set build.nodejs=/node-v15.14.0-linux-x64/bin/node \


### PR DESCRIPTION
It was disabled because it needs `lld`, but since #104748 was merged it is no longer needed.

This will speed this test, since it no longer needs to build LLVM.