### PR TITLE
Include both md and yaml ICE ticket templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ice.md
+++ b/.github/ISSUE_TEMPLATE/ice.md
@@ -1,0 +1,49 @@
+---
+name: Internal Compiler Error
+about: Create a report for an internal compiler error in rustc.
+labels: C-bug, I-ICE, T-compiler
+---
+<!--
+Thank you for finding an Internal Compiler Error! 🧊  If possible, try to provide
+a minimal verifiable example. You can read "Rust Bug Minimization Patterns" for
+how to create smaller examples.
+http://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/
+-->
+
+### Code
+
+```Rust
+<code>
+```
+
+
+### Meta
+<!--
+If you're using the stable version of the compiler, you should also check if the
+bug also exists in the beta or nightly versions.
+-->
+
+`rustc --version --verbose`:
+```
+<version>
+```
+
+### Error output
+
+```
+<output>
+```
+
+<!--
+Include a backtrace in the code block by setting `RUST_BACKTRACE=1` in your
+environment. E.g. `RUST_BACKTRACE=1 cargo build`.
+-->
+<details><summary><strong>Backtrace</strong></summary>
+<p>
+
+```
+<backtrace>
+```
+
+</p>
+</details>

--- a/.github/ISSUE_TEMPLATE/ice.yaml
+++ b/.github/ISSUE_TEMPLATE/ice.yaml
@@ -1,5 +1,5 @@
-name: Internal Compiler Error
-description: Create a report for an internal compiler error in `rustc`
+name: Internal Compiler Error (Structured form)
+description: For now, you'll want to use the other ICE template, as GitHub forms have strict limits on the size of fields so backtraces cannot be pasted directly.
 labels: ["C-bug", "I-ICE", "T-compiler"]
 title: "[ICE]: "
 body:


### PR DESCRIPTION
* Existing compilers link to the md version
* The YAML version field for the backtrace *doesn't let us paste a full backtrace*
* We will need the YAML version in order to be able to submit reports once we start storing the backtrace to disk

Follow up to #106831. Reaction to #106874, which made me realize that *really* long backtraces are rejected by GitHub Forms. A single backtrace won't hit this, but ICEs sometimes compound.