### PR TITLE
rustc_metadata: Encode the set of "rustdoc-reachable" def ids to metadata

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1240,6 +1240,10 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
         }
     }
 
+    fn get_rustdoc_reachable(self) -> impl Iterator<Item = DefId> + 'a {
+        self.root.rustdoc_reachable.decode(self)
+    }
+
     fn get_native_libraries(self, sess: &'a Session) -> impl Iterator<Item = NativeLib> + 'a {
         self.root.native_libraries.decode((self, sess))
     }

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -624,6 +624,10 @@ impl CStore {
         self.get_crate_data(cnum).get_all_incoherent_impls()
     }
 
+    pub fn rustdoc_reachable_untracked(&self, cnum: CrateNum) -> impl Iterator<Item = DefId> + '_ {
+        self.get_crate_data(cnum).get_rustdoc_reachable()
+    }
+
     pub fn associated_item_def_ids_untracked<'a>(
         &'a self,
         def_id: DefId,

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -239,6 +239,7 @@ pub(crate) struct CrateRoot {
     traits: LazyArray<DefIndex>,
     impls: LazyArray<TraitImpls>,
     incoherent_impls: LazyArray<IncoherentImpls>,
+    rustdoc_reachable: LazyArray<DefId>,
     interpret_alloc_index: LazyArray<u32>,
     proc_macro_data: Option<ProcMacroData>,
 

--- a/compiler/rustc_middle/src/ty/parameterized.rs
+++ b/compiler/rustc_middle/src/ty/parameterized.rs
@@ -81,6 +81,7 @@ trivially_parameterized_over_tcx! {
     rustc_hir::IsAsync,
     rustc_hir::LangItem,
     rustc_hir::def::DefKind,
+    rustc_hir::def_id::DefId,
     rustc_hir::def_id::DefIndex,
     rustc_hir::definitions::DefKey,
     rustc_index::bit_set::BitSet<u32>,

--- a/src/librustdoc/visit_lib.rs
+++ b/src/librustdoc/visit_lib.rs
@@ -7,7 +7,7 @@ use rustc_middle::ty::TyCtxt;
 
 #[derive(Default)]
 pub(crate) struct RustdocEffectiveVisibilities {
-    extern_public: DefIdSet,
+    pub extern_public: DefIdSet,
 }
 
 macro_rules! define_method {


### PR DESCRIPTION
`rustdoc` currently calculates this set for every crate in the crate tree, so let's try to pre-compute it in advance.