### PR TITLE
Implement pattern types as the backing logic of rustc_scalar_valid_range attributes

### DIFF
--- a/compiler/rustc_ast/src/lib.rs
+++ b/compiler/rustc_ast/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(negative_impls)]
 #![feature(slice_internals)]
 #![feature(stmt_expr_attributes)]
+#![feature(structural_match)]
 #![recursion_limit = "256"]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -2103,6 +2103,11 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     ProjectionElem::Deref => {
                         let base_ty = place_base.ty(self.body(), self.infcx.tcx).ty;
 
+                        let base_ty = match *base_ty.kind() {
+                            ty::Pat(inner, _) => inner,
+                            _ => base_ty,
+                        };
+
                         // Check the kind of deref to decide
                         match base_ty.kind() {
                             ty::Ref(_, _, mutbl) => {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(once_cell)]
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]
+#![feature(structural_match)]
 #![feature(trusted_step)]
 #![feature(try_blocks)]
 #![recursion_limit = "256"]

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -742,9 +742,17 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
             ProjectionElem::OpaqueCast(ty) => {
                 let ty = self.sanitize_type(place, ty);
                 let ty = self.cx.normalize(ty, location);
+                let compare_ty = match *base.ty.kind() {
+                    ty::Alias(ty::Opaque, _) => base.ty,
+                    ty::Pat(inner, _) => inner,
+                    _ => {
+                        span_mirbug!(self, place, "tried to cast {} to {ty}", base.ty);
+                        base.ty
+                    }
+                };
                 self.cx
                     .eq_types(
-                        base.ty,
+                        compare_ty,
                         ty,
                         location.to_locations(),
                         ConstraintCategory::TypeAnnotation,

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -610,17 +610,13 @@ fn codegen_stmt<'tcx>(
                     }
                 }
                 Rvalue::Cast(
-                    CastKind::Pointer(PointerCast::UnsafeFnPointer),
-                    ref operand,
-                    to_ty,
-                )
-                | Rvalue::Cast(
-                    CastKind::Pointer(PointerCast::MutToConstPointer),
-                    ref operand,
-                    to_ty,
-                )
-                | Rvalue::Cast(
-                    CastKind::Pointer(PointerCast::ArrayToPointer),
+                    CastKind::StripPattern
+                    | CastKind::Patternize
+                    | CastKind::Pointer(
+                        PointerCast::UnsafeFnPointer
+                        | PointerCast::MutToConstPointer
+                        | PointerCast::ArrayToPointer,
+                    ),
                     ref operand,
                     to_ty,
                 ) => {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -462,6 +462,7 @@ pub fn type_di_node<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>, t: Ty<'tcx>) -> &'ll D
         ty::Tuple(_) => build_tuple_type_di_node(cx, unique_type_id),
         // Type parameters from polymorphized functions.
         ty::Param(_) => build_param_type_di_node(cx, t),
+        ty::Pat(inner, _) => return type_di_node(cx, inner),
         _ => bug!("debuginfo: unexpected type in type_di_node(): {:?}", t),
     };
 

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -256,6 +256,9 @@ pub fn unsize_ptr<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             // HACK(eddyb) have to bitcast pointers until LLVM removes pointee types.
             (bx.bitcast(lldata, lldata_ty), bx.bitcast(llextra, llextra_ty))
         }
+        (&ty::Pat(a, a_pat), &ty::Pat(b, b_pat)) if a_pat == b_pat => {
+            unsize_ptr(bx, src, a, b, old_info)
+        }
         _ => bug!("unsize_ptr: called on bad types"),
     }
 }

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -194,6 +194,15 @@ fn push_debuginfo_type_name<'tcx>(
                 }
             }
         }
+        ty::Pat(inner_type, pat) => {
+            if cpp_like_debuginfo {
+                output.push_str("pat$<");
+                push_debuginfo_type_name(tcx, inner_type, true, output, visited);
+                write!(output, ",{:?}>", pat).unwrap();
+            } else {
+                write!(output, "{:?}", t).unwrap();
+            }
+        }
         ty::Slice(inner_type) => {
             if cpp_like_debuginfo {
                 output.push_str("slice2$<");

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -219,7 +219,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             _ => bug!("{} cannot be cast to a fn ptr", operand.layout.ty),
                         }
                     }
-                    mir::CastKind::Pointer(PointerCast::UnsafeFnPointer) => {
+                    mir::CastKind::Patternize
+                    | mir::CastKind::StripPattern
+                    | mir::CastKind::Pointer(PointerCast::UnsafeFnPointer) => {
                         // This is a no-op at the LLVM level.
                         operand.val
                     }

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -83,6 +83,9 @@ pub(crate) fn eval_nullary_intrinsic<'tcx>(
             ty::Alias(..) | ty::Param(_) | ty::Placeholder(_) | ty::Infer(_) => {
                 throw_inval!(TooGeneric)
             }
+            ty::Pat(..) => {
+                unimplemented!("pattern types need to calculate pattern from their pattern")
+            }
             ty::Bound(_, _) => bug!("bound ty during ctfe"),
             ty::Bool
             | ty::Char

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -584,6 +584,7 @@ impl<'rt, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, '
                 // Nothing to check.
                 Ok(true)
             }
+            ty::Pat(..) => unimplemented!(),
             // The above should be all the primitive types. The rest is compound, we
             // check them by visiting their fields/variants.
             ty::Adt(..)

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -627,6 +627,32 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             );
                         }
                     }
+                    CastKind::StripPattern => {
+                        if let ty::Pat(ty, _) = op_ty.kind() {
+                            if ty != target_type {
+                                self.fail(location, format!("Trying to convert types from {ty} to {target_type} while stripping pattern"));
+                            }
+                        } else {
+                            self.fail(
+                                location,
+                                format!("{op_ty} is not a pattern type during pattern stripping"),
+                            );
+                        }
+                    }
+                    CastKind::Patternize => {
+                        if let ty::Pat(ty, _) = *target_type.kind() {
+                            if ty != op_ty {
+                                self.fail(location, format!("Trying to convert types from {ty} to {target_type} while patternizing"));
+                            }
+                        } else {
+                            self.fail(
+                                location,
+                                format!(
+                                    "{target_type} is not a pattern type during patternization"
+                                ),
+                            );
+                        }
+                    }
                 }
             }
             Rvalue::Repeat(_, _)

--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -40,6 +40,7 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
             | ty::Uint(_)
             | ty::Float(_)
             | ty::Str
+            | ty::Pat(_, _)
             | ty::Array(_, _)
             | ty::Slice(_)
             | ty::RawPtr(_)

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -17,6 +17,7 @@
 #![feature(maybe_uninit_uninit_array)]
 #![feature(min_specialization)]
 #![feature(never_type)]
+#![feature(structural_match)]
 #![feature(type_alias_impl_trait)]
 #![feature(new_uninit)]
 #![feature(once_cell)]

--- a/compiler/rustc_error_messages/locales/en-US/lint.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/lint.ftl
@@ -237,6 +237,9 @@ lint_improper_ctypes_128bit = 128-bit integers don't currently have a known stab
 lint_improper_ctypes_char_reason = the `char` type has no C equivalent
 lint_improper_ctypes_char_help = consider using `u32` or `libc::wchar_t` instead
 
+lint_improper_ctypes_pat_reason = pattern types have no C equivalent
+lint_improper_ctypes_pat_help = consider using the patterned type instead
+
 lint_improper_ctypes_non_exhaustive = this enum is non-exhaustive
 lint_improper_ctypes_non_exhaustive_variant = this enum has non-exhaustive variants
 

--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(rustc_attrs)]
+#![feature(structural_match)]
 #![feature(variant_count)]
 #![recursion_limit = "256"]
 #![deny(rustc::untranslatable_diagnostic)]

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -358,8 +358,6 @@ fn visit_implementation_of_dispatch_from_dyn(tcx: TyCtxt<'_>, impl_did: LocalDef
 }
 
 pub fn coerce_unsized_info<'tcx>(tcx: TyCtxt<'tcx>, impl_did: DefId) -> CoerceUnsizedInfo {
-    debug!("compute_coerce_unsized_info(impl_did={:?})", impl_did);
-
     // this provider should only get invoked for local def-ids
     let impl_did = impl_did.expect_local();
     let span = tcx.def_span(impl_did);

--- a/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
@@ -208,6 +208,9 @@ impl<'tcx> InherentCollect<'tcx> {
                 .note("define and implement a new trait or type instead")
                 .emit();
             }
+            ty::Pat(..) => {
+                self.tcx.sess.span_err(ty.span, "cannot define inherent `impl` for pattern types");
+            }
             ty::Bool
             | ty::Char
             | ty::Int(_)

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -69,6 +69,7 @@ This API is completely unstable and subject to change.
 #![feature(never_type)]
 #![feature(once_cell)]
 #![feature(slice_partition_dedup)]
+#![feature(structural_match)]
 #![feature(try_blocks)]
 #![feature(is_some_and)]
 #![feature(type_alias_impl_trait)]

--- a/compiler/rustc_hir_analysis/src/variance/constraints.rs
+++ b/compiler/rustc_hir_analysis/src/variance/constraints.rs
@@ -233,9 +233,13 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
 
             ty::Pat(typ, pat) => {
                 match *pat {
-                    ty::PatternKind::Range { start, end } => {
-                        self.add_constraints_from_const(current, start, variance);
-                        self.add_constraints_from_const(current, end, variance);
+                    ty::PatternKind::Range { start, end, include_end: _ } => {
+                        if let Some(start) = start {
+                            self.add_constraints_from_const(current, start, variance);
+                        }
+                        if let Some(end) = end {
+                            self.add_constraints_from_const(current, end, variance);
+                        }
                     }
                 }
                 self.add_constraints_from_ty(current, typ, variance);

--- a/compiler/rustc_hir_analysis/src/variance/constraints.rs
+++ b/compiler/rustc_hir_analysis/src/variance/constraints.rs
@@ -231,6 +231,16 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 self.add_constraints_from_ty(current, typ, variance);
             }
 
+            ty::Pat(typ, pat) => {
+                match *pat {
+                    ty::PatternKind::Range { start, end } => {
+                        self.add_constraints_from_const(current, start, variance);
+                        self.add_constraints_from_const(current, end, variance);
+                    }
+                }
+                self.add_constraints_from_ty(current, typ, variance);
+            }
+
             ty::Slice(typ) => {
                 self.add_constraints_from_ty(current, typ, variance);
             }

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -132,6 +132,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             | ty::GeneratorWitness(..)
             | ty::RawPtr(_)
             | ty::Ref(..)
+            | ty::Pat(..)
             | ty::FnDef(..)
             | ty::FnPtr(..)
             | ty::Closure(..)

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -277,10 +277,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if let Some((sp, msg, suggestion, applicability, verbose, annotation)) =
             self.check_ref(expr, found, expected)
         {
-            if verbose {
-                err.span_suggestion_verbose(sp, &msg, suggestion, applicability);
-            } else {
-                err.span_suggestion(sp, &msg, suggestion, applicability);
+            if !sp.is_empty() || !suggestion.is_empty() {
+                if verbose {
+                    err.span_suggestion_verbose(sp, &msg, suggestion, applicability);
+                } else {
+                    err.span_suggestion(sp, &msg, suggestion, applicability);
+                }
             }
             if annotation {
                 let suggest_annotation = match expr.peel_drop_temps().kind {

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(min_specialization)]
 #![feature(control_flow_enum)]
 #![feature(drain_filter)]
+#![feature(structural_match)]
 #![allow(rustc::potential_query_instability)]
 #![recursion_limit = "256"]
 

--- a/compiler/rustc_index/src/lib.rs
+++ b/compiler/rustc_index/src/lib.rs
@@ -9,6 +9,7 @@
         new_uninit,
         step_trait,
         stmt_expr_attributes,
+        structural_match,
         test
     )
 )]

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -454,6 +454,7 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for Canonicalizer<'cx, 'tcx> {
             | ty::Tuple(..)
             | ty::Alias(..)
             | ty::Foreign(..)
+            | ty::Pat(..)
             | ty::Param(..) => {
                 if t.flags().intersects(self.needs_canonical_flags) {
                     t.super_fold_with(self)

--- a/compiler/rustc_infer/src/infer/freshen.rs
+++ b/compiler/rustc_infer/src/infer/freshen.rs
@@ -201,6 +201,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
             | ty::RawPtr(..)
             | ty::Ref(..)
             | ty::FnDef(..)
+            | ty::Pat(..)
             | ty::FnPtr(_)
             | ty::Dynamic(..)
             | ty::Never

--- a/compiler/rustc_infer/src/infer/outlives/components.rs
+++ b/compiler/rustc_infer/src/infer/outlives/components.rs
@@ -92,6 +92,7 @@ fn compute_components<'tcx>(
                 }
             }
 
+            ty::Pat(element, _) |
             ty::Array(element, _) => {
                 // Don't look into the len const as it doesn't affect regions
                 compute_components(tcx, element, out, visited);

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -20,6 +20,7 @@
 #![feature(if_let_guard)]
 #![feature(min_specialization)]
 #![feature(never_type)]
+#![feature(structural_match)]
 #![feature(try_blocks)]
 #![recursion_limit = "512"] // For rustdoc
 

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -37,6 +37,7 @@
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(rustc_attrs)]
+#![feature(structural_match)]
 #![recursion_limit = "256"]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -999,6 +999,12 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 help: Some(fluent::lint_improper_ctypes_char_help),
             },
 
+            ty::Pat(..) => FfiUnsafe {
+                ty,
+                reason: fluent::lint_improper_ctypes_pat_reason,
+                help: Some(fluent::lint_improper_ctypes_pat_help),
+            },
+
             ty::Int(ty::IntTy::I128) | ty::Uint(ty::UintTy::U128) => {
                 FfiUnsafe { ty, reason: fluent::lint_improper_ctypes_128bit, help: None }
             }

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -99,6 +99,7 @@ macro_rules! arena_types {
             [] tys: rustc_type_ir::WithCachedTypeInfo<rustc_middle::ty::TyKind<'tcx>>,
             [] predicates: rustc_type_ir::WithCachedTypeInfo<rustc_middle::ty::PredicateKind<'tcx>>,
             [] consts: rustc_middle::ty::ConstData<'tcx>,
+            [] pats: rustc_middle::ty::PatternKind<'tcx>,
 
             // Note that this deliberately duplicates items in the `rustc_hir::arena`,
             // since we need to allocate this type on both the `rustc_hir` arena

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -45,6 +45,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(associated_type_bounds)]
 #![feature(rustc_attrs)]
+#![feature(structural_match)]
 #![feature(control_flow_enum)]
 #![feature(associated_type_defaults)]
 #![feature(trusted_step)]

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -75,20 +75,20 @@ pub use self::pretty::{
 pub type LocalDecls<'tcx> = IndexVec<Local, LocalDecl<'tcx>>;
 
 pub trait HasLocalDecls<'tcx> {
-    fn local_decls(&self) -> &LocalDecls<'tcx>;
+    fn local_decl(&self, local: Local) -> &LocalDecl<'tcx>;
 }
 
 impl<'tcx> HasLocalDecls<'tcx> for LocalDecls<'tcx> {
     #[inline]
-    fn local_decls(&self) -> &LocalDecls<'tcx> {
-        self
+    fn local_decl(&self, local: Local) -> &LocalDecl<'tcx> {
+        &self[local]
     }
 }
 
 impl<'tcx> HasLocalDecls<'tcx> for Body<'tcx> {
     #[inline]
