### PR TITLE
Add failing test for projections used as union field type

### DIFF
--- a/tests/ui/union/projection-as-union-type.rs
+++ b/tests/ui/union/projection-as-union-type.rs
@@ -1,0 +1,18 @@
+// This is currently not possible to use projections as union field's type.
+
+#![crate_type = "lib"]
+
+pub trait Identity {
+    type Identity;
+}
+
+impl<T> Identity for T {
+    type Identity = Self;
+}
+
+pub type Foo = u8;
+
+pub union Bar {
+    a:  <Foo as Identity>::Identity, //~ ERROR
+    b: u8,
+}

--- a/tests/ui/union/projection-as-union-type.stderr
+++ b/tests/ui/union/projection-as-union-type.stderr
@@ -1,0 +1,15 @@
+error[E0740]: unions cannot contain fields that may need dropping
+  --> $DIR/projection-as-union-type.rs:16:5
+   |
+LL |     a:  <Foo as Identity>::Identity,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: a type is guaranteed not to need dropping when it implements `Copy`, or when it is the special `ManuallyDrop<_>` type
+help: when the type does not implement `Copy`, wrap it inside a `ManuallyDrop<_>` and ensure it is manually dropped
+   |
+LL |     a:  std::mem::ManuallyDrop<<Foo as Identity>::Identity>,
+   |         +++++++++++++++++++++++                           +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0740`.


### PR DESCRIPTION
From the experiment https://github.com/rust-lang/rust/pull/103985.

cc @compiler-errors 
r? @oli-obk 