### PR TITLE
Account for opaque variance for region outlives and liveness.

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![allow(rustc::potential_query_instability)]
 #![feature(box_patterns)]
+#![feature(control_flow_enum)]
 #![feature(let_chains)]
 #![feature(min_specialization)]
 #![feature(never_type)]


### PR DESCRIPTION
Should fix https://github.com/rust-lang/rust/issues/106332

I did not manage to extract a MCVE, so I don't have a test yet.

Putting this up for review in the mean time.