### PR TITLE
Small bootstrap improvements

### DIFF
--- a/src/bootstrap/download.rs
+++ b/src/bootstrap/download.rs
@@ -70,6 +70,53 @@ impl Config {
         check_run(cmd, self.is_verbose())
     }
 
+    /// Whether or not `fix_bin_or_dylib` needs to be run; can only be true
+    /// on NixOS
+    fn should_fix_bins_and_dylibs(&self) -> bool {
+        static CACHED: OnceCell<bool> = OnceCell::new();
+
+        let val = *CACHED.get_or_init(|| {
+            match Command::new("uname").arg("-s").stderr(Stdio::inherit()).output() {
+                Err(_) => return false,
+                Ok(output) if !output.status.success() => return false,
+                Ok(output) => {
+                    let mut os_name = output.stdout;
+                    if os_name.last() == Some(&b'\n') {
+                        os_name.pop();
+                    }
+                    if os_name != b"Linux" {
+                        return false;
+                    }
+                }
+            }
+
+            // If the user has asked binaries to be patched for Nix, then
+            // don't check for NixOS or `/lib`.
+            // NOTE: this intentionally comes after the Linux check:
+            // - patchelf only works with ELF files, so no need to run it on Mac or Windows
+            // - On other Unix systems, there is no stable syscall interface, so Nix doesn't manage the global libc.
+            if self.patch_binaries_for_nix {
+                return true;
+            }
+
+            // Use `/etc/os-release` instead of `/etc/NIXOS`.
+            // The latter one does not exist on NixOS when using tmpfs as root.
+            let is_nixos = match File::open("/etc/os-release") {
+                Err(e) if e.kind() == ErrorKind::NotFound => false,
+                Err(e) => panic!("failed to access /etc/os-release: {}", e),
+                Ok(os_release) => BufReader::new(os_release).lines().any(|l| {
+                    let l = l.expect("reading /etc/os-release");
+                    matches!(l.trim(), "ID=nixos" | "ID='nixos'" | "ID=\"nixos\"")
+                }),
+            };
+            is_nixos && !Path::new("/lib").exists()
+        });
+        if val {
+            println!("info: You seem to be using Nix.");
+        }
+        val
+    }
+
     /// Modifies the interpreter section of 'fname' to fix the dynamic linker,
     /// or the RPATH section, to fix the dynamic library search path
     ///
