### PR TITLE
implement Step for bool and add tests

### DIFF
--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -14,7 +14,7 @@ macro_rules! unsafe_impl_trusted_step {
         unsafe impl TrustedStep for $type {}
     )*};
 }
-unsafe_impl_trusted_step![char i8 i16 i32 i64 i128 isize u8 u16 u32 u64 u128 usize];
+unsafe_impl_trusted_step![bool char i8 i16 i32 i64 i128 isize u8 u16 u32 u64 u128 usize];
 
 /// Objects that have a notion of *successor* and *predecessor* operations.
 ///
@@ -481,6 +481,50 @@ impl Step for char {
         // SAFETY: because of the previous contract, this is guaranteed
         // by the caller to be a valid char.
         unsafe { char::from_u32_unchecked(res) }
+    }
+}
+
+#[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
+impl Step for bool {
+    #[inline]
+    fn steps_between(&start: &bool, &end: &bool) -> Option<usize> {
+        match (start, end) {
+            (true, true) | (false, false) => Some(0),
+            (true, false) => None,
+            (false, true) => Some(1),
+        }
+    }
+
+    #[inline]
+    fn forward_checked(start: bool, count: usize) -> Option<bool> {
+        if count == 1 {
+            if start { None } else { Some(true) }
+        } else if count == 0 {
+            Some(start)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn backward_checked(start: bool, count: usize) -> Option<bool> {
+        if count == 1 {
+            if start { Some(false) } else { None }
+        } else if count == 0 {
+            Some(start)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    unsafe fn forward_unchecked(start: bool, count: usize) -> bool {
+        if count % 2 == 0 { start } else { !start }
+    }
+
+    #[inline]
+    unsafe fn backward_unchecked(start: bool, count: usize) -> bool {
+        if count % 2 == 0 { start } else { !start }
     }
 }
 

--- a/library/core/tests/iter/traits/step.rs
+++ b/library/core/tests/iter/traits/step.rs
@@ -2,6 +2,10 @@ use core::iter::*;
 
 #[test]
 fn test_steps_between() {
+    assert_eq!(Step::steps_between(&false, &true), Some(1));
+    assert_eq!(Step::steps_between(&true, &true), Some(0));
+    assert_eq!(Step::steps_between(&false, &false), Some(0));
+    assert_eq!(Step::steps_between(&true, &false), None);
     assert_eq!(Step::steps_between(&20_u8, &200_u8), Some(180_usize));
     assert_eq!(Step::steps_between(&-20_i8, &80_i8), Some(100_usize));
     assert_eq!(Step::steps_between(&-120_i8, &80_i8), Some(200_usize));
@@ -26,6 +30,12 @@ fn test_steps_between() {
 
 #[test]
 fn test_step_forward() {
+    assert_eq!(Step::forward_checked(false, 1), Some(true));
+    assert_eq!(Step::forward_checked(true, 1), None);
+    assert_eq!(Step::forward_checked(false, 2), None);
+    assert_eq!(Step::forward_checked(true, 2), None);
+    assert_eq!(Step::forward_checked(false, 0), Some(false));
+    assert_eq!(Step::forward_checked(true, 0), Some(true));
     assert_eq!(Step::forward_checked(55_u8, 200_usize), Some(255_u8));
     assert_eq!(Step::forward_checked(252_u8, 200_usize), None);
     assert_eq!(Step::forward_checked(0_u8, 256_usize), None);
@@ -63,6 +73,12 @@ fn test_step_forward() {
 
 #[test]
 fn test_step_backward() {
+    assert_eq!(Step::backward_checked(false, 1), None);
+    assert_eq!(Step::backward_checked(true, 1), Some(false));
+    assert_eq!(Step::backward_checked(false, 2), None);
+    assert_eq!(Step::backward_checked(true, 2), None);
+    assert_eq!(Step::backward_checked(false, 0), Some(false));
+    assert_eq!(Step::backward_checked(true, 0), Some(true));
     assert_eq!(Step::backward_checked(255_u8, 200_usize), Some(55_u8));
     assert_eq!(Step::backward_checked(100_u8, 200_usize), None);
     assert_eq!(Step::backward_checked(255_u8, 256_usize), None);


### PR DESCRIPTION
`bool` can be considered as an integer with a very narrow range, so it may make sense to implement `Step` for it.