### PR TITLE
Replace unwrap with ? in TcpListener doc

### DIFF
--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -829,7 +829,7 @@ impl TcpListener {
     /// }
     ///
     /// fn main() -> std::io::Result<()> {
-    ///     let listener = TcpListener::bind("127.0.0.1:80").unwrap();
+    ///     let listener = TcpListener::bind("127.0.0.1:80")?;
     ///
     ///     for stream in listener.incoming() {
     ///         match stream {


### PR DESCRIPTION
The example in TcpListener doc returns `std::io::Result<()>` but the code inside the function uses `unwrap()` instead of `?`.