### PR TITLE
Allow comparing `Discriminants` in const contexts

### DIFF
--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1083,7 +1083,11 @@ impl<T> clone::Clone for Discriminant<T> {
 }
 
 #[stable(feature = "discriminant_value", since = "1.21.0")]
-impl<T> cmp::PartialEq for Discriminant<T> {
+#[rustc_const_unstable(feature = "const_partial_eq_discriminant", issue = "none")]
+impl<T> const cmp::PartialEq for Discriminant<T>
+where
+    <T as DiscriminantKind>::Discriminant: ~const cmp::PartialEq,
+{
     fn eq(&self, rhs: &Self) -> bool {
         self.0 == rhs.0
     }

--- a/library/core/tests/const_discriminant_test.rs
+++ b/library/core/tests/const_discriminant_test.rs
@@ -1,0 +1,16 @@
+enum Enum {
+    A,
+    B,
+}
+
+impl const PartialEq for Enum {
+    fn eq(&self, other: &Self) -> bool {
+        mem::discriminant(self) == mem::discriminant(other)
+    }
+}
+
+#[test]
+const fn const_discriminant_partial_eq() {
+    assert!(Enum::A != Enum::B);
+    assert!(Enum::A == Enum::A);
+}


### PR DESCRIPTION
Allows comparing the discriminant values of enums in const contexts.
This relies on `DiscriminantKind::Discriminant` Type being ~const `PartialEq`. 

cc @fee1-dead