### PR TITLE
Ignore tests move in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,3 +8,5 @@ a06baa56b95674fc626b3c3fd680d6a65357fe60
 283abbf0e7d20176f76006825b5c52e9a4234e4c
 # format libstd/sys
 c34fbfaad38cf5829ef5cfe780dc9d58480adeaa
+# move tests
+cf2dff2b1e3fa55fa5415d524200070d0d7aacfe


### PR DESCRIPTION
This commit is not relevant in the history, but may clobber the git blame output.