### PR TITLE
Inline trivial `core::fmt::Formatter` methods

### DIFF
--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -82,6 +82,7 @@ pub struct DebugStruct<'a, 'b: 'a> {
     has_fields: bool,
 }
 
+#[inline]
 pub(super) fn debug_struct_new<'a, 'b>(
     fmt: &'a mut fmt::Formatter<'b>,
     name: &str,
@@ -435,6 +436,7 @@ pub struct DebugSet<'a, 'b: 'a> {
     inner: DebugInner<'a, 'b>,
 }
 
+#[inline]
 pub(super) fn debug_set_new<'a, 'b>(fmt: &'a mut fmt::Formatter<'b>) -> DebugSet<'a, 'b> {
     let result = fmt.write_str("{");
     DebugSet { inner: DebugInner { fmt, result, has_fields: false } }
@@ -565,6 +567,7 @@ pub struct DebugList<'a, 'b: 'a> {
     inner: DebugInner<'a, 'b>,
 }
 
+#[inline]
 pub(super) fn debug_list_new<'a, 'b>(fmt: &'a mut fmt::Formatter<'b>) -> DebugList<'a, 'b> {
     let result = fmt.write_str("[");
     DebugList { inner: DebugInner { fmt, result, has_fields: false } }
@@ -700,6 +703,7 @@ pub struct DebugMap<'a, 'b: 'a> {
     state: PadAdapterState,
 }
 
+#[inline]
 pub(super) fn debug_map_new<'a, 'b>(fmt: &'a mut fmt::Formatter<'b>) -> DebugMap<'a, 'b> {
     let result = fmt.write_str("{");
     DebugMap { fmt, result, has_fields: false, has_key: false, state: Default::default() }

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -1639,6 +1639,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(&format!("{Foo}"), "Foo");
     /// assert_eq!(&format!("{Foo:0>8}"), "Foo");
     /// ```
+    #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn write_str(&mut self, data: &str) -> Result {
         self.buf.write_str(data)
@@ -1662,6 +1663,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(&format!("{}", Foo(-1)), "Foo -1");
     /// assert_eq!(&format!("{:0>8}", Foo(2)), "Foo 2");
     /// ```
+    #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn write_fmt(&mut self, fmt: Arguments<'_>) -> Result {
         write(self.buf, fmt)
@@ -1669,6 +1671,7 @@ impl<'a> Formatter<'a> {
 
     /// Flags for formatting
     #[must_use]
+    #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[deprecated(
         since = "1.24.0",
@@ -1707,6 +1710,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(&format!("{Foo:t>6}"), "tttttt");
     /// ```
     #[must_use]
+    #[inline]
     #[stable(feature = "fmt_flags", since = "1.5.0")]
     pub fn fill(&self) -> char {
         self.fill
@@ -1744,6 +1748,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(&format!("{Foo}"), "into the void");
     /// ```
     #[must_use]
+    #[inline]
     #[stable(feature = "fmt_flags_align", since = "1.28.0")]
     pub fn align(&self) -> Option<Alignment> {
         match self.align {
@@ -1779,6 +1784,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(&format!("{}", Foo(23)), "Foo(23)");
     /// ```
     #[must_use]
+    #[inline]
     #[stable(feature = "fmt_flags", since = "1.5.0")]
     pub fn width(&self) -> Option<usize> {
         self.width
@@ -1810,6 +1816,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(&format!("{}", Foo(23.2)), "Foo(23.20)");
     /// ```
     #[must_use]
+    #[inline]
     #[stable(feature = "fmt_flags", since = "1.5.0")]
     pub fn precision(&self) -> Option<usize> {
         self.precision
@@ -1842,6 +1849,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(&format!("{}", Foo(23)), "Foo(23)");
     /// ```
     #[must_use]
+    #[inline]
     #[stable(feature = "fmt_flags", since = "1.5.0")]
     pub fn sign_plus(&self) -> bool {
         self.flags & (1 << FlagV1::SignPlus as u32) != 0
@@ -1871,6 +1879,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(&format!("{}", Foo(23)), "Foo(23)");
     /// ```
     #[must_use]
+    #[inline]
     #[stable(feature = "fmt_flags", since = "1.5.0")]
     pub fn sign_minus(&self) -> bool {
         self.flags & (1 << FlagV1::SignMinus as u32) != 0
@@ -1899,6 +1908,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(&format!("{}", Foo(23)), "23");
     /// ```
     #[must_use]
+    #[inline]
     #[stable(feature = "fmt_flags", since = "1.5.0")]
     pub fn alternate(&self) -> bool {
         self.flags & (1 << FlagV1::Alternate as u32) != 0
@@ -1925,6 +1935,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(&format!("{:04}", Foo(23)), "23");
     /// ```
     #[must_use]
+    #[inline]
     #[stable(feature = "fmt_flags", since = "1.5.0")]
     pub fn sign_aware_zero_pad(&self) -> bool {
         self.flags & (1 << FlagV1::SignAwareZeroPad as u32) != 0
@@ -1976,6 +1987,7 @@ impl<'a> Formatter<'a> {
     ///     })
     /// );
     /// ```
+    #[inline]
     #[stable(feature = "debug_builders", since = "1.2.0")]
     pub fn debug_struct<'b>(&'b mut self, name: &str) -> DebugStruct<'b, 'a> {
         builders::debug_struct_new(self, name)
@@ -2255,6 +2267,7 @@ impl<'a> Formatter<'a> {
     ///
     /// assert_eq!(format!("{:?}", Foo(vec![10, 11])), "[10, 11]");
     /// ```
+    #[inline]
     #[stable(feature = "debug_builders", since = "1.2.0")]
     pub fn debug_list<'b>(&'b mut self) -> DebugList<'b, 'a> {
         builders::debug_list_new(self)
@@ -2313,6 +2326,7 @@ impl<'a> Formatter<'a> {
     ///     }
     /// }
     /// ```
+    #[inline]
     #[stable(feature = "debug_builders", since = "1.2.0")]
     pub fn debug_set<'b>(&'b mut self) -> DebugSet<'b, 'a> {
         builders::debug_set_new(self)
@@ -2339,6 +2353,7 @@ impl<'a> Formatter<'a> {
     ///     r#"{"A": 10, "B": 11}"#
     ///  );
     /// ```
+    #[inline]
     #[stable(feature = "debug_builders", since = "1.2.0")]
     pub fn debug_map<'b>(&'b mut self) -> DebugMap<'b, 'a> {
         builders::debug_map_new(self)
@@ -2347,14 +2362,17 @@ impl<'a> Formatter<'a> {
 
 #[stable(since = "1.2.0", feature = "formatter_write")]
 impl Write for Formatter<'_> {
+    #[inline]
     fn write_str(&mut self, s: &str) -> Result {
         self.buf.write_str(s)
     }
 
+    #[inline]
     fn write_char(&mut self, c: char) -> Result {
         self.buf.write_char(c)
     }
 
+    #[inline]
     fn write_fmt(&mut self, args: Arguments<'_>) -> Result {
         write(self.buf, args)
     }


### PR DESCRIPTION
These methods perform little to no work and the function call to use them seems needless.