### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -248,6 +248,12 @@ impl<'a, T: EarlyLintPass> ast_visit::Visitor<'a> for EarlyContextAndPass<'a, T>
     }
 
     fn visit_where_predicate(&mut self, p: &'a ast::WherePredicate) {
+        use rustc_ast::{WhereBoundPredicate, WherePredicate};
+        if let WherePredicate::BoundPredicate(WhereBoundPredicate { bounded_ty, .. }) = p &&
+            let ast::TyKind::BareFn(b) = &bounded_ty.kind &&
+            b.generic_params.len() > 0 {
+                return;
+        }
         ast_visit::walk_where_predicate(self, p);
     }
 

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -248,13 +248,9 @@ impl<'a, T: EarlyLintPass> ast_visit::Visitor<'a> for EarlyContextAndPass<'a, T>
     }
 
     fn visit_where_predicate(&mut self, p: &'a ast::WherePredicate) {
-        use rustc_ast::{WhereBoundPredicate, WherePredicate};
-        if let WherePredicate::BoundPredicate(WhereBoundPredicate { bounded_ty, .. }) = p &&
-            let ast::TyKind::BareFn(b) = &bounded_ty.kind &&
-            b.generic_params.len() > 0 {
-                return;
-        }
+        lint_callback!(self, enter_where_predicate, p);
         ast_visit::walk_where_predicate(self, p);
+        lint_callback!(self, exit_where_predicate, p);
     }
 
     fn visit_poly_trait_ref(&mut self, t: &'a ast::PolyTraitRef) {

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -145,7 +145,7 @@ early_lint_methods!(
     [
         pub BuiltinCombinedEarlyLintPass,
         [
-            UnusedParens: UnusedParens,
+            UnusedParens: UnusedParens::new(),
             UnusedBraces: UnusedBraces,
             UnusedImportBraces: UnusedImportBraces,
             UnsafeCode: UnsafeCode,

--- a/compiler/rustc_lint/src/passes.rs
+++ b/compiler/rustc_lint/src/passes.rs
@@ -171,6 +171,9 @@ macro_rules! early_lint_methods {
 
             /// Counterpart to `enter_lint_attrs`.
             fn exit_lint_attrs(a: &[ast::Attribute]);
+
+            fn enter_where_predicate(a: &ast::WherePredicate);
+            fn exit_where_predicate(a: &ast::WherePredicate);
         ]);
     )
 }

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1002,7 +1002,6 @@ impl EarlyLintPass for UnusedParens {
         if let ast::TyKind::Paren(r) = &ty.kind {
             match &r.kind {
                 ast::TyKind::TraitObject(..) => {}
-                ast::TyKind::BareFn(b) if b.generic_params.len() > 0 => {}
                 ast::TyKind::ImplTrait(_, bounds) if bounds.len() > 1 => {}
                 ast::TyKind::Array(_, len) => {
                     self.check_unused_delims_expr(

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -487,7 +487,6 @@ fn run_analysis_to_runtime_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>
 fn run_analysis_cleanup_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
     let passes: &[&dyn MirPass<'tcx>] = &[
         &cleanup_post_borrowck::CleanupPostBorrowck,
-        &simplify_branches::SimplifyConstCondition::new("initial"),
         &remove_noop_landing_pads::RemoveNoopLandingPads,
         &simplify::SimplifyCfg::new("early-opt"),
         &deref_separator::Derefer,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2465,7 +2465,7 @@ fn show_candidates(
                 msg.push_str(&candidate.0);
             }
 
-            err.note(&msg);
+            err.help(&msg);
         }
     } else if !matches!(mode, DiagnosticMode::Import) {
         assert!(!inaccessible_path_strings.is_empty());

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -5,10 +5,10 @@ use rustc_ast::visit::{self, Visitor};
 use rustc_ast::{self as ast, Crate, ItemKind, ModKind, NodeId, Path, CRATE_NODE_ID};
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_errors::struct_span_err;
 use rustc_errors::{
     pluralize, Applicability, Diagnostic, DiagnosticBuilder, ErrorGuaranteed, MultiSpan,
 };
+use rustc_errors::{struct_span_err, SuggestionStyle};
 use rustc_feature::BUILTIN_ATTRIBUTES;
 use rustc_hir::def::Namespace::{self, *};
 use rustc_hir::def::{self, CtorKind, CtorOf, DefKind, NonMacroAttrKind, PerNS};
@@ -2418,7 +2418,7 @@ fn show_candidates(
         }
 
         if let Some(span) = use_placement_span {
-            let add_use = match mode {
+            let (add_use, trailing) = match mode {
                 DiagnosticMode::Pattern => {
                     err.span_suggestions(
                         span,
@@ -2428,21 +2428,23 @@ fn show_candidates(
                     );
                     return;
                 }
-                DiagnosticMode::Import => "",
-                DiagnosticMode::Normal => "use ",
+                DiagnosticMode::Import => ("", ""),
+                DiagnosticMode::Normal => ("use ", ";\n"),
             };
             for candidate in &mut accessible_path_strings {
                 // produce an additional newline to separate the new use statement
                 // from the directly following item.
-                let additional_newline = if let FoundUse::Yes = found_use { "" } else { "\n" };
-                candidate.0 = format!("{add_use}{}{append};\n{additional_newline}", &candidate.0);
+                let additional_newline = if let FoundUse::No = found_use && let DiagnosticMode::Normal = mode { "\n" } else { "" };
+                candidate.0 =
+                    format!("{add_use}{}{append}{trailing}{additional_newline}", &candidate.0);
             }
 
-            err.span_suggestions(
+            err.span_suggestions_with_style(
                 span,
                 &msg,
                 accessible_path_strings.into_iter().map(|a| a.0),
                 Applicability::MaybeIncorrect,
+                SuggestionStyle::ShowAlways,
             );
             if let [first, .., last] = &path[..] {
                 let sp = first.ident.span.until(last.ident.span);

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -559,10 +559,9 @@ impl str {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_uppercase(&self) -> String {
-        let mut bytes = self.as_bytes().to_vec();
-        bytes.make_ascii_uppercase();
-        // make_ascii_uppercase() preserves the UTF-8 invariant.
-        unsafe { String::from_utf8_unchecked(bytes) }
+        let mut s = self.to_owned();
+        s.make_ascii_uppercase();
+        s
     }
 
     /// Returns a copy of this string where each character is mapped to its
@@ -592,10 +591,9 @@ impl str {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_lowercase(&self) -> String {
-        let mut bytes = self.as_bytes().to_vec();
-        bytes.make_ascii_lowercase();
-        // make_ascii_lowercase() preserves the UTF-8 invariant.
-        unsafe { String::from_utf8_unchecked(bytes) }
+        let mut s = self.to_owned();
+        s.make_ascii_lowercase();
+        s
     }
 }
 

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -662,7 +662,8 @@ impl dyn Any + Send + Sync {
 /// While `TypeId` implements `Hash`, `PartialOrd`, and `Ord`, it is worth
 /// noting that the hashes and ordering will vary between Rust releases. Beware
 /// of relying on them inside of your code!
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Clone, Copy, Debug, Hash, Eq)]
+#[derive_const(PartialEq, PartialOrd, Ord)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {
     t: u64,

--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -374,10 +374,10 @@ static_assert!((TAG_MASK + 1).is_power_of_two());
 static_assert!(align_of::<SimpleMessage>() >= TAG_MASK + 1);
 static_assert!(align_of::<Custom>() >= TAG_MASK + 1);
 
-static_assert!(@usize_eq: (TAG_MASK & TAG_SIMPLE_MESSAGE), TAG_SIMPLE_MESSAGE);
-static_assert!(@usize_eq: (TAG_MASK & TAG_CUSTOM), TAG_CUSTOM);
-static_assert!(@usize_eq: (TAG_MASK & TAG_OS), TAG_OS);
-static_assert!(@usize_eq: (TAG_MASK & TAG_SIMPLE), TAG_SIMPLE);
+static_assert!(@usize_eq: TAG_MASK & TAG_SIMPLE_MESSAGE, TAG_SIMPLE_MESSAGE);
+static_assert!(@usize_eq: TAG_MASK & TAG_CUSTOM, TAG_CUSTOM);
+static_assert!(@usize_eq: TAG_MASK & TAG_OS, TAG_OS);
+static_assert!(@usize_eq: TAG_MASK & TAG_SIMPLE, TAG_SIMPLE);
 
 // This is obviously true (`TAG_CUSTOM` is `0b01`), but in `Repr::new_custom` we
 // offset a pointer by this value, and expect it to both be within the same

--- a/tests/ui/const-generics/issues/issue-90318.rs
+++ b/tests/ui/const-generics/issues/issue-90318.rs
@@ -12,14 +12,14 @@ impl True for If<true> {}
 fn consume<T: 'static>(_val: T)
 where
     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-    //~^ ERROR: can't compare
+    //~^ overly complex generic constant
 {
 }
 
 fn test<T: 'static>()
 where
     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-    //~^ ERROR: can't compare
+    //~^ overly complex generic constant
 {
 }
 

--- a/tests/ui/const-generics/issues/issue-90318.stderr
+++ b/tests/ui/const-generics/issues/issue-90318.stderr
@@ -1,29 +1,24 @@
-error[E0277]: can't compare `TypeId` with `_` in const contexts
-  --> $DIR/issue-90318.rs:14:28
+error: overly complex generic constant
+  --> $DIR/issue-90318.rs:14:8
    |
 LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-   |                            ^^ no implementation for `TypeId == _`
+   |        ^^-----------------^^^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          borrowing is not supported in generic constants
    |
-   = help: the trait `~const PartialEq<_>` is not implemented for `TypeId`
-note: the trait `PartialEq<_>` is implemented for `TypeId`, but that implementation is not `const`
-  --> $DIR/issue-90318.rs:14:28
-   |
-LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-   |                            ^^
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
-error[E0277]: can't compare `TypeId` with `_` in const contexts
-  --> $DIR/issue-90318.rs:21:28
+error: overly complex generic constant
+  --> $DIR/issue-90318.rs:21:8
    |
 LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-   |                            ^^ no implementation for `TypeId == _`
+   |        ^^-----------------^^^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          borrowing is not supported in generic constants
    |
-   = help: the trait `~const PartialEq<_>` is not implemented for `TypeId`
-note: the trait `PartialEq<_>` is implemented for `TypeId`, but that implementation is not `const`
-  --> $DIR/issue-90318.rs:21:28
-   |
-LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-   |                            ^^
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/consts/const_cmp_type_id.rs
+++ b/tests/ui/consts/const_cmp_type_id.rs
@@ -1,0 +1,12 @@
+// run-pass
+#![feature(const_type_id)]
+#![feature(const_trait_impl)]
+
+use std::any::TypeId;
+
+const fn main() {
+    assert!(TypeId::of::<u8>() == TypeId::of::<u8>());
+    assert!(TypeId::of::<()>() != TypeId::of::<u8>());
+    const _A: bool = TypeId::of::<u8>() < TypeId::of::<u16>();
+    // can't assert `_A` because it is not deterministic
+}

--- a/tests/ui/consts/issue-73976-monomorphic.rs
+++ b/tests/ui/consts/issue-73976-monomorphic.rs
@@ -7,6 +7,7 @@
 
 #![feature(const_type_id)]
 #![feature(const_type_name)]
+#![feature(const_trait_impl)]
 
 use std::any::{self, TypeId};
 
@@ -17,7 +18,7 @@ impl<T: 'static> GetTypeId<T> {
 }
 
 const fn check_type_id<T: 'static>() -> bool {
-    matches!(GetTypeId::<T>::VALUE, GetTypeId::<usize>::VALUE)
+    GetTypeId::<T>::VALUE == GetTypeId::<usize>::VALUE
 }
 
 pub struct GetTypeNameLen<T>(T);

--- a/tests/ui/empty/empty-macro-use.stderr
+++ b/tests/ui/empty/empty-macro-use.stderr
@@ -4,7 +4,7 @@ error: cannot find macro `macro_two` in this scope
 LL |     macro_two!();
    |     ^^^^^^^^^
    |
-   = note: consider importing this macro:
+   = help: consider importing this macro:
            two_macros::macro_two
 
 error: aborting due to previous error

--- a/tests/ui/extenv/issue-55897.stderr
+++ b/tests/ui/extenv/issue-55897.stderr
@@ -30,7 +30,7 @@ LL |     use env;
 help: consider importing this module instead
    |
 LL |     use std::env;
-   |         ~~~~~~~~~
+   |         ~~~~~~~~
 
 error: cannot determine resolution for the macro `env`
   --> $DIR/issue-55897.rs:6:22

--- a/tests/ui/hygiene/globs.stderr
+++ b/tests/ui/hygiene/globs.stderr
@@ -51,7 +51,7 @@ LL | n!(f);
 LL |         n!(f);
    |            ^ not found in this scope
    |
-   = note: consider importing this function:
+   = help: consider importing this function:
            foo::f
    = note: this error originates in the macro `n` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -64,7 +64,7 @@ LL | n!(f);
 LL |                 f
    |                 ^ not found in this scope
    |
-   = note: consider importing this function:
+   = help: consider importing this function:
            foo::f
    = note: this error originates in the macro `n` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/hygiene/no_implicit_prelude-2018.stderr
+++ b/tests/ui/hygiene/no_implicit_prelude-2018.stderr
@@ -4,7 +4,7 @@ error: cannot find macro `print` in this scope
 LL |         print!();
    |         ^^^^^
    |
-   = note: consider importing this macro:
+   = help: consider importing this macro:
            std::print
 
 error: aborting due to previous error

--- a/tests/ui/imports/bad-import-in-nested.stderr
+++ b/tests/ui/imports/bad-import-in-nested.stderr
@@ -4,7 +4,7 @@ error[E0432]: unresolved import `super::super::C::D::AA`
 LL |         use super::{super::C::D::AA, AA as _};
    |                     ^^^^^^^^^^^^^^^ no `AA` in `C::D`
    |
-   = note: consider importing this type alias instead:
+   = help: consider importing this type alias instead:
            crate::A::AA
 
 error[E0432]: unresolved import `crate::C::AA`
@@ -13,7 +13,7 @@ error[E0432]: unresolved import `crate::C::AA`
 LL |     use crate::C::{self, AA};
    |                          ^^ no `AA` in `C`
    |
-   = note: consider importing this type alias instead:
+   = help: consider importing this type alias instead:
            crate::A::AA
 
 error[E0432]: unresolved import `crate::C::BB`
@@ -22,7 +22,7 @@ error[E0432]: unresolved import `crate::C::BB`
 LL |     use crate::{A, C::BB};
    |                    ^^^^^ no `BB` in `C`
    |
-   = note: consider importing this type alias instead:
+   = help: consider importing this type alias instead:
            crate::A::BB
 
 error: aborting due to 3 previous errors

--- a/tests/ui/imports/bad-import-with-rename.stderr
+++ b/tests/ui/imports/bad-import-with-rename.stderr
@@ -7,7 +7,7 @@ LL |     use crate::D::B as _;
 help: consider importing this type alias instead
    |
 LL |     use A::B as _;
-   |         ~~~~~~~~~~
+   |         ~~~~~~~~~
 
 error[E0432]: unresolved import `crate::D::B2`
   --> $DIR/bad-import-with-rename.rs:10:9
@@ -18,7 +18,7 @@ LL |     use crate::D::B2;
 help: consider importing this type alias instead
    |
 LL |     use A::B2;
-   |         ~~~~~~
+   |         ~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/imports/issue-56125.stderr
+++ b/tests/ui/imports/issue-56125.stderr
@@ -7,13 +7,13 @@ LL |     use empty::issue_56125;
 help: consider importing one of these items instead
    |
 LL |     use crate::m3::last_segment::issue_56125;
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 LL |     use crate::m3::non_last_segment::non_last_segment::issue_56125;
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 LL |     use issue_56125::issue_56125;
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~
 LL |     use issue_56125::last_segment::issue_56125;
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      and 1 other candidate
 
 error[E0659]: `issue_56125` is ambiguous

--- a/tests/ui/imports/issue-57015.stderr
+++ b/tests/ui/imports/issue-57015.stderr
@@ -7,7 +7,7 @@ LL | use single_err::something;
 help: consider importing this module instead
    |
 LL | use glob_ok::something;
-   |     ~~~~~~~~~~~~~~~~~~~
+   |     ~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/tests/ui/lint/unused/issue-105061-array-lint.rs
+++ b/tests/ui/lint/unused/issue-105061-array-lint.rs
@@ -1,0 +1,11 @@
+#![warn(unused)]
+#![deny(warnings)]
+
+fn main() {
+    let _x: ([u32; 3]); //~ ERROR unnecessary parentheses around type
+    let _y: [u8; (3)]; //~ ERROR unnecessary parentheses around const expression
+    let _z: ([u8; (3)]);
+    //~^ ERROR unnecessary parentheses around const expression
+    //~| ERROR unnecessary parentheses around type
+
+}

--- a/tests/ui/lint/unused/issue-105061-array-lint.stderr
+++ b/tests/ui/lint/unused/issue-105061-array-lint.stderr
@@ -1,0 +1,56 @@
+error: unnecessary parentheses around type
+  --> $DIR/issue-105061-array-lint.rs:5:13
+   |
+LL |     let _x: ([u32; 3]);
+   |             ^        ^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-105061-array-lint.rs:2:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(unused_parens)]` implied by `#[deny(warnings)]`
+help: remove these parentheses
+   |
+LL -     let _x: ([u32; 3]);
+LL +     let _x: [u32; 3];
+   |
+
+error: unnecessary parentheses around const expression
+  --> $DIR/issue-105061-array-lint.rs:6:18
+   |
+LL |     let _y: [u8; (3)];
+   |                  ^ ^
+   |
+help: remove these parentheses
+   |
+LL -     let _y: [u8; (3)];
+LL +     let _y: [u8; 3];
+   |
+
+error: unnecessary parentheses around type
+  --> $DIR/issue-105061-array-lint.rs:7:13
+   |
+LL |     let _z: ([u8; (3)]);
+   |             ^         ^
+   |
+help: remove these parentheses
+   |
+LL -     let _z: ([u8; (3)]);
+LL +     let _z: [u8; (3)];
+   |
+
+error: unnecessary parentheses around const expression
+  --> $DIR/issue-105061-array-lint.rs:7:19
+   |
+LL |     let _z: ([u8; (3)]);
+   |                   ^ ^
+   |
+help: remove these parentheses
+   |
+LL -     let _z: ([u8; (3)]);
+LL +     let _z: ([u8; 3]);
+   |
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/lint/unused/issue-105061-should-lint.rs
+++ b/tests/ui/lint/unused/issue-105061-should-lint.rs
@@ -6,12 +6,18 @@ struct Inv<'a>(&'a mut &'a ());
 trait Trait<'a> {}
 impl<'b> Trait<'b> for for<'a> fn(Inv<'a>) {}
 
-
 fn with_bound()
 where
     for<'b> (for<'a> fn(Inv<'a>)): Trait<'b>, //~ ERROR unnecessary parentheses around type
 {}
 
+trait Hello<T> {}
+fn with_dyn_bound<T>()
+where
+    (dyn Hello<(for<'b> fn(&'b ()))>): Hello<T> //~ ERROR unnecessary parentheses around type
+{}
+
 fn main() {
     with_bound();
+    with_dyn_bound();
 }

--- a/tests/ui/lint/unused/issue-105061-should-lint.rs
+++ b/tests/ui/lint/unused/issue-105061-should-lint.rs
@@ -1,0 +1,17 @@
+#![warn(unused)]
+#![deny(warnings)]
+
+struct Inv<'a>(&'a mut &'a ());
+
+trait Trait<'a> {}
+impl<'b> Trait<'b> for for<'a> fn(Inv<'a>) {}
+
+
+fn with_bound()
+where
+    for<'b> (for<'a> fn(Inv<'a>)): Trait<'b>, //~ ERROR unnecessary parentheses around type
+{}
+
+fn main() {
+    with_bound();
+}

--- a/tests/ui/lint/unused/issue-105061-should-lint.stderr
+++ b/tests/ui/lint/unused/issue-105061-should-lint.stderr
@@ -1,5 +1,5 @@
 error: unnecessary parentheses around type
-  --> $DIR/issue-105061-should-lint.rs:12:13
+  --> $DIR/issue-105061-should-lint.rs:11:13
    |
 LL |     for<'b> (for<'a> fn(Inv<'a>)): Trait<'b>,
    |             ^                   ^
@@ -16,5 +16,17 @@ LL -     for<'b> (for<'a> fn(Inv<'a>)): Trait<'b>,
 LL +     for<'b> for<'a> fn(Inv<'a>): Trait<'b>,
    |
 
-error: aborting due to previous error
+error: unnecessary parentheses around type
+  --> $DIR/issue-105061-should-lint.rs:17:16
+   |
+LL |     (dyn Hello<(for<'b> fn(&'b ()))>): Hello<T>
+   |                ^                  ^
+   |
+help: remove these parentheses
+   |
+LL -     (dyn Hello<(for<'b> fn(&'b ()))>): Hello<T>
+LL +     (dyn Hello<for<'b> fn(&'b ())>): Hello<T>
+   |
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/unused/issue-105061-should-lint.stderr
+++ b/tests/ui/lint/unused/issue-105061-should-lint.stderr
@@ -1,0 +1,20 @@
+error: unnecessary parentheses around type
+  --> $DIR/issue-105061-should-lint.rs:12:13
+   |
+LL |     for<'b> (for<'a> fn(Inv<'a>)): Trait<'b>,
+   |             ^                   ^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-105061-should-lint.rs:2:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(unused_parens)]` implied by `#[deny(warnings)]`
+help: remove these parentheses
+   |
+LL -     for<'b> (for<'a> fn(Inv<'a>)): Trait<'b>,
+LL +     for<'b> for<'a> fn(Inv<'a>): Trait<'b>,
+   |
+
+error: aborting due to previous error
+

--- a/tests/ui/lint/unused/issue-105061.rs
+++ b/tests/ui/lint/unused/issue-105061.rs
@@ -1,0 +1,17 @@
+#![warn(unused)]
+#![deny(warnings)]
+
+struct Inv<'a>(&'a mut &'a ());
+
+trait Trait {}
+impl Trait for (for<'a> fn(Inv<'a>),) {}
+
+
+fn with_bound()
+where
+    ((for<'a> fn(Inv<'a>)),): Trait, //~ ERROR unnecessary parentheses around type
+{}
+
+fn main() {
+    with_bound();
+}

--- a/tests/ui/lint/unused/issue-105061.stderr
+++ b/tests/ui/lint/unused/issue-105061.stderr
@@ -1,0 +1,20 @@
+error: unnecessary parentheses around type
+  --> $DIR/issue-105061.rs:12:6
+   |
+LL |     ((for<'a> fn(Inv<'a>)),): Trait,
+   |      ^                   ^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-105061.rs:2:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(unused_parens)]` implied by `#[deny(warnings)]`
+help: remove these parentheses
+   |
+LL -     ((for<'a> fn(Inv<'a>)),): Trait,
+LL +     (for<'a> fn(Inv<'a>),): Trait,
+   |
+
+error: aborting due to previous error
+

--- a/tests/ui/macros/issue-88228.rs
+++ b/tests/ui/macros/issue-88228.rs
@@ -8,7 +8,7 @@ mod hey {
 
 #[derive(Bla)]
 //~^ ERROR cannot find derive macro `Bla`
-//~| NOTE consider importing this derive macro
+//~| HELP consider importing this derive macro
 struct A;
 
 #[derive(println)]
@@ -19,5 +19,5 @@ struct B;
 fn main() {
     bla!();
     //~^ ERROR cannot find macro `bla`
-    //~| NOTE consider importing this macro
+    //~| HELP consider importing this macro
 }

--- a/tests/ui/macros/issue-88228.stderr
+++ b/tests/ui/macros/issue-88228.stderr
@@ -4,7 +4,7 @@ error: cannot find macro `bla` in this scope
 LL |     bla!();
    |     ^^^
    |
-   = note: consider importing this macro:
+   = help: consider importing this macro:
            crate::hey::bla
 
 error: cannot find derive macro `println` in this scope
@@ -21,7 +21,7 @@ error: cannot find derive macro `Bla` in this scope
 LL | #[derive(Bla)]
    |          ^^^
    |
-   = note: consider importing this derive macro:
+   = help: consider importing this derive macro:
            crate::hey::Bla
 
 error: aborting due to 3 previous errors

--- a/tests/ui/macros/macro-use-wrong-name.stderr
+++ b/tests/ui/macros/macro-use-wrong-name.stderr
@@ -9,7 +9,7 @@ LL |     macro_two!();
 LL | macro_rules! macro_one { () => ("one") }
    | ---------------------- similarly named macro `macro_one` defined here
    |
-   = note: consider importing this macro:
+   = help: consider importing this macro:
            two_macros::macro_two
 
 error: aborting due to previous error

--- a/tests/ui/missing/missing-macro-use.stderr
+++ b/tests/ui/missing/missing-macro-use.stderr
@@ -4,7 +4,7 @@ error: cannot find macro `macro_two` in this scope
 LL |     macro_two!();
    |     ^^^^^^^^^
    |
-   = note: consider importing this macro:
+   = help: consider importing this macro:
            two_macros::macro_two
 
 error: aborting due to previous error

--- a/tests/ui/proc-macro/derive-helper-shadowing.stderr
+++ b/tests/ui/proc-macro/derive-helper-shadowing.stderr
@@ -16,7 +16,7 @@ error: cannot find attribute `empty_helper` in this scope
 LL |             #[derive(GenHelperUse)]
    |                      ^^^^^^^^^^^^
    |
-   = note: consider importing this attribute macro:
+   = help: consider importing this attribute macro:
            empty_helper
    = note: this error originates in the derive macro `GenHelperUse` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -29,7 +29,7 @@ LL |         #[empty_helper]
 LL |             gen_helper_use!();
    |             ----------------- in this macro invocation
    |
-   = note: consider importing this attribute macro:
+   = help: consider importing this attribute macro:
            crate::empty_helper
    = note: this error originates in the macro `gen_helper_use` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/proc-macro/generate-mod.stderr
+++ b/tests/ui/proc-macro/generate-mod.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `FromOutside` in this scope
 LL | generate_mod::check!();
    | ^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: consider importing this struct:
+   = help: consider importing this struct:
            FromOutside
    = note: this error originates in the macro `generate_mod::check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -14,7 +14,7 @@ error[E0412]: cannot find type `Outer` in this scope
 LL | generate_mod::check!();
    | ^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: consider importing this struct:
+   = help: consider importing this struct:
            Outer
    = note: this error originates in the macro `generate_mod::check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -24,7 +24,7 @@ error[E0412]: cannot find type `FromOutside` in this scope
 LL | #[generate_mod::check_attr]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: consider importing this struct:
+   = help: consider importing this struct:
            FromOutside
    = note: this error originates in the attribute macro `generate_mod::check_attr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -34,7 +34,7 @@ error[E0412]: cannot find type `OuterAttr` in this scope
 LL | #[generate_mod::check_attr]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: consider importing this struct:
+   = help: consider importing this struct:
            OuterAttr
    = note: this error originates in the attribute macro `generate_mod::check_attr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -44,7 +44,7 @@ error[E0412]: cannot find type `FromOutside` in this scope
 LL | #[derive(generate_mod::CheckDerive)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: consider importing this struct:
+   = help: consider importing this struct:
            FromOutside
    = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -54,7 +54,7 @@ error[E0412]: cannot find type `OuterDerive` in this scope
 LL | #[derive(generate_mod::CheckDerive)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: consider importing this struct:
+   = help: consider importing this struct:
            OuterDerive
    = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -64,7 +64,7 @@ error[E0412]: cannot find type `FromOutside` in this scope
 LL |     #[derive(generate_mod::CheckDerive)]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: consider importing this struct:
+   = help: consider importing this struct:
            FromOutside
    = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -74,7 +74,7 @@ error[E0412]: cannot find type `OuterDerive` in this scope
 LL |     #[derive(generate_mod::CheckDerive)]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: consider importing this struct:
+   = help: consider importing this struct:
            OuterDerive
    = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -84,7 +84,7 @@ error[E0412]: cannot find type `FromOutside` in this scope
 LL | #[derive(generate_mod::CheckDeriveLint)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: consider importing this struct:
+   = help: consider importing this struct:
            FromOutside
    = note: this error originates in the derive macro `generate_mod::CheckDeriveLint` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -94,7 +94,7 @@ error[E0412]: cannot find type `OuterDeriveLint` in this scope
 LL | #[derive(generate_mod::CheckDeriveLint)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: consider importing this struct:
+   = help: consider importing this struct:
            OuterDeriveLint
    = note: this error originates in the derive macro `generate_mod::CheckDeriveLint` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/rfc-2126-extern-absolute-paths/not-allowed.stderr
+++ b/tests/ui/rfc-2126-extern-absolute-paths/not-allowed.stderr
@@ -7,9 +7,9 @@ LL | use alloc;
 help: consider importing one of these items instead
    |
 LL | use core::alloc;
-   |     ~~~~~~~~~~~~
-LL | use std::alloc;
    |     ~~~~~~~~~~~
+LL | use std::alloc;
+   |     ~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/tests/ui/simd/portable-intrinsics-arent-exposed.stderr
+++ b/tests/ui/simd/portable-intrinsics-arent-exposed.stderr
@@ -15,7 +15,7 @@ LL | use std::simd::intrinsics;
 help: consider importing this module instead
    |
 LL | use std::intrinsics;
-   |     ~~~~~~~~~~~~~~~~
+   |     ~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/test-attrs/inaccessible-test-modules.stderr
+++ b/tests/ui/test-attrs/inaccessible-test-modules.stderr
@@ -13,7 +13,7 @@ LL | use test as y;
 help: consider importing this module instead
    |
 LL | use test::test as y;
-   |     ~~~~~~~~~~~~~~~~
+   |     ~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/unresolved/unresolved-candidates.stderr
+++ b/tests/ui/unresolved/unresolved-candidates.stderr
@@ -7,7 +7,7 @@ LL |     use Trait;
 help: consider importing this trait instead
    |
 LL |     use a::Trait;
-   |         ~~~~~~~~~
+   |         ~~~~~~~~
 
 error[E0405]: cannot find trait `Trait` in this scope
   --> $DIR/unresolved-candidates.rs:10:10


### PR DESCRIPTION
Successful merges:

 - #101698 (Constify `TypeId` ordering impls)
 - #106148 (Fix unused_parens issue for higher ranked function pointers)
 - #106922 (Avoid unsafe code in `to_ascii_[lower/upper]case()`)
 - #106951 (Remove ineffective run of SimplifyConstCondition)
 - #106962 (Fix use suggestion span)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=101698,106148,106922,106951,106962)
<!-- homu-ignore:end -->