### PR TITLE
Add proc-macro boilerplate to crt-static test

### DIFF
--- a/tests/ui/proc-macro/crt-static.rs
+++ b/tests/ui/proc-macro/crt-static.rs
@@ -5,6 +5,9 @@
 // ignore-wasm32
 // ignore-sgx no support for proc-macro crate type
 // build-pass
+// force-host
+// no-prefer-dynamic
+
 #![crate_type = "proc-macro"]
 
 // FIXME: This don't work when crate-type is specified by attribute


### PR DESCRIPTION
I was seeing this failure when running ui tests with with a `-Cpanic=abort` stdlib targeting fuchsia:

```
---- [ui] tests/ui/proc-macro/crt-static.rs stdout ----
normalized stderr:
warning: building proc macro crate with `panic=abort` may crash the compiler should the proc-macro panic

warning: 1 warning emitted


The actual stderr differed from the expected stderr.
```

`force-host` was enough to stop it from running/failing, not sure if I should also add `needs-unwind`?