### PR TITLE
[beta] Clippy: Move manual_clamp to nursery

### DIFF
--- a/src/tools/clippy/clippy_lints/src/manual_clamp.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_clamp.rs
@@ -35,6 +35,9 @@ declare_clippy_lint! {
     /// Some may consider panicking in these situations to be desirable, but it also may
     /// introduce panicking where there wasn't any before.
     ///
+    /// See also [the discussion in the
+    /// PR](https://github.com/rust-lang/rust-clippy/pull/9484#issuecomment-1278922613).
+    ///
     /// ### Examples
     /// ```rust
     /// # let (input, min, max) = (0, -2, 1);
@@ -78,7 +81,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.66.0"]
     pub MANUAL_CLAMP,
-    complexity,
+    nursery,
     "using a clamp pattern instead of the clamp function"
 }
 impl_lint_pass!(ManualClamp => [MANUAL_CLAMP]);


### PR DESCRIPTION
There was a lot of discussion about this lint in https://github.com/rust-lang/rust-clippy/pull/9484#issuecomment-1278922613

We decided to move the lint to `nursery`. But since this lint broke code of many popular projects, we don't want to wait another release cycle until this move gets into stable. So we'd like to backport this commit to `beta`.

cc @rust-lang/clippy for approval from the Clippy side.