### PR TITLE
Let Vec be used as an argument in fluent strings

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/mir_build.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/mir_build.ftl
@@ -332,11 +332,9 @@ mir_build_non_exhaustive_omitted_pattern = some variants are not matched explici
     .note = the matched value is of type `{$scrut_ty}` and the `non_exhaustive_omitted_patterns` attribute was found
 
 mir_build_uncovered = {$count ->
-        [1] pattern `{$witness_1}`
-        [2] patterns `{$witness_1}` and `{$witness_2}`
-        [3] patterns `{$witness_1}`, `{$witness_2}` and `{$witness_3}`
-        *[other] patterns `{$witness_1}`, `{$witness_2}`, `{$witness_3}` and {$remainder} more
-    } not covered
+        [1] pattern
+        *[other] patterns
+    } {$witnesses} not covered
 
 mir_build_pattern_not_covered = refutable pattern in {$origin}
     .pattern_ty = the matched value is of type `{$pattern_ty}`

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -380,7 +380,9 @@ pub use diagnostic::{
     DiagnosticStyledString, IntoDiagnosticArg, SubDiagnostic,
 };
 pub use diagnostic_builder::{DiagnosticBuilder, EmissionGuarantee, Noted};
-pub use diagnostic_impls::{DiagnosticArgFromDisplay, DiagnosticSymbolList};
+pub use diagnostic_impls::{
+    DiagnosticArgFromDisplay, DiagnosticSymbolList, TruncatedDiagnosticList,
+};
 use std::backtrace::Backtrace;
 
 /// A handler deals with errors and other compiler output.

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -1,4 +1,3 @@
-use crate::thir::pattern::deconstruct_pat::DeconstructedPat;
 use crate::thir::pattern::MatchCheckCtxt;
 use rustc_errors::Handler;
 use rustc_errors::{
@@ -723,31 +722,9 @@ pub(crate) struct NonExhaustiveOmittedPattern<'tcx> {
 #[label(mir_build_uncovered)]
 pub(crate) struct Uncovered<'tcx> {
     #[primary_span]
-    span: Span,
-    count: usize,
-    witness_1: Pat<'tcx>,
-    witness_2: Pat<'tcx>,
-    witness_3: Pat<'tcx>,
-    remainder: usize,
-}
-
-impl<'tcx> Uncovered<'tcx> {
-    pub fn new<'p>(
-        span: Span,
-        cx: &MatchCheckCtxt<'p, 'tcx>,
-        witnesses: Vec<DeconstructedPat<'p, 'tcx>>,
-    ) -> Self {
-        let witness_1 = witnesses.get(0).unwrap().to_pat(cx);
-        Self {
-            span,
-            count: witnesses.len(),
-            // Substitute dummy values if witnesses is smaller than 3. These will never be read.
-            witness_2: witnesses.get(1).map(|w| w.to_pat(cx)).unwrap_or_else(|| witness_1.clone()),
-            witness_3: witnesses.get(2).map(|w| w.to_pat(cx)).unwrap_or_else(|| witness_1.clone()),
-            witness_1,
-            remainder: witnesses.len().saturating_sub(3),
-        }
-    }
+    pub span: Span,
+    pub count: usize,
+    pub witnesses: Vec<Pat<'tcx>>,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -2,7 +2,7 @@ use crate::thir::pattern::MatchCheckCtxt;
 use rustc_errors::Handler;
 use rustc_errors::{
     error_code, AddToDiagnostic, Applicability, Diagnostic, DiagnosticBuilder, ErrorGuaranteed,
-    IntoDiagnostic, MultiSpan, SubdiagnosticMessage,
+    IntoDiagnostic, MultiSpan, SubdiagnosticMessage, TruncatedDiagnosticList,
 };
 use rustc_hir::def::Res;
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
@@ -724,7 +724,7 @@ pub(crate) struct Uncovered<'tcx> {
     #[primary_span]
     pub span: Span,
     pub count: usize,
-    pub witnesses: Vec<Pat<'tcx>>,
+    pub witnesses: TruncatedDiagnosticList<4, Pat<'tcx>>,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -456,7 +456,8 @@ impl<'p, 'tcx> MatchVisitor<'_, 'p, 'tcx> {
         };
 
         let witnesses: Vec<_> = witnesses.into_iter().map(|w| w.to_pat(&cx)).collect();
