### PR TITLE
Remove the assume(!is_null) from Vec::as_ptr

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -59,7 +59,6 @@ use core::cmp::Ordering;
 use core::convert::TryFrom;
 use core::fmt;
 use core::hash::{Hash, Hasher};
-use core::intrinsics::assume;
 use core::iter;
 #[cfg(not(no_global_oom_handling))]
 use core::iter::FromIterator;
@@ -1240,11 +1239,7 @@ impl<T, A: Allocator> Vec<T, A> {
     pub fn as_ptr(&self) -> *const T {
         // We shadow the slice method of the same name to avoid going through
         // `deref`, which creates an intermediate reference.
-        let ptr = self.buf.ptr();
-        unsafe {
-            assume(!ptr.is_null());
-        }
-        ptr
+        self.buf.ptr()
     }
 
     /// Returns an unsafe mutable pointer to the vector's buffer, or a dangling
@@ -1277,11 +1272,7 @@ impl<T, A: Allocator> Vec<T, A> {
     pub fn as_mut_ptr(&mut self) -> *mut T {
         // We shadow the slice method of the same name to avoid going through
         // `deref_mut`, which creates an intermediate reference.
-        let ptr = self.buf.ptr();
-        unsafe {
-            assume(!ptr.is_null());
-        }
-        ptr
+        self.buf.ptr()
     }
 
     /// Returns a reference to the underlying allocator.

--- a/tests/codegen/vec-as-ptr.rs
+++ b/tests/codegen/vec-as-ptr.rs
@@ -1,0 +1,19 @@
+// compile-flags: -O -Zmerge-functions=disabled
+
+#![crate_type = "lib"]
+
+// Test that even though we return a *const u8 not a &[u8] or a NonNull<u8>, LLVM knows that this
+// pointer is nonnull.
+// CHECK: nonnull {{i8\*|ptr}} @vec_as_ptr
+#[no_mangle]
+pub fn vec_as_ptr(v: &Vec<u8>) -> *const u8 {
+    v.as_ptr()
+}
+
+// Test that even though we return a *const u8 not a &[u8] or a NonNull<u8>, LLVM knows that this
+// pointer is nonnull.
+// CHECK: nonnull {{i8\*|ptr}} @vec_as_mut_ptr
+#[no_mangle]
+pub fn vec_as_mut_ptr(v: &mut Vec<u8>) -> *mut u8 {
+    v.as_mut_ptr()
+}


### PR DESCRIPTION
At a guess, this code is leftover from LLVM was worse at keeping track of the niche information here. In any case, we don't need this anymore: Removing this `assume` doesn't get rid of the `nonnull` attribute on the return type.