### PR TITLE
new trait solver: rebase impl substs for gats correctly

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -171,7 +171,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
             let impl_substs_with_gat = goal.predicate.projection_ty.substs.rebase_onto(
                 tcx,
                 goal_trait_ref.def_id,
-                impl_trait_ref.substs,
+                impl_substs,
             );
             let substs = translate_substs(
                 acx.infcx,


### PR DESCRIPTION
you might've caught this while working on projection code, if so then you can close this pr

r? @lcnr

 