### PR TITLE
Add consts for `AssocConst` w/ body & ignore regions in `is_satisfied_from_param_env`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -205,10 +205,11 @@ fn satisfied_from_param_env<'tcx>(
 
     let mut single_match: Option<Result<ty::Const<'tcx>, ()>> = None;
 
+    let ct = tcx.erase_regions(ct);
     for pred in param_env.caller_bounds() {
         match pred.kind().skip_binder() {
             ty::PredicateKind::ConstEvaluatable(ce) => {
-                let b_ct = tcx.expand_abstract_consts(ce);
+                let b_ct = tcx.erase_regions(tcx.expand_abstract_consts(ce));
                 let mut v = Visitor { ct, infcx, param_env, single_match };
                 let _ = b_ct.visit_with(&mut v);
 

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -5,7 +5,7 @@ use rustc_middle::mir::interpret::{LitToConstError, LitToConstInput};
 use rustc_middle::thir::visit;
 use rustc_middle::thir::visit::Visitor;
 use rustc_middle::ty::abstract_const::CastKind;
-use rustc_middle::ty::{self, Expr, TyCtxt, TypeVisitable};
+use rustc_middle::ty::{self, DefIdTree, Expr, TyCtxt, TypeVisitable};
 use rustc_middle::{mir, thir};
 use rustc_span::Span;
 use rustc_target::abi::VariantIdx;
@@ -361,6 +361,10 @@ pub fn thir_abstract_const(
             //
             // Right now we do neither of that and simply always fail to unify them.
             DefKind::AnonConst | DefKind::InlineConst => (),
+            DefKind::AssocConst if let Some(parent) = tcx.opt_local_parent(def.did)
+              && DefKind::Impl == tcx.def_kind(parent) => {
+                ()
+            },
             _ => return Ok(None),
         }
 

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(control_flow_enum)]
 #![feature(never_type)]
 #![feature(box_patterns)]
+#![feature(if_let_guard)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/tests/ui/const-generics/issues/issue-105821.rs
+++ b/tests/ui/const-generics/issues/issue-105821.rs
@@ -1,0 +1,26 @@
+#![allow(incomplete_features)]
+#![feature(adt_const_params, const_ptr_read, generic_const_exprs)]
+#![allow(dead_code)]
+
+const fn catone<const M: usize>(_a: &[u8; M]) -> [u8; M + 1]
+where
+    [(); M + 1]:,
+{
+  [0; M+1]
+}
+
+struct Catter<const A: &'static [u8]>;
+impl<const A: &'static [u8]> Catter<A>
+where
+    [(); A.len() + 1]:,
+{
+    const ZEROS: &'static [u8; A.len()] = &[0_u8; A.len()];
+    //~^ ERROR overly complex
+    const R: &'static [u8] = &catone(Self::ZEROS);
+    //~^ ERROR overly complex
+}
+
+fn main() {
+  let _ = Catter::<{&[]}>::R;
+  let _ = Catter::<{&[]}>::ZEROS;
+}

--- a/tests/ui/const-generics/issues/issue-105821.stderr
+++ b/tests/ui/const-generics/issues/issue-105821.stderr
@@ -1,0 +1,19 @@
+error: overly complex generic constant
+  --> $DIR/issue-105821.rs:17:43
+   |
+LL |     const ZEROS: &'static [u8; A.len()] = &[0_u8; A.len()];
+   |                                           ^^^^^^^^^^^^^^^^ borrowing is not supported in generic constants
+   |
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
+
+error: overly complex generic constant
+  --> $DIR/issue-105821.rs:19:30
+   |
+LL |     const R: &'static [u8] = &catone(Self::ZEROS);
+   |                              ^^^^^^^^^^^^^^^^^^^^ pointer casts are not allowed in generic constants
+   |
+   = help: consider moving this anonymous constant into a `const` function
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/const-generics/issues/issue-106423.rs
+++ b/tests/ui/const-generics/issues/issue-106423.rs
@@ -1,0 +1,53 @@
+#![feature(generic_const_exprs, generic_arg_infer)]
+#![allow(incomplete_features)]
+#![allow(unused)]
+
+use std::mem::MaybeUninit;
+
+pub struct Arr<T, const N: usize> {
+    v: [MaybeUninit<T>; N],
+}
+
+impl<T, const N: usize> Arr<T, N> {
+    const ELEM: MaybeUninit<T> = MaybeUninit::uninit();
+    const INIT: [MaybeUninit<T>; N] = [Self::ELEM; N]; // important for optimization of `new`
+    //~^ ERROR overly complex
+
+    fn new() -> Self {
+        Arr { v: Self::INIT }
+    }
+}
+
+pub struct BaFormatFilter<const N: usize> {}
+
+pub enum DigitalFilter<const N: usize>
+where
+    [(); N * 2 + 1]: Sized,
+    [(); N * 2]: Sized,
+{
+    Ba(BaFormatFilter<{ N * 2 + 1 }>),
+}
+
+pub fn iirfilter_st_copy<const N: usize, const M: usize>(_: [f32; M]) -> DigitalFilter<N>
+where
+    [(); N * 2 + 1]: Sized,
+    [(); N * 2]: Sized,
+{
+    let zpk = zpk2tf_st(&Arr::<f32, { N * 2 }>::new(), &Arr::<f32, { N * 2 }>::new());
+    DigitalFilter::Ba(zpk)
+}
+
+pub fn zpk2tf_st<const N: usize>(
+    _z: &Arr<f32, N>,
+    _p: &Arr<f32, N>,
+) -> BaFormatFilter<{ N + 1 }>
+where
+    [(); N + 1]: Sized,
+{
+    BaFormatFilter {}
+}
+
+
+fn main() {
+    iirfilter_st_copy::<4, 2>([10., 50.,]);
+}

--- a/tests/ui/const-generics/issues/issue-106423.stderr
+++ b/tests/ui/const-generics/issues/issue-106423.stderr
@@ -1,0 +1,11 @@
+error: overly complex generic constant
+  --> $DIR/issue-106423.rs:13:39
+   |
+LL |     const INIT: [MaybeUninit<T>; N] = [Self::ELEM; N]; // important for optimization of `new`
+   |                                       ^^^^^^^^^^^^^^^ array construction is not supported in generic constants
+   |
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Add in the ability to unify associated consts and ignore regions when unifying consts.
Attempting to only ignore regions lead to an ice, so I had to add that the associated const would be unified with it.

Handles one of the minimized test cases in #105821, but not sure if it fixes everything.

Fixes #106423 (but I think it may break the compilation of some crates, as I'm not sure if we were previously permitting that behavior?)

r? @BoxyUwU 