### PR TITLE
Remove both StorageLive and StorageDead in CopyProp.

### DIFF
--- a/tests/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/tests/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -56,11 +56,8 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/const_debuginfo.rs:+1:9: +1:10
           _1 = const 1_u8;                 // scope 0 at $DIR/const_debuginfo.rs:+1:13: +1:16
-          StorageLive(_2);                 // scope 1 at $DIR/const_debuginfo.rs:+2:9: +2:10
           _2 = const 2_u8;                 // scope 1 at $DIR/const_debuginfo.rs:+2:13: +2:16
-          StorageLive(_3);                 // scope 2 at $DIR/const_debuginfo.rs:+3:9: +3:10
           _3 = const 3_u8;                 // scope 2 at $DIR/const_debuginfo.rs:+3:13: +3:16
           StorageLive(_4);                 // scope 3 at $DIR/const_debuginfo.rs:+4:9: +4:12
           StorageLive(_5);                 // scope 3 at $DIR/const_debuginfo.rs:+4:15: +4:20

--- a/tests/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
@@ -18,7 +18,6 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/bad_op_mod_by_zero.rs:+1:9: +1:10
           _1 = const 0_i32;                // scope 0 at $DIR/bad_op_mod_by_zero.rs:+1:13: +1:14
           StorageLive(_2);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:9: +2:11
 -         _4 = Eq(_1, const 0_i32);        // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19

