### PR TITLE
Remove extra removal from test path

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -775,7 +775,7 @@ fn make_test_name(
 ) -> test::TestName {
     // Print the name of the file, relative to the repository root.
     // `src_base` looks like `/path/to/rust/tests/ui`
-    let root_directory = config.src_base.parent().unwrap().parent().unwrap().parent().unwrap();
+    let root_directory = config.src_base.parent().unwrap().parent().unwrap();
     let path = testpaths.file.strip_prefix(root_directory).unwrap();
     let debugger = match config.debugger {
         Some(d) => format!("-{}", d),


### PR DESCRIPTION
I don't know how to describe it shortly so better show what it's doing instead. Currently, there is one extra "rust/" before the test folder when running tests:

```
failures:

---- [rustdoc] rust/tests/rustdoc/redirect.rs stdout ----
```

This is a bit annoying when copying the test path. This is due to the moving of the `tests` folder one level up, meaning we were trimming too much of the `root_path`.

Now it is again displaying the correct path:

```
failures:

---- [rustdoc] tests/rustdoc/redirect.rs stdout ----
```