### PR TITLE
Gracefully exit if --keep-stage flag is used on a clean source tree

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1431,6 +1431,13 @@ impl Build {
             return Vec::new();
         }
 
+        if !stamp.exists() {
+            eprintln!(
+                "Warning: Unable to find the stamp file, did you try to keep a nonexistent build stage?"
+            );
+            crate::detail_exit(1);
+        }
+
         let mut paths = Vec::new();
         let contents = t!(fs::read(stamp), &stamp);
         // This is the method we use for extracting paths from the stamp file passed to us. See


### PR DESCRIPTION
Instead of quitting with an obscure No such file or directory error, give the user a clearer and easier to understand error (as well as suggesting a possible cause for the error).

This is the first time I have written rust since 2020, and the first PR I will ever make to rust, so please do point out any mistakes I have made :smile: .

This fixes #107392 