### PR TITLE
builtin Fn impl, require return type wf

### DIFF
--- a/tests/ui/lifetimes/lifetime-errors/issue_74400.rs
+++ b/tests/ui/lifetimes/lifetime-errors/issue_74400.rs
@@ -11,6 +11,7 @@ fn f<T, S>(data: &[T], key: impl Fn(&T) -> S) {
 fn g<T>(data: &[T]) {
     f(data, identity)
     //~^ ERROR the parameter type
+    //~| ERROR the parameter type
     //~| ERROR mismatched types
     //~| ERROR implementation of `FnOnce` is not general
 }

--- a/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
@@ -9,6 +9,17 @@ help: consider adding an explicit lifetime bound...
 LL | fn g<T: 'static>(data: &[T]) {
    |       +++++++++
 
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/issue_74400.rs:12:5
+   |
+LL |     f(data, identity)
+   |     ^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL | fn g<T: 'static>(data: &[T]) {
+   |       +++++++++
+
 error[E0308]: mismatched types
   --> $DIR/issue_74400.rs:12:5
    |
@@ -32,7 +43,7 @@ LL |     f(data, identity)
    = note: `fn(&'2 T) -> &'2 T {identity::<&'2 T>}` must implement `FnOnce<(&'1 T,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 T,)>`, for some specific lifetime `'2`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0308, E0310.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/issue-53398-cyclic-types.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-53398-cyclic-types.stderr
@@ -1,4 +1,4 @@
-error[E0275]: overflow evaluating the requirement `Foo: Sized`
+error[E0275]: overflow evaluating the requirement `Foo well-formed`
   --> $DIR/issue-53398-cyclic-types.rs:5:13
    |
 LL | fn foo() -> Foo {


### PR DESCRIPTION
is kind of a solution for #84533 need explicit implications for binders to fully fix it.

just want to see a crater run for that. Definitely have a write a new test for places where this isn't strong enough though. I can imagine us already having tried to add something like this before. 

r? @types