### PR TITLE
Don't generate unecessary `&&self.field` in deriving Debug

### DIFF
--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -98,7 +98,7 @@ impl ::core::marker::Copy for Point { }
 impl ::core::fmt::Debug for Point {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::debug_struct_field2_finish(f, "Point", "x",
-            &&self.x, "y", &&self.y)
+            &self.x, "y", &&self.y)
     }
 }
 #[automatically_derived]
@@ -183,7 +183,7 @@ impl ::core::marker::Copy for PackedPoint { }
 impl ::core::fmt::Debug for PackedPoint {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::debug_struct_field2_finish(f, "PackedPoint",
-            "x", &&{ self.x }, "y", &&{ self.y })
+            "x", &{ self.x }, "y", &&{ self.y })
     }
 }
 #[automatically_derived]
@@ -277,8 +277,8 @@ impl ::core::fmt::Debug for Big {
         let names: &'static _ =
             &["b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8"];
         let values: &[&dyn ::core::fmt::Debug] =
-            &[&&self.b1, &&self.b2, &&self.b3, &&self.b4, &&self.b5,
-                        &&self.b6, &&self.b7, &&self.b8];
+            &[&self.b1, &self.b2, &self.b3, &self.b4, &self.b5, &self.b6,
+                        &self.b7, &&self.b8];
         ::core::fmt::Formatter::debug_struct_fields_finish(f, "Big", names,
             values)
     }
@@ -565,7 +565,7 @@ impl<T: ::core::fmt::Debug + Trait, U: ::core::fmt::Debug> ::core::fmt::Debug
     for Generic<T, U> where T::A: ::core::fmt::Debug {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::debug_struct_field3_finish(f, "Generic", "t",
-            &&self.t, "ta", &&self.ta, "u", &&self.u)
+            &self.t, "ta", &self.ta, "u", &&self.u)
     }
 }
 #[automatically_derived]
@@ -682,7 +682,7 @@ impl<T: ::core::fmt::Debug + ::core::marker::Copy + Trait,
     {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::debug_tuple_field3_finish(f, "PackedGeneric",
-            &&{ self.0 }, &&{ self.1 }, &&{ self.2 })
+            &{ self.0 }, &{ self.1 }, &&{ self.2 })
     }
 }
 #[automatically_derived]
@@ -1084,7 +1084,7 @@ impl ::core::fmt::Debug for Mixed {
                     &__self_0),
             Mixed::S { d1: __self_0, d2: __self_1 } =>
                 ::core::fmt::Formatter::debug_struct_field2_finish(f, "S",
-                    "d1", &__self_0, "d2", &__self_1),
+                    "d1", __self_0, "d2", &__self_1),
         }
     }
 }


### PR DESCRIPTION
Since unsized fields may only be the last one in a struct, we only need to generate a double reference (`&&self.field`) for the  final one.

cc @nnethercote 