### PR TITLE
Mark `std` integral modules as deprecated (`std::u32`, `std::i16`, etc.)

### DIFF
--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -31,7 +31,7 @@ use crate::num::FpCategory;
 /// let r = f32::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `RADIX` associated constant on `f32`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `RADIX` associated constant on `f32`")]
 pub const RADIX: u32 = f32::RADIX;
 
 /// Number of significant digits in base 2.
@@ -49,7 +49,7 @@ pub const RADIX: u32 = f32::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "replaced by the `MANTISSA_DIGITS` associated constant on `f32`"
 )]
 pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
@@ -68,7 +68,7 @@ pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 /// let d = f32::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `DIGITS` associated constant on `f32`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `DIGITS` associated constant on `f32`")]
 pub const DIGITS: u32 = f32::DIGITS;
 
 /// [Machine epsilon] value for `f32`.
@@ -89,7 +89,7 @@ pub const DIGITS: u32 = f32::DIGITS;
 /// let e = f32::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `EPSILON` associated constant on `f32`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `EPSILON` associated constant on `f32`")]
 pub const EPSILON: f32 = f32::EPSILON;
 
 /// Smallest finite `f32` value.
@@ -106,7 +106,7 @@ pub const EPSILON: f32 = f32::EPSILON;
 /// let min = f32::MIN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN` associated constant on `f32`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `MIN` associated constant on `f32`")]
 pub const MIN: f32 = f32::MIN;
 
 /// Smallest positive normal `f32` value.
@@ -123,7 +123,10 @@ pub const MIN: f32 = f32::MIN;
 /// let min = f32::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN_POSITIVE` associated constant on `f32`")]
+#[deprecated(
+    since = "1.69.0",
+    note = "replaced by the `MIN_POSITIVE` associated constant on `f32`"
+)]
 pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 
 /// Largest finite `f32` value.
@@ -140,7 +143,7 @@ pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 /// let max = f32::MAX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on `f32`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `MAX` associated constant on `f32`")]
 pub const MAX: f32 = f32::MAX;
 
 /// One greater than the minimum possible normal power of 2 exponent.
@@ -157,7 +160,7 @@ pub const MAX: f32 = f32::MAX;
 /// let min = f32::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN_EXP` associated constant on `f32`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `MIN_EXP` associated constant on `f32`")]
 pub const MIN_EXP: i32 = f32::MIN_EXP;
 
 /// Maximum possible power of 2 exponent.
@@ -174,7 +177,7 @@ pub const MIN_EXP: i32 = f32::MIN_EXP;
 /// let max = f32::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MAX_EXP` associated constant on `f32`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `MAX_EXP` associated constant on `f32`")]
 pub const MAX_EXP: i32 = f32::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
@@ -191,7 +194,7 @@ pub const MAX_EXP: i32 = f32::MAX_EXP;
 /// let min = f32::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN_10_EXP` associated constant on `f32`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `MIN_10_EXP` associated constant on `f32`")]
 pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 
 /// Maximum possible power of 10 exponent.
@@ -208,7 +211,7 @@ pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 /// let max = f32::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MAX_10_EXP` associated constant on `f32`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `MAX_10_EXP` associated constant on `f32`")]
 pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 
 /// Not a Number (NaN).
@@ -225,7 +228,7 @@ pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 /// let nan = f32::NAN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `NAN` associated constant on `f32`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `NAN` associated constant on `f32`")]
 pub const NAN: f32 = f32::NAN;
 
 /// Infinity (∞).
@@ -242,7 +245,7 @@ pub const NAN: f32 = f32::NAN;
 /// let inf = f32::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `INFINITY` associated constant on `f32`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `INFINITY` associated constant on `f32`")]
 pub const INFINITY: f32 = f32::INFINITY;
 
 /// Negative infinity (−∞).
@@ -259,7 +262,10 @@ pub const INFINITY: f32 = f32::INFINITY;
 /// let ninf = f32::NEG_INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `NEG_INFINITY` associated constant on `f32`")]
+#[deprecated(
+    since = "1.69.0",
+    note = "replaced by the `NEG_INFINITY` associated constant on `f32`"
+)]
 pub const NEG_INFINITY: f32 = f32::NEG_INFINITY;
 
 /// Basic mathematical constants.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -31,7 +31,7 @@ use crate::num::FpCategory;
 /// let r = f64::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `RADIX` associated constant on `f64`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `RADIX` associated constant on `f64`")]
 pub const RADIX: u32 = f64::RADIX;
 
 /// Number of significant digits in base 2.
@@ -49,7 +49,7 @@ pub const RADIX: u32 = f64::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "replaced by the `MANTISSA_DIGITS` associated constant on `f64`"
 )]
 pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
@@ -68,7 +68,7 @@ pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 /// let d = f64::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `DIGITS` associated constant on `f64`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `DIGITS` associated constant on `f64`")]
 pub const DIGITS: u32 = f64::DIGITS;
 
 /// [Machine epsilon] value for `f64`.
