### PR TITLE
Fix reexport of `doc(hidden)` item

### DIFF
--- a/src/librustdoc/passes/strip_priv_imports.rs
+++ b/src/librustdoc/passes/strip_priv_imports.rs
@@ -12,5 +12,6 @@ pub(crate) const STRIP_PRIV_IMPORTS: Pass = Pass {
 };
 
 pub(crate) fn strip_priv_imports(krate: clean::Crate, cx: &mut DocContext<'_>) -> clean::Crate {
-    ImportStripper { tcx: cx.tcx }.fold_crate(krate)
+    let is_json_output = cx.output_format.is_json() && !cx.show_coverage;
+    ImportStripper { tcx: cx.tcx, is_json_output }.fold_crate(krate)
 }

--- a/src/librustdoc/passes/strip_private.rs
+++ b/src/librustdoc/passes/strip_private.rs
@@ -28,7 +28,8 @@ pub(crate) fn strip_private(mut krate: clean::Crate, cx: &mut DocContext<'_>) ->
             is_json_output,
             tcx: cx.tcx,
         };
-        krate = ImportStripper { tcx: cx.tcx }.fold_crate(stripper.fold_crate(krate));
+        krate =
+            ImportStripper { tcx: cx.tcx, is_json_output }.fold_crate(stripper.fold_crate(krate));
     }
 
     // strip all impls referencing private items

--- a/tests/rustdoc/reexport-doc-hidden.rs
+++ b/tests/rustdoc/reexport-doc-hidden.rs
@@ -1,0 +1,26 @@
+// Part of <https://github.com/rust-lang/rust/issues/59368>.
+// This test ensures that reexporting a `doc(hidden)` item will
+// still show the reexport.
+
+#![crate_name = "foo"]
+
+#[doc(hidden)]
+pub type Type = u32;
+
+// @has 'foo/index.html'
+// @has - '//*[@id="reexport.Type2"]/code' 'pub use crate::Type as Type2;'
+pub use crate::Type as Type2;
+
+// @count - '//*[@id="reexport.Type3"]' 0
+#[doc(hidden)]
+pub use crate::Type as Type3;
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! foo {
+    () => {};
+}
+
+// This is a bug: https://github.com/rust-lang/rust/issues/59368
+// @!has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
+pub use crate::foo as Macro;


### PR DESCRIPTION
Part of #59368.

It doesn't fix the `doc(inline)` nor the `doc(hidden)` on macro. I'll do it in a follow-up PR.

r? @notriddle 