--- a/tests/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
@@ -11,7 +11,6 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/scalar_literal_propagation.rs:+1:9: +1:10
           _1 = const 1_u32;                // scope 0 at $DIR/scalar_literal_propagation.rs:+1:13: +1:14
           StorageLive(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
 -         _2 = consume(_1) -> bb1;         // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15

--- a/tests/mir-opt/copy-prop/cycle.main.CopyProp.diff
+++ b/tests/mir-opt/copy-prop/cycle.main.CopyProp.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-          StorageLive(_2);                 // scope 1 at $DIR/cycle.rs:+2:9: +2:10
+-         StorageLive(_2);                 // scope 1 at $DIR/cycle.rs:+2:9: +2:10
           _2 = _1;                         // scope 1 at $DIR/cycle.rs:+2:13: +2:14
 -         StorageLive(_3);                 // scope 2 at $DIR/cycle.rs:+3:9: +3:10
 -         _3 = _2;                         // scope 2 at $DIR/cycle.rs:+3:13: +3:14

--- a/tests/mir-opt/copy-prop/dead_stores_79191.f.CopyProp.after.mir
+++ b/tests/mir-opt/copy-prop/dead_stores_79191.f.CopyProp.after.mir
@@ -11,7 +11,6 @@ fn f(_1: usize) -> usize {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/dead_stores_79191.rs:+1:9: +1:10
         _2 = _1;                         // scope 0 at $DIR/dead_stores_79191.rs:+1:13: +1:14
         _1 = const 5_usize;              // scope 1 at $DIR/dead_stores_79191.rs:+2:5: +2:10
         _1 = _2;                         // scope 1 at $DIR/dead_stores_79191.rs:+3:5: +3:10

--- a/tests/mir-opt/copy-prop/dead_stores_better.f.CopyProp.after.mir
+++ b/tests/mir-opt/copy-prop/dead_stores_better.f.CopyProp.after.mir
@@ -11,7 +11,6 @@ fn f(_1: usize) -> usize {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/dead_stores_better.rs:+1:9: +1:10
         _2 = _1;                         // scope 0 at $DIR/dead_stores_better.rs:+1:13: +1:14
         _1 = const 5_usize;              // scope 1 at $DIR/dead_stores_better.rs:+2:5: +2:10
         _1 = _2;                         // scope 1 at $DIR/dead_stores_better.rs:+3:5: +3:10

--- a/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.diff
+++ b/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.diff
@@ -98,7 +98,7 @@
       }
   
       bb5: {
-          StorageLive(_17);                // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+-         StorageLive(_17);                // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
           _17 = ((_12 as Some).0: usize);  // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
           StorageLive(_18);                // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
 -         StorageLive(_19);                // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19

--- a/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.diff
+++ b/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.diff
@@ -1,0 +1,146 @@
+- // MIR for `main` before CopyProp
++ // MIR for `main` after CopyProp
+  
+  fn main() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue_107511.rs:+0:11: +0:11
+      let mut _1: i32;                     // in scope 0 at $DIR/issue_107511.rs:+1:9: +1:16
+      let _3: ();                          // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
+      let mut _4: std::ops::Range<usize>;  // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _5: std::ops::Range<usize>;  // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _6: usize;                   // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
+      let mut _7: &[i32];                  // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
+      let mut _8: &[i32; 4];               // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
+      let mut _10: ();                     // in scope 0 at $DIR/issue_107511.rs:+0:1: +11:2
+      let _11: ();                         // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _12: std::option::Option<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _13: &mut std::ops::Range<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _14: &mut std::ops::Range<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _15: isize;                  // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
+      let mut _16: !;                      // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
+      let mut _18: i32;                    // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
+      let _19: usize;                      // in scope 0 at $DIR/issue_107511.rs:+7:18: +7:19
+      let mut _20: usize;                  // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
+      let mut _21: bool;                   // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
+      scope 1 {
+          debug sum => _1;                 // in scope 1 at $DIR/issue_107511.rs:+1:9: +1:16
+          let _2: [i32; 4];                // in scope 1 at $DIR/issue_107511.rs:+2:9: +2:10
+          scope 2 {
+              debug a => _2;               // in scope 2 at $DIR/issue_107511.rs:+2:9: +2:10
+              let mut _9: std::ops::Range<usize>; // in scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+              scope 3 {
+                  debug iter => _9;        // in scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+                  let _17: usize;          // in scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+                  scope 4 {
+                      debug i => _17;      // in scope 4 at $DIR/issue_107511.rs:+6:9: +6:10
+                  }
+              }
+              scope 5 {
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/issue_107511.rs:+1:9: +1:16
+          _1 = const 0_i32;                // scope 0 at $DIR/issue_107511.rs:+1:19: +1:20
+          StorageLive(_2);                 // scope 1 at $DIR/issue_107511.rs:+2:9: +2:10
+          _2 = [const 0_i32, const 10_i32, const 20_i32, const 30_i32]; // scope 1 at $DIR/issue_107511.rs:+2:13: +2:28
+-         StorageLive(_3);                 // scope 2 at $DIR/issue_107511.rs:+6:5: +8:6
+          StorageLive(_4);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_5);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_6);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          StorageLive(_7);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          StorageLive(_8);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          _8 = &_2;                        // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          _7 = move _8 as &[i32] (Pointer(Unsize)); // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          StorageDead(_8);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:18
+          _6 = core::slice::<impl [i32]>::len(move _7) -> bb1; // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+                                           // mir::Constant
+                                           // + span: $DIR/issue_107511.rs:10:19: 10:22
+                                           // + literal: Const { ty: for<'a> fn(&'a [i32]) -> usize {core::slice::<impl [i32]>::len}, val: Value(<ZST>) }
+      }
+  
+      bb1: {
+          StorageDead(_7);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
+          Deinit(_5);                      // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          (_5.0: usize) = const 0_usize;   // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          (_5.1: usize) = move _6;         // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageDead(_6);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
+          _4 = <std::ops::Range<usize> as IntoIterator>::into_iter(move _5) -> bb2; // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+                                           // mir::Constant
+                                           // + span: $DIR/issue_107511.rs:10:14: 10:24
+                                           // + literal: Const { ty: fn(std::ops::Range<usize>) -> <std::ops::Range<usize> as IntoIterator>::IntoIter {<std::ops::Range<usize> as IntoIterator>::into_iter}, val: Value(<ZST>) }
+      }
+  
+      bb2: {
+          StorageDead(_5);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
+          StorageLive(_9);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          _9 = move _4;                    // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          goto -> bb3;                     // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
+      }
+  
+      bb3: {
+-         StorageLive(_11);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_12);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_13);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_14);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          _14 = &mut _9;                   // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          _13 = &mut (*_14);               // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          _12 = <std::ops::Range<usize> as Iterator>::next(move _13) -> bb4; // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+                                           // mir::Constant
+                                           // + span: $DIR/issue_107511.rs:10:14: 10:24
+                                           // + literal: Const { ty: for<'a> fn(&'a mut std::ops::Range<usize>) -> Option<<std::ops::Range<usize> as Iterator>::Item> {<std::ops::Range<usize> as Iterator>::next}, val: Value(<ZST>) }
+      }
+  
+      bb4: {
+          StorageDead(_13);                // scope 3 at $DIR/issue_107511.rs:+6:23: +6:24
+          _15 = discriminant(_12);         // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          switchInt(move _15) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+      }
+  
+      bb5: {
+          StorageLive(_17);                // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+          _17 = ((_12 as Some).0: usize);  // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+          StorageLive(_18);                // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         StorageLive(_19);                // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19
+-         _19 = _17;                       // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19
+          _20 = Len(_2);                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         _21 = Lt(_19, _20);              // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         assert(move _21, "index out of bounds: the length is {} but the index is {}", move _20, _19) -> bb8; // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
++         _21 = Lt(_17, _20);              // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
++         assert(move _21, "index out of bounds: the length is {} but the index is {}", move _20, _17) -> bb8; // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+      }
+  
+      bb6: {
+          unreachable;                     // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+      }
+  
+      bb7: {
+-         _3 = const ();                   // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
+          StorageDead(_14);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_12);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+-         StorageDead(_11);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_9);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_4);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
+-         StorageDead(_3);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
+          _0 = const ();                   // scope 0 at $DIR/issue_107511.rs:+0:11: +11:2
+          StorageDead(_2);                 // scope 1 at $DIR/issue_107511.rs:+11:1: +11:2
+          StorageDead(_1);                 // scope 0 at $DIR/issue_107511.rs:+11:1: +11:2
+          return;                          // scope 0 at $DIR/issue_107511.rs:+11:2: +11:2
+      }
+  
+      bb8: {
+-         _18 = _2[_19];                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
++         _18 = _2[_17];                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+          _1 = Add(_1, move _18);          // scope 4 at $DIR/issue_107511.rs:+7:9: +7:20
+          StorageDead(_18);                // scope 4 at $DIR/issue_107511.rs:+7:19: +7:20
+-         StorageDead(_19);                // scope 4 at $DIR/issue_107511.rs:+7:20: +7:21
+-         _11 = const ();                  // scope 4 at $DIR/issue_107511.rs:+6:25: +8:6
+-         StorageDead(_17);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_14);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_12);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+-         StorageDead(_11);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+-         _10 = const ();                  // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
+          goto -> bb3;                     // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
+      }
+  }
+  

