### PR TITLE
implement Hash for proc_macro::LineColumn

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -581,7 +581,7 @@ impl fmt::Debug for Span {
 
 /// A line-column pair representing the start or end of a `Span`.
 #[unstable(feature = "proc_macro_span", issue = "54725")]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct LineColumn {
     /// The 1-indexed line in the source file on which the span starts or ends (inclusive).
     #[unstable(feature = "proc_macro_span", issue = "54725")]


### PR DESCRIPTION
For use in `HashMap<LineColumn, TokenTree>` or `HashMap<LineColumn, Comment>`, for example.

[Here is an example of one case complicated by the absence of this impl.](https://github.com/andrewbaxter/genemichaels/blob/71bc45e417c3f9dae09f890f1ec4630e758e5c70/src/comments.rs#L25-L34)

Tracking issue: https://github.com/rust-lang/rust/issues/54725