### PR TITLE
Fixing confusion between mod and remainder

### DIFF
--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -335,7 +335,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 format!("cannot divide `{lhs_ty}` by `{rhs_ty}`")
                             }
                             hir::BinOpKind::Rem => {
-                                format!("cannot calculate the remainder of `{lhs_ty}` divided by `{rhs_ty}`")
+                                format!(
+                                    "cannot calculate the remainder of `{lhs_ty}` divided by `{rhs_ty}`"
+                                )
                             }
                             hir::BinOpKind::BitAnd => {
                                 format!("no implementation for `{lhs_ty} & {rhs_ty}`")

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -335,7 +335,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 format!("cannot divide `{lhs_ty}` by `{rhs_ty}`")
                             }
                             hir::BinOpKind::Rem => {
-                                format!("cannot rem `{lhs_ty}` by `{rhs_ty}`")
+                                format!("cannot calculate the remainder of `{lhs_ty}` divided by `{rhs_ty}`")
                             }
                             hir::BinOpKind::BitAnd => {
                                 format!("no implementation for `{lhs_ty} & {rhs_ty}`")

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -335,7 +335,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 format!("cannot divide `{lhs_ty}` by `{rhs_ty}`")
                             }
                             hir::BinOpKind::Rem => {
-                                format!("cannot mod `{lhs_ty}` by `{rhs_ty}`")
+                                format!("cannot rem `{lhs_ty}` by `{rhs_ty}`")
                             }
                             hir::BinOpKind::BitAnd => {
                                 format!("no implementation for `{lhs_ty} & {rhs_ty}`")

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -545,7 +545,7 @@ div_impl_float! { f32 f64 }
 #[lang = "rem"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented(
-    message = "cannot mod `{Self}` by `{Rhs}`",
+    message = "cannot rem `{Self}` by `{Rhs}`",
     label = "no implementation for `{Self} % {Rhs}`"
 )]
 #[doc(alias = "%")]
@@ -981,7 +981,7 @@ div_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 #[lang = "rem_assign"]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
 #[rustc_on_unimplemented(
-    message = "cannot mod-assign `{Self}` by `{Rhs}``",
+    message = "cannot rem-assign `{Self}` by `{Rhs}``",
     label = "no implementation for `{Self} %= {Rhs}`"
 )]
 #[doc(alias = "%")]

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -545,7 +545,7 @@ div_impl_float! { f32 f64 }
 #[lang = "rem"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented(
-    message = "cannot rem `{Self}` by `{Rhs}`",
+    message = "cannot calculate the remainder of `{Self}` divided by `{Rhs}`",
     label = "no implementation for `{Self} % {Rhs}`"
 )]
 #[doc(alias = "%")]
@@ -981,7 +981,7 @@ div_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 #[lang = "rem_assign"]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
 #[rustc_on_unimplemented(
-    message = "cannot rem-assign `{Self}` by `{Rhs}``",
+    message = "cannot calculate and assign the remainder of `{Self}` divided by `{Rhs}`",
     label = "no implementation for `{Self} %= {Rhs}`"
 )]
 #[doc(alias = "%")]

--- a/tests/ui/binop/binary-op-on-double-ref.fixed
+++ b/tests/ui/binop/binary-op-on-double-ref.fixed
@@ -3,7 +3,7 @@ fn main() {
     let v = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
     let vr = v.iter().filter(|x| {
         *x % 2 == 0
-        //~^ ERROR cannot rem `&&{integer}` by `{integer}`
+        //~^ ERROR cannot calculate the remainder of `&&{integer}` divided by `{integer}`
     });
     println!("{:?}", vr);
 }

--- a/tests/ui/binop/binary-op-on-double-ref.fixed
+++ b/tests/ui/binop/binary-op-on-double-ref.fixed
@@ -3,7 +3,7 @@ fn main() {
     let v = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
     let vr = v.iter().filter(|x| {
         *x % 2 == 0
-        //~^ ERROR cannot mod `&&{integer}` by `{integer}`
+        //~^ ERROR cannot rem `&&{integer}` by `{integer}`
     });
     println!("{:?}", vr);
 }

