### PR TITLE
Recover form missing expression in `for` loop

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/parse.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parse.ftl
@@ -128,6 +128,9 @@ parse_missing_in_in_for_loop = missing `in` in `for` loop
     .use_in_not_of = try using `in` here instead
     .add_in = try adding `in` here
 
+parse_missing_expression_in_for_loop = missing expression to iterate on in `for` loop
+    .suggestion = try adding an expression to the `for` loop
+
 parse_missing_comma_after_match_arm = expected `,` following `match` arm
     .suggestion = missing a comma here to end this `match` arm
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -434,6 +434,18 @@ pub(crate) enum MissingInInForLoopSub {
 }
 
 #[derive(Diagnostic)]
+#[diag(parse_missing_expression_in_for_loop)]
+pub(crate) struct MissingExpressionInForLoop {
+    #[primary_span]
+    #[suggestion(
+        code = "/* expression */ ",
+        applicability = "has-placeholders",
+        style = "verbose"
+    )]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(parse_missing_comma_after_match_arm)]
 pub(crate) struct MissingCommaAfterMatchArm {
     #[primary_span]

--- a/tests/ui/parser/missing-expression-in-for-loop.rs
+++ b/tests/ui/parser/missing-expression-in-for-loop.rs
@@ -1,0 +1,5 @@
+fn main() {
+    for i in {
+        //~^ ERROR missing expression to iterate on in `for` loop
+    }
+}

--- a/tests/ui/parser/missing-expression-in-for-loop.stderr
+++ b/tests/ui/parser/missing-expression-in-for-loop.stderr
@@ -1,0 +1,13 @@
+error: missing expression to iterate on in `for` loop
+  --> $DIR/missing-expression-in-for-loop.rs:2:14
+   |
+LL |     for i in {
+   |              ^
+   |
+help: try adding an expression to the `for` loop
+   |
+LL |     for i in /* expression */ {
+   |              ++++++++++++++++
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Close #78537
r? @estebank 