### PR TITLE
fix link in std::path::Path::display()

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2688,6 +2688,7 @@ impl Path {
     /// escapes the path please use [`Debug`] instead.
     ///
     /// [`Display`]: fmt::Display
+    /// [`Debug`]: fmt::Debug
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The link `Debug` points to should be the trait `Debug`, not the macro `Debug`.