### PR TITLE
library/std/sys_common: Define MIN_ALIGN for m68k-unknown-linux-gnu

### DIFF
--- a/library/std/src/sys/common/alloc.rs
+++ b/library/std/src/sys/common/alloc.rs
@@ -7,6 +7,7 @@ use crate::ptr;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "arm",
+    target_arch = "m68k",
     target_arch = "mips",
     target_arch = "powerpc",
     target_arch = "powerpc64",


### PR DESCRIPTION
This PR adds the missing definition of MIN_ALIGN for the m68k-unknown-linux target.