### PR TITLE
remove unnecessary check for opaque types

### DIFF
--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -13,7 +13,7 @@ use rustc_middle::mir::{
     ProjectionElem, RetagKind, RuntimePhase, Rvalue, SourceScope, Statement, StatementKind,
     Terminator, TerminatorKind, UnOp, START_BLOCK,
 };
-use rustc_middle::ty::{self, InstanceDef, ParamEnv, Ty, TyCtxt, TypeVisitable};
+use rustc_middle::ty::{self, InstanceDef, ParamEnv, Ty, TyCtxt};
 use rustc_mir_dataflow::impls::MaybeStorageLive;
 use rustc_mir_dataflow::storage::always_storage_live_locals;
 use rustc_mir_dataflow::{Analysis, ResultsCursor};
@@ -228,11 +228,6 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         // Fast path before we normalize.
         if src == dest {
             // Equal types, all is good.
-            return true;
-        }
-        // Normalization reveals opaque types, but we may be validating MIR while computing
-        // said opaque types, causing cycles.
-        if (src, dest).has_opaque_types() {
             return true;
         }
 


### PR DESCRIPTION
this isn't needed and may hide some errors.

after analysis there are no opaque types so it's a noop anyways

before analysis there are opaque types but due to `Reveal::UserFacing` we don't reveal them. `is_subtype` simply discards the opaque type constraints as these will get checked again during mir borrowck.

r? types 

want to land this after the beta-cutoff as mir validator changes are apparently pretty scary