### PR TITLE
Update once_cell 'get_or_init' to 'get_or_init_with'

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -2282,7 +2282,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
     }
 
     fn dominators(&self) -> &Dominators<BasicBlock> {
-        self.dominators.get_or_init(|| self.body.basic_blocks.dominators())
+        self.dominators.get_or_init_with(|| self.body.basic_blocks.dominators())
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -492,7 +492,7 @@ pub fn type_di_node<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>, t: Ty<'tcx>) -> &'ll D
 
 // FIXME(mw): Cache this via a regular UniqueTypeId instead of an extra field in the debug context.
 fn recursion_marker_type_di_node<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>) -> &'ll DIType {
-    *debug_context(cx).recursion_marker_type.get_or_init(move || {
+    *debug_context(cx).recursion_marker_type.get_or_init_with(move || {
         unsafe {
             // The choice of type here is pretty arbitrary -
             // anything reading the debuginfo for a recursive

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2318,7 +2318,7 @@ fn add_native_libs_from_crate(
                             cmd.link_whole_staticlib(
                                 name,
                                 verbatim,
-                                &search_paths.get_or_init(|| archive_search_paths(sess)),
+                                &search_paths.get_or_init_with(|| archive_search_paths(sess)),
                             );
                         } else {
                             cmd.link_staticlib(name, verbatim)

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -693,12 +693,12 @@ pub fn create_global_ctxt<'tcx>(
         callback(sess, &mut local_providers, &mut extern_providers);
     }
 
-    let queries = queries.get_or_init(|| {
+    let queries = queries.get_or_init_with(|| {
         TcxQueries::new(local_providers, extern_providers, query_result_on_disk_cache)
     });
 
     sess.time("setup_global_ctxt", || {
-        gcx_cell.get_or_init(move || {
+        gcx_cell.get_or_init_with(move || {
             TyCtxt::create_global_ctxt(
                 sess,
                 lint_store,

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -239,7 +239,7 @@ pub fn get_codegen_backend(
 ) -> Box<dyn CodegenBackend> {
     static LOAD: OnceLock<unsafe fn() -> Box<dyn CodegenBackend>> = OnceLock::new();
 
-    let load = LOAD.get_or_init(|| {
+    let load = LOAD.get_or_init_with(|| {
         let default_codegen_backend = option_env!("CFG_DEFAULT_CODEGEN_BACKEND").unwrap_or("llvm");
 
         match backend_name.unwrap_or(default_codegen_backend) {
@@ -264,7 +264,7 @@ pub fn rustc_path<'a>() -> Option<&'a Path> {
 
     const BIN_PATH: &str = env!("RUSTC_INSTALL_BINDIR");
 
-    RUSTC_PATH.get_or_init(|| get_rustc_path_inner(BIN_PATH)).as_deref()
+    RUSTC_PATH.get_or_init_with(|| get_rustc_path_inner(BIN_PATH)).as_deref()
 }
 
 fn get_rustc_path_inner(bin_path: &str) -> Option<PathBuf> {

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1297,7 +1297,7 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
             // Slow path: We need to find out the new `DefIndex` of the provided
             // `DefPathHash`, if its still exists. This requires decoding every `DefPathHash`
             // stored in this crate.
-            let map = self.cdata.expn_hash_map.get_or_init(|| {
+            let map = self.cdata.expn_hash_map.get_or_init_with(|| {
                 let end_id = self.root.expn_hashes.size() as u32;
                 let mut map =
                     UnhashMap::with_capacity_and_hasher(end_id as usize, Default::default());

--- a/compiler/rustc_middle/src/mir/basic_blocks.rs
+++ b/compiler/rustc_middle/src/mir/basic_blocks.rs
@@ -38,7 +38,7 @@ impl<'tcx> BasicBlocks<'tcx> {
     /// Returns true if control-flow graph contains a cycle reachable from the `START_BLOCK`.
     #[inline]
     pub fn is_cfg_cyclic(&self) -> bool {
-        *self.cache.is_cyclic.get_or_init(|| graph::is_cyclic(self))
+        *self.cache.is_cyclic.get_or_init_with(|| graph::is_cyclic(self))
     }
 
     pub fn dominators(&self) -> Dominators<BasicBlock> {
@@ -48,7 +48,7 @@ impl<'tcx> BasicBlocks<'tcx> {
     /// Returns predecessors for each basic block.
     #[inline]
     pub fn predecessors(&self) -> &Predecessors {
-        self.cache.predecessors.get_or_init(|| {
+        self.cache.predecessors.get_or_init_with(|| {
             let mut preds = IndexVec::from_elem(SmallVec::new(), &self.basic_blocks);
             for (bb, data) in self.basic_blocks.iter_enumerated() {
                 if let Some(term) = &data.terminator {
@@ -64,7 +64,7 @@ impl<'tcx> BasicBlocks<'tcx> {
     /// Returns basic blocks in a postorder.
     #[inline]
     pub fn postorder(&self) -> &[BasicBlock] {
-        self.cache.postorder.get_or_init(|| {
+        self.cache.postorder.get_or_init_with(|| {
             Postorder::new(&self.basic_blocks, START_BLOCK).map(|(bb, _)| bb).collect()
         })
     }
@@ -73,7 +73,7 @@ impl<'tcx> BasicBlocks<'tcx> {
     /// values that lead to a `target` block from a `switch` block.
     #[inline]
     pub fn switch_sources(&self) -> &SwitchSources {
-        self.cache.switch_sources.get_or_init(|| {
+        self.cache.switch_sources.get_or_init_with(|| {
             let mut switch_sources: SwitchSources = FxHashMap::default();
             for (bb, data) in self.basic_blocks.iter_enumerated() {
                 if let Some(Terminator {

--- a/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
@@ -594,7 +594,7 @@ where
 macro_rules! regex {
     ($re:literal $(,)?) => {{
         static RE: OnceLock<regex::Regex> = OnceLock::new();
-        RE.get_or_init(|| Regex::new($re).unwrap())
+        RE.get_or_init_with(|| Regex::new($re).unwrap())
     }};
 }
 

--- a/compiler/rustc_mir_transform/src/coverage/debug.rs
+++ b/compiler/rustc_mir_transform/src/coverage/debug.rs
@@ -133,7 +133,7 @@ const RUSTC_COVERAGE_DEBUG_OPTIONS: &str = "RUSTC_COVERAGE_DEBUG_OPTIONS";
 pub(super) fn debug_options<'a>() -> &'a DebugOptions {
     static DEBUG_OPTIONS: OnceLock<DebugOptions> = OnceLock::new();
 
-    &DEBUG_OPTIONS.get_or_init(DebugOptions::from_env)
+    &DEBUG_OPTIONS.get_or_init_with(DebugOptions::from_env)
 }
 
 /// Parses and maintains coverage-specific debug options captured from the environment variable

--- a/library/core/src/cell/lazy.rs
+++ b/library/core/src/cell/lazy.rs
@@ -77,7 +77,7 @@ impl<T, F: FnOnce() -> T> LazyCell<T, F> {
     #[inline]
     #[unstable(feature = "once_cell", issue = "74465")]
     pub fn force(this: &LazyCell<T, F>) -> &T {
-        this.cell.get_or_init(|| match this.init.take() {
+        this.cell.get_or_init_with(|| match this.init.take() {
             Some(f) => f(),
             None => panic!("`Lazy` instance has previously been poisoned"),
         })

--- a/library/core/src/cell/once.rs
+++ b/library/core/src/cell/once.rs
@@ -23,7 +23,7 @@ use crate::mem;
 /// let cell = OnceCell::new();
 /// assert!(cell.get().is_none());
 ///
-/// let value: &String = cell.get_or_init(|| {
+/// let value: &String = cell.get_or_init_with(|| {
 ///     "Hello, World!".to_string()
 /// });
 /// assert_eq!(value, "Hello, World!");
@@ -122,18 +122,18 @@ impl<T> OnceCell<T> {
     /// use std::cell::OnceCell;
     ///
     /// let cell = OnceCell::new();
-    /// let value = cell.get_or_init(|| 92);
+    /// let value = cell.get_or_init_with(|| 92);
     /// assert_eq!(value, &92);
-    /// let value = cell.get_or_init(|| unreachable!());
+    /// let value = cell.get_or_init_with(|| unreachable!());
     /// assert_eq!(value, &92);
     /// ```
     #[inline]
     #[unstable(feature = "once_cell", issue = "74465")]
-    pub fn get_or_init<F>(&self, f: F) -> &T
+    pub fn get_or_init_with<F>(&self, f: F) -> &T
     where
         F: FnOnce() -> T,
     {
-        match self.get_or_try_init(|| Ok::<T, !>(f())) {
+        match self.get_or_try_init_with(|| Ok::<T, !>(f())) {
             Ok(val) => val,
         }
     }
@@ -158,16 +158,16 @@ impl<T> OnceCell<T> {
     /// use std::cell::OnceCell;
     ///
     /// let cell = OnceCell::new();
-    /// assert_eq!(cell.get_or_try_init(|| Err(())), Err(()));
+    /// assert_eq!(cell.get_or_try_init_with(|| Err(())), Err(()));
     /// assert!(cell.get().is_none());
-    /// let value = cell.get_or_try_init(|| -> Result<i32, ()> {
+    /// let value = cell.get_or_try_init_with(|| -> Result<i32, ()> {
     ///     Ok(92)
     /// });
     /// assert_eq!(value, Ok(&92));
     /// assert_eq!(cell.get(), Some(&92))
     /// ```
     #[unstable(feature = "once_cell", issue = "74465")]
-    pub fn get_or_try_init<F, E>(&self, f: F) -> Result<&T, E>
+    pub fn get_or_try_init_with<F, E>(&self, f: F) -> Result<&T, E>
     where
         F: FnOnce() -> Result<T, E>,
     {

--- a/library/core/tests/lazy.rs
+++ b/library/core/tests/lazy.rs
@@ -7,10 +7,10 @@ use core::{
 fn once_cell() {
     let c = OnceCell::new();
     assert!(c.get().is_none());
-    c.get_or_init(|| 92);
+    c.get_or_init_with(|| 92);
     assert_eq!(c.get(), Some(&92));
 
-    c.get_or_init(|| panic!("Kabom!"));
+    c.get_or_init_with(|| panic!("Kabom!"));
     assert_eq!(c.get(), Some(&92));
 }
 
@@ -34,7 +34,7 @@ fn once_cell_drop() {
     }
 
     let x = OnceCell::new();
-    x.get_or_init(|| Dropper);
+    x.get_or_init_with(|| Dropper);
     assert_eq!(DROP_CNT.load(SeqCst), 0);
     drop(x);
     assert_eq!(DROP_CNT.load(SeqCst), 1);
@@ -126,8 +126,8 @@ fn aliasing_in_get() {
 fn reentrant_init() {
     let x: OnceCell<Box<i32>> = OnceCell::new();
     let dangling_ref: Cell<Option<&i32>> = Cell::new(None);
-    x.get_or_init(|| {
-        let r = x.get_or_init(|| Box::new(92));
+    x.get_or_init_with(|| {
+        let r = x.get_or_init_with(|| Box::new(92));
         dangling_ref.set(Some(r));
         Box::new(62)
     });

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -322,7 +322,7 @@ pub struct StdinLock<'a> {
 pub fn stdin() -> Stdin {
     static INSTANCE: OnceLock<Mutex<BufReader<StdinRaw>>> = OnceLock::new();
     Stdin {
-        inner: INSTANCE.get_or_init(|| {
+        inner: INSTANCE.get_or_init_with(|| {
             Mutex::new(BufReader::with_capacity(stdio::STDIN_BUF_SIZE, stdin_raw()))
         }),
     }
@@ -614,7 +614,7 @@ static STDOUT: OnceLock<ReentrantMutex<RefCell<LineWriter<StdoutRaw>>>> = OnceLo
 pub fn stdout() -> Stdout {
     Stdout {
         inner: STDOUT
-            .get_or_init(|| ReentrantMutex::new(RefCell::new(LineWriter::new(stdout_raw())))),
+            .get_or_init_with(|| ReentrantMutex::new(RefCell::new(LineWriter::new(stdout_raw())))),
     }
 }
 
@@ -623,7 +623,7 @@ pub fn stdout() -> Stdout {
 // buffering capacity.
 pub fn cleanup() {
     let mut initialized = false;
-    let stdout = STDOUT.get_or_init(|| {
+    let stdout = STDOUT.get_or_init_with(|| {
         initialized = true;
         ReentrantMutex::new(RefCell::new(LineWriter::with_capacity(0, stdout_raw())))
     });

--- a/library/std/src/sync/lazy_lock/tests.rs
+++ b/library/std/src/sync/lazy_lock/tests.rs
@@ -116,7 +116,7 @@ fn static_sync_lazy() {
 fn static_sync_lazy_via_fn() {
     fn xs() -> &'static Vec<i32> {
         static XS: OnceLock<Vec<i32>> = OnceLock::new();
-        XS.get_or_init(|| {
+        XS.get_or_init_with(|| {
             let mut xs = Vec::new();
             xs.push(1);
             xs.push(2);

--- a/library/std/src/sys/itron/mutex.rs
+++ b/library/std/src/sys/itron/mutex.rs
@@ -31,7 +31,7 @@ impl Mutex {
 
     /// Get the inner mutex's ID, which is lazily created.
     fn raw(&self) -> abi::ID {
-        match self.mtx.get_or_try_init(|| new_mtx().map(|id| (id, ()))) {
+        match self.mtx.get_or_try_init_with(|| new_mtx().map(|id| (id, ()))) {
             Ok((id, ())) => id,
             Err(e) => fail(e, &"acre_mtx"),
         }

--- a/library/std/src/sys/itron/spin.rs
+++ b/library/std/src/sys/itron/spin.rs
@@ -113,7 +113,7 @@ impl<T> SpinIdOnceCell<T> {
     /// Warning: `f` must not perform a blocking operation, which
     /// includes panicking.
     #[inline]
-    pub fn get_or_try_init<F, E>(&self, f: F) -> Result<(abi::ID, &T), E>
+    pub fn get_or_try_init_with<F, E>(&self, f: F) -> Result<(abi::ID, &T), E>
     where
         F: FnOnce() -> Result<(abi::ID, T), E>,
     {

--- a/library/std/src/sys/solid/rwlock.rs
+++ b/library/std/src/sys/solid/rwlock.rs
@@ -28,7 +28,7 @@ impl RwLock {
 
     /// Get the inner mutex's ID, which is lazily created.
     fn raw(&self) -> abi::ID {
-        match self.rwl.get_or_try_init(|| new_rwl().map(|id| (id, ()))) {
+        match self.rwl.get_or_try_init_with(|| new_rwl().map(|id| (id, ()))) {
             Ok((id, ())) => id,
             Err(e) => fail(e, &"rwl_acre_rwl"),
         }

--- a/library/std/src/sys/windows/net.rs
+++ b/library/std/src/sys/windows/net.rs
@@ -34,7 +34,7 @@ static WSA_CLEANUP: OnceLock<unsafe extern "system" fn() -> i32> = OnceLock::new
 /// Checks whether the Windows socket interface has been started already, and
 /// if not, starts it.
 pub fn init() {
-    let _ = WSA_CLEANUP.get_or_init(|| unsafe {
+    let _ = WSA_CLEANUP.get_or_init_with(|| unsafe {
         let mut data: c::WSADATA = mem::zeroed();
         let ret = c::WSAStartup(
             0x202, // version 2.2

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1760,7 +1760,7 @@ impl PrimitiveType {
         static CELL: OnceCell<SimplifiedTypes> = OnceCell::new();
 
         let single = |x| iter::once(x).collect();
-        CELL.get_or_init(move || {
+        CELL.get_or_init_with(move || {
             map! {
                 Isize => single(IntSimplifiedType(IntTy::Isize)),
                 I8 => single(IntSimplifiedType(IntTy::I8)),
@@ -1855,7 +1855,7 @@ impl PrimitiveType {
     /// it's entirely random whether `std` or the other crate is picked. (no_std crates are usually fine unless multiple dependencies define a primitive.)
     pub(crate) fn primitive_locations(tcx: TyCtxt<'_>) -> &FxHashMap<PrimitiveType, DefId> {
         static PRIMITIVE_LOCATIONS: OnceCell<FxHashMap<PrimitiveType, DefId>> = OnceCell::new();
-        PRIMITIVE_LOCATIONS.get_or_init(|| {
+        PRIMITIVE_LOCATIONS.get_or_init_with(|| {
             let mut primitive_locations = FxHashMap::default();
             // NOTE: technically this misses crates that are only passed with `--extern` and not loaded when checking the crate.
             // This is a degenerate case that I don't plan to support.

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -2313,7 +2313,7 @@ pub fn is_hir_ty_cfg_dependant(cx: &LateContext<'_>, ty: &hir::Ty<'_>) -> bool {
 static TEST_ITEM_NAMES_CACHE: OnceLock<Mutex<FxHashMap<LocalDefId, Vec<Symbol>>>> = OnceLock::new();
 
 fn with_test_item_names(tcx: TyCtxt<'_>, module: LocalDefId, f: impl Fn(&[Symbol]) -> bool) -> bool {
-    let cache = TEST_ITEM_NAMES_CACHE.get_or_init(|| Mutex::new(FxHashMap::default()));
+    let cache = TEST_ITEM_NAMES_CACHE.get_or_init_with(|| Mutex::new(FxHashMap::default()));
     let mut map: MutexGuard<'_, FxHashMap<LocalDefId, Vec<Symbol>>> = cache.lock().unwrap();
     let value = map.entry(module);
     match value {

--- a/src/tools/clippy/clippy_utils/src/msrvs.rs
+++ b/src/tools/clippy/clippy_utils/src/msrvs.rs
@@ -107,7 +107,7 @@ impl Msrv {
     pub fn read(conf_msrv: &Option<String>, sess: &Session) -> &'static Self {
         static PARSED: OnceLock<Msrv> = OnceLock::new();
 
-        PARSED.get_or_init(|| Self::read_inner(conf_msrv, sess))
+        PARSED.get_or_init_with(|| Self::read_inner(conf_msrv, sess))
     }
 
     pub fn current(&self) -> Option<RustcVersion> {


### PR DESCRIPTION
Potentially blocks #105587

I hate myself for bikeshedding on a stabilization PR I care about, but I think `get_or_init_with` might be a better name for `get_or_init`.

The main reason is it might make sense in the future to re-add a `get_or_init` that takes a value rather than a closure. I kind of doubt it would ever get added (unless we elect to do it now) as it's just easy sugar for `.get_or_init_with(|| val)`. However, unless we pick a `_with` name for the `FnOnce` version now, we wouldn't be able to add it later and keep a consistent naming scheme.

Other points are that the near cousin `RefCell` has `replace(&self, T)` and `replace_with<F: FnOnce...>(&self, f: F)`, so changing the name would make this consistent. And the `_with` naming pattern is well established anyway, as I mention here https://github.com/rust-lang/rust/pull/105587#issuecomment-1399360192

Downsides of changing are, of course, potential confusion for anyone using the crate, and the slightly longer name.

I'm not tied to the `get_or_init` portion specifically, and matklad mentioned some other options here https://github.com/rust-lang/rust/issues/74465#issuecomment-726020743.

cc @matklad