### PR TITLE
[beta] Bump git2 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be36bc9e0546df253c0cc41fd0af34f5e92845ad8509462ec76672fac6997f5b"
+checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
 dependencies = [
  "bitflags",
  "libc",
@@ -2153,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.1+1.5.0"
+version = "0.14.2+1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a07fb2692bc3593bda59de45a502bb3071659f2c515e28c71e728306b038e17"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
This PR bumps the version of the `git2` and `libgit2-sys` crates to pull in fixes for https://github.com/rust-lang/git2-rs/security/advisories/GHSA-m4ch-rfv5-x5g3.

This **does not fix any security vulnerability**: Cargo is already protected thanks to the fixes we implemented as part of CVE-2022-46176. The only purpose of this PR is to avoid dependency scanners from flagging vulnerabilities.