### PR TITLE
Make clipboard button copy crate version too instead of just crate_name

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -17,6 +17,7 @@ pub(crate) struct Layout {
     pub(crate) external_html: ExternalHtml,
     pub(crate) default_settings: FxHashMap<String, String>,
     pub(crate) krate: String,
+    pub(crate) crate_version: String,
     /// The given user css file which allow to customize the generated
     /// documentation theme.
     pub(crate) css_file_extension: Option<PathBuf>,

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -472,6 +472,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             external_html,
             default_settings,
             krate: krate.name(tcx).to_string(),
+            crate_version: cache.crate_version.clone().unwrap_or_default(),
             css_file_extension: extension_css,
             scrape_examples_extension: !call_locations.is_empty(),
         };

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1149,7 +1149,9 @@ function loadCss(cssUrl) {
 
         onEach(parent.childNodes, child => {
             if (child.tagName === "A") {
-                path.push(child.textContent);
+                const crate_name = child.textContent;
+                const crate_version = getVar("current-crate-version");
+                path.push(`${crate_name} = "${crate_version}"`);
             }
         });
 

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -135,6 +135,7 @@
          data-root-path="{{page.root_path|safe}}" {# -#}
          data-static-root-path="{{static_root_path|safe}}" {# -#}
          data-current-crate="{{layout.krate}}" {# -#}
+         data-current-crate-version="{{layout.crate_version}}" {# -#}
          data-themes="{{themes|join(",") }}" {# -#}
          data-resource-suffix="{{page.resource_suffix}}" {# -#}
          data-rustdoc-version="{{rustdoc_version}}" {# -#}


### PR DESCRIPTION
Fixes #106990

Now clipboard button will copy `crate_name = "0.1.0"`.

r? @jyn514 