### PR TITLE
rustdoc: Collect "rustdoc-reachable" items during early doc link resolution

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -632,6 +632,12 @@ impl CStore {
             .get_attr_flags(def_id.index)
             .contains(AttrFlags::MAY_HAVE_DOC_LINKS)
     }
+
+    pub fn is_doc_hidden_untracked(&self, def_id: DefId) -> bool {
+        self.get_crate_data(def_id.krate)
+            .get_attr_flags(def_id.index)
+            .contains(AttrFlags::IS_DOC_HIDDEN)
+    }
 }
 
 impl CrateStore for CStore {

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -29,11 +29,6 @@ mod tests;
 pub(crate) fn krate(cx: &mut DocContext<'_>) -> Crate {
     let module = crate::visit_ast::RustdocVisitor::new(cx).visit();
 
-    for &cnum in cx.tcx.crates(()) {
-        // Analyze doc-reachability for extern items
-        crate::visit_lib::lib_embargo_visit_item(cx, cnum.as_def_id());
-    }
-
     // Clean the crate, translating the entire librustc_ast AST to one that is
     // understood by rustdoc.
     let mut module = clean_doc_module(&module, cx);

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -41,6 +41,7 @@ pub(crate) struct ResolverCaches {
     pub(crate) traits_in_scope: DefIdMap<Vec<TraitCandidate>>,
     pub(crate) all_trait_impls: Option<Vec<DefId>>,
     pub(crate) all_macro_rules: FxHashMap<Symbol, Res<NodeId>>,
+    pub(crate) extern_doc_reachable: DefIdSet,
 }
 
 pub(crate) struct DocContext<'tcx> {
@@ -362,6 +363,10 @@ pub(crate) fn run_global_ctxt(
         render_options,
         show_coverage,
     };
+
+    ctxt.cache
+        .effective_visibilities
+        .init(mem::take(&mut ctxt.resolver_caches.extern_doc_reachable));
 
     // Small hack to force the Sized trait to be present.
     //

--- a/src/librustdoc/passes/collect_intra_doc_links/early.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links/early.rs
@@ -162,6 +162,7 @@ impl<'ra> EarlyDocLinkResolver<'_, 'ra> {
                         }
                         self.resolve_doc_links_extern_impl(impl_def_id, false);
                     }
+                    self.all_trait_impls.push(impl_def_id);
                 }
                 for (ty_def_id, impl_def_id) in all_inherent_impls {
                     if self.is_doc_reachable(ty_def_id) {
@@ -171,9 +172,6 @@ impl<'ra> EarlyDocLinkResolver<'_, 'ra> {
                 for impl_def_id in all_incoherent_impls {
                     self.resolve_doc_links_extern_impl(impl_def_id, true);
                 }
-
-                self.all_trait_impls
-                    .extend(all_trait_impls.into_iter().map(|(_, def_id, _)| def_id));
             }
 
             if crates.len() > start_cnum {

--- a/src/librustdoc/visit_lib.rs
+++ b/src/librustdoc/visit_lib.rs
@@ -1,7 +1,8 @@
 use crate::core::DocContext;
-use rustc_hir::def::DefKind;
+use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{DefId, DefIdSet};
 use rustc_middle::ty::TyCtxt;
+use rustc_resolve::Resolver;
 
 // FIXME: this may not be exhaustive, but is sufficient for rustdocs current uses
 
@@ -25,6 +26,10 @@ impl RustdocEffectiveVisibilities {
     define_method!(is_directly_public);
     define_method!(is_exported);
     define_method!(is_reachable);
+
+    pub(crate) fn init(&mut self, extern_public: DefIdSet) {
+        self.extern_public = extern_public;
+    }
 }
 
 pub(crate) fn lib_embargo_visit_item(cx: &mut DocContext<'_>, def_id: DefId) {
@@ -37,12 +42,31 @@ pub(crate) fn lib_embargo_visit_item(cx: &mut DocContext<'_>, def_id: DefId) {
     .visit_item(def_id)
 }
 
+pub(crate) fn early_lib_embargo_visit_item(
+    resolver: &Resolver<'_>,
+    extern_public: &mut DefIdSet,
+    def_id: DefId,
+    is_mod: bool,
+) {
+    assert!(!def_id.is_local());
+    EarlyLibEmbargoVisitor { resolver, extern_public, visited_mods: Default::default() }
+        .visit_item(def_id, is_mod)
+}
+
 /// Similar to `librustc_privacy::EmbargoVisitor`, but also takes
 /// specific rustdoc annotations into account (i.e., `doc(hidden)`)
 struct LibEmbargoVisitor<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     // Effective visibilities for reachable nodes
     extern_public: &'a mut DefIdSet,
+    // Keeps track of already visited modules, in case a module re-exports its parent
+    visited_mods: DefIdSet,
+}
+
+struct EarlyLibEmbargoVisitor<'r, 'ra> {
+    resolver: &'r Resolver<'ra>,
+    // Effective visibilities for reachable nodes
+    extern_public: &'r mut DefIdSet,
     // Keeps track of already visited modules, in case a module re-exports its parent
     visited_mods: DefIdSet,
 }
@@ -66,6 +90,31 @@ impl LibEmbargoVisitor<'_, '_> {
         if !self.tcx.is_doc_hidden(def_id) {
             self.extern_public.insert(def_id);
             if self.tcx.def_kind(def_id) == DefKind::Mod {
+                self.visit_mod(def_id);
+            }
+        }
+    }
+}
+
+impl EarlyLibEmbargoVisitor<'_, '_> {
+    fn visit_mod(&mut self, def_id: DefId) {
+        if !self.visited_mods.insert(def_id) {
+            return;
+        }
+
+        for item in self.resolver.cstore().module_children_untracked(def_id, self.resolver.sess()) {
+            if let Some(def_id) = item.res.opt_def_id() {
+                if item.vis.is_public() {
+                    self.visit_item(def_id, matches!(item.res, Res::Def(DefKind::Mod, _)));
+                }
+            }
+        }
+    }
+
+    fn visit_item(&mut self, def_id: DefId, is_mod: bool) {
+        if !self.resolver.cstore().is_doc_hidden_untracked(def_id) {
+            self.extern_public.insert(def_id);
+            if is_mod {
                 self.visit_mod(def_id);
             }
         }


### PR DESCRIPTION
This pass only needs to know about visibilities, attributes and reexports, so it can be run early, similarly to `compute_effective_visibilities` in rustc.
Results of this pass can be used to prune the list of extern impls early thus improving performance of https://github.com/rust-lang/rust/pull/94857.