### PR TITLE
Pass `--locked` to the x test tidy call

### DIFF
--- a/src/etc/pre-push.sh
+++ b/src/etc/pre-push.sh
@@ -14,4 +14,4 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 echo "Running pre-push script $ROOT_DIR/x test tidy"
 
 cd "$ROOT_DIR"
-./x test tidy
+CARGOFLAGS="--locked" ./x test tidy


### PR DESCRIPTION
This allows to fail the push when the `Cargo.lock` file needs to be updated.