### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.69.0"
+version = "0.70.0"
 dependencies = [
  "anyhow",
  "base64",


### PR DESCRIPTION
18 commits in 3c5af6bed9a1a243a693e8e22ee2486bd5b82a6c..e84a7928d93a31f284b497c214a2ece69b4d7719 2023-01-24 15:48:15 +0000 to 2023-01-31 22:18:09 +0000

- chore: Add autolabel for `Command-*` labels (rust-lang/cargo#11664)
- Update cross test instructions for aarch64-apple-darwin (rust-lang/cargo#11663)
- Make cargo install report needed features (rust-lang/cargo#11647)
- docs(contrib): Remove out-of-date process step (rust-lang/cargo#11662)
- Do not error for `auth-required: true` without `-Z sparse-registry` (rust-lang/cargo#11661)
- Warn on commits to non-default branches. (rust-lang/cargo#11655)
- Avoid saving the same future_incompat warning multiple times (rust-lang/cargo#11648)
- Mention current default value in `publish.timeout` docs (rust-lang/cargo#11652)
- Make cargo aware of dwp files. (rust-lang/cargo#11572)
- Reduce target info rustc query calls (rust-lang/cargo#11633)
- Bump to 0.70.0; update changelog (rust-lang/cargo#11640)
- Enable sparse protocol in CI (rust-lang/cargo#11632)
- Fix split-debuginfo support detection (rust-lang/cargo#11347)
- refactor(toml): Move `TomlWorkspaceDependency` out of `TomlDependency` (rust-lang/cargo#11565)
- book: describe how the current resolver sometimes duplicates deps (rust-lang/cargo#11604)
- `cargo add` check `[dependencies]` order without considering the dotted item (rust-lang/cargo#11612)
- Link CoC to  www.rust-lang.org/conduct.html (rust-lang/cargo#11622)
- Add more labels to triagebot (rust-lang/cargo#11621)

r? @ghost