### PR TITLE
rustdoc: remove meta keywords from HTML

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -30,7 +30,6 @@ pub(crate) struct Page<'a> {
     pub(crate) root_path: &'a str,
     pub(crate) static_root_path: Option<&'a str>,
     pub(crate) description: &'a str,
-    pub(crate) keywords: &'a str,
     pub(crate) resource_suffix: &'a str,
 }
 

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -18,7 +18,7 @@ use super::search_index::build_index;
 use super::write_shared::write_shared;
 use super::{
     collect_spans_and_sources, print_sidebar, scrape_examples_help, sidebar_module_like, AllTypes,
-    LinkFromSrc, NameDoc, StylePath, BASIC_KEYWORDS,
+    LinkFromSrc, NameDoc, StylePath,
 };
 
 use crate::clean::{self, types::ExternalLocation, ExternalCrate};
@@ -195,7 +195,6 @@ impl<'tcx> Context<'tcx> {
                 self.shared.layout.krate
             )
         };
-        let keywords = make_item_keywords(it);
         let name;
         let tyname_s = if it.is_crate() {
             name = format!("{} crate", tyname);
@@ -212,7 +211,6 @@ impl<'tcx> Context<'tcx> {
                 static_root_path: clone_shared.static_root_path.as_deref(),
                 title: &title,
                 description: &desc,
-                keywords: &keywords,
                 resource_suffix: &clone_shared.resource_suffix,
             };
             let mut page_buffer = Buffer::html();
@@ -598,7 +596,6 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             root_path: "../",
             static_root_path: shared.static_root_path.as_deref(),
             description: "List of all items in this crate",
-            keywords: BASIC_KEYWORDS,
             resource_suffix: &shared.resource_suffix,
         };
         let all = shared.all.replace(AllTypes::new());
@@ -827,8 +824,4 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
     fn cache(&self) -> &Cache {
         &self.shared.cache
     }
-}
-
-fn make_item_keywords(it: &clean::Item) -> String {
-    format!("{}, {}", BASIC_KEYWORDS, it.name.as_ref().unwrap())
 }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2743,8 +2743,6 @@ fn sidebar_foreign_type(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item) {
     }
 }
 
-pub(crate) const BASIC_KEYWORDS: &str = "rust, rustlang, rust-lang";
-
 /// Returns a list of all paths used in the type.
 /// This is used to help deduplicate imported impls
 /// for reexported types. If any of the contained

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -11,7 +11,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 
-use super::{collect_paths_for_type, ensure_trailing_slash, Context, BASIC_KEYWORDS};
+use super::{collect_paths_for_type, ensure_trailing_slash, Context};
 use crate::clean::Crate;
 use crate::config::{EmitType, RenderOptions};
 use crate::docfs::PathError;
@@ -340,7 +340,6 @@ if (typeof exports !== 'undefined') {exports.searchIndex = searchIndex};
                 root_path: "./",
                 static_root_path: shared.static_root_path.as_deref(),
                 description: "List of crates",
-                keywords: BASIC_KEYWORDS,
                 resource_suffix: &shared.resource_suffix,
             };
 

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 use crate::html::format::Buffer;
 use crate::html::highlight;
 use crate::html::layout;
-use crate::html::render::{Context, BASIC_KEYWORDS};
+use crate::html::render::Context;
 use crate::visit::DocVisitor;
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
@@ -228,7 +228,6 @@ impl SourceCollector<'_, '_> {
             root_path: &root_path,
             static_root_path: shared.static_root_path.as_deref(),
             description: &desc,
-            keywords: BASIC_KEYWORDS,
             resource_suffix: &shared.resource_suffix,
         };
         let v = layout::render(

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"> {#- -#}
     <meta name="generator" content="rustdoc"> {#- -#}
     <meta name="description" content="{{page.description}}"> {#- -#}
-    <meta name="keywords" content="{{page.keywords}}"> {#- -#}
     <title>{{page.title}}</title> {#- -#}
     <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_serif_4_regular}}"> {#- -#}
     <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.fira_sans_regular}}"> {#- -#}


### PR DESCRIPTION
Discussed in <https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/.60.3Cmeta.20name.3D.22keywords.22.3E.60>