### PR TITLE
Fix escaping inference var ICE in `point_at_expr_source_of_inferred_type`

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -270,7 +270,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             lt_op: |_| self.tcx.lifetimes.re_erased,
             ct_op: |c| c,
             ty_op: |t| match *t.kind() {
-                ty::Infer(ty::TyVar(vid)) => self.tcx.mk_ty_infer(ty::TyVar(self.root_var(vid))),
+                ty::Infer(ty::TyVar(_)) => self.tcx.mk_ty_var(ty::TyVid::from_u32(0)),
                 ty::Infer(ty::IntVar(_)) => {
                     self.tcx.mk_ty_infer(ty::IntVar(ty::IntVid { index: 0 }))
                 }
@@ -333,6 +333,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             // inferred in this method call.
                             let arg = &args[i];
                             let arg_ty = self.node_ty(arg.hir_id);
+                            if !arg.span.overlaps(mismatch_span) {
                             err.span_label(
                                 arg.span,
                                 &format!(
@@ -340,6 +341,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                      inferred as `{ty}`",
                                 ),
                             );
+                            }
                             param_args.insert(param_ty, (arg, arg_ty));
                         }
                     }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -808,7 +808,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     kind: TypeVariableOriginKind::MiscVariable,
                     span: full_call_span,
                 });
-                self.point_at_expr_source_of_inferred_type(&mut err, rcvr, expected, callee_ty);
+                self.point_at_expr_source_of_inferred_type(
+                    &mut err,
+                    rcvr,
+                    expected,
+                    callee_ty,
+                    provided_arg_span,
+                );
             }
             // Call out where the function is defined
             self.label_fn_like(

--- a/tests/ui/typeck/bad-type-in-vec-push.rs
+++ b/tests/ui/typeck/bad-type-in-vec-push.rs
@@ -1,0 +1,14 @@
+// The error message here still is pretty confusing.
+
+fn main() {
+    let mut result = vec![1];
+    // The type of `result` is constrained to be `Vec<{integer}>` here.
+    // But the logic we use to find what expression constrains a type
+    // is not sophisticated enough to know this.
+
+    let mut vector = Vec::new();
+    vector.sort();
+    result.push(vector);
+    //~^ ERROR mismatched types
+    // So it thinks that the type of `result` is constrained here.
+}

--- a/tests/ui/typeck/bad-type-in-vec-push.rs
+++ b/tests/ui/typeck/bad-type-in-vec-push.rs
@@ -12,3 +12,9 @@ fn main() {
     //~^ ERROR mismatched types
     // So it thinks that the type of `result` is constrained here.
 }
+
+fn example2() {
+    let mut x = vec![1];
+    x.push("");
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/typeck/bad-type-in-vec-push.stderr
+++ b/tests/ui/typeck/bad-type-in-vec-push.stderr
@@ -4,10 +4,8 @@ error[E0308]: mismatched types
 LL |     vector.sort();
    |     ------ here the type of `vector` is inferred to be `Vec<_>`
 LL |     result.push(vector);
-   |            ---- ^^^^^^
-   |            |    |
-   |            |    expected integer, found struct `Vec`
-   |            |    this is of type `Vec<_>`, which causes `result` to be inferred as `Vec<{integer}>`
+   |            ---- ^^^^^^ expected integer, found struct `Vec`
+   |            |
    |            arguments to this method are incorrect
    |
    = note: expected type `{integer}`
@@ -15,6 +13,17 @@ LL |     result.push(vector);
 note: associated function defined here
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/bad-type-in-vec-push.rs:18:12
+   |
+LL |     x.push("");
+   |       ---- ^^ expected integer, found `&str`
+   |       |
+   |       arguments to this method are incorrect
+   |
+note: associated function defined here
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/typeck/bad-type-in-vec-push.stderr
+++ b/tests/ui/typeck/bad-type-in-vec-push.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/bad-type-in-vec-push.rs:11:17
+   |
+LL |     vector.sort();
+   |     ------ here the type of `vector` is inferred to be `Vec<_>`
+LL |     result.push(vector);
+   |            ---- ^^^^^^
+   |            |    |
+   |            |    expected integer, found struct `Vec`
+   |            |    this is of type `Vec<_>`, which causes `result` to be inferred as `Vec<{integer}>`
+   |            arguments to this method are incorrect
+   |
+   = note: expected type `{integer}`
+            found struct `Vec<_>`
+note: associated function defined here
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #107158

`point_at_expr_source_of_inferred_type` uses `lookup_probe` to adjust the self type of a method receiver -- but that method returns inference variables from inside a probe. That means that the ty vars are no longer valid, so we can't use any infcx methods on them.

Also, pass some extra span info to hack a quick solution to bad labels, resulting in this diagnostic improvement:

```rust
fn example2() {
    let mut x = vec![1];
    x.push("");
}
```

```diff
  error[E0308]: mismatched types
   --> src/main.rs:5:12
    |
  5 |     x.push("");
    |       ---- ^^
    |       |    |
    |       |    expected integer, found `&str`
-   |       |    this is of type `&'static str`, which causes `x` to be inferred as `Vec<{integer}>`
    |       arguments to this method are incorrect
```
(since that "which causes `x` to be inferred as `Vec<{integer}>` part is wrong)

r? @estebank 

(we really should make this code better in general, cc #106590, but that's a bit bigger issue that needs some more thinking about)