### PR TITLE
rustdoc: make item links consistently use `title="{shortty} {path}"`

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -452,7 +452,7 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                     stab = stab.unwrap_or_default(),
                     unsafety_flag = unsafety_flag,
                     href = item_path(myitem.type_(), myitem.name.unwrap().as_str()),
-                    title = [full_path(cx, myitem), myitem.type_().to_string()]
+                    title = [myitem.type_().to_string(), full_path(cx, myitem)]
                         .iter()
                         .filter_map(|s| if !s.is_empty() { Some(s.as_str()) } else { None })
                         .collect::<Vec<_>>()

--- a/tests/rustdoc-gui/unsafe-fn.goml
+++ b/tests/rustdoc-gui/unsafe-fn.goml
@@ -4,8 +4,8 @@ goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
 show-text: true
 
 compare-elements-property: (
-    "//a[@title='test_docs::safe_fn fn']/..",
-    "//a[@title='test_docs::unsafe_fn fn']/..",
+    "//a[@title='fn test_docs::safe_fn']/..",
+    "//a[@title='fn test_docs::unsafe_fn']/..",
     ["clientHeight"]
 )
 

--- a/tests/rustdoc/issue-83375-multiple-mods-w-same-name-doc-inline-last-item.rs
+++ b/tests/rustdoc/issue-83375-multiple-mods-w-same-name-doc-inline-last-item.rs
@@ -11,6 +11,6 @@ pub mod sub {
 #[doc(inline)]
 pub use sub::*;
 
-// @count foo/index.html '//a[@class="mod"][@title="foo::prelude mod"]' 1
+// @count foo/index.html '//a[@class="mod"][@title="mod foo::prelude"]' 1
 // @count foo/prelude/index.html '//div[@class="item-row"]' 0
 pub mod prelude {}

--- a/tests/rustdoc/issue-83375-multiple-mods-w-same-name-doc-inline.rs
+++ b/tests/rustdoc/issue-83375-multiple-mods-w-same-name-doc-inline.rs
@@ -8,7 +8,7 @@ pub mod sub {
     }
 }
 
-// @count foo/index.html '//a[@class="mod"][@title="foo::prelude mod"]' 1
+// @count foo/index.html '//a[@class="mod"][@title="mod foo::prelude"]' 1
 // @count foo/prelude/index.html '//div[@class="item-row"]' 0
 pub mod prelude {}
 

--- a/tests/rustdoc/issue-99221-multiple-structs-w-same-name.rs
+++ b/tests/rustdoc/issue-99221-multiple-structs-w-same-name.rs
@@ -9,6 +9,6 @@ extern crate issue_99221_aux;
 
 pub use issue_99221_aux::*;
 
-// @count foo/index.html '//a[@class="struct"][@title="foo::Print struct"]' 1
+// @count foo/index.html '//a[@class="struct"][@title="struct foo::Print"]' 1
 
 pub struct Print;

--- a/tests/rustdoc/issue-99734-multiple-foreigns-w-same-name.rs
+++ b/tests/rustdoc/issue-99734-multiple-foreigns-w-same-name.rs
@@ -9,7 +9,7 @@ extern crate issue_99734_aux;
 
 pub use issue_99734_aux::*;
 
-// @count foo/index.html '//a[@class="fn"][@title="foo::main fn"]' 1
+// @count foo/index.html '//a[@class="fn"][@title="fn foo::main"]' 1
 
 extern "C" {
     pub fn main() -> std::ffi::c_int;

--- a/tests/rustdoc/issue-99734-multiple-mods-w-same-name.rs
+++ b/tests/rustdoc/issue-99734-multiple-mods-w-same-name.rs
@@ -9,6 +9,6 @@ extern crate issue_99734_aux;
 
 pub use issue_99734_aux::*;
 
-// @count foo/index.html '//a[@class="mod"][@title="foo::task mod"]' 1
+// @count foo/index.html '//a[@class="mod"][@title="mod foo::task"]' 1
 
 pub mod task {}


### PR DESCRIPTION
The ordering in item tables was flipped in 3030cbea957adbd560bf2eaa34c1b8a56daee16a, making it inconsistent with the ordering in method signatures.

Compare these (before this PR is merged):

https://github.com/rust-lang/rust/blob/c8e6a9e8b6251bbc8276cb78cabe1998deecbed7/src/librustdoc/html/render/print_item.rs#L455-L459

https://github.com/rust-lang/rust/blob/c8e6a9e8b6251bbc8276cb78cabe1998deecbed7/src/librustdoc/html/format.rs#L903-L908