### PR TITLE
rustdoc: remove unused CSS from `.setting-check`

### DIFF
--- a/src/librustdoc/html/static/css/settings.css
+++ b/src/librustdoc/html/static/css/settings.css
@@ -40,8 +40,6 @@
 }
 
 .setting-check {
-	position: relative;
-	width: 100%;
 	margin-right: 20px;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
These rules were needed for the mobile-style switches, but those were removed in 0f3ae6218ef1d9e9b14bf983b463785b14abc205