### PR TITLE
Turn on ConstDebugInfo pass.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
@@ -494,6 +494,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         let Some(dbg_loc) = self.dbg_loc(var.source_info) else { continue };
 
                         if let Ok(operand) = self.eval_mir_constant_to_operand(bx, &c) {
+                            self.set_debug_loc(bx, var.source_info);
                             let base = Self::spill_operand_to_stack(
                                 &operand,
                                 Some(var.name.to_string()),

--- a/compiler/rustc_mir_transform/src/const_debuginfo.rs
+++ b/compiler/rustc_mir_transform/src/const_debuginfo.rs
@@ -16,7 +16,7 @@ pub struct ConstDebugInfo;
 
 impl<'tcx> MirPass<'tcx> for ConstDebugInfo {
     fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.opts.unstable_opts.unsound_mir_opts && sess.mir_opt_level() > 0
+        sess.mir_opt_level() > 0
     }
 
     fn run_pass(&self, _tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {

--- a/tests/codegen/debuginfo-constant-locals.rs
+++ b/tests/codegen/debuginfo-constant-locals.rs
@@ -1,0 +1,28 @@
+// compile-flags: -g -O
+
+// Check that simple constant values are preserved in debuginfo across both MIR opts and LLVM opts
+
+#![crate_type = "lib"]
+
+#[no_mangle]
+pub fn check_it() {
+    let a = 1;
+    let b = 42;
+
+    foo(a + b);
+}
+
+#[inline(never)]
+fn foo(x: i32) {
+    std::process::exit(x);
+}
+
+// CHECK-LABEL: @check_it
+// CHECK: call void @llvm.dbg.value(metadata i32 1, metadata ![[a_metadata:[0-9]+]], metadata !DIExpression())
+// CHECK: call void @llvm.dbg.value(metadata i32 42, metadata ![[b_metadata:[0-9]+]], metadata !DIExpression())
+
+// CHECK: ![[a_metadata]] = !DILocalVariable(name: "a"
+// CHECK-SAME: line: 9
+
+// CHECK: ![[b_metadata]] = !DILocalVariable(name: "b"
+// CHECK-SAME: line: 10

--- a/tests/debuginfo/auxiliary/macro-stepping.rs
+++ b/tests/debuginfo/auxiliary/macro-stepping.rs
@@ -5,6 +5,6 @@
 #[macro_export]
 macro_rules! new_scope {
     () => {
-        let x = 1;
+        let x = 1; opaque(x);
     }
 }

--- a/tests/debuginfo/macro-stepping.rs
+++ b/tests/debuginfo/macro-stepping.rs
@@ -79,22 +79,28 @@ extern crate macro_stepping; // exports new_scope!()
 // lldb-check:[...]#inc-loc2[...]
 // lldb-command:next
 // lldb-command:frame select
+// lldb-check:[...]#inc-loc1[...]
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#inc-loc2[...]
+// lldb-command:next
+// lldb-command:frame select
 // lldb-check:[...]#inc-loc3[...]
 
 macro_rules! foo {
     () => {
-        let a = 1;
-        let b = 2;
-        let c = 3;
-    }
+        let a = 1; opaque(a);
+        let b = 2; opaque(b);
+        let c = 3; opaque(c);
+    };
 }
 
 macro_rules! foo2 {
     () => {
         foo!();
-        let x = 1;
+        let x = 1; opaque(x);
         foo!();
-    }
+    };
 }
 
 fn main() {
@@ -117,5 +123,7 @@ fn main() {
 }
 
 fn zzz() {()}
+
+fn opaque(_: u32) {}
 
 include!("macro-stepping.inc");

--- a/tests/incremental/hashes/enum_constructors.rs
+++ b/tests/incremental/hashes/enum_constructors.rs
@@ -334,9 +334,9 @@ pub fn change_constructor_variant_c_like() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_variant_c_like() {
     let _x = Clike::C;

--- a/tests/incremental/hashes/let_expressions.rs
+++ b/tests/incremental/hashes/let_expressions.rs
@@ -91,7 +91,7 @@ pub fn change_mutability_of_slot() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
 #[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
@@ -176,7 +176,7 @@ pub fn change_mutability_of_binding_in_pattern() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
 #[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
@@ -193,9 +193,9 @@ pub fn add_initializer() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_initializer() {
     let _x: i16 = 3i16;
@@ -210,9 +210,9 @@ pub fn change_initializer() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_initializer() {
     let _x = 5u16;

--- a/tests/mir-opt/const_prop/optimizes_into_variable.main.PreCodegen.after.32bit.mir
+++ b/tests/mir-opt/const_prop/optimizes_into_variable.main.PreCodegen.after.32bit.mir
@@ -2,24 +2,17 @@
 
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +0:11
-    let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-    let mut _3: u32;                     // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-        let _2: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+        debug x => const 4_i32;          // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
         scope 2 {
-            debug y => _2;               // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+            debug y => const 3_i32;      // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
             scope 3 {
-                debug z => _3;           // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
+                debug z => const 42_u32; // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
             }
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-        StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
-        StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
-        StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
         return;                          // scope 0 at $DIR/optimizes_into_variable.rs:+4:2: +4:2
     }
 }

--- a/tests/mir-opt/const_prop/optimizes_into_variable.main.PreCodegen.after.64bit.mir
+++ b/tests/mir-opt/const_prop/optimizes_into_variable.main.PreCodegen.after.64bit.mir
@@ -2,24 +2,17 @@
 
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +0:11
-    let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-    let mut _3: u32;                     // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-        let _2: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+        debug x => const 4_i32;          // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
         scope 2 {
-            debug y => _2;               // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+            debug y => const 3_i32;      // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
             scope 3 {
-                debug z => _3;           // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
+                debug z => const 42_u32; // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
             }
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-        StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
-        StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
-        StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
         return;                          // scope 0 at $DIR/optimizes_into_variable.rs:+4:2: +4:2
     }
 }

--- a/tests/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals-final.after.32bit.mir
+++ b/tests/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals-final.after.32bit.mir
@@ -2,24 +2,17 @@
 
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +0:11
-    let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-    let mut _3: u32;                     // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-        let _2: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+        debug x => const 4_i32;          // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
         scope 2 {
-            debug y => _2;               // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+            debug y => const 3_i32;      // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
             scope 3 {
-                debug z => _3;           // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
+                debug z => const 42_u32; // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
             }
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-        StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
-        StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
-        StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
         return;                          // scope 0 at $DIR/optimizes_into_variable.rs:+4:2: +4:2
     }
 }

--- a/tests/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals-final.after.64bit.mir
+++ b/tests/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals-final.after.64bit.mir
@@ -2,24 +2,17 @@
 
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +0:11
-    let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-    let mut _3: u32;                     // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-        let _2: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+        debug x => const 4_i32;          // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
         scope 2 {
-            debug y => _2;               // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+            debug y => const 3_i32;      // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
             scope 3 {
-                debug z => _3;           // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
+                debug z => const 42_u32; // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
             }
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-        StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
-        StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
-        StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
         return;                          // scope 0 at $DIR/optimizes_into_variable.rs:+4:2: +4:2
     }
 }

--- a/tests/mir-opt/inline/issue_106141.outer.Inline.diff
+++ b/tests/mir-opt/inline/issue_106141.outer.Inline.diff
@@ -8,7 +8,7 @@
 +         let mut _2: bool;                // in scope 1 at $DIR/issue_106141.rs:14:8: 14:21
 +         let mut _3: &[bool; 1];          // in scope 1 at $DIR/issue_106141.rs:12:18: 12:25
 +         scope 2 {
-+             debug buffer => _3;          // in scope 2 at $DIR/issue_106141.rs:12:9: 12:15
++             debug buffer => const _;     // in scope 2 at $DIR/issue_106141.rs:12:9: 12:15
 +             scope 3 {
 +                 debug index => _0;       // in scope 3 at $DIR/issue_106141.rs:13:9: 13:14
 +             }

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -4,31 +4,29 @@ fn num_to_digit(_1: char) -> u32 {
     debug num => _1;                     // in scope 0 at $DIR/issue_59352.rs:+0:21: +0:24
     let mut _0: u32;                     // return place in scope 0 at $DIR/issue_59352.rs:+0:35: +0:38
     let mut _2: std::option::Option<u32>; // in scope 0 at $DIR/issue_59352.rs:+2:26: +2:41
-    let mut _3: u32;                     // in scope 0 at $DIR/issue_59352.rs:+2:12: +2:23
     scope 1 (inlined char::methods::<impl char>::is_digit) { // at $DIR/issue_59352.rs:15:12: 15:23
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        debug radix => _3;               // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        let mut _4: &std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        let _5: std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        debug radix => const 8_u32;      // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        let mut _3: &std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        let _4: std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         scope 2 (inlined Option::<u32>::is_some) { // at $SRC_DIR/core/src/char/methods.rs:LL:COL
-            debug self => _4;            // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
-            let mut _6: isize;           // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+            debug self => _3;            // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+            let mut _5: isize;           // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
         }
     }
     scope 3 (inlined #[track_caller] Option::<u32>::unwrap) { // at $DIR/issue_59352.rs:15:42: 15:50
         debug self => _2;                // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        let mut _7: isize;               // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        let mut _8: !;                   // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        let mut _6: isize;               // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        let mut _7: !;                   // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         scope 4 {
             debug val => _0;             // in scope 4 at $SRC_DIR/core/src/option.rs:LL:COL
         }
     }
 
     bb0: {
-        StorageLive(_3);                 // scope 0 at $DIR/issue_59352.rs:+2:12: +2:23
+        StorageLive(_3);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageLive(_4);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        _5 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> bb5; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        _4 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> bb5; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // + literal: Const { ty: fn(char, u32) -> Option<u32> {char::methods::<impl char>::to_digit}, val: Value(<ZST>) }
@@ -43,8 +41,8 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb2: {
-        _7 = discriminant(_2);           // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        switchInt(move _7) -> [0: bb6, 1: bb8, otherwise: bb7]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        _6 = discriminant(_2);           // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(move _6) -> [0: bb6, 1: bb8, otherwise: bb7]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
     bb3: {
@@ -57,16 +55,15 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb5: {
-        _4 = &_5;                        // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        _6 = discriminant((*_4));        // scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+        _3 = &_4;                        // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        _5 = discriminant((*_3));        // scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageDead(_3);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageDead(_4);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageDead(_3);                 // scope 0 at $DIR/issue_59352.rs:+2:12: +2:23
-        switchInt(move _6) -> [1: bb1, otherwise: bb3]; // scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
+        switchInt(move _5) -> [1: bb1, otherwise: bb3]; // scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
     }
 
     bb6: {
-        _8 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        _7 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/option.rs:LL:COL
                                          // + literal: Const { ty: fn(&'static str) -> ! {core::panicking::panic}, val: Value(<ZST>) }

--- a/tests/mir-opt/lower_intrinsics_e2e.f_u64.PreCodegen.after.mir
+++ b/tests/mir-opt/lower_intrinsics_e2e.f_u64.PreCodegen.after.mir
@@ -2,24 +2,21 @@
 
 fn f_u64() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics_e2e.rs:+0:16: +0:16
-    let mut _1: u64;                     // in scope 0 at $DIR/lower_intrinsics_e2e.rs:+1:5: +1:21
     scope 1 (inlined f_dispatch::<u64>) { // at $DIR/lower_intrinsics_e2e.rs:15:5: 15:21
-        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics_e2e.rs:19:22: 19:23
-        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics_e2e.rs:23:9: 23:21
+        debug t => const 0_u64;          // in scope 1 at $DIR/lower_intrinsics_e2e.rs:19:22: 19:23
+        let _1: ();                      // in scope 1 at $DIR/lower_intrinsics_e2e.rs:23:9: 23:21
         scope 2 (inlined std::mem::size_of::<u64>) { // at $DIR/lower_intrinsics_e2e.rs:20:8: 20:32
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics_e2e.rs:+1:5: +1:21
-        _2 = f_non_zst::<u64>(const 0_u64) -> [return: bb1, unwind unreachable]; // scope 1 at $DIR/lower_intrinsics_e2e.rs:23:9: 23:21
+        _1 = f_non_zst::<u64>(const 0_u64) -> [return: bb1, unwind unreachable]; // scope 1 at $DIR/lower_intrinsics_e2e.rs:23:9: 23:21
                                          // mir::Constant
                                          // + span: $DIR/lower_intrinsics_e2e.rs:23:9: 23:18
                                          // + literal: Const { ty: fn(u64) {f_non_zst::<u64>}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics_e2e.rs:+1:5: +1:21
         return;                          // scope 0 at $DIR/lower_intrinsics_e2e.rs:+2:2: +2:2
     }
 }


### PR DESCRIPTION
Split from https://github.com/rust-lang/rust/pull/103657

Moving those constant into debuginfo allows to shrink the number of locals and the actual size of the MIR body.