### PR TITLE
Update snap from `1.0.1` to `1.1.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5214,9 +5214,9 @@ checksum = "cc88c725d61fc6c3132893370cac4a0200e3fedf5da8331c570664b1987f5ca2"
 
 [[package]]
 name = "snap"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da73c8f77aebc0e40c300b93f0a5f1bece7a248a36eee287d4e095f35c7b7d6e"
+checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "snapbox"


### PR DESCRIPTION
As spotted by @mejrs, snap 1.0.1 emits a future compatibility warning. This was fixed in https://github.com/BurntSushi/rust-snappy/pull/39