### PR TITLE
Begin migrating rustdoc diagnostics for translation

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/rustdoc.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/rustdoc.ftl
@@ -109,3 +109,22 @@ rustdoc_error_reading_file_not_utf8 =
 
 rustdoc_error_loading_examples =
     failed to load examples: {$error} (for path {$path})
+
+rustdoc_anonymous_imports_cannot_be_inlined =
+    anonymous imports cannot be inlined
+    .import_span = anonymous import
+
+rustdoc_invalid_codeblock_attribute =
+    unknown attribute `{$attr_name}`. Did you mean `{$suggested_attr_name}`?
+    .compile_fail = the code block will either not be tested if not marked as a rust one or won't fail if it compiles successfully
+    .should_panic = the code block will either not be tested if not marked as a rust one or won't fail if it doesn't panic when running
+    .no_run = the code block will either not be tested if not marked as a rust one or will be run (which you might not want)
+    .test_harness = the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
+
+rustdoc_failed_to_read_file =
+    failed to read file {$path}: {$error}
+
+rustdoc_bare_url_not_hyperlink =
+    this URL is not a hyperlink
+    .note = bare URLs are not automatically turned into clickable links
+    .suggestion = use an automatic link instead

--- a/compiler/rustc_error_messages/locales/en-US/rustdoc.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/rustdoc.ftl
@@ -149,3 +149,21 @@ rustdoc_cfg_expected_one_cfg_pattern =
 
 rustdoc_cfg_invalid_predicate =
     invalid predicate
+
+rustdoc_unclosed_html_tag =
+    unclosed HTML tag `{$tag}`
+
+rustdoc_unclosed_html_comment =
+    Unclosed HTML comment
+
+rustdoc_mark_source_code =
+    try marking as source code
+
+rustdoc_unopened_html_tag =
+    unopened HTML tag `{$tag_name}`
+
+rustdoc_unclosed_quoted_html_attribute =
+    unclosed quoted HTML attribute on tag `{$tag_name}`
+
+rustdoc_invalid_self_closing_html_tag =
+    invalid self-closing HTML tag `{$tag_name}`

--- a/compiler/rustc_error_messages/locales/en-US/rustdoc.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/rustdoc.ftl
@@ -134,3 +134,18 @@ rustdoc_missing_doc_code_examples =
 
 rustdoc_private_doc_tests =
     documentation test in private item
+
+rustdoc_cfg_unexpected_literal =
+    unexpected literal
+
+rustdoc_cfg_expected_single_identifier =
+    expected a single identifier
+
+rustdoc_cfg_option_value_not_string_literal =
+    value of cfg option should be a string literal
+
+rustdoc_cfg_expected_one_cfg_pattern =
+    expected 1 cfg-pattern
+
+rustdoc_cfg_invalid_predicate =
+    invalid predicate

--- a/compiler/rustc_error_messages/locales/en-US/rustdoc.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/rustdoc.ftl
@@ -128,3 +128,9 @@ rustdoc_bare_url_not_hyperlink =
     this URL is not a hyperlink
     .note = bare URLs are not automatically turned into clickable links
     .suggestion = use an automatic link instead
+
+rustdoc_missing_doc_code_examples =
+    missing code example in this documentation
+
+rustdoc_private_doc_tests =
+    documentation test in private item

