### PR TITLE
rustdoc: remove redundant CSS selector `.sidebar .current`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -497,7 +497,7 @@ ul.block, .block li {
 	padding-left: 24px;
 }
 
-.sidebar a, .sidebar .current {
+.sidebar a {
 	color: var(--sidebar-link-color);
 }
 .sidebar .current,


### PR DESCRIPTION
Since the current sidebar item is already a link, it doesn't do anything.