### PR TITLE
suggest adding parameters to exactly match the trait definition

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1404,6 +1404,15 @@ fn compare_number_of_method_arguments<'tcx>(
                     potentially_plural_count(trait_number_args, "parameter")
                 ),
             );
+            if let Ok(snip) = tcx.sess.source_map().span_to_snippet(trait_span) {
+                let args_suggestion = if trait_number_args != 0 { snip } else { "".to_string() };
+                err.span_suggestion_verbose(
+                    impl_span,
+                    "modify the signature to match the trait definition",
+                    format!("{}", args_suggestion),
+                    Applicability::HasPlaceholders,
+                );
+            }
         } else {
             err.note_trait_signature(trait_m.name, trait_m.signature(tcx));
         }

--- a/tests/ui/error-codes/E0050.rs
+++ b/tests/ui/error-codes/E0050.rs
@@ -8,8 +8,11 @@ struct Bar;
 
 impl Foo for Bar {
     fn foo(&self) -> bool { true } //~ ERROR E0050
+    //~| HELP: modify the signature to match the trait definition
     fn bar(&self) { } //~ ERROR E0050
+    //~| HELP: modify the signature to match the trait definition
     fn less(&self, x: u8, y: u8, z: u8) { } //~ ERROR E0050
+    //~| HELP: modify the signature to match the trait definition
 }
 
 fn main() {

--- a/tests/ui/error-codes/E0050.stderr
+++ b/tests/ui/error-codes/E0050.stderr
@@ -6,24 +6,39 @@ LL |     fn foo(&self, x: u8) -> bool;
 ...
 LL |     fn foo(&self) -> bool { true }
    |            ^^^^^ expected 2 parameters, found 1
+   |
+help: modify the signature to match the trait definition
+   |
+LL |     fn foo(&self, x: u8) -> bool { true }
+   |            ~~~~~~~~~~~~
 
 error[E0050]: method `bar` has 1 parameter but the declaration in trait `Foo::bar` has 4
-  --> $DIR/E0050.rs:11:12
+  --> $DIR/E0050.rs:12:12
    |
 LL |     fn bar(&self, x: u8, y: u8, z: u8);
    |            -------------------------- trait requires 4 parameters
 ...
 LL |     fn bar(&self) { }
    |            ^^^^^ expected 4 parameters, found 1
+   |
+help: modify the signature to match the trait definition
+   |
+LL |     fn bar(&self, x: u8, y: u8, z: u8) { }
+   |            ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0050]: method `less` has 4 parameters but the declaration in trait `Foo::less` has 1
-  --> $DIR/E0050.rs:12:13
+  --> $DIR/E0050.rs:14:13
    |
 LL |     fn less(&self);
    |             ----- trait requires 1 parameter
 ...
 LL |     fn less(&self, x: u8, y: u8, z: u8) { }
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 parameter, found 4
+   |
+help: modify the signature to match the trait definition
+   |
+LL |     fn less(&self) { }
+   |             ~~~~~
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/in-trait/method-signature-matches.stderr
+++ b/tests/ui/impl-trait/in-trait/method-signature-matches.stderr
@@ -50,6 +50,12 @@ LL |     fn calm_down_please() -> impl Sized;
 ...
 LL |     fn calm_down_please(_: (), _: (), _: ()) {}
    |                            ^^^^^^^^^^^^^^^^ expected 0 parameters, found 3
+   |
+help: modify the signature to match the trait definition
+   |
+LL -     fn calm_down_please(_: (), _: (), _: ()) {}
+LL +     fn calm_down_please(_: ) {}
+   |
 
 error[E0050]: method `come_on_a_little_more_effort` has 0 parameters but the declaration in trait `TooLittle::come_on_a_little_more_effort` has 3
   --> $DIR/method-signature-matches.rs:38:5
@@ -59,6 +65,11 @@ LL |     fn come_on_a_little_more_effort(_: (), _: (), _: ()) -> impl Sized;
 ...
 LL |     fn come_on_a_little_more_effort() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 3 parameters, found 0
+   |
+help: modify the signature to match the trait definition
+   |
+LL |     (), _: (), _: () {}
+   |     ~~~~~~~~~~~~~~~~
 
 error[E0053]: method `early` has an incompatible type for trait
   --> $DIR/method-signature-matches.rs:47:27

--- a/tests/ui/trait-method-number-parameters.rs
+++ b/tests/ui/trait-method-number-parameters.rs
@@ -5,6 +5,7 @@ trait Foo {
 impl Foo for i32 {
     fn foo(
         &mut self, //~ ERROR
+        //~| HELP: modify the signature to match the trait definition
         x: i32,
     ) {
     }

--- a/tests/ui/trait-method-number-parameters.stderr
+++ b/tests/ui/trait-method-number-parameters.stderr
@@ -5,8 +5,14 @@ LL |       fn foo(&mut self, x: i32, y: i32) -> i32;
    |              ------------------------- trait requires 3 parameters
 ...
 LL | /         &mut self,
+LL | |
 LL | |         x: i32,
    | |______________^ expected 3 parameters, found 2
+   |
+help: modify the signature to match the trait definition
+   |
+LL |         &mut self, x: i32, y: i32,
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/tests/ui/traits/impl-different-num-params.rs
+++ b/tests/ui/traits/impl-different-num-params.rs
@@ -4,6 +4,7 @@ trait Foo {
 impl Foo for isize {
     fn bar(&self) -> isize {
         //~^ ERROR method `bar` has 1 parameter but the declaration in trait `Foo::bar` has 2
+        //~| HELP: modify the signature to match the trait definition
         *self
     }
 }

--- a/tests/ui/traits/impl-different-num-params.stderr
+++ b/tests/ui/traits/impl-different-num-params.stderr
@@ -6,6 +6,11 @@ LL |     fn bar(&self, x: usize) -> Self;
 ...
 LL |     fn bar(&self) -> isize {
    |            ^^^^^ expected 2 parameters, found 1
+   |
+help: modify the signature to match the trait definition
+   |
+LL |     fn bar(&self, x: usize) -> isize {
+   |            ~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 


### PR DESCRIPTION
when the impl of the function doesn't match with the trait declaration
this will fix #106999