### PR TITLE
Use `ObligationCtxt::new_in_snapshot` in `satisfied_from_param_env`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -219,7 +219,7 @@ fn satisfied_from_param_env<'tcx>(
     }
 
     if let Some(Ok(c)) = single_match {
-        let ocx = ObligationCtxt::new(infcx);
+        let ocx = ObligationCtxt::new_in_snapshot(infcx);
         assert!(ocx.eq(&ObligationCause::dummy(), param_env, c.ty(), ct.ty()).is_ok());
         assert!(ocx.eq(&ObligationCause::dummy(), param_env, c, ct).is_ok());
         assert!(ocx.select_all_or_error().is_empty());

--- a/tests/rustdoc/document-item-with-associated-const-in-where-clause.rs
+++ b/tests/rustdoc/document-item-with-associated-const-in-where-clause.rs
@@ -1,0 +1,17 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+pub trait Enumerable {
+    const N: usize;
+}
+
+#[derive(Clone)]
+pub struct SymmetricGroup<S>
+where
+    S: Enumerable,
+    [(); S::N]: Sized,
+{
+    _phantom: std::marker::PhantomData<S>,
+}
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/single-satisfied-ConstEvaluatable-in-probe.rs
+++ b/tests/ui/const-generics/generic_const_exprs/single-satisfied-ConstEvaluatable-in-probe.rs
@@ -1,0 +1,39 @@
+// check-pass
+
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+use std::marker::PhantomData;
+
+pub trait Bytes {
+    const BYTES: usize;
+}
+
+#[derive(Clone, Debug)]
+pub struct Conster<OT>
+where
+    OT: Bytes,
+    [(); OT::BYTES]: Sized,
+{
+    _offset_type: PhantomData<fn(OT) -> OT>,
+}
+
+impl<OT> Conster<OT>
+where
+    OT: Bytes,
+    [(); OT::BYTES]: Sized,
+{
+    pub fn new() -> Self {
+        Conster { _offset_type: PhantomData }
+    }
+}
+
+pub fn make_conster<COT>() -> Conster<COT>
+where
+    COT: Bytes,
+    [(); COT::BYTES]: Sized,
+{
+    Conster::new()
+}
+
+fn main() {}


### PR DESCRIPTION
We can evaluate nested `ConstEvaluatable` obligations in an evaluation probe, which will ICE if we use `ObligationCtxt::new`.

Fixes #107474
Fixes #106666

r? @BoxyUwU but feel free to reassign
cc @JulianKnodt who i think added this assertion code

Not sure if the rustdoc test is needed, but can't hurt. They're the same root cause, though.