### PR TITLE
Add missing normalization for union fields types

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -121,7 +121,7 @@ fn check_union_fields(tcx: TyCtxt<'_>, span: Span, item_def_id: LocalDefId) -> b
 
         let param_env = tcx.param_env(item_def_id);
         for field in &def.non_enum_variant().fields {
-            let field_ty = field.ty(tcx, substs);
+            let field_ty = tcx.normalize_erasing_regions(param_env, field.ty(tcx, substs));
 
             if !allowed_union_field(field_ty, tcx, param_env) {
                 let (field_span, ty_span) = match tcx.hir().get_if_local(field.did) {

--- a/tests/ui/union/projection-as-union-type-error-2.rs
+++ b/tests/ui/union/projection-as-union-type-error-2.rs
@@ -1,0 +1,20 @@
+// Test to ensure that there is no ICE when normalizing a projection
+// which is invalid (from <https://github.com/rust-lang/rust/pull/106938>).
+
+#![crate_type = "lib"]
+
+trait Identity {
+    type Identity;
+}
+trait NotImplemented {}
+
+impl<T: NotImplemented> Identity for T {
+    type Identity = Self;
+}
+
+type Foo = u8;
+
+union Bar {
+    a: <Foo as Identity>::Identity, //~ ERROR
+    b: u8,
+}

--- a/tests/ui/union/projection-as-union-type-error-2.stderr
+++ b/tests/ui/union/projection-as-union-type-error-2.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `u8: NotImplemented` is not satisfied
+  --> $DIR/projection-as-union-type-error-2.rs:18:8
+   |
+LL |     a: <Foo as Identity>::Identity,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotImplemented` is not implemented for `u8`
+   |
+note: required for `u8` to implement `Identity`
+  --> $DIR/projection-as-union-type-error-2.rs:11:25
+   |
+LL | impl<T: NotImplemented> Identity for T {
+   |         --------------  ^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/union/projection-as-union-type-error.rs
+++ b/tests/ui/union/projection-as-union-type-error.rs
@@ -1,0 +1,15 @@
+// Test to ensure that there is no ICE when normalizing a projection
+// which is invalid (from <https://github.com/rust-lang/rust/pull/106938>).
+
+#![crate_type = "lib"]
+
+pub trait Identity {
+    type Identity;
+}
+
+pub type Foo = u8;
+
+pub union Bar {
+    a:  <Foo as Identity>::Identity, //~ ERROR
+    b: u8,
+}

--- a/tests/ui/union/projection-as-union-type-error.stderr
+++ b/tests/ui/union/projection-as-union-type-error.stderr
@@ -1,0 +1,9 @@
+error[E0277]: the trait bound `u8: Identity` is not satisfied
+  --> $DIR/projection-as-union-type-error.rs:13:9
+   |
+LL |     a:  <Foo as Identity>::Identity,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Identity` is not implemented for `u8`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/union/projection-as-union-type.rs
+++ b/tests/ui/union/projection-as-union-type.rs
@@ -1,0 +1,19 @@
+// Ensures that we can use projections as union field's type.
+// check-pass
+
+#![crate_type = "lib"]
+
+pub trait Identity {
+    type Identity;
+}
+
+impl<T> Identity for T {
+    type Identity = Self;
+}
+
+pub type Foo = u8;
+
+pub union Bar {
+    pub a: <Foo as Identity>::Identity,
+    pub b: u8,
+}


### PR DESCRIPTION
Overshadows https://github.com/rust-lang/rust/pull/106808.
From the experiment https://github.com/rust-lang/rust/pull/103985.

In short, it allows to use projections as a type for union's fields.

cc @compiler-errors 
r? @oli-obk 