### PR TITLE
BPF: Disable atomic CAS

### DIFF
--- a/compiler/rustc_target/src/spec/bpf_base.rs
+++ b/compiler/rustc_target/src/spec/bpf_base.rs
@@ -6,7 +6,7 @@ pub fn opts(endian: Endian) -> TargetOptions {
         allow_asm: true,
         endian,
         linker_flavor: LinkerFlavor::Bpf,
-        atomic_cas: true,
+        atomic_cas: false,
         dynamic_linking: true,
         no_builtins: true,
         panic_strategy: PanicStrategy::Abort,


### PR DESCRIPTION
Enabling CAS for BPF targets (https://github.com/rust-lang/rust/pull/105708) breaks the build of core library.
The failure occurs both when building rustc for BPF targets and when
building crates for BPF targets with the current nightly.

The LLVM BPF backend does not correctly lower all `atomicrmw` operations
and crashes for unsupported ones.

Before we can enable CAS for BPF in Rust, we need to fix the LLVM BPF
backend first.

Fixes #106795

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>