### PR TITLE
Remove `GenFuture` from core

### DIFF
--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -56,51 +56,6 @@ unsafe impl Send for ResumeTy {}
 #[unstable(feature = "gen_future", issue = "50547")]
 unsafe impl Sync for ResumeTy {}
 
-/// Wrap a generator in a future.
-///
-/// This function returns a `GenFuture` underneath, but hides it in `impl Trait` to give
-/// better error messages (`impl Future` rather than `GenFuture<[closure.....]>`).
-// This is `const` to avoid extra errors after we recover from `const async fn`
-#[doc(hidden)]
-#[unstable(feature = "gen_future", issue = "50547")]
-#[rustc_const_unstable(feature = "gen_future", issue = "50547")]
-#[inline]
-pub const fn from_generator<T>(gen: T) -> impl Future<Output = T::Return>
-where
-    T: crate::ops::Generator<ResumeTy, Yield = ()>,
-{
-    use crate::{
-        ops::{Generator, GeneratorState},
-        pin::Pin,
-        task::Poll,
-    };
-
-    #[rustc_diagnostic_item = "gen_future"]
-    struct GenFuture<T: Generator<ResumeTy, Yield = ()>>(T);
-
-    // We rely on the fact that async/await futures are immovable in order to create
-    // self-referential borrows in the underlying generator.
-    impl<T: Generator<ResumeTy, Yield = ()>> !Unpin for GenFuture<T> {}
-
-    impl<T: Generator<ResumeTy, Yield = ()>> Future for GenFuture<T> {
-        type Output = T::Return;
-        #[track_caller]
-        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            // SAFETY: Safe because we're !Unpin + !Drop, and this is just a field projection.
-            let gen = unsafe { Pin::map_unchecked_mut(self, |s| &mut s.0) };
-
-            // Resume the generator, turning the `&mut Context` into a `NonNull` raw pointer. The
-            // `.await` lowering will safely cast that back to a `&mut Context`.
-            match gen.resume(ResumeTy(NonNull::from(cx).cast::<Context<'static>>())) {
-                GeneratorState::Yielded(()) => Poll::Pending,
-                GeneratorState::Complete(x) => Poll::Ready(x),
-            }
-        }
-    }
-
-    GenFuture(gen)
-}
-
 #[lang = "get_context"]
 #[doc(hidden)]
 #[unstable(feature = "gen_future", issue = "50547")]


### PR DESCRIPTION
The handling of async constructs in the compiler does not rely on `GenFuture` anymore since `1.67`, so this code can now be removed from `core`.