### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
  "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
- "clap 4.0.32",
+ "clap 4.1.1",
  "crates-io",
  "curl",
  "curl-sys",
@@ -655,12 +655,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
 dependencies = [
  "bitflags",
- "clap_derive 4.0.21",
+ "clap_derive 4.1.0",
  "clap_lex 0.3.0",
  "is-terminal",
  "once_cell",
@@ -675,7 +675,7 @@ version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10861370d2ba66b0f5989f83ebf35db6421713fd92351790e7fdd6c36774c56b"
 dependencies = [
- "clap 4.0.32",
+ "clap 4.1.1",
 ]
 
 [[package]]
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2294,7 +2294,7 @@ name = "jsondoclint"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.0.32",
+ "clap 4.1.1",
  "fs-err",
  "rustdoc-json-types",
  "serde",
@@ -2557,7 +2557,7 @@ dependencies = [
  "ammonia",
  "anyhow",
  "chrono",
- "clap 4.0.32",
+ "clap 4.1.1",
  "clap_complete",
  "elasticlunr-rs",
  "env_logger 0.10.0",
@@ -3528,7 +3528,7 @@ dependencies = [
 name = "rustbook"
 version = "0.1.0"
 dependencies = [
- "clap 4.0.32",
+ "clap 4.1.1",
  "env_logger 0.7.1",
  "mdbook",
 ]


### PR DESCRIPTION
9 commits in 1cd6d3803dfb0b342272862a8590f5dfc9f72573..a5d47a72595dd6fbe7d4e4f6ec20dc5fe724edd1 2023-01-12 18:40:36 +0000 to 2023-01-16 18:51:50 +0000

- Add network container tests (rust-lang/cargo#11583)
- Show progress of crates.io index update even `net.git-fetch-with-cli` option enabled (rust-lang/cargo#11579)
- `cargo metadata` supports artifact dependencies (rust-lang/cargo#11550)
- fix(docs): add required "inherits" option to example profile (rust-lang/cargo#11504)
- add documentation that SSH markers aren't supported (rust-lang/cargo#11586)
- Fix typo (rust-lang/cargo#11585)
- Enable source_config_env test on Windows (rust-lang/cargo#11582)
- Support `codegen-backend` and `rustflags` in profiles in config file (rust-lang/cargo#11562)
- ci: reflect to clap updates (rust-lang/cargo#11578)

r? @ghost