### PR TITLE
docs: remove colon from time header

### DIFF
--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -1,6 +1,6 @@
 //! Temporal quantification.
 //!
-//! # Examples:
+//! # Examples
 //!
 //! There are multiple ways to create a new [`Duration`]:
 //!


### PR DESCRIPTION
It's not used anywhere else; the inconsistency is weird.