### PR TITLE
Automatically generate static file names

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -417,7 +417,7 @@ impl Options {
         let to_check = matches.opt_strs("check-theme");
         if !to_check.is_empty() {
             let paths = match theme::load_css_paths(
-                std::str::from_utf8(static_files::STATIC_FILES.theme_light_css.bytes).unwrap(),
+                std::str::from_utf8(&static_files::STATIC_FILES.theme_light_css.bytes).unwrap(),
             ) {
                 Ok(p) => p,
                 Err(e) => {
@@ -560,7 +560,7 @@ impl Options {
         let mut themes = Vec::new();
         if matches.opt_present("theme") {
             let paths = match theme::load_css_paths(
-                std::str::from_utf8(static_files::STATIC_FILES.theme_light_css.bytes).unwrap(),
+                std::str::from_utf8(&static_files::STATIC_FILES.theme_light_css.bytes).unwrap(),
             ) {
                 Ok(p) => p,
                 Err(e) => {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1,18 +1,10 @@
-/* When static files are updated, their suffixes need to be updated.
-	1. In the top directory run:
-		./x.py doc --stage 1 library/core
-	2. Find the directory containing files named with updated suffixes:
-		find build -path '*'/stage1-std/'*'/static.files
-	3. Copy the filenames with updated suffixes from the directory.
-*/
-
 /* See FiraSans-LICENSE.txt for the Fira Sans license. */
 @font-face {
 	font-family: 'Fira Sans';
 	font-style: normal;
 	font-weight: 400;
 	src: local('Fira Sans'),
-		url("FiraSans-Regular-018c141bf0843ffd.woff2") format("woff2");
+		url("/* REPLACE FiraSans-Regular.woff2 */") format("woff2");
 	font-display: swap;
 }
 @font-face {
@@ -20,7 +12,7 @@
 	font-style: normal;
 	font-weight: 500;
 	src: local('Fira Sans Medium'),
-		url("FiraSans-Medium-8f9a781e4970d388.woff2") format("woff2");
+		url("/* REPLACE FiraSans-Medium.woff2 */") format("woff2");
 	font-display: swap;
 }
 
@@ -30,7 +22,7 @@
 	font-style: normal;
 	font-weight: 400;
 	src: local('Source Serif 4'),
-		url("SourceSerif4-Regular-46f98efaafac5295.ttf.woff2") format("woff2");
+		url("/* REPLACE SourceSerif4-Regular.ttf.woff2 */") format("woff2");
 	font-display: swap;
 }
 @font-face {
@@ -38,7 +30,7 @@
 	font-style: italic;
 	font-weight: 400;
 	src: local('Source Serif 4 Italic'),
-		url("SourceSerif4-It-acdfaf1a8af734b1.ttf.woff2") format("woff2");
+		url("/* REPLACE SourceSerif4-It.ttf.woff2 */") format("woff2");
 	font-display: swap;
 }
 @font-face {
@@ -46,7 +38,7 @@
 	font-style: normal;
 	font-weight: 700;
 	src: local('Source Serif 4 Bold'),
-		url("SourceSerif4-Bold-a2c9cd1067f8b328.ttf.woff2") format("woff2");
+		url("/* REPLACE SourceSerif4-Bold.ttf.woff2 */") format("woff2");
 	font-display: swap;
 }
 
@@ -57,28 +49,28 @@
 	font-weight: 400;
 	/* Avoid using locally installed font because bad versions are in circulation:
 	 * see https://github.com/rust-lang/rust/issues/24355 */
-	src: url("SourceCodePro-Regular-562dcc5011b6de7d.ttf.woff2") format("woff2");
+	src: url("/* REPLACE SourceCodePro-Regular.ttf.woff2 */") format("woff2");
 	font-display: swap;
 }
 @font-face {
 	font-family: 'Source Code Pro';
 	font-style: italic;
 	font-weight: 400;
-	src: url("SourceCodePro-It-1cc31594bf4f1f79.ttf.woff2") format("woff2");
+	src: url("/* REPLACE SourceCodePro-It.ttf.woff2 */") format("woff2");
 	font-display: swap;
 }
 @font-face {
 	font-family: 'Source Code Pro';
 	font-style: normal;
 	font-weight: 600;
-	src: url("SourceCodePro-Semibold-d899c5a5c4aeb14a.ttf.woff2") format("woff2");
+	src: url("/* REPLACE SourceCodePro-Semibold.ttf.woff2 */") format("woff2");
 	font-display: swap;
 }
 
 /* Avoid using legacy CJK serif fonts in Windows like Batang. */
 @font-face {
 	font-family: 'NanumBarunGothic';
-	src: url("NanumBarunGothic-0f09457c7a19b7c6.ttf.woff2") format("woff2");
+	src: url("/* REPLACE NanumBarunGothic.ttf.woff2 */") format("woff2");
 	font-display: swap;
 	unicode-range: U+AC00-D7AF, U+1100-11FF, U+3130-318F, U+A960-A97F, U+D7B0-D7FF;
 }


### PR DESCRIPTION
Based on https://github.com/rust-lang/rust/pull/107531 so needs it to be merged first.

In https://github.com/rust-lang/rust/pull/107354, we were able to see that being able to correctly update the static files is not as simple and straight-forward as it could be. So instead of forcing the devs to do the work manually, this PR allows it to be done automatically to prevent such errors to occur again.

r? @notriddle 