### PR TITLE
[core] Fix a soundness hole in `core::sync::Exclusive`

### DIFF
--- a/library/core/src/sync/exclusive.rs
+++ b/library/core/src/sync/exclusive.rs
@@ -33,9 +33,8 @@ use core::task::{Context, Poll};
 /// assert_sync(State {
 ///     future: async {
 ///         let cell = Cell::new(1);
-///         let cell_ref = &cell;
 ///         other().await;
-///         let value = cell_ref.get();
+///         let value = cell.get();
 ///     }
 /// });
 /// ```
@@ -55,10 +54,9 @@ use core::task::{Context, Poll};
 ///
 /// assert_sync(State {
 ///     future: Exclusive::new(async {
-///         let cell = Cell::new(1);
-///         let cell_ref = &cell;
+///         let mut cell = Cell::new(1);
 ///         other().await;
-///         let value = cell_ref.get();
+///         let value = cell.get();
 ///     })
 /// });
 /// ```
@@ -87,7 +85,7 @@ pub struct Exclusive<T: ?Sized> {
 
 // See `Exclusive`'s docs for justification.
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-unsafe impl<T: ?Sized> Sync for Exclusive<T> {}
+unsafe impl<T: ?Sized + Send> Sync for Exclusive<T> {}
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 impl<T: ?Sized> fmt::Debug for Exclusive<T> {


### PR DESCRIPTION
Just like `Mutex<T>` is only `Sync` if `T` is `Send`, `Exclusive<T>` should contain the same constraints.

As an example, `sd_journal*` instances created per https://www.freedesktop.org/software/systemd/man/sd_journal_open.html# cannot be either `Send` or `Sync`, and wrapper types likewise can't.

> All functions listed here are thread-agnostic and only a single specific thread may operate on a given object during its entire lifetime. It's safe to allocate multiple independent objects and use each from a specific thread in parallel. **However, it's not safe to allocate such an object in one thread, and operate or free it from any other, even if locking is used to ensure these threads don't operate on it at the very same time.**

The current API would technically allow a wrapper that (correctly) doesn't implement `Send` or `Sync` to be erroneously moved to another thread. This fixes that soundness hole.

Edit: Relevant issue: https://github.com/rust-lang/rust/issues/98407