### PR TITLE
[DO NOT MERGE] switch back some type imports to libc

### DIFF
--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -14,7 +14,7 @@ use crate::sys::net::{cvt, cvt_gai, cvt_r, init, wrlen_t, Socket};
 use crate::sys_common::{AsInner, FromInner, IntoInner};
 use crate::time::Duration;
 
-use crate::ffi::{c_int, c_void};
+use libc::{c_int, c_void};
 
 cfg_if::cfg_if! {
     if #[cfg(any(


### PR DESCRIPTION
This is just to investigate a new error while trying to build std after c50d3e28ab0bfaedd1f0f90a376e6f93e4e83c62 using a custom build.
```
error[E0308]: mismatched types
   --> library/std/src/sys_common/net.rs:286:42
    |
286 |             c::send(self.inner.as_raw(), buf.as_ptr() as *const c_void, len, MSG_NOSIGNAL)
    |             -------                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `libc::c_void`, found enum `core::ffi::c_void`
    |             |
    |             arguments to this function are incorrect
```