### PR TITLE
fix check macro expansion

### DIFF
--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
 
                 let handle = s.spawn(|| {
                     let mut flag = false;
-                    $p::check($($args),* , &mut flag);
+                    $p::check($($args, )* &mut flag);
                     if (flag) {
                         bad.store(true, Ordering::Relaxed);
                     }


### PR DESCRIPTION
If the only argument to `check!` is the module name I get this error:

```
error: expected expression, found `,`
   --> src/tools/tidy/src/main.rs:63:42
    |
57  | /         macro_rules! check {
58  | |             ($p:ident $(, $args:expr)* ) => {
59  | |                 drain_handles(&mut handles);
60  | |
...   |
63  | |                     $p::check($($args),* , &mut flag);
    | |                                          ^ expected expression
...   |
69  | |             }
70  | |         }
    | |_________- in this expansion of `check!`
...
117 |           check!(hey);
    |           ----------- in this macro invocation
```

This change makes it so commas are added only when there are `args`.

r? @albertlarsan68 