### PR TITLE
Add display of lifetime of Ref in fn fmt() for TypeError

### DIFF
--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -303,7 +303,7 @@ impl<'tcx> Ty<'tcx> {
                 if tymut_string != "_"
                     && (ty.is_simple_text() || tymut_string.len() < "mutable reference".len())
                 {
-                    format!("`&{}`", tymut_string).into()
+                    format!("`{}`", self).into()
                 } else {
                     // Unknown type name, it's long or has type arguments
                     match mutbl {

--- a/tests/ui/argument-suggestions/invalid_arguments.stderr
+++ b/tests/ui/argument-suggestions/invalid_arguments.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
   --> $DIR/invalid_arguments.rs:16:19
    |
 LL |   two_arg_same(1, "");
-   |   ------------    ^^ expected `i32`, found `&str`
+   |   ------------    ^^ expected `i32`, found `&'static str`
    |   |
    |   arguments to this function are incorrect
    |
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
   --> $DIR/invalid_arguments.rs:17:16
    |
 LL |   two_arg_same("", 1);
-   |   ------------ ^^ expected `i32`, found `&str`
+   |   ------------ ^^ expected `i32`, found `&'static str`
    |   |
    |   arguments to this function are incorrect
    |
@@ -44,9 +44,9 @@ error[E0308]: arguments to this function are incorrect
   --> $DIR/invalid_arguments.rs:18:3
    |
 LL |   two_arg_same("", "");
-   |   ^^^^^^^^^^^^ --  -- expected `i32`, found `&str`
+   |   ^^^^^^^^^^^^ --  -- expected `i32`, found `&'static str`
    |                |
-   |                expected `i32`, found `&str`
+   |                expected `i32`, found `&'static str`
    |
 note: function defined here
   --> $DIR/invalid_arguments.rs:6:4
@@ -58,7 +58,7 @@ error[E0308]: mismatched types
   --> $DIR/invalid_arguments.rs:19:19
    |
 LL |   two_arg_diff(1, "");
-   |   ------------    ^^ expected `f32`, found `&str`
+   |   ------------    ^^ expected `f32`, found `&'static str`
    |   |
    |   arguments to this function are incorrect
    |
@@ -72,7 +72,7 @@ error[E0308]: mismatched types
   --> $DIR/invalid_arguments.rs:20:16
    |
 LL |   two_arg_diff("", 1.0);
-   |   ------------ ^^ expected `i32`, found `&str`
+   |   ------------ ^^ expected `i32`, found `&'static str`
    |   |
    |   arguments to this function are incorrect
    |
@@ -86,9 +86,9 @@ error[E0308]: arguments to this function are incorrect
   --> $DIR/invalid_arguments.rs:21:3
    |
 LL |   two_arg_diff("", "");
-   |   ^^^^^^^^^^^^ --  -- expected `f32`, found `&str`
+   |   ^^^^^^^^^^^^ --  -- expected `f32`, found `&'static str`
    |                |
-   |                expected `i32`, found `&str`
+   |                expected `i32`, found `&'static str`
    |
 note: function defined here
   --> $DIR/invalid_arguments.rs:7:4

--- a/tests/ui/argument-suggestions/issue-96638.stderr
+++ b/tests/ui/argument-suggestions/issue-96638.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/issue-96638.rs:8:5
    |
 LL |     f(&x, "");
-   |     ^ --  -- expected `usize`, found `&str`
+   |     ^ --  -- expected `usize`, found `&'static str`
    |       |
    |       an argument of type `usize` is missing
    |

--- a/tests/ui/argument-suggestions/mixed_cases.stderr
+++ b/tests/ui/argument-suggestions/mixed_cases.stderr
@@ -4,7 +4,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
 LL |   two_args(1, "", X {});
    |   ^^^^^^^^    --  ---- argument of type `X` unexpected
    |               |
-   |               expected `f32`, found `&str`
+   |               expected `f32`, found `&'static str`
    |
 note: function defined here
   --> $DIR/mixed_cases.rs:5:4

--- a/tests/ui/associated-consts/associated-const-generic-obligations.stderr
+++ b/tests/ui/associated-consts/associated-const-generic-obligations.stderr
@@ -2,7 +2,7 @@ error[E0326]: implemented const `FROM` has an incompatible type for trait
   --> $DIR/associated-const-generic-obligations.rs:14:17
    |
 LL |     const FROM: &'static str = "foo";
-   |                 ^^^^^^^^^^^^ expected associated type, found `&str`
+   |                 ^^^^^^^^^^^^ expected associated type, found `&'static str`
    |
 note: type in trait
   --> $DIR/associated-const-generic-obligations.rs:10:17

--- a/tests/ui/associated-type-bounds/elision.stderr
+++ b/tests/ui/associated-type-bounds/elision.stderr
@@ -14,7 +14,7 @@ error[E0308]: mismatched types
   --> $DIR/elision.rs:5:79
    |
 LL | fn f(x: &mut dyn Iterator<Item: Iterator<Item = &'_ ()>>) -> Option<&'_ ()> { x.next() }
-   |                           -----------------------------      --------------   ^^^^^^^^ expected `&()`, found type parameter `impl Iterator<Item = &'_ ()>`
+   |                           -----------------------------      --------------   ^^^^^^^^ expected `&'static ()`, found type parameter `impl Iterator<Item = &'_ ()>`
    |                           |                                  |
    |                           |                                  expected `Option<&'static ()>` because of return type
    |                           this type parameter

--- a/tests/ui/closures/closure-return-type-mismatch.stderr
+++ b/tests/ui/closures/closure-return-type-mismatch.stderr
@@ -14,7 +14,7 @@ error[E0308]: mismatched types
   --> $DIR/closure-return-type-mismatch.rs:12:20
    |
 LL |             return "hello"
-   |                    ^^^^^^^ expected `bool`, found `&str`
+   |                    ^^^^^^^ expected `bool`, found `&'static str`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/codemap_tests/tab.stderr
+++ b/tests/ui/codemap_tests/tab.stderr
@@ -10,7 +10,7 @@ error[E0308]: mismatched types
 LL | fn foo() {
    |          - help: try adding a return type: `-> &'static str`
 LL |     "bar            boo"
-   |     ^^^^^^^^^^^^^^^^^^^^ expected `()`, found `&str`
+   |     ^^^^^^^^^^^^^^^^^^^^ expected `()`, found `&'static str`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/issue-69310-array-size-lit-wrong-ty.stderr
+++ b/tests/ui/consts/issue-69310-array-size-lit-wrong-ty.stderr
@@ -8,7 +8,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-69310-array-size-lit-wrong-ty.rs:11:15
    |
 LL | const B: [(); b"a"] = [()];
-   |               ^^^^ expected `usize`, found `&[u8; 1]`
+   |               ^^^^ expected `usize`, found `&'static [u8; 1]`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/deref-patterns/gate.stderr
+++ b/tests/ui/deref-patterns/gate.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     match String::new() {
    |           ------------- this expression has type `String`
 LL |         "" | _ => {}
-   |         ^^ expected struct `String`, found `&str`
+   |         ^^ expected struct `String`, found `&'static str`
 
 error: aborting due to previous error
 

--- a/tests/ui/did_you_mean/brackets-to-braces-single-element.stderr
+++ b/tests/ui/did_you_mean/brackets-to-braces-single-element.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/brackets-to-braces-single-element.rs:1:24
    |
 LL | const A: [&str; 1] = { "hello" };
-   |                        ^^^^^^^ expected array `[&'static str; 1]`, found `&str`
+   |                        ^^^^^^^ expected array `[&'static str; 1]`, found `&'static str`
    |
 help: to create an array, use square brackets instead of curly braces
    |

--- a/tests/ui/inference/char-as-str-multi.stderr
+++ b/tests/ui/inference/char-as-str-multi.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/char-as-str-multi.rs:5:19
    |
 LL |     let _: char = "foo";
-   |            ----   ^^^^^ expected `char`, found `&str`
+   |            ----   ^^^^^ expected `char`, found `&'static str`
    |            |
    |            expected due to this
 
@@ -10,7 +10,7 @@ error[E0308]: mismatched types
   --> $DIR/char-as-str-multi.rs:6:19
    |
 LL |     let _: char = "";
-   |            ----   ^^ expected `char`, found `&str`
+   |            ----   ^^ expected `char`, found `&'static str`
    |            |
    |            expected due to this
 

--- a/tests/ui/inference/char-as-str-single.stderr
+++ b/tests/ui/inference/char-as-str-single.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/char-as-str-single.rs:9:19
    |
 LL |     let _: char = "a";
-   |            ----   ^^^ expected `char`, found `&str`
+   |            ----   ^^^ expected `char`, found `&'static str`
    |            |
    |            expected due to this
    |
@@ -15,7 +15,7 @@ error[E0308]: mismatched types
   --> $DIR/char-as-str-single.rs:10:19
    |
 LL |     let _: char = "人";
-   |            ----   ^^^^ expected `char`, found `&str`
+   |            ----   ^^^^ expected `char`, found `&'static str`
    |            |
    |            expected due to this
    |
@@ -28,7 +28,7 @@ error[E0308]: mismatched types
   --> $DIR/char-as-str-single.rs:11:19
    |
 LL |     let _: char = "'";
-   |            ----   ^^^ expected `char`, found `&str`
+   |            ----   ^^^ expected `char`, found `&'static str`
    |            |
    |            expected due to this
    |

--- a/tests/ui/issues/issue-20225.stderr
+++ b/tests/ui/issues/issue-20225.stderr
@@ -6,7 +6,7 @@ LL | impl<'a, T> Fn<(&'a T,)> for Foo {
 LL |   extern "rust-call" fn call(&self, (_,): (T,)) {}
    |                                           ^^^^
    |                                           |
-   |                                           expected `&T`, found type parameter `T`
+   |                                           expected `&'a T`, found type parameter `T`
    |                                           help: change the parameter type to match the trait: `(&'a T,)`
    |
    = note: expected signature `extern "rust-call" fn(&Foo, (&'a T,))`
@@ -20,7 +20,7 @@ LL | impl<'a, T> FnMut<(&'a T,)> for Foo {
 LL |   extern "rust-call" fn call_mut(&mut self, (_,): (T,)) {}
    |                                                   ^^^^
    |                                                   |
-   |                                                   expected `&T`, found type parameter `T`
+   |                                                   expected `&'a T`, found type parameter `T`
    |                                                   help: change the parameter type to match the trait: `(&'a T,)`
    |
    = note: expected signature `extern "rust-call" fn(&mut Foo, (&'a T,))`
@@ -35,7 +35,7 @@ LL | impl<'a, T> FnOnce<(&'a T,)> for Foo {
 LL |   extern "rust-call" fn call_once(self, (_,): (T,)) {}
    |                                               ^^^^
    |                                               |
-   |                                               expected `&T`, found type parameter `T`
+   |                                               expected `&'a T`, found type parameter `T`
    |                                               help: change the parameter type to match the trait: `(&'a T,)`
    |
    = note: expected signature `extern "rust-call" fn(Foo, (&'a T,))`

--- a/tests/ui/issues/issue-41742.stderr
+++ b/tests/ui/issues/issue-41742.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-41742.rs:24:7
    |
 LL |     H["?"].f();
-   |       ^^^ expected `u32`, found `&str`
+   |       ^^^ expected `u32`, found `&'static str`
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-7061.stderr
+++ b/tests/ui/issues/issue-7061.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-7061.rs:4:46
    |
 LL |     fn foo(&'a mut self) -> Box<BarStruct> { self }
-   |                             --------------   ^^^^ expected struct `Box`, found `&mut BarStruct`
+   |                             --------------   ^^^^ expected struct `Box`, found `&'a mut BarStruct`
    |                             |
    |                             expected `Box<BarStruct>` because of return type
    |

--- a/tests/ui/lexer/lex-bad-char-literals-6.stderr
+++ b/tests/ui/lexer/lex-bad-char-literals-6.stderr
@@ -35,7 +35,7 @@ error[E0308]: mismatched types
   --> $DIR/lex-bad-char-literals-6.rs:13:20
    |
 LL |     let a: usize = "";
-   |            -----   ^^ expected `usize`, found `&str`
+   |            -----   ^^ expected `usize`, found `&'static str`
    |            |
    |            expected due to this
 

--- a/tests/ui/lifetimes/issue-26638.stderr
+++ b/tests/ui/lifetimes/issue-26638.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-26638.rs:1:69
    |
 LL | fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.next() }
-   |                                                              ----   ^^^^^^^^^^^ expected `&str`, found enum `Option`
+   |                                                              ----   ^^^^^^^^^^^ expected `&'static str`, found enum `Option`
    |                                                              |
    |                                                              expected `&'static str` because of return type
    |

--- a/tests/ui/loops/loop-break-value.stderr
+++ b/tests/ui/loops/loop-break-value.stderr
@@ -149,13 +149,13 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:16:15
    |
 LL |         break "asdf";
-   |               ^^^^^^ expected `i32`, found `&str`
+   |               ^^^^^^ expected `i32`, found `&'static str`
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:21:31
    |
 LL |             break 'outer_loop "nope";
-   |                               ^^^^^^ expected `i32`, found `&str`
+   |                               ^^^^^^ expected `i32`, found `&'static str`
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:73:26

--- a/tests/ui/match/match-arm-resolving-to-never.stderr
+++ b/tests/ui/match/match-arm-resolving-to-never.stderr
@@ -9,7 +9,7 @@ LL | |         E::D => 4,
 LL | |         E::E => unimplemented!(""),
    | |                 ------------------ this and all prior arms are found to be of type `{integer}`
 LL | |         E::F => "",
-   | |                 ^^ expected integer, found `&str`
+   | |                 ^^ expected integer, found `&'static str`
 LL | |     };
    | |_____- `match` arms have incompatible types
 

--- a/tests/ui/match/single-line.stderr
+++ b/tests/ui/match/single-line.stderr
@@ -2,7 +2,7 @@ error[E0308]: `match` arms have incompatible types
   --> $DIR/single-line.rs:2:52
    |
 LL |     let _ = match Some(42) { Some(x) => x, None => "" };
-   |             --------------              -          ^^ expected integer, found `&str`
+   |             --------------              -          ^^ expected integer, found `&'static str`
    |             |                           |
    |             |                           this is found to be of type `{integer}`
    |             `match` arms have incompatible types

--- a/tests/ui/methods/issues/issue-61525.stderr
+++ b/tests/ui/methods/issues/issue-61525.stderr
@@ -21,7 +21,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-61525.rs:14:33
    |
 LL |         1.query::<dyn ToString>("")
-   |           --------------------- ^^ expected trait object `dyn ToString`, found `&str`
+   |           --------------------- ^^ expected trait object `dyn ToString`, found `&'static str`
    |           |
    |           arguments to this method are incorrect
    |

--- a/tests/ui/mismatched_types/normalize-fn-sig.stderr
+++ b/tests/ui/mismatched_types/normalize-fn-sig.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/normalize-fn-sig.rs:14:22
    |
 LL |     needs_i32_ref_fn(foo::<()>);
-   |     ---------------- ^^^^^^^^^ expected `&i32`, found `i32`
+   |     ---------------- ^^^^^^^^^ expected `&'static i32`, found `i32`
    |     |
    |     arguments to this function are incorrect
    |

--- a/tests/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/tests/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/overloaded-calls-bad.rs:33:17
    |
 LL |     let ans = s("what");
-   |               - ^^^^^^ expected `isize`, found `&str`
+   |               - ^^^^^^ expected `isize`, found `&'static str`
    |               |
    |               arguments to this function are incorrect
    |
@@ -34,7 +34,7 @@ error[E0057]: this function takes 1 argument but 2 arguments were supplied
 LL |     let ans = s("burma", "shave");
    |               ^ -------  ------- argument of type `&'static str` unexpected
    |                 |
-   |                 expected `isize`, found `&str`
+   |                 expected `isize`, found `&'static str`
    |
 note: implementation defined here
   --> $DIR/overloaded-calls-bad.rs:10:1
@@ -50,7 +50,7 @@ error[E0308]: mismatched types
   --> $DIR/overloaded-calls-bad.rs:40:7
    |
 LL |     F("");
-   |     - ^^ expected `i32`, found `&str`
+   |     - ^^ expected `i32`, found `&'static str`
    |     |
    |     arguments to this struct are incorrect
    |

--- a/tests/ui/never_type/call-fn-never-arg-wrong-type.stderr
+++ b/tests/ui/never_type/call-fn-never-arg-wrong-type.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/call-fn-never-arg-wrong-type.rs:10:9
    |
 LL |     foo("wow");
-   |     --- ^^^^^ expected `!`, found `&str`
+   |     --- ^^^^^ expected `!`, found `&'static str`
    |     |
    |     arguments to this function are incorrect
    |

--- a/tests/ui/never_type/never-assign-wrong-type.stderr
+++ b/tests/ui/never_type/never-assign-wrong-type.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/never-assign-wrong-type.rs:7:16
    |
 LL |     let x: ! = "hello";
-   |            -   ^^^^^^^ expected `!`, found `&str`
+   |            -   ^^^^^^^ expected `!`, found `&'static str`
    |            |
    |            expected due to this
    |

--- a/tests/ui/parser/fn-arg-doc-comment.rs
+++ b/tests/ui/parser/fn-arg-doc-comment.rs
@@ -21,10 +21,10 @@ fn main() {
     // verify that the parser recovered and properly typechecked the args
     f("", "");
     //~^ ERROR arguments to this function are incorrect
-    //~| NOTE expected `u8`, found `&str`
-    //~| NOTE expected `u8`, found `&str`
+    //~| NOTE expected `u8`, found `&'static str`
+    //~| NOTE expected `u8`, found `&'static str`
     bar("");
     //~^ ERROR mismatched types
     //~| NOTE arguments to this function are incorrect
-    //~| NOTE expected `i32`, found `&str`
+    //~| NOTE expected `i32`, found `&'static str`
 }

--- a/tests/ui/parser/fn-arg-doc-comment.stderr
+++ b/tests/ui/parser/fn-arg-doc-comment.stderr
@@ -20,9 +20,9 @@ error[E0308]: arguments to this function are incorrect
   --> $DIR/fn-arg-doc-comment.rs:22:5
    |
 LL |     f("", "");
-   |     ^ --  -- expected `u8`, found `&str`
+   |     ^ --  -- expected `u8`, found `&'static str`
    |       |
-   |       expected `u8`, found `&str`
+   |       expected `u8`, found `&'static str`
    |
 note: function defined here
   --> $DIR/fn-arg-doc-comment.rs:1:8
@@ -46,7 +46,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-arg-doc-comment.rs:26:9
    |
 LL |     bar("");
-   |     --- ^^ expected `i32`, found `&str`
+   |     --- ^^ expected `i32`, found `&'static str`
    |     |
    |     arguments to this function are incorrect
    |

--- a/tests/ui/parser/numeric-lifetime.stderr
+++ b/tests/ui/parser/numeric-lifetime.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/numeric-lifetime.rs:6:20
    |
 LL |     let x: usize = "";
-   |            -----   ^^ expected `usize`, found `&str`
+   |            -----   ^^ expected `usize`, found `&'static str`
    |            |
    |            expected due to this
 

--- a/tests/ui/parser/recover-tuple.stderr
+++ b/tests/ui/parser/recover-tuple.stderr
@@ -8,7 +8,7 @@ error[E0308]: mismatched types
   --> $DIR/recover-tuple.rs:6:20
    |
 LL |     let y: usize = "";
-   |            -----   ^^ expected `usize`, found `&str`
+   |            -----   ^^ expected `usize`, found `&'static str`
    |            |
    |            expected due to this
 

--- a/tests/ui/proc-macro/attribute-spans-preserved.stderr
+++ b/tests/ui/proc-macro/attribute-spans-preserved.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/attribute-spans-preserved.rs:7:23
    |
 LL | #[ foo ( let y: u32 = "z"; ) ]
-   |                 ---   ^^^ expected `u32`, found `&str`
+   |                 ---   ^^^ expected `u32`, found `&'static str`
    |                 |
    |                 expected due to this
 
@@ -10,7 +10,7 @@ error[E0308]: mismatched types
   --> $DIR/attribute-spans-preserved.rs:8:23
    |
 LL | #[ bar { let x: u32 = "y"; } ]
-   |                 ---   ^^^ expected `u32`, found `&str`
+   |                 ---   ^^^ expected `u32`, found `&'static str`
    |                 |
    |                 expected due to this
 

--- a/tests/ui/proc-macro/attribute-with-error.stderr
+++ b/tests/ui/proc-macro/attribute-with-error.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/attribute-with-error.rs:10:18
    |
 LL |     let a: i32 = "foo";
-   |            ---   ^^^^^ expected `i32`, found `&str`
+   |            ---   ^^^^^ expected `i32`, found `&'static str`
    |            |
    |            expected due to this
 
@@ -10,7 +10,7 @@ error[E0308]: mismatched types
   --> $DIR/attribute-with-error.rs:12:18
    |
 LL |     let b: i32 = "f'oo";
-   |            ---   ^^^^^^ expected `i32`, found `&str`
+   |            ---   ^^^^^^ expected `i32`, found `&'static str`
    |            |
    |            expected due to this
 
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
   --> $DIR/attribute-with-error.rs:25:22
    |
 LL |         let a: i32 = "foo";
-   |                ---   ^^^^^ expected `i32`, found `&str`
+   |                ---   ^^^^^ expected `i32`, found `&'static str`
    |                |
    |                expected due to this
 
@@ -26,7 +26,7 @@ error[E0308]: mismatched types
   --> $DIR/attribute-with-error.rs:35:22
    |
 LL |         let a: i32 = "foo";
-   |                ---   ^^^^^ expected `i32`, found `&str`
+   |                ---   ^^^^^ expected `i32`, found `&'static str`
    |                |
    |                expected due to this
 

--- a/tests/ui/proc-macro/issue-75801.stderr
+++ b/tests/ui/proc-macro/issue-75801.stderr
@@ -5,7 +5,7 @@ LL |             let _bar: u32 = $arg;
    |                       --- expected due to this
 ...
 LL | foo!("baz");
-   |      ^^^^^ expected `u32`, found `&str`
+   |      ^^^^^ expected `u32`, found `&'static str`
 
 error: aborting due to previous error
 

--- a/tests/ui/proc-macro/nested-item-spans.stderr
+++ b/tests/ui/proc-macro/nested-item-spans.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/nested-item-spans.rs:9:22
    |
 LL |         let x: u32 = "x";
-   |                ---   ^^^ expected `u32`, found `&str`
+   |                ---   ^^^ expected `u32`, found `&'static str`
    |                |
    |                expected due to this
 
@@ -10,7 +10,7 @@ error[E0308]: mismatched types
   --> $DIR/nested-item-spans.rs:18:22
    |
 LL |         let x: u32 = "x";
-   |                ---   ^^^ expected `u32`, found `&str`
+   |                ---   ^^^ expected `u32`, found `&'static str`
    |                |
    |                expected due to this
 

--- a/tests/ui/proc-macro/span-preservation.stderr
+++ b/tests/ui/proc-macro/span-preservation.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/span-preservation.rs:11:20
    |
 LL |     let x: usize = "hello";
-   |            -----   ^^^^^^^ expected `usize`, found `&str`
+   |            -----   ^^^^^^^ expected `usize`, found `&'static str`
    |            |
    |            expected due to this
 

--- a/tests/ui/repeat-expr/repeat_count.rs
+++ b/tests/ui/repeat-expr/repeat_count.rs
@@ -15,7 +15,7 @@ fn main() {
     //~| expected `usize`, found floating-point number
     let e = [0; "foo"];
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `&str`
+    //~| expected `usize`, found `&'static str`
     let f = [0; -4_isize];
     //~^ ERROR mismatched types
     //~| expected `usize`, found `isize`

--- a/tests/ui/repeat-expr/repeat_count.stderr
+++ b/tests/ui/repeat-expr/repeat_count.stderr
@@ -28,7 +28,7 @@ error[E0308]: mismatched types
   --> $DIR/repeat_count.rs:16:17
    |
 LL |     let e = [0; "foo"];
-   |                 ^^^^^ expected `usize`, found `&str`
+   |                 ^^^^^ expected `usize`, found `&'static str`
 
 error[E0308]: mismatched types
   --> $DIR/repeat_count.rs:31:17

--- a/tests/ui/return/return-from-diverging.stderr
+++ b/tests/ui/return/return-from-diverging.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn fail() -> ! {
    |              - expected `!` because of return type
 LL |     return "wow";
-   |            ^^^^^ expected `!`, found `&str`
+   |            ^^^^^ expected `!`, found `&'static str`
    |
    = note:   expected type `!`
            found reference `&'static str`

--- a/tests/ui/return/return-impl-trait-bad.stderr
+++ b/tests/ui/return/return-impl-trait-bad.stderr
@@ -6,7 +6,7 @@ LL | fn bad_echo<T>(_t: T) -> T {
    |             |
    |             this type parameter
 LL |     "this should not suggest impl Trait"
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `T`, found `&str`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `T`, found `&'static str`
    |
    = note: expected type parameter `T`
                    found reference `&'static str`
@@ -19,7 +19,7 @@ LL | fn bad_echo_2<T: Trait>(_t: T) -> T {
    |               |
    |               this type parameter
 LL |     "this will not suggest it, because that would probably be wrong"
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `T`, found `&str`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `T`, found `&'static str`
    |
    = note: expected type parameter `T`
                    found reference `&'static str`
@@ -33,7 +33,7 @@ LL | fn other_bounds_bad<T>() -> T
    |                     this type parameter
 ...
 LL |     "don't suggest this, because Option<T> places additional constraints"
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `T`, found `&str`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `T`, found `&'static str`
    |
    = note: expected type parameter `T`
                    found reference `&'static str`
@@ -49,7 +49,7 @@ LL | fn used_in_trait<T>() -> T
    |                  this type parameter
 ...
 LL |     "don't suggest this, because the generic param is used in the bound."
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `T`, found `&str`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `T`, found `&'static str`
    |
    = note: expected type parameter `T`
                    found reference `&'static str`

--- a/tests/ui/span/issue-34264.stderr
+++ b/tests/ui/span/issue-34264.stderr
@@ -70,7 +70,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-34264.rs:8:13
    |
 LL |     bar("", "");
-   |     ---     ^^ expected `usize`, found `&str`
+   |     ---     ^^ expected `usize`, found `&'static str`
    |     |
    |     arguments to this function are incorrect
    |

--- a/tests/ui/suggestions/recover-from-semicolon-trailing-item.stderr
+++ b/tests/ui/suggestions/recover-from-semicolon-trailing-item.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
   --> $DIR/recover-from-semicolon-trailing-item.rs:14:9
    |
 LL |     foo("");
-   |     --- ^^ expected `usize`, found `&str`
+   |     --- ^^ expected `usize`, found `&'static str`
    |     |
    |     arguments to this function are incorrect
    |

--- a/tests/ui/tuple/add-tuple-within-arguments.stderr
+++ b/tests/ui/tuple/add-tuple-within-arguments.stderr
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
   --> $DIR/add-tuple-within-arguments.rs:8:15
    |
 LL |     bar("hi", "hi", "hi");
-   |     ---       ^^^^ expected tuple, found `&str`
+   |     ---       ^^^^ expected tuple, found `&'static str`
    |     |
    |     arguments to this function are incorrect
    |

--- a/tests/ui/type-alias-impl-trait/declared_but_not_defined_in_scope.stderr
+++ b/tests/ui/type-alias-impl-trait/declared_but_not_defined_in_scope.stderr
@@ -15,7 +15,7 @@ LL |     pub type Boo = impl ::std::fmt::Debug;
 LL | fn bomp() -> boo::Boo {
    |              -------- expected `Boo` because of return type
 LL |     ""
-   |     ^^ expected opaque type, found `&str`
+   |     ^^ expected opaque type, found `&'static str`
    |
    = note: expected opaque type `Boo`
                 found reference `&'static str`

--- a/tests/ui/type-alias-impl-trait/no_revealing_outside_defining_module.stderr
+++ b/tests/ui/type-alias-impl-trait/no_revealing_outside_defining_module.stderr
@@ -21,7 +21,7 @@ LL |     pub type Boo = impl ::std::fmt::Debug;
 LL | fn bomp() -> boo::Boo {
    |              -------- expected `Boo` because of return type
 LL |     ""
-   |     ^^ expected opaque type, found `&str`
+   |     ^^ expected opaque type, found `&'static str`
    |
    = note: expected opaque type `Boo`
                 found reference `&'static str`

--- a/tests/ui/type/type-shadow.stderr
+++ b/tests/ui/type/type-shadow.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/type-shadow.rs:6:20
    |
 LL |         let y: Y = "hello";
-   |                -   ^^^^^^^ expected `isize`, found `&str`
+   |                -   ^^^^^^^ expected `isize`, found `&'static str`
    |                |
    |                expected due to this
 

--- a/tests/ui/typeck/bad-type-in-vec-push.stderr
+++ b/tests/ui/typeck/bad-type-in-vec-push.stderr
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
   --> $DIR/bad-type-in-vec-push.rs:18:12
    |
 LL |     x.push("");
-   |       ---- ^^ expected integer, found `&str`
+   |       ---- ^^ expected integer, found `&'static str`
    |       |
    |       arguments to this method are incorrect
    |

--- a/tests/ui/typeck/conversion-methods.stderr
+++ b/tests/ui/typeck/conversion-methods.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     let _tis_an_instants_play: String = "'Tis a fond Ambush—";
    |                                ------   ^^^^^^^^^^^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
    |                                |        |
-   |                                |        expected struct `String`, found `&str`
+   |                                |        expected struct `String`, found `&'static str`
    |                                expected due to this
 
 error[E0308]: mismatched types


### PR DESCRIPTION
Fix for #106517.

Problem:
When explaining the source of a type error, the lifetime portion of references is sometimes omitted in order to shorten the message. This can lead to confusion as the message can disagree with other spans which use the long form with the lifetime portion. For example, for the same type error, one span may print `expected '&str', found enum 'option'` while another span may print `expected '&'static str' because of return type` and `note: expected reference '&'static str' found enum 'option<&str>'`.

Solution:
To add the lifetime portion of the references when generating the message. This will ensure consistency between the messages and avoid confusion, especially when the message is already short and the omitted information does not have to be removed.
