### PR TITLE
assume MIR types are fully normalized in ascribe_user_type

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/canonical.rs
+++ b/compiler/rustc_borrowck/src/type_check/canonical.rs
@@ -181,9 +181,6 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         user_ty: ty::UserType<'tcx>,
         span: Span,
     ) {
-        // FIXME: Ideally MIR types are normalized, but this is not always true.
-        let mir_ty = self.normalize(mir_ty, Locations::All(span));
-
         self.fully_perform_op(
             Locations::All(span),
             ConstraintCategory::Boring,
@@ -217,7 +214,9 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             return;
         }
 
+        // FIXME: Ideally MIR types are normalized, but this is not always true.
         let mir_ty = self.normalize(mir_ty, Locations::All(span));
+
         let cause = ObligationCause::dummy_with_span(span);
         let param_env = self.param_env;
         let op = |infcx: &'_ _| {


### PR DESCRIPTION
This FIXME was introduced in c6a17bf8bcfa60c8b0436251d2cf70d8eca4d198 but it should've been restricted to `ascribe_user_type_skip_wf`.