-    fn local_decls(&self) -> &LocalDecls<'tcx> {
-        &self.local_decls
+    fn local_decl(&self, local: Local) -> &LocalDecl<'tcx> {
+        &self.local_decls[local]
     }
 }
 

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1954,6 +1954,8 @@ impl<'tcx> Rvalue<'tcx> {
                 | CastKind::PtrToPtr
                 | CastKind::Pointer(_)
                 | CastKind::PointerFromExposedAddress
+                | CastKind::StripPattern
+                | CastKind::Patternize
                 | CastKind::DynStar,
                 _,
                 _,

--- a/compiler/rustc_middle/src/mir/patch.rs
+++ b/compiler/rustc_middle/src/mir/patch.rs
@@ -17,6 +17,12 @@ pub struct MirPatch<'tcx> {
 }
 
 impl<'tcx> MirPatch<'tcx> {
+    pub fn local_decl<'a>(&'a self, body: &'a Body<'tcx>, local: Local) -> &'a LocalDecl<'tcx> {
+        body.local_decls
+            .get(local)
+            .unwrap_or_else(|| &self.new_locals[local.as_usize() - body.local_decls.len()])
+    }
+
     pub fn new(body: &Body<'tcx>) -> Self {
         let mut result = MirPatch {
             patch_map: IndexVec::from_elem(None, &body.basic_blocks),

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -1181,6 +1181,10 @@ pub enum CastKind {
     IntToFloat,
     PtrToPtr,
     FnPtrToPtr,
+    /// A cast from a `T is 1..10` type to `T`.
+    StripPattern,
+    /// An unsafe cast from `T` to `T is 1..10`.
+    Patternize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, Hash, HashStable)]

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -959,8 +959,10 @@ pub enum ProjectionElem<V, T> {
     /// The included Symbol is the name of the variant, used for printing MIR.
     Downcast(Option<Symbol>, VariantIdx),
 
-    /// Like an explicit cast from an opaque type to a concrete type, but without
-    /// requiring an intermediate variable.
+    /// Like an explicit cast, but without requiring an intermediate variable.
+    /// Can cast the following things:
+    /// * from an opaque type to a concrete type
+    /// * from a pattern type to its inner type
     OpaqueCast(T),
 }
 

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -127,7 +127,7 @@ impl<'tcx> Place<'tcx> {
     {
         projection
             .iter()
-            .fold(PlaceTy::from_ty(local_decls.local_decls()[local].ty), |place_ty, &elem| {
+            .fold(PlaceTy::from_ty(local_decls.local_decl(local).ty), |place_ty, &elem| {
                 place_ty.projection_ty(tcx, elem)
             })
     }

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -660,6 +660,11 @@ pub enum PatKind<'tcx> {
         value: mir::ConstantKind<'tcx>,
     },
 
+    /// A refinement type like `u32 is 1..100`
+    PatTy {
+        value: Box<Pat<'tcx>>,
+    },
+
     Range(Box<PatRange<'tcx>>),
 
     /// Matches against a slice, checking the length and extracting elements.
@@ -814,6 +819,7 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
                 }
                 write!(f, "{}", subpattern)
             }
+            PatKind::PatTy { ref value } => write!(f, "{value}"),
             PatKind::Constant { value } => write!(f, "{}", value),
             PatKind::Range(box PatRange { lo, hi, end }) => {
                 write!(f, "{}", lo)?;

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -230,6 +230,7 @@ pub fn walk_pat<'a, 'tcx: 'a, V: Visitor<'a, 'tcx>>(visitor: &mut V, pat: &Pat<'
             }
         }
         Constant { value: _ } => {}
+        PatTy { value } => visitor.visit_pat(value),
         Range(_) => {}
         Slice { prefix, slice, suffix } | Array { prefix, slice, suffix } => {
             for subpattern in prefix.iter() {

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -139,6 +139,12 @@ impl<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>> Encodable<E> for ty::Const<'tcx> {
     }
 }
 
+impl<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>> Encodable<E> for ty::Pattern<'tcx> {
+    fn encode(&self, e: &mut E) {
+        self.0.0.encode(e);
+    }
+}
+
 impl<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>> Encodable<E> for ConstAllocation<'tcx> {
     fn encode(&self, e: &mut E) {
         self.inner().encode(e)
@@ -312,6 +318,12 @@ impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> Decodable<D> for ty::Const<'tcx> {
     fn decode(decoder: &mut D) -> Self {
         let consts: ty::ConstData<'tcx> = Decodable::decode(decoder);
         decoder.interner().mk_const(consts.kind, consts.ty)
+    }
+}
+
+impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> Decodable<D> for ty::Pattern<'tcx> {
+    fn decode(decoder: &mut D) -> Self {
+        decoder.interner().mk_pat(Decodable::decode(decoder))
     }
 }
 

--- a/compiler/rustc_middle/src/ty/consts/kind.rs
+++ b/compiler/rustc_middle/src/ty/consts/kind.rs
@@ -95,6 +95,12 @@ pub enum Expr<'tcx> {
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 static_assert_size!(Expr<'_>, 24);
 
+impl<'tcx> From<ty::ScalarInt> for ConstKind<'tcx> {
+    fn from(v: ty::ScalarInt) -> Self {
+        Self::Value(v.into())
+    }
+}
+
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 static_assert_size!(ConstKind<'_>, 32);
 

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -35,6 +35,12 @@ pub enum ValTree<'tcx> {
     Branch(&'tcx [ValTree<'tcx>]),
 }
 
