### PR TITLE
Replace ZST operands and debuginfo by constants.

### DIFF
--- a/compiler/rustc_mir_transform/src/remove_zsts.rs
+++ b/compiler/rustc_mir_transform/src/remove_zsts.rs
@@ -1,7 +1,9 @@
 //! Removes assignments to ZST places.
 
 use crate::MirPass;
-use rustc_middle::mir::{Body, StatementKind};
+use rustc_middle::mir::interpret::ConstValue;
+use rustc_middle::mir::visit::*;
+use rustc_middle::mir::*;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 
 pub struct RemoveZsts;
@@ -16,36 +18,22 @@ impl<'tcx> MirPass<'tcx> for RemoveZsts {
         if tcx.type_of(body.source.def_id()).subst_identity().is_generator() {
             return;
         }
-        let param_env = tcx.param_env(body.source.def_id());
-        let basic_blocks = body.basic_blocks.as_mut_preserves_cfg();
+        let param_env = tcx.param_env_reveal_all_normalized(body.source.def_id());
         let local_decls = &body.local_decls;
-        for block in basic_blocks {
-            for statement in block.statements.iter_mut() {
-                if let StatementKind::Assign(box (place, _)) | StatementKind::Deinit(box place) =
-                    statement.kind
-                {
-                    let place_ty = place.ty(local_decls, tcx).ty;
-                    if !maybe_zst(place_ty) {
-                        continue;
-                    }
-                    let Ok(layout) = tcx.layout_of(param_env.and(place_ty)) else {
-                        continue;
-                    };
-                    if !layout.is_zst() {
-                        continue;
-                    }
-                    if tcx.consider_optimizing(|| {
-                        format!(
-                            "RemoveZsts - Place: {:?} SourceInfo: {:?}",
-                            place, statement.source_info
-                        )
-                    }) {
-                        statement.make_nop();
-                    }
-                }
-            }
+        let mut replacer = Replacer { tcx, param_env, local_decls };
+        for var_debug_info in &mut body.var_debug_info {
+            replacer.visit_var_debug_info(var_debug_info);
+        }
+        for (bb, data) in body.basic_blocks.as_mut_preserves_cfg().iter_enumerated_mut() {
+            replacer.visit_basic_block_data(bb, data);
         }
     }
+}
+
+struct Replacer<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+    local_decls: &'a LocalDecls<'tcx>,
 }
 
 /// A cheap, approximate check to avoid unnecessary `layout_of` calls.
@@ -61,5 +49,82 @@ fn maybe_zst(ty: Ty<'_>) -> bool {
         ty::FnDef(..) | ty::Never => true,
         // unreachable or can't be ZST
         _ => false,
+    }
+}
+
+impl<'tcx> Replacer<'_, 'tcx> {
+    fn is_zst(&self, ty: Ty<'tcx>) -> bool {
+        if !maybe_zst(ty) {
+            return false;
+        }
+        let Ok(layout) = self.tcx.layout_of(self.param_env.and(ty)) else {
+            return false;
+        };
+        layout.is_zst()
+    }
+
+    fn make_zst(&self, ty: Ty<'tcx>) -> Constant<'tcx> {
+        debug_assert!(self.is_zst(ty));
+        Constant {
+            span: rustc_span::DUMMY_SP,
+            user_ty: None,
+            literal: ConstantKind::Val(ConstValue::ZeroSized, ty),
+        }
+    }
+}
+
+impl<'tcx> MutVisitor<'tcx> for Replacer<'_, 'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
+    fn visit_var_debug_info(&mut self, var_debug_info: &mut VarDebugInfo<'tcx>) {
+        match var_debug_info.value {
+            VarDebugInfoContents::Const(_) => {}
+            VarDebugInfoContents::Place(place) => {
+                let place_ty = place.ty(self.local_decls, self.tcx).ty;
+                if self.is_zst(place_ty) {
+                    var_debug_info.value = VarDebugInfoContents::Const(self.make_zst(place_ty))
+                }
+            }
+            VarDebugInfoContents::Composite { ty, fragments: _ } => {
+                if self.is_zst(ty) {
+                    var_debug_info.value = VarDebugInfoContents::Const(self.make_zst(ty))
+                }
+            }
+        }
+    }
+
+    fn visit_operand(&mut self, operand: &mut Operand<'tcx>, loc: Location) {
+        if let Operand::Constant(_) = operand {
+            return;
+        }
+        let op_ty = operand.ty(self.local_decls, self.tcx);
+        if self.is_zst(op_ty)
+            && self.tcx.consider_optimizing(|| {
+                format!("RemoveZsts - Operand: {:?} Location: {:?}", operand, loc)
+            })
+        {
+            *operand = Operand::Constant(Box::new(self.make_zst(op_ty)))
+        }
+    }
+
+    fn visit_statement(&mut self, statement: &mut Statement<'tcx>, loc: Location) {
+        if let StatementKind::Assign(box (place, _)) | StatementKind::Deinit(box place) =
+            statement.kind
+        {
+            let place_ty = place.ty(self.local_decls, self.tcx).ty;
+            if self.is_zst(place_ty)
+                && self.tcx.consider_optimizing(|| {
+                    format!(
+                        "RemoveZsts - Place: {:?} SourceInfo: {:?}",
+                        place, statement.source_info
+                    )
+                })
+            {
+                statement.make_nop();
+            }
+        }
+        self.super_statement(statement, loc);
     }
 }

--- a/tests/debuginfo/type-names.rs
+++ b/tests/debuginfo/type-names.rs
@@ -175,7 +175,6 @@
 // 0-sized structs appear to be optimized away in some cases, so only check the structs that do
 // actually appear.
 // cdb-command:dv /t *_struct
