### PR TITLE
Use `Try` trait to make `Once[Cell | Lock]::get_or_try_init` generic over return type

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -361,6 +361,8 @@
 #![feature(str_internals)]
 #![feature(strict_provenance)]
 #![feature(strict_provenance_atomic_ptr)]
+#![feature(try_trait_v2)]
+#![feature(try_trait_v2_residual)]
 #![feature(ub_checks)]
 // tidy-alphabetical-end
 //

--- a/library/std/src/sync/once_lock/tests.rs
+++ b/library/std/src/sync/once_lock/tests.rs
@@ -83,7 +83,7 @@ fn clone() {
 #[test]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn get_or_try_init() {
-    let cell: OnceLock<String> = OnceLock::new();
+    let mut cell: OnceLock<String> = OnceLock::new();
     assert!(cell.get().is_none());
 
     let res = panic::catch_unwind(|| cell.get_or_try_init(|| -> Result<_, ()> { panic!() }));
@@ -91,10 +91,14 @@ fn get_or_try_init() {
     assert!(!cell.is_initialized());
     assert!(cell.get().is_none());
 
+    assert_eq!(cell.get_or_try_init(|| None), None);
     assert_eq!(cell.get_or_try_init(|| Err(())), Err(()));
 
     assert_eq!(cell.get_or_try_init(|| Ok::<_, ()>("hello".to_string())), Ok(&"hello".to_string()));
-    assert_eq!(cell.get(), Some(&"hello".to_string()));
+    assert_eq!(cell.take(), Some("hello".to_string()));
+
+    assert_eq!(cell.get_or_try_init(|| Some("42".to_string())), Some(&"42".to_string()));
+    assert_eq!(cell.get(), Some(&"42".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/107122)*
<!-- homu-ignore:end -->

This came up in the stabilization PR: https://github.com/rust-lang/rust/pull/105587#issuecomment-1396827617

Using `Try` allows these methods to accept types like `Option` in cases where there is no applicable error type.

@rustbot label +T-libs-api +T-libs
r? @scottmcm