### PR TITLE
Include parent substs in `substs` argument in `nominal_obligations` when const param defaults exist

### DIFF
--- a/tests/ui/const-generics/generic_const_exprs/issue-101036.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-101036.rs
@@ -1,0 +1,16 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+const fn t<const N: usize>() -> u8 {
+    N as u8
+}
+
+#[repr(u8)]
+enum T<const N: u8 = { T::<0>::A as u8 + T::<0>::B as u8 }>
+where
+    [(); N as usize]:
+{
+    A = t::<N>() as u8, B //~ ERROR: unconstrained generic constant
+}
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/issue-101036.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-101036.stderr
@@ -1,0 +1,10 @@
+error: unconstrained generic constant
+  --> $DIR/issue-101036.rs:13:9
+   |
+LL |     A = t::<N>() as u8, B
+   |         ^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); t::<N>() as u8]:`
+
+error: aborting due to previous error
+

--- a/tests/ui/const-generics/generic_const_exprs/issue-105631.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-105631.rs
@@ -1,0 +1,11 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+struct A<const B: str = 1, C>;
+//~^ ERROR generic parameters with a default must be trailing
+//~| ERROR the size for values of type `str` cannot be known at compilation time
+//~| ERROR mismatched types
+//~| ERROR parameter `C` is never used
+//~| ERROR `str` is forbidden as the type of a const generic parameter
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/issue-105631.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-105631.stderr
@@ -1,0 +1,43 @@
+error: generic parameters with a default must be trailing
+  --> $DIR/issue-105631.rs:4:16
+   |
+LL | struct A<const B: str = 1, C>;
+   |                ^
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/issue-105631.rs:4:25
+   |
+LL | struct A<const B: str = 1, C>;
+   |                         ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: constant expressions must have a statically known size
+
+error[E0308]: mismatched types
+  --> $DIR/issue-105631.rs:4:25
+   |
+LL | struct A<const B: str = 1, C>;
+   |                         ^ expected `str`, found integer
+
+error[E0392]: parameter `C` is never used
+  --> $DIR/issue-105631.rs:4:28
+   |
+LL | struct A<const B: str = 1, C>;
+   |                            ^ unused parameter
+   |
+   = help: consider removing `C`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `C` to be a const parameter, use `const C: usize` instead
+
+error: `str` is forbidden as the type of a const generic parameter
+  --> $DIR/issue-105631.rs:4:19
+   |
+LL | struct A<const B: str = 1, C>;
+   |                   ^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: more complex types are supported with `#![feature(adt_const_params)]`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0277, E0308, E0392.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-106473.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-106473.rs
@@ -1,0 +1,14 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+const DEFAULT: u32 = 1;
+
+struct V<const U: usize = DEFAULT> //~ ERROR mismatched types
+where
+    [(); U]:;
+
+trait Tr {}
+
+impl Tr for V {}
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/issue-106473.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-106473.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-106473.rs:6:27
+   |
+LL | struct V<const U: usize = DEFAULT>
+   |                           ^^^^^^^ expected `usize`, found `u32`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #106994