### PR TITLE
[DRAFT] Replace `AsRef<Path>` with `PathLike`

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -17,7 +17,9 @@ use crate::error::Error;
 use crate::ffi::{OsStr, OsString};
 use crate::fmt;
 use crate::io;
-use crate::path::{Path, PathBuf};
+#[cfg(doc)]
+use crate::path::Path;
+use crate::path::{PathBuf, PathLike};
 use crate::sys;
 use crate::sys::os as os_imp;
 
@@ -80,8 +82,8 @@ pub fn current_dir() -> io::Result<PathBuf> {
 /// ```
 #[doc(alias = "chdir")]
 #[stable(feature = "env", since = "1.0.0")]
-pub fn set_current_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    os_imp::chdir(path.as_ref())
+pub fn set_current_dir<P: PathLike>(path: P) -> io::Result<()> {
+    path.with_path(os_imp::chdir)
 }
 
 /// An iterator over a snapshot of the environment variables of this process.

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -14,7 +14,7 @@ mod tests;
 use crate::ffi::OsString;
 use crate::fmt;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, Read, Seek, SeekFrom, Write};
-use crate::path::{Path, PathBuf};
+use crate::path::{NativePath, Path, PathBuf, PathLike};
 use crate::sys::fs as fs_imp;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 use crate::time::SystemTime;