--- a/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.diff
+++ b/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.diff
@@ -4,37 +4,34 @@
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/issue_107511.rs:+0:11: +0:11
       let mut _1: i32;                     // in scope 0 at $DIR/issue_107511.rs:+1:9: +1:16
-      let _3: ();                          // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
+      let mut _3: std::ops::Range<usize>;  // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
       let mut _4: std::ops::Range<usize>;  // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
-      let mut _5: std::ops::Range<usize>;  // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
-      let mut _6: usize;                   // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
-      let mut _7: &[i32];                  // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
-      let mut _8: &[i32; 4];               // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
-      let mut _10: ();                     // in scope 0 at $DIR/issue_107511.rs:+0:1: +11:2
-      let _11: ();                         // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
-      let mut _12: std::option::Option<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _5: usize;                   // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
+      let mut _6: &[i32];                  // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
+      let mut _7: &[i32; 4];               // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
+      let mut _9: ();                      // in scope 0 at $DIR/issue_107511.rs:+0:1: +9:2
+      let _10: ();                         // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _11: std::option::Option<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _12: &mut std::ops::Range<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
       let mut _13: &mut std::ops::Range<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
-      let mut _14: &mut std::ops::Range<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
-      let mut _15: isize;                  // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
-      let mut _16: !;                      // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
-      let mut _18: i32;                    // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
-      let _19: usize;                      // in scope 0 at $DIR/issue_107511.rs:+7:18: +7:19
-      let mut _20: usize;                  // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
-      let mut _21: bool;                   // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
+      let mut _14: isize;                  // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
+      let mut _15: !;                      // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
+      let mut _17: i32;                    // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
+      let _18: usize;                      // in scope 0 at $DIR/issue_107511.rs:+7:18: +7:19
+      let mut _19: usize;                  // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
+      let mut _20: bool;                   // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
       scope 1 {
           debug sum => _1;                 // in scope 1 at $DIR/issue_107511.rs:+1:9: +1:16
           let _2: [i32; 4];                // in scope 1 at $DIR/issue_107511.rs:+2:9: +2:10
           scope 2 {
               debug a => _2;               // in scope 2 at $DIR/issue_107511.rs:+2:9: +2:10
-              let mut _9: std::ops::Range<usize>; // in scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+              let mut _8: std::ops::Range<usize>; // in scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
               scope 3 {
-                  debug iter => _9;        // in scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
-                  let _17: usize;          // in scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+                  debug iter => _8;        // in scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+                  let _16: usize;          // in scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
                   scope 4 {
-                      debug i => _17;      // in scope 4 at $DIR/issue_107511.rs:+6:9: +6:10
+                      debug i => _16;      // in scope 4 at $DIR/issue_107511.rs:+6:9: +6:10
                   }
-              }
-              scope 5 {
               }
           }
       }
