### PR TITLE
Also erase substs for new infcx in pin move error

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -1128,8 +1128,12 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                 "{place_name} {partially_str}moved due to this method call{loop_message}",
                             ),
                         );
+
                         let infcx = tcx.infer_ctxt().build();
+                        // Erase and shadow everything that could be passed to the new infcx.
                         let ty = tcx.erase_regions(moved_place.ty(self.body, tcx).ty);
+                        let method_substs = tcx.erase_regions(method_substs);
+
                         if let ty::Adt(def, substs) = ty.kind()
                             && Some(def.did()) == tcx.lang_items().pin_type()
                             && let ty::Ref(_, _, hir::Mutability::Mut) = substs.type_at(0).kind()

--- a/tests/ui/moves/pin-mut-reborrow-infer-var-issue-107419.fixed
+++ b/tests/ui/moves/pin-mut-reborrow-infer-var-issue-107419.fixed
@@ -1,0 +1,11 @@
+// run-rustfix
+use std::pin::Pin;
+
+fn foo(_: &mut ()) {}
+
+fn main() {
+    let mut uwu = ();
+    let mut r = Pin::new(&mut uwu);
+    foo(r.as_mut().get_mut());
+    foo(r.get_mut()); //~ ERROR use of moved value
+}

--- a/tests/ui/moves/pin-mut-reborrow-infer-var-issue-107419.rs
+++ b/tests/ui/moves/pin-mut-reborrow-infer-var-issue-107419.rs
@@ -1,0 +1,11 @@
+// run-rustfix
+use std::pin::Pin;
+
+fn foo(_: &mut ()) {}
+
+fn main() {
+    let mut uwu = ();
+    let mut r = Pin::new(&mut uwu);
+    foo(r.get_mut());
+    foo(r.get_mut()); //~ ERROR use of moved value
+}

--- a/tests/ui/moves/pin-mut-reborrow-infer-var-issue-107419.stderr
+++ b/tests/ui/moves/pin-mut-reborrow-infer-var-issue-107419.stderr
@@ -1,0 +1,20 @@
+error[E0382]: use of moved value: `r`
+  --> $DIR/pin-mut-reborrow-infer-var-issue-107419.rs:10:9
+   |
+LL |     let mut r = Pin::new(&mut uwu);
+   |         ----- move occurs because `r` has type `Pin<&mut ()>`, which does not implement the `Copy` trait
+LL |     foo(r.get_mut());
+   |           --------- `r` moved due to this method call
+LL |     foo(r.get_mut());
+   |         ^ value used here after move
+   |
+note: `Pin::<&'a mut T>::get_mut` takes ownership of the receiver `self`, which moves `r`
+  --> $SRC_DIR/core/src/pin.rs:LL:COL
+help: consider reborrowing the `Pin` instead of moving it
+   |
+LL |     foo(r.as_mut().get_mut());
+   |           +++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.


### PR DESCRIPTION
The code originally correctly erased the regions of the type it passed to the newly created infcx. But after the `fn_sig` query was made to return an `EarlyBinder<T>`, some substs that were around were substituted there without erasing their regions. They were then passed into the newly cerated infcx, which caused the ICE.

Fixes #107419

r? compiler-errors who reviewed the original PR adding this diagnostic