@@ -246,7 +246,7 @@ pub struct DirBuilder {
 /// }
 /// ```
 #[stable(feature = "fs_read_write_bytes", since = "1.26.0")]
-pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
+pub fn read<P: PathLike>(path: P) -> io::Result<Vec<u8>> {
     fn inner(path: &Path) -> io::Result<Vec<u8>> {
         let mut file = File::open(path)?;
         let size = file.metadata().map(|m| m.len()).unwrap_or(0);
@@ -254,7 +254,7 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
         io::default_read_to_end(&mut file, &mut bytes)?;
         Ok(bytes)
     }
-    inner(path.as_ref())
+    path.with_path(inner)
 }
 
 /// Read the entire contents of a file into a string.
@@ -286,7 +286,7 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 /// }
 /// ```
 #[stable(feature = "fs_read_write", since = "1.26.0")]
-pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
+pub fn read_to_string<P: PathLike>(path: P) -> io::Result<String> {
     fn inner(path: &Path) -> io::Result<String> {
         let mut file = File::open(path)?;
         let size = file.metadata().map(|m| m.len()).unwrap_or(0);
@@ -294,7 +294,7 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
         io::default_read_to_string(&mut file, &mut string)?;
         Ok(string)
     }
-    inner(path.as_ref())
+    path.with_path(inner)
 }
 
 /// Write a slice as the entire contents of a file.
@@ -322,11 +322,11 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
 /// }
 /// ```
 #[stable(feature = "fs_read_write_bytes", since = "1.26.0")]
-pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
+pub fn write<P: PathLike, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
     fn inner(path: &Path, contents: &[u8]) -> io::Result<()> {
         File::create(path)?.write_all(contents)
     }
-    inner(path.as_ref(), contents.as_ref())
+    path.with_path(|path| inner(path.as_ref(), contents.as_ref()))
 }
 
 impl File {
@@ -357,8 +357,8 @@ impl File {
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<File> {
-        OpenOptions::new().read(true).open(path.as_ref())
+    pub fn open<P: PathLike>(path: P) -> io::Result<File> {
+        OpenOptions::new().read(true).open(path)
     }
 
     /// Opens a file in write-only mode.
@@ -386,8 +386,8 @@ impl File {
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn create<P: AsRef<Path>>(path: P) -> io::Result<File> {
-        OpenOptions::new().write(true).create(true).truncate(true).open(path.as_ref())
+    pub fn create<P: PathLike>(path: P) -> io::Result<File> {
+        OpenOptions::new().write(true).create(true).truncate(true).open(path)
     }
 
     /// Creates a new file in read-write mode; error if the file exists.
@@ -417,8 +417,8 @@ impl File {
     /// }
     /// ```
     #[unstable(feature = "file_create_new", issue = "105135")]
-    pub fn create_new<P: AsRef<Path>>(path: P) -> io::Result<File> {
-        OpenOptions::new().read(true).write(true).create_new(true).open(path.as_ref())
+    pub fn create_new<P: PathLike>(path: P) -> io::Result<File> {
+        OpenOptions::new().read(true).write(true).create_new(true).open(path)
     }
 
     /// Returns a new OpenOptions object.
@@ -1073,12 +1073,12 @@ impl OpenOptions {
     /// [`NotFound`]: io::ErrorKind::NotFound
     /// [`PermissionDenied`]: io::ErrorKind::PermissionDenied
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn open<P: AsRef<Path>>(&self, path: P) -> io::Result<File> {
-        self._open(path.as_ref())
+    pub fn open<P: PathLike>(&self, path: P) -> io::Result<File> {
+        path.with_native_path(|path| self._open(path))
     }
 
-    fn _open(&self, path: &Path) -> io::Result<File> {
-        fs_imp::File::open(path, &self.0).map(|inner| File { inner })
+    fn _open(&self, path: &NativePath) -> io::Result<File> {
+        fs_imp::File::open_native(path, &self.0).map(|inner| File { inner })
     }
 }
 
@@ -1805,8 +1805,8 @@ impl AsInner<fs_imp::DirEntry> for DirEntry {
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    fs_imp::unlink(path.as_ref())
+pub fn remove_file<P: PathLike>(path: P) -> io::Result<()> {
+    path.with_path(fs_imp::unlink)
 }
 
 /// Given a path, query the file system to get information about a file,
@@ -1843,8 +1843,8 @@ pub fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
-    fs_imp::stat(path.as_ref()).map(Metadata)
+pub fn metadata<P: PathLike>(path: P) -> io::Result<Metadata> {
+    path.with_path(fs_imp::stat).map(Metadata)
 }
 
 /// Query the metadata about a file without following symlinks.
@@ -1877,8 +1877,8 @@ pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
 /// }
 /// ```
 #[stable(feature = "symlink_metadata", since = "1.1.0")]
-pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
-    fs_imp::lstat(path.as_ref()).map(Metadata)
+pub fn symlink_metadata<P: PathLike>(path: P) -> io::Result<Metadata> {
+    path.with_path(fs_imp::lstat).map(Metadata)
 }
 
 /// Rename a file or directory to a new name, replacing the original file if
@@ -1920,8 +1920,8 @@ pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
-    fs_imp::rename(from.as_ref(), to.as_ref())
+pub fn rename<P: PathLike, Q: PathLike>(from: P, to: Q) -> io::Result<()> {
+    from.with_path(|from| to.with_path(|to| fs_imp::rename(from, to)))
 }
 
 /// Copies the contents of one file to another. This function will also
@@ -1978,8 +1978,8 @@ pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> 
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
-    fs_imp::copy(from.as_ref(), to.as_ref())
+pub fn copy<P: PathLike, Q: PathLike>(from: P, to: Q) -> io::Result<u64> {
+    from.with_path(|from| to.with_path(|to| fs_imp::copy(from, to)))
 }
 
 /// Creates a new hard link on the filesystem.
@@ -2022,8 +2022,8 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
-    fs_imp::link(original.as_ref(), link.as_ref())
+pub fn hard_link<P: PathLike, Q: PathLike>(original: P, link: Q) -> io::Result<()> {
+    original.with_path(|original| link.with_path(|link| fs_imp::link(original, link)))
 }
 
 /// Creates a new symbolic link on the filesystem.
@@ -2054,8 +2054,8 @@ pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Re
     note = "replaced with std::os::unix::fs::symlink and \
             std::os::windows::fs::{symlink_file, symlink_dir}"
 )]
-pub fn soft_link<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
-    fs_imp::symlink(original.as_ref(), link.as_ref())
+pub fn soft_link<P: PathLike, Q: PathLike>(original: P, link: Q) -> io::Result<()> {
+    original.with_path(|original| link.with_path(|link| fs_imp::symlink(original, link)))
 }
 
 /// Reads a symbolic link, returning the file that the link points to.
@@ -2088,8 +2088,8 @@ pub fn soft_link<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Re
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
-    fs_imp::readlink(path.as_ref())
+pub fn read_link<P: PathLike>(path: P) -> io::Result<PathBuf> {
+    path.with_path(fs_imp::readlink)
 }
 
 /// Returns the canonical, absolute form of a path with all intermediate
@@ -2131,8 +2131,8 @@ pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
 #[doc(alias = "realpath")]
 #[doc(alias = "GetFinalPathNameByHandle")]
 #[stable(feature = "fs_canonicalize", since = "1.5.0")]
-pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
-    fs_imp::canonicalize(path.as_ref())
+pub fn canonicalize<P: PathLike>(path: P) -> io::Result<PathBuf> {
+    path.with_path(fs_imp::canonicalize)
 }
 
 /// Creates a new, empty directory at the provided path
@@ -2172,8 +2172,8 @@ pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
 /// ```
 #[doc(alias = "mkdir")]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    DirBuilder::new().create(path.as_ref())
+pub fn create_dir<P: PathLike>(path: P) -> io::Result<()> {
+    DirBuilder::new().create(path)
 }
 
 /// Recursively create a directory and all of its parent components if they
@@ -2216,8 +2216,8 @@ pub fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    DirBuilder::new().recursive(true).create(path.as_ref())
+pub fn create_dir_all<P: PathLike>(path: P) -> io::Result<()> {
+    DirBuilder::new().recursive(true).create(path)
 }
 
 /// Removes an empty directory.
@@ -2252,8 +2252,8 @@ pub fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// ```
 #[doc(alias = "rmdir")]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    fs_imp::rmdir(path.as_ref())
+pub fn remove_dir<P: PathLike>(path: P) -> io::Result<()> {
+    path.with_path(fs_imp::rmdir)
 }
 
 /// Removes a directory at this path, after removing all its contents. Use
@@ -2294,8 +2294,8 @@ pub fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    fs_imp::remove_dir_all(path.as_ref())
+pub fn remove_dir_all<P: PathLike>(path: P) -> io::Result<()> {
+    path.with_path(fs_imp::remove_dir_all)
 }
 
 /// Returns an iterator over the entries within a directory.
@@ -2369,8 +2369,8 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn read_dir<P: AsRef<Path>>(path: P) -> io::Result<ReadDir> {
-    fs_imp::readdir(path.as_ref()).map(ReadDir)
+pub fn read_dir<P: PathLike>(path: P) -> io::Result<ReadDir> {
+    path.with_path(fs_imp::readdir).map(ReadDir)
 }
 
 /// Changes the permissions found on a file or a directory.
@@ -2404,8 +2404,8 @@ pub fn read_dir<P: AsRef<Path>>(path: P) -> io::Result<ReadDir> {
 /// }
 /// ```
 #[stable(feature = "set_permissions", since = "1.1.0")]
-pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result<()> {
-    fs_imp::set_perm(path.as_ref(), perm.0)
+pub fn set_permissions<P: PathLike>(path: P, perm: Permissions) -> io::Result<()> {
+    path.with_path(|path| fs_imp::set_perm(path, perm.0))
 }
 
 impl DirBuilder {
@@ -2464,8 +2464,8 @@ impl DirBuilder {
     /// assert!(fs::metadata(path).unwrap().is_dir());
     /// ```
     #[stable(feature = "dir_builder", since = "1.6.0")]
-    pub fn create<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
-        self._create(path.as_ref())
+    pub fn create<P: PathLike>(&self, path: P) -> io::Result<()> {
+        path.with_path(|path| self._create(path))
     }
 
     fn _create(&self, path: &Path) -> io::Result<()> {
@@ -2534,6 +2534,6 @@ impl AsInnerMut<fs_imp::DirBuilder> for DirBuilder {
 // instead.
 #[unstable(feature = "fs_try_exists", issue = "83186")]
 #[inline]
-pub fn try_exists<P: AsRef<Path>>(path: P) -> io::Result<bool> {
-    fs_imp::try_exists(path.as_ref())
+pub fn try_exists<P: PathLike>(path: P) -> io::Result<bool> {
+    path.with_path(fs_imp::try_exists)
 }

--- a/library/std/src/os/unix/ffi/mod.rs
+++ b/library/std/src/os/unix/ffi/mod.rs
@@ -38,5 +38,24 @@
 
 mod os_str;
 
+use crate::ffi::CStr;
+use crate::path::NativePath;
+
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::os_str::{OsStrExt, OsStringExt};
+
+#[unstable(feature = "pathlike", issue = "none")]
+pub trait NativePathExt: crate::sealed::Sealed {
+    fn from_cstr(cstr: &CStr) -> &NativePath;
+    fn into_cstr(&self) -> &CStr;
+}
+
+#[unstable(feature = "pathlike", issue = "none")]
+impl NativePathExt for NativePath {
+    fn from_cstr(cstr: &CStr) -> &NativePath {
+        unsafe { &*(cstr as *const CStr as *const NativePath) }
+    }
+    fn into_cstr(&self) -> &CStr {
+        unsafe { &*(self as *const Self as *const CStr) }
+    }
+}

--- a/library/std/src/os/windows/ffi.rs
+++ b/library/std/src/os/windows/ffi.rs
@@ -54,6 +54,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::ffi::{OsStr, OsString};
+use crate::path::NativePath;
 use crate::sealed::Sealed;
 use crate::sys::os_str::Buf;
 use crate::sys_common::wtf8::Wtf8Buf;
@@ -132,5 +133,21 @@ impl OsStrExt for OsStr {
     #[inline]
     fn encode_wide(&self) -> EncodeWide<'_> {
         self.as_inner().inner.encode_wide()
+    }
+}
+
+#[unstable(feature = "pathlike", issue = "none")]
+pub trait NativePathExt: Sealed {
+    fn from_wide(wide: &[u16]) -> &NativePath;
+    fn into_wide(&self) -> &[u16];
+}
+#[unstable(feature = "pathlike", issue = "none")]
+impl NativePathExt for NativePath {
+    fn from_wide(wide: &[u16]) -> &NativePath {
+        assert_eq!(wide.last(), Some(&0));
+        unsafe { &*(wide as *const [u16] as *const Self) }
+    }
+    fn into_wide(&self) -> &[u16] {
+        unsafe { &*(self as *const Self as *const [u16]) }
     }
 }

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -17,7 +17,7 @@ use crate::mem;
 ))]
 use crate::mem::MaybeUninit;
 use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd};
-use crate::path::{Path, PathBuf};
+use crate::path::{NativePath, Path, PathBuf};
 use crate::ptr;
 use crate::sync::Arc;
 use crate::sys::common::small_c_string::run_path_with_cstr;
@@ -988,8 +988,8 @@ impl OpenOptions {
 }
 
 impl File {
-    pub fn open(path: &Path, opts: &OpenOptions) -> io::Result<File> {
-        run_path_with_cstr(path, |path| File::open_c(path, opts))
+    pub fn open_native(path: &NativePath, opts: &OpenOptions) -> io::Result<File> {
+        File::open_c(&path.0, opts)
     }
 
     pub fn open_c(path: &CStr, opts: &OpenOptions) -> io::Result<File> {

--- a/library/std/src/sys/unix/path.rs
+++ b/library/std/src/sys/unix/path.rs
@@ -1,7 +1,18 @@
 use crate::env;
-use crate::ffi::OsStr;
+use crate::ffi::{CStr, OsStr, OsString};
 use crate::io;
+use crate::os::unix::ffi::OsStringExt;
 use crate::path::{Path, PathBuf, Prefix};
+
+pub type NativePath = CStr;
+pub use crate::sys::common::small_c_string::run_path_with_cstr as with_native_path;
+pub fn with_std_path<T, F>(path: &CStr, f: F) -> io::Result<T>
+where
+    F: FnOnce(&Path) -> io::Result<T>,
+{
+    let path = PathBuf::from(OsString::from_vec(path.to_bytes().to_vec()));
+    f(&path)
+}
 
 #[inline]
 pub fn is_sep_byte(b: u8) -> bool {

--- a/library/std/src/sys/windows/path.rs
+++ b/library/std/src/sys/windows/path.rs
@@ -11,6 +11,22 @@ mod tests;
 pub const MAIN_SEP_STR: &str = "\\";
 pub const MAIN_SEP: char = '\\';
 
+pub type NativePath = [u16];
+pub fn with_native_path<T, F>(path: &Path, f: F) -> io::Result<T>
+where
+    F: FnOnce(&[u16]) -> io::Result<T>,
+{
+    let path = maybe_verbatim(path)?;
+    f(&path)
+}
+pub fn with_std_path<T, F>(path: &[u16], f: F) -> io::Result<T>
+where
+    F: FnOnce(&Path) -> io::Result<T>,
+{
+    let path = super::os2path(path);
+    f(&path)
+}
+
 /// # Safety
 ///
 /// `bytes` must be a valid wtf8 encoded slice

--- a/src/tools/miri/tests/fail/shims/fs/isolated_file.stderr
+++ b/src/tools/miri/tests/fail/shims/fs/isolated_file.stderr
@@ -10,12 +10,14 @@ LL |         let fd = cvt_r(|| unsafe { open64(path.as_ptr(), flags, opts.mode a
    = note: inside closure at RUSTLIB/std/src/sys/PLATFORM/fs.rs:LL:CC
    = note: inside `std::sys::PLATFORM::cvt_r::<i32, [closure@std::sys::PLATFORM::fs::File::open_c::{closure#0}]>` at RUSTLIB/std/src/sys/PLATFORM/mod.rs:LL:CC
    = note: inside `std::sys::PLATFORM::fs::File::open_c` at RUSTLIB/std/src/sys/PLATFORM/fs.rs:LL:CC
-   = note: inside closure at RUSTLIB/std/src/sys/PLATFORM/fs.rs:LL:CC
-   = note: inside `std::sys::PLATFORM::small_c_string::run_with_cstr::<std::sys::PLATFORM::fs::File, [closure@std::sys::PLATFORM::fs::File::open::{closure#0}]>` at RUSTLIB/std/src/sys/PLATFORM/small_c_string.rs:LL:CC
-   = note: inside `std::sys::PLATFORM::small_c_string::run_path_with_cstr::<std::sys::PLATFORM::fs::File, [closure@std::sys::PLATFORM::fs::File::open::{closure#0}]>` at RUSTLIB/std/src/sys/PLATFORM/small_c_string.rs:LL:CC
-   = note: inside `std::sys::PLATFORM::fs::File::open` at RUSTLIB/std/src/sys/PLATFORM/fs.rs:LL:CC
+   = note: inside `std::sys::PLATFORM::fs::File::open_native` at RUSTLIB/std/src/sys/PLATFORM/fs.rs:LL:CC
    = note: inside `std::fs::OpenOptions::_open` at RUSTLIB/std/src/fs.rs:LL:CC
-   = note: inside `std::fs::OpenOptions::open::<&std::path::Path>` at RUSTLIB/std/src/fs.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/fs.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/path.rs:LL:CC
+   = note: inside `std::sys::PLATFORM::small_c_string::run_with_cstr::<std::fs::File, [closure@<&str as std::path::PathLike>::with_native_path<std::fs::File, [closure@std::fs::OpenOptions::open<&str>::{closure#0}]>::{closure#0}]>` at RUSTLIB/std/src/sys/PLATFORM/small_c_string.rs:LL:CC
+   = note: inside `std::sys::PLATFORM::small_c_string::run_path_with_cstr::<std::fs::File, [closure@<&str as std::path::PathLike>::with_native_path<std::fs::File, [closure@std::fs::OpenOptions::open<&str>::{closure#0}]>::{closure#0}]>` at RUSTLIB/std/src/sys/PLATFORM/small_c_string.rs:LL:CC
+   = note: inside `<&str as std::path::PathLike>::with_native_path::<std::fs::File, [closure@std::fs::OpenOptions::open<&str>::{closure#0}]>` at RUSTLIB/std/src/path.rs:LL:CC
+   = note: inside `std::fs::OpenOptions::open::<&str>` at RUSTLIB/std/src/fs.rs:LL:CC
    = note: inside `std::fs::File::open::<&str>` at RUSTLIB/std/src/fs.rs:LL:CC
 note: inside `main`
   --> $DIR/isolated_file.rs:LL:CC

--- a/tests/ui/async-await/issue-72442.stderr
+++ b/tests/ui/async-await/issue-72442.stderr
@@ -6,6 +6,8 @@ LL |             let mut f = File::open(path.to_str())?;
    |                         |
    |                         required by a bound introduced by this call
    |
+   = help: the trait `PathLike` is implemented for `&NativePath`
+   = note: required for `Option<&str>` to implement `PathLike`
 note: required by a bound in `File::open`
   --> $SRC_DIR/std/src/fs.rs:LL:COL
 


### PR DESCRIPTION
A minimal implementation of https://github.com/rust-lang/libs-team/issues/62.

```rust
pub trait PathLike {
    /// Convert to a `Path` reference.
    fn with_path<T, F: FnOnce(&Path) -> T>(&self, f: F) -> T;
    /// Convert to the native platform representation of a path.
    fn with_native_path<T, F: FnOnce(&NativePath) -> io::Result<T>>(&self, f: F) -> io::Result<T>;
}

/// Represents a path in the OS' native format.
///
/// Use OS specific extension trait to access the inner type.
pub struct NativePath(/* private */);
```

To keep things simple, this PR currently only uses `with_native_path` within `File::open`. Other `fs` function use `with_path`.

r? @ghost