### PR TITLE
Add 'static lifetime suggestion when GAT implied 'static requirement from HRTB

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -527,6 +527,14 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         self.scc_values.region_value_str(scc)
     }
 
+    pub(crate) fn placeholders_contained_in<'a>(
+        &'a self,
+        r: RegionVid,
+    ) -> impl Iterator<Item = ty::PlaceholderRegion> + 'a {
+        let scc = self.constraint_sccs.scc(r.to_region_vid());
+        self.scc_values.placeholders_contained_in(scc)
+    }
+
     /// Returns access to the value of `r` for debugging purposes.
     pub(crate) fn region_universe(&self, r: RegionVid) -> ty::UniverseIndex {
         let scc = self.constraint_sccs.scc(r.to_region_vid());

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -100,6 +100,13 @@ impl BoundRegionKind {
 
         None
     }
+
+    pub fn get_id(&self) -> Option<DefId> {
+        match *self {
+            BoundRegionKind::BrNamed(id, _) => return Some(id),
+            _ => None,
+        }
+    }
 }
 
 pub trait Article {

--- a/tests/ui/generic-associated-types/collectivity-regression.stderr
+++ b/tests/ui/generic-associated-types/collectivity-regression.stderr
@@ -9,6 +9,16 @@ LL | |         // probably should work.
 LL | |         let _x = x;
 LL | |     };
    | |_____^
