### PR TITLE
Fix test names generated by compiletest

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -775,7 +775,7 @@ fn make_test_name(
 ) -> test::TestName {
     // Print the name of the file, relative to the repository root.
     // `src_base` looks like `/path/to/rust/tests/ui`
-    let root_directory = config.src_base.parent().unwrap().parent().unwrap().parent().unwrap();
+    let root_directory = config.src_base.parent().unwrap().parent().unwrap();
     let path = testpaths.file.strip_prefix(root_directory).unwrap();
     let debugger = match config.debugger {
         Some(d) => format!("-{}", d),


### PR DESCRIPTION
This is fallout from moving tests from src/test/ to tests/. Before this commit compiletest would give a test at tests/ui/foo.rs if your rust checkout is called my_rust_checkout the name my_rust_checkout/tests/ui/foo.rs rather than the proper tests/ui/foo.rs