@@ -44,70 +41,69 @@
           _1 = const 0_i32;                // scope 0 at $DIR/issue_107511.rs:+1:19: +1:20
           StorageLive(_2);                 // scope 1 at $DIR/issue_107511.rs:+2:9: +2:10
           _2 = [const 0_i32, const 10_i32, const 20_i32, const 30_i32]; // scope 1 at $DIR/issue_107511.rs:+2:13: +2:28
--         StorageLive(_3);                 // scope 2 at $DIR/issue_107511.rs:+6:5: +8:6
+          StorageLive(_3);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
           StorageLive(_4);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
-          StorageLive(_5);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_5);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
           StorageLive(_6);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
           StorageLive(_7);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
-          StorageLive(_8);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
-          _8 = &_2;                        // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
-          _7 = move _8 as &[i32] (Pointer(Unsize)); // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
-          StorageDead(_8);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:18
-          _6 = core::slice::<impl [i32]>::len(move _7) -> bb1; // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          _7 = &_2;                        // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          _6 = move _7 as &[i32] (Pointer(Unsize)); // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          StorageDead(_7);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:18
+          _5 = core::slice::<impl [i32]>::len(move _6) -> bb1; // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
                                            // mir::Constant
                                            // + span: $DIR/issue_107511.rs:10:19: 10:22
                                            // + literal: Const { ty: for<'a> fn(&'a [i32]) -> usize {core::slice::<impl [i32]>::len}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_7);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
-          Deinit(_5);                      // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
-          (_5.0: usize) = const 0_usize;   // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
-          (_5.1: usize) = move _6;         // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
           StorageDead(_6);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
-          _4 = <std::ops::Range<usize> as IntoIterator>::into_iter(move _5) -> bb2; // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          Deinit(_4);                      // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          (_4.0: usize) = const 0_usize;   // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          (_4.1: usize) = move _5;         // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageDead(_5);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
+          _3 = <std::ops::Range<usize> as IntoIterator>::into_iter(move _4) -> bb2; // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
                                            // mir::Constant
                                            // + span: $DIR/issue_107511.rs:10:14: 10:24
                                            // + literal: Const { ty: fn(std::ops::Range<usize>) -> <std::ops::Range<usize> as IntoIterator>::IntoIter {<std::ops::Range<usize> as IntoIterator>::into_iter}, val: Value(<ZST>) }
       }
   
       bb2: {
-          StorageDead(_5);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
-          StorageLive(_9);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
-          _9 = move _4;                    // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageDead(_4);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
+          StorageLive(_8);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          _8 = move _3;                    // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
           goto -> bb3;                     // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
       }
   
       bb3: {
--         StorageLive(_11);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+-         StorageLive(_10);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_11);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
           StorageLive(_12);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
           StorageLive(_13);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