@@ -89,7 +89,7 @@ pub const DIGITS: u32 = f64::DIGITS;
 /// let e = f64::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `EPSILON` associated constant on `f64`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `EPSILON` associated constant on `f64`")]
 pub const EPSILON: f64 = f64::EPSILON;
 
 /// Smallest finite `f64` value.
@@ -106,7 +106,7 @@ pub const EPSILON: f64 = f64::EPSILON;
 /// let min = f64::MIN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN` associated constant on `f64`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `MIN` associated constant on `f64`")]
 pub const MIN: f64 = f64::MIN;
 
 /// Smallest positive normal `f64` value.
@@ -123,7 +123,10 @@ pub const MIN: f64 = f64::MIN;
 /// let min = f64::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN_POSITIVE` associated constant on `f64`")]
+#[deprecated(
+    since = "1.69.0",
+    note = "replaced by the `MIN_POSITIVE` associated constant on `f64`"
+)]
 pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 
 /// Largest finite `f64` value.
@@ -140,7 +143,7 @@ pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 /// let max = f64::MAX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on `f64`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `MAX` associated constant on `f64`")]
 pub const MAX: f64 = f64::MAX;
 
 /// One greater than the minimum possible normal power of 2 exponent.
@@ -157,7 +160,7 @@ pub const MAX: f64 = f64::MAX;
 /// let min = f64::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN_EXP` associated constant on `f64`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `MIN_EXP` associated constant on `f64`")]
 pub const MIN_EXP: i32 = f64::MIN_EXP;
 
 /// Maximum possible power of 2 exponent.
@@ -174,7 +177,7 @@ pub const MIN_EXP: i32 = f64::MIN_EXP;
 /// let max = f64::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MAX_EXP` associated constant on `f64`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `MAX_EXP` associated constant on `f64`")]
 pub const MAX_EXP: i32 = f64::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
@@ -191,7 +194,7 @@ pub const MAX_EXP: i32 = f64::MAX_EXP;
 /// let min = f64::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN_10_EXP` associated constant on `f64`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `MIN_10_EXP` associated constant on `f64`")]
 pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 
 /// Maximum possible power of 10 exponent.
@@ -208,7 +211,7 @@ pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 /// let max = f64::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MAX_10_EXP` associated constant on `f64`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `MAX_10_EXP` associated constant on `f64`")]
 pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 
 /// Not a Number (NaN).
@@ -225,7 +228,7 @@ pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 /// let nan = f64::NAN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `NAN` associated constant on `f64`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `NAN` associated constant on `f64`")]
 pub const NAN: f64 = f64::NAN;
 
 /// Infinity (∞).
@@ -242,7 +245,7 @@ pub const NAN: f64 = f64::NAN;
 /// let inf = f64::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `INFINITY` associated constant on `f64`")]
+#[deprecated(since = "1.69.0", note = "replaced by the `INFINITY` associated constant on `f64`")]
 pub const INFINITY: f64 = f64::INFINITY;
 
 /// Negative infinity (−∞).
@@ -259,7 +262,10 @@ pub const INFINITY: f64 = f64::INFINITY;
 /// let ninf = f64::NEG_INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `NEG_INFINITY` associated constant on `f64`")]
+#[deprecated(
+    since = "1.69.0",
+    note = "replaced by the `NEG_INFINITY` associated constant on `f64`"
+)]
 pub const NEG_INFINITY: f64 = f64::NEG_INFINITY;
 
 /// Basic mathematical constants.

--- a/library/core/src/num/shells/i128.rs
+++ b/library/core/src/num/shells/i128.rs
@@ -6,7 +6,7 @@
 
 #![stable(feature = "i128", since = "1.26.0")]
 #![deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "all constants in this module replaced by associated constants on `i128`"
 )]
 

--- a/library/core/src/num/shells/i16.rs
+++ b/library/core/src/num/shells/i16.rs
@@ -6,7 +6,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "all constants in this module replaced by associated constants on `i16`"
 )]
 

--- a/library/core/src/num/shells/i32.rs
+++ b/library/core/src/num/shells/i32.rs
@@ -6,7 +6,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "all constants in this module replaced by associated constants on `i32`"
 )]
 

--- a/library/core/src/num/shells/i64.rs
+++ b/library/core/src/num/shells/i64.rs
@@ -6,7 +6,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "all constants in this module replaced by associated constants on `i64`"
 )]
 

--- a/library/core/src/num/shells/i8.rs
+++ b/library/core/src/num/shells/i8.rs
@@ -6,7 +6,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "all constants in this module replaced by associated constants on `i8`"
 )]
 

