### PR TITLE
Disable thread support in libtest if `RUST_TEST_THREADS=1`

### DIFF
--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -82,7 +82,7 @@ mod tests;
 
 use core::any::Any;
 use event::{CompletedTest, TestEvent};
-use helpers::concurrency::get_concurrency;
+use helpers::concurrency::{get_concurrency, supports_threads};
 use helpers::exit_code::get_exit_code;
 use helpers::shuffle::{get_shuffle_seed, shuffle_tests};
 use options::RunStrategy;
@@ -592,8 +592,7 @@ pub fn run_test(
         // If the platform is single-threaded we're just going to run
         // the test synchronously, regardless of the concurrency
         // level.
-        let supports_threads = !cfg!(target_os = "emscripten") && !cfg!(target_family = "wasm");
-        if supports_threads {
+        if supports_threads() {
             let cfg = thread::Builder::new().name(name.as_slice().to_owned());
             let mut runtest = Arc::new(Mutex::new(Some(runtest)));
             let runtest2 = runtest.clone();


### PR DESCRIPTION
After #103681, each test now runs in it's own thread if the platform supports it. This was true even if `RUST_TEST_THREADS=1`. Unfortunately, this causes some subtle breakage for certain libraries that may rely on thread-local storage being shared across tests (as is the case for `libruby` and Julia, and probably more).

The feature [never intended to cause any breakage](https://github.com/rust-lang/rust/issues/104053#issuecomment-1304992972), so restoring the previous behavior should be OK. I considered adding a new option, such as `RUST_TEST_THREADS=0`, which would allow both the new and previous behavior to exist side-by-side. But the idea of 0 threads felt... wrong. So I think this is the best way forward.

This is my first rust PR, so please let me know if I missed anything!  ❤️ 