--- a/compiler/rustc_error_messages/locales/en-US/rustdoc.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/rustdoc.ftl
@@ -1,0 +1,111 @@
+rustdoc_compilation_failed =
+    Compilation failed, aborting rustdoc
+
+rustdoc_couldnt_generate_documentation =
+    couldn't generate documentation: {$error}
+    .note = failed to create or modify "{$file}"
+
+rustdoc_missing_crate_level_docs =
+    no documentation found for this crate's top-level module
+    .help = The following guide may be of use:
+            {$doc_rust_lang_org_channel}/rustdoc/how-to-write-documentation.html
+
+rustdoc_deprecated_attr =
+    the `#![doc({$attr_name})]` attribute is deprecated
+    .note = see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
+
+rustdoc_deprecated_attr_no_default_passes =
+    `#![doc(no_default_passes)]` no longer functions; you may want to use `#![doc(document_private_items)]`
+
+rustdoc_deprecated_attr_passes =
+    `#![doc(passes = "...")]` no longer functions; you may want to use `#![doc(document_private_items)]`
+
+rustdoc_deprecated_attr_plugins =
+    `#![doc(plugins = "...")]` no longer functions; see CVE-2018-1000622 <https://nvd.nist.gov/vuln/detail/CVE-2018-1000622>
+
+rustdoc_could_not_resolve_path =
+    failed to resolve: could not resolve path `{$path}`
+    .label = could not resolve path `{$path}`
+    .note = this error was originally ignored because you are running `rustdoc`
+    .help = try running again with `rustc` or `cargo check` and you may get a more detailed error
+
+rustdoc_unrecognized_emission_type =
+    unrecognized emission type: {$kind}
+
+rustdoc_invalid_extern_html_root_url =
+    --extern-html-root-url must be of the form name=url
+
+rustdoc_missing_file_operand =
+    missing file operand
+
+rustdoc_too_many_file_operands =
+    too many file operands
+
+rustdoc_no_run_flag_without_test_flag =
+    the `--test` flag must be passed to enable `--no-run`
+
+rustdoc_cannot_use_out_dir_and_output_flags =
+    cannot use both 'out-dir' and 'output' at once
+
+rustdoc_option_extend_css_arg_not_file =
+    option --extend-css argument must be a file
+
+rustdoc_theme_arg_not_file =
+    invalid argument: "{$theme_arg}"
+    .help = arguments to --theme must be files
+
+rustdoc_theme_arg_not_css_file =
+    invalid argument: "{$theme_arg}"
+    .help = arguments to --theme must have a .css extension
+
+rustdoc_error_loading_theme_file =
+    error loading theme file: "{$theme_arg}"
+
+rustdoc_theme_file_missing_default_theme_css_rules =
+    theme file "{$theme_arg}" is missing CSS rules from the default theme
+    .warn = the theme may appear incorrect when loaded
+    .help = "to see what rules are missing, call `rustdoc --check-theme "{$theme_arg}"`
+
+rustdoc_unknown_input_format =
+    unkown input format: {$theme_arg}
+
+rustdoc_index_page_arg_not_file =
+    option `--index-page` argument must be a file
+
+rustdoc_unknown_crate_type =
+    unknown crate type: {$error}
+
+rustdoc_html_output_not_supported_with_show_coverage_flag =
+    html output format isn't supported for the --show-coverage option
+
+rustdoc_generate_link_to_definition_flag_not_with_html_output_format =
+    --generate-link-to-definition option can only be used with HTML output format
+
+rustdoc_scrape_examples_output_path_and_target_crate_not_used_together =
+    must use --scrape-examples-output-path and --scrape-examples-target-crate together
+
+rustdoc_scrape_tests_not_with_scrape_examples_output_path_and_target_crate =
+    must use --scrape-examples-output-path and --scrape-examples-target-crate with --scrape-tests
+
+rustdoc_flag_deprecated =
+    the `{$flag}` flag is deprecated
+    .note = see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
+
+rustdoc_flag_removed =
+    the `{$flag}` flag no longer functions
+    .note = see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
+
+rustdoc_use_document_private_items_flag =
+    you may want to use --document-private-items
+
+rustdoc_see_rustdoc_plugins_cve =
+    see CVE-2018-1000622
+
+rustdoc_error_reading_file =
+    error reading `{$file_path}`: {$error}
+
+rustdoc_error_reading_file_not_utf8 =
+    error reading `{$file_path}`: not UTF-8
+
+rustdoc_error_loading_examples =
+    failed to load examples: {$error} (for path {$path})

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -66,6 +66,7 @@ fluent_messages! {
     privacy => "../locales/en-US/privacy.ftl",
     query_system => "../locales/en-US/query_system.ftl",
     resolve => "../locales/en-US/resolve.ftl",
+    rustdoc => "../locales/en-US/rustdoc.ftl",
     save_analysis => "../locales/en-US/save_analysis.ftl",
     session => "../locales/en-US/session.ftl",
     symbol_mangling => "../locales/en-US/symbol_mangling.ftl",

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -38,6 +38,7 @@ use std::mem;
 use thin_vec::ThinVec;
 
 use crate::core::{self, DocContext, ImplTraitParam};
+use crate::errors::AnonymousImportsCannotBeInlined;
 use crate::formats::item_type::ItemType;
 use crate::visit_ast::Module as DocModule;
 
@@ -2405,14 +2406,10 @@ fn clean_use_statement_inner<'tcx>(
 
     if pub_underscore {
         if let Some(ref inline) = inline_attr {
-            rustc_errors::struct_span_err!(
-                cx.tcx.sess,
-                inline.span(),
-                E0780,
-                "anonymous imports cannot be inlined"
-            )
-            .span_label(import.span, "anonymous import")
-            .emit();
+            cx.tcx.sess.emit_err(AnonymousImportsCannotBeInlined {
+                inline_span: inline.span(),
+                import_span: import.span,
+            });
         }
     }
 

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -971,7 +971,7 @@ impl AttributesExt for [ast::Attribute] {
                             match Cfg::parse(cfg_mi) {
                                 Ok(new_cfg) => cfg &= new_cfg,
                                 Err(e) => {
-                                    sess.span_err(e.span, e.msg);
+                                    sess.emit_err(e);
                                 }
                             }
                         }

--- a/src/librustdoc/errors.rs
+++ b/src/librustdoc/errors.rs
@@ -3,7 +3,7 @@ use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_span::Span;
 
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 #[derive(Diagnostic)]
 #[diag(rustdoc_compilation_failed)]
@@ -248,3 +248,11 @@ pub struct BareUrlNotHyperlink<'a> {
     pub span: Span,
     pub url: &'a str,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(rustdoc_missing_doc_code_examples)]
+pub struct MissingDocCodeExamples;
+
+#[derive(LintDiagnostic)]
+#[diag(rustdoc_private_doc_tests)]
+pub struct PrivateDocTests;

--- a/src/librustdoc/errors.rs
+++ b/src/librustdoc/errors.rs
@@ -1,0 +1,181 @@
+use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
+use rustc_span::Span;
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_compilation_failed)]
+pub struct CompilationFailed;
+
+#[derive(LintDiagnostic)]
+#[help]
+#[diag(rustdoc_missing_crate_level_docs)]
+pub struct MissingCrateLevelDocs {
+    pub doc_rust_lang_org_channel: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[note]
+#[diag(rustdoc_deprecated_attr)]
+pub struct DeprecatedAttr<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub attr_name: &'a str,
+    #[subdiagnostic]
+    pub kind: Option<DeprecatedAttrKind>,
+}
+
+#[derive(Subdiagnostic)]
+pub enum DeprecatedAttrKind {
+    #[help(rustdoc_deprecated_attr_no_default_passes)]
+    NoDefaultPasses,
+    #[help(rustdoc_deprecated_attr_passes)]
+    Passes,
+    #[warning(rustdoc_deprecated_attr_plugins)]
+    Plugins,
+}
+
+#[derive(Diagnostic)]
+#[note]
+#[help]
+#[diag(rustdoc_could_not_resolve_path, code = "E0433")]
+pub struct CouldNotResolvePath {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub path: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_unrecognized_emission_type)]
+pub struct UnrecognizedEmissionType<'a> {
+    pub kind: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_invalid_extern_html_root_url)]
+pub struct InvalidExternHtmlRootUrl;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_missing_file_operand)]
+pub struct MissingFileOperand;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_too_many_file_operands)]
+pub struct TooManyFileOperands;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_no_run_flag_without_test_flag)]
+pub struct NoRunFlagWithoutTestFlag;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_cannot_use_out_dir_and_output_flags)]
+pub struct CannotUseOutDirAndOutputFlags;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_option_extend_css_arg_not_file)]
+pub struct ExtendCssArgNotFile;
+
+#[derive(Diagnostic)]
+#[help]
+#[diag(rustdoc_theme_arg_not_file)]
+pub struct ThemeArgNotFile<'a> {
+    pub theme_arg: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[help]
+#[diag(rustdoc_theme_arg_not_css_file)]
+pub struct ThemeArgNotCssFile<'a> {
+    pub theme_arg: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_error_loading_theme_file)]
+pub struct ErrorLoadingThemeFile<'a> {
+    pub theme_arg: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[help]
+#[diag(rustdoc_theme_file_missing_default_theme_css_rules)]
+pub struct ThemeFileMissingDefaultThemeCssRules<'a> {
+    pub theme_arg: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_unknown_input_format)]
+pub struct UnknownInputFormat<'a> {
+    pub input_format_arg: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_index_page_arg_not_file)]
+pub struct IndexPageArgNotFile;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_unknown_crate_type)]
+pub struct UnknownCrateType {
+    pub error: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_html_output_not_supported_with_show_coverage_flag)]
+pub struct HtmlOutputNotSupportedWithShowCoverageFlag;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_generate_link_to_definition_flag_not_with_html_output_format)]
+pub struct GenerateLinkToDefinitionFlagNotWithHtmlOutputFormat;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_scrape_examples_output_path_and_target_crate_not_used_together)]
+pub struct ScrapeExamplesOutputPathAndTargetCrateNotTogether;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_scrape_tests_not_with_scrape_examples_output_path_and_target_crate)]
+pub struct ScrapeTestsNotWithScrapeExamplesOutputPathAndTargetCrate;
+
+#[derive(Diagnostic)]
+#[note]
+#[diag(rustdoc_flag_deprecated)]
+pub struct FlagDeprecated<'a> {
+    pub flag: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[note]
+#[diag(rustdoc_flag_removed)]
+pub struct FlagRemoved<'a> {
+    pub flag: &'a str,
+    #[subdiagnostic]
+    pub suggestion: Option<FlagRemovedSuggestion>,
+}
+
+#[derive(Subdiagnostic)]
+pub enum FlagRemovedSuggestion {
+    #[help(rustdoc_use_document_private_items_flag)]
+    DocumentPrivateItems,
+    #[warning(rustdoc_see_rustdoc_plugins_cve)]
+    SeeRustdocPluginsCve,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_error_reading_file)]
+pub struct ErrorReadingFile<'a> {
+    pub file_path: &'a Path,
+    pub error: io::Error,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_error_reading_file_not_utf8)]
+pub struct ErrorReadingFileNotUtf8<'a> {
+    pub file_path: &'a Path,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_error_loading_examples)]
+pub struct ErrorLoadingExamples {
+    pub error: io::Error,
+    pub path: String,
+}

