### PR TITLE
emit `ConstEquate` in `TypeRelating<D>`

### DIFF
--- a/compiler/rustc_infer/src/infer/nll_relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/nll_relate/mod.rs
@@ -817,12 +817,13 @@ impl<'tcx, D> ConstEquateRelation<'tcx> for TypeRelating<'_, 'tcx, D>
 where
     D: TypeRelatingDelegate<'tcx>,
 {
-    fn const_equate_obligation(&mut self, _a: ty::Const<'tcx>, _b: ty::Const<'tcx>) {
-        // We don't have to worry about the equality of consts during borrow checking
-        // as consts always have a static lifetime.
-        // FIXME(oli-obk): is this really true? We can at least have HKL and with
-        // inline consts we may have further lifetimes that may be unsound to treat as
-        // 'static.
+    fn const_equate_obligation(&mut self, a: ty::Const<'tcx>, b: ty::Const<'tcx>) {
+        self.delegate.register_obligations(vec![Obligation::new(
+            self.tcx(),
+            ObligationCause::dummy(),
+            self.param_env(),
+            ty::Binder::dummy(ty::PredicateKind::ConstEquate(a, b)),
+        )]);
     }
 }
 

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/relate_binop_arg_tys.rs
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/relate_binop_arg_tys.rs
@@ -1,0 +1,18 @@
+// checks that when we relate a `Expr::Binop` we also relate the types of the
+// const arguments.
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+struct Bar<const B: bool>;
+
+const fn make_generic(_: usize, a: bool) -> bool {
+    a
+}
+
+fn foo<const N: usize>() -> Bar<{ make_generic(N, true == false) }> {
+    Bar::<{ make_generic(N, 1_u8 == 0_u8) }>
+    //~^ error: mismatched types
+    //~| error: unconstrained generic constant
+}
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/relate_binop_arg_tys.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/relate_binop_arg_tys.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/relate_binop_arg_tys.rs:13:5
+   |
+LL |     Bar::<{ make_generic(N, 1_u8 == 0_u8) }>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ make_generic(N, true == false) }`, found `{ make_generic(N, 1_u8 == 0_u8) }`
+   |
+   = note: expected constant `{ make_generic(N, true == false) }`
+              found constant `{ make_generic(N, 1_u8 == 0_u8) }`
+
+error: unconstrained generic constant
+  --> $DIR/relate_binop_arg_tys.rs:13:11
+   |
+LL |     Bar::<{ make_generic(N, 1_u8 == 0_u8) }>
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { make_generic(N, 1_u8 == 0_u8) }]:`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/relate_cast_arg_ty.rs
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/relate_cast_arg_ty.rs
@@ -1,0 +1,12 @@
+// checks that when we relate a `Expr::Cast` we also relate the type of the
+// const argument.
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+fn foo<const N: usize>() -> [(); (true as usize) + N] {
+    [(); (1_u8 as usize) + N]
+    //~^ error: mismatched types
+    //~| error: unconstrained generic constant
+}
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/relate_cast_arg_ty.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/relate_cast_arg_ty.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/relate_cast_arg_ty.rs:7:5
+   |
+LL |     [(); (1_u8 as usize) + N]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `(true as usize) + N`, found `(1_u8 as usize) + N`
+   |
+   = note: expected constant `(true as usize) + N`
+              found constant `(1_u8 as usize) + N`
+
+error: unconstrained generic constant
+  --> $DIR/relate_cast_arg_ty.rs:7:10
+   |
+LL |     [(); (1_u8 as usize) + N]
+   |          ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); (1_u8 as usize) + N]:`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
emitting `ConstEquate` during mir typeck is useful since it can help catch bugs in hir typeck incase our impl of `ConstEquate` is wrong. 

doing this did actually catch a bug, when relating `Expr::Call` we `==` the types of all the argument consts which spuriously returns false if the type contains const projections/aliases which causes us to fall through to the `expected_found` error arm.
Generally its an ICE if the `Const`'s `Ty`s arent equal but `ConstKind::Expr` is kind of special since they are sort of like const items that are `const CALL<F: const Fn(...), const N: F>` though we dont actually explicitly represent the `F` type param explicitly in `Expr::Call` so I just made us relate the `Const`'s ty field to avoid getting ICEs from the tests I added and the following existing test: 
```rust
// tests/ui/const-generics/generic_const_exprs/different-fn.rs
#![feature(generic_const_exprs)]
#![allow(incomplete_features)]

use std::mem::size_of;
use std::marker::PhantomData;

struct Foo<T>(PhantomData<T>);

fn test<T>() -> [u8; size_of::<T>()] {
    [0; size_of::<Foo<T>>()]
    //~^ ERROR unconstrained generic constant
    //~| ERROR mismatched types
}

fn main() {
    test::<u32>();
}
```
which has us relate two `ConstKind::Value` one for the fn item of `size_of::<Foo<T>>` and one for the fn item of `size_of::<T>()`, these only differ by their `Ty` and if we don't relate the `Ty` we'll end up getting an ICE from the checks that ensure the `ty` fields always match.

In theory `Expr::UnOp` has the same problem so I added a call to `relate` for the ty's, although I was unable to create a repro test.