### PR TITLE
rustdoc: remove redundant CSS rule `#settings .setting-line`

### DIFF
--- a/src/librustdoc/html/static/css/settings.css
+++ b/src/librustdoc/html/static/css/settings.css
@@ -1,5 +1,5 @@
 .setting-line {
-	margin: 0.6em 0 0.6em 0.3em;
+	margin: 1.2em 0.6em;
 	position: relative;
 }
 
@@ -53,10 +53,6 @@
 	display: flex;
 	align-items: center;
 	cursor: pointer;
-}
-
-#settings .setting-line {
-	margin: 1.2em 0.6em;
 }
 
 .setting-line .radio-line input:checked {

--- a/tests/rustdoc-gui/settings.goml
+++ b/tests/rustdoc-gui/settings.goml
@@ -8,6 +8,10 @@ assert-false: "#settings"
 click: "#settings-menu"
 wait-for: "#settings"
 assert-css: ("#settings", {"display": "block"})
+
+// Store the line margin to compare with the settings.html later.
+store-css: (setting_line_margin, ".setting-line", "margin")
+
 // Let's close it by clicking on the same button.
 click: "#settings-menu"
 wait-for-css: ("#settings", {"display": "none"})
@@ -210,6 +214,9 @@ assert-css: (".setting-line", {"position": "relative"})
 
 assert-attribute-false: ("#settings", {"class": "popover"}, CONTAINS)
 compare-elements-position: (".sub form", "#settings", ("x"))
+
+// Check that setting-line has the same margin in this mode as in the popover.
+assert-css: (".setting-line", {"margin": |setting_line_margin|})
 
 // We now check the display with JS disabled.
 assert-false: "noscript section"


### PR DESCRIPTION
Since the current version of settings.js always nests things below a div with ID `settings`, this rule always overrode the one above.