--- a/src/librustdoc/errors.rs
+++ b/src/librustdoc/errors.rs
@@ -256,3 +256,32 @@ pub struct MissingDocCodeExamples;
 #[derive(LintDiagnostic)]
 #[diag(rustdoc_private_doc_tests)]
 pub struct PrivateDocTests;
+
+#[derive(Diagnostic)]
+pub enum InvalidCfgError {
+    #[diag(rustdoc_cfg_unexpected_literal)]
+    UnexpectedLiteral {
+        #[primary_span]
+        span: Span,
+    },
+    #[diag(rustdoc_cfg_expected_single_identifier)]
+    ExpectedSingleIdentifier {
+        #[primary_span]
+        span: Span,
+    },
+    #[diag(rustdoc_cfg_option_value_not_string_literal)]
+    OptionValueNotStringLiteral {
+        #[primary_span]
+        span: Span,
+    },
+    #[diag(rustdoc_cfg_expected_one_cfg_pattern)]
+    ExpectedOneCfgPattern {
+        #[primary_span]
+        span: Span,
+    },
+    #[diag(rustdoc_cfg_invalid_predicate)]
+    InvalidPredicate {
+        #[primary_span]
+        span: Span,
+    },
+}

--- a/src/librustdoc/errors.rs
+++ b/src/librustdoc/errors.rs
@@ -285,3 +285,42 @@ pub enum InvalidCfgError {
         span: Span,
     },
 }
+
+#[derive(LintDiagnostic)]
+#[diag(rustdoc_unclosed_html_tag)]
+pub struct UnclosedHtmlTag<'a> {
+    pub tag: &'a str,
+    #[subdiagnostic]
+    pub mark_source_code: Option<MarkSourceCode>,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(rustdoc_mark_source_code, applicability = "maybe-incorrect")]
+pub struct MarkSourceCode {
+    #[suggestion_part(code = "`")]
+    pub left: Span,
+    #[suggestion_part(code = "`")]
+    pub right: Span,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(rustdoc_unclosed_html_comment)]
+pub struct UnclosedHtmlComment;
+
+#[derive(LintDiagnostic)]
+#[diag(rustdoc_unopened_html_tag)]
+pub struct UnopenedHtmlTag {
+    pub tag_name: String,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(rustdoc_unclosed_quoted_html_attribute)]
+pub struct UnclosedQuotedHtmlAttribute<'a> {
+    pub tag_name: &'a str,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(rustdoc_invalid_self_closing_html_tag)]
+pub struct InvalidSelfClosingHtmlTag<'a> {
+    pub tag_name: &'a str,
+}

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -82,6 +82,7 @@ use rustc_session::getopts;
 use rustc_session::{early_error, early_warn};
 
 use crate::clean::utils::DOC_RUST_LANG_ORG_CHANNEL;
+use crate::errors::CompilationFailed;
 use crate::passes::collect_intra_doc_links;
 
 /// A macro to create a FxHashMap.
@@ -108,6 +109,7 @@ mod core;
 mod docfs;
 mod doctest;
 mod error;
+mod errors;
 mod externalfiles;
 mod fold;
 mod formats;
@@ -812,7 +814,7 @@ fn main_args(at_args: &[String]) -> MainResult {
             };
 
             if sess.diagnostic().has_errors_or_lint_errors().is_some() {
-                sess.fatal("Compilation failed, aborting rustdoc");
+                sess.emit_fatal(CompilationFailed);
             }
 
             let global_ctxt = abort_on_err(queries.global_ctxt(), sess);

--- a/src/librustdoc/passes/lint/bare_urls.rs
+++ b/src/librustdoc/passes/lint/bare_urls.rs
@@ -3,12 +3,12 @@
 
 use crate::clean::*;
 use crate::core::DocContext;
+use crate::errors::BareUrlNotHyperlink;
 use crate::html::markdown::main_body_opts;
 use crate::passes::source_span_for_markdown_range;
 use core::ops::Range;
 use pulldown_cmark::{Event, Parser, Tag};
 use regex::Regex;
-use rustc_errors::Applicability;
 use std::mem;
 use std::sync::LazyLock;
 
@@ -20,25 +20,31 @@ pub(super) fn visit_item(cx: &DocContext<'_>, item: &Item) {
         };
     let dox = item.attrs.collapsed_doc_value().unwrap_or_default();
     if !dox.is_empty() {
-        let report_diag = |cx: &DocContext<'_>, msg: &str, url: &str, range: Range<usize>| {
-            let sp = source_span_for_markdown_range(cx.tcx, &dox, &range, &item.attrs)
-                .unwrap_or_else(|| item.attr_span(cx.tcx));
-            cx.tcx.struct_span_lint_hir(crate::lint::BARE_URLS, hir_id, sp, msg, |lint| {
-                lint.note("bare URLs are not automatically turned into clickable links")
-                    .span_suggestion(
-                        sp,
-                        "use an automatic link instead",
-                        format!("<{}>", url),
-                        Applicability::MachineApplicable,
-                    )
-            });
-        };
-
         let mut p = Parser::new_ext(&dox, main_body_opts()).into_offset_iter();
 
         while let Some((event, range)) = p.next() {
             match event {
-                Event::Text(s) => find_raw_urls(cx, &s, range, &report_diag),
+                Event::Text(text) => {
+                    trace!("looking for raw urls in {}", text);
+                    // For now, we only check "full" URLs (meaning, starting with "http://" or "https://").
+                    for match_ in URL_REGEX.find_iter(&text) {
+                        let url = match_.as_str();
+                        let url_range = match_.range();
+                        let range = Range {
+                            start: range.start + url_range.start,
+                            end: range.start + url_range.end,
+                        };
+                        let span =
+                            source_span_for_markdown_range(cx.tcx, &dox, &range, &item.attrs)
+                                .unwrap_or_else(|| item.attr_span(cx.tcx));
+                        cx.tcx.emit_spanned_lint(
+                            crate::lint::BARE_URLS,
+                            hir_id,
+                            span,
+                            BareUrlNotHyperlink { span, url },
+                        );
+                    }
+                }
                 // We don't want to check the text inside code blocks or links.
                 Event::Start(tag @ (Tag::CodeBlock(_) | Tag::Link(..))) => {
                     while let Some((event, _)) = p.next() {
@@ -67,23 +73,3 @@ static URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     ))
     .expect("failed to build regex")
 });
