### PR TITLE
Instantiate dominators algorithm only once

### DIFF
--- a/compiler/rustc_middle/src/mir/basic_blocks.rs
+++ b/compiler/rustc_middle/src/mir/basic_blocks.rs
@@ -35,7 +35,6 @@ impl<'tcx> BasicBlocks<'tcx> {
         self.is_cyclic.is_cyclic(self)
     }
 
-    #[inline]
     pub fn dominators(&self) -> Dominators<BasicBlock> {
         dominators(&self)
     }


### PR DESCRIPTION
Remove inline from BasicBlocks::dominators to instantiate the dominator algorithm only once - in the rustc_middle crate.