-          StorageLive(_14);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
-          _14 = &mut _9;                   // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
-          _13 = &mut (*_14);               // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
-          _12 = <std::ops::Range<usize> as Iterator>::next(move _13) -> bb4; // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          _13 = &mut _8;                   // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          _12 = &mut (*_13);               // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          _11 = <std::ops::Range<usize> as Iterator>::next(move _12) -> bb4; // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
                                            // mir::Constant
                                            // + span: $DIR/issue_107511.rs:10:14: 10:24
                                            // + literal: Const { ty: for<'a> fn(&'a mut std::ops::Range<usize>) -> Option<<std::ops::Range<usize> as Iterator>::Item> {<std::ops::Range<usize> as Iterator>::next}, val: Value(<ZST>) }
       }
   
       bb4: {
-          StorageDead(_13);                // scope 3 at $DIR/issue_107511.rs:+6:23: +6:24
-          _15 = discriminant(_12);         // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
-          switchInt(move _15) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageDead(_12);                // scope 3 at $DIR/issue_107511.rs:+6:23: +6:24
+          _14 = discriminant(_11);         // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          switchInt(move _14) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
       }
   
       bb5: {
--         StorageLive(_17);                // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
-          _17 = ((_12 as Some).0: usize);  // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
-          StorageLive(_18);                // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
--         StorageLive(_19);                // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19
--         _19 = _17;                       // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19
-          _20 = Len(_2);                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
--         _21 = Lt(_19, _20);              // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
--         assert(move _21, "index out of bounds: the length is {} but the index is {}", move _20, _19) -> bb8; // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
-+         _21 = Lt(_17, _20);              // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
-+         assert(move _21, "index out of bounds: the length is {} but the index is {}", move _20, _17) -> bb8; // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         StorageLive(_16);                // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+          _16 = ((_11 as Some).0: usize);  // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+          StorageLive(_17);                // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         StorageLive(_18);                // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19
+-         _18 = _16;                       // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19
+          _19 = Len(_2);                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         _20 = Lt(_18, _19);              // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         assert(move _20, "index out of bounds: the length is {} but the index is {}", move _19, _18) -> bb8; // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
++         _20 = Lt(_16, _19);              // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
++         assert(move _20, "index out of bounds: the length is {} but the index is {}", move _19, _16) -> bb8; // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
       }
   
       bb6: {
@@ -115,31 +111,29 @@
       }
   
       bb7: {
--         _3 = const ();                   // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
-          StorageDead(_14);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
-          StorageDead(_12);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
--         StorageDead(_11);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
-          StorageDead(_9);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
-          StorageDead(_4);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
--         StorageDead(_3);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
-          _0 = const ();                   // scope 0 at $DIR/issue_107511.rs:+0:11: +11:2
-          StorageDead(_2);                 // scope 1 at $DIR/issue_107511.rs:+11:1: +11:2
-          StorageDead(_1);                 // scope 0 at $DIR/issue_107511.rs:+11:1: +11:2
-          return;                          // scope 0 at $DIR/issue_107511.rs:+11:2: +11:2
+          _0 = const ();                   // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
+          StorageDead(_13);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_11);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+-         StorageDead(_10);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_8);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_3);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_2);                 // scope 1 at $DIR/issue_107511.rs:+9:1: +9:2
+          StorageDead(_1);                 // scope 0 at $DIR/issue_107511.rs:+9:1: +9:2
+          return;                          // scope 0 at $DIR/issue_107511.rs:+9:2: +9:2
       }
   
       bb8: {
--         _18 = _2[_19];                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
-+         _18 = _2[_17];                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
-          _1 = Add(_1, move _18);          // scope 4 at $DIR/issue_107511.rs:+7:9: +7:20
-          StorageDead(_18);                // scope 4 at $DIR/issue_107511.rs:+7:19: +7:20
--         StorageDead(_19);                // scope 4 at $DIR/issue_107511.rs:+7:20: +7:21
--         _11 = const ();                  // scope 4 at $DIR/issue_107511.rs:+6:25: +8:6
--         StorageDead(_17);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
-          StorageDead(_14);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
-          StorageDead(_12);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
--         StorageDead(_11);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
--         _10 = const ();                  // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
+-         _17 = _2[_18];                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
++         _17 = _2[_16];                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+          _1 = Add(_1, move _17);          // scope 4 at $DIR/issue_107511.rs:+7:9: +7:20
+          StorageDead(_17);                // scope 4 at $DIR/issue_107511.rs:+7:19: +7:20
+-         StorageDead(_18);                // scope 4 at $DIR/issue_107511.rs:+7:20: +7:21
+-         _10 = const ();                  // scope 4 at $DIR/issue_107511.rs:+6:25: +8:6
+-         StorageDead(_16);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_13);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_11);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+-         StorageDead(_10);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+-         _9 = const ();                   // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
           goto -> bb3;                     // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
       }
   }

--- a/tests/mir-opt/copy-prop/issue_107511.rs
+++ b/tests/mir-opt/copy-prop/issue_107511.rs
@@ -1,0 +1,15 @@
+// unit-test: CopyProp
+
+// EMIT_MIR issue_107511.main.CopyProp.diff
+fn main() {
+    let mut sum = 0;
+    let a = [0, 10, 20, 30];
+
+    // `i` is assigned in a loop. Only removing its `StorageDead` would mean that
+    // execution sees repeated `StorageLive`. This would be UB.
+    for i in 0..a.len() {
+        sum += a[i];
+    }
+
+    let _ = sum;
+}

