### PR TITLE
Customize ICE link to include some metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3948,6 +3948,7 @@ dependencies = [
  "libc",
  "rustc_ast",
  "rustc_ast_pretty",
+ "rustc_codegen_llvm",
  "rustc_codegen_ssa",
  "rustc_data_structures",
  "rustc_error_codes",

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -23,7 +23,7 @@ extern crate tracing;
 use back::write::{create_informational_target_machine, create_target_machine};
 
 use errors::FailParsingTargetMachineConfigToTargetMachine;
-pub use llvm_util::target_features;
+pub use llvm_util::{get_version, target_features};
 use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_codegen_ssa::back::lto::{LtoModuleCodegen, SerializedModule, ThinModule};
 use rustc_codegen_ssa::back::write::{

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -25,6 +25,7 @@ rustc_parse = { path = "../rustc_parse" }
 rustc_plugin_impl = { path = "../rustc_plugin_impl" }
 rustc_save_analysis = { path = "../rustc_save_analysis" }
 rustc_codegen_ssa = { path = "../rustc_codegen_ssa" }
+rustc_codegen_llvm = { path = "../rustc_codegen_llvm" }
 rustc_session = { path = "../rustc_session" }
 rustc_error_codes = { path = "../rustc_error_codes" }
 rustc_interface = { path = "../rustc_interface" }

--- a/tests/ui/impl-trait/issues/issue-86800.stderr
+++ b/tests/ui/impl-trait/issues/issue-86800.stderr
@@ -9,9 +9,7 @@ LL | type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResu
 
 stack backtrace:
 
-error: internal compiler error: unexpected panic
-
-
+error: internal compiler error: the compiler unexpectedly panicked. this is a bug.
 
 
 

--- a/tests/ui/layout/valid_range_oob.stderr
+++ b/tests/ui/layout/valid_range_oob.stderr
@@ -1,4 +1,4 @@
-error: internal compiler error: unexpected panic
+error: internal compiler error: the compiler unexpectedly panicked. this is a bug.
 
 query stack during panic:
 #0 [layout_of] computing layout of `Foo`

--- a/tests/ui/panics/default-backtrace-ice.stderr
+++ b/tests/ui/panics/default-backtrace-ice.stderr
@@ -4,9 +4,7 @@ LL | fn main() { missing_ident; }
 
 stack backtrace:
 
-error: internal compiler error: unexpected panic
-
-
+error: internal compiler error: the compiler unexpectedly panicked. this is a bug.
 
 
 

--- a/tests/ui/treat-err-as-bug/delay_span_bug.stderr
+++ b/tests/ui/treat-err-as-bug/delay_span_bug.stderr
@@ -4,7 +4,7 @@ error: internal compiler error: delayed span bug triggered by #[rustc_error(dela
 LL | fn main() {}
    | ^^^^^^^^^
 
-error: internal compiler error: unexpected panic
+error: internal compiler error: the compiler unexpectedly panicked. this is a bug.
 
 query stack during panic:
 #0 [trigger_delay_span_bug] triggering a delay span bug

--- a/tests/ui/treat-err-as-bug/err.stderr
+++ b/tests/ui/treat-err-as-bug/err.stderr
@@ -4,7 +4,7 @@ error[E0080]: could not evaluate static initializer
 LL | pub static C: u32 = 0 - 1;
    |                     ^^^^^ attempt to compute `0_u32 - 1_u32`, which would overflow
 
-error: internal compiler error: unexpected panic
+error: internal compiler error: the compiler unexpectedly panicked. this is a bug.
 
 query stack during panic:
 #0 [eval_to_allocation_raw] const-evaluating + checking `C`


### PR DESCRIPTION
The new URL will look like https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.yaml&version=rustc%201.68.0-dev%20running%20on%20x86_64-unknown-linux-gnu%20with%20LLVM%2015.0.6&title=%5BICE%5D%3A%20not%20implemented%2C%20compiler%2Frustc_const_eval%2Fsrc%2Ftransform%2Fcheck_consts%2Fcheck.rs%3A55%39%3A17