--- a/tests/ui/binop/binary-op-on-double-ref.rs
+++ b/tests/ui/binop/binary-op-on-double-ref.rs
@@ -3,7 +3,7 @@ fn main() {
     let v = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
     let vr = v.iter().filter(|x| {
         x % 2 == 0
-        //~^ ERROR cannot mod `&&{integer}` by `{integer}`
+        //~^ ERROR cannot rem `&&{integer}` by `{integer}`
     });
     println!("{:?}", vr);
 }

--- a/tests/ui/binop/binary-op-on-double-ref.rs
+++ b/tests/ui/binop/binary-op-on-double-ref.rs
@@ -3,7 +3,7 @@ fn main() {
     let v = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
     let vr = v.iter().filter(|x| {
         x % 2 == 0
-        //~^ ERROR cannot rem `&&{integer}` by `{integer}`
+        //~^ ERROR cannot calculate the remainder of `&&{integer}` divided by `{integer}`
     });
     println!("{:?}", vr);
 }

--- a/tests/ui/binop/binary-op-on-double-ref.stderr
+++ b/tests/ui/binop/binary-op-on-double-ref.stderr
@@ -1,4 +1,4 @@
-error[E0369]: cannot rem `&&{integer}` by `{integer}`
+error[E0369]: cannot calculate the remainder of `&&{integer}` divided by `{integer}`
   --> $DIR/binary-op-on-double-ref.rs:5:11
    |
 LL |         x % 2 == 0

--- a/tests/ui/binop/binary-op-on-double-ref.stderr
+++ b/tests/ui/binop/binary-op-on-double-ref.stderr
@@ -1,4 +1,4 @@
-error[E0369]: cannot mod `&&{integer}` by `{integer}`
+error[E0369]: cannot rem `&&{integer}` by `{integer}`
   --> $DIR/binary-op-on-double-ref.rs:5:11
    |
 LL |         x % 2 == 0

--- a/tests/ui/binop/issue-28837.rs
+++ b/tests/ui/binop/issue-28837.rs
@@ -11,7 +11,7 @@ fn main() {
 
     a / a; //~ ERROR cannot divide `A` by `A`
 
-    a % a; //~ ERROR cannot mod `A` by `A`
+    a % a; //~ ERROR cannot rem `A` by `A`
 
     a & a; //~ ERROR no implementation for `A & A`
 

--- a/tests/ui/binop/issue-28837.rs
+++ b/tests/ui/binop/issue-28837.rs
@@ -11,7 +11,7 @@ fn main() {
 
     a / a; //~ ERROR cannot divide `A` by `A`
 
-    a % a; //~ ERROR cannot rem `A` by `A`
+    a % a; //~ ERROR cannot calculate the remainder of `A` divided by `A`
 
     a & a; //~ ERROR no implementation for `A & A`
 

--- a/tests/ui/binop/issue-28837.stderr
+++ b/tests/ui/binop/issue-28837.stderr
@@ -62,7 +62,7 @@ LL | struct A;
 note: the trait `Div` must be implemented
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 
-error[E0369]: cannot rem `A` by `A`
+error[E0369]: cannot calculate the remainder of `A` divided by `A`
   --> $DIR/issue-28837.rs:14:7
    |
 LL |     a % a;

--- a/tests/ui/binop/issue-28837.stderr
+++ b/tests/ui/binop/issue-28837.stderr
@@ -62,7 +62,7 @@ LL | struct A;
 note: the trait `Div` must be implemented
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 
-error[E0369]: cannot mod `A` by `A`
+error[E0369]: cannot rem `A` by `A`
   --> $DIR/issue-28837.rs:14:7
    |
 LL |     a % a;


### PR DESCRIPTION
Like many programming languages, rust too confuses remainder and modulus.  The `%` operator and the associated `Rem` trait is (as the trait name suggests) the remainder, but since most people are linguistically more familiar with the modulus the documentation sometimes claims otherwise.  This PR tries to fix this problem in rustc.