### PR TITLE
Stabilize `anonymous_lifetime_in_impl_trait`

### DIFF
--- a/tests/ui/impl-trait/impl-trait-lifetimes.rs
+++ b/tests/ui/impl-trait/impl-trait-lifetimes.rs
@@ -1,0 +1,60 @@
+trait Foo<T> {
+    fn foo(&self, _: T) { }
+}
+
+trait FooBar<'a> {
+    type Item;
+}
+
+mod foo {
+    fn fun(t: impl crate::Foo<&u32>, n: u32) {
+        t.foo(&n);
+        //~^ ERROR `n` does not live long enough
+    }
+}
+
+mod fun {
+    fn fun(t: impl Fn(&u32), n: u32) {
+        t(&n);
+    }
+}
+
+mod iterator_fun {
+    fn fun(t: impl Iterator<Item = impl Fn(&u32)>, n: u32) {
+        for elem in t {
+            elem(&n);
+        }
+    }
+}
+
+mod iterator_foo {
+    fn fun(t: impl Iterator<Item = impl crate::Foo<&u32>>, n: u32) {
+        for elem in t {
+            elem.foo(&n);
+            //~^ ERROR `n` does not live long enough
+        }
+    }
+}
+
+mod placeholder {
+    trait Placeholder<'a> {
+        fn foo(&self, _: &'a u32) {}
+    }
+
+    fn fun(t: impl Placeholder<'_>, n: u32) {
+        t.foo(&n);
+        //~^ ERROR `n` does not live long enough
+    }
+}
+
+mod stabilized {
+    trait InTrait {
+        fn in_trait(&self) -> impl Iterator<Item = &u32>;
+    }
+
+    fn foo1(_: impl Iterator<Item = &u32>) {}
+    fn foo2<'b>(_: impl crate::FooBar<'b, Item = &u32>) {}
+}
+
+fn main() {
+}

