### PR TITLE
Recover labels written as identifiers

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1709,10 +1709,10 @@ impl<'a> Parser<'a> {
     fn parse_break_expr(&mut self) -> PResult<'a, P<Expr>> {
         let lo = self.prev_token.span;
         let mut label = self.eat_label();
-        let kind = if label.is_some() && self.token == token::Colon {
+        let kind = if self.token == token::Colon && let Some(label) = label.take() {
             // The value expression can be a labeled loop, see issue #86948, e.g.:
             // `loop { break 'label: loop { break 'label 42; }; }`
-            let lexpr = self.parse_labeled_expr(label.take().unwrap(), true)?;
+            let lexpr = self.parse_labeled_expr(label, true)?;
             self.sess.emit_err(LabeledLoopInBreak {
                 span: lexpr.span,
                 sub: WrapExpressionInParentheses {

--- a/tests/ui/parser/recover-unticked-labels.fixed
+++ b/tests/ui/parser/recover-unticked-labels.fixed
@@ -1,0 +1,7 @@
+// run-rustfix
+
+fn main() {
+    'label: loop { break 'label };    //~ error: cannot find value `label` in this scope
+    'label: loop { break 'label 0 };  //~ error: expected a label, found an identifier
+    'label: loop { continue 'label }; //~ error: expected a label, found an identifier
+}

--- a/tests/ui/parser/recover-unticked-labels.rs
+++ b/tests/ui/parser/recover-unticked-labels.rs
@@ -1,5 +1,7 @@
+// run-rustfix
+
 fn main() {
-    'label: loop { break label }    //~ error: cannot find value `label` in this scope
-    'label: loop { break label 0 }  //~ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `0`
-    'label: loop { continue label } //~ error: expected one of `.`, `;`, `?`, `}`, or an operator, found `label`
+    'label: loop { break label };    //~ error: cannot find value `label` in this scope
+    'label: loop { break label 0 };  //~ error: expected a label, found an identifier
+    'label: loop { continue label }; //~ error: expected a label, found an identifier
 }

--- a/tests/ui/parser/recover-unticked-labels.rs
+++ b/tests/ui/parser/recover-unticked-labels.rs
@@ -1,0 +1,5 @@
+fn main() {
+    'label: loop { break label }    //~ error: cannot find value `label` in this scope
+    'label: loop { break label 0 }  //~ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `0`
+    'label: loop { continue label } //~ error: expected one of `.`, `;`, `?`, `}`, or an operator, found `label`
+}

--- a/tests/ui/parser/recover-unticked-labels.stderr
+++ b/tests/ui/parser/recover-unticked-labels.stderr
@@ -1,0 +1,25 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `0`
+  --> $DIR/recover-unticked-labels.rs:3:32
+   |
+LL |     'label: loop { break label 0 }
+   |                                ^ expected one of 8 possible tokens
+
+error: expected one of `.`, `;`, `?`, `}`, or an operator, found `label`
+  --> $DIR/recover-unticked-labels.rs:4:29
+   |
+LL |     'label: loop { continue label }
+   |                             ^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
+
+error[E0425]: cannot find value `label` in this scope
+  --> $DIR/recover-unticked-labels.rs:2:26
+   |
+LL |     'label: loop { break label }
+   |     ------               ^^^^^
+   |     |                    |
+   |     |                    not found in this scope
+   |     |                    help: use the similarly named label: `'label`
+   |     a label with a similar name exists
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/parser/recover-unticked-labels.stderr
+++ b/tests/ui/parser/recover-unticked-labels.stderr
@@ -1,19 +1,19 @@
-error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `0`
-  --> $DIR/recover-unticked-labels.rs:3:32
+error: expected a label, found an identifier
+  --> $DIR/recover-unticked-labels.rs:5:26
    |
-LL |     'label: loop { break label 0 }
-   |                                ^ expected one of 8 possible tokens
+LL |     'label: loop { break label 0 };
+   |                          ^^^^^ help: labels start with a tick: `'label`
 
-error: expected one of `.`, `;`, `?`, `}`, or an operator, found `label`
-  --> $DIR/recover-unticked-labels.rs:4:29
+error: expected a label, found an identifier
+  --> $DIR/recover-unticked-labels.rs:6:29
    |
-LL |     'label: loop { continue label }
-   |                             ^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
+LL |     'label: loop { continue label };
+   |                             ^^^^^ help: labels start with a tick: `'label`
 
 error[E0425]: cannot find value `label` in this scope
-  --> $DIR/recover-unticked-labels.rs:2:26
+  --> $DIR/recover-unticked-labels.rs:4:26
    |
-LL |     'label: loop { break label }
+LL |     'label: loop { break label };
    |     ------               ^^^^^
    |     |                    |
    |     |                    not found in this scope


### PR DESCRIPTION
This adds recovery for `break label expr` and `continue label`, as well as a test for `break label`.