### PR TITLE
bump failing assembly & codegen tests from LLVM 14 to LLVM 15

### DIFF
--- a/tests/assembly/is_aligned.rs
+++ b/tests/assembly/is_aligned.rs
@@ -1,5 +1,5 @@
 // assembly-output: emit-asm
-// min-llvm-version: 14.0
+// min-llvm-version: 15.0
 // only-x86_64
 // revisions: opt-speed opt-size
 // [opt-speed] compile-flags: -Copt-level=1

--- a/tests/codegen/issue-96497-slice-size-nowrap.rs
+++ b/tests/codegen/issue-96497-slice-size-nowrap.rs
@@ -3,7 +3,7 @@
 // in some situations, see https://github.com/rust-lang/rust/issues/96497#issuecomment-1112865218
 
 // compile-flags: -O
-// min-llvm-version: 14.0
+// min-llvm-version: 15.0
 
 #![crate_type="lib"]
 


### PR DESCRIPTION
These tests need LLVM 15.

Found by @Robert-Cunningham in https://github.com/rust-lang/rust/pull/100601#issuecomment-1385400008

Passed tests at 006506e93fc80318ebfd7939fe1fd4dc19ecd8cb in https://github.com/rust-lang/rust/actions/runs/3942442730/jobs/6746104740.