### PR TITLE
[crater experiment] Enable validate-mir by default

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1671,7 +1671,7 @@ options! {
         "adds unstable command line options to rustc interface (default: no)"),
     use_ctors_section: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "use legacy .ctors section for initializers rather than .init_array"),
-    validate_mir: bool = (false, parse_bool, [UNTRACKED],
+    validate_mir: bool = (true, parse_bool, [UNTRACKED],
         "validate MIR after each transformation"),
     #[rustc_lint_opt_deny_field_access("use `Session::verbose` instead of this field")]
     verbose: bool = (false, parse_bool, [UNTRACKED],


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/106612 made our MIR validation checks pickier. So this branch enables validation after every pass, to exercise those checks (and MIR validation in general) as much as possible.

Additionally, we recently merged https://github.com/rust-lang/rust/pull/106294 which comes with this remark:

> This [the UB this PR weaponizes] is hopefully rare enough to not break anything.

It would be good to know if these changes are causing issues in the ecosystem sooner rather than later.

Just a crater build run would exercise the MIR checks, but I would also like to see if crater can tell us anything about the `noundef` change. I think if we can do a crater test run with `+rustflags=-Copt-level=3` we have a chance of breaking tests if someone is accidentally relying on UB.

---

_sigh_ I forgot to r? @ghost, sorry about that. If someone wants to cruise through and fixup the labels/etc please do.