--- a/tests/ui/impl-trait/impl-trait-lifetimes.stderr
+++ b/tests/ui/impl-trait/impl-trait-lifetimes.stderr
@@ -1,0 +1,43 @@
+error[E0597]: `n` does not live long enough
+  --> $DIR/impl-trait-lifetimes.rs:11:15
+   |
+LL |     fn fun(t: impl crate::Foo<&u32>, n: u32) {
+   |            - has type `t`            - binding `n` declared here
+LL |         t.foo(&n);
+   |         ------^^-
+   |         |     |
+   |         |     borrowed value does not live long enough
+   |         argument requires that `n` is borrowed for `'1`
+LL |
+LL |     }
+   |      - `n` dropped here while still borrowed
+
+error[E0597]: `n` does not live long enough
+  --> $DIR/impl-trait-lifetimes.rs:33:22
+   |
+LL |     fn fun(t: impl Iterator<Item = impl crate::Foo<&u32>>, n: u32) {
+   |                                                            - binding `n` declared here
+LL |         for elem in t {
+LL |             elem.foo(&n);
+   |                      ^^ borrowed value does not live long enough
+...
+LL |     }
+   |      - `n` dropped here while still borrowed
+
+error[E0597]: `n` does not live long enough
+  --> $DIR/impl-trait-lifetimes.rs:45:15
+   |
+LL |     fn fun(t: impl Placeholder<'_>, n: u32) {
+   |            - has type `t`           - binding `n` declared here
+LL |         t.foo(&n);
+   |         ------^^-
+   |         |     |
+   |         |     borrowed value does not live long enough
+   |         argument requires that `n` is borrowed for `'1`
+LL |
+LL |     }
+   |      - `n` dropped here while still borrowed
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/impl-trait/partial-anonymous-lifetime-in-impl-trait.rs
+++ b/tests/ui/impl-trait/partial-anonymous-lifetime-in-impl-trait.rs
@@ -1,0 +1,33 @@
+// Incremental stabilization of `non-generic associated types` for non-generic associated types.
+
+mod stabilized {
+    trait FooBar<'a> {
+        type Item;
+    }
+
+    fn foo0(x: impl Iterator<Item = &u32>) {
+    }
+
+    fn foo1<'b>(_: impl FooBar<'b, Item = &u32>) {
+    }
+}
+
+mod not_stabilized {
+    trait FooBar<'a> {
+        type Item;
+    }
+
+    trait LendingIterator {
+        type Item<'a>
+        where
+            Self: 'a;
+    }
+
+    fn foo0(_: impl LendingIterator<Item<'_> = &u32>) {}
+    //~^ ERROR `'_` cannot be used here
+    //~| ERROR anonymous lifetimes in `impl Trait` are unstable
+
+    fn foo1(_: impl FooBar<'_, Item = &u32>) {}
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/partial-anonymous-lifetime-in-impl-trait.stderr
+++ b/tests/ui/impl-trait/partial-anonymous-lifetime-in-impl-trait.stderr
@@ -1,0 +1,23 @@
+error[E0637]: `'_` cannot be used here
+  --> $DIR/partial-anonymous-lifetime-in-impl-trait.rs:26:42
+   |
+LL |     fn foo0(_: impl LendingIterator<Item<'_> = &u32>) {}
+   |                                          ^^ `'_` is a reserved lifetime name
+
+error[E0658]: anonymous lifetimes in `impl Trait` are unstable
+  --> $DIR/partial-anonymous-lifetime-in-impl-trait.rs:26:49
+   |
+LL |     fn foo0(_: impl LendingIterator<Item<'_> = &u32>) {}
+   |                                                 ^ expected named lifetime parameter
+   |
+   = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+help: consider introducing a named lifetime parameter
+   |
+LL |     fn foo0<'a>(_: impl LendingIterator<Item<'_> = &'a u32>) {}
+   |            ++++                                     ++
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0637, E0658.
+For more information about an error, try `rustc --explain E0637`.

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.rs
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.rs
@@ -1,13 +1,13 @@
 //@ edition:2021
 // gate-test-anonymous_lifetime_in_impl_trait
+
 // Verify the behaviour of `feature(anonymous_lifetime_in_impl_trait)`.
 
 mod elided {
     fn f(_: impl Iterator<Item = &()>) {}
-    //~^ ERROR anonymous lifetimes in `impl Trait` are unstable
 
     fn g(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
-    //~^ ERROR anonymous lifetimes in `impl Trait` are unstable
+    //~^ ERROR lifetime may not live long
     //~| ERROR missing lifetime specifier
 
     // Anonymous lifetimes in async fn are already allowed.
@@ -17,16 +17,15 @@ mod elided {
     // Anonymous lifetimes in async fn are already allowed.
     // But that lifetime does not participate in resolution.
     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
-    //~^ ERROR missing lifetime specifier
-    //~| ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not live long
+    //~| ERROR missing lifetime specifier
 }
 
 mod underscore {
     fn f(_: impl Iterator<Item = &'_ ()>) {}
-    //~^ ERROR anonymous lifetimes in `impl Trait` are unstable
 
     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
-    //~^ ERROR anonymous lifetimes in `impl Trait` are unstable
+    //~^ ERROR lifetime may not live long
     //~| ERROR missing lifetime specifier
 
     // Anonymous lifetimes in async fn are already allowed.
@@ -36,18 +35,17 @@ mod underscore {
     // Anonymous lifetimes in async fn are already allowed.
     // But that lifetime does not participate in resolution.
     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
-    //~^ ERROR missing lifetime specifier
-    //~| ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not live long
+    //~| ERROR missing lifetime specifier
 }
 
 mod alone_in_path {
     trait Foo<'a> { fn next(&mut self) -> Option<&'a ()>; }
 
     fn f(_: impl Foo) {}
-    //~^ ERROR anonymous lifetimes in `impl Trait` are unstable
 
     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
-    //~^ ERROR anonymous lifetimes in `impl Trait` are unstable
+    //~^ ERROR lifetime may not live long
     //~| ERROR missing lifetime specifier
 }
 
@@ -55,10 +53,9 @@ mod in_path {
     trait Foo<'a, T> { fn next(&mut self) -> Option<&'a T>; }
 
     fn f(_: impl Foo<()>) {}
-    //~^ ERROR anonymous lifetimes in `impl Trait` are unstable
 
     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
-    //~^ ERROR anonymous lifetimes in `impl Trait` are unstable
+    //~^ ERROR lifetime may not live long
     //~| ERROR missing lifetime specifier
 }
 

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -41,7 +41,7 @@ LL +     async fn i(mut x: impl Iterator<Item = &()>) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:28:58
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:27:58
    |
 LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                          ^^ expected named lifetime parameter
@@ -62,7 +62,7 @@ LL +     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:38:64
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:37:64
    |
 LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                                ^^ expected named lifetime parameter
@@ -83,7 +83,7 @@ LL +     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next(
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:49:37
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:47:37
    |
 LL |     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
    |                                     ^ expected named lifetime parameter
@@ -104,7 +104,7 @@ LL +     fn g(mut x: impl Foo) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:60:41
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:57:41
    |
 LL |     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
    |                                         ^ expected named lifetime parameter
@@ -124,32 +124,6 @@ LL -     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
 LL +     fn g(mut x: impl Foo<()>) -> Option<()> { x.next() }
    |
 
-error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:6:35
-   |
-LL |     fn f(_: impl Iterator<Item = &()>) {}
-   |                                   ^ expected named lifetime parameter
-   |
-   = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-help: consider introducing a named lifetime parameter
-   |
-LL |     fn f<'a>(_: impl Iterator<Item = &'a ()>) {}
-   |         ++++                          ++
-
-error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:9:39
-   |
-LL |     fn g(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
-   |                                       ^ expected named lifetime parameter
-   |
-   = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-help: consider introducing a named lifetime parameter
-   |
-LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&()> { x.next() }
-   |         ++++                              ++
-
 error: lifetime may not live long enough
   --> $DIR/impl-trait-missing-lifetime-gated.rs:19:67
    |
@@ -158,93 +132,38 @@ LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() 
    |     |
    |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
 
-error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:25:35
-   |
-LL |     fn f(_: impl Iterator<Item = &'_ ()>) {}
-   |                                   ^^ expected named lifetime parameter
-   |
-   = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-help: consider introducing a named lifetime parameter
-   |
-LL |     fn f<'a>(_: impl Iterator<Item = &'a ()>) {}
-   |         ++++                          ~~
-
-error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:28:39
-   |
-LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
-   |                                       ^^ expected named lifetime parameter
-   |
-   = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-help: consider introducing a named lifetime parameter
-   |
-LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'_ ()> { x.next() }
-   |         ++++                              ~~
-
 error: lifetime may not live long enough
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:38:73
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:37:73
    |
 LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |     -----------------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
    |     |
    |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
 
-error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:46:18
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:9:61
    |
-LL |     fn f(_: impl Foo) {}
-   |                  ^^^ expected named lifetime parameter
-   |
-   = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-help: consider introducing a named lifetime parameter
-   |
-LL |     fn f<'a>(_: impl Foo<'a>) {}
-   |         ++++            ++++
+LL |     fn g(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
+   |          ----- has type `x`                                 ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
 
-error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:49:22
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:27:67
+   |
+LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+   |          ----- has type `x`                                       ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:47:44
    |
 LL |     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
-   |                      ^^^ expected named lifetime parameter
-   |
-   = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-help: consider introducing a named lifetime parameter
-   |
-LL |     fn g<'a>(mut x: impl Foo<'a>) -> Option<&()> { x.next() }
-   |         ++++                ++++
+   |          ----- has type `x`                ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
 
-error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:57:22
-   |
-LL |     fn f(_: impl Foo<()>) {}
-   |                      ^ expected named lifetime parameter
-   |
-   = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-help: consider introducing a named lifetime parameter
-   |
-LL |     fn f<'a>(_: impl Foo<'a, ()>) {}
-   |         ++++             +++
-
-error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:60:26
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:57:48
    |
 LL |     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
-   |                          ^ expected named lifetime parameter
-   |
-   = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-help: consider introducing a named lifetime parameter
-   |
-LL |     fn g<'a>(mut x: impl Foo<'a, ()>) -> Option<&()> { x.next() }
-   |         ++++                 +++
+   |          ----- has type `x`                    ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
 
-error: aborting due to 16 previous errors
+error: aborting due to 12 previous errors
 
-Some errors have detailed explanations: E0106, E0658.
-For more information about an error, try `rustc --explain E0106`.
+For more information about this error, try `rustc --explain E0106`.


### PR DESCRIPTION
## Stabilization proposal

This PR proposes the stabilization of `#![feature(anonymous_lifetime_in_impl_trait)]`.

Version: 1.69 (beta => 2023-03-09, stable => 2023-04-20).

### What is stabilized

For non-asynchronous functions, allows the usage of anonymous lifetimes in APITs.

```rust
fn _example(_: impl Iterator<Item = &()>) {}
```

### Motivation

In addition to ergonomics, the lack of parity between asynchronous and non-asynchronous functions can be confusing as the former is already allowed on stable toolchains.

```rust
// OK!
async fn _example(_: impl Iterator<Item = &()>) {}
```
### History

* 2022-06-04, [Zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/Anonymous.20lifetimes.20in.20universal.20impl-trait/near/284968606)
* 2022-07-03, [Always create elided lifetime parameters for functions](https://github.com/rust-lang/rust/pull/97720)
* 2022-09-26, [Suggest additional lifetime parameter](https://github.com/rust-lang/rust/pull/102323)
* 2022-10-21, [Don't ICE when reporting borrowck errors involving regions from `anonymous_lifetime_in_impl_trait`](https://github.com/rust-lang/rust/pull/103382)
* 2023-01-05, [Correct detection of elided lifetimes in impl-trait](https://github.com/rust-lang/rust/pull/106501)

cc @cjgillot 