### PR TITLE
Make stage2 rustdoc and proc-macro-srv disableable in x.py install

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -285,11 +285,24 @@ changelog-seen = 2
 # be built if `extended = true`.
 #extended = false
 
-# Installs chosen set of extended tools if `extended = true`. By default builds
-# all extended tools except `rust-demangler`, unless the target is also being
-# built with `profiler = true`. If chosen tool failed to build the installation
-# fails. If `extended = false`, this option is ignored.
-#tools = ["cargo", "rls", "clippy", "rustfmt", "analysis", "src"] # + "rust-demangler" if `profiler`
+# Set of tools to be included in the installation.
+#
+# If `extended = false`, the only one of these built by default is rustdoc.
+#
+# If `extended = true`, they're all included, with the exception of
+# rust-demangler which additionally requires `profiler = true` to be set.
+#
+# If any enabled tool fails to build, the installation fails.
+#tools = [
+#    "cargo",
+#    "clippy",
+#    "rustdoc",
+#    "rustfmt",
+#    "rust-analyzer",
+#    "analysis",
+#    "src",
+#    "rust-demangler",  # if profiler = true
+#]
 
 # Verbosity level: 0 == not verbose, 1 == verbose, 2 == very verbose
 #verbose = 0

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -392,19 +392,29 @@ impl Step for Rustc {
             t!(fs::create_dir_all(image.join("bin")));
             builder.cp_r(&src.join("bin"), &image.join("bin"));
 
-            builder.install(&builder.rustdoc(compiler), &image.join("bin"), 0o755);
+            if builder
+                .config
+                .tools
+                .as_ref()
+                .map_or(true, |tools| tools.iter().any(|tool| tool == "rustdoc"))
+            {
+                let rustdoc = builder.rustdoc(compiler);
+                builder.install(&rustdoc, &image.join("bin"), 0o755);
+            }
 
-            let ra_proc_macro_srv = builder
-                .ensure(tool::RustAnalyzerProcMacroSrv {
+            if let Some(ra_proc_macro_srv) = builder.ensure_if_default(
+                tool::RustAnalyzerProcMacroSrv {
                     compiler: builder.compiler_for(
                         compiler.stage,
                         builder.config.build,
                         compiler.host,
                     ),
                     target: compiler.host,
-                })
-                .expect("rust-analyzer-proc-macro-server always builds");
-            builder.install(&ra_proc_macro_srv, &image.join("libexec"), 0o755);
+                },
+                builder.kind,
+            ) {
+                builder.install(&ra_proc_macro_srv, &image.join("libexec"), 0o755);
+            }
 
             let libdir_relative = builder.libdir_relative(compiler);
 

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -765,9 +765,15 @@ impl Step for RustAnalyzerProcMacroSrv {
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        let builder = run.builder;
         // Allow building `rust-analyzer-proc-macro-srv` both as part of the `rust-analyzer` and as a stand-alone tool.
         run.path("src/tools/rust-analyzer")
             .path("src/tools/rust-analyzer/crates/proc-macro-srv-cli")
+            .default_condition(builder.config.tools.as_ref().map_or(true, |tools| {
+                tools
+                    .iter()
+                    .any(|tool| tool == "rust-analyzer" || tool == "rust-analyzer-proc-macro-srv")
+            }))
     }
 
     fn make_run(run: RunConfig<'_>) {


### PR DESCRIPTION
Rustdoc will build if `[build] tools = ["rustdoc"]` is set, and rust-analyzer-proc-macro-srv will build if `[build] tools = ["rust-analyzer"]` is set.

On my machine skipping these tools speeds up `x.py install` from 7m15s to 6m08s (0m43s for rustdoc and 0m24s for rust-analyzer-proc-macro-srv). This is a significant speedup, since I never use rust-analyzer-proc-macro-srv, and I practically never need to use a custom build of rustdoc.