--- a/tests/mir-opt/copy-prop/issue_107511.rs
+++ b/tests/mir-opt/copy-prop/issue_107511.rs
@@ -10,6 +10,4 @@ fn main() {
     for i in 0..a.len() {
         sum += a[i];
     }
-
-    let _ = sum;
 }

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.diff
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.diff
@@ -16,9 +16,7 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
           _1 = const u8::MAX;              // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
-          StorageLive(_2);                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
           _2 = const 1_u8;                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
           _5 = CheckedAdd(const u8::MAX, const 1_u8); // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           assert(!move (_5.1: bool), "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> bb1; // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -79,7 +79,6 @@
       }
   
       bb6: {
-          StorageLive(_10);                // scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
           _10 = ((_7 as Some).0: usize);   // scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
           StorageLive(_11);                // scope 3 at $DIR/funky_arms.rs:+15:43: +15:46
           _11 = &mut (*_1);                // scope 3 at $DIR/funky_arms.rs:+15:43: +15:46

--- a/tests/mir-opt/issue_101973.inner.ConstProp.diff
+++ b/tests/mir-opt/issue_101973.inner.ConstProp.diff
@@ -33,7 +33,6 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/issue_101973.rs:+1:5: +1:65
           StorageLive(_3);                 // scope 0 at $DIR/issue_101973.rs:+1:5: +1:58
-          StorageLive(_4);                 // scope 0 at $DIR/issue_101973.rs:+1:5: +1:17
           StorageLive(_12);                // scope 2 at $DIR/issue_101973.rs:7:12: 7:27
           StorageLive(_13);                // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
           _14 = CheckedShr(_1, const 0_i32); // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
@@ -63,7 +62,6 @@
           StorageDead(_13);                // scope 2 at $DIR/issue_101973.rs:7:26: 7:27
           _4 = BitOr(const 0_u32, move _12); // scope 2 at $DIR/issue_101973.rs:7:5: 7:27
           StorageDead(_12);                // scope 2 at $DIR/issue_101973.rs:7:26: 7:27
-          StorageLive(_6);                 // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
           StorageLive(_7);                 // scope 0 at $DIR/issue_101973.rs:+1:31: +1:52
           StorageLive(_8);                 // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
           _10 = CheckedShr(_1, const 8_i32); // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -29,7 +29,6 @@
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/issue_76432.rs:+1:9: +1:10
-          StorageLive(_4);                 // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
           StorageLive(_5);                 // scope 0 at $DIR/issue_76432.rs:+1:20: +1:29
           _5 = [_1, _1, _1];               // scope 0 at $DIR/issue_76432.rs:+1:20: +1:29
           _4 = &_5;                        // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29

--- a/tests/mir-opt/simplify_match.main.ConstProp.diff
+++ b/tests/mir-opt/simplify_match.main.ConstProp.diff
@@ -10,7 +10,6 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify_match.rs:+1:17: +1:18
           _2 = const false;                // scope 0 at $DIR/simplify_match.rs:+1:21: +1:26
 -         switchInt(_2) -> [0: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:+1:5: +1:31
 +         switchInt(const false) -> [0: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:+1:5: +1:31

--- a/tests/mir-opt/slice_filter.variant_a-{closure#0}.CopyProp.diff
+++ b/tests/mir-opt/slice_filter.variant_a-{closure#0}.CopyProp.diff
@@ -101,16 +101,16 @@
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
+-         StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
           _25 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
           _3 = &((*_25).0: usize);         // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
-          StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
+-         StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
           _26 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
           _4 = &((*_26).1: usize);         // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
-          StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
+-         StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
           _27 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
           _5 = &((*_27).2: usize);         // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
-          StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
+-         StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           _28 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           _6 = &((*_28).3: usize);         // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56

--- a/tests/mir-opt/slice_filter.variant_a-{closure#0}.DestinationPropagation.diff
+++ b/tests/mir-opt/slice_filter.variant_a-{closure#0}.DestinationPropagation.diff
@@ -85,16 +85,12 @@
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
           _25 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
           _3 = &((*_25).0: usize);         // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
-          StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
           _26 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
           _4 = &((*_26).1: usize);         // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
-          StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
           _27 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
           _5 = &((*_27).2: usize);         // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
-          StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           _28 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           _6 = &((*_28).3: usize);         // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
 -         StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56

--- a/tests/mir-opt/slice_filter.variant_b-{closure#0}.CopyProp.diff
+++ b/tests/mir-opt/slice_filter.variant_b-{closure#0}.CopyProp.diff
@@ -33,16 +33,16 @@
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
+-         StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
           _21 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
           _3 = ((*_21).0: usize);          // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
-          StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
+-         StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
           _22 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
           _4 = ((*_22).1: usize);          // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
-          StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
+-         StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
           _23 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
           _5 = ((*_23).2: usize);          // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
-          StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
+-         StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
           _24 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
           _6 = ((*_24).3: usize);          // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
           StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:42: +0:58

--- a/tests/mir-opt/slice_filter.variant_b-{closure#0}.DestinationPropagation.diff
+++ b/tests/mir-opt/slice_filter.variant_b-{closure#0}.DestinationPropagation.diff
@@ -25,16 +25,12 @@
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
           _13 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
           _3 = ((*_13).0: usize);          // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
-          StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
           _14 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
           _4 = ((*_14).1: usize);          // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
-          StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
           _15 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
           _5 = ((*_15).2: usize);          // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
-          StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
           _16 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
           _6 = ((*_16).3: usize);          // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
 -         StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:42: +0:58

--- a/tests/mir-opt/try_identity_e2e.new.PreCodegen.after.mir
+++ b/tests/mir-opt/try_identity_e2e.new.PreCodegen.after.mir
@@ -30,7 +30,6 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb1: {
-        StorageLive(_5);                 // scope 0 at $DIR/try_identity_e2e.rs:+5:21: +5:22
         _5 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity_e2e.rs:+5:21: +5:22
         Deinit(_2);                      // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
         ((_2 as Break).0: E) = move _5;  // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
@@ -40,7 +39,6 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb2: {
-        StorageLive(_4);                 // scope 0 at $DIR/try_identity_e2e.rs:+4:20: +4:21
         _4 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity_e2e.rs:+4:20: +4:21
         Deinit(_2);                      // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
         ((_2 as Continue).0: T) = move _4; // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
@@ -50,7 +48,6 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb3: {
-        StorageLive(_8);                 // scope 0 at $DIR/try_identity_e2e.rs:+9:32: +9:33
         _8 = move ((_2 as Break).0: E);  // scope 0 at $DIR/try_identity_e2e.rs:+9:32: +9:33
         Deinit(_0);                      // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
         ((_0 as Err).0: E) = move _8;    // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
@@ -64,7 +61,6 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb5: {
-        StorageLive(_7);                 // scope 0 at $DIR/try_identity_e2e.rs:+8:35: +8:36
         _7 = move ((_2 as Continue).0: T); // scope 0 at $DIR/try_identity_e2e.rs:+8:35: +8:36
         Deinit(_0);                      // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +11:6
         ((_0 as Ok).0: T) = move _7;     // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +11:6

--- a/tests/mir-opt/try_identity_e2e.old.PreCodegen.after.mir
+++ b/tests/mir-opt/try_identity_e2e.old.PreCodegen.after.mir
@@ -19,7 +19,6 @@ fn old(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb1: {
-        StorageLive(_4);                 // scope 0 at $DIR/try_identity_e2e.rs:+4:17: +4:18
         _4 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity_e2e.rs:+4:17: +4:18
         Deinit(_0);                      // scope 2 at $DIR/try_identity_e2e.rs:+4:30: +4:36
         ((_0 as Err).0: E) = move _4;    // scope 2 at $DIR/try_identity_e2e.rs:+4:30: +4:36
@@ -32,7 +31,6 @@ fn old(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb3: {
-        StorageLive(_3);                 // scope 0 at $DIR/try_identity_e2e.rs:+3:16: +3:17
         _3 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity_e2e.rs:+3:16: +3:17
         Deinit(_0);                      // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +6:6
         ((_0 as Ok).0: T) = move _3;     // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +6:6


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/107511

https://github.com/rust-lang/rust/pull/106908 removed StorageDead without the accompanying StorageLive. In loops, execution would see repeated StorageLive, without any StorageDead, which is UB.

So when removing storage statements, we have to remove both StorageLive and StorageDead.

~I also added a MIR validation pass for StorageLive. It may be a bit overzealous.~
