### PR TITLE
Disable ConstGoto opt in cleanup blocks

### DIFF
--- a/compiler/rustc_mir_transform/src/const_goto.rs
+++ b/compiler/rustc_mir_transform/src/const_goto.rs
@@ -57,6 +57,15 @@ impl<'tcx> MirPass<'tcx> for ConstGoto {
 }
 
 impl<'tcx> Visitor<'tcx> for ConstGotoOptimizationFinder<'_, 'tcx> {
+    fn visit_basic_block_data(&mut self, block: BasicBlock, data: &BasicBlockData<'tcx>) {
+        if data.is_cleanup {
+            // Because of the restrictions around control flow in cleanup blocks, we don't perform
+            // this optimization at all in such blocks.
+            return;
+        }
+        self.super_basic_block_data(block, data);
+    }
+
     fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
         let _: Option<_> = try {
             let target = terminator.kind.as_goto()?;


### PR DESCRIPTION
Fixes #107315 .

There is probably a smaller hammer that we could use here, but none that is super obviously correct. We can always revisit this in the future.

Could not add a test because custom mir does not support cleanup blocks. However, did check that the fallible_iterator crate no longer ICEs with the other PR cherry picked.

r? @tmiasko 