### PR TITLE
Add `clone_from` specializations to `Rc` and `Arc`

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1632,7 +1632,7 @@ impl<T: ?Sized> Clone for Rc<T> {
     fn clone_from(&mut self, source: &Self) {
         // If `self` and `source` share ownership of the same value, no extra
         // work needs to happen
-        if self.ptr != other.ptr {
+        if self.ptr != source.ptr {
             *self = source.clone()
         }
     }

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1627,6 +1627,15 @@ impl<T: ?Sized> Clone for Rc<T> {
             Self::from_inner(self.ptr)
         }
     }
+
+    #[inline]
+    fn clone_from(&mut self, source: &Self) {
+        // If `self` and `source` share ownership of the same value, no extra
+        // work needs to happen
+        if self.ptr != other.ptr {
+            *self = source.clone()
+        }
+    }
 }
 
 #[cfg(not(no_global_oom_handling))]
@@ -2557,6 +2566,15 @@ impl<T: ?Sized> Clone for Weak<T> {
             inner.inc_weak()
         }
         Weak { ptr: self.ptr }
+    }
+
+    #[inline]
+    fn clone_from(&mut self, source: &Self) {
+        // If `self` and `source` share the same resource, nothing else needs
+        // to happen
+        if self.ptr != other.ptr {
+            *self = source.clone()
+        }
     }
 }
 

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2572,7 +2572,7 @@ impl<T: ?Sized> Clone for Weak<T> {
     fn clone_from(&mut self, source: &Self) {
         // If `self` and `source` share the same resource, nothing else needs
         // to happen
-        if self.ptr != other.ptr {
+        if self.ptr != source.ptr {
             *self = source.clone()
         }
     }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2344,7 +2344,7 @@ impl<T: ?Sized> Clone for Weak<T> {
     fn clone_from(&mut self, source: &Self) {
         // If `self` and `source` share the same resource, nothing else needs
         // to happen
-        if self.ptr != other.ptr {
+        if self.ptr != source.ptr {
             *self = source.clone()
         }
     }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1525,6 +1525,15 @@ impl<T: ?Sized> Clone for Arc<T> {
 
         unsafe { Self::from_inner(self.ptr) }
     }
+
+    #[inline]
+    fn clone_from(&mut self, source: &Self) {
+        // If `self` and `source` share the same resource, nothing else needs
+        // to happen
+        if self.ptr != other.ptr {
+            *self = source.clone()
+        }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -2329,6 +2338,15 @@ impl<T: ?Sized> Clone for Weak<T> {
         }
 
         Weak { ptr: self.ptr }
+    }
+
+    #[inline]
+    fn clone_from(&mut self, source: &Self) {
+        // If `self` and `source` share the same resource, nothing else needs
+        // to happen
+        if self.ptr != other.ptr {
+            *self = source.clone()
+        }
     }
 }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1530,7 +1530,7 @@ impl<T: ?Sized> Clone for Arc<T> {
     fn clone_from(&mut self, source: &Self) {
         // If `self` and `source` share the same resource, nothing else needs
         // to happen
-        if self.ptr != other.ptr {
+        if self.ptr != source.ptr {
             *self = source.clone()
         }
     }


### PR DESCRIPTION
Add specializations for `clone_from` to `Rc` and `Arc`. These check to see if the pointers already share ownership of the same object and, if so, don't do any additional work.