+   |
+note: due to current limitations in the borrow checker, this implies a `'static` lifetime
+  --> $DIR/collectivity-regression.rs:11:16
+   |
+LL |     for<'a> T: Get<Value<'a> = ()>,
+   |                ^^^^^^^^^^^^^^^^^^^
+help: consider restricting the type parameter to the `'static` lifetime
+   |
+LL |     for<'a> T: Get<Value<'a> = ()> + 'static,
+   |                                    +++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/lifetimes/issue-105507.fixed
+++ b/tests/ui/lifetimes/issue-105507.fixed
@@ -1,0 +1,43 @@
+// run-rustfix
+//
+#![allow(warnings)]
+struct Wrapper<'a, T: ?Sized>(&'a T);
+
+trait Project {
+    type Projected<'a> where Self: 'a;
+    fn project(this: Wrapper<'_, Self>) -> Self::Projected<'_>;
+}
+trait MyTrait {}
+trait ProjectedMyTrait {}
+
+impl<T> Project for Option<T> {
+    type Projected<'a> = Option<Wrapper<'a, T>> where T: 'a;
+    fn project(this: Wrapper<'_, Self>) -> Self::Projected<'_> {
+        this.0.as_ref().map(Wrapper)
+    }
+}
+
+impl<T: MyTrait> MyTrait for Option<Wrapper<'_, T>> {}
+
+impl<T: ProjectedMyTrait> MyTrait for Wrapper<'_, T> {}
+
+impl<T> ProjectedMyTrait for T
+    where
+        T: Project,
+        for<'a> T::Projected<'a>: MyTrait,
+        //~^ NOTE due to current limitations in the borrow checker, this implies a `'static` lifetime
+        //~| NOTE due to current limitations in the borrow checker, this implies a `'static` lifetime
+{}
+
+fn require_trait<T: MyTrait>(_: T) {}
+
+fn foo<T : MyTrait + 'static + 'static, U : MyTrait + 'static + 'static>(wrap: Wrapper<'_, Option<T>>, wrap1: Wrapper<'_, Option<U>>) {
+    //~^ HELP consider restricting the type parameter to the `'static` lifetime
+    //~| HELP consider restricting the type parameter to the `'static` lifetime
+    require_trait(wrap);
+    //~^ ERROR `T` does not live long enough
+    require_trait(wrap1);
+    //~^ ERROR `U` does not live long enough
+}
+
+fn main() {}

--- a/tests/ui/lifetimes/issue-105507.rs
+++ b/tests/ui/lifetimes/issue-105507.rs
@@ -1,0 +1,43 @@
+// run-rustfix
+//
+#![allow(warnings)]
+struct Wrapper<'a, T: ?Sized>(&'a T);
+
+trait Project {
+    type Projected<'a> where Self: 'a;
+    fn project(this: Wrapper<'_, Self>) -> Self::Projected<'_>;
+}
+trait MyTrait {}
+trait ProjectedMyTrait {}
+
+impl<T> Project for Option<T> {
+    type Projected<'a> = Option<Wrapper<'a, T>> where T: 'a;
+    fn project(this: Wrapper<'_, Self>) -> Self::Projected<'_> {
+        this.0.as_ref().map(Wrapper)
+    }
+}
+
+impl<T: MyTrait> MyTrait for Option<Wrapper<'_, T>> {}
+
+impl<T: ProjectedMyTrait> MyTrait for Wrapper<'_, T> {}
+
+impl<T> ProjectedMyTrait for T
+    where
+        T: Project,
+        for<'a> T::Projected<'a>: MyTrait,
+        //~^ NOTE due to current limitations in the borrow checker, this implies a `'static` lifetime
+        //~| NOTE due to current limitations in the borrow checker, this implies a `'static` lifetime
+{}
+
+fn require_trait<T: MyTrait>(_: T) {}
+
+fn foo<T : MyTrait, U : MyTrait>(wrap: Wrapper<'_, Option<T>>, wrap1: Wrapper<'_, Option<U>>) {
+    //~^ HELP consider restricting the type parameter to the `'static` lifetime
+    //~| HELP consider restricting the type parameter to the `'static` lifetime
+    require_trait(wrap);
+    //~^ ERROR `T` does not live long enough
+    require_trait(wrap1);
+    //~^ ERROR `U` does not live long enough
+}
+
+fn main() {}

--- a/tests/ui/lifetimes/issue-105507.stderr
+++ b/tests/ui/lifetimes/issue-105507.stderr
@@ -1,0 +1,34 @@
+error: `T` does not live long enough
+  --> $DIR/issue-105507.rs:37:5
+   |
+LL |     require_trait(wrap);
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+note: due to current limitations in the borrow checker, this implies a `'static` lifetime
+  --> $DIR/issue-105507.rs:27:35
+   |
+LL |         for<'a> T::Projected<'a>: MyTrait,
+   |                                   ^^^^^^^
+help: consider restricting the type parameter to the `'static` lifetime
+   |
+LL | fn foo<T : MyTrait + 'static, U : MyTrait + 'static>(wrap: Wrapper<'_, Option<T>>, wrap1: Wrapper<'_, Option<U>>) {
+   |                    +++++++++              +++++++++
+
+error: `U` does not live long enough
+  --> $DIR/issue-105507.rs:39:5
+   |
+LL |     require_trait(wrap1);
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+note: due to current limitations in the borrow checker, this implies a `'static` lifetime
+  --> $DIR/issue-105507.rs:27:35
+   |
+LL |         for<'a> T::Projected<'a>: MyTrait,
+   |                                   ^^^^^^^
+help: consider restricting the type parameter to the `'static` lifetime
+   |
+LL | fn foo<T : MyTrait + 'static, U : MyTrait + 'static>(wrap: Wrapper<'_, Option<T>>, wrap1: Wrapper<'_, Option<U>>) {
+   |                    +++++++++              +++++++++
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fix for issue #105507

The problem:
When generic associated types (GATs) are from higher-ranked trait bounds (HRTB), they are implied 'static requirement (see 
[Implied 'static requirement from higher-ranked trait bounds](https://blog.rust-lang.org/2022/10/28/gats-stabilization.html#implied-static-requirement-from-higher-ranked-trait-bounds) for more details). If the user did not explicitly specify the `'static` lifetime when using the GAT, the current error message will only point out the type `does not live long enough` where the type is used, but not where the GAT is specified and how to fix the problem.

The solution:
Add notes at the span where the problematic GATs are specified and suggestions of how to fix the problem by adding `'static` lifetime at the right spans.
