### PR TITLE
rustdoc: Add support for --remap-path-prefix

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -129,6 +129,7 @@ pub(crate) fn run(
         edition: options.edition,
         target_triple: options.target.clone(),
         crate_name: options.crate_name.clone(),
+        remap_path_prefix: options.remap_path_prefix.clone(),
         ..config::Options::default()
     };
 
@@ -572,7 +573,6 @@ fn make_maybe_absolute_path(path: PathBuf) -> PathBuf {
         std::env::current_dir().map(|c| c.join(&path)).unwrap_or_else(|_| path)
     }
 }
-
 struct IndividualTestOptions {
     outdir: DirState,
     test_id: String,
@@ -651,7 +651,7 @@ impl CreateRunnableDoctests {
         if !item_path.is_empty() {
             item_path.push(' ');
         }
-        format!("{} - {item_path}(line {line})", filename.prefer_local())
+        format!("{} - {item_path}(line {line})", filename.prefer_remapped_unconditionaly())
     }
 
     fn add_test(&mut self, test: ScrapedDoctest) {

--- a/src/librustdoc/doctest/rust.rs
+++ b/src/librustdoc/doctest/rust.rs
@@ -27,11 +27,13 @@ struct RustCollector {
 impl RustCollector {
     fn get_filename(&self) -> FileName {
         let filename = self.source_map.span_to_filename(self.position);
-        if let FileName::Real(ref filename) = filename
-            && let Ok(cur_dir) = env::current_dir()
-            && let Some(local_path) = filename.local_path()
-            && let Ok(path) = local_path.strip_prefix(&cur_dir)
-        {
+        if let FileName::Real(ref filename) = filename {
+            let path = filename.remapped_path_if_available();
+            // Strip the cwd prefix from the path. This will likely exist if
+            // the path was not remapped.
+            let path = env::current_dir()
+                .map(|cur_dir| path.strip_prefix(&cur_dir).unwrap_or(path))
+                .unwrap_or(path);
             return path.to_owned().into();
         }
         filename

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -555,6 +555,14 @@ fn opts() -> Vec<RustcOptGroup> {
         unstable("no-run", |o| {
             o.optflagmulti("", "no-run", "Compile doctests without running them")
         }),
+        unstable("remap-path-prefix", |o| {
+            o.optmulti(
+                "",
+                "remap-path-prefix",
+                "Remap source names in compiler messages",
+                "FROM=TO",
+            )
+        }),
         unstable("show-type-layout", |o| {
             o.optflagmulti("", "show-type-layout", "Include the memory layout of types in the docs")
         }),

--- a/tests/run-make/issue-88756-default-output/output-default.stdout
+++ b/tests/run-make/issue-88756-default-output/output-default.stdout
@@ -157,6 +157,8 @@ Options:
                         Comma separated list of types of output for rustdoc to
                         emit
         --no-run        Compile doctests without running them
+        --remap-path-prefix FROM=TO
+                        Remap source names in compiler messages
         --show-type-layout 
                         Include the memory layout of types in the docs
         --nocapture     Don't capture stdout and stderr of tests

--- a/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.rs
@@ -1,0 +1,14 @@
+// FIXME: if/when the output of the test harness can be tested on its own, this test should be
+// adapted to use that, and that normalize line can go away
+
+//@ failure-status: 101
+//@ compile-flags:--test -Z unstable-options --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
+//@ rustc-env:RUST_BACKTRACE=0
+//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test "exit (status|code): 101" -> "exit status: 101"
+
+// doctest fails at runtime
+/// ```
+/// panic!("oh no");
+/// ```
+pub struct SomeStruct;

--- a/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.stdout
+++ b/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.stdout
@@ -1,0 +1,21 @@
+
+running 1 test
+test remapped_path/remap-path-prefix-failed-doctest-output.rs - SomeStruct (line 11) ... FAILED
+
+failures:
+
+---- remapped_path/remap-path-prefix-failed-doctest-output.rs - SomeStruct (line 11) stdout ----
+Test executable failed (exit status: 101).
+
+stderr:
+thread 'main' panicked at remapped_path/remap-path-prefix-failed-doctest-output.rs:3:1:
+oh no
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+
+failures:
+    remapped_path/remap-path-prefix-failed-doctest-output.rs - SomeStruct (line 11)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.rs
@@ -1,0 +1,13 @@
+// FIXME: if/when the output of the test harness can be tested on its own, this test should be
+// adapted to use that, and that normalize line can go away
+
+//@ failure-status: 101
+//@ compile-flags:--test -Z unstable-options --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
+//@ rustc-env:RUST_BACKTRACE=0
+//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+
+// doctest fails to compile
+/// ```
+/// this is not real code
+/// ```
+pub struct SomeStruct;

--- a/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.stdout
+++ b/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.stdout
@@ -1,0 +1,22 @@
+
+running 1 test
+test remapped_path/remap-path-prefix-invalid-doctest.rs - SomeStruct (line 10) ... FAILED
+
+failures:
+
+---- remapped_path/remap-path-prefix-invalid-doctest.rs - SomeStruct (line 10) stdout ----
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `is`
+  --> remapped_path/remap-path-prefix-invalid-doctest.rs:11:6
+   |
+LL | this is not real code
+   |      ^^ expected one of 8 possible tokens
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+
+failures:
+    remapped_path/remap-path-prefix-invalid-doctest.rs - SomeStruct (line 10)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+//@ check-run-results
+
+// FIXME: if/when the output of the test harness can be tested on its own, this test should be
+// adapted to use that, and that normalize line can go away
+
+//@ compile-flags:--test -Z unstable-options --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
+//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+
+// doctest passes at runtime
+/// ```
+/// assert!(true);
+/// ```
+pub struct SomeStruct;

--- a/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.stdout
+++ b/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test remapped_path/remap-path-prefix-passed-doctest-output.rs - SomeStruct (line 11) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
Adds `--remap-path-prefix` as an unstable option. This is implemented to mimic the behavior of `rustc`'s `--remap-path-prefix`.

This flag similarly takes in two paths, a prefix to replace and a replacement string. 

This is useful for build tools (e.g. Buck) other than cargo that can run doc tests.

cc: @dtolnay