### PR TITLE
Remove hardcoded iOS version of clang target for Mac Catalyst

### DIFF
--- a/compiler/rustc_target/src/spec/aarch64_apple_ios_macabi.rs
+++ b/compiler/rustc_target/src/spec/aarch64_apple_ios_macabi.rs
@@ -2,7 +2,7 @@ use super::apple_base::{opts, Arch};
 use crate::spec::{Cc, FramePointer, LinkerFlavor, Lld, Target, TargetOptions};
 
 pub fn target() -> Target {
-    let llvm_target = "arm64-apple-ios14.0-macabi";
+    let llvm_target = "arm64-apple-ios-macabi";
 
     let arch = Arch::Arm64_macabi;
     let mut base = opts("ios", arch);
@@ -22,7 +22,7 @@ pub fn target() -> Target {
             // These arguments are not actually invoked - they just have
             // to look right to pass App Store validation.
             bitcode_llvm_cmdline: "-triple\0\
-                arm64-apple-ios14.0-macabi\0\
+                arm64-apple-ios-macabi\0\
                 -emit-obj\0\
                 -disable-llvm-passes\0\
                 -Os\0"

--- a/compiler/rustc_target/src/spec/x86_64_apple_ios_macabi.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_ios_macabi.rs
@@ -2,7 +2,7 @@ use super::apple_base::{opts, Arch};
 use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetOptions};
 
 pub fn target() -> Target {
-    let llvm_target = "x86_64-apple-ios13.0-macabi";
+    let llvm_target = "x86_64-apple-ios-macabi";
 
     let arch = Arch::X86_64_macabi;
     let mut base = opts("ios", arch);


### PR DESCRIPTION
## Background

From `clang` 13.x, `-target x86_64-apple-ios13.0-macabi` fails while linking:

```
  = note: clang: error: invalid version number in '-target x86_64-apple-ios13.0-macabi'
```

<details>
<summary>Verbose output</summary>

```
error: linking with `cc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="[removed]" VSLANG="1033" ZERO_AR_DATE="1" "cc" "-Wl,-exported_symbols_list,/var/folders/p8/qpmzbsdn07g5gxykwfxxw7y40000gn/T/rustci8tkvp/list" "-target" "x86_64-apple-ios13.0-macabi" "/var/folders/p8/qpmzbsdn07g5gxykwfxxw7y40000gn/T/rustci8tkvp/symbols.o" "/path/to/my/[project]/[user]/target/x86_64-apple-ios-macabi/release/deps/[user].[user].a2ccc648-cgu.0.rcgu.o" "-L" "/path/to/my/[project]/[user]/target/x86_64-apple-ios-macabi/release/deps" "-L" "/path/to/my/[project]/[user]/target/release/deps" "-L" "/path/to/my/[project]/[user]/target/x86_64-apple-ios-macabi/release/build/blake3-74e6ba91506ce712/out" "-L" "/path/to/my/[project]/[user]/target/x86_64-apple-ios-macabi/release/build/blake3-74e6ba91506ce712/out" "-L" "/Users/[user]/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/x86_64-apple-ios-macabi/lib" "/var/folders/p8/qpmzbsdn07g5gxykwfxxw7y40000gn/T/rustci8tkvp/libblake3-343c1616c8f62c66.rlib" "/path/to/my/[project]/[user]/target/x86_64-apple-ios-macabi/release/deps/libcompiler_builtins-15d4f20b641cf9ef.rlib" "-framework" "Security" "-framework" "CoreFoundation" "-framework" "Security" "-liconv" "-lSystem" "-lobjc" "-framework" "Security" "-framework" "Foundation" "-lc" "-lm" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk" "-Wl,-syslibroot" "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk" "-L" "/Users/[user]/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/x86_64-apple-ios-macabi/lib" "-o" "/path/to/my/[project]/[user]/target/x86_64-apple-ios-macabi/release/deps/lib[user].dylib" "-Wl,-dead_strip" "-dynamiclib" "-Wl,-dylib" "-nodefaultlibs"
  = note: clang: error: invalid version number in '-target x86_64-apple-ios13.0-macabi'
          

warning: `[user]` (lib) generated 6 warnings
error: could not compile `[user]` due to previous error; 6 warnings emitted
```
</details>

### Minimal example

C code:

```c
#include <stdio.h>
void main() {
    int a = 1;
    int b = 2;
    int c = a + b;
    printf("%d", c);
}
```

`clang` command sample:

```
➜  202301 clang -target x86_64-apple-ios13.0-macabi main.c
clang: error: invalid version number in '-target x86_64-apple-ios13.0-macabi'
➜  202301 clang -target x86_64-apple-ios14.0-macabi main.c
main.c:2:1: warning: return type of 'main' is not 'int' [-Wmain-return-type]
void main() {
^
main.c:2:1: note: change return type to 'int'
void main() {
^~~~
int
1 warning generated.
➜  202301 clang -target x86_64-apple-ios15.0-macabi main.c
main.c:2:1: warning: return type of 'main' is not 'int' [-Wmain-return-type]
void main() {
^
main.c:2:1: note: change return type to 'int'
void main() {
^~~~
int
1 warning generated.
➜  202301 clang -target x86_64-apple-ios-macabi main.c
main.c:2:1: warning: return type of 'main' is not 'int' [-Wmain-return-type]
void main() {
^
main.c:2:1: note: change return type to 'int'
void main() {
^~~~
int
1 warning generated.

➜  202301 clang --version
Apple clang version 14.0.0 (clang-1400.0.29.202)
Target: arm64-apple-darwin22.2.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

This PR is a simplified version of #96392, inspired by https://github.com/rust-lang/cc-rs/pull/727