### PR TITLE
Document panic from thread::current

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -717,6 +717,13 @@ where
 
 /// Gets a handle to the thread that invokes it.
 ///
+/// # Panics
+///
+/// Panics if called beyond the end of `main`, when the Rust standard library's
+/// thread state has been torn down. For example, use of `libc::atexit` on some
+/// platforms can hit this. In general much of the standard library is not okay
+/// to use before or after `main`.
+///
 /// # Examples
 ///
 /// Getting a handle to the current thread with `thread::current()`:


### PR DESCRIPTION
Playground: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=978be7b8cb9d857f33f217ab4ff13eca

```rust
extern "C" fn get_thread() {
    let _ = std::panic::catch_unwind(std::thread::current);
}

fn main() {
    unsafe { libc::atexit(get_thread) };
}
```

```console
thread '<unnamed>' panicked at 'use of std::thread::current() is not possible after the thread's local data has been destroyed', library/std/src/thread/mod.rs:733:5
stack backtrace:
   5: core::option::Option<T>::expect
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/option.rs:741:21
   6: std::thread::current
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/thread/mod.rs:733:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/ops/function.rs:251:5
  11: std::panic::catch_unwind
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panic.rs:137:14
  12: playground::get_thread
             at ./[src/main.rs:2](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021#):13
  14: exit
  15: __libc_start_main
  16: _start
```