### PR TITLE
Enable Cargo's sparse protocol in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     name: PR
     env:
       CI_JOB_NAME: "${{ matrix.name }}"
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
       SCCACHE_BUCKET: rust-lang-ci-sccache2
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
       CACHE_DOMAIN: ci-caches.rust-lang.org
@@ -162,6 +163,7 @@ jobs:
     name: auto
     env:
       CI_JOB_NAME: "${{ matrix.name }}"
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
       SCCACHE_BUCKET: rust-lang-ci-sccache2
       DEPLOY_BUCKET: rust-lang-ci2
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
@@ -584,6 +586,7 @@ jobs:
     name: try
     env:
       CI_JOB_NAME: "${{ matrix.name }}"
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
       SCCACHE_BUCKET: rust-lang-ci-sccache2
       DEPLOY_BUCKET: rust-lang-ci2
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -33,6 +33,7 @@ x--expand-yaml-anchors--remove:
 
   - &shared-ci-variables
     CI_JOB_NAME: ${{ matrix.name }}
+    CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
   - &public-variables
     SCCACHE_BUCKET: rust-lang-ci-sccache2

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -45,6 +45,8 @@ fi
 ci_dir=`cd $(dirname $0) && pwd`
 source "$ci_dir/shared.sh"
 
+export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
 if ! isCI || isCiBranch auto || isCiBranch beta || isCiBranch try || isCiBranch try-perf; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.print-step-timings --enable-verbose-tests"
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.metrics"


### PR DESCRIPTION
This enables the sparse protocol in CI in order to exercise and dogfood it. This is intended test the production server in a real-world situation.

Closes #107342
