### PR TITLE
Document required fd/socket flags for I/O safety.

### DIFF
--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -56,13 +56,20 @@
 //!
 //! ## Required file-descriptor flags
 //!
-//! On Unix platforms, file descriptors that don't have the `O_CLOEXEC` flag
-//! set may be implicitly leaked into spawned child processes. This can be
-//! violate I/O safety, when the a file descriptor held in one part of the code
-//! is not intended to be exposed to child processes, and a spawn in another
-//! part of the code unknowingly exposes it. Consequently, Rust code that
-//! produces new `OwnedFd` or `BorrowedFd` values must either set the
-//! `O_CLOEXEC` flag, or be marked `unsafe`.
+//! On Unix platforms with the ability to spawn processes, file descriptors
+//! that don't have the `O_CLOEXEC` flag set may be implicitly leaked into
+//! spawned child processes. This can be violate I/O safety, when the a file
+//! descriptor held in one part of the code is not intended to be exposed to
+//! child processes, and a spawn in another part of the code unknowingly
+//! exposes it. Consequently, on these platforms, Rust code that produces new
+//! `OwnedFd` or `BorrowedFd` values must either set the `O_CLOEXEC` flag, or
+//! be marked `unsafe`.
+//!
+//! On platforms where it's possible to do so, the `O_CLOEXEC` flag must be set
+//! atomically by passing the appropriate flags to the OS API that creates the
+//! file descriptor. On some platforms though, it's not possible to do this for
+//! some resources, such as sockets or pipes. In these situations, `O_CLOEXEC`
+//! must be set as soon as possible after the new file descriptor.
 //!
 //! ## `/proc/self/mem` and similar OS features
 //!

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -54,6 +54,16 @@
 //! Like boxes, `OwnedFd` values conceptually own the resource they point to,
 //! and free (close) it when they are dropped.
 //!
+//! ## Required file-descriptor flags
+//!
+//! On Unix platforms, file descriptors that don't have the `O_CLOEXEC` flag
+//! set may be implicitly leaked into spawned child processes. This can be
+//! violate I/O safety, when the a file descriptor held in one part of the code
+//! is not intended to be exposed to child processes, and a spawn in another
+//! part of the code unknowingly exposes it. Consequently, Rust code that
+//! produces new `OwnedFd` or `BorrowedFd` values must either set the
+//! `O_CLOEXEC` flag, or be marked `unsafe`.
+//!
 //! ## `/proc/self/mem` and similar OS features
 //!
 //! Some platforms have special files, such as `/proc/self/mem`, which

--- a/library/std/src/os/windows/io/mod.rs
+++ b/library/std/src/os/windows/io/mod.rs
@@ -45,6 +45,19 @@
 //! Like boxes, `OwnedHandle` and `OwnedSocket` values conceptually own the
 //! resource they point to, and free (close) it when they are dropped.
 //!
+//! ## Required socket flags
+//!
+//! On Windows, sockets that don't have the `WSA_FLAG_OVERLAPPED` flag can't be
+//! passed to `WSASend` calls when a non-NULL `lpOverlapped` argument is
+//! provided. And sockets that don't have the `WSA_FLAG_NO_HANDLE_INHERIT`
+//! flag set may be implicitly leaked into spawned child processes. This can be
+//! violate I/O safety, when the a socket held in one part of the code is not
+//! intended to be exposed to child processes, and a spawn in another part of
+//! the code unknowingly exposes it. Consequently, Rust code that produces new
+//! `OwnedSocket` or `BorrowedSocket` values must either set the
+//! `WSA_FLAG_OVERLAPPED` and `WSA_FLAG_NO_HANDLE_INHERIT` flags, or be marked
+//! `unsafe`.
+//!
 //! [`BorrowedHandle<'a>`]: crate::os::windows::io::BorrowedHandle
 //! [`BorrowedSocket<'a>`]: crate::os::windows::io::BorrowedSocket
 


### PR DESCRIPTION
On Unix, document that the `O_CLOEXEC` flag is required on all file descriptors, and on Windows, document that the `WSA_FLAG_OVERLAPPED` and `WSA_FLAG_NO_HANDLE_INHERIT` flags are required on all sockets, as a as a requirement for I/O safety. `O_CLOEXEC` and
`WSA_FLAG_NO_HANDLE_INHERIT` prevent resources from being implicitly leaked into child processes, and `WSA_FLAG_OVERLAPPED` prevents undefined behavior in usage patterns which safe Rust ought to be able to depend on.

The Rust standard library already sets these flags on all file descriptors and sockets it creates, so there's no need to change any code in std for this. And, this behavior is already a common expectation of crates in the ecosystem, specifically because it avoids the problems mentioned here.

Rustix is one crate that currently creates file descriptors without guaranteeing that `O_CLOEXEC` is set, because it was originally conveived of as a low-level API where `O_CLOEXEC` isn't its responsibility. However, as a rustix author, I now think it makes sense include `O_CLOEXEC` in as a part of the task of providing a safe API, and am submitting this PR to seek broader consensus on this.

[rustix will follow Rust's decision here]: https://github.com/bytecodealliance/rustix/issues/495