### PR TITLE
Do not normalize field types in elaborate_drops.

### DIFF
--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -274,8 +274,7 @@ where
                 let tcx = self.tcx();
 
                 assert_eq!(self.elaborator.param_env().reveal(), Reveal::All);
-                let field_ty =
-                    tcx.normalize_erasing_regions(self.elaborator.param_env(), f.ty(tcx, substs));
+                let field_ty = tcx.erase_regions(f.ty(tcx, substs));
                 (tcx.mk_place_field(base_place, field, field_ty), subpath)
             })
             .collect()

--- a/tests/mir-opt/inline/issue_106444.bar.Inline.diff
+++ b/tests/mir-opt/inline/issue_106444.bar.Inline.diff
@@ -1,0 +1,32 @@
+- // MIR for `bar` before Inline
++ // MIR for `bar` after Inline
+  
+  fn bar(_1: *mut S<T>) -> () {
+      debug p => _1;                       // in scope 0 at $DIR/issue_106444.rs:+0:28: +0:29
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue_106444.rs:+0:42: +0:42
+      let _2: ();                          // in scope 0 at $DIR/issue_106444.rs:+2:14: +2:41
+      let mut _3: *mut S<T>;               // in scope 0 at $DIR/issue_106444.rs:+2:39: +2:40
+      scope 1 {
++         scope 2 (inlined std::ptr::drop_in_place::<S<T>> - shim(Some(S<T>))) { // at $DIR/issue_106444.rs:16:14: 16:41
++         }
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/issue_106444.rs:+2:5: +2:43
+          StorageLive(_3);                 // scope 1 at $DIR/issue_106444.rs:+2:39: +2:40
+          _3 = _1;                         // scope 1 at $DIR/issue_106444.rs:+2:39: +2:40
+-         _2 = std::ptr::drop_in_place::<S<T>>(move _3) -> bb1; // scope 1 at $DIR/issue_106444.rs:+2:14: +2:41
+-                                          // mir::Constant
+-                                          // + span: $DIR/issue_106444.rs:16:14: 16:38
+-                                          // + literal: Const { ty: unsafe fn(*mut S<T>) {std::ptr::drop_in_place::<S<T>>}, val: Value(<ZST>) }
++         drop(((*_3).0: U)) -> bb1;       // scope 2 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+      }
+  
+      bb1: {
+          StorageDead(_3);                 // scope 1 at $DIR/issue_106444.rs:+2:40: +2:41
+          StorageDead(_2);                 // scope 0 at $DIR/issue_106444.rs:+2:43: +2:44
+          _0 = const ();                   // scope 0 at $DIR/issue_106444.rs:+0:42: +3:2
+          return;                          // scope 0 at $DIR/issue_106444.rs:+3:2: +3:2
+      }
+  }
+  

--- a/tests/mir-opt/inline/issue_106444.foo.Inline.diff
+++ b/tests/mir-opt/inline/issue_106444.foo.Inline.diff
@@ -1,0 +1,32 @@
+- // MIR for `foo` before Inline
++ // MIR for `foo` after Inline
+  
+  fn foo(_1: *mut S<T>) -> () {
+      debug p => _1;                       // in scope 0 at $DIR/issue_106444.rs:+0:18: +0:19
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue_106444.rs:+0:32: +0:32
+      let _2: ();                          // in scope 0 at $DIR/issue_106444.rs:+2:14: +2:41
+      let mut _3: *mut S<T>;               // in scope 0 at $DIR/issue_106444.rs:+2:39: +2:40
+      scope 1 {
++         scope 2 (inlined std::ptr::drop_in_place::<S<T>> - shim(Some(S<T>))) { // at $DIR/issue_106444.rs:11:14: 11:41
++         }
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/issue_106444.rs:+2:5: +2:43
+          StorageLive(_3);                 // scope 1 at $DIR/issue_106444.rs:+2:39: +2:40
+          _3 = _1;                         // scope 1 at $DIR/issue_106444.rs:+2:39: +2:40
+-         _2 = std::ptr::drop_in_place::<S<T>>(move _3) -> bb1; // scope 1 at $DIR/issue_106444.rs:+2:14: +2:41
+-                                          // mir::Constant
+-                                          // + span: $DIR/issue_106444.rs:11:14: 11:38
+-                                          // + literal: Const { ty: unsafe fn(*mut S<T>) {std::ptr::drop_in_place::<S<T>>}, val: Value(<ZST>) }
++         drop(((*_3).0: <T as A>::B)) -> bb1; // scope 2 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+      }
+  
+      bb1: {
+          StorageDead(_3);                 // scope 1 at $DIR/issue_106444.rs:+2:40: +2:41
+          StorageDead(_2);                 // scope 0 at $DIR/issue_106444.rs:+2:43: +2:44
+          _0 = const ();                   // scope 0 at $DIR/issue_106444.rs:+0:32: +3:2
+          return;                          // scope 0 at $DIR/issue_106444.rs:+3:2: +3:2
+      }
+  }
+  

--- a/tests/mir-opt/inline/issue_106444.rs
+++ b/tests/mir-opt/inline/issue_106444.rs
@@ -1,0 +1,20 @@
+#![crate_type = "lib"]
+
+pub trait A {
+    type B;
+}
+
+pub struct S<T: A>(T::B);
+
+pub fn foo<T: A>(p: *mut S<T>) {
+    // Verify that we do not ICE when elaborating `Drop(*p)`.
+    unsafe { core::ptr::drop_in_place(p) };
+}
+
+pub fn bar<U, T: A<B = U>>(p: *mut S<T>) {
+    // Verify that we use the correct type for `(*p).0` when elaborating `Drop(*p)`.
+    unsafe { core::ptr::drop_in_place(p) };
+}
+
+// EMIT_MIR issue_106444.foo.Inline.diff
+// EMIT_MIR issue_106444.bar.Inline.diff


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/106444