### PR TITLE
Recover from more const arguments that are not wrapped in curly braces

### DIFF
--- a/tests/ui/const-generics/bad-const-generic-exprs.rs
+++ b/tests/ui/const-generics/bad-const-generic-exprs.rs
@@ -13,10 +13,34 @@ fn main() {
     let _: Wow<A.0>;
     //~^ ERROR expected one of
     //~| HELP expressions must be enclosed in braces to be used as const generic arguments
-
-    // FIXME(compiler-errors): This one is still unsatisfying,
-    // and probably a case I could see someone typing by accident..
+    let _: Wow<[]>;
+    //~^ ERROR expected type
+    //~| HELP expressions must be enclosed in braces to be used as const generic arguments
     let _: Wow<[12]>;
-    //~^ ERROR expected type, found
-    //~| ERROR type provided when a constant was expected
+    //~^ ERROR expected type
+    //~| ERROR invalid const generic expression
+    //~| HELP expressions must be enclosed in braces to be used as const generic arguments
+    let _: Wow<[0, 1, 3]>;
+    //~^ ERROR expected type
+    //~| HELP expressions must be enclosed in braces to be used as const generic arguments
+    let _: Wow<[0xff; 8]>;
+    //~^ ERROR expected type
+    //~| ERROR invalid const generic expression
+    //~| HELP expressions must be enclosed in braces to be used as const generic arguments
+    let _: Wow<[1, 2]>; // Regression test for issue #81698.
+    //~^ ERROR expected type
+    //~| HELP expressions must be enclosed in braces to be used as const generic arguments
+    let _: Wow<&0>;
+    //~^ ERROR expected type
+    //~| HELP expressions must be enclosed in braces to be used as const generic arguments
+    let _: Wow<("", 0)>;
+    //~^ ERROR expected type
+    //~| HELP expressions must be enclosed in braces to be used as const generic arguments
+    let _: Wow<(1 + 2) * 3>;
+    //~^ ERROR expected type
+    //~| HELP expressions must be enclosed in braces to be used as const generic arguments
+    // FIXME(fmease): This one is pretty bad.
+    let _: Wow<!0>;
+    //~^ ERROR expected one of
+    //~| HELP you might have meant to end the type parameters here
 }

--- a/tests/ui/const-generics/bad-const-generic-exprs.stderr
+++ b/tests/ui/const-generics/bad-const-generic-exprs.stderr
@@ -42,18 +42,118 @@ help: expressions must be enclosed in braces to be used as const generic argumen
 LL |     let _: Wow<{ A.0 }>;
    |                +     +
 
+error: expected type, found `]`
+  --> $DIR/bad-const-generic-exprs.rs:16:17
+   |
+LL |     let _: Wow<[]>;
+   |                 ^ expected type
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     let _: Wow<{ [] }>;
+   |                +    +
+
 error: expected type, found `12`
   --> $DIR/bad-const-generic-exprs.rs:19:17
    |
 LL |     let _: Wow<[12]>;
    |                 ^^ expected type
 
-error[E0747]: type provided when a constant was expected
+error: invalid const generic expression
   --> $DIR/bad-const-generic-exprs.rs:19:16
    |
 LL |     let _: Wow<[12]>;
    |                ^^^^
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     let _: Wow<{ [12] }>;
+   |                +      +
 
-error: aborting due to 6 previous errors
+error: expected type, found `0`
+  --> $DIR/bad-const-generic-exprs.rs:23:17
+   |
+LL |     let _: Wow<[0, 1, 3]>;
+   |                 ^ expected type
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     let _: Wow<{ [0, 1, 3] }>;
+   |                +           +
 
-For more information about this error, try `rustc --explain E0747`.
+error: expected type, found `0xff`
+  --> $DIR/bad-const-generic-exprs.rs:26:17
+   |
+LL |     let _: Wow<[0xff; 8]>;
+   |                 ^^^^ expected type
+
+error: invalid const generic expression
+  --> $DIR/bad-const-generic-exprs.rs:26:16
+   |
+LL |     let _: Wow<[0xff; 8]>;
+   |                ^^^^^^^^^
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     let _: Wow<{ [0xff; 8] }>;
+   |                +           +
+
+error: expected type, found `1`
+  --> $DIR/bad-const-generic-exprs.rs:30:17
+   |
+LL |     let _: Wow<[1, 2]>; // Regression test for issue #81698.
+   |                 ^ expected type
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     let _: Wow<{ [1, 2] }>; // Regression test for issue #81698.
+   |                +        +
+
+error: expected type, found `0`
+  --> $DIR/bad-const-generic-exprs.rs:33:17
+   |
+LL |     let _: Wow<&0>;
+   |                 ^ expected type
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     let _: Wow<{ &0 }>;
+   |                +    +
+
+error: expected type, found `""`
+  --> $DIR/bad-const-generic-exprs.rs:36:17
+   |
+LL |     let _: Wow<("", 0)>;
+   |                 ^^ expected type
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     let _: Wow<{ ("", 0) }>;
+   |                +         +
+
+error: expected type, found `1`
+  --> $DIR/bad-const-generic-exprs.rs:39:17
+   |
+LL |     let _: Wow<(1 + 2) * 3>;
+   |                 ^ expected type
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     let _: Wow<{ (1 + 2) * 3 }>;
+   |                +             +
+
+error: expected one of `,` or `>`, found `0`
+  --> $DIR/bad-const-generic-exprs.rs:43:17
+   |
+LL |     let _: Wow<!0>;
+   |         -       ^ expected one of `,` or `>`
+   |         |
+   |         while parsing the type for `_`
+   |
+help: you might have meant to end the type parameters here
+   |
+LL |     let _: Wow<!>0>;
+   |                 +
+
+error: aborting due to 15 previous errors
+


### PR DESCRIPTION
Recover from some array, borrow, tuple & arithmetic expressions in const argument positions that lack curly braces and provide a suggestion to fix the issue continuing where #92884 left off. Examples of such expressions: `[]`, `[0]`, `[1, 2]`, `[0; 0xff]`, `&9`, `("", 0)` and `(1 + 2) * 3` (we previously did not recover from them).

I am not entirely happy with my current solution because the code that recovers from `[0]` (coinciding with a malformed slice type) and `[0; 0]` (coinciding with a malformed array type) is quite fragile as the aforementioned snippets are actually successfully parsed as types by `parse_ty` since it itself already recovers from them (returning `[⟨error⟩]` and `[⟨error⟩; 0]` respectively) meaning I have to manually look for `TyKind::Err`s and construct a separate diagnostic for the suggestion to attach to (thereby emitting two diagnostics in total).

Fixes #81698.
@rustbot label A-diagnostics
r? diagnostics