### PR TITLE
prevent E0512 from emitting [type error] by checking the references_error

### DIFF
--- a/compiler/rustc_hir_typeck/src/intrinsicck.rs
+++ b/compiler/rustc_hir_typeck/src/intrinsicck.rs
@@ -105,6 +105,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         } else {
             err.note(&format!("source type: `{}` ({})", from, skeleton_string(from, sk_from)))
                 .note(&format!("target type: `{}` ({})", to, skeleton_string(to, sk_to)));
+            let mut should_delay_as_bug = false;
+            if let Err(LayoutError::Unknown(bad_from)) = sk_from && bad_from.references_error() {
+                should_delay_as_bug = true;
+            }
+            if let Err(LayoutError::Unknown(bad_to)) = sk_to && bad_to.references_error() {
+                should_delay_as_bug = true;
+            }
+            if should_delay_as_bug {
+                err.delay_as_bug();
+            }
         }
         err.emit();
     }

--- a/tests/ui/type-alias-impl-trait/issue-53092-2.rs
+++ b/tests/ui/type-alias-impl-trait/issue-53092-2.rs
@@ -4,7 +4,6 @@
 type Bug<T, U> = impl Fn(T) -> U + Copy; //~ ERROR cycle detected
 
 const CONST_BUG: Bug<u8, ()> = unsafe { std::mem::transmute(|_: u8| ()) };
-//~^ ERROR: cannot transmute
 
 fn make_bug<T, U: From<T>>() -> Bug<T, U> {
     |x| x.into() //~ ERROR the trait bound `U: From<T>` is not satisfied

--- a/tests/ui/type-alias-impl-trait/issue-53092-2.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-53092-2.stderr
@@ -24,23 +24,14 @@ LL | |     CONST_BUG(0);
 LL | | }
    | |_^
 
-error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/issue-53092-2.rs:6:41
-   |
-LL | const CONST_BUG: Bug<u8, ()> = unsafe { std::mem::transmute(|_: u8| ()) };
-   |                                         ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: source type: `[closure@$DIR/issue-53092-2.rs:6:61: 6:68]` (0 bits)
-   = note: target type: `Bug<u8, ()>` (size can vary because of [type error])
-
 error[E0277]: the trait bound `U: From<T>` is not satisfied
-  --> $DIR/issue-53092-2.rs:10:5
+  --> $DIR/issue-53092-2.rs:9:5
    |
 LL |     |x| x.into()
    |     ^^^^^^^^^^^^ the trait `From<T>` is not implemented for `U`
    |
 note: required by a bound in `make_bug`
-  --> $DIR/issue-53092-2.rs:9:19
+  --> $DIR/issue-53092-2.rs:8:19
    |
 LL | fn make_bug<T, U: From<T>>() -> Bug<T, U> {
    |                   ^^^^^^^ required by this bound in `make_bug`
@@ -49,7 +40,7 @@ help: consider restricting type parameter `U`
 LL | type Bug<T, U: std::convert::From<T>> = impl Fn(T) -> U + Copy;
    |              +++++++++++++++++++++++
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0277, E0391, E0512.
+Some errors have detailed explanations: E0277, E0391.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/type-alias-impl-trait/no_inferrable_concrete_type.rs
+++ b/tests/ui/type-alias-impl-trait/no_inferrable_concrete_type.rs
@@ -15,5 +15,4 @@ mod foo {
 
 fn main() {
     let _: foo::Foo = std::mem::transmute(0u8);
-    //~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 }

--- a/tests/ui/type-alias-impl-trait/no_inferrable_concrete_type.stderr
+++ b/tests/ui/type-alias-impl-trait/no_inferrable_concrete_type.stderr
@@ -6,15 +6,5 @@ LL |     pub type Foo = impl Copy;
    |
    = note: `Foo` must be used in combination with a concrete type within the same module
 
-error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/no_inferrable_concrete_type.rs:17:23
-   |
-LL |     let _: foo::Foo = std::mem::transmute(0u8);
-   |                       ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: source type: `u8` (8 bits)
-   = note: target type: `Foo` (size can vary because of [type error])
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0512`.


### PR DESCRIPTION
but still emit E0512
this will fix #106695