### PR TITLE
Add internal lint against `Ty == Ty`

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -505,6 +505,13 @@ lint_suspicious_double_ref_deref =
 
 lint_trivial_untranslatable_diag = diagnostic with static strings only
 
+
+lint_ty_compare_operator_used = using the a comparison operator on `Ty`
+    .note = this does probably not what you want as it does not handle inference variables and more
+    .help = for more information, see https://rustc-dev-guide.rust-lang.org/ty.html#comparing-types
+
+lint_ty_no_compare_operator_for_diagnostics = it's also not recommended to use it for diagnostics
+
 lint_ty_qualified = usage of qualified `ty::{$ty}`
     .suggestion = try importing it and using it unqualified
 

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -524,6 +524,8 @@ fn register_internals(store: &mut LintStore) {
     store.register_late_mod_pass(|_| Box::new(ExistingDocKeyword));
     store.register_lints(&TyTyKind::get_lints());
     store.register_late_mod_pass(|_| Box::new(TyTyKind));
+    store.register_lints(&TyCompareOperator::get_lints());
+    store.register_late_mod_pass(|_| Box::new(TyCompareOperator));
     store.register_lints(&Diagnostics::get_lints());
     store.register_early_pass(|| Box::new(Diagnostics));
     store.register_late_mod_pass(|_| Box::new(Diagnostics));
@@ -543,6 +545,7 @@ fn register_internals(store: &mut LintStore) {
             LintId::of(DEFAULT_HASH_TYPES),
             LintId::of(POTENTIAL_QUERY_INSTABILITY),
             LintId::of(USAGE_OF_TY_TYKIND),
+            LintId::of(TY_COMPARE_OPERATOR),
             LintId::of(PASS_BY_VALUE),
             LintId::of(LINT_PASS_IMPL_WITHOUT_MACRO),
             LintId::of(USAGE_OF_QUALIFIED_TY),

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -921,6 +921,13 @@ pub struct TyQualified {
 }
 
 #[derive(LintDiagnostic)]
+#[diag(lint_ty_compare_operator_used)]
+#[note]
+#[note(lint_ty_no_compare_operator_for_diagnostics)]
+#[help]
+pub struct TyCompareOperatorUsed;
+
+#[derive(LintDiagnostic)]
 #[diag(lint_lintpass_by_hand)]
 #[help]
 pub struct LintPassByHand;

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1881,6 +1881,13 @@ impl<'a> Builder<'a> {
         if mode == Mode::Rustc {
             rustflags.arg("-Zunstable-options");
             rustflags.arg("-Wrustc::internal");
+
+            // #[cfg(not(bootstrap))]
+            if stage != 0 {
+                // FIXME(Nilstrieb): Allow this lint for now.
+                // After it's in beta, we can start work on fixing it.
+                rustflags.arg("-Arustc::ty-compare-operator");
+            }
         }
 
         // Throughout the build Cargo can execute a number of build scripts

--- a/tests/ui/lint/internal/ty_compare_operator.rs
+++ b/tests/ui/lint/internal/ty_compare_operator.rs
@@ -1,0 +1,37 @@
+// compile-flags: -Z unstable-options
+
+#![feature(rustc_attrs)]
+#![forbid(rustc::ty_compare_operator)]
+
+mod ty1 {
+    #[derive(PartialEq, PartialOrd)]
+    #[rustc_diagnostic_item = "Ty"]
+    pub struct Ty;
+}
+
+mod ty2 {
+    #[derive(PartialEq, PartialOrd)]
+    pub struct Ty;
+}
+
+fn main() {
+    let _ = ty1::Ty == ty1::Ty;
+    //~^ ERROR using the a comparison operator on `Ty`
+    let _ = ty1::Ty != ty1::Ty;
+    //~^ ERROR using the a comparison operator on `Ty`
+    let _ = ty1::Ty < ty1::Ty;
+    //~^ ERROR using the a comparison operator on `Ty`
+    let _ = ty1::Ty <= ty1::Ty;
+    //~^ ERROR using the a comparison operator on `Ty`
+    let _ = ty1::Ty > ty1::Ty;
+    //~^ ERROR using the a comparison operator on `Ty`
+    let _ = ty1::Ty >= ty1::Ty;
+    //~^ ERROR using the a comparison operator on `Ty`
+
+    let _ = ty2::Ty == ty2::Ty;
+    let _ = ty2::Ty != ty2::Ty;
+    let _ = ty2::Ty < ty2::Ty;
+    let _ = ty2::Ty <= ty2::Ty;
+    let _ = ty2::Ty > ty2::Ty;
+    let _ = ty2::Ty >= ty2::Ty;
+}

--- a/tests/ui/lint/internal/ty_compare_operator.stderr
+++ b/tests/ui/lint/internal/ty_compare_operator.stderr
@@ -1,0 +1,67 @@
+error: using the a comparison operator on `Ty`
+  --> $DIR/ty_compare_operator.rs:18:21
+   |
+LL |     let _ = ty1::Ty == ty1::Ty;
+   |                     ^^
+   |
+   = note: this does probably not what you want as it does not handle inference variables and more
+   = note: it's also not recommended to use it for diagnostics
+   = help: for more information, see https://rustc-dev-guide.rust-lang.org/ty.html#comparing-types
+note: the lint level is defined here
+  --> $DIR/ty_compare_operator.rs:4:11
+   |
+LL | #![forbid(rustc::ty_compare_operator)]
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: using the a comparison operator on `Ty`
+  --> $DIR/ty_compare_operator.rs:20:21
+   |
+LL |     let _ = ty1::Ty != ty1::Ty;
+   |                     ^^
+   |
+   = note: this does probably not what you want as it does not handle inference variables and more
+   = note: it's also not recommended to use it for diagnostics
+   = help: for more information, see https://rustc-dev-guide.rust-lang.org/ty.html#comparing-types
+
+error: using the a comparison operator on `Ty`
+  --> $DIR/ty_compare_operator.rs:22:21
+   |
+LL |     let _ = ty1::Ty < ty1::Ty;
+   |                     ^
+   |
+   = note: this does probably not what you want as it does not handle inference variables and more
+   = note: it's also not recommended to use it for diagnostics
+   = help: for more information, see https://rustc-dev-guide.rust-lang.org/ty.html#comparing-types
+
+error: using the a comparison operator on `Ty`
+  --> $DIR/ty_compare_operator.rs:24:21
+   |
+LL |     let _ = ty1::Ty <= ty1::Ty;
+   |                     ^^
+   |
+   = note: this does probably not what you want as it does not handle inference variables and more
+   = note: it's also not recommended to use it for diagnostics
+   = help: for more information, see https://rustc-dev-guide.rust-lang.org/ty.html#comparing-types
+
+error: using the a comparison operator on `Ty`
+  --> $DIR/ty_compare_operator.rs:26:21
+   |
+LL |     let _ = ty1::Ty > ty1::Ty;
+   |                     ^
+   |
+   = note: this does probably not what you want as it does not handle inference variables and more
+   = note: it's also not recommended to use it for diagnostics
+   = help: for more information, see https://rustc-dev-guide.rust-lang.org/ty.html#comparing-types
+
+error: using the a comparison operator on `Ty`
+  --> $DIR/ty_compare_operator.rs:28:21
+   |
+LL |     let _ = ty1::Ty >= ty1::Ty;
+   |                     ^^
+   |
+   = note: this does probably not what you want as it does not handle inference variables and more
+   = note: it's also not recommended to use it for diagnostics
+   = help: for more information, see https://rustc-dev-guide.rust-lang.org/ty.html#comparing-types
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
`==` is often the first and most obvious operation people use to check whether types are equal, but it's usually not what they want, as it doesn't consider inference variables, bound vars and normalization.

We still need `Ty: Eq` for various things, for example for the query system.
There are still places where using it is "good enough" if the types are known to not have the caveats above (it should NOT be used in diagnostics though as the caveats will lead to worse diagnostics).

The lint points people to a yet-to-be-written section of the rustc dev guide about how to compare types properly.

I have not yet activated it by default because all the `cfg_attr(bootstrap, allow)` would be really annoying, so we should only activate and fix it after the bootstrap compiler is bumped to contain the lint.