### PR TITLE
Add option to include private items in library docs

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -233,6 +233,9 @@ changelog-seen = 2
 # and generated in already-minified form from the beginning.
 #docs-minification = true
 
+# Flag to specify whether private items should be included in the library docs.
+#library-docs-private-items = false
+
 # Indicate whether the compiler should be documented in addition to the standard
 # library and facade crates.
 #compiler-docs = false

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -65,6 +65,7 @@ pub struct Config {
     pub verbose: usize,
     pub submodules: Option<bool>,
     pub compiler_docs: bool,
+    pub library_docs_private_items: bool,
     pub docs_minification: bool,
     pub docs: bool,
     pub locked_deps: bool,
@@ -606,6 +607,7 @@ define_config! {
         rustfmt: Option<PathBuf> = "rustfmt",
         docs: Option<bool> = "docs",
         compiler_docs: Option<bool> = "compiler-docs",
+        library_docs_private_items: Option<bool> = "library-docs-private-items",
         docs_minification: Option<bool> = "docs-minification",
         submodules: Option<bool> = "submodules",
         gdb: Option<String> = "gdb",
@@ -1015,6 +1017,7 @@ impl Config {
         config.submodules = build.submodules;
         set(&mut config.low_priority, build.low_priority);
         set(&mut config.compiler_docs, build.compiler_docs);
+        set(&mut config.library_docs_private_items, build.library_docs_private_items);
         set(&mut config.docs_minification, build.docs_minification);
         set(&mut config.docs, build.docs);
         set(&mut config.locked_deps, build.locked_deps);

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -597,6 +597,9 @@ fn doc_std(
             .arg("--resource-suffix")
             .arg(&builder.version)
             .args(extra_args);
+        if builder.config.library_docs_private_items {
+            cargo.arg("--document-private-items");
+        }
         builder.run(&mut cargo.into());
     };
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -598,7 +598,7 @@ fn doc_std(
             .arg(&builder.version)
             .args(extra_args);
         if builder.config.library_docs_private_items {
-            cargo.arg("--document-private-items");
+            cargo.arg("--document-private-items").arg("--document-hidden-items");
         }
         builder.run(&mut cargo.into());
     };


### PR DESCRIPTION
I need to perform some one-off analysis on libcore, and I wanted to use the unstable JSON rustdoc output to easily do it. Unfortunately, there is currently no way to include unstable items in the library docs. This PR adds support for that, with the off-by-default `build.library-docs-private-items` setting.