@@ -78,45 +125,7 @@ impl Config {
     ///
     /// Please see https://nixos.org/patchelf.html for more information
     fn fix_bin_or_dylib(&self, fname: &Path) {
-        // FIXME: cache NixOS detection?
-        match Command::new("uname").arg("-s").stderr(Stdio::inherit()).output() {
-            Err(_) => return,
-            Ok(output) if !output.status.success() => return,
-            Ok(output) => {
-                let mut s = output.stdout;
-                if s.last() == Some(&b'\n') {
-                    s.pop();
-                }
-                if s != b"Linux" {
-                    return;
-                }
-            }
-        }
-
-        // If the user has asked binaries to be patched for Nix, then
-        // don't check for NixOS or `/lib`, just continue to the patching.
-        // NOTE: this intentionally comes after the Linux check:
-        // - patchelf only works with ELF files, so no need to run it on Mac or Windows
-        // - On other Unix systems, there is no stable syscall interface, so Nix doesn't manage the global libc.
-        if !self.patch_binaries_for_nix {
-            // Use `/etc/os-release` instead of `/etc/NIXOS`.
-            // The latter one does not exist on NixOS when using tmpfs as root.
-            const NIX_IDS: &[&str] = &["ID=nixos", "ID='nixos'", "ID=\"nixos\""];
-            let os_release = match File::open("/etc/os-release") {
-                Err(e) if e.kind() == ErrorKind::NotFound => return,
-                Err(e) => panic!("failed to access /etc/os-release: {}", e),
-                Ok(f) => f,
-            };
-            if !BufReader::new(os_release).lines().any(|l| NIX_IDS.contains(&t!(l).trim())) {
-                return;
-            }
-            if Path::new("/lib").exists() {
-                return;
-            }
-        }
-
-        // At this point we're pretty sure the user is running NixOS or using Nix
-        println!("info: you seem to be using Nix. Attempting to patch {}", fname.display());
+        println!("attempting to patch {}", fname.display());
 
         // Only build `.nix-deps` once.
         static NIX_DEPS_DIR: OnceCell<PathBuf> = OnceCell::new();
@@ -328,8 +337,10 @@ impl Config {
         let filename = format!("rustfmt-{version}-{build}.tar.xz", build = host.triple);
         self.download_component(DownloadSource::Dist, filename, "rustfmt-preview", &date, "stage0");
 
-        self.fix_bin_or_dylib(&bin_root.join("bin").join("rustfmt"));
-        self.fix_bin_or_dylib(&bin_root.join("bin").join("cargo-fmt"));
+        if self.should_fix_bins_and_dylibs() {
+            self.fix_bin_or_dylib(&bin_root.join("bin").join("rustfmt"));
+            self.fix_bin_or_dylib(&bin_root.join("bin").join("cargo-fmt"));
+        }
 
         self.create(&rustfmt_stamp, &channel);
         Some(rustfmt_path)
@@ -358,16 +369,21 @@ impl Config {
             let filename = format!("rust-src-{version}.tar.xz");
             self.download_ci_component(filename, "rust-src", commit);
 
-            self.fix_bin_or_dylib(&bin_root.join("bin").join("rustc"));
-            self.fix_bin_or_dylib(&bin_root.join("bin").join("rustdoc"));
-            self.fix_bin_or_dylib(&bin_root.join("libexec").join("rust-analyzer-proc-macro-srv"));
-            let lib_dir = bin_root.join("lib");
-            for lib in t!(fs::read_dir(&lib_dir), lib_dir.display().to_string()) {
-                let lib = t!(lib);
-                if lib.path().extension() == Some(OsStr::new("so")) {
-                    self.fix_bin_or_dylib(&lib.path());
+            if self.should_fix_bins_and_dylibs() {
+                self.fix_bin_or_dylib(&bin_root.join("bin").join("rustc"));
+                self.fix_bin_or_dylib(&bin_root.join("bin").join("rustdoc"));
+                self.fix_bin_or_dylib(
+                    &bin_root.join("libexec").join("rust-analyzer-proc-macro-srv"),
+                );
+                let lib_dir = bin_root.join("lib");
+                for lib in t!(fs::read_dir(&lib_dir), lib_dir.display().to_string()) {
+                    let lib = t!(lib);
+                    if lib.path().extension() == Some(OsStr::new("so")) {
+                        self.fix_bin_or_dylib(&lib.path());
+                    }
                 }
             }
+
             t!(fs::write(rustc_stamp, commit));
         }
     }
@@ -459,8 +475,10 @@ impl Config {
         let key = format!("{}{}", llvm_sha, self.llvm_assertions);
         if program_out_of_date(&llvm_stamp, &key) && !self.dry_run() {
             self.download_ci_llvm(&llvm_sha);
-            for entry in t!(fs::read_dir(llvm_root.join("bin"))) {
-                self.fix_bin_or_dylib(&t!(entry).path());
+            if self.should_fix_bins_and_dylibs() {
+                for entry in t!(fs::read_dir(llvm_root.join("bin"))) {
+                    self.fix_bin_or_dylib(&t!(entry).path());
+                }
             }
 
             // Update the timestamp of llvm-config to force rustc_llvm to be
@@ -475,13 +493,16 @@ impl Config {
             let llvm_config = llvm_root.join("bin").join(exe("llvm-config", self.build));
             t!(filetime::set_file_times(&llvm_config, now, now));
 
-            let llvm_lib = llvm_root.join("lib");
-            for entry in t!(fs::read_dir(&llvm_lib)) {
-                let lib = t!(entry).path();
-                if lib.extension().map_or(false, |ext| ext == "so") {
-                    self.fix_bin_or_dylib(&lib);
+            if self.should_fix_bins_and_dylibs() {
+                let llvm_lib = llvm_root.join("lib");
+                for entry in t!(fs::read_dir(&llvm_lib)) {
+                    let lib = t!(entry).path();
+                    if lib.extension().map_or(false, |ext| ext == "so") {
+                        self.fix_bin_or_dylib(&lib);
+                    }
                 }
             }
+
             t!(fs::write(llvm_stamp, key));
         }
     }

--- a/x.py
+++ b/x.py
@@ -22,7 +22,7 @@ if sys.version_info.major < 3:
             pass
 
 rust_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.join(rust_dir, "src", "bootstrap"))
+sys.path[:0] = [os.path.join(rust_dir, "src", "bootstrap")]
 
 import bootstrap
 bootstrap.main()

--- a/x.py
+++ b/x.py
@@ -22,7 +22,8 @@ if sys.version_info.major < 3:
             pass
 
 rust_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path[:0] = [os.path.join(rust_dir, "src", "bootstrap")]
+# For the import below, have Python search in src/bootstrap first.
+sys.path.insert(0, os.path.join(rust_dir, "src", "bootstrap"))
 
 import bootstrap
 bootstrap.main()


### PR DESCRIPTION
- i/o-less check for `xz` availability
- cache result of NixOS detection
- load correct `bootstrap` module even when a package of that name is installed
- no `-W semicolon_in_expressions_from_macros` – it is warn-by-default
- one type per variable (making dynamic typing less confusing)
- integrate python-side `--help` flag into the argument parser (makes `-hv` work as a short form of `--help --verbose`)

I even checked that it works with Python 2.