### PR TITLE
Explain base expression for struct update syntax

### DIFF
--- a/compiler/rustc_ast_lowering/messages.ftl
+++ b/compiler/rustc_ast_lowering/messages.ftl
@@ -35,7 +35,7 @@ ast_lowering_bad_return_type_notation_output =
 
 ast_lowering_base_expression_double_dot =
     base expression required after `..`
-    .label = add a base expression here
+    .suggestion = add a base expression here
 
 ast_lowering_clobber_abi_not_supported =
     `clobber_abi` is not supported on this target

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -114,10 +114,10 @@ pub struct UnderscoreExprLhsAssign {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering_base_expression_double_dot)]
+#[diag(ast_lowering_base_expression_double_dot, code = "E0797")]
 pub struct BaseExpressionDoubleDot {
     #[primary_span]
-    #[label]
+    #[suggestion(code = "/* expr */", applicability = "has-placeholders", style = "verbose")]
     pub span: Span,
 }
 

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -516,6 +516,7 @@ E0793: include_str!("./error_codes/E0793.md"),
 E0794: include_str!("./error_codes/E0794.md"),
 E0795: include_str!("./error_codes/E0795.md"),
 E0796: include_str!("./error_codes/E0796.md"),
+E0797: include_str!("./error_codes/E0797.md"),
 }
 
 // Undocumented removed error codes. Note that many removed error codes are kept in the list above

--- a/compiler/rustc_error_codes/src/error_codes/E0797.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0797.md
@@ -1,0 +1,26 @@
+Struct update syntax was used without a base expression.
+
+Erroneous code example:
+
+```compile_fail,E0797
+struct Foo {
+    fizz: u8,
+    buzz: u8
+}
+
+let f1 = Foo { fizz: 10, buzz: 1};
+let f2 = Foo { fizz: 10, .. }; // error
+```
+
+Using struct update syntax requires a 'base expression'.
+This will be used to fill remaining fields.
+
+```
+struct Foo {
+    fizz: u8,
+    buzz: u8
+}
+
+let f1 = Foo { fizz: 10, buzz: 1};
+let f2 = Foo { fizz: 10, ..f1 };
+```

--- a/tests/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/tests/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -12,11 +12,16 @@ error: functional record updates are not allowed in destructuring assignments
 LL |     Struct { a, ..d } = Struct { a: 1, b: 2 };
    |                   ^ help: consider removing the trailing pattern
 
-error: base expression required after `..`
+error[E0797]: base expression required after `..`
   --> $DIR/struct_destructure_fail.rs:15:19
    |
 LL |     Struct { a, .. };
-   |                   ^ add a base expression here
+   |                   ^
+   |
+help: add a base expression here
+   |
+LL |     Struct { a, ../* expr */ };
+   |                   ++++++++++
 
 error[E0026]: struct `Struct` does not have a field named `c`
   --> $DIR/struct_destructure_fail.rs:10:20
@@ -41,5 +46,5 @@ LL |     Struct { a, .. } = Struct { a: 1, b: 2 };
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0026, E0027.
+Some errors have detailed explanations: E0026, E0027, E0797.
 For more information about an error, try `rustc --explain E0026`.


### PR DESCRIPTION
Fixes #106890

@rustbot label +A-diagnostics