### PR TITLE
PointeeInfo is advisory only

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1456,6 +1456,8 @@ pub enum PointerKind {
     UniqueOwned,
 }
 
+/// Note that this information is advisory only, and backends are free to ignore it.
+/// It can only be used to encode potential optimizations, but no critical information.
 #[derive(Copy, Clone, Debug)]
 pub struct PointeeInfo {
     pub size: Size,


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/107248 fixed PointeeInfo being used in ways that don't actually work. Hopefully this comments helps avoid such issues in the future.

Cc @eddyb 