### PR TITLE
Consider doc(alias) when providing typo suggestions

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -76,7 +76,7 @@ pub struct NoMatchData<'tcx> {
     pub unsatisfied_predicates:
         Vec<(ty::Predicate<'tcx>, Option<ty::Predicate<'tcx>>, Option<ObligationCause<'tcx>>)>,
     pub out_of_scope_traits: Vec<DefId>,
-    pub lev_candidate: Option<ty::AssocItem>,
+    pub similar_candidate: Option<ty::AssocItem>,
     pub mode: probe::Mode,
 }
 

--- a/tests/ui/methods/method-not-found-but-doc-alias.rs
+++ b/tests/ui/methods/method-not-found-but-doc-alias.rs
@@ -1,0 +1,11 @@
+struct Foo;
+
+impl Foo {
+    #[doc(alias = "quux")]
+    fn bar(&self) {}
+}
+
+fn main() {
+    Foo.quux();
+    //~^ ERROR  no method named `quux` found for struct `Foo` in the current scope
+}

--- a/tests/ui/methods/method-not-found-but-doc-alias.stderr
+++ b/tests/ui/methods/method-not-found-but-doc-alias.stderr
@@ -1,0 +1,12 @@
+error[E0599]: no method named `quux` found for struct `Foo` in the current scope
+  --> $DIR/method-not-found-but-doc-alias.rs:9:9
+   |
+LL | struct Foo;
+   | ---------- method `quux` not found for this struct
+...
+LL |     Foo.quux();
+   |         ^^^^ help: there is a method with a similar name: `bar`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
This means that

```rust
impl Foo {
    #[doc(alias = "quux")]
    fn bar(&self) {}
}

fn main() {
    (Foo {}).quux();
}
```

will suggest `bar`. This currently uses the "there is a method with a similar name" help text, because the point where we choose and emit a suggestion is different from where we gather the suggestions. Changes have mainly been made to the latter.

The selection code will now fall back to aliased candidates, but generally only if there is no candidate that matches based on the existing Levenshtein methodology.

Fixes #83968.