### PR TITLE
Don't add A-bootstrap to PRs modifying Cargo.lock

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -185,7 +185,6 @@ trigger_files = [
     "src/tools/x",
     "configure",
     "Cargo.toml",
-    "Cargo.lock",
     "config.toml.example",
     "src/stage0.json"
 ]


### PR DESCRIPTION
Changing Cargo.lock is common even when adding dependencies between existing rustc crates.

cc https://github.com/rust-lang/rust/pull/103204#discussion_r1070268737, @m-ou-se