### PR TITLE
Emit only one nbsp error per file

### DIFF
--- a/tests/ui/parser/unicode-chars.rs
+++ b/tests/ui/parser/unicode-chars.rs
@@ -6,10 +6,4 @@ fn main() {
     //~^ ERROR unknown start of token: \u{a0}
     //~^^ NOTE character appears 3 more times
     //~^^^ HELP Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
-    //~^^^^ ERROR unknown start of token: \u{a0}
-    //~^^^^^ HELP Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
-    //~^^^^^^ ERROR unknown start of token: \u{a0}
-    //~^^^^^^^ HELP Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
-    //~^^^^^^^^ ERROR unknown start of token: \u{a0}
-    //~^^^^^^^^^ HELP Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
 }

--- a/tests/ui/parser/unicode-chars.rs
+++ b/tests/ui/parser/unicode-chars.rs
@@ -2,8 +2,14 @@ fn main() {
     let y = 0;
     //~^ ERROR unknown start of token: \u{37e}
     //~^^ HELP Unicode character ';' (Greek Question Mark) looks like ';' (Semicolon), but it is not
-        let x = 0;
+        let x = 0;
     //~^ ERROR unknown start of token: \u{a0}
     //~^^ NOTE character appears 3 more times
     //~^^^ HELP Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
+    //~^^^^ ERROR unknown start of token: \u{a0}
+    //~^^^^^ HELP Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
+    //~^^^^^^ ERROR unknown start of token: \u{a0}
+    //~^^^^^^^ HELP Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
+    //~^^^^^^^^ ERROR unknown start of token: \u{a0}
+    //~^^^^^^^^^ HELP Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
 }

--- a/tests/ui/parser/unicode-chars.stderr
+++ b/tests/ui/parser/unicode-chars.stderr
@@ -12,14 +12,47 @@ LL |     let y = 0;
 error: unknown start of token: \u{a0}
   --> $DIR/unicode-chars.rs:5:5
    |
-LL |         let x = 0;
+LL |         let x = 0;
    |     ^^^^
    |
    = note: character appears 3 more times
 help: Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
    |
-LL |         let x = 0;
+LL |         let x = 0;
    |     ++++
 
-error: aborting due to 2 previous errors
+error: unknown start of token: \u{a0}
+  --> $DIR/unicode-chars.rs:5:12
+   |
+LL |         let x = 0;
+   |            ^
+   |
+help: Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
+   |
+LL |         let x = 0;
+   |            +
+
+error: unknown start of token: \u{a0}
+  --> $DIR/unicode-chars.rs:5:14
+   |
+LL |         let x = 0;
+   |              ^
+   |
+help: Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
+   |
+LL |         let x = 0;
+   |              +
+
+error: unknown start of token: \u{a0}
+  --> $DIR/unicode-chars.rs:5:16
+   |
+LL |         let x = 0;
+   |                ^
+   |
+help: Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
+   |
+LL |         let x = 0;
+   |                +
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/parser/unicode-chars.stderr
+++ b/tests/ui/parser/unicode-chars.stderr
@@ -21,38 +21,5 @@ help: Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is 
 LL |         let x = 0;
    |     ++++
 
-error: unknown start of token: \u{a0}
-  --> $DIR/unicode-chars.rs:5:12
-   |
-LL |         let x = 0;
-   |            ^
-   |
-help: Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
-   |
-LL |         let x = 0;
-   |            +
-
-error: unknown start of token: \u{a0}
-  --> $DIR/unicode-chars.rs:5:14
-   |
-LL |         let x = 0;
-   |              ^
-   |
-help: Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
-   |
-LL |         let x = 0;
-   |              +
-
-error: unknown start of token: \u{a0}
-  --> $DIR/unicode-chars.rs:5:16
-   |
-LL |         let x = 0;
-   |                ^
-   |
-help: Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
-   |
-LL |         let x = 0;
-   |                +
-
-error: aborting due to 5 previous errors
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes #106101.

See https://github.com/rust-lang/rust/issues/106098 for an explanation of how someone would end up with a large number of these nbsp characters in their source code, which is why I think rustc needs to handle this specific case in a friendlier way.