### PR TITLE
Added const-generic ui test case for issue #106419

### DIFF
--- a/tests/ui/const-generics/issue-106419-struct-with-multiple-const-params.rs
+++ b/tests/ui/const-generics/issue-106419-struct-with-multiple-const-params.rs
@@ -1,0 +1,12 @@
+// check-pass
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+#[derive(Clone)]
+struct Bar<const A: usize, const B: usize>
+where
+    [(); A as usize]:,
+    [(); B as usize]:,
+{}
+
+fn main() {}


### PR DESCRIPTION
This PR adds a test case for #106419 which has been fixed in master by #105292

I also ran the test on f769d34291e489db19d3c972348ddb24b6b32481 (the commit before #105292 was merged)
and it did fail there with the following output.
```
--- stderr -------------------------------
error[E0308]: mismatched types
  --> /home/patrikk/src/rust/src/test/ui/const-generics/issue-106419-struct-with-multiple-const-params.rs:5:10
   |
LL | #[derive(Clone)]
   |          ^^^^^
   |          |
   |          expected `A`, found `B`
   |          expected `Bar<A, B>` because of return type
   |
   = note: expected struct `Bar<A, _>`
              found struct `Bar<B, _>`
   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
------------------------------------------
```