-// cdb-check:struct type_names::GenericStruct<enum2$<type_names::mod1::Enum2>,f64> mut_generic_struct = [...]
 
 // ENUMS
 // cdb-command:dv /t *_enum_*

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
@@ -14,7 +14,6 @@
       }
   
       bb1: {
-          StorageLive(_2);                 // scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
           _2 = begin_panic::<&str>(const "explicit panic"); // scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/std/src/panic.rs:LL:COL

--- a/tests/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
@@ -12,12 +12,10 @@
           let _3: [E; 1];                  // in scope 1 at $DIR/invalid_constant.rs:+13:9: +13:21
           scope 3 {
               debug _invalid_tag => _3;    // in scope 3 at $DIR/invalid_constant.rs:+13:9: +13:21
-              let _6: [Empty; 1];          // in scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
               scope 5 {
-                  debug _enum_without_variants => _6; // in scope 5 at $DIR/invalid_constant.rs:+20:9: +20:31
-                  let _7: main::Str<"���">; // in scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
+                  debug _enum_without_variants => const [ZeroSized: Empty]; // in scope 5 at $DIR/invalid_constant.rs:+20:9: +20:31
                   scope 7 {
-                      debug _non_utf8_str => _7; // in scope 7 at $DIR/invalid_constant.rs:+24:9: +24:22
+                      debug _non_utf8_str => const Str::<"���">; // in scope 7 at $DIR/invalid_constant.rs:+24:9: +24:22
                   }
               }
               scope 6 {
@@ -52,10 +50,6 @@
 +                                          // + literal: Const { ty: E, val: Value(Scalar(0x00000004)) }
           StorageDead(_4);                 // scope 1 at $DIR/invalid_constant.rs:+13:59: +13:60
           StorageDead(_5);                 // scope 1 at $DIR/invalid_constant.rs:+13:60: +13:61
-          StorageLive(_6);                 // scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
-          StorageLive(_7);                 // scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
-          StorageDead(_7);                 // scope 5 at $DIR/invalid_constant.rs:+27:1: +27:2
-          StorageDead(_6);                 // scope 3 at $DIR/invalid_constant.rs:+27:1: +27:2
           StorageDead(_3);                 // scope 1 at $DIR/invalid_constant.rs:+27:1: +27:2
           StorageDead(_1);                 // scope 0 at $DIR/invalid_constant.rs:+27:1: +27:2
           return;                          // scope 0 at $DIR/invalid_constant.rs:+27:2: +27:2

--- a/tests/mir-opt/const_prop/invalid_constant.main.RemoveZsts.diff
+++ b/tests/mir-opt/const_prop/invalid_constant.main.RemoveZsts.diff
@@ -1,0 +1,70 @@
+- // MIR for `main` before RemoveZsts
++ // MIR for `main` after RemoveZsts
+  
+  fn main() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/invalid_constant.rs:+0:11: +0:11
+      let _1: char;                        // in scope 0 at $DIR/invalid_constant.rs:+6:9: +6:22
+      let mut _2: main::InvalidChar;       // in scope 0 at $DIR/invalid_constant.rs:+6:34: +6:63
+      let mut _4: E;                       // in scope 0 at $DIR/invalid_constant.rs:+13:25: +13:59
+      let mut _5: main::InvalidTag;        // in scope 0 at $DIR/invalid_constant.rs:+13:34: +13:55
+      let mut _7: Empty;                   // in scope 0 at $DIR/invalid_constant.rs:+20:35: +20:73
+      let mut _8: main::NoVariants;        // in scope 0 at $DIR/invalid_constant.rs:+20:44: +20:65
+      scope 1 {
+          debug _invalid_char => _1;       // in scope 1 at $DIR/invalid_constant.rs:+6:9: +6:22
+          let _3: [E; 1];                  // in scope 1 at $DIR/invalid_constant.rs:+13:9: +13:21
+          scope 3 {
+              debug _invalid_tag => _3;    // in scope 3 at $DIR/invalid_constant.rs:+13:9: +13:21
+              let _6: [Empty; 1];          // in scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
+              scope 5 {
+-                 debug _enum_without_variants => _6; // in scope 5 at $DIR/invalid_constant.rs:+20:9: +20:31
++                 debug _enum_without_variants => const [ZeroSized: Empty]; // in scope 5 at $DIR/invalid_constant.rs:+20:9: +20:31
+                  let _9: main::Str<"���">; // in scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
+                  scope 7 {
+-                     debug _non_utf8_str => _9; // in scope 7 at $DIR/invalid_constant.rs:+24:9: +24:22
++                     debug _non_utf8_str => const Str::<"���">; // in scope 7 at $DIR/invalid_constant.rs:+24:9: +24:22
+                  }
+              }
+              scope 6 {
+              }
+          }
+          scope 4 {
+          }
+      }
+      scope 2 {
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/invalid_constant.rs:+6:9: +6:22
+          StorageLive(_2);                 // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:63
+          _2 = InvalidChar { int: const 1114113_u32 }; // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:63
+          _1 = (_2.1: char);               // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:67
+          StorageDead(_2);                 // scope 0 at $DIR/invalid_constant.rs:+6:69: +6:70
+          StorageLive(_3);                 // scope 1 at $DIR/invalid_constant.rs:+13:9: +13:21
+          StorageLive(_4);                 // scope 1 at $DIR/invalid_constant.rs:+13:25: +13:59
+          StorageLive(_5);                 // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
+          _5 = InvalidTag { int: const 4_u32 }; // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
+          _4 = (_5.1: E);                  // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:57
+          _3 = [move _4];                  // scope 1 at $DIR/invalid_constant.rs:+13:24: +13:60
+          StorageDead(_4);                 // scope 1 at $DIR/invalid_constant.rs:+13:59: +13:60
+          StorageDead(_5);                 // scope 1 at $DIR/invalid_constant.rs:+13:60: +13:61
+          StorageLive(_6);                 // scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
+          StorageLive(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:35: +20:73
+          StorageLive(_8);                 // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
+          _8 = NoVariants { int: const 0_u32 }; // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
+-         _7 = (_8.1: Empty);              // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:71
+-         _6 = [move _7];                  // scope 3 at $DIR/invalid_constant.rs:+20:34: +20:74
++         nop;                             // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:71
++         nop;                             // scope 3 at $DIR/invalid_constant.rs:+20:34: +20:74
+          StorageDead(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:73: +20:74
+          StorageDead(_8);                 // scope 3 at $DIR/invalid_constant.rs:+20:74: +20:75
+          StorageLive(_9);                 // scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
+-         _0 = const ();                   // scope 0 at $DIR/invalid_constant.rs:+0:11: +27:2
++         nop;                             // scope 0 at $DIR/invalid_constant.rs:+0:11: +27:2
+          StorageDead(_9);                 // scope 5 at $DIR/invalid_constant.rs:+27:1: +27:2
+          StorageDead(_6);                 // scope 3 at $DIR/invalid_constant.rs:+27:1: +27:2
+          StorageDead(_3);                 // scope 1 at $DIR/invalid_constant.rs:+27:1: +27:2
+          StorageDead(_1);                 // scope 0 at $DIR/invalid_constant.rs:+27:1: +27:2
+          return;                          // scope 0 at $DIR/invalid_constant.rs:+27:2: +27:2
+      }
+  }
+  

--- a/tests/mir-opt/const_prop/invalid_constant.main.RemoveZsts.diff
+++ b/tests/mir-opt/const_prop/invalid_constant.main.RemoveZsts.diff
@@ -47,21 +47,27 @@
           _3 = [move _4];                  // scope 1 at $DIR/invalid_constant.rs:+13:24: +13:60
           StorageDead(_4);                 // scope 1 at $DIR/invalid_constant.rs:+13:59: +13:60
           StorageDead(_5);                 // scope 1 at $DIR/invalid_constant.rs:+13:60: +13:61
-          StorageLive(_6);                 // scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
-          StorageLive(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:35: +20:73
+-         StorageLive(_6);                 // scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
+-         StorageLive(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:35: +20:73
++         nop;                             // scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
++         nop;                             // scope 3 at $DIR/invalid_constant.rs:+20:35: +20:73
           StorageLive(_8);                 // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
           _8 = NoVariants { int: const 0_u32 }; // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
 -         _7 = (_8.1: Empty);              // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:71
 -         _6 = [move _7];                  // scope 3 at $DIR/invalid_constant.rs:+20:34: +20:74
+-         StorageDead(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:73: +20:74
 +         nop;                             // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:71
 +         nop;                             // scope 3 at $DIR/invalid_constant.rs:+20:34: +20:74
-          StorageDead(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:73: +20:74
++         nop;                             // scope 3 at $DIR/invalid_constant.rs:+20:73: +20:74
           StorageDead(_8);                 // scope 3 at $DIR/invalid_constant.rs:+20:74: +20:75
-          StorageLive(_9);                 // scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
+-         StorageLive(_9);                 // scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
 -         _0 = const ();                   // scope 0 at $DIR/invalid_constant.rs:+0:11: +27:2
+-         StorageDead(_9);                 // scope 5 at $DIR/invalid_constant.rs:+27:1: +27:2
+-         StorageDead(_6);                 // scope 3 at $DIR/invalid_constant.rs:+27:1: +27:2
++         nop;                             // scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
 +         nop;                             // scope 0 at $DIR/invalid_constant.rs:+0:11: +27:2
-          StorageDead(_9);                 // scope 5 at $DIR/invalid_constant.rs:+27:1: +27:2
-          StorageDead(_6);                 // scope 3 at $DIR/invalid_constant.rs:+27:1: +27:2
++         nop;                             // scope 5 at $DIR/invalid_constant.rs:+27:1: +27:2
++         nop;                             // scope 3 at $DIR/invalid_constant.rs:+27:1: +27:2
           StorageDead(_3);                 // scope 1 at $DIR/invalid_constant.rs:+27:1: +27:2
           StorageDead(_1);                 // scope 0 at $DIR/invalid_constant.rs:+27:1: +27:2
           return;                          // scope 0 at $DIR/invalid_constant.rs:+27:2: +27:2

--- a/tests/mir-opt/const_prop/invalid_constant.rs
+++ b/tests/mir-opt/const_prop/invalid_constant.rs
@@ -11,6 +11,7 @@ enum E { A, B, C }
 #[derive(Copy, Clone)]
 enum Empty {}
 
+// EMIT_MIR invalid_constant.main.RemoveZsts.diff
 // EMIT_MIR invalid_constant.main.ConstProp.diff
 fn main() {
     // An invalid char.

--- a/tests/mir-opt/const_prop/issue_66971.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/issue_66971.main.ConstProp.diff
@@ -7,7 +7,6 @@
       let mut _2: ((), u8, u8);            // in scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/issue_66971.rs:+1:5: +1:23
           StorageLive(_2);                 // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
           _2 = (const (), const 0_u8, const 0_u8); // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
           _1 = encode(move _2) -> bb1;     // scope 0 at $DIR/issue_66971.rs:+1:5: +1:23
@@ -18,7 +17,6 @@
   
       bb1: {
           StorageDead(_2);                 // scope 0 at $DIR/issue_66971.rs:+1:22: +1:23
-          StorageDead(_1);                 // scope 0 at $DIR/issue_66971.rs:+1:23: +1:24
           return;                          // scope 0 at $DIR/issue_66971.rs:+2:2: +2:2
       }
   }

--- a/tests/mir-opt/const_prop/issue_66971.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/issue_66971.main.ConstProp.diff
@@ -5,14 +5,11 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/issue_66971.rs:+0:11: +0:11
       let _1: ();                          // in scope 0 at $DIR/issue_66971.rs:+1:5: +1:23
       let mut _2: ((), u8, u8);            // in scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
-      let mut _3: ();                      // in scope 0 at $DIR/issue_66971.rs:+1:13: +1:15
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/issue_66971.rs:+1:5: +1:23
           StorageLive(_2);                 // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
-          StorageLive(_3);                 // scope 0 at $DIR/issue_66971.rs:+1:13: +1:15
-          _2 = (move _3, const 0_u8, const 0_u8); // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
-          StorageDead(_3);                 // scope 0 at $DIR/issue_66971.rs:+1:21: +1:22
+          _2 = (const (), const 0_u8, const 0_u8); // scope 0 at $DIR/issue_66971.rs:+1:12: +1:22
           _1 = encode(move _2) -> bb1;     // scope 0 at $DIR/issue_66971.rs:+1:5: +1:23
                                            // mir::Constant
                                            // + span: $DIR/issue_66971.rs:17:5: 17:11

--- a/tests/mir-opt/const_prop/issue_67019.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/issue_67019.main.ConstProp.diff
@@ -8,7 +8,6 @@
       let mut _3: (u8, u8);                // in scope 0 at $DIR/issue_67019.rs:+1:11: +1:17
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/issue_67019.rs:+1:5: +1:20
           StorageLive(_2);                 // scope 0 at $DIR/issue_67019.rs:+1:10: +1:19
           StorageLive(_3);                 // scope 0 at $DIR/issue_67019.rs:+1:11: +1:17
 -         _3 = (const 1_u8, const 2_u8);   // scope 0 at $DIR/issue_67019.rs:+1:11: +1:17
@@ -23,7 +22,6 @@
   
       bb1: {
           StorageDead(_2);                 // scope 0 at $DIR/issue_67019.rs:+1:19: +1:20
-          StorageDead(_1);                 // scope 0 at $DIR/issue_67019.rs:+1:20: +1:21
           return;                          // scope 0 at $DIR/issue_67019.rs:+2:2: +2:2
       }
   }

--- a/tests/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
@@ -12,7 +12,6 @@
   
       bb0: {
           _1 = const 1_u32;                // scope 0 at $DIR/scalar_literal_propagation.rs:+1:13: +1:14
-          StorageLive(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
 -         _2 = consume(_1) -> bb1;         // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
 +         _2 = consume(const 1_u32) -> bb1; // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
                                            // mir::Constant
@@ -21,7 +20,6 @@
       }
   
       bb1: {
-          StorageDead(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:+2:15: +2:16
           return;                          // scope 0 at $DIR/scalar_literal_propagation.rs:+3:2: +3:2
       }
   }

--- a/tests/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
@@ -13,7 +13,6 @@
       bb0: {
 -         _1 = (const 1_u32, const 2_u32); // scope 0 at $DIR/tuple_literal_propagation.rs:+1:13: +1:19
 +         _1 = const (1_u32, 2_u32);       // scope 0 at $DIR/tuple_literal_propagation.rs:+1:13: +1:19
-          StorageLive(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:+3:5: +3:15
           _2 = consume(_1) -> bb1;         // scope 1 at $DIR/tuple_literal_propagation.rs:+3:5: +3:15
                                            // mir::Constant
                                            // + span: $DIR/tuple_literal_propagation.rs:5:5: 5:12
@@ -21,7 +20,6 @@
       }
   
       bb1: {
-          StorageDead(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:+3:15: +3:16
           return;                          // scope 0 at $DIR/tuple_literal_propagation.rs:+4:2: +4:2
       }
   }

--- a/tests/mir-opt/inline/asm_unwind.main.Inline.diff
+++ b/tests/mir-opt/inline/asm_unwind.main.Inline.diff
@@ -7,7 +7,7 @@
 +     scope 1 (inlined foo) {              // at $DIR/asm_unwind.rs:21:5: 21:10
 +         let _2: D;                       // in scope 1 at $DIR/asm_unwind.rs:15:9: 15:11
 +         scope 2 {
-+             debug _d => _2;              // in scope 2 at $DIR/asm_unwind.rs:15:9: 15:11
++             debug _d => const D;         // in scope 2 at $DIR/asm_unwind.rs:15:9: 15:11
 +             scope 3 {
 +             }
 +         }

--- a/tests/mir-opt/inline/asm_unwind.main.Inline.diff
+++ b/tests/mir-opt/inline/asm_unwind.main.Inline.diff
@@ -19,19 +19,19 @@
 -                                          // mir::Constant
 -                                          // + span: $DIR/asm_unwind.rs:21:5: 21:8
 -                                          // + literal: Const { ty: fn() {foo}, val: Value(<ZST>) }
-+         StorageLive(_2);                 // scope 1 at $DIR/asm_unwind.rs:15:9: 15:11
-+         asm!("", options(MAY_UNWIND)) -> [return: bb1, unwind: bb3]; // scope 3 at $DIR/asm_unwind.rs:16:14: 16:54
++         StorageLive(_2);                 // scope 0 at $DIR/asm_unwind.rs:+1:5: +1:10
++         asm!("", options(MAY_UNWIND)) -> [return: bb2, unwind: bb3]; // scope 3 at $DIR/asm_unwind.rs:16:14: 16:54
       }
   
       bb1: {
-+         drop(_2) -> bb2;                 // scope 1 at $DIR/asm_unwind.rs:17:1: 17:2
-+     }
-+ 
-+     bb2: {
-+         StorageDead(_2);                 // scope 1 at $DIR/asm_unwind.rs:17:1: 17:2
++         StorageDead(_2);                 // scope 0 at $DIR/asm_unwind.rs:+1:5: +1:10
           StorageDead(_1);                 // scope 0 at $DIR/asm_unwind.rs:+1:10: +1:11
           _0 = const ();                   // scope 0 at $DIR/asm_unwind.rs:+0:15: +2:2
           return;                          // scope 0 at $DIR/asm_unwind.rs:+2:2: +2:2
++     }
++ 
++     bb2: {
++         drop(_2) -> bb1;                 // scope 1 at $DIR/asm_unwind.rs:17:1: 17:2
 +     }
 + 
 +     bb3 (cleanup): {

--- a/tests/mir-opt/inline/cycle.g.Inline.diff
+++ b/tests/mir-opt/inline/cycle.g.Inline.diff
@@ -5,11 +5,11 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:+0:8: +0:8
       let _1: ();                          // in scope 0 at $DIR/cycle.rs:+1:5: +1:12
 +     let mut _2: fn() {main};             // in scope 0 at $DIR/cycle.rs:+1:5: +1:12
++     let mut _5: ();                      // in scope 0 at $DIR/cycle.rs:6:5: 6:8
 +     scope 1 (inlined f::<fn() {main}>) { // at $DIR/cycle.rs:12:5: 12:12
 +         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:5:6: 5:7
 +         let _3: ();                      // in scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         let mut _4: &fn() {main};        // in scope 1 at $DIR/cycle.rs:6:5: 6:6
-+         let mut _5: ();                  // in scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         scope 2 (inlined <fn() {main} as Fn<()>>::call - shim(fn() {main})) { // at $DIR/cycle.rs:6:5: 6:8
 +         }
 +     }
@@ -29,6 +29,7 @@
 +         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:6:5: 6:6
 +         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
 +         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
++         _5 = const ();                   // scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         _3 = move (*_4)() -> [return: bb4, unwind: bb2]; // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
       }
   
@@ -48,7 +49,7 @@
 +     }
 + 
 +     bb4: {
-+         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
++         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
 +         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:6:8: 6:9
 +         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2

--- a/tests/mir-opt/inline/cycle.g.Inline.diff
+++ b/tests/mir-opt/inline/cycle.g.Inline.diff
@@ -25,7 +25,7 @@
 -                                          // mir::Constant
                                            // + span: $DIR/cycle.rs:12:7: 12:11
                                            // + literal: Const { ty: fn() {main}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
++         StorageLive(_3);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
 +         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:6:5: 6:6
 +         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
 +         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
@@ -34,6 +34,7 @@
       }
   
       bb1: {
++         StorageDead(_3);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
 +         StorageDead(_2);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
           StorageDead(_1);                 // scope 0 at $DIR/cycle.rs:+1:12: +1:13
           _0 = const ();                   // scope 0 at $DIR/cycle.rs:+0:8: +2:2
@@ -51,7 +52,6 @@
 +     bb4: {
 +         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
-+         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:6:8: 6:9
 +         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2
       }
   }

--- a/tests/mir-opt/inline/cycle.main.Inline.diff
+++ b/tests/mir-opt/inline/cycle.main.Inline.diff
@@ -25,7 +25,7 @@
 -                                          // mir::Constant
                                            // + span: $DIR/cycle.rs:17:7: 17:8
                                            // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
++         StorageLive(_3);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
 +         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:6:5: 6:6
 +         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
 +         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
@@ -34,6 +34,7 @@
       }
   
       bb1: {
++         StorageDead(_3);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
 +         StorageDead(_2);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
           StorageDead(_1);                 // scope 0 at $DIR/cycle.rs:+1:9: +1:10
           _0 = const ();                   // scope 0 at $DIR/cycle.rs:+0:11: +2:2
@@ -51,7 +52,6 @@
 +     bb4: {
 +         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
-+         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:6:8: 6:9
 +         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2
       }
   }

--- a/tests/mir-opt/inline/cycle.main.Inline.diff
+++ b/tests/mir-opt/inline/cycle.main.Inline.diff
@@ -5,11 +5,11 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:+0:11: +0:11
       let _1: ();                          // in scope 0 at $DIR/cycle.rs:+1:5: +1:9
 +     let mut _2: fn() {g};                // in scope 0 at $DIR/cycle.rs:+1:5: +1:9
++     let mut _5: ();                      // in scope 0 at $DIR/cycle.rs:6:5: 6:8
 +     scope 1 (inlined f::<fn() {g}>) {    // at $DIR/cycle.rs:17:5: 17:9
 +         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:5:6: 5:7
 +         let _3: ();                      // in scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         let mut _4: &fn() {g};           // in scope 1 at $DIR/cycle.rs:6:5: 6:6
-+         let mut _5: ();                  // in scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         scope 2 (inlined <fn() {g} as Fn<()>>::call - shim(fn() {g})) { // at $DIR/cycle.rs:6:5: 6:8
 +         }
 +     }
@@ -29,6 +29,7 @@
 +         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:6:5: 6:6
 +         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
 +         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
++         _5 = const ();                   // scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         _3 = move (*_4)() -> [return: bb4, unwind: bb2]; // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
       }
   
@@ -48,7 +49,7 @@
 +     }
 + 
 +     bb4: {
-+         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
++         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
 +         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:6:8: 6:9
 +         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2

--- a/tests/mir-opt/inline/exponential_runtime.main.Inline.diff
+++ b/tests/mir-opt/inline/exponential_runtime.main.Inline.diff
@@ -18,9 +18,13 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/exponential_runtime.rs:+1:5: +1:22
 -         _1 = <() as G>::call() -> bb1;   // scope 0 at $DIR/exponential_runtime.rs:+1:5: +1:22
-+         StorageLive(_2);                 // scope 1 at $DIR/exponential_runtime.rs:73:9: 73:25
-+         StorageLive(_5);                 // scope 2 at $DIR/exponential_runtime.rs:61:9: 61:25
-+         _5 = <() as E>::call() -> bb3;   // scope 2 at $DIR/exponential_runtime.rs:61:9: 61:25
++         StorageLive(_2);                 // scope 0 at $DIR/exponential_runtime.rs:+1:5: +1:22
++         StorageLive(_3);                 // scope 0 at $DIR/exponential_runtime.rs:+1:5: +1:22
++         StorageLive(_4);                 // scope 0 at $DIR/exponential_runtime.rs:+1:5: +1:22
++         StorageLive(_5);                 // scope 1 at $DIR/exponential_runtime.rs:73:9: 73:25
++         StorageLive(_6);                 // scope 1 at $DIR/exponential_runtime.rs:73:9: 73:25
++         StorageLive(_7);                 // scope 1 at $DIR/exponential_runtime.rs:73:9: 73:25
++         _5 = <() as E>::call() -> bb4;   // scope 2 at $DIR/exponential_runtime.rs:61:9: 61:25
                                            // mir::Constant
 -                                          // + span: $DIR/exponential_runtime.rs:86:5: 86:20
 -                                          // + literal: Const { ty: fn() {<() as G>::call}, val: Value(<ZST>) }
@@ -29,47 +33,43 @@
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 1 at $DIR/exponential_runtime.rs:74:25: 74:26
-+         StorageLive(_4);                 // scope 1 at $DIR/exponential_runtime.rs:75:9: 75:25
-+         _4 = <() as F>::call() -> bb2;   // scope 1 at $DIR/exponential_runtime.rs:75:9: 75:25
-+                                          // mir::Constant
-+                                          // + span: $DIR/exponential_runtime.rs:75:9: 75:23
-+                                          // + literal: Const { ty: fn() {<() as F>::call}, val: Value(<ZST>) }
-+     }
-+ 
-+     bb2: {
-+         StorageDead(_4);                 // scope 1 at $DIR/exponential_runtime.rs:75:25: 75:26
++         StorageDead(_4);                 // scope 0 at $DIR/exponential_runtime.rs:+1:5: +1:22
++         StorageDead(_3);                 // scope 0 at $DIR/exponential_runtime.rs:+1:5: +1:22
++         StorageDead(_2);                 // scope 0 at $DIR/exponential_runtime.rs:+1:5: +1:22
           StorageDead(_1);                 // scope 0 at $DIR/exponential_runtime.rs:+1:22: +1:23
           _0 = const ();                   // scope 0 at $DIR/exponential_runtime.rs:+0:11: +2:2
           return;                          // scope 0 at $DIR/exponential_runtime.rs:+2:2: +2:2
 +     }
 + 
++     bb2: {
++         StorageDead(_7);                 // scope 1 at $DIR/exponential_runtime.rs:73:9: 73:25
++         StorageDead(_6);                 // scope 1 at $DIR/exponential_runtime.rs:73:9: 73:25
++         StorageDead(_5);                 // scope 1 at $DIR/exponential_runtime.rs:73:9: 73:25
++         _3 = <() as F>::call() -> bb3;   // scope 1 at $DIR/exponential_runtime.rs:74:9: 74:25
++                                          // mir::Constant
++                                          // + span: $DIR/exponential_runtime.rs:74:9: 74:23
++                                          // + literal: Const { ty: fn() {<() as F>::call}, val: Value(<ZST>) }
++     }
++ 
 +     bb3: {
-+         StorageDead(_5);                 // scope 2 at $DIR/exponential_runtime.rs:61:25: 61:26
-+         StorageLive(_6);                 // scope 2 at $DIR/exponential_runtime.rs:62:9: 62:25
-+         _6 = <() as E>::call() -> bb4;   // scope 2 at $DIR/exponential_runtime.rs:62:9: 62:25
++         _4 = <() as F>::call() -> bb1;   // scope 1 at $DIR/exponential_runtime.rs:75:9: 75:25
++                                          // mir::Constant
++                                          // + span: $DIR/exponential_runtime.rs:75:9: 75:23
++                                          // + literal: Const { ty: fn() {<() as F>::call}, val: Value(<ZST>) }
++     }
++ 
++     bb4: {
++         _6 = <() as E>::call() -> bb5;   // scope 2 at $DIR/exponential_runtime.rs:62:9: 62:25
 +                                          // mir::Constant
 +                                          // + span: $DIR/exponential_runtime.rs:62:9: 62:23
 +                                          // + literal: Const { ty: fn() {<() as E>::call}, val: Value(<ZST>) }
 +     }
 + 
-+     bb4: {
-+         StorageDead(_6);                 // scope 2 at $DIR/exponential_runtime.rs:62:25: 62:26
-+         StorageLive(_7);                 // scope 2 at $DIR/exponential_runtime.rs:63:9: 63:25
-+         _7 = <() as E>::call() -> bb5;   // scope 2 at $DIR/exponential_runtime.rs:63:9: 63:25
++     bb5: {
++         _7 = <() as E>::call() -> bb2;   // scope 2 at $DIR/exponential_runtime.rs:63:9: 63:25
 +                                          // mir::Constant
 +                                          // + span: $DIR/exponential_runtime.rs:63:9: 63:23
 +                                          // + literal: Const { ty: fn() {<() as E>::call}, val: Value(<ZST>) }
-+     }
-+ 
-+     bb5: {
-+         StorageDead(_7);                 // scope 2 at $DIR/exponential_runtime.rs:63:25: 63:26
-+         StorageDead(_2);                 // scope 1 at $DIR/exponential_runtime.rs:73:25: 73:26
-+         StorageLive(_3);                 // scope 1 at $DIR/exponential_runtime.rs:74:9: 74:25
-+         _3 = <() as F>::call() -> bb1;   // scope 1 at $DIR/exponential_runtime.rs:74:9: 74:25
-+                                          // mir::Constant
-+                                          // + span: $DIR/exponential_runtime.rs:74:9: 74:23
-+                                          // + literal: Const { ty: fn() {<() as F>::call}, val: Value(<ZST>) }
       }
   }
   

--- a/tests/mir-opt/inline/inline_cycle.two.Inline.diff
+++ b/tests/mir-opt/inline/inline_cycle.two.Inline.diff
@@ -24,7 +24,7 @@
 -                                          // mir::Constant
                                            // + span: $DIR/inline_cycle.rs:49:10: 49:11
                                            // + literal: Const { ty: fn() {f}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 1 at $DIR/inline_cycle.rs:54:5: 54:8
++         StorageLive(_3);                 // scope 0 at $DIR/inline_cycle.rs:+1:5: +1:12
 +         StorageLive(_4);                 // scope 1 at $DIR/inline_cycle.rs:54:5: 54:8
 +         _4 = const ();                   // scope 1 at $DIR/inline_cycle.rs:54:5: 54:8
 +         _3 = move _2() -> bb1;           // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -32,7 +32,7 @@
   
       bb1: {
 +         StorageDead(_4);                 // scope 1 at $DIR/inline_cycle.rs:54:5: 54:8
-+         StorageDead(_3);                 // scope 1 at $DIR/inline_cycle.rs:54:8: 54:9
++         StorageDead(_3);                 // scope 0 at $DIR/inline_cycle.rs:+1:5: +1:12
 +         StorageDead(_2);                 // scope 0 at $DIR/inline_cycle.rs:+1:5: +1:12
           StorageDead(_1);                 // scope 0 at $DIR/inline_cycle.rs:+1:12: +1:13
           _0 = const ();                   // scope 0 at $DIR/inline_cycle.rs:+0:10: +2:2

--- a/tests/mir-opt/inline/inline_cycle.two.Inline.diff
+++ b/tests/mir-opt/inline/inline_cycle.two.Inline.diff
@@ -5,10 +5,10 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/inline_cycle.rs:+0:10: +0:10
       let _1: ();                          // in scope 0 at $DIR/inline_cycle.rs:+1:5: +1:12
 +     let mut _2: fn() {f};                // in scope 0 at $DIR/inline_cycle.rs:+1:5: +1:12
++     let mut _4: ();                      // in scope 0 at $DIR/inline_cycle.rs:54:5: 54:8
 +     scope 1 (inlined call::<fn() {f}>) { // at $DIR/inline_cycle.rs:49:5: 49:12
 +         debug f => _2;                   // in scope 1 at $DIR/inline_cycle.rs:53:22: 53:23
 +         let _3: ();                      // in scope 1 at $DIR/inline_cycle.rs:54:5: 54:8
-+         let mut _4: ();                  // in scope 1 at $DIR/inline_cycle.rs:54:5: 54:8
 +         scope 2 (inlined <fn() {f} as FnOnce<()>>::call_once - shim(fn() {f})) { // at $DIR/inline_cycle.rs:54:5: 54:8
 +         }
 +     }
@@ -26,11 +26,12 @@
                                            // + literal: Const { ty: fn() {f}, val: Value(<ZST>) }
 +         StorageLive(_3);                 // scope 1 at $DIR/inline_cycle.rs:54:5: 54:8
 +         StorageLive(_4);                 // scope 1 at $DIR/inline_cycle.rs:54:5: 54:8
++         _4 = const ();                   // scope 1 at $DIR/inline_cycle.rs:54:5: 54:8
 +         _3 = move _2() -> bb1;           // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
       }
   
       bb1: {
-+         StorageDead(_4);                 // scope 1 at $DIR/inline_cycle.rs:54:7: 54:8
++         StorageDead(_4);                 // scope 1 at $DIR/inline_cycle.rs:54:5: 54:8
 +         StorageDead(_3);                 // scope 1 at $DIR/inline_cycle.rs:54:8: 54:9
 +         StorageDead(_2);                 // scope 0 at $DIR/inline_cycle.rs:+1:5: +1:12
           StorageDead(_1);                 // scope 0 at $DIR/inline_cycle.rs:+1:12: +1:13

--- a/tests/mir-opt/inline/inline_diverging.g.Inline.diff
+++ b/tests/mir-opt/inline/inline_diverging.g.Inline.diff
@@ -34,7 +34,7 @@
       bb2: {
           StorageLive(_6);                 // scope 0 at $DIR/inline_diverging.rs:+4:9: +4:16
 -         _6 = panic();                    // scope 0 at $DIR/inline_diverging.rs:+4:9: +4:16
-+         StorageLive(_7);                 // scope 1 at $SRC_DIR/std/src/panic.rs:LL:COL
++         StorageLive(_7);                 // scope 0 at $DIR/inline_diverging.rs:+4:9: +4:16
 +         _7 = begin_panic::<&str>(const "explicit panic"); // scope 1 at $SRC_DIR/std/src/panic.rs:LL:COL
                                            // mir::Constant
 -                                          // + span: $DIR/inline_diverging.rs:16:9: 16:14

--- a/tests/mir-opt/inline/inline_diverging.h.Inline.diff
+++ b/tests/mir-opt/inline/inline_diverging.h.Inline.diff
@@ -5,19 +5,18 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/inline_diverging.rs:+0:12: +0:12
       let _1: (!, !);                      // in scope 0 at $DIR/inline_diverging.rs:+1:5: +1:22
 +     let mut _2: fn() -> ! {sleep};       // in scope 0 at $DIR/inline_diverging.rs:+1:5: +1:22
++     let mut _8: ();                      // in scope 0 at $DIR/inline_diverging.rs:27:13: 27:16
 +     scope 1 (inlined call_twice::<!, fn() -> ! {sleep}>) { // at $DIR/inline_diverging.rs:22:5: 22:22
 +         debug f => _2;                   // in scope 1 at $DIR/inline_diverging.rs:26:36: 26:37
 +         let _3: !;                       // in scope 1 at $DIR/inline_diverging.rs:27:9: 27:10
 +         let mut _4: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline_diverging.rs:27:13: 27:14
-+         let mut _5: ();                  // in scope 1 at $DIR/inline_diverging.rs:27:13: 27:16
-+         let mut _6: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline_diverging.rs:28:13: 28:14
-+         let mut _7: ();                  // in scope 1 at $DIR/inline_diverging.rs:28:13: 28:16
-+         let mut _8: !;                   // in scope 1 at $DIR/inline_diverging.rs:29:6: 29:7
-+         let mut _9: !;                   // in scope 1 at $DIR/inline_diverging.rs:29:9: 29:10
++         let mut _5: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline_diverging.rs:28:13: 28:14
++         let mut _6: !;                   // in scope 1 at $DIR/inline_diverging.rs:29:6: 29:7
++         let mut _7: !;                   // in scope 1 at $DIR/inline_diverging.rs:29:9: 29:10
 +         scope 2 {
 +             debug a => _3;               // in scope 2 at $DIR/inline_diverging.rs:27:9: 27:10
 +             scope 3 {
-+                 debug b => _9;           // in scope 3 at $DIR/inline_diverging.rs:28:9: 28:10
++                 debug b => _7;           // in scope 3 at $DIR/inline_diverging.rs:28:9: 28:10
 +             }
 +         }
 +         scope 4 (inlined <fn() -> ! {sleep} as Fn<()>>::call - shim(fn() -> ! {sleep})) { // at $DIR/inline_diverging.rs:27:13: 27:16
@@ -35,21 +34,21 @@
 -                                          // mir::Constant
                                            // + span: $DIR/inline_diverging.rs:22:16: 22:21
                                            // + literal: Const { ty: fn() -> ! {sleep}, val: Value(<ZST>) }
-+         StorageLive(_9);                 // scope 0 at $DIR/inline_diverging.rs:+1:5: +1:22
++         StorageLive(_7);                 // scope 0 at $DIR/inline_diverging.rs:+1:5: +1:22
 +         StorageLive(_3);                 // scope 1 at $DIR/inline_diverging.rs:27:9: 27:10
 +         StorageLive(_4);                 // scope 1 at $DIR/inline_diverging.rs:27:13: 27:14
 +         _4 = &_2;                        // scope 1 at $DIR/inline_diverging.rs:27:13: 27:14
-+         StorageLive(_5);                 // scope 1 at $DIR/inline_diverging.rs:27:13: 27:16
++         StorageLive(_8);                 // scope 1 at $DIR/inline_diverging.rs:27:13: 27:16
++         _8 = const ();                   // scope 1 at $DIR/inline_diverging.rs:27:13: 27:16
 +         _3 = move (*_4)() -> [return: bb6, unwind: bb4]; // scope 4 at $SRC_DIR/core/src/ops/function.rs:LL:COL
 +     }
 + 
 +     bb1: {
-+         StorageDead(_7);                 // scope 2 at $DIR/inline_diverging.rs:28:15: 28:16
-+         StorageDead(_6);                 // scope 2 at $DIR/inline_diverging.rs:28:15: 28:16
-+         StorageLive(_8);                 // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
-+         _8 = move _3;                    // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
-+         _1 = (move _8, move _9);         // scope 3 at $DIR/inline_diverging.rs:29:5: 29:11
-+         StorageDead(_8);                 // scope 3 at $DIR/inline_diverging.rs:29:10: 29:11
++         StorageDead(_5);                 // scope 2 at $DIR/inline_diverging.rs:28:15: 28:16
++         StorageLive(_6);                 // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
++         _6 = move _3;                    // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
++         _1 = (move _6, move _7);         // scope 3 at $DIR/inline_diverging.rs:29:5: 29:11
++         StorageDead(_6);                 // scope 3 at $DIR/inline_diverging.rs:29:10: 29:11
 +         StorageDead(_3);                 // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2
 +         drop(_2) -> bb2;                 // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2
 +     }
@@ -71,12 +70,11 @@
 +     }
 + 
 +     bb6: {
-+         StorageDead(_5);                 // scope 1 at $DIR/inline_diverging.rs:27:15: 27:16
++         StorageDead(_8);                 // scope 1 at $DIR/inline_diverging.rs:27:13: 27:16
 +         StorageDead(_4);                 // scope 1 at $DIR/inline_diverging.rs:27:15: 27:16
-+         StorageLive(_6);                 // scope 2 at $DIR/inline_diverging.rs:28:13: 28:14
-+         _6 = &_2;                        // scope 2 at $DIR/inline_diverging.rs:28:13: 28:14
-+         StorageLive(_7);                 // scope 2 at $DIR/inline_diverging.rs:28:13: 28:16
-+         _9 = <fn() -> ! {sleep} as Fn<()>>::call(move _6, move _7) -> [return: bb1, unwind: bb3]; // scope 2 at $DIR/inline_diverging.rs:28:13: 28:16
++         StorageLive(_5);                 // scope 2 at $DIR/inline_diverging.rs:28:13: 28:14
++         _5 = &_2;                        // scope 2 at $DIR/inline_diverging.rs:28:13: 28:14
++         _7 = <fn() -> ! {sleep} as Fn<()>>::call(move _5, const ()) -> [return: bb1, unwind: bb3]; // scope 2 at $DIR/inline_diverging.rs:28:13: 28:16
 +                                          // mir::Constant
 +                                          // + span: $DIR/inline_diverging.rs:28:13: 28:14
 +                                          // + literal: Const { ty: for<'a> extern "rust-call" fn(&'a fn() -> ! {sleep}, ()) -> <fn() -> ! {sleep} as FnOnce<()>>::Output {<fn() -> ! {sleep} as Fn<()>>::call}, val: Value(<ZST>) }

--- a/tests/mir-opt/inline/inline_options.main.Inline.after.mir
+++ b/tests/mir-opt/inline/inline_options.main.Inline.after.mir
@@ -21,35 +21,35 @@ fn main() -> () {
     bb1: {
         StorageDead(_1);                 // scope 0 at $DIR/inline_options.rs:+1:18: +1:19
         StorageLive(_2);                 // scope 0 at $DIR/inline_options.rs:+2:5: +2:21
-        StorageLive(_3);                 // scope 1 at $DIR/inline_options.rs:16:23: 16:26
-        _3 = g() -> bb2;                 // scope 1 at $DIR/inline_options.rs:16:23: 16:26
+        StorageLive(_3);                 // scope 0 at $DIR/inline_options.rs:+2:5: +2:21
+        StorageLive(_4);                 // scope 0 at $DIR/inline_options.rs:+2:5: +2:21
+        StorageLive(_5);                 // scope 0 at $DIR/inline_options.rs:+2:5: +2:21
+        _3 = g() -> bb3;                 // scope 1 at $DIR/inline_options.rs:16:23: 16:26
                                          // mir::Constant
                                          // + span: $DIR/inline_options.rs:16:23: 16:24
                                          // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_3);                 // scope 1 at $DIR/inline_options.rs:16:26: 16:27
-        StorageLive(_4);                 // scope 1 at $DIR/inline_options.rs:16:28: 16:31
-        _4 = g() -> bb3;                 // scope 1 at $DIR/inline_options.rs:16:28: 16:31
+        StorageDead(_5);                 // scope 0 at $DIR/inline_options.rs:+2:5: +2:21
+        StorageDead(_4);                 // scope 0 at $DIR/inline_options.rs:+2:5: +2:21
+        StorageDead(_3);                 // scope 0 at $DIR/inline_options.rs:+2:5: +2:21
+        StorageDead(_2);                 // scope 0 at $DIR/inline_options.rs:+2:21: +2:22
+        _0 = const ();                   // scope 0 at $DIR/inline_options.rs:+0:11: +3:2
+        return;                          // scope 0 at $DIR/inline_options.rs:+3:2: +3:2
+    }
+
+    bb3: {
+        _4 = g() -> bb4;                 // scope 1 at $DIR/inline_options.rs:16:28: 16:31
                                          // mir::Constant
                                          // + span: $DIR/inline_options.rs:16:28: 16:29
                                          // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
     }
 
-    bb3: {
-        StorageDead(_4);                 // scope 1 at $DIR/inline_options.rs:16:31: 16:32
-        StorageLive(_5);                 // scope 1 at $DIR/inline_options.rs:16:33: 16:36
-        _5 = g() -> bb4;                 // scope 1 at $DIR/inline_options.rs:16:33: 16:36
+    bb4: {
+        _5 = g() -> bb2;                 // scope 1 at $DIR/inline_options.rs:16:33: 16:36
                                          // mir::Constant
                                          // + span: $DIR/inline_options.rs:16:33: 16:34
                                          // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
-    }
-
-    bb4: {
-        StorageDead(_5);                 // scope 1 at $DIR/inline_options.rs:16:36: 16:37
-        StorageDead(_2);                 // scope 0 at $DIR/inline_options.rs:+2:21: +2:22
-        _0 = const ();                   // scope 0 at $DIR/inline_options.rs:+0:11: +3:2
-        return;                          // scope 0 at $DIR/inline_options.rs:+3:2: +3:2
     }
 }

--- a/tests/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
+++ b/tests/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
@@ -10,10 +10,9 @@ fn main() -> () {
     scope 1 {
         debug f => _1;                   // in scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+1:9: +1:10
         scope 2 (inlined main::{closure#0}) { // at $DIR/issue_76997_inline_scopes_parenting.rs:6:5: 6:10
-            debug x => _5;               // in scope 2 at $DIR/issue_76997_inline_scopes_parenting.rs:+1:14: +1:15
-            let _6: ();                  // in scope 2 at $DIR/issue_76997_inline_scopes_parenting.rs:+1:23: +1:24
+            debug x => const ();         // in scope 2 at $DIR/issue_76997_inline_scopes_parenting.rs:+1:14: +1:15
             scope 3 {
-                debug y => _6;           // in scope 3 at $DIR/issue_76997_inline_scopes_parenting.rs:+1:23: +1:24
+                debug y => const ();     // in scope 3 at $DIR/issue_76997_inline_scopes_parenting.rs:+1:23: +1:24
             }
         }
     }
@@ -36,8 +35,6 @@ fn main() -> () {
         _3 = (move _4,);                 // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
         StorageLive(_5);                 // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
         _5 = move (_3.0: ());            // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
-        StorageLive(_6);                 // scope 2 at $DIR/issue_76997_inline_scopes_parenting.rs:+1:23: +1:24
-        StorageDead(_6);                 // scope 2 at $DIR/issue_76997_inline_scopes_parenting.rs:+1:32: +1:33
         StorageDead(_5);                 // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:5: +2:10
         StorageDead(_4);                 // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:9: +2:10
         StorageDead(_3);                 // scope 1 at $DIR/issue_76997_inline_scopes_parenting.rs:+2:9: +2:10

--- a/tests/mir-opt/intrinsic_asserts.generic.InstCombine.diff
+++ b/tests/mir-opt/intrinsic_asserts.generic.InstCombine.diff
@@ -8,7 +8,7 @@
       let _3: ();                          // in scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:60
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/intrinsic_asserts.rs:+1:5: +1:46
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+1:5: +1:46
           _1 = assert_inhabited::<T>() -> bb1; // scope 0 at $DIR/intrinsic_asserts.rs:+1:5: +1:46
                                            // mir::Constant
                                            // + span: $DIR/intrinsic_asserts.rs:25:5: 25:44
@@ -16,8 +16,8 @@
       }
   
       bb1: {
-          StorageDead(_1);                 // scope 0 at $DIR/intrinsic_asserts.rs:+1:46: +1:47
-          StorageLive(_2);                 // scope 0 at $DIR/intrinsic_asserts.rs:+2:5: +2:47
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+1:46: +1:47
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+2:5: +2:47
           _2 = assert_zero_valid::<T>() -> bb2; // scope 0 at $DIR/intrinsic_asserts.rs:+2:5: +2:47
                                            // mir::Constant
                                            // + span: $DIR/intrinsic_asserts.rs:26:5: 26:45
@@ -25,8 +25,8 @@
       }
   
       bb2: {
-          StorageDead(_2);                 // scope 0 at $DIR/intrinsic_asserts.rs:+2:47: +2:48
-          StorageLive(_3);                 // scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:60
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+2:47: +2:48
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:60
           _3 = assert_mem_uninitialized_valid::<T>() -> bb3; // scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:60
                                            // mir::Constant
                                            // + span: $DIR/intrinsic_asserts.rs:27:5: 27:58
@@ -34,7 +34,7 @@
       }
   
       bb3: {
-          StorageDead(_3);                 // scope 0 at $DIR/intrinsic_asserts.rs:+3:60: +3:61
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+3:60: +3:61
           nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+0:21: +4:2
           return;                          // scope 0 at $DIR/intrinsic_asserts.rs:+4:2: +4:2
       }

--- a/tests/mir-opt/intrinsic_asserts.panics.InstCombine.diff
+++ b/tests/mir-opt/intrinsic_asserts.panics.InstCombine.diff
@@ -8,7 +8,7 @@
       let _3: ();                          // in scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:62
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/intrinsic_asserts.rs:+1:5: +1:50
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+1:5: +1:50
 -         _1 = assert_inhabited::<Never>() -> bb1; // scope 0 at $DIR/intrinsic_asserts.rs:+1:5: +1:50
 +         _1 = assert_inhabited::<Never>(); // scope 0 at $DIR/intrinsic_asserts.rs:+1:5: +1:50
                                            // mir::Constant
@@ -17,8 +17,8 @@
       }
   
       bb1: {
-          StorageDead(_1);                 // scope 0 at $DIR/intrinsic_asserts.rs:+1:50: +1:51
-          StorageLive(_2);                 // scope 0 at $DIR/intrinsic_asserts.rs:+2:5: +2:49
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+1:50: +1:51
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+2:5: +2:49
 -         _2 = assert_zero_valid::<&u8>() -> bb2; // scope 0 at $DIR/intrinsic_asserts.rs:+2:5: +2:49
 +         _2 = assert_zero_valid::<&u8>(); // scope 0 at $DIR/intrinsic_asserts.rs:+2:5: +2:49
                                            // mir::Constant
@@ -28,8 +28,8 @@
       }
   
       bb2: {
-          StorageDead(_2);                 // scope 0 at $DIR/intrinsic_asserts.rs:+2:49: +2:50
-          StorageLive(_3);                 // scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:62
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+2:49: +2:50
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:62
 -         _3 = assert_mem_uninitialized_valid::<&u8>() -> bb3; // scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:62
 +         _3 = assert_mem_uninitialized_valid::<&u8>(); // scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:62
                                            // mir::Constant
@@ -39,7 +39,7 @@
       }
   
       bb3: {
-          StorageDead(_3);                 // scope 0 at $DIR/intrinsic_asserts.rs:+3:62: +3:63
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+3:62: +3:63
           nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+0:17: +4:2
           return;                          // scope 0 at $DIR/intrinsic_asserts.rs:+4:2: +4:2
       }

--- a/tests/mir-opt/intrinsic_asserts.removable.InstCombine.diff
+++ b/tests/mir-opt/intrinsic_asserts.removable.InstCombine.diff
@@ -8,7 +8,7 @@
       let _3: ();                          // in scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:61
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/intrinsic_asserts.rs:+1:5: +1:47
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+1:5: +1:47
 -         _1 = assert_inhabited::<()>() -> bb1; // scope 0 at $DIR/intrinsic_asserts.rs:+1:5: +1:47
 -                                          // mir::Constant
 -                                          // + span: $DIR/intrinsic_asserts.rs:7:5: 7:45
@@ -17,8 +17,8 @@
       }
   
       bb1: {
-          StorageDead(_1);                 // scope 0 at $DIR/intrinsic_asserts.rs:+1:47: +1:48
-          StorageLive(_2);                 // scope 0 at $DIR/intrinsic_asserts.rs:+2:5: +2:48
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+1:47: +1:48
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+2:5: +2:48
 -         _2 = assert_zero_valid::<u8>() -> bb2; // scope 0 at $DIR/intrinsic_asserts.rs:+2:5: +2:48
 -                                          // mir::Constant
 -                                          // + span: $DIR/intrinsic_asserts.rs:8:5: 8:46
@@ -27,8 +27,8 @@
       }
   
       bb2: {
-          StorageDead(_2);                 // scope 0 at $DIR/intrinsic_asserts.rs:+2:48: +2:49
-          StorageLive(_3);                 // scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:61
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+2:48: +2:49
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:61
 -         _3 = assert_mem_uninitialized_valid::<u8>() -> bb3; // scope 0 at $DIR/intrinsic_asserts.rs:+3:5: +3:61
 -                                          // mir::Constant
 -                                          // + span: $DIR/intrinsic_asserts.rs:9:5: 9:59
@@ -37,7 +37,7 @@
       }
   
       bb3: {
-          StorageDead(_3);                 // scope 0 at $DIR/intrinsic_asserts.rs:+3:61: +3:62
+          nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+3:61: +3:62
           nop;                             // scope 0 at $DIR/intrinsic_asserts.rs:+0:20: +4:2
           return;                          // scope 0 at $DIR/intrinsic_asserts.rs:+4:2: +4:2
       }

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -42,7 +42,6 @@
       }
   
       bb1: {
-          StorageLive(_15);                // scope 1 at $SRC_DIR/core/src/panic.rs:LL:COL
           _15 = core::panicking::panic(const "internal error: entered unreachable code"); // scope 1 at $SRC_DIR/core/src/panic.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/panic.rs:LL:COL

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -66,7 +66,6 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb6: {
-        StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         _8 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/mir-opt/lower_intrinsics_e2e.f_u64.PreCodegen.after.mir
+++ b/tests/mir-opt/lower_intrinsics_e2e.f_u64.PreCodegen.after.mir
@@ -12,7 +12,6 @@ fn f_u64() -> () {
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics_e2e.rs:+1:5: +1:21
-        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics_e2e.rs:23:9: 23:21
         _2 = f_non_zst::<u64>(const 0_u64) -> bb1; // scope 1 at $DIR/lower_intrinsics_e2e.rs:23:9: 23:21
                                          // mir::Constant
                                          // + span: $DIR/lower_intrinsics_e2e.rs:23:9: 23:18
@@ -20,7 +19,6 @@ fn f_u64() -> () {
     }
 
     bb1: {
-        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics_e2e.rs:23:21: 23:22
         StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics_e2e.rs:+1:5: +1:21
         return;                          // scope 0 at $DIR/lower_intrinsics_e2e.rs:+2:2: +2:2
     }

--- a/tests/mir-opt/lower_intrinsics_e2e.f_unit.PreCodegen.after.mir
+++ b/tests/mir-opt/lower_intrinsics_e2e.f_unit.PreCodegen.after.mir
@@ -10,7 +10,6 @@ fn f_unit() -> () {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 1 at $DIR/lower_intrinsics_e2e.rs:21:9: 21:17
         _1 = f_zst::<()>(const ()) -> bb1; // scope 1 at $DIR/lower_intrinsics_e2e.rs:21:9: 21:17
                                          // mir::Constant
                                          // + span: $DIR/lower_intrinsics_e2e.rs:21:9: 21:14
@@ -18,7 +17,6 @@ fn f_unit() -> () {
     }
 
     bb1: {
-        StorageDead(_1);                 // scope 1 at $DIR/lower_intrinsics_e2e.rs:21:17: 21:18
         return;                          // scope 0 at $DIR/lower_intrinsics_e2e.rs:+2:2: +2:2
     }
 }

--- a/tests/mir-opt/lower_intrinsics_e2e.f_unit.PreCodegen.after.mir
+++ b/tests/mir-opt/lower_intrinsics_e2e.f_unit.PreCodegen.after.mir
@@ -2,26 +2,23 @@
 
 fn f_unit() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics_e2e.rs:+0:17: +0:17
-    let mut _1: ();                      // in scope 0 at $DIR/lower_intrinsics_e2e.rs:+1:16: +1:18
     scope 1 (inlined f_dispatch::<()>) { // at $DIR/lower_intrinsics_e2e.rs:9:5: 9:19
-        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics_e2e.rs:19:22: 19:23
-        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics_e2e.rs:21:9: 21:17
+        debug t => const ();             // in scope 1 at $DIR/lower_intrinsics_e2e.rs:19:22: 19:23
+        let _1: ();                      // in scope 1 at $DIR/lower_intrinsics_e2e.rs:21:9: 21:17
         scope 2 (inlined std::mem::size_of::<()>) { // at $DIR/lower_intrinsics_e2e.rs:20:8: 20:32
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics_e2e.rs:+1:16: +1:18
-        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics_e2e.rs:21:9: 21:17
-        _2 = f_zst::<()>(move _1) -> bb1; // scope 1 at $DIR/lower_intrinsics_e2e.rs:21:9: 21:17
+        StorageLive(_1);                 // scope 1 at $DIR/lower_intrinsics_e2e.rs:21:9: 21:17
+        _1 = f_zst::<()>(const ()) -> bb1; // scope 1 at $DIR/lower_intrinsics_e2e.rs:21:9: 21:17
                                          // mir::Constant
                                          // + span: $DIR/lower_intrinsics_e2e.rs:21:9: 21:14
                                          // + literal: Const { ty: fn(()) {f_zst::<()>}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics_e2e.rs:21:17: 21:18
-        StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics_e2e.rs:+1:18: +1:19
+        StorageDead(_1);                 // scope 1 at $DIR/lower_intrinsics_e2e.rs:21:17: 21:18
         return;                          // scope 0 at $DIR/lower_intrinsics_e2e.rs:+2:2: +2:2
     }
 }

--- a/tests/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
+++ b/tests/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
@@ -11,7 +11,7 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+          nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
           _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
           drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
@@ -23,7 +23,7 @@
   
       bb2: {
           StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:11: +1:12
-          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
+          nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
           nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+0:32: +2:2
           return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+2:2: +2:2
       }

--- a/tests/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
+++ b/tests/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
@@ -11,7 +11,7 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+          nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
           _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
           drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
@@ -23,7 +23,7 @@
   
       bb2: {
           StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:11: +1:12
-          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
+          nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
           nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+0:27: +2:2
           return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+2:2: +2:2
       }

--- a/tests/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
+++ b/tests/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
@@ -11,7 +11,7 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+-         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
           _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
 -         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
@@ -19,7 +19,7 @@
 - 
 -     bb1: {
           StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:11: +1:12
-          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
+-         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
 -         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+0:17: +2:2
           return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+2:2: +2:2
       }

--- a/tests/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
+++ b/tests/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
@@ -11,7 +11,7 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+-         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
           _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
 -         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
@@ -19,7 +19,7 @@
 - 
 -     bb1: {
           StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:11: +1:12
-          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
+-         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
 -         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+0:36: +2:2
           return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+2:2: +2:2
       }

--- a/tests/mir-opt/remove_zsts.get_union.PreCodegen.after.mir
+++ b/tests/mir-opt/remove_zsts.get_union.PreCodegen.after.mir
@@ -2,12 +2,9 @@
 
 fn get_union() -> Foo {
     let mut _0: Foo;                     // return place in scope 0 at $DIR/remove_zsts.rs:+0:19: +0:22
-    let mut _1: ();                      // in scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
-        _0 = Foo { x: move _1 };         // scope 0 at $DIR/remove_zsts.rs:+1:5: +1:18
-        StorageDead(_1);                 // scope 0 at $DIR/remove_zsts.rs:+1:17: +1:18
+        _0 = Foo { x: const () };        // scope 0 at $DIR/remove_zsts.rs:+1:5: +1:18
         return;                          // scope 0 at $DIR/remove_zsts.rs:+2:2: +2:2
     }
 }

--- a/tests/mir-opt/remove_zsts.get_union.RemoveZsts.diff
+++ b/tests/mir-opt/remove_zsts.get_union.RemoveZsts.diff
@@ -8,8 +8,9 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
 -         _1 = ();                         // scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
+-         _0 = Foo { x: move _1 };         // scope 0 at $DIR/remove_zsts.rs:+1:5: +1:18
 +         nop;                             // scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
-          _0 = Foo { x: move _1 };         // scope 0 at $DIR/remove_zsts.rs:+1:5: +1:18
++         _0 = Foo { x: const () };        // scope 0 at $DIR/remove_zsts.rs:+1:5: +1:18
           StorageDead(_1);                 // scope 0 at $DIR/remove_zsts.rs:+1:17: +1:18
           return;                          // scope 0 at $DIR/remove_zsts.rs:+2:2: +2:2
       }

--- a/tests/mir-opt/remove_zsts.get_union.RemoveZsts.diff
+++ b/tests/mir-opt/remove_zsts.get_union.RemoveZsts.diff
@@ -6,12 +6,14 @@
       let mut _1: ();                      // in scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
+-         StorageLive(_1);                 // scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
 -         _1 = ();                         // scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
 -         _0 = Foo { x: move _1 };         // scope 0 at $DIR/remove_zsts.rs:+1:5: +1:18
+-         StorageDead(_1);                 // scope 0 at $DIR/remove_zsts.rs:+1:17: +1:18
++         nop;                             // scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
 +         nop;                             // scope 0 at $DIR/remove_zsts.rs:+1:14: +1:16
 +         _0 = Foo { x: const () };        // scope 0 at $DIR/remove_zsts.rs:+1:5: +1:18
-          StorageDead(_1);                 // scope 0 at $DIR/remove_zsts.rs:+1:17: +1:18
++         nop;                             // scope 0 at $DIR/remove_zsts.rs:+1:17: +1:18
           return;                          // scope 0 at $DIR/remove_zsts.rs:+2:2: +2:2
       }
   }

--- a/tests/mir-opt/simple_option_map_e2e.ezmap.PreCodegen.after.mir
+++ b/tests/mir-opt/simple_option_map_e2e.ezmap.PreCodegen.after.mir
@@ -3,30 +3,28 @@
 fn ezmap(_1: Option<i32>) -> Option<i32> {
     debug x => _1;                       // in scope 0 at $DIR/simple_option_map_e2e.rs:+0:14: +0:15
     let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/simple_option_map_e2e.rs:+0:33: +0:44
-    let mut _2: [closure@$DIR/simple_option_map_e2e.rs:14:12: 14:15]; // in scope 0 at $DIR/simple_option_map_e2e.rs:+1:12: +1:21
     scope 1 (inlined map::<i32, i32, [closure@$DIR/simple_option_map_e2e.rs:14:12: 14:15]>) { // at $DIR/simple_option_map_e2e.rs:14:5: 14:22
         debug slf => _1;                 // in scope 1 at $DIR/simple_option_map_e2e.rs:2:17: 2:20
-        debug f => _2;                   // in scope 1 at $DIR/simple_option_map_e2e.rs:2:33: 2:34
-        let mut _3: isize;               // in scope 1 at $DIR/simple_option_map_e2e.rs:7:9: 7:16
-        let _4: i32;                     // in scope 1 at $DIR/simple_option_map_e2e.rs:7:14: 7:15
-        let mut _5: i32;                 // in scope 1 at $DIR/simple_option_map_e2e.rs:7:25: 7:29
+        debug f => const ZeroSized: [closure@$DIR/simple_option_map_e2e.rs:14:12: 14:15]; // in scope 1 at $DIR/simple_option_map_e2e.rs:2:33: 2:34
+        let mut _2: isize;               // in scope 1 at $DIR/simple_option_map_e2e.rs:7:9: 7:16
+        let _3: i32;                     // in scope 1 at $DIR/simple_option_map_e2e.rs:7:14: 7:15
+        let mut _4: i32;                 // in scope 1 at $DIR/simple_option_map_e2e.rs:7:25: 7:29
         scope 2 {
-            debug x => _4;               // in scope 2 at $DIR/simple_option_map_e2e.rs:7:14: 7:15
+            debug x => _3;               // in scope 2 at $DIR/simple_option_map_e2e.rs:7:14: 7:15
             scope 3 (inlined ezmap::{closure#0}) { // at $DIR/simple_option_map_e2e.rs:7:25: 7:29
-                debug n => _4;           // in scope 3 at $DIR/simple_option_map_e2e.rs:+1:13: +1:14
+                debug n => _3;           // in scope 3 at $DIR/simple_option_map_e2e.rs:+1:13: +1:14
             }
         }
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/simple_option_map_e2e.rs:+1:12: +1:21
-        _3 = discriminant(_1);           // scope 1 at $DIR/simple_option_map_e2e.rs:6:11: 6:14
-        switchInt(move _3) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 1 at $DIR/simple_option_map_e2e.rs:6:5: 6:14
+        _2 = discriminant(_1);           // scope 1 at $DIR/simple_option_map_e2e.rs:6:11: 6:14
+        switchInt(move _2) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 1 at $DIR/simple_option_map_e2e.rs:6:5: 6:14
     }
 
     bb1: {
         _0 = Option::<i32>::None;        // scope 1 at $DIR/simple_option_map_e2e.rs:8:17: 8:21
-        goto -> bb4;                     // scope 1 at $DIR/simple_option_map_e2e.rs:8:17: 8:21
+        return;                          // scope 1 at $DIR/simple_option_map_e2e.rs:8:17: 8:21
     }
 
     bb2: {
@@ -34,16 +32,11 @@ fn ezmap(_1: Option<i32>) -> Option<i32> {
     }
 
     bb3: {
-        _4 = ((_1 as Some).0: i32);      // scope 1 at $DIR/simple_option_map_e2e.rs:7:14: 7:15
-        StorageLive(_5);                 // scope 2 at $DIR/simple_option_map_e2e.rs:7:25: 7:29
-        _5 = Add(_4, const 1_i32);       // scope 3 at $DIR/simple_option_map_e2e.rs:+1:16: +1:21
-        _0 = Option::<i32>::Some(move _5); // scope 2 at $DIR/simple_option_map_e2e.rs:7:20: 7:30
-        StorageDead(_5);                 // scope 2 at $DIR/simple_option_map_e2e.rs:7:29: 7:30
-        goto -> bb4;                     // scope 1 at $DIR/simple_option_map_e2e.rs:10:1: 10:2
-    }
-
-    bb4: {
-        StorageDead(_2);                 // scope 0 at $DIR/simple_option_map_e2e.rs:+1:21: +1:22
-        return;                          // scope 0 at $DIR/simple_option_map_e2e.rs:+2:2: +2:2
+        _3 = ((_1 as Some).0: i32);      // scope 1 at $DIR/simple_option_map_e2e.rs:7:14: 7:15
+        StorageLive(_4);                 // scope 2 at $DIR/simple_option_map_e2e.rs:7:25: 7:29
+        _4 = Add(_3, const 1_i32);       // scope 3 at $DIR/simple_option_map_e2e.rs:+1:16: +1:21
+        _0 = Option::<i32>::Some(move _4); // scope 2 at $DIR/simple_option_map_e2e.rs:7:20: 7:30
+        StorageDead(_4);                 // scope 2 at $DIR/simple_option_map_e2e.rs:7:29: 7:30
+        return;                          // scope 1 at $DIR/simple_option_map_e2e.rs:10:1: 10:2
     }
 }

--- a/tests/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.diff
+++ b/tests/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.diff
@@ -14,7 +14,6 @@
       }
   
       bb1: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify_if.rs:+2:9: +2:15
           _2 = noop() -> bb2;              // scope 0 at $DIR/simplify_if.rs:+2:9: +2:15
                                            // mir::Constant
                                            // + span: $DIR/simplify_if.rs:7:9: 7:13
@@ -22,7 +21,6 @@
       }
   
       bb2: {
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_if.rs:+2:15: +2:16
           goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:+1:5: +3:6
       }
   


### PR DESCRIPTION
This is work that ConstProp will not have to do.
Split from https://github.com/rust-lang/rust/pull/107267