### PR TITLE
Emit warnings on unused parens in index expressions

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -495,6 +495,7 @@ enum UnusedDelimsCtx {
     ArrayLenExpr,
     AnonConst,
     MatchArmExpr,
+    IndexExpr,
 }
 
 impl From<UnusedDelimsCtx> for &'static str {
@@ -514,6 +515,7 @@ impl From<UnusedDelimsCtx> for &'static str {
             UnusedDelimsCtx::LetScrutineeExpr => "`let` scrutinee expression",
             UnusedDelimsCtx::ArrayLenExpr | UnusedDelimsCtx::AnonConst => "const expression",
             UnusedDelimsCtx::MatchArmExpr => "match arm expression",
+            UnusedDelimsCtx::IndexExpr => "index expression",
         }
     }
 }
@@ -732,6 +734,8 @@ trait UnusedDelimLint {
                 let left = e.span.lo() + rustc_span::BytePos(3);
                 (value, UnusedDelimsCtx::ReturnValue, false, Some(left), None)
             }
+
+            Index(_, ref value) => (value, UnusedDelimsCtx::IndexExpr, false, None, None),
 
             Assign(_, ref value, _) | AssignOp(.., ref value) => {
                 (value, UnusedDelimsCtx::AssignedValue, false, None, None)

--- a/tests/ui/lint/unused/issue-96606.rs
+++ b/tests/ui/lint/unused/issue-96606.rs
@@ -1,0 +1,8 @@
+#[deny(unused)]
+fn main() {
+    let arr = [0; 10];
+    let _ = arr[(0)]; //~ ERROR unnecessary parentheses around index expression
+    let _ = arr[{0}]; //~ ERROR unnecessary braces around index expression
+    let _ = arr[1 + (0)];
+    let _ = arr[{ let x = 0; x }];
+}

--- a/tests/ui/lint/unused/issue-96606.stderr
+++ b/tests/ui/lint/unused/issue-96606.stderr
@@ -1,0 +1,33 @@
+error: unnecessary parentheses around index expression
+  --> $DIR/issue-96606.rs:4:17
+   |
+LL |     let _ = arr[(0)];
+   |                 ^ ^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-96606.rs:1:8
+   |
+LL | #[deny(unused)]
+   |        ^^^^^^
+   = note: `#[deny(unused_parens)]` implied by `#[deny(unused)]`
+help: remove these parentheses
+   |
+LL -     let _ = arr[(0)];
+LL +     let _ = arr[0];
+   |
+
+error: unnecessary braces around index expression
+  --> $DIR/issue-96606.rs:5:17
+   |
+LL |     let _ = arr[{0}];
+   |                 ^ ^
+   |
+   = note: `#[deny(unused_braces)]` implied by `#[deny(unused)]`
+help: remove these braces
+   |
+LL -     let _ = arr[{0}];
+LL +     let _ = arr[0];
+   |
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes: #96606.

I am not sure what the best term for "index expression" is. Is there a better term we could use?