### PR TITLE
Change turbofish context link to an archive link

### DIFF
--- a/tests/ui/parser/bastion-of-the-turbofish.rs
+++ b/tests/ui/parser/bastion-of-the-turbofish.rs
@@ -34,7 +34,7 @@
 
 // See https://github.com/rust-lang/rust/pull/53562
 // and https://github.com/rust-lang/rfcs/pull/2527
-// and https://twitter.com/garblefart/status/1393236602856611843
+// and https://web.archive.org/web/20211010063452/https://twitter.com/garblefart/status/1393236602856611843
 // for context.
 
 fn main() {


### PR DESCRIPTION
The original tweet in the chain linked to (via quote tweet), and thus the through line of links back to Anna's tweet where she named the turbofish (https://web.archive.org/web/20210911061514/https://twitter.com/whoisaldeka/status/914914008225816576) are lost as the user whoisaldeka has deleted their twitter account.

Switching to an archive link preserves this through line, allowing someone to browse back to see the point at which Anna created the turbofish, as was the original intent of including this context.

I was sharing this test with some friends as I often do, and noticed the changes (I had only seen the version from before her death previously). Looking for context myself, I realized the deleted twitter account was breaking an important link in the chain for the context of who Anna was to begin with, and the exact moment the turbofish was so named.

As an alternative to using an archive, we could link to both the tweet where Anna names the turbofish, and the tweet where she refers to herself as its guardian, as two separate links - not requiring the quote tweet to connect them.