### PR TITLE
compiler: Fix E0587 explanation

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0587.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0587.md
@@ -11,6 +11,6 @@ You cannot use `packed` and `align` hints on a same type. If you want to pack a
 type to a given size, you should provide a size to packed:
 
 ```
-#[repr(packed)] // ok!
+#[repr(packed(8))] // ok!
 struct Umbrella(i32);
 ```


### PR DESCRIPTION
We meant to use 8 as the packed argument.

Signed-off-by: Samuel Ortiz <sameo@rivosinc.com>