### PR TITLE
Allow impl on projection

### DIFF
--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -339,7 +339,15 @@ trait VisibilityLike: Sized {
         effective_visibilities: &EffectiveVisibilities,
     ) -> Self {
         let mut find = FindMin { tcx, effective_visibilities, min: Self::MAX };
-        find.visit(tcx.type_of(def_id));
+        let mut ty = tcx.type_of(def_id);
+        let param_env = tcx.param_env(def_id);
+        // We need this normalization when we check the visibility of a projection so it is applied
+        // to the item behind the projection and not to the projection itself.
+        ty = match tcx.try_normalize_erasing_regions(param_env, ty) {
+            Ok(new_ty) => new_ty,
+            Err(_) => ty,
+        };
+        find.visit(ty);
         if let Some(trait_ref) = tcx.impl_trait_ref(def_id) {
             find.visit_trait(trait_ref.subst_identity());
         }

--- a/tests/ui/privacy/private-in-public-ill-formed.rs
+++ b/tests/ui/privacy/private-in-public-ill-formed.rs
@@ -12,8 +12,10 @@ mod aliases_pub {
     }
 
     impl <Priv as PrivTr>::AssocAlias {
-        //~^ ERROR no nominal type found for inherent implementation
-        pub fn f(arg: Priv) {} // private type `aliases_pub::Priv` in public interface
+        pub fn f(arg: Priv) {}
+        //~^ ERROR private type `aliases_pub::Priv` in public interface
+        //~| ERROR private type `aliases_pub::Priv` in public interface
+        //~| ERROR private trait `aliases_pub::PrivTr` in public interface
     }
 }
 
@@ -29,7 +31,6 @@ mod aliases_priv {
     }
 
     impl <Priv as PrivTr>::AssocAlias {
-        //~^ ERROR no nominal type found for inherent implementation
         pub fn f(arg: Priv) {} // OK
     }
 }

--- a/tests/ui/privacy/private-in-public-ill-formed.stderr
+++ b/tests/ui/privacy/private-in-public-ill-formed.stderr
@@ -1,19 +1,31 @@
-error[E0118]: no nominal type found for inherent implementation
-  --> $DIR/private-in-public-ill-formed.rs:14:10
+error[E0446]: private type `aliases_pub::Priv` in public interface
+  --> $DIR/private-in-public-ill-formed.rs:15:9
    |
