### PR TITLE
Clippy: Make sure to include in beta: Move `unchecked_duration_subtraction` to pedantic

### DIFF
--- a/src/tools/clippy/clippy_lints/src/instant_subtraction.rs
+++ b/src/tools/clippy/clippy_lints/src/instant_subtraction.rs
@@ -61,7 +61,7 @@ declare_clippy_lint! {
     /// [`Instant::now()`]: std::time::Instant::now;
     #[clippy::version = "1.65.0"]
     pub UNCHECKED_DURATION_SUBTRACTION,
-    suspicious,
+    pedantic,
     "finds unchecked subtraction of a 'Duration' from an 'Instant'"
 }
 


### PR DESCRIPTION
This was merged one day too late in order to make it into the last sync. But since we talked about moving this lint to `pedantic` in the meeting, I'd like to get this in rather sooner than later.

https://github.com/rust-lang/rust-clippy/pull/10194

r? @Manishearth 