### PR TITLE
Clean up eslint annotations and remove unused JS function

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -180,7 +180,6 @@ function browserSupportsHistoryApi() {
     return window.history && typeof window.history.pushState === "function";
 }
 
-// eslint-disable-next-line no-unused-vars
 function loadCss(cssUrl) {
     const link = document.createElement("link");
     link.href = cssUrl;

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -51,7 +51,6 @@ function hasClass(elem, className) {
     return elem && elem.classList && elem.classList.contains(className);
 }
 
-// eslint-disable-next-line no-unused-vars
 function addClass(elem, className) {
     if (!elem || !elem.classList) {
         return;


### PR DESCRIPTION
Thanks to https://github.com/rust-lang/rust/pull/107177 I realized that some eslint annotations might be unneeded so I cleaned them up. I also removed the unused function while we wait for https://github.com/rust-lang/rust/pull/107177 to be updated.

r? @notriddle 