### PR TITLE
allow negative numeric literals in `concat!`

### DIFF
--- a/tests/ui/macros/bad-concat.stderr
+++ b/tests/ui/macros/bad-concat.stderr
@@ -4,7 +4,7 @@ error: expected a literal
 LL |     let _ = concat!(x, y, z, "bar");
    |                     ^  ^  ^
    |
-   = note: only literals (like `"foo"`, `42` and `3.14`) can be passed to `concat!()`
+   = note: only literals (like `"foo"`, `-42` and `3.14`) can be passed to `concat!()`
 
 error: aborting due to previous error
 

--- a/tests/ui/macros/concat.stderr
+++ b/tests/ui/macros/concat.stderr
@@ -16,7 +16,7 @@ error: expected a literal
 LL |     concat!(foo);
    |             ^^^
    |
-   = note: only literals (like `"foo"`, `42` and `3.14`) can be passed to `concat!()`
+   = note: only literals (like `"foo"`, `-42` and `3.14`) can be passed to `concat!()`
 
 error: expected a literal
   --> $DIR/concat.rs:5:13
@@ -24,7 +24,7 @@ error: expected a literal
 LL |     concat!(foo());
    |             ^^^^^
    |
-   = note: only literals (like `"foo"`, `42` and `3.14`) can be passed to `concat!()`
+   = note: only literals (like `"foo"`, `-42` and `3.14`) can be passed to `concat!()`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/macros/issue-106837.rs
+++ b/tests/ui/macros/issue-106837.rs
@@ -1,0 +1,10 @@
+fn main() {
+    concat!(-42);
+    concat!(-3.14);
+
+    concat!(-"hello");
+    //~^ ERROR expected a literal
+
+    concat!(--1);
+    //~^ ERROR expected a literal
+}

--- a/tests/ui/macros/issue-106837.stderr
+++ b/tests/ui/macros/issue-106837.stderr
@@ -1,0 +1,18 @@
+error: expected a literal
+  --> $DIR/issue-106837.rs:5:13
+   |
+LL |     concat!(-"hello");
+   |             ^^^^^^^^
+   |
+   = note: only literals (like `"foo"`, `-42` and `3.14`) can be passed to `concat!()`
+
+error: expected a literal
+  --> $DIR/issue-106837.rs:8:13
+   |
+LL |     concat!(--1);
+   |             ^^^
+   |
+   = note: only literals (like `"foo"`, `-42` and `3.14`) can be passed to `concat!()`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #106837

While *technically* negative numeric literals are implemented as unary operations, users can reasonably expect that negative literals are treated the same as positive literals.