### PR TITLE
solver comments + remove `TyCtxt::evaluate_goal`

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -28,8 +28,8 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         // To only compute normalization once for each projection we only
         // normalize if the expected term is an unconstrained inference variable.
         //
-        // E.g. for `<T as Trait>::Assoc = u32` we recursively compute the goal
-        // `exists<U> <T as Trait>::Assoc = U` and then take the resulting type for
+        // E.g. for `<T as Trait>::Assoc == u32` we recursively compute the goal
+        // `exists<U> <T as Trait>::Assoc == U` and then take the resulting type for
         // `U` and equate it with `u32`. This means that we don't need a separate
         // projection cache in the solver.
         if self.term_is_fully_unconstrained(goal) {


### PR DESCRIPTION
from the `RustcContributor::explore` session yesterday.

This also removes `TyCtxt::evaluate_goal` because to canonicalize you have to use an `InferCtxt` anyways at which point we should just always get people to use `evaluate_root_goal`.

r? @spastorino 