--- a/library/core/src/num/shells/int_macros.rs
+++ b/library/core/src/num/shells/int_macros.rs
@@ -19,7 +19,7 @@ macro_rules! int_module {
         /// ```
         ///
         #[$attr]
-        #[deprecated(since = "TBD", note = "replaced by the `MIN` associated constant on this type")]
+        #[deprecated(since = "1.69.0", note = "replaced by the `MIN` associated constant on this type")]
         pub const MIN: $T = $T::MIN;
 
         #[doc = concat!(
@@ -38,7 +38,7 @@ macro_rules! int_module {
         /// ```
         ///
         #[$attr]
-        #[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on this type")]
+        #[deprecated(since = "1.69.0", note = "replaced by the `MAX` associated constant on this type")]
         pub const MAX: $T = $T::MAX;
     )
 }

--- a/library/core/src/num/shells/isize.rs
+++ b/library/core/src/num/shells/isize.rs
@@ -6,7 +6,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "all constants in this module replaced by associated constants on `isize`"
 )]
 

--- a/library/core/src/num/shells/u128.rs
+++ b/library/core/src/num/shells/u128.rs
@@ -6,7 +6,7 @@
 
 #![stable(feature = "i128", since = "1.26.0")]
 #![deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "all constants in this module replaced by associated constants on `u128`"
 )]
 

--- a/library/core/src/num/shells/u16.rs
+++ b/library/core/src/num/shells/u16.rs
@@ -6,7 +6,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "all constants in this module replaced by associated constants on `u16`"
 )]
 

--- a/library/core/src/num/shells/u32.rs
+++ b/library/core/src/num/shells/u32.rs
@@ -6,7 +6,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "all constants in this module replaced by associated constants on `u32`"
 )]
 

--- a/library/core/src/num/shells/u64.rs
+++ b/library/core/src/num/shells/u64.rs
@@ -6,7 +6,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "all constants in this module replaced by associated constants on `u64`"
 )]
 

--- a/library/core/src/num/shells/u8.rs
+++ b/library/core/src/num/shells/u8.rs
@@ -6,7 +6,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "all constants in this module replaced by associated constants on `u8`"
 )]
 

--- a/library/core/src/num/shells/usize.rs
+++ b/library/core/src/num/shells/usize.rs
@@ -6,7 +6,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![deprecated(
-    since = "TBD",
+    since = "1.69.0",
     note = "all constants in this module replaced by associated constants on `usize`"
 )]
 


### PR DESCRIPTION
This PR seeks to officially deprecate the number modules in `core` and `std`, which is the last remaining open item on #68490. It also marks them as `#[doc(hidden)]` to avoid confusion.

### Motivation

The main reason to hide the documentation rather than just deprecating is user confusion: it seems like users have not infrequent questions about why Rust is deprecating integers (@Nilstrieb mentioned in chat and @jsha linked in this comment https://github.com/rust-lang/rust/issues/107579#issuecomment-1413076567). 

It also isn't great for the optics of language stability that the first result for some common-ish searches link to a page stamped with "deprecation planned" all over.

<img width="601" alt="image" src="https://user-images.githubusercontent.com/13724985/216254847-8bd119c5-35df-4d86-a060-8f0eab04af0e.png">

Jsha linked this relevant RFC, which indicates that removing these modules from the docs was part of the original plan: https://github.com/rust-lang/rust/issues/107579#issuecomment-1413076567

Links:

- Relevant recent zulip thread https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Deprecation.20of.20std.3A.3Au32.20shells
- Related discussion about SEO https://github.com/rust-lang/rust/issues/107579
- Former zulip thread from 2020 https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Deprecate.20.7Binteger.7D.3A.3Amax_value.20and.20min_value.20methods

### Newly deprecated & hidden modules

- `core::u16`
- `core::u32`
- `core::u64`
- `core::u128`
- `core::usize`
- `core::i8`
- `core::i16`
- `core::i32`
- `core::i64`
- `core::i128`
- `core::isize`
- `core::f32::{DIGITS, EPSILON, INFINITY, MANTISSA_DIGITS, MAX, MAX_10_EXP, MAX_EXP, MIN, MIN_10_EXP, MIN_EXP, MIN_POSITIVE, NAN, NEG_INFINITY, RADIX}`
- `core::f64::{DIGITS, EPSILON, INFINITY, MANTISSA_DIGITS, MAX, MAX_10_EXP, MAX_EXP, MIN, MIN_10_EXP, MIN_EXP, MIN_POSITIVE, NAN, NEG_INFINITY, RADIX}`
- `std` reexports of these modules & consts

The float modules are a bit weird since all the constants mentioned above are redundant, but they also contain the `core::{f32, f64}::consts` modules, and these do contain information that isn't available elsewhere (constants like E, PI, SQRT_2, etc). A good long term plan could be to re-export the contents of `consts` into their parent modules of `f32` and `f64`, then deprecate the `consts` module. There is some more discussion of this in the original post at  #68490, but no decision is needed here at this time.

### Alternatives

If the team is still against full deprecation (as indicated in the old zulip thread), I think it at least makes sense to still mark the items `#[doc(hidden)]` to help resolve the user confusion mentioned above.

cc @bstrie, original author of the RFC

@rustbot label +T-libs-api