### PR TITLE
Suggest `{var:?}` when finding `{?:var}` in inline format strings

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -271,7 +271,13 @@ impl<'a> Iterator for Parser<'a> {
                                 );
                             }
                         } else {
-                            self.suggest_positional_arg_instead_of_captured_arg(arg);
+                            if let Some(&(_, maybe)) = self.cur.peek() {
+                                if maybe == '?' {
+                                    self.suggest_format();
+                                } else {
+                                    self.suggest_positional_arg_instead_of_captured_arg(arg);
+                                }
+                            }
                         }
                         Some(NextArgument(Box::new(arg)))
                     }
@@ -821,6 +827,27 @@ impl<'a> Parser<'a> {
         }
 
         if found { Some(cur) } else { None }
+    }
+
+    fn suggest_format(&mut self) {
+        if let (Some(pos), Some(_)) = (self.consume_pos('?'), self.consume_pos(':')) {
+            let word = self.word();
+            let _end = self.current_pos();
+            let pos = self.to_span_index(pos);
+            self.errors.insert(
+                0,
+                ParseError {
+                    description: "expected format parameter to occur after `:`".to_owned(),
+                    note: Some(
+                        format!("`?` comes after `:`, try `{}:{}` instead", word, "?").to_owned(),
+                    ),
+                    label: "expected `?` to occur after `:`".to_owned(),
+                    span: pos.to(pos),
+                    secondary_label: None,
+                    should_be_replaced_with_positional_argument: false,
+                },
+            );
+        }
     }
 
     fn suggest_positional_arg_instead_of_captured_arg(&mut self, arg: Argument<'a>) {

--- a/tests/ui/fmt/format-string-wrong-order.rs
+++ b/tests/ui/fmt/format-string-wrong-order.rs
@@ -1,0 +1,15 @@
+fn main() {
+    let bar = 3;
+    format!("{?:}", bar);
+    //~^ ERROR invalid format string: expected format parameter to occur after `:`
+    format!("{?:bar}");
+    //~^ ERROR invalid format string: expected format parameter to occur after `:`
+    format!("{?:?}", bar);
+    //~^ ERROR invalid format string: expected format parameter to occur after `:`
+    format!("{??}", bar);
+    //~^ ERROR invalid format string: expected `'}'`, found `'?'`
+    format!("{?;bar}");
+    //~^ ERROR invalid format string: expected `'}'`, found `'?'`
+    format!("{?:#?}", bar);
+    //~^ ERROR invalid format string: expected format parameter to occur after `:`
+}

--- a/tests/ui/fmt/format-string-wrong-order.stderr
+++ b/tests/ui/fmt/format-string-wrong-order.stderr
@@ -1,0 +1,54 @@
+error: invalid format string: expected format parameter to occur after `:`
+  --> $DIR/format-string-wrong-order.rs:3:15
+   |
+LL |     format!("{?:}", bar);
+   |               ^ expected `?` to occur after `:` in format string
+   |
+   = note: `?` comes after `:`, try `:?` instead
+
+error: invalid format string: expected format parameter to occur after `:`
+  --> $DIR/format-string-wrong-order.rs:5:15
+   |
+LL |     format!("{?:bar}");
+   |               ^ expected `?` to occur after `:` in format string
+   |
+   = note: `?` comes after `:`, try `bar:?` instead
+
+error: invalid format string: expected format parameter to occur after `:`
+  --> $DIR/format-string-wrong-order.rs:7:15
+   |
+LL |     format!("{?:?}", bar);
+   |               ^ expected `?` to occur after `:` in format string
+   |
+   = note: `?` comes after `:`, try `:?` instead
+
+error: invalid format string: expected `'}'`, found `'?'`
+  --> $DIR/format-string-wrong-order.rs:9:15
+   |
+LL |     format!("{??}", bar);
+   |              -^ expected `}` in format string
+   |              |
+   |              because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'?'`
+  --> $DIR/format-string-wrong-order.rs:11:15
+   |
+LL |     format!("{?;bar}");
+   |              -^ expected `}` in format string
+   |              |
+   |              because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected format parameter to occur after `:`
+  --> $DIR/format-string-wrong-order.rs:13:15
+   |
+LL |     format!("{?:#?}", bar);
+   |               ^ expected `?` to occur after `:` in format string
+   |
+   = note: `?` comes after `:`, try `:?` instead
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/106572

This is my first PR to this project, so hopefully I can get some good pointers with me from the first PR.

Currently my idea was to test out whether or not this is the correct solution to this issue and then hopefully expand upon the idea to not only work for Debug formatting but for all of  them. If this is a valid solution, I will create a new issue to give a better error message to a broader range of wrong-order formatting.