-
-fn find_raw_urls(
-    cx: &DocContext<'_>,
-    text: &str,
-    range: Range<usize>,
-    f: &impl Fn(&DocContext<'_>, &str, &str, Range<usize>),
-) {
-    trace!("looking for raw urls in {}", text);
-    // For now, we only check "full" URLs (meaning, starting with "http://" or "https://").
-    for match_ in URL_REGEX.find_iter(text) {
-        let url = match_.as_str();
-        let url_range = match_.range();
-        f(
-            cx,
-            "this URL is not a hyperlink",
-            url,
-            Range { start: range.start + url_range.start, end: range.start + url_range.end },
-        );
-    }
-}

--- a/src/librustdoc/passes/lint/html_tags.rs
+++ b/src/librustdoc/passes/lint/html_tags.rs
@@ -1,159 +1,23 @@
 //! Detects invalid HTML (like an unclosed `<span>`) in doc comments.
 use crate::clean::*;
 use crate::core::DocContext;
+use crate::errors::{
+    InvalidSelfClosingHtmlTag, MarkSourceCode, UnclosedHtmlComment, UnclosedHtmlTag,
+    UnclosedQuotedHtmlAttribute, UnopenedHtmlTag,
+};
 use crate::html::markdown::main_body_opts;
 use crate::passes::source_span_for_markdown_range;
 
 use pulldown_cmark::{BrokenLink, Event, LinkType, Parser, Tag};
+use rustc_errors::DecorateLint;
+use rustc_hir::HirId;
 
 use std::iter::Peekable;
 use std::ops::Range;
 use std::str::CharIndices;
 
-pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item) {
-    let tcx = cx.tcx;
-    let Some(hir_id) = DocContext::as_local_hir_id(tcx, item.item_id)
-    // If non-local, no need to check anything.
-    else { return };
-    let dox = item.attrs.collapsed_doc_value().unwrap_or_default();
-    if !dox.is_empty() {
-        let report_diag = |msg: &str, range: &Range<usize>, is_open_tag: bool| {
-            let sp = match source_span_for_markdown_range(tcx, &dox, range, &item.attrs) {
-                Some(sp) => sp,
-                None => item.attr_span(tcx),
-            };
-            tcx.struct_span_lint_hir(crate::lint::INVALID_HTML_TAGS, hir_id, sp, msg, |lint| {
-                use rustc_lint_defs::Applicability;
-                // If a tag looks like `<this>`, it might actually be a generic.
-                // We don't try to detect stuff `<like, this>` because that's not valid HTML,
-                // and we don't try to detect stuff `<like this>` because that's not valid Rust.
-                let mut generics_end = range.end;
-                if let Some(Some(mut generics_start)) = (is_open_tag
-                    && dox[..generics_end].ends_with('>'))
-                .then(|| extract_path_backwards(&dox, range.start))
-                {
-                    while generics_start != 0
-                        && generics_end < dox.len()
-                        && dox.as_bytes()[generics_start - 1] == b'<'
-                        && dox.as_bytes()[generics_end] == b'>'
-                    {
-                        generics_end += 1;
-                        generics_start -= 1;
-                        if let Some(new_start) = extract_path_backwards(&dox, generics_start) {
-                            generics_start = new_start;
-                        }
-                        if let Some(new_end) = extract_path_forward(&dox, generics_end) {
-                            generics_end = new_end;
-                        }
-                    }
-                    if let Some(new_end) = extract_path_forward(&dox, generics_end) {
-                        generics_end = new_end;
-                    }
-                    let generics_sp = match source_span_for_markdown_range(
-                        tcx,
-                        &dox,
-                        &(generics_start..generics_end),
-                        &item.attrs,
-                    ) {
-                        Some(sp) => sp,
-                        None => item.attr_span(tcx),
-                    };
-                    // Sometimes, we only extract part of a path. For example, consider this:
-                    //
-                    //     <[u32] as IntoIter<u32>>::Item
-                    //                       ^^^^^ unclosed HTML tag `u32`
-                    //
-                    // We don't have any code for parsing fully-qualified trait paths.
-                    // In theory, we could add it, but doing it correctly would require
-                    // parsing the entire path grammar, which is problematic because of
-                    // overlap between the path grammar and Markdown.
-                    //
-                    // The example above shows that ambiguity. Is `[u32]` intended to be an
-                    // intra-doc link to the u32 primitive, or is it intended to be a slice?
-                    //
-                    // If the below conditional were removed, we would suggest this, which is
-                    // not what the user probably wants.
-                    //
-                    //     <[u32] as `IntoIter<u32>`>::Item
-                    //
-                    // We know that the user actually wants to wrap the whole thing in a code
-                    // block, but the only reason we know that is because `u32` does not, in
-                    // fact, implement IntoIter. If the example looks like this:
-                    //
-                    //     <[Vec<i32>] as IntoIter<i32>::Item
-                    //
-                    // The ideal fix would be significantly different.
-                    if (generics_start > 0 && dox.as_bytes()[generics_start - 1] == b'<')
-                        || (generics_end < dox.len() && dox.as_bytes()[generics_end] == b'>')
-                    {
-                        return lint;
-                    }
-                    // multipart form is chosen here because ``Vec<i32>`` would be confusing.
-                    lint.multipart_suggestion(
-                        "try marking as source code",
-                        vec![
-                            (generics_sp.shrink_to_lo(), String::from("`")),
-                            (generics_sp.shrink_to_hi(), String::from("`")),
-                        ],
-                        Applicability::MaybeIncorrect,
-                    );
-                }
-
-                lint
-            });
-        };
-
-        let mut tags = Vec::new();
-        let mut is_in_comment = None;
-        let mut in_code_block = false;
-
-        let link_names = item.link_names(&cx.cache);
-
-        let mut replacer = |broken_link: BrokenLink<'_>| {
-            if let Some(link) =
-                link_names.iter().find(|link| *link.original_text == *broken_link.reference)
-            {
-                Some((link.href.as_str().into(), link.new_text.as_str().into()))
-            } else if matches!(
-                &broken_link.link_type,
-                LinkType::Reference | LinkType::ReferenceUnknown
-            ) {
-                // If the link is shaped [like][this], suppress any broken HTML in the [this] part.
-                // The `broken_intra_doc_links` will report typos in there anyway.
-                Some((
-                    broken_link.reference.to_string().into(),
-                    broken_link.reference.to_string().into(),
-                ))
-            } else {
-                None
-            }
-        };
-
-        let p = Parser::new_with_broken_link_callback(&dox, main_body_opts(), Some(&mut replacer))
-            .into_offset_iter();
-
-        for (event, range) in p {
-            match event {
-                Event::Start(Tag::CodeBlock(_)) => in_code_block = true,
-                Event::Html(text) if !in_code_block => {
-                    extract_tags(&mut tags, &text, range, &mut is_in_comment, &report_diag)
-                }
-                Event::End(Tag::CodeBlock(_)) => in_code_block = false,
-                _ => {}
-            }
-        }
-
-        for (tag, range) in tags.iter().filter(|(t, _)| {
-            let t = t.to_lowercase();
-            !ALLOWED_UNCLOSED.contains(&t.as_str())
-        }) {
-            report_diag(&format!("unclosed HTML tag `{}`", tag), range, true);
-        }
-
-        if let Some(range) = is_in_comment {
-            report_diag("Unclosed HTML comment", &range, false);
-        }
-    }
+pub(crate) fn visit_item(cx: &mut DocContext<'_>, item: &Item) {
+    HtmlTagsVisitor { cx }.visit_item(item)
 }
 
 const ALLOWED_UNCLOSED: &[&str] = &[
@@ -161,39 +25,381 @@ const ALLOWED_UNCLOSED: &[&str] = &[
     "source", "track", "wbr",
 ];
 
-fn drop_tag(
-    tags: &mut Vec<(String, Range<usize>)>,
-    tag_name: String,
-    range: Range<usize>,
-    f: &impl Fn(&str, &Range<usize>, bool),
-) {
-    let tag_name_low = tag_name.to_lowercase();
-    if let Some(pos) = tags.iter().rposition(|(t, _)| t.to_lowercase() == tag_name_low) {
-        // If the tag is nested inside a "<script>" or a "<style>" tag, no warning should
-        // be emitted.
-        let should_not_warn = tags.iter().take(pos + 1).any(|(at, _)| {
-            let at = at.to_lowercase();
-            at == "script" || at == "style"
-        });
-        for (last_tag_name, last_tag_span) in tags.drain(pos + 1..) {
-            if should_not_warn {
-                continue;
+struct ItemInfo<'a> {
+    item: &'a Item,
+    hir_id: HirId,
+    dox: &'a str,
+}
+
+struct HtmlTagsVisitor<'a, 'tcx> {
+    cx: &'a mut DocContext<'tcx>,
+}
+
+impl<'a, 'tcx> HtmlTagsVisitor<'a, 'tcx> {
+    fn visit_item(&self, item: &Item) {
+        let tcx = self.cx.tcx;
+        // If non-local, no need to check anything.
+        let Some(hir_id) = DocContext::as_local_hir_id(tcx, item.item_id) else { return };
+        let dox = item.attrs.collapsed_doc_value().unwrap_or_default();
+        if !dox.is_empty() {
+            let mut tags = Vec::new();
+            let mut is_in_comment = None;
+            let mut in_code_block = false;
+
+            let link_names = item.link_names(&self.cx.cache);
+
+            let mut replacer = |broken_link: BrokenLink<'_>| {
+                if let Some(link) =
+                    link_names.iter().find(|link| *link.original_text == *broken_link.reference)
+                {
+                    Some((link.href.as_str().into(), link.new_text.as_str().into()))
+                } else if matches!(
+                    &broken_link.link_type,
+                    LinkType::Reference | LinkType::ReferenceUnknown
+                ) {
+                    // If the link is shaped [like][this], suppress any broken HTML in the [this] part.
+                    // The `broken_intra_doc_links` will report typos in there anyway.
+                    Some((
+                        broken_link.reference.to_string().into(),
+                        broken_link.reference.to_string().into(),
+                    ))
+                } else {
+                    None
+                }
+            };
+
+            let p =
+                Parser::new_with_broken_link_callback(&dox, main_body_opts(), Some(&mut replacer))
+                    .into_offset_iter();
+
+            let item_info = ItemInfo { item, hir_id, dox: &dox };
+
+            for (event, range) in p {
+                match event {
+                    Event::Start(Tag::CodeBlock(_)) => in_code_block = true,
+                    Event::Html(text) if !in_code_block => {
+                        self.extract_tags(&mut tags, &text, range, &mut is_in_comment, &item_info)
+                    }
+                    Event::End(Tag::CodeBlock(_)) => in_code_block = false,
+                    _ => {}
+                }
             }
-            let last_tag_name_low = last_tag_name.to_lowercase();
-            if ALLOWED_UNCLOSED.contains(&last_tag_name_low.as_str()) {
-                continue;
+
+            for (tag, range) in tags.iter().filter(|(t, _)| {
+                let t = t.to_lowercase();
+                !ALLOWED_UNCLOSED.contains(&t.as_str())
+            }) {
+                self.report_diag(
+                    UnclosedHtmlTag {
+                        tag,
+                        mark_source_code: self.mark_source_code(range, &item_info),
+                    },
+                    range,
+                    &item_info,
+                );
             }
-            // `tags` is used as a queue, meaning that everything after `pos` is included inside it.
-            // So `<h2><h3></h2>` will look like `["h2", "h3"]`. So when closing `h2`, we will still
-            // have `h3`, meaning the tag wasn't closed as it should have.
-            f(&format!("unclosed HTML tag `{}`", last_tag_name), &last_tag_span, true);
+
+            if let Some(range) = is_in_comment {
+                self.report_diag(UnclosedHtmlComment, &range, &item_info);
+            }
         }
-        // Remove the `tag_name` that was originally closed
-        tags.pop();
-    } else {
-        // It can happen for example in this case: `<h2></script></h2>` (the `h2` tag isn't required
-        // but it helps for the visualization).
-        f(&format!("unopened HTML tag `{}`", tag_name), &range, false);
+    }
+
+    fn report_diag(
+        &self,
+        diag: impl for<'b> DecorateLint<'b, ()>,
+        range: &Range<usize>,
+        item_info: &ItemInfo<'_>,
+    ) {
+        let sp = match source_span_for_markdown_range(
+            self.cx.tcx,
+            item_info.dox,
+            range,
+            &item_info.item.attrs,
+        ) {
+            Some(sp) => sp,
+            None => item_info.item.attr_span(self.cx.tcx),
+        };
+        self.cx.tcx.emit_spanned_lint(crate::lint::INVALID_HTML_TAGS, item_info.hir_id, sp, diag);
+    }
+
+    fn mark_source_code(
+        &self,
+        range: &Range<usize>,
+        item_info: &ItemInfo<'_>,
+    ) -> Option<MarkSourceCode> {
+        let ItemInfo { item, hir_id: _, dox } = item_info;
+
+        // If a tag looks like `<this>`, it might actually be a generic.
+        // We don't try to detect stuff `<like, this>` because that's not valid HTML,
+        // and we don't try to detect stuff `<like this>` because that's not valid Rust.
+        let mut generics_end = range.end;
+        if let Some(Some(mut generics_start)) =
+            (dox[..generics_end].ends_with('>')).then(|| extract_path_backwards(&dox, range.start))
+        {
+            while generics_start != 0
+                && generics_end < dox.len()
+                && dox.as_bytes()[generics_start - 1] == b'<'
+                && dox.as_bytes()[generics_end] == b'>'
+            {
+                generics_end += 1;
+                generics_start -= 1;
+                if let Some(new_start) = extract_path_backwards(&dox, generics_start) {
+                    generics_start = new_start;
+                }
+                if let Some(new_end) = extract_path_forward(&dox, generics_end) {
+                    generics_end = new_end;
+                }
+            }
+            if let Some(new_end) = extract_path_forward(&dox, generics_end) {
+                generics_end = new_end;
+            }
+            let generics_sp = match source_span_for_markdown_range(
+                self.cx.tcx,
+                &dox,
+                &(generics_start..generics_end),
+                &item.attrs,
+            ) {
+                Some(sp) => sp,
+                None => item.attr_span(self.cx.tcx),
+            };
+            // Sometimes, we only extract part of a path. For example, consider this:
+            //
+            //     <[u32] as IntoIter<u32>>::Item
+            //                       ^^^^^ unclosed HTML tag `u32`
+            //
+            // We don't have any code for parsing fully-qualified trait paths.
+            // In theory, we could add it, but doing it correctly would require
+            // parsing the entire path grammar, which is problematic because of
+            // overlap between the path grammar and Markdown.
+            //
+            // The example above shows that ambiguity. Is `[u32]` intended to be an
+            // intra-doc link to the u32 primitive, or is it intended to be a slice?
+            //
+            // If the below conditional were removed, we would suggest this, which is
+            // not what the user probably wants.
+            //
+            //     <[u32] as `IntoIter<u32>`>::Item
+            //
+            // We know that the user actually wants to wrap the whole thing in a code
+            // block, but the only reason we know that is because `u32` does not, in
+            // fact, implement IntoIter. If the example looks like this:
+            //
+            //     <[Vec<i32>] as IntoIter<i32>::Item
+            //
+            // The ideal fix would be significantly different.
+            if (generics_start > 0 && dox.as_bytes()[generics_start - 1] == b'<')
+                || (generics_end < dox.len() && dox.as_bytes()[generics_end] == b'>')
+            {
+                return None;
+            }
+            // multipart form is chosen here because ``Vec<i32>`` would be confusing.
+            Some(MarkSourceCode {
+                left: generics_sp.shrink_to_lo(),
+                right: generics_sp.shrink_to_hi(),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn drop_tag(
+        &self,
+        tags: &mut Vec<(String, Range<usize>)>,
+        tag_name: String,
+        range: Range<usize>,
+        item_info: &ItemInfo<'_>,
+    ) {
+        let tag_name_low = tag_name.to_lowercase();
+        if let Some(pos) = tags.iter().rposition(|(t, _)| t.to_lowercase() == tag_name_low) {
+            // If the tag is nested inside a "<script>" or a "<style>" tag, no warning should
+            // be emitted.
+            let should_not_warn = tags.iter().take(pos + 1).any(|(at, _)| {
+                let at = at.to_lowercase();
+                at == "script" || at == "style"
+            });
+            for (last_tag_name, last_tag_span) in tags.drain(pos + 1..) {
+                if should_not_warn {
+                    continue;
+                }
+                let last_tag_name_low = last_tag_name.to_lowercase();
+                if ALLOWED_UNCLOSED.contains(&last_tag_name_low.as_str()) {
+                    continue;
+                }
+                // `tags` is used as a queue, meaning that everything after `pos` is included inside it.
+                // So `<h2><h3></h2>` will look like `["h2", "h3"]`. So when closing `h2`, we will still
+                // have `h3`, meaning the tag wasn't closed as it should have.
+                self.report_diag(
+                    UnclosedHtmlTag {
+                        tag: &last_tag_name,
+                        mark_source_code: self.mark_source_code(&last_tag_span, item_info),
+                    },
+                    &last_tag_span,
+                    item_info,
+                );
+            }
+            // Remove the `tag_name` that was originally closed
+            tags.pop();
+        } else {
+            // It can happen for example in this case: `<h2></script></h2>` (the `h2` tag isn't required
+            // but it helps for the visualization).
+            self.report_diag(UnopenedHtmlTag { tag_name }, &range, item_info);
+        }
+    }
+
+    fn extract_html_tag(
+        &self,
+        tags: &mut Vec<(String, Range<usize>)>,
+        text: &str,
+        range: &Range<usize>,
+        start_pos: usize,
+        iter: &mut Peekable<CharIndices<'_>>,
+        item_info: &ItemInfo<'_>,
+    ) {
+        let mut tag_name = String::new();
+        let mut is_closing = false;
+        let mut prev_pos = start_pos;
+
+        loop {
+            let (pos, c) = match iter.peek() {
+                Some((pos, c)) => (*pos, *c),
+                // In case we reached the of the doc comment, we want to check that it's an
+                // unclosed HTML tag. For example "/// <h3".
+                None => (prev_pos, '\0'),
+            };
+            prev_pos = pos;
+            // Checking if this is a closing tag (like `</a>` for `<a>`).
+            if c == '/' && tag_name.is_empty() {
+                is_closing = true;
+            } else if is_valid_for_html_tag_name(c, tag_name.is_empty()) {
+                tag_name.push(c);
+            } else {
+                if !tag_name.is_empty() {
+                    let mut r = Range { start: range.start + start_pos, end: range.start + pos };
+                    if c == '>' {
+                        // In case we have a tag without attribute, we can consider the span to
+                        // refer to it fully.
+                        r.end += 1;
+                    }
+                    if is_closing {
+                        // In case we have "</div >" or even "</div         >".
+                        if c != '>' {
+                            if !c.is_whitespace() {
+                                // It seems like it's not a valid HTML tag.
+                                break;
+                            }
+                            let mut found = false;
+                            for (new_pos, c) in text[pos..].char_indices() {
+                                if !c.is_whitespace() {
+                                    if c == '>' {
+                                        r.end = range.start + new_pos + 1;
+                                        found = true;
+                                    }
+                                    break;
+                                }
+                            }
+                            if !found {
+                                break;
+                            }
+                        }
+                        self.drop_tag(tags, tag_name, r, item_info);
+                    } else {
+                        let mut is_self_closing = false;
+                        let mut quote_pos = None;
+                        if c != '>' {
+                            let mut quote = None;
+                            let mut after_eq = false;
+                            for (i, c) in text[pos..].char_indices() {
+                                if !c.is_whitespace() {
+                                    if let Some(q) = quote {
+                                        if c == q {
+                                            quote = None;
+                                            quote_pos = None;
+                                            after_eq = false;
+                                        }
+                                    } else if c == '>' {
+                                        break;
+                                    } else if c == '/' && !after_eq {
+                                        is_self_closing = true;
+                                    } else {
+                                        if is_self_closing {
+                                            is_self_closing = false;
+                                        }
+                                        if (c == '"' || c == '\'') && after_eq {
+                                            quote = Some(c);
+                                            quote_pos = Some(pos + i);
+                                        } else if c == '=' {
+                                            after_eq = true;
+                                        }
+                                    }
+                                } else if quote.is_none() {
+                                    after_eq = false;
+                                }
+                            }
+                        }
+                        if let Some(quote_pos) = quote_pos {
+                            let qr = Range { start: quote_pos, end: quote_pos };
+                            self.report_diag(
+                                UnclosedQuotedHtmlAttribute { tag_name: &tag_name },
+                                &qr,
+                                item_info,
+                            );
+                        }
+                        if is_self_closing {
+                            // https://html.spec.whatwg.org/#parse-error-non-void-html-element-start-tag-with-trailing-solidus
+                            let valid = ALLOWED_UNCLOSED.contains(&&tag_name[..])
+                                || tags.iter().take(pos + 1).any(|(at, _)| {
+                                    let at = at.to_lowercase();
+                                    at == "svg" || at == "math"
+                                });
+                            if !valid {
+                                self.report_diag(
+                                    InvalidSelfClosingHtmlTag { tag_name: &tag_name },
+                                    &r,
+                                    item_info,
+                                );
+                            }
+                        } else {
+                            tags.push((tag_name, r));
+                        }
+                    }
+                }
+                break;
+            }
+            iter.next();
+        }
+    }
+
+    fn extract_tags(
+        &self,
+        tags: &mut Vec<(String, Range<usize>)>,
+        text: &str,
+        range: Range<usize>,
+        is_in_comment: &mut Option<Range<usize>>,
+        item_info: &ItemInfo<'_>,
+    ) {
+        let mut iter = text.char_indices().peekable();
+
+        while let Some((start_pos, c)) = iter.next() {
+            if is_in_comment.is_some() {
+                if text[start_pos..].starts_with("-->") {
+                    *is_in_comment = None;
+                }
+            } else if c == '<' {
+                if text[start_pos..].starts_with("<!--") {
+                    // We skip the "!--" part. (Once `advance_by` is stable, might be nice to use it!)
+                    iter.next();
+                    iter.next();
+                    iter.next();
+                    *is_in_comment = Some(Range {
+                        start: range.start + start_pos,
+                        end: range.start + start_pos + 3,
+                    });
+                } else {
+                    self.extract_html_tag(tags, text, &range, start_pos, &mut iter, item_info);
+                }
+            }
+        }
     }
 }
 
@@ -255,153 +461,4 @@ fn is_valid_for_html_tag_name(c: char, is_empty: bool) -> bool {
     // > A tag name consists of an ASCII letter followed by zero or more ASCII letters, digits, or
     // > hyphens (-).
     c.is_ascii_alphabetic() || !is_empty && (c == '-' || c.is_ascii_digit())
-}
-
-fn extract_html_tag(
-    tags: &mut Vec<(String, Range<usize>)>,
-    text: &str,
-    range: &Range<usize>,
-    start_pos: usize,
-    iter: &mut Peekable<CharIndices<'_>>,
-    f: &impl Fn(&str, &Range<usize>, bool),
-) {
-    let mut tag_name = String::new();
-    let mut is_closing = false;
-    let mut prev_pos = start_pos;
-
-    loop {
-        let (pos, c) = match iter.peek() {
-            Some((pos, c)) => (*pos, *c),
-            // In case we reached the of the doc comment, we want to check that it's an
-            // unclosed HTML tag. For example "/// <h3".
-            None => (prev_pos, '\0'),
-        };
-        prev_pos = pos;
-        // Checking if this is a closing tag (like `</a>` for `<a>`).
-        if c == '/' && tag_name.is_empty() {
-            is_closing = true;
-        } else if is_valid_for_html_tag_name(c, tag_name.is_empty()) {
-            tag_name.push(c);
-        } else {
-            if !tag_name.is_empty() {
-                let mut r = Range { start: range.start + start_pos, end: range.start + pos };
-                if c == '>' {
-                    // In case we have a tag without attribute, we can consider the span to
-                    // refer to it fully.
-                    r.end += 1;
-                }
-                if is_closing {
-                    // In case we have "</div >" or even "</div         >".
-                    if c != '>' {
-                        if !c.is_whitespace() {
-                            // It seems like it's not a valid HTML tag.
-                            break;
-                        }
-                        let mut found = false;
-                        for (new_pos, c) in text[pos..].char_indices() {
-                            if !c.is_whitespace() {
-                                if c == '>' {
-                                    r.end = range.start + new_pos + 1;
-                                    found = true;
-                                }
-                                break;
-                            }
-                        }
-                        if !found {
-                            break;
-                        }
-                    }
-                    drop_tag(tags, tag_name, r, f);
-                } else {
-                    let mut is_self_closing = false;
-                    let mut quote_pos = None;
-                    if c != '>' {
-                        let mut quote = None;
-                        let mut after_eq = false;
-                        for (i, c) in text[pos..].char_indices() {
-                            if !c.is_whitespace() {
-                                if let Some(q) = quote {
-                                    if c == q {
-                                        quote = None;
-                                        quote_pos = None;
-                                        after_eq = false;
-                                    }
-                                } else if c == '>' {
-                                    break;
-                                } else if c == '/' && !after_eq {
-                                    is_self_closing = true;
-                                } else {
-                                    if is_self_closing {
-                                        is_self_closing = false;
-                                    }
-                                    if (c == '"' || c == '\'') && after_eq {
-                                        quote = Some(c);
-                                        quote_pos = Some(pos + i);
-                                    } else if c == '=' {
-                                        after_eq = true;
-                                    }
-                                }
-                            } else if quote.is_none() {
-                                after_eq = false;
-                            }
-                        }
-                    }
-                    if let Some(quote_pos) = quote_pos {
-                        let qr = Range { start: quote_pos, end: quote_pos };
-                        f(
-                            &format!("unclosed quoted HTML attribute on tag `{}`", tag_name),
-                            &qr,
-                            false,
-                        );
-                    }
-                    if is_self_closing {
-                        // https://html.spec.whatwg.org/#parse-error-non-void-html-element-start-tag-with-trailing-solidus
-                        let valid = ALLOWED_UNCLOSED.contains(&&tag_name[..])
-                            || tags.iter().take(pos + 1).any(|(at, _)| {
-                                let at = at.to_lowercase();
-                                at == "svg" || at == "math"
-                            });
-                        if !valid {
-                            f(&format!("invalid self-closing HTML tag `{}`", tag_name), &r, false);
-                        }
-                    } else {
-                        tags.push((tag_name, r));
-                    }
-                }
-            }
-            break;
-        }
-        iter.next();
-    }
-}
-
-fn extract_tags(
-    tags: &mut Vec<(String, Range<usize>)>,
-    text: &str,
-    range: Range<usize>,
-    is_in_comment: &mut Option<Range<usize>>,
-    f: &impl Fn(&str, &Range<usize>, bool),
-) {
-    let mut iter = text.char_indices().peekable();
-
-    while let Some((start_pos, c)) = iter.next() {
-        if is_in_comment.is_some() {
-            if text[start_pos..].starts_with("-->") {
-                *is_in_comment = None;
-            }
-        } else if c == '<' {
-            if text[start_pos..].starts_with("<!--") {
-                // We skip the "!--" part. (Once `advance_by` is stable, might be nice to use it!)
-                iter.next();
-                iter.next();
-                iter.next();
-                *is_in_comment = Some(Range {
-                    start: range.start + start_pos,
-                    end: range.start + start_pos + 3,
-                });
-            } else {
-                extract_html_tag(tags, text, &range, start_pos, &mut iter, f);
-            }
-        }
-    }
 }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -139,7 +139,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     .iter()
                     .filter_map(|attr| {
                         Cfg::parse(attr.meta_item()?)
-                            .map_err(|e| self.cx.sess().diagnostic().span_err(e.span, e.msg))
+                            .map_err(|e| self.cx.sess().diagnostic().emit_err(e))
                             .ok()
                     })
                     .collect::<Vec<_>>()

--- a/tests/rustdoc-ui/check-attr-test.stderr
+++ b/tests/rustdoc-ui/check-attr-test.stderr
@@ -15,55 +15,7 @@ note: the lint level is defined here
 3 | #![deny(rustdoc::invalid_codeblock_attributes)]
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unknown attribute `compilefail`. Did you mean `compile_fail`?
- --> $DIR/check-attr-test.rs:5:1
-  |
-5 | / /// foo
-6 | | ///
-7 | | /// ```compile-fail,compilefail,comPile_fail
-8 | | /// boo
-9 | | /// ```
-  | |_______^
-  |
-  = help: the code block will either not be tested if not marked as a rust one or won't fail if it compiles successfully
-
-error: unknown attribute `comPile_fail`. Did you mean `compile_fail`?
- --> $DIR/check-attr-test.rs:5:1
-  |
-5 | / /// foo
-6 | | ///
-7 | | /// ```compile-fail,compilefail,comPile_fail
-8 | | /// boo
-9 | | /// ```
-  | |_______^
-  |
-  = help: the code block will either not be tested if not marked as a rust one or won't fail if it compiles successfully
-
 error: unknown attribute `should-panic`. Did you mean `should_panic`?
-  --> $DIR/check-attr-test.rs:12:1
-   |
-12 | / /// bar
-13 | | ///
-14 | | /// ```should-panic,shouldpanic,shOuld_panic
-15 | | /// boo
-16 | | /// ```
-   | |_______^
-   |
-   = help: the code block will either not be tested if not marked as a rust one or won't fail if it doesn't panic when running
-
-error: unknown attribute `shouldpanic`. Did you mean `should_panic`?
-  --> $DIR/check-attr-test.rs:12:1
-   |
-12 | / /// bar
-13 | | ///
-14 | | /// ```should-panic,shouldpanic,shOuld_panic
-15 | | /// boo
-16 | | /// ```
-   | |_______^
-   |
-   = help: the code block will either not be tested if not marked as a rust one or won't fail if it doesn't panic when running
-
-error: unknown attribute `shOuld_panic`. Did you mean `should_panic`?
   --> $DIR/check-attr-test.rs:12:1
    |
 12 | / /// bar
@@ -87,30 +39,6 @@ error: unknown attribute `no-run`. Did you mean `no_run`?
    |
    = help: the code block will either not be tested if not marked as a rust one or will be run (which you might not want)
 
-error: unknown attribute `norun`. Did you mean `no_run`?
-  --> $DIR/check-attr-test.rs:19:1
-   |
-19 | / /// foobar
-20 | | ///
-21 | | /// ```no-run,norun,nO_run
-22 | | /// boo
-23 | | /// ```
-   | |_______^
-   |
-   = help: the code block will either not be tested if not marked as a rust one or will be run (which you might not want)
-
-error: unknown attribute `nO_run`. Did you mean `no_run`?
-  --> $DIR/check-attr-test.rs:19:1
-   |
-19 | / /// foobar
-20 | | ///
-21 | | /// ```no-run,norun,nO_run
-22 | | /// boo
-23 | | /// ```
-   | |_______^
-   |
-   = help: the code block will either not be tested if not marked as a rust one or will be run (which you might not want)
-
 error: unknown attribute `test-harness`. Did you mean `test_harness`?
   --> $DIR/check-attr-test.rs:26:1
    |
@@ -123,29 +51,5 @@ error: unknown attribute `test-harness`. Did you mean `test_harness`?
    |
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
-error: unknown attribute `testharness`. Did you mean `test_harness`?
-  --> $DIR/check-attr-test.rs:26:1
-   |
-26 | / /// b
-27 | | ///
-28 | | /// ```test-harness,testharness,tesT_harness
-29 | | /// boo
-30 | | /// ```
-   | |_______^
-   |
-   = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
-
-error: unknown attribute `tesT_harness`. Did you mean `test_harness`?
-  --> $DIR/check-attr-test.rs:26:1
-   |
-26 | / /// b
-27 | | ///
-28 | | /// ```test-harness,testharness,tesT_harness
-29 | | /// boo
-30 | | /// ```
-   | |_______^
-   |
-   = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
-
-error: aborting due to 12 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/rustdoc-ui/scrape-examples-fail-if-type-error.stderr
+++ b/tests/rustdoc-ui/scrape-examples-fail-if-type-error.stderr
@@ -5,7 +5,7 @@ LL |   INVALID_FUNC();
    |   ^^^^^^^^^^^^ could not resolve path `INVALID_FUNC`
    |
    = note: this error was originally ignored because you are running `rustdoc`
-   = note: try running again with `rustc` or `cargo check` and you may get a more detailed error
+   = help: try running again with `rustc` or `cargo check` and you may get a more detailed error
 
 error: Compilation failed, aborting rustdoc
 


### PR DESCRIPTION
Currently a draft while I translate the remaining errors, so not ready for review. When finished I will rebase and tidy up these work-in-progress commits.

This PR does not address the 23 diagnostics in `passes/collect_intra_doc_links.rs` and a bunch of other ones using the internal `Error` type (consisting of a path and string), but I plan to do those next.

r? @davidtwco 

## To-do

### Error sites

Error sites to fix (indicative of but not necessarily corresponding to individual errors):

- [x] `clean/types.rs` (1/1)
- [ ] `config.rs` (**13/16**)
- [x] `core.rs` (2/2)
- [x] `externalfiles.rs` (2/2)
- [x] `html/markdown.rs` (1/1)
- [x] `html/render/mod.rs` (1/1)
- [x] `passes/check_doc_test_visibility.rs` (2/2)
- [x] `passes/lint/bare_urls.rs` (1/1)
- [ ] `passes/lint/check_code_block_syntax.rs` (0/1)
- [x] `passes/lint/html_tags.rs` (1/1)
- [ ] `scrape_examples.rs` (0/1)
- [x] `visit_ast.rs` (1/1)
- [ ] `lib.rs` (0/1)

**Total:** 25/31 (81%)

### Other tasks

- [ ] Re-order and rename errors.
- [ ] Clean up and consolidate commits.
- [ ] Qualify instead of import errors (see relevant [Zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/147480-t-compiler.2Fwg-diagnostics/topic/massive.20use.20statements)).