### PR TITLE
Add new bootstrap members to triagebot.toml

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -175,7 +175,7 @@ exclude_labels = [
     "T-*",
 ]
 
-[autolabel."A-bootstrap"]
+[autolabel."T-bootstrap"]
 trigger_files = [
     "x.py",
     "x",
@@ -493,6 +493,8 @@ libs = [
 ]
 bootstrap = [
     "@Mark-Simulacrum",
+    "@albertlarsan68",
+    "@ozkanonur",
 ]
 infra-ci = [
     "@Mark-Simulacrum",


### PR DESCRIPTION
@ozkanonur if you want to be assigned to review PRs too, just post a message to this thread.

Should a `T-bootstrap` label be created, since `src/tools/tidy` is assigned to the `bootstrap` members, but labeled `A-testsuite` (and not `A-bootstrap`) ?

cc @jyn514 