### PR TITLE
Remove confusing 'while checking' note from opaque future type mismatches

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -60,7 +60,7 @@ use crate::traits::{
 
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 use rustc_errors::{pluralize, struct_span_err, Diagnostic, ErrorGuaranteed, IntoDiagnosticArg};
-use rustc_errors::{Applicability, DiagnosticBuilder, DiagnosticStyledString, MultiSpan};
+use rustc_errors::{Applicability, DiagnosticBuilder, DiagnosticStyledString};
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -1468,51 +1468,17 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 for (key, values) in types.iter() {
                     let count = values.len();
                     let kind = key.descr();
-                    let mut returned_async_output_error = false;
                     for &sp in values {
-                        if sp.is_desugaring(DesugaringKind::Async) && !returned_async_output_error {
-                            if [sp] != err.span.primary_spans() {
-                                let mut span: MultiSpan = sp.into();
-                                span.push_span_label(
-                                    sp,
-                                    format!(
-                                        "checked the `Output` of this `async fn`, {}{} {}{}",
-                                        if count > 1 { "one of the " } else { "" },
-                                        target,
-                                        kind,
-                                        pluralize!(count),
-                                    ),
-                                );
-                                err.span_note(
-                                    span,
-                                    "while checking the return type of the `async fn`",
-                                );
-                            } else {
-                                err.span_label(
-                                    sp,
-                                    format!(
-                                        "checked the `Output` of this `async fn`, {}{} {}{}",
-                                        if count > 1 { "one of the " } else { "" },
-                                        target,
-                                        kind,
-                                        pluralize!(count),
-                                    ),
-                                );
-                                err.note("while checking the return type of the `async fn`");
-                            }
-                            returned_async_output_error = true;
-                        } else {
-                            err.span_label(
-                                sp,
-                                format!(
-                                    "{}{} {}{}",
-                                    if count == 1 { "the " } else { "one of the " },
-                                    target,
-                                    kind,
-                                    pluralize!(count),
-                                ),
-                            );
-                        }
+                        err.span_label(
+                            sp,
+                            format!(
+                                "{}{} {}{}",
+                                if count == 1 { "the " } else { "one of the " },
+                                target,
+                                kind,
+                                pluralize!(count),
+                            ),
+                        );
                     }
                 }
             }
@@ -1535,7 +1501,11 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     //    |
                     //    = note: expected unit type `()`
                     //                 found closure `[closure@$DIR/issue-20862.rs:2:5: 2:14 x:_]`
-                    if !self.ignore_span.overlaps(span) {
+                    //
+                    // Also ignore opaque `Future`s that come from async fns.
+                    if !self.ignore_span.overlaps(span)
+                        && !span.is_desugaring(DesugaringKind::Async)
+                    {
                         self.types.entry(kind).or_default().insert(span);
                     }
                 }