+impl<'tcx> From<ScalarInt> for ValTree<'tcx> {
+    fn from(v: ScalarInt) -> Self {
+        Self::Leaf(v)
+    }
+}
+
 impl<'tcx> ValTree<'tcx> {
     pub fn zst() -> Self {
         Self::Branch(&[])

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -19,9 +19,9 @@ use crate::ty::query::{self, TyCtxtAt};
 use crate::ty::{
     self, AdtDef, AdtDefData, AdtKind, Binder, Const, ConstData, DefIdTree, FloatTy, FloatVar,
     FloatVid, GenericParamDefKind, ImplPolarity, InferTy, IntTy, IntVar, IntVid, List, ParamConst,
-    ParamTy, PolyExistentialPredicate, PolyFnSig, Predicate, PredicateKind, Region, RegionKind,
-    ReprOptions, TraitObjectVisitor, Ty, TyKind, TyVar, TyVid, TypeAndMut, TypeckResults, UintTy,
-    Visibility,
+    ParamTy, Pattern, PatternKind, PolyExistentialPredicate, PolyFnSig, Predicate, PredicateKind,
+    Region, RegionKind, ReprOptions, TraitObjectVisitor, Ty, TyKind, TyVar, TyVid, TypeAndMut,
+    TypeckResults, UintTy, Visibility,
 };
 use crate::ty::{GenericArg, InternalSubsts, SubstsRef};
 use rustc_ast as ast;
@@ -96,6 +96,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     type SubstsRef = ty::SubstsRef<'tcx>;
     type DefId = DefId;
     type Ty = Ty<'tcx>;
+    type Pat = Pattern<'tcx>;
     type Const = ty::Const<'tcx>;
     type Region = Region<'tcx>;
     type TypeAndMut = TypeAndMut<'tcx>;
@@ -140,6 +141,7 @@ pub struct CtxtInterners<'tcx> {
     projs: InternedSet<'tcx, List<ProjectionKind>>,
     place_elems: InternedSet<'tcx, List<PlaceElem<'tcx>>>,
     const_: InternedSet<'tcx, ConstData<'tcx>>,
+    pat: InternedSet<'tcx, PatternKind<'tcx>>,
     const_allocation: InternedSet<'tcx, Allocation>,
     bound_variable_kinds: InternedSet<'tcx, List<ty::BoundVariableKind>>,
     layout: InternedSet<'tcx, LayoutS<VariantIdx>>,
@@ -161,6 +163,7 @@ impl<'tcx> CtxtInterners<'tcx> {
             projs: Default::default(),
             place_elems: Default::default(),
             const_: Default::default(),
+            pat: Default::default(),
             const_allocation: Default::default(),
             bound_variable_kinds: Default::default(),
             layout: Default::default(),
@@ -1196,6 +1199,7 @@ macro_rules! nop_list_lift {
 nop_lift! {type_; Ty<'a> => Ty<'tcx>}
 nop_lift! {region; Region<'a> => Region<'tcx>}
 nop_lift! {const_; Const<'a> => Const<'tcx>}
+nop_lift! {pat; Pattern<'a> => Pattern<'tcx>}
 nop_lift! {const_allocation; ConstAllocation<'a> => ConstAllocation<'tcx>}
 nop_lift! {predicate; Predicate<'a> => Predicate<'tcx>}
 
@@ -1483,6 +1487,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     Param,
                     Infer,
                     Alias,
+                    Pat,
                     Foreign
                 )?;
 
@@ -1609,6 +1614,7 @@ macro_rules! direct_interners {
 direct_interners! {
     region: mk_region(RegionKind<'tcx>): Region -> Region<'tcx>,
     const_: mk_const_internal(ConstData<'tcx>): Const -> Const<'tcx>,
+    pat: mk_pat(PatternKind<'tcx>): Pattern -> Pattern<'tcx>,
     const_allocation: intern_const_alloc(Allocation): ConstAllocation -> ConstAllocation<'tcx>,
     layout: intern_layout(LayoutS<VariantIdx>): Layout -> Layout<'tcx>,
     adt_def: intern_adt_def(AdtDefData): AdtDef -> AdtDef<'tcx>,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1865,6 +1865,11 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     #[inline]
+    pub fn mk_pat_ty(self, ty: Ty<'tcx>, pat: Pattern<'tcx>) -> Ty<'tcx> {
+        self.mk_ty(Pat(ty, pat))
+    }
+
+    #[inline]
     pub fn mk_imm_ref(self, r: Region<'tcx>, ty: Ty<'tcx>) -> Ty<'tcx> {
         self.mk_ref(r, TypeAndMut { ty, mutbl: hir::Mutability::Not })
     }

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -287,6 +287,8 @@ impl<'tcx> Ty<'tcx> {
                 }
                 "array".into()
             }
+            ty::Pat(ty, _) if ty.is_simple_ty() => format!("pattern `{}`", self).into(),
+            ty::Pat(..) => "pattern".into(),
             ty::Slice(ty) if ty.is_simple_ty() => format!("slice `{}`", self).into(),
             ty::Slice(_) => "slice".into(),
             ty::RawPtr(tymut) => {
@@ -363,6 +365,7 @@ impl<'tcx> Ty<'tcx> {
             ty::Adt(def, _) => def.descr().into(),
             ty::Foreign(_) => "extern type".into(),
             ty::Array(..) => "array".into(),
+            ty::Pat(..) => "pattern type".into(),
             ty::Slice(_) => "slice".into(),
             ty::RawPtr(_) => "raw pointer".into(),
             ty::Ref(.., mutbl) => match mutbl {

--- a/compiler/rustc_middle/src/ty/fast_reject.rs
+++ b/compiler/rustc_middle/src/ty/fast_reject.rs
@@ -21,6 +21,7 @@ pub enum SimplifiedType {
     StrSimplifiedType,
     ArraySimplifiedType,
     SliceSimplifiedType,
+    PatSimplifiedType,
     RefSimplifiedType(Mutability),
     PtrSimplifiedType(Mutability),
     NeverSimplifiedType,
@@ -97,6 +98,7 @@ pub fn simplify_type<'tcx>(
         ty::Str => Some(StrSimplifiedType),
         ty::Array(..) => Some(ArraySimplifiedType),
         ty::Slice(..) => Some(SliceSimplifiedType),
+        ty::Pat(..) => Some(PatSimplifiedType),
         ty::RawPtr(ptr) => Some(PtrSimplifiedType(ptr.mutbl)),
         ty::Dynamic(trait_info, ..) => match trait_info.principal_def_id() {
             Some(principal_def_id) if !tcx.trait_is_auto(principal_def_id) => {
@@ -199,6 +201,7 @@ impl DeepRejectCtxt {
             | ty::Slice(..)
             | ty::RawPtr(..)
             | ty::Dynamic(..)
+            | ty::Pat(..)
             | ty::Ref(..)
             | ty::Never
             | ty::Tuple(..)
@@ -238,6 +241,9 @@ impl DeepRejectCtxt {
                 }
                 _ => false,
             },
+            ty::Pat(obl_ty, _) => {
+                matches!(k, &ty::Pat(impl_ty, _) if self.types_may_unify(obl_ty, impl_ty))
+            }
             ty::Slice(obl_ty) => {
                 matches!(k, &ty::Slice(impl_ty) if self.types_may_unify(obl_ty, impl_ty))
             }

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -195,6 +195,20 @@ impl FlagComputation {
                 self.add_const(len);
             }
 
+            &ty::Pat(ty, pat) => {
+                self.add_ty(ty);
+                match *pat {
+                    ty::PatternKind::Range { start, end, include_end: _ } => {
+                        if let Some(start) = start {
+                            self.add_const(start)
+                        }
+                        if let Some(end) = end {
+                            self.add_const(end)
+                        }
+                    }
+                }
+            }
+
             &ty::Slice(tt) => self.add_ty(tt),
 
             ty::RawPtr(m) => {

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -646,6 +646,7 @@ where
                 | ty::FnDef(..)
                 | ty::GeneratorWitness(..)
                 | ty::Foreign(..)
+                | ty::Pat(_, _)
                 | ty::Dynamic(_, _, ty::Dyn) => {
                     bug!("TyAndLayout::field({:?}): not applicable", this)
                 }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -88,6 +88,7 @@ pub use self::context::{
 pub use self::instance::{Instance, InstanceDef, ShortInstance, UnusedGenericParams};
 pub use self::list::List;
 pub use self::parameterized::ParameterizedOverTcx;
+pub use self::pattern::{Pattern, PatternKind};
 pub use self::rvalue_scopes::RvalueScopes;
 pub use self::sty::BoundRegionKind::*;
 pub use self::sty::{
@@ -119,6 +120,7 @@ pub mod fold;
 pub mod inhabitedness;
 pub mod layout;
 pub mod normalize_erasing_regions;
+pub mod pattern;
 pub mod print;
 pub mod query;
 pub mod relate;

--- a/compiler/rustc_middle/src/ty/pattern.rs
+++ b/compiler/rustc_middle/src/ty/pattern.rs
@@ -1,0 +1,48 @@
+use std::fmt;
+
+use crate::ty;
+use rustc_data_structures::intern::Interned;
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable)]
+#[rustc_pass_by_value]
+pub struct Pattern<'tcx>(pub Interned<'tcx, PatternKind<'tcx>>);
+
+impl<'tcx> std::ops::Deref for Pattern<'tcx> {
+    type Target = PatternKind<'tcx>;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+impl<'tcx> fmt::Debug for Pattern<'tcx> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", **self)
+    }
+}
+
+impl<'tcx> fmt::Debug for PatternKind<'tcx> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            PatternKind::Range { start, end, include_end } => {
+                if let Some(start) = start {
+                    write!(f, "{start}")?;
+                }
+                write!(f, "..")?;
+                if include_end {
+                    write!(f, "=")?;
+                }
+                if let Some(end) = end {
+                    write!(f, "{end}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(HashStable, TyEncodable, TyDecodable, TypeVisitable, TypeFoldable)]
+pub enum PatternKind<'tcx> {
+    Range { start: ty::Const<'tcx>, end: ty::Const<'tcx> },
+}

--- a/compiler/rustc_middle/src/ty/pattern.rs
+++ b/compiler/rustc_middle/src/ty/pattern.rs
@@ -44,5 +44,5 @@ impl<'tcx> fmt::Debug for PatternKind<'tcx> {
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[derive(HashStable, TyEncodable, TyDecodable, TypeVisitable, TypeFoldable)]
 pub enum PatternKind<'tcx> {
-    Range { start: ty::Const<'tcx>, end: ty::Const<'tcx> },
+    Range { start: Option<ty::Const<'tcx>>, end: Option<ty::Const<'tcx>>, include_end: bool },
 }

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -247,7 +247,7 @@ fn characteristic_def_id_of_type_cached<'a>(
 
         ty::Dynamic(data, ..) => data.principal_def_id(),
 
-        ty::Array(subty, _) | ty::Slice(subty) => {
+        ty::Pat(subty, _) | ty::Array(subty, _) | ty::Slice(subty) => {
             characteristic_def_id_of_type_cached(subty, visited)
         }
 

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -649,6 +649,9 @@ pub trait PrettyPrinter<'tcx>:
             ty::Int(t) => p!(write("{}", t.name_str())),
             ty::Uint(t) => p!(write("{}", t.name_str())),
             ty::Float(t) => p!(write("{}", t.name_str())),
+            ty::Pat(ty, pat) => {
+                p!("(", print(ty), ") is ", write("{pat:?}"))
+            }
             ty::RawPtr(ref tm) => {
                 p!(write(
                     "*{} ",

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -579,6 +579,10 @@ pub fn super_relate_tys<'tcx, R: TypeRelation<'tcx>>(
             }
         }
 
+        (&ty::Pat(a_t, pat_a), &ty::Pat(b_t, pat_b)) if pat_a == pat_b => {
+            Ok(tcx.mk_pat_ty(relation.relate(a_t, b_t)?, pat_a))
+        }
+
         _ => Err(TypeError::Sorts(expected_found(relation, a, b))),
     }
 }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1927,17 +1927,19 @@ impl<'tcx> Ty<'tcx> {
     /// contents are abstract to rustc.)
     #[inline]
     pub fn is_scalar(self) -> bool {
-        matches!(
-            self.kind(),
-            Bool | Char
-                | Int(_)
-                | Float(_)
-                | Uint(_)
-                | FnDef(..)
-                | FnPtr(_)
-                | RawPtr(_)
-                | Infer(IntVar(_) | FloatVar(_))
-        )
+        match *self.kind() {
+            Bool
+            | Char
+            | Int(_)
+            | Float(_)
+            | Uint(_)
+            | FnDef(..)
+            | FnPtr(_)
+            | RawPtr(_)
+            | Infer(IntVar(_) | FloatVar(_)) => true,
+            ty::Pat(inner, _) => inner.is_scalar(),
+            _ => false,
+        }
     }
 
     /// Returns `true` if this type is a floating point type.
@@ -2045,6 +2047,15 @@ impl<'tcx> Ty<'tcx> {
             }
             Ref(_, ty, mutbl) => Some(TypeAndMut { ty: *ty, mutbl: *mutbl }),
             RawPtr(mt) if explicit => Some(*mt),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    /// Obtain the type part of a `type is pat` type.
+    pub fn strip_pattern(self) -> Option<Self> {
+        match *self.kind() {
+            ty::Pat(inner, _) => Some(inner),
             _ => None,
         }
     }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2158,6 +2158,8 @@ impl<'tcx> Ty<'tcx> {
                 tcx.mk_projection(assoc_items[0], tcx.intern_substs(&[self.into()]))
             }
 
+            ty::Pat(ty, _) => ty.discriminant_ty(tcx),
+
             ty::Bool
             | ty::Char
             | ty::Int(_)
@@ -2234,6 +2236,7 @@ impl<'tcx> Ty<'tcx> {
             ty::Param(_) |  ty::Alias(..) => (tcx.types.unit, true),
 
             ty::Infer(ty::TyVar(_))
+            | ty::Pat(..)
             | ty::Bound(..)
             | ty::Placeholder(..)
             | ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
@@ -2305,6 +2308,8 @@ impl<'tcx> Ty<'tcx> {
 
             ty::Tuple(tys) => tys.iter().all(|ty| ty.is_trivially_sized(tcx)),
 
+            ty::Pat(ty, _) => ty.is_trivially_sized(tcx),
+
             ty::Adt(def, _substs) => def.sized_constraint(tcx).0.is_empty(),
 
             ty::Alias(..) | ty::Param(_) => false,
@@ -2348,6 +2353,8 @@ impl<'tcx> Ty<'tcx> {
             ty::Tuple(field_tys) => {
                 field_tys.len() <= 3 && field_tys.iter().all(Self::is_trivially_pure_clone_copy)
             }
+
+            ty::Pat(ty, _) => ty.is_trivially_pure_clone_copy(),
 
             // Sometimes traits aren't implemented for every ABI or arity,
             // because we can't be generic over everything yet.

--- a/compiler/rustc_middle/src/ty/walk.rs
+++ b/compiler/rustc_middle/src/ty/walk.rs
@@ -153,9 +153,9 @@ fn push_inner<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent: GenericArg<'tcx>)
 
             ty::Pat(ty, pat) => {
                 match *pat {
-                    ty::PatternKind::Range { start, end } => {
-                        stack.push(start.into());
-                        stack.push(end.into());
+                    ty::PatternKind::Range { start, end, include_end: _ } => {
+                        stack.extend(start.map(Into::into));
+                        stack.extend(end.map(Into::into));
                     }
                 }
                 stack.push(ty.into());

--- a/compiler/rustc_middle/src/ty/walk.rs
+++ b/compiler/rustc_middle/src/ty/walk.rs
@@ -151,6 +151,15 @@ fn push_inner<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent: GenericArg<'tcx>)
             | ty::Bound(..)
             | ty::Foreign(..) => {}
 
+            ty::Pat(ty, pat) => {
+                match *pat {
+                    ty::PatternKind::Range { start, end } => {
+                        stack.push(start.into());
+                        stack.push(end.into());
+                    }
+                }
+                stack.push(ty.into());
+            }
             ty::Array(ty, len) => {
                 stack.push(len.into());
                 stack.push(ty.into());

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -763,7 +763,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 }
             }
 
-            PatKind::Constant { .. } | PatKind::Range { .. } | PatKind::Wild => {}
+            PatKind::PatTy { .. }
+            | PatKind::Constant { .. }
+            | PatKind::Range { .. }
+            | PatKind::Wild => {}
 
             PatKind::Deref { ref subpattern } => {
                 self.visit_primary_bindings(subpattern, pattern_user_ty.deref(), f);

--- a/compiler/rustc_mir_build/src/build/matches/simplify.rs
+++ b/compiler/rustc_mir_build/src/build/matches/simplify.rs
@@ -16,6 +16,7 @@ use crate::build::expr::as_place::PlaceBuilder;
 use crate::build::matches::{Ascription, Binding, Candidate, MatchPair};
 use crate::build::Builder;
 use rustc_hir::RangeEnd;
+use rustc_middle::mir::ProjectionElem;
 use rustc_middle::thir::{self, *};
 use rustc_middle::ty;
 use rustc_middle::ty::layout::IntegerExt;
@@ -174,7 +175,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
 
             PatKind::PatTy { ref value } => {
-                candidate.match_pairs.push(MatchPair::new(match_pair.place, value, self));
+                let place = match_pair.place.project(ProjectionElem::OpaqueCast(value.ty));
+                candidate.match_pairs.push(MatchPair::new(place, value, self));
                 Ok(())
             }
 

--- a/compiler/rustc_mir_build/src/build/matches/simplify.rs
+++ b/compiler/rustc_mir_build/src/build/matches/simplify.rs
@@ -173,6 +173,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 Ok(())
             }
 
+            PatKind::PatTy { ref value } => {
+                candidate.match_pairs.push(MatchPair::new(match_pair.place, value, self));
+                Ok(())
+            }
+
             PatKind::Binding {
                 name: _,
                 mutability: _,

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -75,6 +75,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             PatKind::AscribeUserType { .. }
             | PatKind::Array { .. }
             | PatKind::Wild
+            | PatKind::PatTy { .. }
             | PatKind::Binding { .. }
             | PatKind::Leaf { .. }
             | PatKind::Deref { .. } => self.error_simplifyable(match_pair),
@@ -108,6 +109,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
             PatKind::Slice { .. }
             | PatKind::Array { .. }
+            | PatKind::PatTy { .. }
             | PatKind::Wild
             | PatKind::Or { .. }
             | PatKind::Binding { .. }

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -158,7 +158,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ) {
         let place = place_builder.to_place(self);
         let place_ty = place.ty(&self.local_decls, self.tcx);
-        debug!(?place, ?place_ty,);
+        debug!(?place, ?place_ty);
 
         let source_info = self.source_info(test.span);
         match test.kind {

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -206,6 +206,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 PatKind::Binding { .. }
                 // match is conditional on having this value
                 | PatKind::Constant { .. }
+                | PatKind::PatTy { .. }
                 | PatKind::Variant { .. }
                 | PatKind::Leaf { .. }
                 | PatKind::Deref { .. }

--- a/compiler/rustc_mir_build/src/lib.rs
+++ b/compiler/rustc_mir_build/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(min_specialization)]
 #![feature(once_cell)]
 #![feature(try_blocks)]
+#![feature(structural_match)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -229,7 +229,7 @@ impl<'tcx> ConstToPat<'tcx> {
     }
 
     // Recursive helper for `to_pat`; invoke that (instead of calling this directly).
-    #[instrument(skip(self), level = "debug")]
+    #[instrument(skip(self), level = "debug", ret)]
     fn recur(
         &self,
         cv: mir::ConstantKind<'tcx>,

--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -1287,6 +1287,7 @@ impl<'p, 'tcx> DeconstructedPat<'p, 'tcx> {
         match &pat.kind {
             PatKind::AscribeUserType { subpattern, .. } => return mkpat(subpattern),
             PatKind::Binding { subpattern: Some(subpat), .. } => return mkpat(subpat),
+            PatKind::PatTy { value } => return mkpat(value),
             PatKind::Binding { subpattern: None, .. } | PatKind::Wild => {
                 ctor = Wildcard;
                 fields = Fields::empty();

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -794,6 +794,7 @@ impl<'tcx> PatternFoldable<'tcx> for PatKind<'tcx> {
                 PatKind::Deref { subpattern: subpattern.fold_with(folder) }
             }
             PatKind::Constant { value } => PatKind::Constant { value },
+            PatKind::PatTy { ref value } => PatKind::PatTy { value: value.fold_with(folder) },
             PatKind::Range(ref range) => PatKind::Range(range.clone()),
             PatKind::Slice { ref prefix, ref slice, ref suffix } => PatKind::Slice {
                 prefix: prefix.fold_with(folder),

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -95,7 +95,7 @@ impl Unwind {
     }
 }
 
-pub trait DropElaborator<'a, 'tcx>: fmt::Debug {
+pub trait DropElaborator<'a, 'tcx>: fmt::Debug + HasLocalDecls<'tcx> {
     /// The type representing paths that can be moved out of.
     ///
     /// Users can move out of individual fields of a struct, such as `a.b.c`. This type is used to
@@ -195,7 +195,7 @@ where
     'tcx: 'b,
 {
     fn place_ty(&self, place: Place<'tcx>) -> Ty<'tcx> {
-        place.ty(self.elaborator.body(), self.tcx()).ty
+        place.ty(&*self.elaborator, self.tcx()).ty
     }
 
     fn tcx(&self) -> TyCtxt<'tcx> {

--- a/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
@@ -24,7 +24,7 @@ impl<'tcx> AnalysisDomain<'tcx> for MaybeBorrowedLocals {
 
     fn bottom_value(&self, body: &mir::Body<'tcx>) -> Self::Domain {
         // bottom = unborrowed
-        BitSet::new_empty(body.local_decls().len())
+        BitSet::new_empty(body.local_decls.len())
     }
 
     fn initialize_start_block(&self, _: &mir::Body<'tcx>, _: &mut Self::Domain) {

--- a/compiler/rustc_mir_dataflow/src/lib.rs
+++ b/compiler/rustc_mir_dataflow/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(exact_size_is_empty)]
 #![feature(min_specialization)]
 #![feature(once_cell)]
+#![feature(structural_match)]
 #![feature(stmt_expr_attributes)]
 #![feature(trusted_step)]
 #![recursion_limit = "256"]

--- a/compiler/rustc_mir_transform/src/const_goto.rs
+++ b/compiler/rustc_mir_transform/src/const_goto.rs
@@ -84,7 +84,7 @@ impl<'tcx> Visitor<'tcx> for ConstGotoOptimizationFinder<'_, 'tcx> {
                 let target_bb_terminator = target_bb.terminator();
                 let (discr, targets) = target_bb_terminator.kind.as_switch()?;
                 if discr.place() == Some(*place) {
-                    let switch_ty = place.ty(self.body.local_decls(), self.tcx).ty;
+                    let switch_ty = place.ty(self.body, self.tcx).ty;
                     // We now know that the Switch matches on the const place, and it is statementless
                     // Now find which value in the Switch matches the const value.
                     let const_value =

--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -131,7 +131,7 @@ impl<'tcx> MirPass<'tcx> for EarlyOtherwiseBranch {
                 Operand::Copy(x) => Operand::Copy(*x),
                 Operand::Constant(x) => Operand::Constant(x.clone()),
             };
-            let parent_ty = parent_op.ty(body.local_decls(), tcx);
+            let parent_ty = parent_op.ty(body, tcx);
             let statements_before = bbs[parent].statements.len();
             let parent_end = Location { block: parent, statement_index: statements_before };
 
@@ -268,7 +268,7 @@ fn may_hoist<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>, place: Place<'tcx>) -> 
             //    `otherwise` branch in `BBC, BBD` in the input to our transformation, which would
             //    have invalidated the data when computing `discriminant(P)`
             // So dereferencing here is correct.
-            ProjectionElem::Deref => match place.ty(body.local_decls(), tcx).ty.kind() {
+            ProjectionElem::Deref => match place.ty(body, tcx).ty.kind() {
                 ty::Ref(..) => {}
                 _ => return false,
             },
@@ -317,7 +317,7 @@ fn evaluate_candidate<'tcx>(
     } = &bbs[parent].terminator().kind else {
         return None
     };
-    let parent_ty = parent_discr.ty(body.local_decls(), tcx);
+    let parent_ty = parent_discr.ty(body, tcx);
     let parent_dest = {
         let poss = targets.otherwise();
         // If the fallthrough on the parent is trivially unreachable, we can let the
@@ -338,7 +338,7 @@ fn evaluate_candidate<'tcx>(
     } = &child_terminator.kind else {
         return None
     };
-    let child_ty = child_discr.ty(body.local_decls(), tcx);
+    let child_ty = child_discr.ty(body, tcx);
     if child_ty != parent_ty {
         return None;
     }

--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -156,6 +156,12 @@ impl fmt::Debug for Elaborator<'_, '_, '_> {
     }
 }
 
+impl<'tcx> HasLocalDecls<'tcx> for Elaborator<'_, '_, 'tcx> {
+    fn local_decl(&self, local: Local) -> &LocalDecl<'tcx> {
+        self.ctxt.patch.local_decl(self.ctxt.body, local)
+    }
+}
+
 impl<'a, 'tcx> DropElaborator<'a, 'tcx> for Elaborator<'a, '_, 'tcx> {
     type Path = MovePathIndex;
 

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(never_type)]
 #![feature(once_cell)]
 #![feature(option_get_or_insert_default)]
+#![feature(structural_match)]
 #![feature(trusted_step)]
 #![feature(try_blocks)]
 #![feature(yeet_expr)]

--- a/compiler/rustc_mir_transform/src/pass_manager.rs
+++ b/compiler/rustc_mir_transform/src/pass_manager.rs
@@ -151,6 +151,7 @@ fn run_passes_inner<'tcx>(
     }
 }
 
+#[instrument(level = "trace", skip(tcx, body))]
 pub fn validate_body<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>, when: String) {
     validate::Validator { when, mir_phase: body.phase }.run_pass(tcx, body);
 }

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -190,7 +190,7 @@ fn build_drop_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, ty: Option<Ty<'tcx>>)
             BorrowKind::Mut { allow_two_phase_borrow: false },
             tcx.mk_place_deref(dropee_ptr),
         );
-        let ref_ty = reborrow.ty(body.local_decls(), tcx);
+        let ref_ty = reborrow.ty(&body, tcx);
         dropee_ptr = body.local_decls.push(LocalDecl::new(ref_ty, span)).into();
         let new_statements = [
             StatementKind::Assign(Box::new((dropee_ptr, reborrow))),
@@ -268,6 +268,11 @@ pub struct DropShimElaborator<'a, 'tcx> {
 impl fmt::Debug for DropShimElaborator<'_, '_> {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         Ok(())
+    }
+}
+impl<'tcx> HasLocalDecls<'tcx> for DropShimElaborator<'_, 'tcx> {
+    fn local_decl(&self, local: Local) -> &LocalDecl<'tcx> {
+        self.patch.local_decl(self.body, local)
     }
 }
 

--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -32,7 +32,7 @@ impl<'tcx> MirPass<'tcx> for ScalarReplacementOfAggregates {
 fn escaping_locals(body: &Body<'_>) -> BitSet<Local> {
     let mut set = BitSet::new_empty(body.local_decls.len());
     set.insert_range(RETURN_PLACE..=Local::from_usize(body.arg_count));
-    for (local, decl) in body.local_decls().iter_enumerated() {
+    for (local, decl) in body.local_decls.iter_enumerated() {
         if decl.ty.is_union() || decl.ty.is_enum() {
             set.insert(local);
         }

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1081,10 +1081,10 @@ fn find_vtable_types_for_unsizing<'tcx>(
         }
     };
 
-    match (&source_ty.kind(), &target_ty.kind()) {
+    match (source_ty.kind(), target_ty.kind()) {
         (&ty::Ref(_, a, _), &ty::Ref(_, b, _) | &ty::RawPtr(ty::TypeAndMut { ty: b, .. }))
         | (&ty::RawPtr(ty::TypeAndMut { ty: a, .. }), &ty::RawPtr(ty::TypeAndMut { ty: b, .. })) => {
-            ptr_vtable(*a, *b)
+            ptr_vtable(a, b)
         }
         (&ty::Adt(def_a, _), &ty::Adt(def_b, _)) if def_a.is_box() && def_b.is_box() => {
             ptr_vtable(source_ty.boxed_ty(), target_ty.boxed_ty())
@@ -1111,6 +1111,9 @@ fn find_vtable_types_for_unsizing<'tcx>(
                 source_fields[coerce_index].ty(*tcx, source_substs),
                 target_fields[coerce_index].ty(*tcx, target_substs),
             )
+        }
+        (&ty::Pat(source_ty, a), &ty::Pat(target_ty, b)) if a == b => {
+            find_vtable_types_for_unsizing(tcx, source_ty, target_ty)
         }
         _ => bug!(
             "find_vtable_types_for_unsizing: invalid coercion {:?} -> {:?}",

--- a/compiler/rustc_passes/src/lib.rs
+++ b/compiler/rustc_passes/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(let_chains)]
 #![feature(map_try_insert)]
 #![feature(min_specialization)]
+#![feature(structural_match)]
 #![feature(try_blocks)]
 #![recursion_limit = "256"]
 

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -263,6 +263,7 @@ where
             | ty::Str
             | ty::Never
             | ty::Array(..)
+            | ty::Pat(..)
             | ty::Slice(..)
             | ty::Tuple(..)
             | ty::RawPtr(..)

--- a/compiler/rustc_query_system/src/lib.rs
+++ b/compiler/rustc_query_system/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(hash_raw_entry)]
 #![feature(min_specialization)]
 #![feature(extern_types)]
+#![feature(structural_match)]
 #![allow(rustc::potential_query_instability)]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -19,6 +19,7 @@
 #![feature(negative_impls)]
 #![feature(min_specialization)]
 #![feature(rustc_attrs)]
+#![feature(structural_match)]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
 

--- a/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
+++ b/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
@@ -690,7 +690,7 @@ fn transform_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, options: TransformTyOptio
         }
 
         ty::Pat(ty0, pat) => {
-            ty = tcx.mk_ty(ty::Pat(transform_ty(tcx, *ty0, options), *pat));
+            ty = tcx.mk_pat_ty(transform_ty(tcx, *ty0, options), *pat);
         }
 
         ty::Slice(ty0) => {

--- a/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
+++ b/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
@@ -525,12 +525,7 @@ fn encode_ty<'tcx>(
             // u3patI<element-type><pattern>E as vendor extended type
             let mut s = String::from("u3patI");
             s.push_str(&encode_ty(tcx, *ty0, dict, options));
-            match **pat {
-                ty::PatternKind::Range { start, end } => {
-                    s.push_str(&encode_const(tcx, start, dict, options));
-                    s.push_str(&encode_const(tcx, end, dict, options));
-                }
-            }
+            write!(s, "{:?}", **pat).unwrap();
             s.push('E');
             compress(dict, DictKey::Ty(ty, TyQ::None), &mut s);
             typeid.push_str(&s);

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -419,6 +419,18 @@ impl<'tcx> Printer<'tcx> for &mut SymbolMangler<'tcx> {
                 self = mt.ty.print(self)?;
             }
 
+            ty::Pat(ty, pat) => {
+                self.push("T");
+                self = ty.print(self)?;
+                match *pat {
+                    ty::PatternKind::Range { start, end } => {
+                        self = self.print_const(start)?;
+                        self = self.print_const(end)?;
+                    }
+                }
+                self.push("E");
+            }
+
             ty::Array(ty, len) => {
                 self.push("A");
                 self = ty.print(self)?;

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -423,9 +423,16 @@ impl<'tcx> Printer<'tcx> for &mut SymbolMangler<'tcx> {
                 self.push("T");
                 self = ty.print(self)?;
                 match *pat {
-                    ty::PatternKind::Range { start, end } => {
-                        self = self.print_const(start)?;
-                        self = self.print_const(end)?;
+                    ty::PatternKind::Range { start, end, include_end } => {
+                        if let Some(start) = start {
+                            self = self.print_const(start)?;
+                        }
+                        let _ = write!(self.out, "_");
+                        if let Some(end) = end {
+                            self = self.print_const(end)?;
+                        }
+
+                        let _ = write!(self.out, "{:x}_", include_end as u8);
                     }
                 }
                 self.push("E");

--- a/compiler/rustc_target/src/lib.rs
+++ b/compiler/rustc_target/src/lib.rs
@@ -15,6 +15,7 @@
 #![feature(never_type)]
 #![feature(rustc_attrs)]
 #![feature(step_trait)]
+#![feature(structural_match)]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
 

--- a/compiler/rustc_trait_selection/src/lib.rs
+++ b/compiler/rustc_trait_selection/src/lib.rs
@@ -20,6 +20,7 @@
 #![feature(if_let_guard)]
 #![feature(never_type)]
 #![feature(result_option_inspect)]
+#![feature(structural_match)]
 #![feature(type_alias_impl_trait)]
 #![feature(min_specialization)]
 #![recursion_limit = "512"] // For rustdoc

--- a/compiler/rustc_trait_selection/src/solve/assembly.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly.rs
@@ -330,6 +330,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             | ty::Dynamic(..)
             | ty::Closure(..)
             | ty::Generator(..)
+            | ty::Pat(..)
             | ty::GeneratorWitness(_)
             | ty::Never
             | ty::Tuple(_)
@@ -377,6 +378,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             | ty::RawPtr(_)
             | ty::Ref(_, _, _)
             | ty::FnDef(_, _)
+            | ty::Pat(_, _)
             | ty::FnPtr(_)
             | ty::Alias(..)
             | ty::Closure(..)

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -407,6 +407,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
                 | ty::Float(..)
                 | ty::Array(..)
                 | ty::RawPtr(..)
+                | ty::Pat(..)
                 | ty::Ref(..)
                 | ty::FnDef(..)
                 | ty::FnPtr(..)

--- a/compiler/rustc_trait_selection/src/solve/trait_goals/structural_traits.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals/structural_traits.rs
@@ -39,7 +39,9 @@ pub(super) fn instantiate_constituent_tys_for_auto_trait<'tcx>(
             Ok(vec![element_ty])
         }
 
-        ty::Array(element_ty, _) | ty::Slice(element_ty) => Ok(vec![element_ty]),
+        ty::Pat(element_ty, _) | ty::Array(element_ty, _) | ty::Slice(element_ty) => {
+            Ok(vec![element_ty])
+        }
 
         ty::Tuple(ref tys) => {
             // (T1, ..., Tn) -- meets any bound that all of T1...Tn meet
@@ -108,6 +110,7 @@ pub(super) fn instantiate_constituent_tys_for_sized_trait<'tcx>(
         }
 
         ty::Tuple(tys) => Ok(tys.to_vec()),
+        ty::Pat(ty, _) => Ok(vec![ty]),
 
         ty::Adt(def, substs) => {
             let sized_crit = def.sized_constraint(infcx.tcx);
@@ -158,6 +161,7 @@ pub(super) fn instantiate_constituent_tys_for_copy_clone_trait<'tcx>(
         }
 
         ty::Tuple(tys) => Ok(tys.to_vec()),
+        ty::Pat(ty, _) => Ok(vec![ty]),
 
         ty::Closure(_, substs) => Ok(vec![substs.as_closure().tupled_upvars_ty()]),
 
@@ -218,6 +222,7 @@ pub(crate) fn extract_tupled_inputs_and_output_from_callable<'tcx>(
         | ty::Never
         | ty::Tuple(_)
         | ty::Alias(_, _)
+        | ty::Pat(_, _)
         | ty::Param(_)
         | ty::Placeholder(..)
         | ty::Infer(ty::IntVar(_) | ty::FloatVar(_))

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -642,6 +642,7 @@ impl<'tcx> TypeVisitor<'tcx> for OrphanChecker<'tcx> {
             | ty::Float(..)
             | ty::Str
             | ty::FnDef(..)
+            | ty::Pat(..)
             | ty::FnPtr(_)
             | ty::Array(..)
             | ty::Slice(..)

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1891,6 +1891,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 ty::Generator(..) => Some(16),
                 ty::Foreign(..) => Some(17),
                 ty::GeneratorWitness(..) => Some(18),
+                ty::Pat(..) => Some(19),
                 ty::Placeholder(..) | ty::Bound(..) | ty::Infer(..) | ty::Error(_) => None,
             }
         }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1597,7 +1597,7 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                         | ty::Str
                         | ty::Array(..)
                         | ty::Pat(..)
-                    | ty::Slice(_)
+                        | ty::Slice(_)
                         | ty::RawPtr(..)
                         | ty::Ref(..)
                         | ty::FnDef(..)

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1596,7 +1596,8 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                         | ty::Foreign(_)
                         | ty::Str
                         | ty::Array(..)
-                        | ty::Slice(_)
+                        | ty::Pat(..)
+                    | ty::Slice(_)
                         | ty::RawPtr(..)
                         | ty::Ref(..)
                         | ty::FnDef(..)
@@ -1645,7 +1646,8 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                         | ty::Float(_)
                         | ty::Str
                         | ty::Array(..)
-                        | ty::Slice(_)
+                        | ty::Pat(..)
+                    | ty::Slice(_)
                         | ty::RawPtr(..)
                         | ty::Ref(..)
                         | ty::FnDef(..)

--- a/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
@@ -37,8 +37,8 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         | ty::Foreign(..)
         | ty::Error(_) => true,
 
-        // [T; N] and [T] have same properties as T.
-        ty::Array(ty, _) | ty::Slice(ty) => trivial_dropck_outlives(tcx, *ty),
+        // `T is PAT` [T; N] and [T] have same properties as T.
+        ty::Pat(ty, _) | ty::Array(ty, _) | ty::Slice(ty) => trivial_dropck_outlives(tcx, *ty),
 
         // (T1..Tn) and closures have same properties as T1..Tn --
         // check if *all* of them are trivial.

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -761,6 +761,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             | ty::Never
             | ty::Foreign(_)
             | ty::Array(..)
+            | ty::Pat(..)
             | ty::Slice(_)
             | ty::Closure(..)
             | ty::Generator(..)
@@ -821,6 +822,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             | ty::RawPtr(_)
             | ty::Ref(_, _, _)
             | ty::FnDef(_, _)
+            | ty::Pat(_, _)
             | ty::FnPtr(_)
             | ty::Dynamic(_, _, _)
             | ty::Closure(_, _)

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2052,6 +2052,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 obligation.predicate.rebind(tys.last().map_or_else(Vec::new, |&last| vec![last])),
             ),
 
+            ty::Pat(ty, _) => Where(obligation.predicate.rebind(vec![*ty])),
+
             ty::Adt(def, substs) => {
                 let sized_crit = def.sized_constraint(self.tcx());
                 // (*) binder moved here
@@ -2114,6 +2116,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::Tuple(tys) => {
                 // (*) binder moved here
                 Where(obligation.predicate.rebind(tys.iter().collect()))
+            }
+
+            ty::Pat(ty, _) => {
+                // (*) binder moved here
+                Where(obligation.predicate.rebind(vec![ty]))
             }
 
             ty::Generator(_, substs, hir::Movability::Movable) => {
@@ -2227,7 +2234,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 t.rebind(vec![element_ty])
             }
 
-            ty::Array(element_ty, _) | ty::Slice(element_ty) => t.rebind(vec![element_ty]),
+            ty::Pat(ty, _) | ty::Array(ty, _) | ty::Slice(ty) => t.rebind(vec![ty]),
 
             ty::Tuple(ref tys) => {
                 // (T1, ..., Tn) -- meets any bound that all of T1...Tn meet

--- a/compiler/rustc_trait_selection/src/traits/structural_match.rs
+++ b/compiler/rustc_trait_selection/src/traits/structural_match.rs
@@ -161,7 +161,7 @@ impl<'tcx> TypeVisitor<'tcx> for Search<'tcx> {
                 }
             }
 
-            ty::Array(..) | ty::Slice(_) | ty::Ref(..) | ty::Tuple(..) => {
+            ty::Pat(..) | ty::Array(..) | ty::Slice(_) | ty::Ref(..) | ty::Tuple(..) => {
                 // First check all contained types and then tell the caller to continue searching.
                 return ty.super_visit_with(self);
             }

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -565,11 +565,7 @@ impl<'tcx> WfPredicates<'tcx> {
                 // Can only infer to `ty::Float(_)`.
                 ty::Infer(ty::FloatVar(_)) => {}
 
-                ty::Slice(subty) => {
-                    self.require_sized(subty, traits::SliceOrArrayElem);
-                }
-
-                ty::Array(subty, _) => {
+                ty::Pat(subty, _) | ty::Slice(subty) | ty::Array(subty, _) => {
                     self.require_sized(subty, traits::SliceOrArrayElem);
                     // Note that we handle the len is implicitly checked while walking `arg`.
                 }

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -343,7 +343,7 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Ty<RustInterner<'tcx>>> for Ty<'tcx> {
                 substs.lower_into(interner),
             ),
             ty::GeneratorWitness(_) => unimplemented!(),
-            ty::Pat(..) => unimplemented!(),
+            ty::Pat(inner, _) => return inner.lower_into(interner),
             ty::Never => chalk_ir::TyKind::Never,
             ty::Tuple(types) => {
                 chalk_ir::TyKind::Tuple(types.len(), types.as_substs().lower_into(interner))

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -343,6 +343,7 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Ty<RustInterner<'tcx>>> for Ty<'tcx> {
                 substs.lower_into(interner),
             ),
             ty::GeneratorWitness(_) => unimplemented!(),
+            ty::Pat(..) => unimplemented!(),
             ty::Never => chalk_ir::TyKind::Never,
             ty::Tuple(types) => {
                 chalk_ir::TyKind::Tuple(types.len(), types.as_substs().lower_into(interner))

--- a/compiler/rustc_traits/src/dropck_outlives.rs
+++ b/compiler/rustc_traits/src/dropck_outlives.rs
@@ -168,7 +168,7 @@ fn dtorck_constraint_for_ty<'tcx>(
             // these types never have a destructor
         }
 
-        ty::Array(ety, _) | ty::Slice(ety) => {
+        ty::Pat(ety, _) | ty::Array(ety, _) | ty::Slice(ety) => {
             // single-element containers, behave like their element
             rustc_data_structures::stack::ensure_sufficient_stack(|| {
                 dtorck_constraint_for_ty(tcx, span, for_ty, depth + 1, *ety, constraints)

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -26,6 +26,8 @@ fn sized_constraint_for_ty<'tcx>(
             Some(&ty) => sized_constraint_for_ty(tcx, adtdef, ty),
         },
 
+        Pat(ty, _) => sized_constraint_for_ty(tcx, adtdef, *ty),
+
         Adt(adt, substs) => {
             // recursive case
             let adt_tys = adt.sized_constraint(tcx);

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -33,6 +33,8 @@ pub trait Interner {
     type SubstsRef: Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord;
     type DefId: Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord;
     type Ty: Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord;
+    /// A pattern type pattern.
+    type Pat: Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord;
     type Const: Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord;
     type Region: Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord;
     type TypeAndMut: Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord;

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(fmt_helpers_for_derive)]
 #![feature(min_specialization)]
 #![feature(rustc_attrs)]
+#![feature(structural_match)]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
 
@@ -818,20 +819,20 @@ impl UniverseIndex {
     /// name the region `'a`, but that region was not nameable from
     /// `U` because it was not in scope there.
     pub fn next_universe(self) -> UniverseIndex {
-        UniverseIndex::from_u32(self.private.checked_add(1).unwrap())
+        UniverseIndex::from_u32(self.as_u32().checked_add(1).unwrap())
     }
 
     /// Returns `true` if `self` can name a name from `other` -- in other words,
     /// if the set of names in `self` is a superset of those in
     /// `other` (`self >= other`).
     pub fn can_name(self, other: UniverseIndex) -> bool {
-        self.private >= other.private
+        self.as_u32() >= other.as_u32()
     }
 
     /// Returns `true` if `self` cannot name some names from `other` -- in other
     /// words, if the set of names in `self` is a strict subset of
     /// those in `other` (`self < other`).
     pub fn cannot_name(self, other: UniverseIndex) -> bool {
-        self.private < other.private
+        self.as_u32() < other.as_u32()
     }
 }

--- a/compiler/rustc_type_ir/src/sty.rs
+++ b/compiler/rustc_type_ir/src/sty.rs
@@ -201,6 +201,10 @@ pub enum TyKind<I: Interner> {
     /// A placeholder for a type which could not be computed; this is
     /// propagated to avoid useless error messages.
     Error(I::ErrorGuaranteed),
+
+    /// A pattern subtype. Takes any type and restricts it to its pattern.
+    /// Only supports integer range patterns for now.
+    Pat(I::Ty, I::Pat),
 }
 
 impl<I: Interner> TyKind<I> {
@@ -241,6 +245,7 @@ const fn tykind_discriminant<I: Interner>(value: &TyKind<I>) -> usize {
         Placeholder(_) => 23,
         Infer(_) => 24,
         Error(_) => 25,
+        Pat(_, _) => 26,
     }
 }
 
@@ -254,6 +259,7 @@ impl<I: Interner> Clone for TyKind<I> {
             Uint(u) => Uint(*u),
             Float(f) => Float(*f),
             Adt(d, s) => Adt(d.clone(), s.clone()),
+            Pat(t, c) => Pat(t.clone(), c.clone()),
             Foreign(d) => Foreign(d.clone()),
             Str => Str,
             Array(t, c) => Array(t.clone(), c.clone()),
@@ -290,6 +296,7 @@ impl<I: Interner> PartialEq for TyKind<I> {
                 (Adt(a_d, a_s), Adt(b_d, b_s)) => a_d == b_d && a_s == b_s,
                 (Foreign(a_d), Foreign(b_d)) => a_d == b_d,
                 (Array(a_t, a_c), Array(b_t, b_c)) => a_t == b_t && a_c == b_c,
+                (Pat(a_t, a_c), Pat(b_t, b_c)) => a_t == b_t && a_c == b_c,
                 (Slice(a_t), Slice(b_t)) => a_t == b_t,
                 (RawPtr(a_t), RawPtr(b_t)) => a_t == b_t,
                 (Ref(a_r, a_t, a_m), Ref(b_r, b_t, b_m)) => a_r == b_r && a_t == b_t && a_m == b_m,
@@ -345,6 +352,7 @@ impl<I: Interner> Ord for TyKind<I> {
                 (Adt(a_d, a_s), Adt(b_d, b_s)) => a_d.cmp(b_d).then_with(|| a_s.cmp(b_s)),
                 (Foreign(a_d), Foreign(b_d)) => a_d.cmp(b_d),
                 (Array(a_t, a_c), Array(b_t, b_c)) => a_t.cmp(b_t).then_with(|| a_c.cmp(b_c)),
+                (Pat(a_t, a_c), Pat(b_t, b_c)) => a_t.cmp(b_t).then_with(|| a_c.cmp(b_c)),
                 (Slice(a_t), Slice(b_t)) => a_t.cmp(b_t),
                 (RawPtr(a_t), RawPtr(b_t)) => a_t.cmp(b_t),
                 (Ref(a_r, a_t, a_m), Ref(b_r, b_t, b_m)) => {
@@ -422,6 +430,10 @@ impl<I: Interner> hash::Hash for TyKind<I> {
             }
             GeneratorWitness(g) => g.hash(state),
             Tuple(t) => t.hash(state),
+            Pat(t, p) => {
+                t.hash(state);
+                p.hash(state);
+            }
             Alias(i, p) => {
                 i.hash(state);
                 p.hash(state);
@@ -449,6 +461,7 @@ impl<I: Interner> fmt::Debug for TyKind<I> {
             Uint(u) => f.debug_tuple_field1_finish("Uint", u),
             Float(float) => f.debug_tuple_field1_finish("Float", float),
             Adt(d, s) => f.debug_tuple_field2_finish("Adt", d, s),
+            Pat(f0, f1) => f.debug_tuple_field2_finish("Pat", f0, f1),
             Foreign(d) => f.debug_tuple_field1_finish("Foreign", d),
             Str => f.write_str("Str"),
             Array(t, c) => f.debug_tuple_field2_finish("Array", t, c),
@@ -481,6 +494,7 @@ where
     I::SubstsRef: Encodable<E>,
     I::DefId: Encodable<E>,
     I::Ty: Encodable<E>,
+    I::Pat: Encodable<E>,
     I::Const: Encodable<E>,
     I::Region: Encodable<E>,
     I::TypeAndMut: Encodable<E>,
@@ -515,6 +529,10 @@ where
             Adt(adt, substs) => e.emit_enum_variant(disc, |e| {
                 adt.encode(e);
                 substs.encode(e);
+            }),
+            Pat(ty, pat) => e.emit_enum_variant(disc, |e| {
+                ty.encode(e);
+                pat.encode(e);
             }),
             Foreign(def_id) => e.emit_enum_variant(disc, |e| {
                 def_id.encode(e);
@@ -612,6 +630,7 @@ where
     I::InferTy: Decodable<D>,
     I::PredicateKind: Decodable<D>,
     I::AllocId: Decodable<D>,
+    I::Pat: Decodable<D>,
 {
     fn decode(d: &mut D) -> Self {
         match Decoder::read_usize(d) {
@@ -641,6 +660,7 @@ where
             23 => Placeholder(Decodable::decode(d)),
             24 => Infer(Decodable::decode(d)),
             25 => Error(Decodable::decode(d)),
+            26 => Pat(Decodable::decode(d), Decodable::decode(d)),
             _ => panic!(
                 "{}",
                 format!(
@@ -660,6 +680,7 @@ where
     I::DefId: HashStable<CTX>,
     I::SubstsRef: HashStable<CTX>,
     I::Ty: HashStable<CTX>,
+    I::Pat: HashStable<CTX>,
     I::Const: HashStable<CTX>,
     I::TypeAndMut: HashStable<CTX>,
     I::PolyFnSig: HashStable<CTX>,
@@ -698,6 +719,10 @@ where
             Adt(adt, substs) => {
                 adt.hash_stable(__hcx, __hasher);
                 substs.hash_stable(__hcx, __hasher);
+            }
+            Pat(ty, pat) => {
+                ty.hash_stable(__hcx, __hasher);
+                pat.hash_stable(__hcx, __hasher);
             }
             Foreign(def_id) => {
                 def_id.hash_stable(__hcx, __hasher);

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -35,6 +35,8 @@ const MICROS_PER_SEC: u64 = 1_000_000;
 #[rustc_layout_scalar_valid_range_end(999_999_999)]
 struct Nanoseconds(u32);
 
+impl crate::marker::StructuralPartialEq for Nanoseconds {}
+
 impl PartialEq for Nanoseconds {
     fn eq(&self, other: &Self) -> bool {
         self.0 as u32 == other.0 as u32

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -73,7 +73,7 @@ impl BorrowedFd<'_> {
     pub const unsafe fn borrow_raw(fd: RawFd) -> Self {
         assert!(fd != u32::MAX as RawFd);
         // SAFETY: we just asserted that the value is in the valid range and isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
-        unsafe { Self { fd, _phantom: PhantomData } }
+        unsafe { Self { fd: fd as _, _phantom: PhantomData as _ } }
     }
 }
 
@@ -126,7 +126,7 @@ impl BorrowedFd<'_> {
 impl AsRawFd for BorrowedFd<'_> {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
-        self.fd
+        self.fd as i32
     }
 }
 
@@ -134,7 +134,7 @@ impl AsRawFd for BorrowedFd<'_> {
 impl AsRawFd for OwnedFd {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
-        self.fd
+        self.fd as i32
     }
 }
 
@@ -142,7 +142,7 @@ impl AsRawFd for OwnedFd {
 impl IntoRawFd for OwnedFd {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
-        let fd = self.fd;
+        let fd = self.as_raw_fd();
         forget(self);
         fd
     }
@@ -160,7 +160,7 @@ impl FromRawFd for OwnedFd {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         assert_ne!(fd, u32::MAX as RawFd);
         // SAFETY: we just asserted that the value is in the valid range and isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
-        unsafe { Self { fd } }
+        unsafe { Self { fd: fd as _ } }
     }
 }
 
@@ -174,7 +174,7 @@ impl Drop for OwnedFd {
             // the file descriptor was closed or not, and if we retried (for
             // something like EINTR), we might close another valid file descriptor
             // opened after we closed ours.
-            let _ = libc::close(self.fd);
+            let _ = libc::close(self.fd as i32);
         }
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1709,6 +1709,10 @@ pub(crate) fn clean_middle_ty<'tcx>(
         ty::Float(float_ty) => Primitive(float_ty.into()),
         ty::Str => Primitive(PrimitiveType::Str),
         ty::Slice(ty) => Slice(Box::new(clean_middle_ty(bound_ty.rebind(ty), cx, None))),
+        ty::Pat(ty, pat) => Type::Pat(
+            Box::new(clean_middle_ty(bound_ty.rebind(ty), cx, None)),
+            format!("{pat:?}").into_boxed_str(),
+        ),
         ty::Array(ty, mut n) => {
             n = n.eval(cx.tcx, ty::ParamEnv::reveal_all());
             let n = print_const(cx, n);

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1613,7 +1613,9 @@ pub(crate) enum Type {
     ///
     /// This is mostly Rustdoc's version of [`hir::Path`].
     /// It has to be different because Rustdoc's [`PathSegment`] can contain cleaned generics.
-    Path { path: Path },
+    Path {
+        path: Path,
+    },
     /// A `dyn Trait` object: `dyn for<'a> Trait<'a> + Send + 'static`
     DynTrait(Vec<PolyTrait>, Option<Lifetime>),
     /// A type parameter.
@@ -1630,10 +1632,15 @@ pub(crate) enum Type {
     ///
     /// The `String` field is a stringified version of the array's length parameter.
     Array(Box<Type>, Box<str>),
+    Pat(Box<Type>, Box<str>),
     /// A raw pointer type: `*const i32`, `*mut i32`
     RawPointer(Mutability, Box<Type>),
     /// A reference type: `&i32`, `&'a mut Foo`
-    BorrowedRef { lifetime: Option<Lifetime>, mutability: Mutability, type_: Box<Type> },
+    BorrowedRef {
+        lifetime: Option<Lifetime>,
+        mutability: Mutability,
+        type_: Box<Type>,
+    },
 
     /// A qualified path to an associated item: `<Type as Trait>::Name`
     QPath(Box<QPathData>),
@@ -1758,6 +1765,7 @@ impl Type {
             BareFunction(..) => PrimitiveType::Fn,
             Slice(..) => PrimitiveType::Slice,
             Array(..) => PrimitiveType::Array,
+            Type::Pat(..) => PrimitiveType::Pat,
             RawPointer(..) => PrimitiveType::RawPointer,
             QPath(box QPathData { ref self_type, .. }) => return self_type.inner_def_id(cache),
             Generic(_) | Infer | ImplTrait(_) => return None,
@@ -1810,6 +1818,7 @@ pub(crate) enum PrimitiveType {
     Slice,
     Array,
     Tuple,
+    Pat,
     Unit,
     RawPointer,
     Reference,
@@ -1955,6 +1964,7 @@ impl PrimitiveType {
             Str => sym::str,
             Bool => sym::bool,
             Char => sym::char,
+            Pat => sym::pat,
             Array => sym::array,
             Slice => sym::slice,
             Tuple => sym::tuple,

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1031,6 +1031,20 @@ fn fmt_type<'cx>(
                 write!(f, "]")
             }
         },
+        clean::Type::Pat(ref t, ref n) => match **t {
+            clean::Generic(name) if !f.alternate() => {
+                primitive_link(f, PrimitiveType::Pat, &format!("{name} is {n}", n = Escape(n)), cx)
+            }
+            _ => {
+                fmt::Display::fmt(&t.print(cx), f)?;
+                write!(f, " is ")?;
+                if f.alternate() {
+                    write!(f, "{n}")
+                } else {
+                    primitive_link(f, PrimitiveType::Pat, &format!("{n}", n = Escape(n)), cx)
+                }
+            }
+        },
         clean::RawPointer(m, ref t) => {
             let m = match m {
                 hir::Mutability::Mut => "mut",

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -369,6 +369,7 @@ fn get_index_type_id(clean_type: &clean::Type) -> Option<RenderTypeId> {
         | clean::Tuple(_)
         | clean::Slice(_)
         | clean::Array(_, _)
+        | clean::Type::Pat(_, _)
         | clean::QPath { .. }
         | clean::Infer => None,
     }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -484,7 +484,7 @@ pub(crate) fn from_trait_bound_modifier(
 impl FromWithTcx<clean::Type> for Type {
     fn from_tcx(ty: clean::Type, tcx: TyCtxt<'_>) -> Self {
         use clean::Type::{
-            Array, BareFunction, BorrowedRef, Generic, ImplTrait, Infer, Primitive, QPath,
+            Array, BareFunction, BorrowedRef, Generic, ImplTrait, Infer, Pat, Primitive, QPath,
             RawPointer, Slice, Tuple,
         };
 
@@ -500,6 +500,7 @@ impl FromWithTcx<clean::Type> for Type {
             Tuple(t) => Type::Tuple(t.into_tcx(tcx)),
             Slice(t) => Type::Slice(Box::new((*t).into_tcx(tcx))),
             Array(t, s) => Type::Array { type_: Box::new((*t).into_tcx(tcx)), len: s.to_string() },
+            Pat(t, s) => Type::Pat { type_: Box::new((*t).into_tcx(tcx)), pat: s.to_string() },
             ImplTrait(g) => Type::ImplTrait(g.into_tcx(tcx)),
             Infer => Type::Infer,
             RawPointer(mutability, type_) => Type::RawPointer {

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -528,6 +528,7 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
             ty::Str => Res::Primitive(Str),
             ty::Tuple(tys) if tys.is_empty() => Res::Primitive(Unit),
             ty::Tuple(_) => Res::Primitive(Tuple),
+            ty::Pat(..) => Res::Primitive(Pat),
             ty::Array(..) => Res::Primitive(Array),
             ty::Slice(_) => Res::Primitive(Slice),
             ty::RawPtr(_) => Res::Primitive(RawPointer),

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -565,6 +565,12 @@ pub enum Type {
         type_: Box<Type>,
         len: String,
     },
+    /// u32 is 0..=100
+    Pat {
+        #[serde(rename = "type")]
+        type_: Box<Type>,
+        pat: String,
+    },
     /// `impl TraitA + TraitB + ...`
     ImplTrait(Vec<GenericBound>),
     /// `_`

--- a/src/tools/clippy/clippy_lints/src/dereference.rs
+++ b/src/tools/clippy/clippy_lints/src/dereference.rs
@@ -1410,6 +1410,7 @@ fn ty_auto_deref_stability<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>, precedenc
             | ty::Int(_)
             | ty::Uint(_)
             | ty::Array(..)
+            | ty::Pat(..)
             | ty::Float(_)
             | ty::RawPtr(..)
             | ty::FnPtr(_) => Position::DerefStable(precedence, true).into(),

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -133,6 +133,8 @@ fn check_rvalue<'tcx>(
         | Rvalue::Use(operand)
         | Rvalue::Cast(
             CastKind::PointerFromExposedAddress
+            | CastKind::StripPattern
+            | CastKind::Patternize
             | CastKind::IntToInt
             | CastKind::FloatToInt
             | CastKind::IntToFloat

--- a/tests/mir-opt/const_prop/boxes.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/boxes.main.ConstProp.diff
@@ -35,11 +35,11 @@
       bb1: {
           StorageLive(_7);                 // scope 0 at $DIR/boxes.rs:+1:14: +1:22
           _7 = ShallowInitBox(move _6, i32); // scope 0 at $DIR/boxes.rs:+1:14: +1:22
-          _8 = (((_7.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: *const i32); // scope 0 at $DIR/boxes.rs:+1:19: +1:21
+          _8 = (((_7.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: (*const i32) is 1..) as *const i32 (StripPattern); // scope 0 at $DIR/boxes.rs:+1:19: +1:21
           (*_8) = const 42_i32;            // scope 0 at $DIR/boxes.rs:+1:19: +1:21
           _3 = move _7;                    // scope 0 at $DIR/boxes.rs:+1:14: +1:22
           StorageDead(_7);                 // scope 0 at $DIR/boxes.rs:+1:21: +1:22
-          _9 = (((_3.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: *const i32); // scope 0 at $DIR/boxes.rs:+1:13: +1:22
+          _9 = (((_3.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: (*const i32) is 1..) as *const i32 (StripPattern); // scope 0 at $DIR/boxes.rs:+1:13: +1:22
           _2 = (*_9);                      // scope 0 at $DIR/boxes.rs:+1:13: +1:22
           _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/boxes.rs:+1:13: +1:26
           StorageDead(_2);                 // scope 0 at $DIR/boxes.rs:+1:25: +1:26

--- a/tests/mir-opt/inline/inline_into_box_place.main.Inline.diff
+++ b/tests/mir-opt/inline/inline_into_box_place.main.Inline.diff
@@ -9,16 +9,17 @@
       let mut _4: *mut u8;                 // in scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
       let mut _5: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
       let mut _6: ();                      // in scope 0 at $DIR/inline_into_box_place.rs:+1:42: +1:43
-      let mut _7: *const std::vec::Vec<u32>; // in scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
-+     let mut _8: &mut std::vec::Vec<u32>; // in scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
-+     let mut _9: std::vec::Vec<u32>;      // in scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
+      let mut _7: *const std::vec::Vec<u32>; // in scope 0 at $DIR/inline_into_box_place.rs:+1:42: +1:43
+      let mut _8: *const std::vec::Vec<u32>; // in scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
++     let mut _9: &mut std::vec::Vec<u32>; // in scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
++     let mut _10: std::vec::Vec<u32>;     // in scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
       scope 1 {
           debug _x => _1;                  // in scope 1 at $DIR/inline_into_box_place.rs:+1:9: +1:11
       }
       scope 2 {
       }
 +     scope 3 (inlined Vec::<u32>::new) {  // at $DIR/inline_into_box_place.rs:8:33: 8:43
-+         let mut _10: alloc::raw_vec::RawVec<u32>; // in scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
++         let mut _11: alloc::raw_vec::RawVec<u32>; // in scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +     }
   
       bb0: {
@@ -34,13 +35,13 @@
       bb1: {
           StorageLive(_5);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
           _5 = ShallowInitBox(move _4, std::vec::Vec<u32>); // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
-          _7 = (((_5.0: std::ptr::Unique<std::vec::Vec<u32>>).0: std::ptr::NonNull<std::vec::Vec<u32>>).0: *const std::vec::Vec<u32>); // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
--         (*_7) = Vec::<u32>::new() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
-+         StorageLive(_8);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
-+         _8 = &mut (*_7);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
+          _8 = (((_5.0: std::ptr::Unique<std::vec::Vec<u32>>).0: std::ptr::NonNull<std::vec::Vec<u32>>).0: (*const std::vec::Vec<u32>) is 1..) as *const std::vec::Vec<u32> (StripPattern); // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
+-         (*_8) = Vec::<u32>::new() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
 +         StorageLive(_9);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
-+         StorageLive(_10);                // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-+         _10 = const _;                   // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
++         _9 = &mut (*_8);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
++         StorageLive(_10);                // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
++         StorageLive(_11);                // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
++         _11 = const _;                   // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
                                            // mir::Constant
 -                                          // + span: $DIR/inline_into_box_place.rs:8:33: 8:41
 -                                          // + user_ty: UserType(1)
@@ -51,13 +52,13 @@
 +                                          // + span: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Unevaluated(alloc::raw_vec::RawVec::<T>::NEW, [u32], None) }
-+         Deinit(_9);                      // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-+         (_9.0: alloc::raw_vec::RawVec<u32>) = move _10; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-+         (_9.1: usize) = const 0_usize;   // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-+         StorageDead(_10);                // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-+         (*_8) = move _9;                 // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
++         Deinit(_10);                     // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
++         (_10.0: alloc::raw_vec::RawVec<u32>) = move _11; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
++         (_10.1: usize) = const 0_usize;  // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
++         StorageDead(_11);                // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
++         (*_9) = move _10;                // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
++         StorageDead(_10);                // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
 +         StorageDead(_9);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
-+         StorageDead(_8);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:33: +1:43
           _1 = move _5;                    // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:43
           StorageDead(_5);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:42: +1:43
           _0 = const ();                   // scope 0 at $DIR/inline_into_box_place.rs:+0:11: +2:2
@@ -77,6 +78,7 @@
 -     }
 - 
 -     bb5 (cleanup): {
+-         _7 = (((_5.0: std::ptr::Unique<std::vec::Vec<u32>>).0: std::ptr::NonNull<std::vec::Vec<u32>>).0: (*const std::vec::Vec<u32>) is 1..) as *const std::vec::Vec<u32> (StripPattern); // scope 0 at $DIR/inline_into_box_place.rs:+1:42: +1:43
 -         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_5.1: std::alloc::Global)) -> bb4; // scope 0 at $DIR/inline_into_box_place.rs:+1:42: +1:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline_into_box_place.rs:8:42: 8:43

--- a/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
+++ b/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
@@ -22,7 +22,7 @@ fn b(_1: &mut Box<T>) -> &mut T {
         StorageLive(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         StorageLive(_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _7 = deref_copy (*_4);           // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        _8 = (((_7.0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>).0: *const T); // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        _8 = (((_7.0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>).0: (*const T) is 1..) as *const T (StripPattern); // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _6 = &mut (*_8);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _5 = &mut (*_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
+++ b/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
@@ -16,7 +16,7 @@ fn d(_1: &Box<T>) -> &T {
         StorageLive(_3);                 // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
         _3 = &(*_1);                     // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
         _4 = deref_copy (*_3);           // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        _5 = (((_4.0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>).0: *const T); // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        _5 = (((_4.0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>).0: (*const T) is 1..) as *const T (StripPattern); // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _2 = &(*_5);                     // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _0 = &(*_2);                     // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:5: +1:15
         StorageDead(_3);                 // scope 0 at $DIR/issue_58867_inline_as_ref_as_mut.rs:+1:14: +1:15

--- a/tests/mir-opt/match_pattern_type.rs
+++ b/tests/mir-opt/match_pattern_type.rs
@@ -1,0 +1,11 @@
+use std::time::Duration;
+
+// EMIT_MIR match_pattern_type.system_time_math.built.after.mir
+fn system_time_math() {
+    match Duration::ZERO {
+        Duration::ZERO => {}
+        _ => {}
+    }
+}
+
+fn main() {}

--- a/tests/mir-opt/match_pattern_type.system_time_math.built.after.mir
+++ b/tests/mir-opt/match_pattern_type.system_time_math.built.after.mir
@@ -1,0 +1,39 @@
+// MIR for `system_time_math` after built
+
+fn system_time_math() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/match_pattern_type.rs:+0:23: +0:23
+    let mut _1: std::time::Duration;     // in scope 0 at $DIR/match_pattern_type.rs:+1:11: +1:25
+
+    bb0: {
+        StorageLive(_1);                 // scope 0 at $DIR/match_pattern_type.rs:+1:11: +1:25
+        _1 = const _;                    // scope 0 at $DIR/match_pattern_type.rs:+1:11: +1:25
+                                         // mir::Constant
+                                         // + span: $DIR/match_pattern_type.rs:5:11: 5:25
+                                         // + literal: Const { ty: Duration, val: Unevaluated(Duration::ZERO, [], None) }
+        FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/match_pattern_type.rs:+1:11: +1:25
+        switchInt((_1.0: u64)) -> [0: bb1, otherwise: bb3]; // scope 0 at $DIR/match_pattern_type.rs:+1:5: +1:25
+    }
+
+    bb1: {
+        switchInt((((_1.1: core::time::Nanoseconds).0: u32 is 0..=999999999) as u32)) -> [0: bb2, otherwise: bb3]; // scope 0 at $DIR/match_pattern_type.rs:+1:5: +1:25
+    }
+
+    bb2: {
+        falseEdge -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/match_pattern_type.rs:+2:9: +2:23
+    }
+
+    bb3: {
+        _0 = const ();                   // scope 0 at $DIR/match_pattern_type.rs:+3:14: +3:16
+        goto -> bb5;                     // scope 0 at $DIR/match_pattern_type.rs:+3:14: +3:16
+    }
+
+    bb4: {
+        _0 = const ();                   // scope 0 at $DIR/match_pattern_type.rs:+2:27: +2:29
+        goto -> bb5;                     // scope 0 at $DIR/match_pattern_type.rs:+2:27: +2:29
+    }
+
+    bb5: {
+        StorageDead(_1);                 // scope 0 at $DIR/match_pattern_type.rs:+5:1: +5:2
+        return;                          // scope 0 at $DIR/match_pattern_type.rs:+5:2: +5:2
+    }
+}

--- a/tests/ui/attributes/unsafe/unsafe-borrow-match.mirunsafeck.stderr
+++ b/tests/ui/attributes/unsafe/unsafe-borrow-match.mirunsafeck.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/unsafe-borrow-match.rs:13:17
+   |
+LL |     match &mut foo {
+   |           -------- this expression has type `&mut NonZero<_>`
+LL |         NonZero((a,)) => *a = 0_i32 as _,
+   |                 ^^^^ expected pattern, found tuple
+   |
+   = note: expected pattern type `_ is 1..`
+                     found tuple `(_,)`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/attributes/unsafe/unsafe-borrow-match.rs
+++ b/tests/ui/attributes/unsafe/unsafe-borrow-match.rs
@@ -1,0 +1,18 @@
+// revisions: mirunsafeck thirunsafeck
+// [thirunsafeck]compile-flags: -Z thir-unsafeck
+
+#![feature(rustc_attrs)]
+#![allow(unused,dead_code)]
+
+fn mtch() {
+    #[rustc_layout_scalar_valid_range_start(1)]
+    struct NonZero<T>(T);
+
+    let mut foo = unsafe { NonZero((1_i32,) as _) };
+    match &mut foo {
+        NonZero((a,)) => *a = 0_i32 as _,
+        //~^ ERROR: mismatched type
+    }
+}
+
+fn main() {}

--- a/tests/ui/attributes/unsafe/unsafe-borrow-match.thirunsafeck.stderr
+++ b/tests/ui/attributes/unsafe/unsafe-borrow-match.thirunsafeck.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/unsafe-borrow-match.rs:13:17
+   |
+LL |     match &mut foo {
+   |           -------- this expression has type `&mut NonZero<_>`
+LL |         NonZero((a,)) => *a = 0_i32 as _,
+   |                 ^^^^ expected pattern, found tuple
+   |
+   = note: expected pattern type `_ is 1..`
+                     found tuple `(_,)`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/attributes/unsafe/unsafe-borrow-tuple.mirunsafeck.stderr
+++ b/tests/ui/attributes/unsafe/unsafe-borrow-tuple.mirunsafeck.stderr
@@ -1,14 +1,14 @@
 error[E0282]: type annotations needed
-  --> $DIR/unsafe-assign.rs:12:5
+  --> $DIR/unsafe-borrow-tuple.rs:12:18
    |
-LL |     foo.0.0 = 0_i32;
-   |     ^^^^^^^ cannot infer type
+LL |     let a = &mut foo.0.0;
+   |                  ^^^^^^^ cannot infer type
 
 error[E0609]: no field `0` on type `_ is 1..`
-  --> $DIR/unsafe-assign.rs:12:11
+  --> $DIR/unsafe-borrow-tuple.rs:12:24
    |
-LL |     foo.0.0 = 0_i32;
-   |           ^
+LL |     let a = &mut foo.0.0;
+   |                        ^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/attributes/unsafe/unsafe-borrow-tuple.rs
+++ b/tests/ui/attributes/unsafe/unsafe-borrow-tuple.rs
@@ -1,0 +1,17 @@
+// revisions: mirunsafeck thirunsafeck
+// [thirunsafeck]compile-flags: -Z thir-unsafeck
+
+#![feature(rustc_attrs)]
+#![allow(unused,dead_code)]
+
+fn tuple_struct() {
+    #[rustc_layout_scalar_valid_range_start(1)]
+    struct NonZero<T>(T);
+
+    let mut foo = unsafe { NonZero((1,) as _) };
+    let a = &mut foo.0.0;
+    //~^ ERROR: type annotations needed
+    //~| ERROR: no field `0` on type `_ is 1..`
+}
+
+fn main() {}

--- a/tests/ui/attributes/unsafe/unsafe-borrow-tuple.thirunsafeck.stderr
+++ b/tests/ui/attributes/unsafe/unsafe-borrow-tuple.thirunsafeck.stderr
@@ -1,14 +1,14 @@
 error[E0282]: type annotations needed
-  --> $DIR/unsafe-assign.rs:12:5
+  --> $DIR/unsafe-borrow-tuple.rs:12:18
    |
-LL |     foo.0.0 = 0_i32;
-   |     ^^^^^^^ cannot infer type
+LL |     let a = &mut foo.0.0;
+   |                  ^^^^^^^ cannot infer type
 
 error[E0609]: no field `0` on type `_ is 1..`
-  --> $DIR/unsafe-assign.rs:12:11
+  --> $DIR/unsafe-borrow-tuple.rs:12:24
    |
-LL |     foo.0.0 = 0_i32;
-   |           ^
+LL |     let a = &mut foo.0.0;
+   |                        ^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
@@ -54,10 +54,10 @@ LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::tran
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:54:1
+  --> $DIR/raw-bytes.rs:53:1
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .pointer: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
@@ -65,10 +65,10 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:57:1
+  --> $DIR/raw-bytes.rs:56:1
    |
 LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 1, align: 1) {
@@ -76,10 +76,10 @@ LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:59:1
+  --> $DIR/raw-bytes.rs:58:1
    |
 LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
@@ -87,10 +87,10 @@ LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:65:1
+  --> $DIR/raw-bytes.rs:64:1
    |
-LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 42, but expected something in the range 10..=30
+LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42_u32 as _) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 42, but expected something in the range 10..=30
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
@@ -98,10 +98,10 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:71:1
+  --> $DIR/raw-bytes.rs:70:1
    |
-LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 20, but expected something less or equal to 10, or greater or equal to 30
+LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20_u32 as _) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 20, but expected something less or equal to 10, or greater or equal to 30
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
@@ -109,10 +109,10 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:74:1
+  --> $DIR/raw-bytes.rs:73:1
    |
 LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .pointer: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
@@ -120,7 +120,7 @@ LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:82:1
+  --> $DIR/raw-bytes.rs:80:1
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
@@ -131,7 +131,7 @@ LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:86:1
+  --> $DIR/raw-bytes.rs:84:1
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
@@ -142,7 +142,7 @@ LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:90:1
+  --> $DIR/raw-bytes.rs:88:1
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^ constructing invalid value: encountered a null reference
@@ -153,7 +153,7 @@ LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:93:1
+  --> $DIR/raw-bytes.rs:91:1
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a null box
@@ -164,7 +164,7 @@ LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:96:1
+  --> $DIR/raw-bytes.rs:94:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (address 0x539 is unallocated)
@@ -175,7 +175,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:99:1
+  --> $DIR/raw-bytes.rs:97:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (address 0x539 is unallocated)
@@ -186,7 +186,7 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:102:1
+  --> $DIR/raw-bytes.rs:100:1
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered null pointer, but expected a function pointer
@@ -197,7 +197,7 @@ LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:104:1
+  --> $DIR/raw-bytes.rs:102:1
    |
 LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0xd[noalloc], but expected a function pointer
@@ -208,7 +208,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:106:1
+  --> $DIR/raw-bytes.rs:104:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered allocN, but expected a function pointer
@@ -219,7 +219,7 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:112:1
+  --> $DIR/raw-bytes.rs:110:1
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a reference pointing to uninhabited type Bar
@@ -230,7 +230,7 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:137:1
+  --> $DIR/raw-bytes.rs:134:1
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
@@ -241,7 +241,7 @@ LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:139:1
+  --> $DIR/raw-bytes.rs:136:1
    |
 LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered invalid reference metadata: slice is bigger than largest supported object
@@ -252,7 +252,7 @@ LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, us
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:141:1
+  --> $DIR/raw-bytes.rs:138:1
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
@@ -263,7 +263,7 @@ LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize:
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:144:1
+  --> $DIR/raw-bytes.rs:141:1
    |
 LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>: encountered uninitialized data in `str`
@@ -274,9 +274,9 @@ LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit:
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:146:1
+  --> $DIR/raw-bytes.rs:143:1
    |
-LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
+LL | const MYSTR_NO_INIT: &MyStr =
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered uninitialized data in `str`
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
@@ -285,7 +285,7 @@ LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUni
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:148:1
+  --> $DIR/raw-bytes.rs:146:1
    |
 LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>(&[&()]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into raw bytes
@@ -297,7 +297,7 @@ LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:152:1
+  --> $DIR/raw-bytes.rs:150:1
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
@@ -308,7 +308,7 @@ LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:154:1
+  --> $DIR/raw-bytes.rs:152:1
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
@@ -319,7 +319,7 @@ LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, is
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:157:1
+  --> $DIR/raw-bytes.rs:155:1
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (going beyond the bounds of its allocation)
@@ -330,7 +330,7 @@ LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999us
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:160:1
+  --> $DIR/raw-bytes.rs:158:1
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
@@ -341,13 +341,13 @@ LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
            }
 
 note: erroneous constant used
-  --> $DIR/raw-bytes.rs:160:40
+  --> $DIR/raw-bytes.rs:158:40
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:166:1
+  --> $DIR/raw-bytes.rs:163:1
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
@@ -358,13 +358,13 @@ LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3
            }
 
 note: erroneous constant used
-  --> $DIR/raw-bytes.rs:166:42
+  --> $DIR/raw-bytes.rs:163:42
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:170:1
+  --> $DIR/raw-bytes.rs:167:1
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
@@ -375,13 +375,13 @@ LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::tran
            }
 
 note: erroneous constant used
-  --> $DIR/raw-bytes.rs:170:42
+  --> $DIR/raw-bytes.rs:167:42
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:175:1
+  --> $DIR/raw-bytes.rs:172:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered allocN, but expected a vtable pointer
@@ -392,7 +392,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:179:1
+  --> $DIR/raw-bytes.rs:176:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered allocN, but expected a vtable pointer
@@ -403,7 +403,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:183:1
+  --> $DIR/raw-bytes.rs:180:1
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0x4[noalloc], but expected a vtable pointer
@@ -414,9 +414,9 @@ LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:186:1
+  --> $DIR/raw-bytes.rs:183:1
    |
-LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
+LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> =
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered allocN, but expected a vtable pointer
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
@@ -425,7 +425,7 @@ LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::trans
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:190:1
+  --> $DIR/raw-bytes.rs:188:1
    |
 LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.<dyn-downcast>: encountered 0x03, but expected a boolean
@@ -436,7 +436,7 @@ LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, 
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:194:1
+  --> $DIR/raw-bytes.rs:192:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered null pointer, but expected a vtable pointer
@@ -447,7 +447,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:196:1
+  --> $DIR/raw-bytes.rs:194:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered allocN, but expected a vtable pointer
@@ -458,7 +458,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transm
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:201:1
+  --> $DIR/raw-bytes.rs:198:1
    |
 LL | const LAYOUT_INVALID_ZERO: Layout = unsafe { Layout::from_size_align_unchecked(0x1000, 0x00) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .align.0.<enum-tag>: encountered 0x0000000000000000, but expected a valid enum tag
@@ -469,7 +469,7 @@ LL | const LAYOUT_INVALID_ZERO: Layout = unsafe { Layout::from_size_align_unchec
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:205:1
+  --> $DIR/raw-bytes.rs:202:1
    |
 LL | const LAYOUT_INVALID_THREE: Layout = unsafe { Layout::from_size_align_unchecked(9, 3) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .align.0.<enum-tag>: encountered 0x0000000000000003, but expected a valid enum tag
@@ -480,7 +480,7 @@ LL | const LAYOUT_INVALID_THREE: Layout = unsafe { Layout::from_size_align_unche
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:209:1
+  --> $DIR/raw-bytes.rs:205:1
    |
 LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
    | ^^^^^^^^^^^^^^^^ constructing invalid value: encountered a reference pointing to uninhabited type [!; 1]
@@ -491,7 +491,7 @@ LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:210:1
+  --> $DIR/raw-bytes.rs:206:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
    | ^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a value of the never type `!`
@@ -502,7 +502,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:211:1
+  --> $DIR/raw-bytes.rs:207:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
    | ^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a value of the never type `!`
@@ -513,7 +513,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:215:1
+  --> $DIR/raw-bytes.rs:210:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered uninitialized bytes
@@ -524,7 +524,7 @@ LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:218:1
+  --> $DIR/raw-bytes.rs:213:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem::size_of::<&u32>()) };
    | ^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into raw bytes
@@ -536,7 +536,7 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem:
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:221:1
+  --> $DIR/raw-bytes.rs:216:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean
@@ -547,7 +547,7 @@ LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4)
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:225:1
+  --> $DIR/raw-bytes.rs:220:1
    |
 LL | pub static S7: &[u16] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[1]: encountered uninitialized bytes
@@ -558,7 +558,7 @@ LL | pub static S7: &[u16] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:232:1
+  --> $DIR/raw-bytes.rs:227:1
    |
 LL | pub static R4: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered uninitialized bytes
@@ -569,7 +569,7 @@ LL | pub static R4: &[u8] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:237:1
+  --> $DIR/raw-bytes.rs:232:1
    |
 LL | pub static R5: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into raw bytes
@@ -581,7 +581,7 @@ LL | pub static R5: &[u8] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:242:1
+  --> $DIR/raw-bytes.rs:237:1
    |
 LL | pub static R6: &[bool] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean

--- a/tests/ui/consts/const-eval/ub-nonnull.stderr
+++ b/tests/ui/consts/const-eval/ub-nonnull.stderr
@@ -2,7 +2,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-nonnull.rs:14:1
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .pointer: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
@@ -10,27 +10,27 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-nonnull.rs:20:30
+  --> $DIR/ub-nonnull.rs:21:34
    |
-LL |     let out_of_bounds_ptr = &ptr[255];
-   |                              ^^^^^^^^ dereferencing pointer failed: alloc11 has size 1, so pointer to 256 bytes starting at offset 0 is out-of-bounds
-
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:24:1
-   |
-LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+LL |         let out_of_bounds_ptr = &ptr[255];
+   |                                  ^^^^^^^^ dereferencing pointer failed: alloc11 has size 1, so pointer to 256 bytes starting at offset 0 is out-of-bounds
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-nonnull.rs:26:1
    |
+LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/ub-nonnull.rs:28:1
+   |
 LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
@@ -38,27 +38,16 @@ LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-nonnull.rs:34:36
+  --> $DIR/ub-nonnull.rs:36:36
    |
 LL | const UNINIT: NonZeroU8 = unsafe { MaybeUninit { uninit: () }.init };
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:43:1
+  --> $DIR/ub-nonnull.rs:45:1
    |
-LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 42, but expected something in the range 10..=30
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
-
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:49:1
-   |
-LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 20, but expected something less or equal to 10, or greater or equal to 30
+LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42_u32 as _) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 42, but expected something in the range 10..=30
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
@@ -66,10 +55,21 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:52:1
+  --> $DIR/ub-nonnull.rs:51:1
+   |
+LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20_u32 as _) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 20, but expected something less or equal to 10, or greater or equal to 30
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/ub-nonnull.rs:54:1
    |
 LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .pointer: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {

--- a/tests/ui/impl-trait/unsafety-checking-cycle.rs
+++ b/tests/ui/impl-trait/unsafety-checking-cycle.rs
@@ -26,7 +26,7 @@ fn not_field(c: bool) -> impl Sized {
         let x = unsafe { NonZero(not_field(false)) };
         &x;
     }
-    5u32
+    unsafe { NonZero::<u32>(5u32 as _) }.0
 }
 
 fn main() {}

--- a/tests/ui/layout/valid_range_oob.rs
+++ b/tests/ui/layout/valid_range_oob.rs
@@ -10,6 +10,6 @@ struct Foo(i8);
 
 // Need to do in a constant, as runtime codegen
 // does not compute the layout of `Foo` in check builds.
-const FOO: Foo = unsafe { Foo(1) };
+const FOO: Foo = unsafe { Foo(1_i8 as _) };
 
 fn main() {}

--- a/tests/ui/layout/valid_range_oob.stderr
+++ b/tests/ui/layout/valid_range_oob.stderr
@@ -1,6 +1,13 @@
 error: internal compiler error: unexpected panic
 
 query stack during panic:
-#0 [layout_of] computing layout of `Foo`
-#1 [eval_to_allocation_raw] const-evaluating + checking `FOO`
+#0 [layout_of] computing layout of `i8 is ..=257`
+#1 [check_mod_deathness] checking deathness of variables in top-level module
+end of query stack
+
+error: internal compiler error: unexpected panic
+
+query stack during panic:
+#0 [layout_of] computing layout of `i8 is ..=257`
+#1 [layout_of] computing layout of `Foo`
 end of query stack

--- a/tests/ui/lint/invalid_value.stderr
+++ b/tests/ui/lint/invalid_value.stderr
@@ -332,7 +332,6 @@ LL |         let _val: NonNull<i32> = mem::uninitialized();
    |                                  help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
    = note: `std::ptr::NonNull<i32>` must be non-null
-   = note: raw pointers must be initialized
 
 error: the type `(NonZeroU32, i32)` does not permit zero-initialization
   --> $DIR/invalid_value.rs:95:39
@@ -355,7 +354,6 @@ LL |         let _val: (NonZeroU32, i32) = mem::uninitialized();
    |                                       help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
    = note: `std::num::NonZeroU32` must be non-null
-   = note: integers must be initialized
 
 error: the type `*const dyn Send` does not permit zero-initialization
   --> $DIR/invalid_value.rs:98:37
@@ -462,7 +460,6 @@ note: because `std::num::NonZeroU32` must be non-null (in this field of the only
    |
 LL |     Banana(NonZeroU32),
    |            ^^^^^^^^^^
-   = note: integers must be initialized
 
 error: the type `bool` does not permit being left uninitialized
   --> $DIR/invalid_value.rs:112:26
@@ -501,11 +498,6 @@ LL |         let _val: NonBig = mem::uninitialized();
    |                            help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
    = note: `NonBig` must be initialized inside its custom valid range
-note: integers must be initialized (in this struct field)
-  --> $DIR/invalid_value.rs:23:26
-   |
-LL | pub(crate) struct NonBig(u64);
-   |                          ^^^
 
 error: the type `Fruit` does not permit being left uninitialized
   --> $DIR/invalid_value.rs:121:27
@@ -587,11 +579,6 @@ LL |         let _val: WrapAroundRange = mem::uninitialized();
    |                                     help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
    = note: `WrapAroundRange` must be initialized inside its custom valid range
-note: integers must be initialized (in this struct field)
-  --> $DIR/invalid_value.rs:49:35
-   |
-LL | pub(crate) struct WrapAroundRange(u8);
-   |                                   ^^
 
 error: the type `Result<i32, i32>` does not permit being left uninitialized
   --> $DIR/invalid_value.rs:144:38
@@ -659,7 +646,6 @@ LL |         let _val: NonNull<i32> = MaybeUninit::uninit().assume_init();
    |                                  help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
    = note: `std::ptr::NonNull<i32>` must be non-null
-   = note: raw pointers must be initialized
 
 error: the type `bool` does not permit being left uninitialized
   --> $DIR/invalid_value.rs:159:26

--- a/tests/ui/mir/ssa-analysis-regression-50041.rs
+++ b/tests/ui/mir/ssa-analysis-regression-50041.rs
@@ -2,9 +2,12 @@
 // compile-flags: -Z mir-opt-level=4
 
 #![crate_type = "lib"]
-#![feature(lang_items)]
+#![feature(lang_items, rustc_attrs)]
 #![no_std]
 
+#[repr(transparent)]
+#[rustc_layout_scalar_valid_range_start(1)]
+#[rustc_nonnull_optimization_guaranteed]
 struct NonNull<T: ?Sized>(*const T);
 
 struct Unique<T: ?Sized>(NonNull<T>);
@@ -19,7 +22,7 @@ impl<T: ?Sized> Drop for Box<T> {
 #[lang = "box_free"]
 #[inline(always)]
 unsafe fn box_free<T: ?Sized>(ptr: Unique<T>) {
-    dealloc(ptr.0.0)
+    dealloc(ptr.0.0 as _)
 }
 
 #[inline(never)]

--- a/tests/ui/unique/unique-autoderef-index.rs
+++ b/tests/ui/unique/unique-autoderef-index.rs
@@ -1,6 +1,31 @@
 // run-pass
+// compile-flags: -C opt-level=0
+
+#![allow(unused_must_use, unused_variables)]
+#![feature(rustc_attrs)]
+
+#[repr(transparent)]
+#[rustc_layout_scalar_valid_range_start(1)]
+#[rustc_nonnull_optimization_guaranteed]
+pub struct Unique<T: ?Sized> {
+    pointer: *const T,
+}
+
+impl<T: ?Sized> Unique<T> {
+    pub fn as_ptr(&self) -> *mut T {
+        self.pointer as *const T as *mut T
+    }
+}
+
+struct Droppy(Unique<i32>);
+
+impl Drop for Droppy {
+    fn drop(&mut self) {
+        self.0.as_ptr();
+    }
+}
 
 pub fn main() {
-    let i: Box<_> = Box::new(vec![100]);
-    assert_eq!((*i)[0], 100);
+    let mut x = 42;
+    Box::new(Droppy(unsafe { Unique { pointer: &mut x as *const i32 as _ } }));
 }

--- a/tests/ui/unique/unique-object-move.rs
+++ b/tests/ui/unique/unique-object-move.rs
@@ -4,13 +4,15 @@
 
 // pretty-expanded FIXME #23616
 
-pub trait EventLoop { fn foo(&self) {} }
-
-pub struct UvEventLoop {
-    uvio: isize
+pub trait EventLoop {
+    fn foo(&self) {}
 }
 
-impl EventLoop for UvEventLoop { }
+pub struct UvEventLoop {
+    uvio: isize,
+}
+
+impl EventLoop for UvEventLoop {}
 
 pub fn main() {
     let loop_: Box<dyn EventLoop> = Box::new(UvEventLoop { uvio: 0 }) as Box<dyn EventLoop>;

--- a/tests/ui/unsafe/ranged_ints.mir.stderr
+++ b/tests/ui/unsafe/ranged_ints.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints.rs:10:14
    |
-LL |     let _x = NonZero(0);
-   |              ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
+LL |     let _x = NonZero(0 as _);
+   |              ^^^^^^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
    |
    = note: initializing a layout restricted type's field with a value outside the valid range is undefined behavior
 

--- a/tests/ui/unsafe/ranged_ints.rs
+++ b/tests/ui/unsafe/ranged_ints.rs
@@ -7,5 +7,5 @@
 #[repr(transparent)]
 pub(crate) struct NonZero<T>(pub(crate) T);
 fn main() {
-    let _x = NonZero(0); //~ ERROR initializing type with `rustc_layout_scalar_valid_range` attr
+    let _x = NonZero(0 as _); //~ ERROR initializing type with `rustc_layout_scalar_valid_range` attr
 }

--- a/tests/ui/unsafe/ranged_ints.thir.stderr
+++ b/tests/ui/unsafe/ranged_ints.thir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints.rs:10:14
    |
-LL |     let _x = NonZero(0);
-   |              ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
+LL |     let _x = NonZero(0 as _);
+   |              ^^^^^^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
    |
    = note: initializing a layout restricted type's field with a value outside the valid range is undefined behavior
 

--- a/tests/ui/unsafe/ranged_ints2.rs
+++ b/tests/ui/unsafe/ranged_ints2.rs
@@ -7,6 +7,6 @@
 #[repr(transparent)]
 pub(crate) struct NonZero<T>(pub(crate) T);
 fn main() {
-    let mut x = unsafe { NonZero(1) };
+    let mut x = unsafe { NonZero(1 as _) };
     let y = &mut x.0; //~ ERROR mutation of layout constrained field is unsafe
 }

--- a/tests/ui/unsafe/ranged_ints2_const.rs
+++ b/tests/ui/unsafe/ranged_ints2_const.rs
@@ -10,20 +10,20 @@ fn main() {
 }
 
 const fn foo() -> NonZero<u32> {
-    let mut x = unsafe { NonZero(1) };
+    let mut x = unsafe { NonZero(1 as _) };
     let y = &mut x.0; //~ ERROR mutable references
     //~^ ERROR mutation of layout constrained field is unsafe
-    unsafe { NonZero(1) }
+    unsafe { NonZero(1_u32 as _) }
 }
 
 const fn bar() -> NonZero<u32> {
-    let mut x = unsafe { NonZero(1) };
+    let mut x = unsafe { NonZero(1 as _) };
     let y = unsafe { &mut x.0 }; //~ ERROR mutable references
-    unsafe { NonZero(1) }
+    unsafe { NonZero(1_u32 as _) }
 }
 
 const fn boo() -> NonZero<u32> {
-    let mut x = unsafe { NonZero(1) };
+    let mut x = unsafe { NonZero(1 as _) };
     unsafe { let y = &mut x.0; } //~ ERROR mutable references
-    unsafe { NonZero(1) }
+    unsafe { NonZero(1_u32 as _) }
 }

--- a/tests/ui/unsafe/ranged_ints3.rs
+++ b/tests/ui/unsafe/ranged_ints3.rs
@@ -9,6 +9,6 @@ use std::cell::Cell;
 #[repr(transparent)]
 pub(crate) struct NonZero<T>(pub(crate) T);
 fn main() {
-    let mut x = unsafe { NonZero(Cell::new(1)) };
+    let mut x = unsafe { NonZero(Cell::new(1) as _) };
     let y = &x.0; //~ ERROR borrow of layout constrained field with interior mutability
 }

--- a/tests/ui/unsafe/ranged_ints3_const.rs
+++ b/tests/ui/unsafe/ranged_ints3_const.rs
@@ -11,14 +11,14 @@ pub(crate) struct NonZero<T>(pub(crate) T);
 fn main() {}
 
 const fn foo() -> NonZero<Cell<u32>> {
-    let mut x = unsafe { NonZero(Cell::new(1)) };
+    let mut x = unsafe { NonZero(Cell::new(1) as _) };
     let y = &x.0; //~ ERROR the borrowed element may contain interior mutability
     //~^ ERROR borrow of layout constrained field with interior mutability
-    unsafe { NonZero(Cell::new(1)) }
+    unsafe { NonZero(Cell::new(1_u32) as _) }
 }
 
 const fn bar() -> NonZero<Cell<u32>> {
-    let mut x = unsafe { NonZero(Cell::new(1)) };
+    let mut x = unsafe { NonZero(Cell::new(1) as _) };
     let y = unsafe { &x.0 }; //~ ERROR the borrowed element may contain interior mutability
-    unsafe { NonZero(Cell::new(1)) }
+    unsafe { NonZero(Cell::new(1_u32) as _) }
 }

--- a/tests/ui/unsafe/ranged_ints3_match.rs
+++ b/tests/ui/unsafe/ranged_ints3_match.rs
@@ -9,13 +9,13 @@ use std::cell::Cell;
 #[repr(transparent)]
 pub(crate) struct NonZero<T>(pub(crate) T);
 fn main() {
-    let mut x = unsafe { NonZero(Cell::new(1)) };
+    let mut x = unsafe { NonZero(Cell::new(1) as _) };
     match x {
         NonZero(ref x) => { x }
         //~^ ERROR borrow of layout constrained field with interior mutability
     };
 
-    let mut y = unsafe { NonZero(42) };
+    let mut y = unsafe { NonZero(42 as _) };
     match y { NonZero(ref y) => { y } }; // OK, type of `y` is freeze
     match y { NonZero(ref mut y) => { y } };
     //~^ ERROR mutation of layout constrained field

--- a/tests/ui/unsafe/ranged_ints4.mirunsafeck.stderr
+++ b/tests/ui/unsafe/ranged_ints4.mirunsafeck.stderr
@@ -1,8 +1,8 @@
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints4.rs:11:5
    |
-LL |     x.0 = 0;
-   |     ^^^^^^^ mutation of layout constrained field
+LL |     x.0 = 0 as _;
+   |     ^^^^^^^^^^^^ mutation of layout constrained field
    |
    = note: mutating layout constrained fields cannot statically be checked for valid values
 

--- a/tests/ui/unsafe/ranged_ints4.rs
+++ b/tests/ui/unsafe/ranged_ints4.rs
@@ -7,6 +7,6 @@
 #[repr(transparent)]
 pub(crate) struct NonZero<T>(pub(crate) T);
 fn main() {
-    let mut x = unsafe { NonZero(1) };
-    x.0 = 0; //~ ERROR mutation of layout constrained field is unsafe
+    let mut x = unsafe { NonZero(1 as _) };
+    x.0 = 0 as _; //~ ERROR mutation of layout constrained field is unsafe
 }

--- a/tests/ui/unsafe/ranged_ints4.thirunsafeck.stderr
+++ b/tests/ui/unsafe/ranged_ints4.thirunsafeck.stderr
@@ -1,8 +1,8 @@
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints4.rs:11:5
    |
-LL |     x.0 = 0;
-   |     ^^^^^^^ mutation of layout constrained field
+LL |     x.0 = 0 as _;
+   |     ^^^^^^^^^^^^ mutation of layout constrained field
    |
    = note: mutating layout constrained fields cannot statically be checked for valid values
 

--- a/tests/ui/unsafe/ranged_ints4_const.mirunsafeck.stderr
+++ b/tests/ui/unsafe/ranged_ints4_const.mirunsafeck.stderr
@@ -1,8 +1,8 @@
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints4_const.rs:13:5
    |
-LL |     x.0 = 0;
-   |     ^^^^^^^ mutation of layout constrained field
+LL |     x.0 = 0_u32 as _;
+   |     ^^^^^^^^^^^^^^^^ mutation of layout constrained field
    |
    = note: mutating layout constrained fields cannot statically be checked for valid values
 

--- a/tests/ui/unsafe/ranged_ints4_const.rs
+++ b/tests/ui/unsafe/ranged_ints4_const.rs
@@ -9,14 +9,14 @@ pub(crate) struct NonZero<T>(pub(crate) T);
 fn main() {}
 
 const fn foo() -> NonZero<u32> {
-    let mut x = unsafe { NonZero(1) };
-    x.0 = 0;
+    let mut x = unsafe { NonZero(1_u32 as _) };
+    x.0 = 0_u32 as _;
     //~^ ERROR mutation of layout constrained field is unsafe
     x
 }
 
 const fn bar() -> NonZero<u32> {
-    let mut x = unsafe { NonZero(1) };
-    unsafe { x.0 = 0 }; // this is UB
+    let mut x = unsafe { NonZero(1_u32 as _) };
+    unsafe { x.0 = 0_u32 as _ }; // this is UB
     x
 }

--- a/tests/ui/unsafe/ranged_ints4_const.thirunsafeck.stderr
+++ b/tests/ui/unsafe/ranged_ints4_const.thirunsafeck.stderr
@@ -1,8 +1,8 @@
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints4_const.rs:13:5
    |
-LL |     x.0 = 0;
-   |     ^^^^^^^ mutation of layout constrained field
+LL |     x.0 = 0_u32 as _;
+   |     ^^^^^^^^^^^^^^^^ mutation of layout constrained field
    |
    = note: mutating layout constrained fields cannot statically be checked for valid values
 

--- a/tests/ui/unsafe/ranged_ints_const.mir.stderr
+++ b/tests/ui/unsafe/ranged_ints_const.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints_const.rs:11:34
    |
-LL | const fn foo() -> NonZero<u32> { NonZero(0) }
-   |                                  ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
+LL | const fn foo() -> NonZero<u32> { NonZero(0_u32 as _) }
+   |                                  ^^^^^^^^^^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
    |
    = note: initializing a layout restricted type's field with a value outside the valid range is undefined behavior
 

--- a/tests/ui/unsafe/ranged_ints_const.rs
+++ b/tests/ui/unsafe/ranged_ints_const.rs
@@ -8,7 +8,7 @@
 pub(crate) struct NonZero<T>(pub(crate) T);
 fn main() {}
 
-const fn foo() -> NonZero<u32> { NonZero(0) }
+const fn foo() -> NonZero<u32> { NonZero(0_u32 as _) }
 //~^ ERROR initializing type with `rustc_layout_scalar_valid_range` attr is unsafe
 
-const fn bar() -> NonZero<u32> { unsafe { NonZero(0) } }
+const fn bar() -> NonZero<u32> { unsafe { NonZero(0_u32 as _) } }

--- a/tests/ui/unsafe/ranged_ints_const.thir.stderr
+++ b/tests/ui/unsafe/ranged_ints_const.thir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints_const.rs:11:34
    |
-LL | const fn foo() -> NonZero<u32> { NonZero(0) }
-   |                                  ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
+LL | const fn foo() -> NonZero<u32> { NonZero(0_u32 as _) }
+   |                                  ^^^^^^^^^^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
    |
    = note: initializing a layout restricted type's field with a value outside the valid range is undefined behavior
 

--- a/tests/ui/unsafe/ranged_ints_macro.rs
+++ b/tests/ui/unsafe/ranged_ints_macro.rs
@@ -15,5 +15,5 @@ macro_rules! apply {
 apply!(1);
 
 fn main() {
-    let _x = unsafe { NonZero(1) };
+    let _x = unsafe { NonZero(1 as _) };
 }

--- a/tests/ui/unsafe/unsafe-assign.rs
+++ b/tests/ui/unsafe/unsafe-assign.rs
@@ -8,17 +8,18 @@ fn nested_field() {
     #[rustc_layout_scalar_valid_range_start(1)]
     struct NonZero<T>(T);
 
-    let mut foo = unsafe { NonZero((1,)) };
-    foo.0.0 = 0;
-    //~^ ERROR: mutation of layout constrained field is unsafe
+    let mut foo = unsafe { NonZero((1_i32,) as _) };
+    foo.0.0 = 0_i32;
+    //~^ ERROR: type annotations needed
+    //~| ERROR: no field `0` on type `_ is 1..`
 }
 
 fn block() {
     #[rustc_layout_scalar_valid_range_start(1)]
     struct NonZero<T>(T);
 
-    let mut foo = unsafe { NonZero((1,)) };
-    { foo.0 }.0 = 0;
+    let mut foo = unsafe { NonZero((1_i32,) as _) };
+    { foo.0 as (_,) }.0 = 0_i32;
     // ^ not unsafe because the result of the block expression is a new place
 }
 

--- a/tests/ui/unsafe/unsafe-assign.thirunsafeck.stderr
+++ b/tests/ui/unsafe/unsafe-assign.thirunsafeck.stderr
@@ -1,11 +1,16 @@
-error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
+error[E0282]: type annotations needed
   --> $DIR/unsafe-assign.rs:12:5
    |
-LL |     foo.0.0 = 0;
-   |     ^^^^^^^^^^^ mutation of layout constrained field
+LL |     foo.0.0 = 0_i32;
+   |     ^^^^^^^ cannot infer type
+
+error[E0609]: no field `0` on type `_ is 1..`
+  --> $DIR/unsafe-assign.rs:12:11
    |
-   = note: mutating layout constrained fields cannot statically be checked for valid values
+LL |     foo.0.0 = 0_i32;
+   |           ^
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0133`.
+Some errors have detailed explanations: E0282, E0609.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/unsafe/unsafe-borrow.mirunsafeck.stderr
+++ b/tests/ui/unsafe/unsafe-borrow.mirunsafeck.stderr
@@ -1,27 +1,19 @@
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-borrow.rs:12:13
-   |
-LL |     let a = &mut foo.0.0;
-   |             ^^^^^^^^^^^^ mutation of layout constrained field
-   |
-   = note: mutating layout constrained fields cannot statically be checked for valid values
-
-error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-borrow.rs:32:13
+  --> $DIR/unsafe-borrow.rs:13:18
    |
 LL |     let a = &mut foo.0[2];
-   |             ^^^^^^^^^^^^^ mutation of layout constrained field
+   |                  ^^^^^ mutation of layout constrained field
    |
    = note: mutating layout constrained fields cannot statically be checked for valid values
 
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-borrow.rs:51:18
+  --> $DIR/unsafe-borrow.rs:23:18
    |
-LL |         NonZero((a,)) => *a = 0,
-   |                  ^ mutation of layout constrained field
+LL |     let a = &mut foo.0[2];
+   |                  ^^^^^ mutation of layout constrained field
    |
    = note: mutating layout constrained fields cannot statically be checked for valid values
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0133`.

--- a/tests/ui/unsafe/unsafe-borrow.thirunsafeck.stderr
+++ b/tests/ui/unsafe/unsafe-borrow.thirunsafeck.stderr
@@ -1,27 +1,19 @@
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-borrow.rs:12:13
-   |
-LL |     let a = &mut foo.0.0;
-   |             ^^^^^^^^^^^^ mutation of layout constrained field
-   |
-   = note: mutating layout constrained fields cannot statically be checked for valid values
-
-error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-borrow.rs:32:13
+  --> $DIR/unsafe-borrow.rs:13:18
    |
 LL |     let a = &mut foo.0[2];
-   |             ^^^^^^^^^^^^^ mutation of layout constrained field
+   |                  ^^^^^ mutation of layout constrained field
    |
    = note: mutating layout constrained fields cannot statically be checked for valid values
 
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-borrow.rs:51:18
+  --> $DIR/unsafe-borrow.rs:23:18
    |
-LL |         NonZero((a,)) => *a = 0,
-   |                  ^ mutation of layout constrained field
+LL |     let a = &mut foo.0[2];
+   |                  ^^^^^ mutation of layout constrained field
    |
    = note: mutating layout constrained fields cannot statically be checked for valid values
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0133`.


### PR DESCRIPTION
Alternative to https://github.com/rust-lang/rust/pull/103724

Some explanation of the three alternatives can be found [on my blog](https://cohost.org/oli-obk/post/203456-strong-typing-has-do)

r? @BoxyUwU 

cc @joshtriplett 

This PR causes fields of types that use `rustc_scalar_valid_range` to be of a new `TyKind`: the `Pat` kind which at present has a nested type and a u128 range of valid values. This represents the status quo exactly, but before I rip out the old attribute checks and implement them on top of pattern types, I wanted to open this PR for discussion.

For now I added an inherently unsafe way to construct these types: you cast an arbitrary other type to them. So initializing `NonNull` works similar to `NonNull { pointer: some_raw_ptr as _ }`. The underscore figures our the right type, as right now there is *no user visible syntax* for these types.

As a next step I would like to remove the cast and instead implement it so that initialization of `NonNull` works like

```rust
match some_value {
    value @ 1.. => Some(NonZeroU8 { value }),
    _ => None,
}
```

where we teach pattern matching that the type of `pointer` is one of the new pattern types. The type of `value` is `(*const T) is 1..`

At this stage we would not support


```rust
match some_value {
    0 => None,
    value => Some(NonZeroU8 { value }),
}
```

because that requires reasoning across arms, which requires more work than just doing some local reasoning. The compiler *already* has this information for exhaustiveness checking, so we're not inventing anything new here, but we need to still fetch the information from exhaustiveness checking, so it seems best to start simple.