### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
  "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
- "clap 4.1.1",
+ "clap 4.1.3",
  "crates-io",
  "curl",
  "curl-sys",
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.1"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
+checksum = "d8d93d855ce6a0aa87b8473ef9169482f40abaa2e9e0993024c35c902cbd5920"
 dependencies = [
  "bitflags",
  "clap_derive 4.1.0",
@@ -675,7 +675,7 @@ version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10861370d2ba66b0f5989f83ebf35db6421713fd92351790e7fdd6c36774c56b"
 dependencies = [
- "clap 4.1.1",
+ "clap 4.1.3",
 ]
 
 [[package]]
@@ -1799,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.16.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+checksum = "be36bc9e0546df253c0cc41fd0af34f5e92845ad8509462ec76672fac6997f5b"
 dependencies = [
  "bitflags",
  "libc",
@@ -2294,7 +2294,7 @@ name = "jsondoclint"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.1.1",
+ "clap 4.1.3",
  "fs-err",
  "rustdoc-json-types",
  "serde",
@@ -2365,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.14.1+1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "4a07fb2692bc3593bda59de45a502bb3071659f2c515e28c71e728306b038e17"
 dependencies = [
  "cc",
  "libc",
@@ -2557,7 +2557,7 @@ dependencies = [
  "ammonia",
  "anyhow",
  "chrono",
- "clap 4.1.1",
+ "clap 4.1.3",
  "clap_complete",
  "elasticlunr-rs",
  "env_logger 0.10.0",
@@ -3528,7 +3528,7 @@ dependencies = [
 name = "rustbook"
 version = "0.1.0"
 dependencies = [
- "clap 4.1.1",
+ "clap 4.1.3",
  "env_logger 0.7.1",
  "mdbook",
 ]


### PR DESCRIPTION
11 commits in 985d561f0bb9b76ec043a2b12511790ec7a2b954..3c5af6bed9a1a243a693e8e22ee2486bd5b82a6c 2023-01-20 14:39:28 +0000 to 2023-01-24 15:48:15 +0000

- Add a note about verifying your email address on crates.io (rust-lang/cargo#11620)
- Improve CI caching by skipping mtime checks for paths in $CARGO_HOME (rust-lang/cargo#11613)
- test: Update for clap 4.1.3 (rust-lang/cargo#11619)
- Fix unused attribute on Windows. (rust-lang/cargo#11614)
- [Doc]: Added links to the `Target` section of the glossary for occurences of `target triple` (rust-lang/cargo#11603)
- feat: stabilize auto fix note (rust-lang/cargo#11558)
- Clarify the difference between CARGO_CRATE_NAME and CARGO_PKG_NAME (rust-lang/cargo#11576)
- Temporarily pin libgit2-sys. (rust-lang/cargo#11609)
- Disable network SSH tests on windows. (rust-lang/cargo#11610)
- fix(toml): Add `default-features` to `TomlWorkspaceDependency` (rust-lang/cargo#11409)
- doc(contrib): remove rls in release process (rust-lang/cargo#11601)

r? @ghost