--- a/tests/ui/async-await/dont-suggest-missing-await.stderr
+++ b/tests/ui/async-await/dont-suggest-missing-await.stderr
@@ -6,11 +6,6 @@ LL |         take_u32(x)
    |         |
    |         arguments to this function are incorrect
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/dont-suggest-missing-await.rs:7:24
-   |
-LL | async fn make_u32() -> u32 {
-   |                        ^^^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `u32`
            found opaque type `impl Future<Output = u32>`
 note: function defined here

--- a/tests/ui/async-await/generator-desc.stderr
+++ b/tests/ui/async-await/generator-desc.stderr
@@ -21,16 +21,6 @@ LL |     fun(one(), two());
    |     |
    |     arguments to this function are incorrect
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/generator-desc.rs:5:16
-   |
-LL | async fn one() {}
-   |                ^ checked the `Output` of this `async fn`, expected opaque type
-note: while checking the return type of the `async fn`
-  --> $DIR/generator-desc.rs:6:16
-   |
-LL | async fn two() {}
-   |                ^ checked the `Output` of this `async fn`, found opaque type
    = note: expected opaque type `impl Future<Output = ()>` (opaque type at <$DIR/generator-desc.rs:5:16>)
               found opaque type `impl Future<Output = ()>` (opaque type at <$DIR/generator-desc.rs:6:16>)
    = help: consider `await`ing on both `Future`s

--- a/tests/ui/async-await/issue-61076.rs
+++ b/tests/ui/async-await/issue-61076.rs
@@ -54,9 +54,6 @@ async fn struct_() -> Struct {
 }
 
 async fn tuple() -> Tuple {
-    //~^ NOTE checked the `Output` of this `async fn`, expected opaque type
-    //~| NOTE while checking the return type of the `async fn`
-    //~| NOTE in this expansion of desugaring of `async` block or function
     Tuple(1i32)
 }
 

--- a/tests/ui/async-await/issue-61076.stderr
+++ b/tests/ui/async-await/issue-61076.stderr
@@ -11,7 +11,7 @@ LL |     foo().await?;
    |          ++++++
 
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
-  --> $DIR/issue-61076.rs:65:5
+  --> $DIR/issue-61076.rs:62:5
    |
 LL |     t?;
    |     ^^ the `?` operator cannot be applied to type `T`
@@ -23,7 +23,7 @@ LL |     t.await?;
    |      ++++++
 
 error[E0609]: no field `0` on type `impl Future<Output = Tuple>`
-  --> $DIR/issue-61076.rs:74:26
+  --> $DIR/issue-61076.rs:71:26
    |
 LL |     let _: i32 = tuple().0;
    |                          ^ field not available in `impl Future`, but it is available in its `Output`
@@ -34,7 +34,7 @@ LL |     let _: i32 = tuple().await.0;
    |                         ++++++
 
 error[E0609]: no field `a` on type `impl Future<Output = Struct>`
-  --> $DIR/issue-61076.rs:78:28
+  --> $DIR/issue-61076.rs:75:28
    |
 LL |     let _: i32 = struct_().a;
    |                            ^ field not available in `impl Future`, but it is available in its `Output`
@@ -45,7 +45,7 @@ LL |     let _: i32 = struct_().await.a;
    |                           ++++++
 
 error[E0599]: no method named `method` found for opaque type `impl Future<Output = Struct>` in the current scope
-  --> $DIR/issue-61076.rs:82:15
+  --> $DIR/issue-61076.rs:79:15
    |
 LL |     struct_().method();
    |               ^^^^^^ method not found in `impl Future<Output = Struct>`
@@ -56,7 +56,7 @@ LL |     struct_().await.method();
    |               ++++++
 
 error[E0308]: mismatched types
-  --> $DIR/issue-61076.rs:91:9
+  --> $DIR/issue-61076.rs:88:9
    |
 LL |     match tuple() {
    |           ------- this expression has type `impl Future<Output = Tuple>`
@@ -64,11 +64,6 @@ LL |
 LL |         Tuple(_) => {}
    |         ^^^^^^^^ expected opaque type, found struct `Tuple`
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/issue-61076.rs:56:21
-   |
-LL | async fn tuple() -> Tuple {
-   |                     ^^^^^ checked the `Output` of this `async fn`, expected opaque type
    = note: expected opaque type `impl Future<Output = Tuple>`
                    found struct `Tuple`
 help: consider `await`ing on the `Future`

--- a/tests/ui/async-await/issue-98634.stderr
+++ b/tests/ui/async-await/issue-98634.stderr
@@ -4,11 +4,6 @@ error[E0271]: expected `fn() -> impl Future<Output = ()> {callback}` to be a fn 
 LL |         StructAsync { callback }.await;
    |                       ^^^^^^^^ expected struct `Pin`, found opaque type
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/issue-98634.rs:24:21
-   |
-LL | async fn callback() {}
-   |                     ^ checked the `Output` of this `async fn`, found opaque type
    = note:   expected struct `Pin<Box<(dyn Future<Output = ()> + 'static)>>`
            found opaque type `impl Future<Output = ()>`
 note: required by a bound in `StructAsync`
@@ -23,11 +18,6 @@ error[E0271]: expected `fn() -> impl Future<Output = ()> {callback}` to be a fn 
 LL |         StructAsync { callback }.await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `Pin`, found opaque type
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/issue-98634.rs:24:21
-   |
-LL | async fn callback() {}
-   |                     ^ checked the `Output` of this `async fn`, found opaque type
    = note:   expected struct `Pin<Box<(dyn Future<Output = ()> + 'static)>>`
            found opaque type `impl Future<Output = ()>`
 note: required by a bound in `StructAsync`
@@ -42,11 +32,6 @@ error[E0271]: expected `fn() -> impl Future<Output = ()> {callback}` to be a fn 
 LL |         StructAsync { callback }.await;
    |                                 ^^^^^^ expected struct `Pin`, found opaque type
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/issue-98634.rs:24:21
-   |
-LL | async fn callback() {}
-   |                     ^ checked the `Output` of this `async fn`, found opaque type
    = note:   expected struct `Pin<Box<(dyn Future<Output = ()> + 'static)>>`
            found opaque type `impl Future<Output = ()>`
 note: required by a bound in `StructAsync`

--- a/tests/ui/async-await/issues/issue-102206.stderr
+++ b/tests/ui/async-await/issues/issue-102206.stderr
@@ -8,11 +8,6 @@ LL |     std::mem::size_of_val(foo());
    |     |                     help: consider borrowing here: `&foo()`
    |     arguments to this function are incorrect
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/issue-102206.rs:3:16
-   |
-LL | async fn foo() {}
-   |                ^ checked the `Output` of this `async fn`, found opaque type
    = note: expected reference `&_`
             found opaque type `impl Future<Output = ()>`
 note: function defined here

--- a/tests/ui/async-await/suggest-missing-await-closure.stderr
+++ b/tests/ui/async-await/suggest-missing-await-closure.stderr
@@ -6,11 +6,6 @@ LL |         take_u32(x)
    |         |
    |         arguments to this function are incorrect
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/suggest-missing-await-closure.rs:8:24
-   |
-LL | async fn make_u32() -> u32 {
-   |                        ^^^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `u32`
            found opaque type `impl Future<Output = u32>`
 note: function defined here

--- a/tests/ui/async-await/suggest-missing-await.stderr
+++ b/tests/ui/async-await/suggest-missing-await.stderr
@@ -6,11 +6,6 @@ LL |     take_u32(x)
    |     |
    |     arguments to this function are incorrect
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/suggest-missing-await.rs:5:24
-   |
-LL | async fn make_u32() -> u32 {
-   |                        ^^^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `u32`
            found opaque type `impl Future<Output = u32>`
 note: function defined here
@@ -29,11 +24,6 @@ error[E0308]: mismatched types
 LL |     dummy()
    |     ^^^^^^^ expected `()`, found opaque type
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/suggest-missing-await.rs:18:18
-   |
-LL | async fn dummy() {}
-   |                  ^ checked the `Output` of this `async fn`, found opaque type
    = note: expected unit type `()`
             found opaque type `impl Future<Output = ()>`
 help: consider `await`ing on the `Future`
@@ -60,11 +50,6 @@ LL | |
 LL | |     };
    | |_____- `if` and `else` have incompatible types
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/suggest-missing-await.rs:18:18
-   |
-LL | async fn dummy() {}
-   |                  ^ checked the `Output` of this `async fn`, expected opaque type
    = note: expected opaque type `impl Future<Output = ()>`
                 found unit type `()`
 help: consider `await`ing on the `Future`
@@ -87,11 +72,6 @@ LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/suggest-missing-await.rs:18:18
-   |
-LL | async fn dummy() {}
-   |                  ^ checked the `Output` of this `async fn`, expected opaque type
    = note: expected opaque type `impl Future<Output = ()>`
                 found unit type `()`
 help: consider `await`ing on the `Future`
@@ -108,11 +88,6 @@ LL |     let _x = match dummy() {
 LL |         () => {}
    |         ^^ expected opaque type, found `()`
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/suggest-missing-await.rs:18:18
-   |
-LL | async fn dummy() {}
-   |                  ^ checked the `Output` of this `async fn`, expected opaque type
    = note: expected opaque type `impl Future<Output = ()>`
                 found unit type `()`
 help: consider `await`ing on the `Future`
@@ -129,11 +104,6 @@ LL |     match dummy_result() {
 LL |         Ok(_) => {}
    |         ^^^^^ expected opaque type, found enum `Result`
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/suggest-missing-await.rs:57:28
-   |
-LL | async fn dummy_result() -> Result<(), ()> {
-   |                            ^^^^^^^^^^^^^^ checked the `Output` of this `async fn`, expected opaque type
    = note: expected opaque type `impl Future<Output = Result<(), ()>>`
                      found enum `Result<_, _>`
 help: consider `await`ing on the `Future`
@@ -150,11 +120,6 @@ LL |     match dummy_result() {
 LL |         Err(_) => {}
    |         ^^^^^^ expected opaque type, found enum `Result`
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/suggest-missing-await.rs:57:28
-   |
-LL | async fn dummy_result() -> Result<(), ()> {
-   |                            ^^^^^^^^^^^^^^ checked the `Output` of this `async fn`, expected opaque type
    = note: expected opaque type `impl Future<Output = Result<(), ()>>`
                      found enum `Result<_, _>`
 help: consider `await`ing on the `Future`

--- a/tests/ui/impl-trait/in-trait/method-signature-matches.stderr
+++ b/tests/ui/impl-trait/in-trait/method-signature-matches.stderr
@@ -24,16 +24,6 @@ LL |     async fn owo(_: u8) {}
    |                     expected `()`, found `u8`
    |                     help: change the parameter type to match the trait: `()`
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/method-signature-matches.rs:20:25
-   |
-LL |     async fn owo(_: u8) {}
-   |                         ^ checked the `Output` of this `async fn`, expected opaque type
-note: while checking the return type of the `async fn`
-  --> $DIR/method-signature-matches.rs:20:25
-   |
-LL |     async fn owo(_: u8) {}
-   |                         ^ checked the `Output` of this `async fn`, found opaque type
 note: type in trait
   --> $DIR/method-signature-matches.rs:16:21
    |

--- a/tests/ui/impl-trait/issue-102605.stderr
+++ b/tests/ui/impl-trait/issue-102605.stderr
@@ -6,11 +6,6 @@ LL |     convert_result(foo())
    |     |
    |     arguments to this function are incorrect
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/issue-102605.rs:3:19
-   |
-LL | async fn foo() -> Result<(), String> {
-   |                   ^^^^^^^^^^^^^^^^^^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected enum `Result<(), _>`
            found opaque type `impl Future<Output = Result<(), String>>`
 note: function defined here

--- a/tests/ui/impl-trait/issue-99914.stderr
+++ b/tests/ui/impl-trait/issue-99914.stderr
@@ -4,11 +4,6 @@ error[E0308]: mismatched types
 LL |     t.and_then(|t| -> _ { bar(t) });
    |                           ^^^^^^ expected enum `Result`, found opaque type
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/issue-99914.rs:13:23
-   |
-LL | async fn bar(t: Okay) {}
-   |                       ^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected enum `Result<_, Error>`
            found opaque type `impl Future<Output = ()>`
 help: try wrapping the expression in `Ok`

--- a/tests/ui/suggestions/if-then-neeing-semi.rs
+++ b/tests/ui/suggestions/if-then-neeing-semi.rs
@@ -15,18 +15,9 @@ fn extra_semicolon() {
     };
 }
 
-async fn async_dummy() {} //~ NOTE checked the `Output` of this `async fn`, found opaque type
-//~| NOTE while checking the return type of the `async fn`
-//~| NOTE in this expansion of desugaring of `async` block or function
-//~| NOTE checked the `Output` of this `async fn`, expected opaque type
-//~| NOTE while checking the return type of the `async fn`
-//~| NOTE in this expansion of desugaring of `async` block or function
-async fn async_dummy2() {} //~ NOTE checked the `Output` of this `async fn`, found opaque type
-//~| NOTE checked the `Output` of this `async fn`, found opaque type
-//~| NOTE while checking the return type of the `async fn`
-//~| NOTE in this expansion of desugaring of `async` block or function
-//~| NOTE while checking the return type of the `async fn`
-//~| NOTE in this expansion of desugaring of `async` block or function
+async fn async_dummy() {}
+
+async fn async_dummy2() {}
 
 async fn async_extra_semicolon_same() {
     let _ = if true {

--- a/tests/ui/suggestions/if-then-neeing-semi.stderr
+++ b/tests/ui/suggestions/if-then-neeing-semi.stderr
@@ -1,5 +1,5 @@
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/if-then-neeing-semi.rs:37:9
+  --> $DIR/if-then-neeing-semi.rs:28:9
    |
 LL |       let _ = if true {
    |  _____________-
@@ -15,11 +15,6 @@ LL | |
 LL | |     };
    | |_____- `if` and `else` have incompatible types
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/if-then-neeing-semi.rs:18:24
-   |
-LL | async fn async_dummy() {}
-   |                        ^ checked the `Output` of this `async fn`, found opaque type
    = note: expected unit type `()`
             found opaque type `impl Future<Output = ()>`
 help: consider `await`ing on the `Future`
@@ -33,7 +28,7 @@ LL +         async_dummy()
    |
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/if-then-neeing-semi.rs:50:9
+  --> $DIR/if-then-neeing-semi.rs:41:9
    |
 LL |       let _ = if true {
    |  _____________-
@@ -49,11 +44,6 @@ LL | |
 LL | |     };
    | |_____- `if` and `else` have incompatible types
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/if-then-neeing-semi.rs:24:25
-   |
-LL | async fn async_dummy2() {}
-   |                         ^ checked the `Output` of this `async fn`, found opaque type
    = note: expected unit type `()`
             found opaque type `impl Future<Output = ()>`
 help: consider `await`ing on the `Future`
@@ -69,7 +59,7 @@ LL ~         Box::new(async_dummy2())
    |
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/if-then-neeing-semi.rs:63:9
+  --> $DIR/if-then-neeing-semi.rs:54:9
    |
 LL |       let _ = if true {
    |  _____________-
@@ -85,18 +75,8 @@ LL | |
 LL | |     };
    | |_____- `if` and `else` have incompatible types
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/if-then-neeing-semi.rs:18:24
-   |
-LL | async fn async_dummy() {}
-   |                        ^ checked the `Output` of this `async fn`, expected opaque type
-note: while checking the return type of the `async fn`
-  --> $DIR/if-then-neeing-semi.rs:24:25
-   |
-LL | async fn async_dummy2() {}
-   |                         ^ checked the `Output` of this `async fn`, found opaque type
    = note: expected opaque type `impl Future<Output = ()>` (opaque type at <$DIR/if-then-neeing-semi.rs:18:24>)
-              found opaque type `impl Future<Output = ()>` (opaque type at <$DIR/if-then-neeing-semi.rs:24:25>)
+              found opaque type `impl Future<Output = ()>` (opaque type at <$DIR/if-then-neeing-semi.rs:20:25>)
    = note: distinct uses of `impl Trait` result in different opaque types
 help: consider `await`ing on both `Future`s
    |

--- a/tests/ui/suggestions/issue-81839.stderr
+++ b/tests/ui/suggestions/issue-81839.stderr
@@ -14,11 +14,6 @@ LL | |         _ => cx.answer_str("hi"),
 LL | |     }
    | |_____- `match` arms have incompatible types
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/auxiliary/issue-81839.rs:6:49
-   |
-LL |     pub async fn answer_str(&self, _s: &str) -> Test {
-   |                                                 ^^^^ checked the `Output` of this `async fn`, found opaque type
    = note: expected unit type `()`
             found opaque type `impl Future<Output = Test>`
 

--- a/tests/ui/suggestions/match-prev-arm-needing-semi.rs
+++ b/tests/ui/suggestions/match-prev-arm-needing-semi.rs
@@ -13,18 +13,9 @@ fn extra_semicolon() {
     };
 }
 
-async fn async_dummy() {} //~ NOTE checked the `Output` of this `async fn`, found opaque type
-//~| NOTE while checking the return type of the `async fn`
-//~| NOTE in this expansion of desugaring of `async` block or function
-//~| NOTE checked the `Output` of this `async fn`, expected opaque type
-//~| NOTE while checking the return type of the `async fn`
-//~| NOTE in this expansion of desugaring of `async` block or function
-async fn async_dummy2() {} //~ NOTE checked the `Output` of this `async fn`, found opaque type
-//~| NOTE checked the `Output` of this `async fn`, found opaque type
-//~| NOTE while checking the return type of the `async fn`
-//~| NOTE in this expansion of desugaring of `async` block or function
-//~| NOTE while checking the return type of the `async fn`
-//~| NOTE in this expansion of desugaring of `async` block or function
+async fn async_dummy() {}
+
+async fn async_dummy2() {}
 
 async fn async_extra_semicolon_same() {
     let _ = match true { //~ NOTE `match` arms have incompatible types

--- a/tests/ui/suggestions/match-prev-arm-needing-semi.stderr
+++ b/tests/ui/suggestions/match-prev-arm-needing-semi.stderr
@@ -1,5 +1,5 @@
 error[E0308]: `match` arms have incompatible types
-  --> $DIR/match-prev-arm-needing-semi.rs:35:18
+  --> $DIR/match-prev-arm-needing-semi.rs:26:18
    |
 LL |       let _ = match true {
    |  _____________-
@@ -15,11 +15,6 @@ LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/match-prev-arm-needing-semi.rs:16:24
-   |
-LL | async fn async_dummy() {}
-   |                        ^ checked the `Output` of this `async fn`, found opaque type
    = note: expected unit type `()`
             found opaque type `impl Future<Output = ()>`
 help: consider `await`ing on the `Future`
@@ -33,7 +28,7 @@ LL +             async_dummy()
    |
 
 error[E0308]: `match` arms have incompatible types
-  --> $DIR/match-prev-arm-needing-semi.rs:48:18
+  --> $DIR/match-prev-arm-needing-semi.rs:39:18
    |
 LL |       let _ = match true {
    |  _____________-
@@ -49,11 +44,6 @@ LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/match-prev-arm-needing-semi.rs:22:25
-   |
-LL | async fn async_dummy2() {}
-   |                         ^ checked the `Output` of this `async fn`, found opaque type
    = note: expected unit type `()`
             found opaque type `impl Future<Output = ()>`
 help: consider `await`ing on the `Future`
@@ -69,7 +59,7 @@ LL ~         false => Box::new(async_dummy2()),
    |
 
 error[E0308]: `match` arms have incompatible types
-  --> $DIR/match-prev-arm-needing-semi.rs:59:18
+  --> $DIR/match-prev-arm-needing-semi.rs:50:18
    |
 LL |       let _ = match true {
    |  _____________-
@@ -83,18 +73,8 @@ LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/match-prev-arm-needing-semi.rs:16:24
-   |
-LL | async fn async_dummy() {}
-   |                        ^ checked the `Output` of this `async fn`, expected opaque type
-note: while checking the return type of the `async fn`
-  --> $DIR/match-prev-arm-needing-semi.rs:22:25
-   |
-LL | async fn async_dummy2() {}
-   |                         ^ checked the `Output` of this `async fn`, found opaque type
    = note: expected opaque type `impl Future<Output = ()>` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:16:24>)
-              found opaque type `impl Future<Output = ()>` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:22:25>)
+              found opaque type `impl Future<Output = ()>` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:18:25>)
    = note: distinct uses of `impl Trait` result in different opaque types
 help: consider `await`ing on both `Future`s
    |

--- a/tests/ui/type-alias-impl-trait/issue-98604.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-98604.stderr
@@ -4,11 +4,6 @@ error[E0271]: expected `fn() -> impl Future<Output = ()> {test}` to be a fn item
 LL |     Box::new(test) as AsyncFnPtr;
    |     ^^^^^^^^^^^^^^ expected struct `Pin`, found opaque type
    |
-note: while checking the return type of the `async fn`
-  --> $DIR/issue-98604.rs:5:17
-   |
-LL | async fn test() {}
-   |                 ^ checked the `Output` of this `async fn`, found opaque type
    = note:   expected struct `Pin<Box<(dyn Future<Output = ()> + 'static)>>`
            found opaque type `impl Future<Output = ()>`
    = note: required for the cast from `fn() -> impl Future<Output = ()> {test}` to the object type `dyn Fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>>`


### PR DESCRIPTION
Maybe I'm just misinterpreting the wording of the note. The only value I can see in this note is that it points out where the async's opaque future is coming from, but the way it's doing it is misleading IMO.

For example:

```rust
note: while checking the return type of the `async fn`
  --> $DIR/dont-suggest-missing-await.rs:7:24
   |
LL | async fn make_u32() -> u32 {
   |                        ^^^ checked the `Output` of this `async fn`, found opaque type
```

We point at the type `u32` in the HIR, but then say "found opaque type". We also say "while checking"... but we're typechecking a totally different function when we get this type mismatch!

r? @estebank but feel free to reassign and/or take your time reviewing this. I'd be inclined to also discuss reworking the presentation of this type mismatch to restore some of these labels in a way that makes it more clear what it's trying to point out.