### PR TITLE
Add `Option::transpose_fn` methods

### DIFF
--- a/tests/ui/error-codes/E0401.stderr
+++ b/tests/ui/error-codes/E0401.stderr
@@ -52,6 +52,8 @@ LL |     bfnr(x);
    = note: multiple `impl`s satisfying `_: Fn<()>` found in the following crates: `alloc`, `core`:
            - impl<A, F> Fn<A> for &F
              where A: Tuple, F: Fn<A>, F: ?Sized;
+           - impl<A, F> Fn<A> for option::TransposeFn<F>
+             where F: Fn<A>, A: Tuple;
            - impl<Args, F, A> Fn<Args> for Box<F, A>
              where Args: Tuple, F: Fn<Args>, A: Allocator, F: ?Sized;
 note: required by a bound in `bfnr`


### PR DESCRIPTION
Converts an `Option` of an `Fn` into an `Fn` that returns an `Option`.

ACP: https://github.com/rust-lang/libs-team/issues/166 [Accepted]