### PR TITLE
[RFC 2397] Deny incorrect locations

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -4,6 +4,9 @@
 -passes_see_issue =
     see issue #{$issue} <https://github.com/rust-lang/rust/issues/{$issue}> for more information
 
+passes_incorrect_do_not_recommend_location =
+    `#[do_not_recommend]` can only be placed on trait implementations
+
 passes_outer_crate_level_attr =
     crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -14,6 +14,13 @@ use rustc_span::{Span, Symbol, DUMMY_SP};
 
 use crate::lang_items::Duplicate;
 
+#[derive(Diagnostic)]
+#[diag(passes_incorrect_do_not_recommend_location)]
+pub struct IncorrectDoNotRecommendLocation {
+    #[primary_span]
+    pub span: Span,
+}
+
 #[derive(LintDiagnostic)]
 #[diag(passes_outer_crate_level_attr)]
 pub struct OuterCrateLevelAttr;

--- a/tests/ui/rfc-2397-do-not-recommend/incorrect-locations.rs
+++ b/tests/ui/rfc-2397-do-not-recommend/incorrect-locations.rs
@@ -1,0 +1,45 @@
+#![feature(do_not_recommend)]
+
+#[do_not_recommend]
+//~^ `#[do_not_recommend]` can only be placed
+const CONST: () = ();
+
+#[do_not_recommend]
+//~^ `#[do_not_recommend]` can only be placed
+static Static: () = ();
+
+#[do_not_recommend]
+//~^ `#[do_not_recommend]` can only be placed
+type Type = ();
+
+#[do_not_recommend]
+//~^ `#[do_not_recommend]` can only be placed
+enum Enum {
+}
+
+#[do_not_recommend]
+//~^ `#[do_not_recommend]` can only be placed
+extern {
+}
+
+#[do_not_recommend]
+//~^ `#[do_not_recommend]` can only be placed
+fn fun() {
+}
+
+#[do_not_recommend]
+//~^ `#[do_not_recommend]` can only be placed
+struct Struct {
+}
+
+#[do_not_recommend]
+//~^ `#[do_not_recommend]` can only be placed
+trait Trait {
+}
+
+#[do_not_recommend]
+impl Trait for i32 {
+}
+
+fn main() {
+}

--- a/tests/ui/rfc-2397-do-not-recommend/incorrect-locations.stderr
+++ b/tests/ui/rfc-2397-do-not-recommend/incorrect-locations.stderr
@@ -1,0 +1,50 @@
+error: `#[do_not_recommend]` can only be placed on trait implementations
+  --> $DIR/incorrect-locations.rs:3:1
+   |
+LL | #[do_not_recommend]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: `#[do_not_recommend]` can only be placed on trait implementations
+  --> $DIR/incorrect-locations.rs:7:1
+   |
+LL | #[do_not_recommend]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: `#[do_not_recommend]` can only be placed on trait implementations
+  --> $DIR/incorrect-locations.rs:11:1
+   |
+LL | #[do_not_recommend]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: `#[do_not_recommend]` can only be placed on trait implementations
+  --> $DIR/incorrect-locations.rs:15:1
+   |
+LL | #[do_not_recommend]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: `#[do_not_recommend]` can only be placed on trait implementations
+  --> $DIR/incorrect-locations.rs:20:1
+   |
+LL | #[do_not_recommend]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: `#[do_not_recommend]` can only be placed on trait implementations
+  --> $DIR/incorrect-locations.rs:25:1
+   |
+LL | #[do_not_recommend]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: `#[do_not_recommend]` can only be placed on trait implementations
+  --> $DIR/incorrect-locations.rs:30:1
+   |
+LL | #[do_not_recommend]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: `#[do_not_recommend]` can only be placed on trait implementations
+  --> $DIR/incorrect-locations.rs:35:1
+   |
+LL | #[do_not_recommend]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui/rfc-2397-do-not-recommend/unstable-feature.rs
+++ b/tests/ui/rfc-2397-do-not-recommend/unstable-feature.rs
@@ -1,6 +1,9 @@
+trait Foo {
+}
+
 #[do_not_recommend]
 //~^ ERROR the `#[do_not_recommend]` attribute is an experimental feature
-trait Foo {
+impl Foo for i32 {
 }
 
 fn main() {

--- a/tests/ui/rfc-2397-do-not-recommend/unstable-feature.stderr
+++ b/tests/ui/rfc-2397-do-not-recommend/unstable-feature.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the `#[do_not_recommend]` attribute is an experimental feature
-  --> $DIR/unstable-feature.rs:1:1
+  --> $DIR/unstable-feature.rs:4:1
    |
 LL | #[do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
cc #51992

As declared in the RFC, `#[do_not_recommend]` should only be applicable on trait implementations.