### PR TITLE
rustdoc: use CSS inline layout for radio line instead of flexbox

### DIFF
--- a/src/librustdoc/html/static/css/settings.css
+++ b/src/librustdoc/html/static/css/settings.css
@@ -3,11 +3,6 @@
 	position: relative;
 }
 
-.setting-line .choices {
-	display: flex;
-	flex-wrap: wrap;
-}
-
 .setting-line .radio-line input,
 .setting-line .settings-toggle input {
 	margin-right: 0.3em;
@@ -38,7 +33,7 @@
 	margin-bottom: 0.1em;
 	min-width: 3.8em;
 	padding: 0.3em;
-	display: flex;
+	display: inline-flex;
 	align-items: center;
 	cursor: pointer;
 }


### PR DESCRIPTION
This uses less code to lay them out the same way. Already tested here:

https://github.com/rust-lang/rust/blob/5ce39f42bd2c8bca9c570f0560ebe1fce4eddb14/tests/rustdoc-gui/settings.goml#L123