### PR TITLE
Fix regression in `unused_braces` with macros

### DIFF
--- a/tests/ui/lint/unused_braces.fixed
+++ b/tests/ui/lint/unused_braces.fixed
@@ -50,4 +50,8 @@ fn main() {
     if { return } {
 
     }
+
+    // regression test for https://github.com/rust-lang/rust/issues/106899
+    return println!("!");
+    //~^ WARN unnecessary braces
 }

--- a/tests/ui/lint/unused_braces.rs
+++ b/tests/ui/lint/unused_braces.rs
@@ -50,4 +50,8 @@ fn main() {
     if { return } {
 
     }
+
+    // regression test for https://github.com/rust-lang/rust/issues/106899
+    return { println!("!") };
+    //~^ WARN unnecessary braces
 }

--- a/tests/ui/lint/unused_braces.stderr
+++ b/tests/ui/lint/unused_braces.stderr
@@ -68,5 +68,17 @@ LL -     consume({ 7 });
 LL +     consume(7);
    |
 
-warning: 5 warnings emitted
+warning: unnecessary braces around `return` value
+  --> $DIR/unused_braces.rs:55:12
+   |
+LL |     return { println!("!") };
+   |            ^^             ^^
+   |
+help: remove these braces
+   |
+LL -     return { println!("!") };
+LL +     return println!("!");
+   |
+
+warning: 6 warnings emitted
 


### PR DESCRIPTION
Fixes #106899

