### PR TITLE
use `RefLock` in `GatedSpans` of Session

### DIFF
--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(associated_type_bounds)]
 #![feature(auto_traits)]
 #![feature(cell_leak)]
+#![feature(core_intrinsics)]
 #![feature(extend_one)]
 #![feature(hash_raw_entry)]
 #![feature(hasher_prefixfree_extras)]

--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -488,7 +488,10 @@ impl<T> RefLock<T> {
 
     #[inline(always)]
     fn assert_thread(&self) {
+        #[cfg(parallel_compiler)]
         assert_eq!(get_thread_id(), self.thread_id);
+        #[cfg(not(parallel_compiler))]
+        return;
     }
 
     #[inline(always)]

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -8,7 +8,7 @@ use crate::lint::{
 };
 use rustc_ast::node_id::NodeId;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexSet};
-use rustc_data_structures::sync::{Lock, Lrc};
+use rustc_data_structures::sync::{Lock, Lrc, RefLock};
 use rustc_errors::{emitter::SilentEmitter, ColorConfig, Handler};
 use rustc_errors::{
     fallback_fluent_bundle, Diagnostic, DiagnosticBuilder, DiagnosticId, DiagnosticMessage,
@@ -32,7 +32,7 @@ pub type CrateCheckConfig = CheckCfg<Symbol>;
 /// used and should be feature gated accordingly in `check_crate`.
 #[derive(Default)]
 pub struct GatedSpans {
-    pub spans: Lock<FxHashMap<Symbol, Vec<Span>>>,
+    pub spans: RefLock<FxHashMap<Symbol, Vec<Span>>>,
 }
 
 impl GatedSpans {


### PR DESCRIPTION
part of #101566 

`RefLock` is a thread-safe data structure because it can only be accessed within the thread in which it was created.

The `GatedSpans` in the Session will only be accessed in a single thread, so we can reduce the access cost in a multi-threaded environment by using `RefCell` instead of `Lock`.