### PR TITLE
Implement `FromIterator` for `(impl Default + Extend, impl Default + Extend)`

### DIFF
--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -150,6 +150,25 @@ pub trait FromIterator<A>: Sized {
     fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self;
 }
 
+/// This implementation turns an iterator of tuples into a tuple of types which implement
+/// [`Default`] and [`Extend`].
+///
+/// This is similar to [`Iterator::unzip`], but is also composable with other [`FromIterator`]
+/// implementations:
+///
+/// ```rust
+/// # fn main() -> Result<(), core::num::ParseIntError> {
+/// let string = "1,2,123,4";
+///
+/// let (numbers, lengths): (Vec<_>, Vec<_>) = string
+///     .split(',')
+///     .map(|s| s.parse().map(|n: u32| (n, s.len())))
+///     .collect::<Result<_, _>>()?;
+///
+/// assert_eq!(numbers, [1, 2, 123, 4]);
+/// assert_eq!(lengths, [1, 1, 3, 1]);
+/// # Ok(()) }
+/// ```
 #[stable(feature = "from_iterator_for_tuple", since = "CURRENT_RUSTC_VERSION")]
 impl<A, B, AE, BE> FromIterator<(AE, BE)> for (A, B)
 where

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -150,6 +150,20 @@ pub trait FromIterator<A>: Sized {
     fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self;
 }
 
+#[stable(feature = "from_iterator_for_tuple", since = "CURRENT_RUSTC_VERSION")]
+impl<A, B, AE, BE> FromIterator<(AE, BE)> for (A, B)
+where
+    A: Default + Extend<AE>,
+    B: Default + Extend<BE>,
+{
+    fn from_iter<I: IntoIterator<Item = (AE, BE)>>(iter: I) -> Self {
+        let mut res = <(A, B)>::default();
+        res.extend(iter);
+
+        res
+    }
+}
+
 /// Conversion into an [`Iterator`].
 ///
 /// By implementing `IntoIterator` for a type, you define how it will be


### PR DESCRIPTION
Similarly to how https://github.com/rust-lang/rust/pull/85835 implemented `Extend` for `(impl Extend, impl Extend)`:
```rust
impl<A, B, AE, BE> FromIterator<(AE, BE)> for (A, B)
where
    A: Default + Extend<AE>,
    B: Default + Extend<BE>,
{ ... }
```