### PR TITLE
Remove redundant session field

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1133,7 +1133,7 @@ impl<'a, 'b> DefIdTree for &'a Resolver<'b> {
     }
 }
 
-impl Resolver<'_> {
+impl<'a> Resolver<'a> {
     fn opt_local_def_id(&self, node: NodeId) -> Option<LocalDefId> {
         self.node_id_to_def_id.get(&node).copied()
     }
@@ -1189,6 +1189,10 @@ impl Resolver<'_> {
         } else {
             self.cstore().item_generics_num_lifetimes(def_id, self.session)
         }
+    }
+
+    pub fn sess(&self) -> &'a Session {
+        self.session
     }
 }
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -772,7 +772,6 @@ fn main_args(at_args: &[String]) -> MainResult {
     let crate_version = options.crate_version.clone();
 
     let output_format = options.output_format;
-    let externs = options.externs.clone();
     let scrape_examples_options = options.scrape_examples_options.clone();
     let bin_crate = options.bin_crate;
 
@@ -805,9 +804,7 @@ fn main_args(at_args: &[String]) -> MainResult {
                 let resolver_caches = resolver.borrow_mut().access(|resolver| {
                     collect_intra_doc_links::early_resolve_intra_doc_links(
                         resolver,
-                        sess,
                         krate,
-                        externs,
                         render_options.document_private,
                     )
                 });


### PR DESCRIPTION
There was already a session available in the resolver, so we access that session.