-        let uncovered = Uncovered { span: pat.span, count: witnesses.len(), witnesses };
+        let uncovered =
+            Uncovered { span: pat.span, count: witnesses.len(), witnesses: witnesses.into() };
 
         self.tcx.sess.emit_err(PatternNotCovered {
             span: pat.span,

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -455,10 +455,13 @@ impl<'p, 'tcx> MatchVisitor<'_, 'p, 'tcx> {
             AdtDefinedHere { adt_def_span, ty, variants }
         };
 
+        let witnesses: Vec<_> = witnesses.into_iter().map(|w| w.to_pat(&cx)).collect();
+        let uncovered = Uncovered { span: pat.span, count: witnesses.len(), witnesses };
+
         self.tcx.sess.emit_err(PatternNotCovered {
             span: pat.span,
             origin,
-            uncovered: Uncovered::new(pat.span, &cx, witnesses),
+            uncovered,
             inform,
             interpreted_as_const,
             _p: (),

--- a/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
@@ -900,7 +900,11 @@ fn is_useful<'p, 'tcx>(
                         uncovered: {
                             let witnesses: Vec<_> =
                                 patterns.into_iter().map(|w| w.to_pat(&pcx.cx)).collect();
-                            Uncovered { span: pcx.span, count: witnesses.len(), witnesses }
+                            Uncovered {
+                                span: pcx.span,
+                                count: witnesses.len(),
+                                witnesses: witnesses.into(),
+                            }
                         },
                     },
                 );

--- a/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
@@ -897,7 +897,11 @@ fn is_useful<'p, 'tcx>(
                     pcx.span,
                     NonExhaustiveOmittedPattern {
                         scrut_ty: pcx.ty,
-                        uncovered: Uncovered::new(pcx.span, pcx.cx, patterns),
+                        uncovered: {
+                            let witnesses: Vec<_> =
+                                patterns.into_iter().map(|w| w.to_pat(&pcx.cx)).collect();
+                            Uncovered { span: pcx.span, count: witnesses.len(), witnesses }
+                        },
                     },
                 );
             }

--- a/tests/ui/closures/2229_closure_analysis/match/non-exhaustive-match.rs
+++ b/tests/ui/closures/2229_closure_analysis/match/non-exhaustive-match.rs
@@ -52,3 +52,19 @@ fn main() {
     let mut mut_e4 = e4;
     _h();
 }
+
+pub enum X {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+}
+
+pub fn many(x: X) {
+    match x {}
+    //~^ ERROR non-exhaustive patterns: `X::A`, `X::B`, `X::C` and 5 more not covered [E0004]
+}

--- a/tests/ui/closures/2229_closure_analysis/match/non-exhaustive-match.stderr
+++ b/tests/ui/closures/2229_closure_analysis/match/non-exhaustive-match.stderr
@@ -51,6 +51,25 @@ help: ensure that all possible cases are being handled by adding a match arm wit
 LL |     let _e = || { match e2 { E2::A => (), E2::B => (), _ => todo!() } };
    |                                                      ++++++++++++++
 
+error[E0004]: non-exhaustive patterns: `X::A`, `X::B`, `X::C` and 5 more not covered
+  --> $DIR/non-exhaustive-match.rs:68:11
+   |
+LL |     match x {}
+   |           ^ patterns `X::A`, `X::B`, `X::C` and 5 more not covered
+   |
+note: `X` defined here
+  --> $DIR/non-exhaustive-match.rs:56:10
+   |
+LL | pub enum X {
+   |          ^
+   = note: the matched value is of type `X`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
+   |
+LL ~     match x {
+LL +         _ => todo!(),
+LL +     }
+   |
+
 error[E0505]: cannot move out of `e3` because it is borrowed
   --> $DIR/non-exhaustive-match.rs:46:22
    |
@@ -64,7 +83,7 @@ LL |
 LL |     _g();
    |     -- borrow later used here
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0004, E0505.
 For more information about an error, try `rustc --explain E0004`.

--- a/tests/ui/consts/const_let_refutable.stderr
+++ b/tests/ui/consts/const_let_refutable.stderr
@@ -2,7 +2,7 @@ error[E0005]: refutable pattern in function argument
   --> $DIR/const_let_refutable.rs:3:16
    |
 LL | const fn slice(&[a, b]: &[i32]) -> i32 {
-   |                ^^^^^^^ patterns `&[]`, `&[_]` and `&[_, _, _, ..]` not covered
+   |                ^^^^^^^ patterns `&[]`, `&[_]`, and `&[_, _, _, ..]` not covered
    |
    = note: the matched value is of type `&[i32]`
 

--- a/tests/ui/issues/issue-15381.rs
+++ b/tests/ui/issues/issue-15381.rs
@@ -3,7 +3,7 @@ fn main() {
 
     for &[x,y,z] in values.chunks(3).filter(|&xs| xs.len() == 3) {
         //~^ ERROR refutable pattern in `for` loop binding
-        //~| patterns `&[]`, `&[_]`, `&[_, _]` and 1 more not covered
+        //~| patterns `&[]`, `&[_]`, `&[_, _]`, and `&[_, _, _, _, ..]` not covered
         println!("y={}", y);
     }
 }

--- a/tests/ui/issues/issue-15381.stderr
+++ b/tests/ui/issues/issue-15381.stderr
@@ -2,7 +2,7 @@ error[E0005]: refutable pattern in `for` loop binding
   --> $DIR/issue-15381.rs:4:9
    |
 LL |     for &[x,y,z] in values.chunks(3).filter(|&xs| xs.len() == 3) {
-   |         ^^^^^^^^ patterns `&[]`, `&[_]`, `&[_, _]` and 1 more not covered
+   |         ^^^^^^^^ patterns `&[]`, `&[_]`, `&[_, _]`, and `&[_, _, _, _, ..]` not covered
    |
    = note: the matched value is of type `&[u8]`
 


### PR DESCRIPTION
An alternative approach would be to have some kind of `#[list]` attribute for the derive macro to use, or a newtype for doing this. I chose the current approach because it's what people will try first and it'd be nice to have it "Just Work" - there's no need to write or read documentation.