-LL |     impl <Priv as PrivTr>::AssocAlias {
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl requires a nominal type
-   |
-   = note: either implement a trait on it or create a newtype to wrap it instead
+LL |     struct Priv;
+   |     ----------- `aliases_pub::Priv` declared as private
+...
+LL |         pub fn f(arg: Priv) {}
+   |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
 
-error[E0118]: no nominal type found for inherent implementation
-  --> $DIR/private-in-public-ill-formed.rs:31:10
+error[E0445]: private trait `aliases_pub::PrivTr` in public interface
+  --> $DIR/private-in-public-ill-formed.rs:15:9
    |
-LL |     impl <Priv as PrivTr>::AssocAlias {
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl requires a nominal type
+LL |     trait PrivTr {
+   |     ------------ `aliases_pub::PrivTr` declared as private
+...
+LL |         pub fn f(arg: Priv) {}
+   |         ^^^^^^^^^^^^^^^^^^^ can't leak private trait
+
+error[E0446]: private type `aliases_pub::Priv` in public interface
+  --> $DIR/private-in-public-ill-formed.rs:15:9
    |
-   = note: either implement a trait on it or create a newtype to wrap it instead
+LL |     struct Priv;
+   |     ----------- `aliases_pub::Priv` declared as private
+...
+LL |         pub fn f(arg: Priv) {}
+   |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0118`.
+Some errors have detailed explanations: E0445, E0446.
+For more information about an error, try `rustc --explain E0445`.

--- a/tests/ui/projection/impl-foreign.rs
+++ b/tests/ui/projection/impl-foreign.rs
@@ -1,0 +1,13 @@
+#![crate_type = "lib"]
+
+pub trait Identity {
+    type Identity: ?Sized;
+}
+
+impl<T: ?Sized> Identity for T {
+    type Identity = Self;
+}
+
+impl <String as Identity>::Identity { //~ ERROR
+    pub fn foo(&self) {}
+}

--- a/tests/ui/projection/impl-foreign.stderr
+++ b/tests/ui/projection/impl-foreign.stderr
@@ -1,0 +1,13 @@
+error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/impl-foreign.rs:11:1
+   |
+LL | / impl <String as Identity>::Identity {
+LL | |     pub fn foo(&self) {}
+LL | | }
+   | |_^ impl for type defined outside of crate.
+   |
+   = note: define and implement a trait or new type instead
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0116`.

--- a/tests/ui/projection/impl-on-assoc-const.rs
+++ b/tests/ui/projection/impl-on-assoc-const.rs
@@ -1,0 +1,15 @@
+#![crate_type = "lib"]
+
+pub trait Identity {
+    const Identity: u32;
+}
+
+impl<T: ?Sized> Identity for T {
+    const Identity: u32 = 0;
+}
+
+pub struct S;
+
+impl <S as Identity>::Identity { //~ ERROR
+    pub fn foo(&self) {}
+}

--- a/tests/ui/projection/impl-on-assoc-const.stderr
+++ b/tests/ui/projection/impl-on-assoc-const.stderr
@@ -1,0 +1,9 @@
+error[E0575]: expected associated type, found associated constant `Identity::Identity`
+  --> $DIR/impl-on-assoc-const.rs:13:6
+   |
+LL | impl <S as Identity>::Identity {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^ not a associated type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0575`.

--- a/tests/ui/projection/impl-on-weird-projection.rs
+++ b/tests/ui/projection/impl-on-weird-projection.rs
@@ -1,0 +1,16 @@
+//~ ERROR
+#![crate_type = "lib"]
+
+pub trait Identity {
+    type Identity: ?Sized;
+}
+
+impl<T: ?Sized> Identity for T {
+    type Identity = Self;
+}
+
+pub struct I8<const F: i8>;
+
+impl <I8<{i8::MIN}> as Identity>::Identity {
+    pub fn foo(&self) {}
+}

--- a/tests/ui/projection/impl-on-weird-projection.stderr
+++ b/tests/ui/projection/impl-on-weird-projection.stderr
@@ -1,0 +1,76 @@
+error[E0391]: cycle detected when finding all inherent impls defined in crate
+   |
+   = note: ...which requires normalizing `<I8<{i8::MIN}> as Identity>::Identity`...
+note: ...which requires evaluating type-level constant...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+note: ...which requires const-evaluating + checking `<impl at $DIR/impl-on-weird-projection.rs:14:1: 14:43>::{constant#0}`...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+note: ...which requires const-evaluating + checking `<impl at $DIR/impl-on-weird-projection.rs:14:1: 14:43>::{constant#0}`...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+note: ...which requires caching MIR for CTFE of the const argument `<impl at $DIR/impl-on-weird-projection.rs:14:1: 14:43>::{constant#0}`...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+note: ...which requires elaborating drops for `<impl at $DIR/impl-on-weird-projection.rs:14:1: 14:43>::{constant#0}`...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+note: ...which requires borrow-checking the const argument`<impl at $DIR/impl-on-weird-projection.rs:14:1: 14:43>::{constant#0}`...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+note: ...which requires processing MIR for the const argument `<impl at $DIR/impl-on-weird-projection.rs:14:1: 14:43>::{constant#0}`...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+note: ...which requires const checking the const argument `<impl at $DIR/impl-on-weird-projection.rs:14:1: 14:43>::{constant#0}`...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+note: ...which requires preparing the const argument `<impl at $DIR/impl-on-weird-projection.rs:14:1: 14:43>::{constant#0}` for borrow checking...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+note: ...which requires unsafety-checking the const argument `<impl at $DIR/impl-on-weird-projection.rs:14:1: 14:43>::{constant#0}`...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+note: ...which requires building MIR for `<impl at $DIR/impl-on-weird-projection.rs:14:1: 14:43>::{constant#0}`...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+note: ...which requires building THIR for `<impl at $DIR/impl-on-weird-projection.rs:14:1: 14:43>::{constant#0}`...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+note: ...which requires type-checking the const argument `<impl at $DIR/impl-on-weird-projection.rs:14:1: 14:43>::{constant#0}`...
+  --> $DIR/impl-on-weird-projection.rs:14:10
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |          ^^^^^^^^^
+   = note: ...which requires collecting all inherent impls for `IntSimplifiedType(I8)`...
+   = note: ...which requires collecting all impls for a type in a crate...
+   = note: ...which again requires finding all inherent impls defined in crate, completing the cycle
+   = note: cycle used when running analysis passes on this crate
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/projection/impl-projection-on-primitive.rs
+++ b/tests/ui/projection/impl-projection-on-primitive.rs
@@ -1,0 +1,15 @@
+#![crate_type = "lib"]
+
+pub trait Identity {
+    type Identity: ?Sized;
+}
+
+impl<T: ?Sized> Identity for T {
+    type Identity = ();
+}
+
+pub struct S;
+
+impl <S as Identity>::Identity { //~ ERROR
+    pub fn foo(&self) {}
+}

--- a/tests/ui/projection/impl-projection-on-primitive.stderr
+++ b/tests/ui/projection/impl-projection-on-primitive.stderr
@@ -1,0 +1,11 @@
+error[E0390]: cannot define inherent `impl` for primitive types
+  --> $DIR/impl-projection-on-primitive.rs:13:6
+   |
+LL | impl <S as Identity>::Identity {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using an extension trait instead
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0390`.

--- a/tests/ui/projection/impl-projection.rs
+++ b/tests/ui/projection/impl-projection.rs
@@ -1,0 +1,23 @@
+// check-pass
+
+#![crate_type = "lib"]
+
+pub trait Identity {
+    type Identity: ?Sized;
+}
+
+impl<T: ?Sized> Identity for T {
+    type Identity = Self;
+}
+
+pub struct S;
+
+impl <S as Identity>::Identity {
+    pub fn foo(&self) {}
+}
+
+impl S {
+    pub fn bar(&self) {
+        self.foo();
+    }
+}

--- a/tests/ui/projection/impl-projection2.rs
+++ b/tests/ui/projection/impl-projection2.rs
@@ -1,0 +1,24 @@
+// check-pass
+
+#![crate_type = "lib"]
+
+pub trait Identity {
+    type Identity: ?Sized;
+}
+
+impl<T: ?Sized> Identity for T {
+    type Identity = S;
+}
+
+pub struct S;
+pub struct Bar;
+
+impl <Bar as Identity>::Identity {
+    pub fn foo(&self) {}
+}
+
+impl S {
+    pub fn bar(&self) {
+        self.foo();
+    }
+}


### PR DESCRIPTION
Got this one from #103985 as well.

<details>
<summary>Issue (solved) with privacy check</summary>

However, a bug appeared from the privacy check as the CI will show: it has some false positive with "private type in public interface". Not sure why though. The backtrace for it is here:

```
  12:     0x7fef586494c5 - <rustc_privacy[dc2692dda3b059d]::SearchInterfaceForPrivateItemsVisitor as rustc_privacy[dc2692dda3b059d]::DefIdVisitor>::visit_def_id
  13:     0x7fef5863f6ff - <rustc_privacy[dc2692dda3b059d]::DefIdVisitorSkeleton<rustc_privacy[dc2692dda3b059d]::SearchInterfaceForPrivateItemsVisitor> as rustc_middle[2d95345cc9d1265e]::ty::visit::TypeVisitor>::visit_ty
  14:     0x7fef5863f9d2 - <rustc_privacy[dc2692dda3b059d]::DefIdVisitorSkeleton<rustc_privacy[dc2692dda3b059d]::SearchInterfaceForPrivateItemsVisitor> as rustc_middle[2d95345cc9d1265e]::ty::visit::TypeVisitor>::visit_ty
  15:     0x7fef586484c2 - <rustc_privacy[dc2692dda3b059d]::SearchInterfaceForPrivateItemsVisitor>::ty
  16:     0x7fef586497c5 - <rustc_privacy[dc2692dda3b059d]::PrivateItemsInPublicInterfacesChecker>::check_assoc_item
  17:     0x7fef5864bba5 - rustc_privacy[dc2692dda3b059d]::check_private_in_public
  18:     0x7fef59c15a66 - rustc_query_system[a3c6a6fb37b6854f]::query::plumbing::try_execute_query::<rustc_query_impl[eee68f6de69b6b9]::queries::check_private_in_public, rustc_query_impl[eee68f6de69b6b9]::plumbing::QueryCtxt>
  19:     0x7fef598fc292 - <rustc_query_impl[eee68f6de69b6b9]::Queries as rustc_middle[2d95345cc9d1265e]::ty::query::QueryEngine>::check_private_in_public
  20:     0x7fef58179756 - <core[3d15cbc1632fd665]::panic::unwind_safe::AssertUnwindSafe<rustc_interface[2af05e4c67454c01]::passes::analysis::{closure#5}::{closure#1}> as core[3d15cbc1632fd665]::ops::function::FnOnce<()>>::call_once
  21:     0x7fef580e26c5 - <rustc_session[da714fc9e163a7bd]::session::Session>::time::<(), rustc_interface[2af05e4c67454c01]::passes::analysis::{closure#5}>
  22:     0x7fef580b9dac - rustc_interface[2af05e4c67454c01]::passes::analysis
  23:     0x7fef59c644b2 - rustc_query_system[a3c6a6fb37b6854f]::query::plumbing::try_execute_query::<rustc_query_impl[eee68f6de69b6b9]::queries::analysis, rustc_query_impl[eee68f6de69b6b9]::plumbing::QueryCtxt>
  24:     0x7fef598cfb95 - <rustc_query_impl[eee68f6de69b6b9]::Queries as rustc_middle[2d95345cc9d1265e]::ty::query::QueryEngine>::analysis
  25:     0x7fef57f91c03 - <rustc_interface[2af05e4c67454c01]::passes::QueryContext>::enter::<rustc_driver[de5d577c9fbc1a01]::run_compiler::{closure#1}::{closure#2}::{closure#2}, core[3d15cbc1632fd665]::result::Result<(), rustc_errors[c6c462034af138b3]::ErrorGuaranteed>>
  26:     0x7fef57f7383a - <rustc_interface[2af05e4c67454c01]::queries::QueryResult<rustc_interface[2af05e4c67454c01]::passes::QueryContext>>::enter::<core[3d15cbc1632fd665]::result::Result<(), rustc_errors[c6c462034af138b3]::ErrorGuaranteed>, rustc_driver[de5d577c9fbc1a01]::run_compiler::{closure#1}::{closure#2}::{closure#2}>
  27:     0x7fef57fddc76 - <rustc_interface[2af05e4c67454c01]::interface::Compiler>::enter::<rustc_driver[de5d577c9fbc1a01]::run_compiler::{closure#1}::{closure#2}, core[3d15cbc1632fd665]::result::Result<core[3d15cbc1632fd665]::option::Option<rustc_interface[2af05e4c67454c01]::queries::Linker>, rustc_errors[c6c462034af138b3]::ErrorGuaranteed>>
  28:     0x7fef5800406a - rustc_span[29a73c65a118f2f3]::with_source_map::<core[3d15cbc1632fd665]::result::Result<(), rustc_errors[c6c462034af138b3]::ErrorGuaranteed>, rustc_interface[2af05e4c67454c01]::interface::run_compiler<core[3d15cbc1632fd665]::result::Result<(), rustc_errors[c6c462034af138b3]::ErrorGuaranteed>, rustc_driver[de5d577c9fbc1a01]::run_compiler::{closure#1}>::{closure#0}::{closure#0}>
  29:     0x7fef57fd44c5 - <scoped_tls[535ca24a62cbd8c4]::ScopedKey<rustc_span[29a73c65a118f2f3]::SessionGlobals>>::set::<rustc_interface[2af05e4c67454c01]::interface::run_compiler<core[3d15cbc1632fd665]::result::Result<(), rustc_errors[c6c462034af138b3]::ErrorGuaranteed>, rustc_driver[de5d577c9fbc1a01]::run_compiler::{closure#1}>::{closure#0}, core[3d15cbc1632fd665]::result::Result<(), rustc_errors[c6c462034af138b3]::ErrorGuaranteed>>
  30:     0x7fef57f9ad30 - std[1177681641634ed6]::sys_common::backtrace::__rust_begin_short_backtrace::<rustc_interface[2af05e4c67454c01]::util::run_in_thread_pool_with_globals<rustc_interface[2af05e4c67454c01]::interface::run_compiler<core[3d15cbc1632fd665]::result::Result<(), rustc_errors[c6c462034af138b3]::ErrorGuaranteed>, rustc_driver[de5d577c9fbc1a01]::run_compiler::{closure#1}>::{closure#0}, core[3d15cbc1632fd665]::result::Result<(), rustc_errors[c6c462034af138b3]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[3d15cbc1632fd665]::result::Result<(), rustc_errors[c6c462034af138b3]::ErrorGuaranteed>>
  31:     0x7fef57f7bdbd - <<std[1177681641634ed6]::thread::Builder>::spawn_unchecked_<rustc_interface[2af05e4c67454c01]::util::run_in_thread_pool_with_globals<rustc_interface[2af05e4c67454c01]::interface::run_compiler<core[3d15cbc1632fd665]::result::Result<(), rustc_errors[c6c462034af138b3]::ErrorGuaranteed>, rustc_driver[de5d577c9fbc1a01]::run_compiler::{closure#1}>::{closure#0}, core[3d15cbc1632fd665]::result::Result<(), rustc_errors[c6c462034af138b3]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[3d15cbc1632fd665]::result::Result<(), rustc_errors[c6c462034af138b3]::ErrorGuaranteed>>::{closure#1} as core[3d15cbc1632fd665]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
```

</details>

cc @compiler-errors 
r? @oli-obk 