### PR TITLE
Add documentation about the memory layout of `Cell`

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -209,6 +209,12 @@ pub use once::OnceCell;
 
 /// A mutable memory location.
 ///
+/// # Memory layout
+///
+/// `Cell<T>` has the same [memory layout and caveats as
+/// `UnsafeCell<T>`](UnsafeCell#memory-layout). In particular, this means that
+/// `Cell<T>` has the same in-memory representation as its inner type `T`.
+///
 /// # Examples
 ///
 /// In this example, you can see that `Cell<T>` enables mutation inside an


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/101717 guaranteed the memory layout of `UnsafeCell<T>`.

This property (a guaranteed memory layout) can be useful to have on `Cell<T>` as well.

(Note that `Cell<u8>` [already doesn't trigger the `improper_ctypes` lint](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=34af59ef60b96d8a8bdaec1d52cb5420) since it is `#[repr(transparent)]`).

The concrete use-case is for the crate [`objc2`](https://github.com/madsmtm/objc2) to specify that `Cell<T>` is safe to use as an instance variable when `T` is.

Fixes https://github.com/rust-lang/rust/issues/79303.

---

I'm unsure if we should specify less, for example say that the `Cell` may have extra restrictions on when it may be accessed, or if that's implicit in the (deliberately minimal) way I've worded it here?