### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -131,7 +131,7 @@ pub fn print_crate<'a>(
 
         // Currently, in Rust 2018 we don't have `extern crate std;` at the crate
         // root, so this is not needed, and actually breaks things.
-        if edition.rust_2015() {
+        if edition.is_rust_2015() {
             // `#![no_std]`
             let fake_attr = attr::mk_attr_word(g, ast::AttrStyle::Inner, sym::no_std, DUMMY_SP);
             s.print_attribute(&fake_attr);

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -474,9 +474,11 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         let err = FnMutError {
             span: *span,
             ty_err: match output_ty.kind() {
-                ty::Closure(_, _) => FnMutReturnTypeErr::ReturnClosure { span: *span },
                 ty::Generator(def, ..) if self.infcx.tcx.generator_is_async(*def) => {
                     FnMutReturnTypeErr::ReturnAsyncBlock { span: *span }
+                }
+                _ if output_ty.contains_closure() => {
+                    FnMutReturnTypeErr::ReturnClosure { span: *span }
                 }
                 _ => FnMutReturnTypeErr::ReturnRef { span: *span },
             },
@@ -867,7 +869,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
     fn suggest_move_on_borrowing_closure(&self, diag: &mut Diagnostic) {
         let map = self.infcx.tcx.hir();
         let body_id = map.body_owned_by(self.mir_def_id());
-        let expr = &map.body(body_id).value;
+        let expr = &map.body(body_id).value.peel_blocks();
         let mut closure_span = None::<rustc_span::Span>;
         match expr.kind {
             hir::ExprKind::MethodCall(.., args, _) => {
@@ -882,20 +884,14 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     }
                 }
             }
-            hir::ExprKind::Block(blk, _) => {
-                if let Some(expr) = blk.expr {
-                    // only when the block is a closure
-                    if let hir::ExprKind::Closure(hir::Closure {
-                        capture_clause: hir::CaptureBy::Ref,
-                        body,
-                        ..
-                    }) = expr.kind
-                    {
-                        let body = map.body(*body);
-                        if !matches!(body.generator_kind, Some(hir::GeneratorKind::Async(..))) {
-                            closure_span = Some(expr.span.shrink_to_lo());
-                        }
-                    }
+            hir::ExprKind::Closure(hir::Closure {
+                capture_clause: hir::CaptureBy::Ref,
+                body,
+                ..
+            }) => {
+                let body = map.body(*body);
+                if !matches!(body.generator_kind, Some(hir::GeneratorKind::Async(..))) {
+                    closure_span = Some(expr.span.shrink_to_lo());
                 }
             }
             _ => {}

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1484,7 +1484,10 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 }
             }
             None => {
-                if !sig.output().is_privately_uninhabited(self.tcx(), self.param_env) {
+                // The signature in this call can reference region variables,
+                // so erase them before calling a query.
+                let output_ty = self.tcx().erase_regions(sig.output());
+                if !output_ty.is_privately_uninhabited(self.tcx(), self.param_env) {
                     span_mirbug!(self, term, "call to converging function {:?} w/o dest", sig);
                 }
             }

--- a/compiler/rustc_error_messages/locales/en-US/parse.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parse.ftl
@@ -203,8 +203,9 @@ parse_inclusive_range_extra_equals = unexpected `=` after inclusive range
     .suggestion_remove_eq = use `..=` instead
     .note = inclusive ranges end with a single equals sign (`..=`)
 
-parse_inclusive_range_match_arrow = unexpected `=>` after open range
-    .suggestion_add_space = add a space between the pattern and `=>`
+parse_inclusive_range_match_arrow = unexpected `>` after inclusive range
+    .label = this is parsed as an inclusive range `..=`
+    .suggestion = add a space between the pattern and `=>`
 
 parse_inclusive_range_no_end = inclusive range with no end
     .suggestion_open_range = use `..` instead

--- a/compiler/rustc_error_messages/locales/en-US/parse.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parse.ftl
@@ -535,8 +535,8 @@ parse_dot_dot_dot_range_to_pattern_not_allowed = range-to patterns with `...` ar
 
 parse_enum_pattern_instead_of_identifier = expected identifier, found enum pattern
 
-parse_dot_dot_dot_for_remaining_fields = expected field pattern, found `...`
-    .suggestion = to omit remaining fields, use one fewer `.`
+parse_dot_dot_dot_for_remaining_fields = expected field pattern, found `{$token_str}`
+    .suggestion = to omit remaining fields, use `..`
 
 parse_expected_comma_after_pattern_field = expected `,`
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -454,8 +454,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             None if let Some(e) = self.tainted_by_errors() => self.tcx.ty_error_with_guaranteed(e),
             None => {
                 bug!(
-                    "no type for node {}: {} in fcx {}",
-                    id,
+                    "no type for node {} in fcx {}",
                     self.tcx.hir().node_to_string(id),
                     self.tag()
                 );

--- a/compiler/rustc_hir_typeck/src/mem_categorization.rs
+++ b/compiler/rustc_hir_typeck/src/mem_categorization.rs
@@ -155,8 +155,7 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
             None if self.is_tainted_by_errors() => Err(()),
             None => {
                 bug!(
-                    "no type for node {}: {} in mem_categorization",
-                    id,
+                    "no type for node {} in mem_categorization",
                     self.tcx().hir().node_to_string(id)
                 );
             }

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -290,7 +290,7 @@ impl<'hir> Map<'hir> {
     #[track_caller]
     pub fn parent_id(self, hir_id: HirId) -> HirId {
         self.opt_parent_id(hir_id)
-            .unwrap_or_else(|| bug!("No parent for node {:?}", self.node_to_string(hir_id)))
+            .unwrap_or_else(|| bug!("No parent for node {}", self.node_to_string(hir_id)))
     }
 
     pub fn get_parent(self, hir_id: HirId) -> Node<'hir> {
@@ -1191,12 +1191,10 @@ fn upstream_crates(tcx: TyCtxt<'_>) -> Vec<(StableCrateId, Svh)> {
 }
 
 fn hir_id_to_string(map: Map<'_>, id: HirId) -> String {
-    let id_str = format!(" (hir_id={})", id);
-
     let path_str = |def_id: LocalDefId| map.tcx.def_path_str(def_id.to_def_id());
 
     let span_str = || map.tcx.sess.source_map().span_to_snippet(map.span(id)).unwrap_or_default();
-    let node_str = |prefix| format!("{} {}{}", prefix, span_str(), id_str);
+    let node_str = |prefix| format!("{id} ({prefix} `{}`)", span_str());
 
     match map.find(id) {
         Some(Node::Item(item)) => {
@@ -1225,10 +1223,10 @@ fn hir_id_to_string(map: Map<'_>, id: HirId) -> String {
                 ItemKind::TraitAlias(..) => "trait alias",
                 ItemKind::Impl { .. } => "impl",
             };
-            format!("{} {}{}", item_str, path_str(item.owner_id.def_id), id_str)
+            format!("{id} ({item_str} {})", path_str(item.owner_id.def_id))
         }
         Some(Node::ForeignItem(item)) => {
-            format!("foreign item {}{}", path_str(item.owner_id.def_id), id_str)
+            format!("{id} (foreign item {})", path_str(item.owner_id.def_id))
         }
         Some(Node::ImplItem(ii)) => {
             let kind = match ii.kind {
@@ -1236,7 +1234,7 @@ fn hir_id_to_string(map: Map<'_>, id: HirId) -> String {
                 ImplItemKind::Fn(..) => "method",
                 ImplItemKind::Type(_) => "assoc type",
             };
-            format!("{} {} in {}{}", kind, ii.ident, path_str(ii.owner_id.def_id), id_str)
+            format!("{id} ({kind} `{}` in {})", ii.ident, path_str(ii.owner_id.def_id))
         }
         Some(Node::TraitItem(ti)) => {
             let kind = match ti.kind {
@@ -1245,13 +1243,13 @@ fn hir_id_to_string(map: Map<'_>, id: HirId) -> String {
                 TraitItemKind::Type(..) => "assoc type",
             };
 
-            format!("{} {} in {}{}", kind, ti.ident, path_str(ti.owner_id.def_id), id_str)
+            format!("{id} ({kind} `{}` in {})", ti.ident, path_str(ti.owner_id.def_id))
         }
         Some(Node::Variant(ref variant)) => {
-            format!("variant {} in {}{}", variant.ident, path_str(variant.def_id), id_str)
+            format!("{id} (variant `{}` in {})", variant.ident, path_str(variant.def_id))
         }
         Some(Node::Field(ref field)) => {
-            format!("field {} in {}{}", field.ident, path_str(field.def_id), id_str)
+            format!("{id} (field `{}` in {})", field.ident, path_str(field.def_id))
         }
         Some(Node::AnonConst(_)) => node_str("const"),
         Some(Node::Expr(_)) => node_str("expr"),
@@ -1269,16 +1267,15 @@ fn hir_id_to_string(map: Map<'_>, id: HirId) -> String {
         Some(Node::Infer(_)) => node_str("infer"),
         Some(Node::Local(_)) => node_str("local"),
         Some(Node::Ctor(ctor)) => format!(
-            "ctor {}{}",
+            "{id} (ctor {})",
             ctor.ctor_def_id().map_or("<missing path>".into(), |def_id| path_str(def_id)),
-            id_str
         ),
         Some(Node::Lifetime(_)) => node_str("lifetime"),
         Some(Node::GenericParam(ref param)) => {
-            format!("generic_param {}{}", path_str(param.def_id), id_str)
+            format!("{id} (generic_param {})", path_str(param.def_id))
         }
-        Some(Node::Crate(..)) => String::from("root_crate"),
-        None => format!("unknown node{}", id_str),
+        Some(Node::Crate(..)) => String::from("(root_crate)"),
+        None => format!("{id} (unknown node)"),
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2171,7 +2171,7 @@ impl<'tcx> TyCtxt<'tcx> {
             self.late_bound_vars_map(id.owner)
                 .and_then(|map| map.get(&id.local_id).cloned())
                 .unwrap_or_else(|| {
-                    bug!("No bound vars found for {:?} ({:?})", self.hir().node_to_string(id), id)
+                    bug!("No bound vars found for {}", self.hir().node_to_string(id))
                 })
                 .iter(),
         )

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1937,6 +1937,28 @@ impl<'tcx> Ty<'tcx> {
         cf.is_break()
     }
 
+    /// Checks whether a type recursively contains any closure
+    ///
+    /// Example: `Option<[closure@file.rs:4:20]>` returns true
+    pub fn contains_closure(self) -> bool {
+        struct ContainsClosureVisitor;
+
+        impl<'tcx> TypeVisitor<'tcx> for ContainsClosureVisitor {
+            type BreakTy = ();
+
+            fn visit_ty(&mut self, t: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
+                if let ty::Closure(_, _) = t.kind() {
+                    ControlFlow::BREAK
+                } else {
+                    t.super_visit_with(self)
+                }
+            }
+        }
+
+        let cf = self.visit_with(&mut ContainsClosureVisitor);
+        cf.is_break()
+    }
+
     /// Returns the type and mutability of `*ty`.
     ///
     /// The parameter `explicit` indicates if this is an *explicit* dereference.

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -372,7 +372,7 @@ impl<'tcx> TypeckResults<'tcx> {
 
     pub fn node_type(&self, id: hir::HirId) -> Ty<'tcx> {
         self.node_type_opt(id).unwrap_or_else(|| {
-            bug!("node_type: no type for node `{}`", tls::with(|tcx| tcx.hir().node_to_string(id)))
+            bug!("node_type: no type for node {}", tls::with(|tcx| tcx.hir().node_to_string(id)))
         })
     }
 
@@ -551,9 +551,8 @@ fn validate_hir_id_for_typeck_results(hir_owner: OwnerId, hir_id: hir::HirId) {
 fn invalid_hir_id_for_typeck_results(hir_owner: OwnerId, hir_id: hir::HirId) {
     ty::tls::with(|tcx| {
         bug!(
-            "node {} with HirId::owner {:?} cannot be placed in TypeckResults with hir_owner {:?}",
+            "node {} cannot be placed in TypeckResults with hir_owner {:?}",
             tcx.hir().node_to_string(hir_id),
-            hir_id.owner,
             hir_owner
         )
     });

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use rustc_ast::token::Token;
 use rustc_ast::{Path, Visibility};
 use rustc_errors::{fluent, AddToDiagnostic, Applicability, EmissionGuarantee, IntoDiagnostic};
@@ -1802,8 +1804,9 @@ pub(crate) struct EnumPatternInsteadOfIdentifier {
 #[diag(parse_dot_dot_dot_for_remaining_fields)]
 pub(crate) struct DotDotDotForRemainingFields {
     #[primary_span]
-    #[suggestion(code = "..", applicability = "machine-applicable")]
+    #[suggestion(code = "..", style = "verbose", applicability = "machine-applicable")]
     pub span: Span,
+    pub token_str: Cow<'static, str>,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -668,13 +668,10 @@ pub(crate) struct InclusiveRangeExtraEquals {
 #[diag(parse_inclusive_range_match_arrow)]
 pub(crate) struct InclusiveRangeMatchArrow {
     #[primary_span]
+    pub arrow: Span,
+    #[label]
     pub span: Span,
-    #[suggestion(
-        suggestion_add_space,
-        style = "verbose",
-        code = " ",
-        applicability = "machine-applicable"
-    )]
+    #[suggestion(style = "verbose", code = " ", applicability = "machine-applicable")]
     pub after_pat: Span,
 }
 

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2717,6 +2717,14 @@ impl<'a> Parser<'a> {
                     );
                     err.emit();
                     this.bump();
+                } else if matches!(
+                    (&this.prev_token.kind, &this.token.kind),
+                    (token::DotDotEq, token::Gt)
+                ) {
+                    // `error_inclusive_range_match_arrow` handles cases like `0..=> {}`,
+                    // so we supress the error here
+                    err.delay_as_bug();
+                    this.bump();
                 } else {
                     return Err(err);
                 }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2247,7 +2247,7 @@ impl<'a> Parser<'a> {
         let ext = self.parse_extern(case);
 
         if let Async::Yes { span, .. } = asyncness {
-            if span.rust_2015() {
+            if span.is_rust_2015() {
                 self.sess.emit_err(AsyncFnIn2015 { span, help: HelpUseLatestEdition::new() });
             }
         }

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -744,7 +744,7 @@ impl<'a> Parser<'a> {
             }
             token::Gt if no_space => {
                 let after_pat = span.with_hi(span.hi() - rustc_span::BytePos(1)).shrink_to_hi();
-                self.sess.emit_err(InclusiveRangeMatchArrow { span, after_pat });
+                self.sess.emit_err(InclusiveRangeMatchArrow { span, arrow: tok.span, after_pat });
             }
             _ => {
                 self.sess.emit_err(InclusiveRangeNoEnd { span });

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -963,12 +963,15 @@ impl<'a> Parser<'a> {
             }
             ate_comma = false;
 
-            if self.check(&token::DotDot) || self.token == token::DotDotDot {
+            if self.check(&token::DotDot)
+                || self.check_noexpect(&token::DotDotDot)
+                || self.check_keyword(kw::Underscore)
+            {
                 etc = true;
                 let mut etc_sp = self.token.span;
 
-                self.recover_one_fewer_dotdot();
-                self.bump(); // `..` || `...`
+                self.recover_bad_dot_dot();
+                self.bump(); // `..` || `...` || `_`
 
                 if self.token == token::CloseDelim(Delimiter::Brace) {
                     etc_span = Some(etc_sp);
@@ -1061,14 +1064,15 @@ impl<'a> Parser<'a> {
         Ok((fields, etc))
     }
 
-    /// Recover on `...` as if it were `..` to avoid further errors.
+    /// Recover on `...` or `_` as if it were `..` to avoid further errors.
     /// See issue #46718.
-    fn recover_one_fewer_dotdot(&self) {
-        if self.token != token::DotDotDot {
+    fn recover_bad_dot_dot(&self) {
+        if self.token == token::DotDot {
             return;
         }
 
-        self.sess.emit_err(DotDotDotForRemainingFields { span: self.token.span });
+        let token_str = pprust::token_to_string(&self.token);
+        self.sess.emit_err(DotDotDotForRemainingFields { span: self.token.span, token_str });
     }
 
     fn parse_pat_field(&mut self, lo: Span, attrs: AttrVec) -> PResult<'a, PatField> {

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -673,7 +673,7 @@ impl<'a> Parser<'a> {
     /// Is a `dyn B0 + ... + Bn` type allowed here?
     fn is_explicit_dyn_type(&mut self) -> bool {
         self.check_keyword(kw::Dyn)
-            && (!self.token.uninterpolated_span().is_rust_2015()
+            && (self.token.uninterpolated_span().rust_2018()
                 || self.look_ahead(1, |t| {
                     (t.can_begin_bound() || t.kind == TokenKind::BinOp(token::Star))
                         && !can_continue_type_after_non_fn_ident(t)

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -673,7 +673,7 @@ impl<'a> Parser<'a> {
     /// Is a `dyn B0 + ... + Bn` type allowed here?
     fn is_explicit_dyn_type(&mut self) -> bool {
         self.check_keyword(kw::Dyn)
-            && (!self.token.uninterpolated_span().rust_2015()
+            && (!self.token.uninterpolated_span().is_rust_2015()
                 || self.look_ahead(1, |t| {
                     (t.can_begin_bound() || t.kind == TokenKind::BinOp(token::Star))
                         && !can_continue_type_after_non_fn_ident(t)

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -265,7 +265,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                 let ident = path.segments.get(0).expect("empty path in visibility").ident;
                 let crate_root = if ident.is_path_segment_keyword() {
                     None
-                } else if ident.span.rust_2015() {
+                } else if ident.span.is_rust_2015() {
                     Some(Segment::from_ident(Ident::new(
                         kw::PathRoot,
                         path.span.shrink_to_lo().with_ctxt(ident.span.ctxt()),
@@ -435,10 +435,10 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
         // appears, so imports in braced groups can have roots prepended independently.
         let is_glob = matches!(use_tree.kind, ast::UseTreeKind::Glob);
         let crate_root = match prefix_iter.peek() {
-            Some(seg) if !seg.ident.is_path_segment_keyword() && seg.ident.span.rust_2015() => {
+            Some(seg) if !seg.ident.is_path_segment_keyword() && seg.ident.span.is_rust_2015() => {
                 Some(seg.ident.span.ctxt())
             }
-            None if is_glob && use_tree.span.rust_2015() => Some(use_tree.span.ctxt()),
+            None if is_glob && use_tree.span.is_rust_2015() => Some(use_tree.span.ctxt()),
             _ => None,
         }
         .map(|ctxt| {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -462,7 +462,9 @@ impl<'a> Resolver<'a> {
 
         let first_name = match path.get(0) {
             // In the 2018 edition this lint is a hard error, so nothing to do
-            Some(seg) if seg.ident.span.rust_2015() && self.session.rust_2015() => seg.ident.name,
+            Some(seg) if seg.ident.span.is_rust_2015() && self.session.is_rust_2015() => {
+                seg.ident.name
+            }
             _ => return,
         };
 
@@ -1717,7 +1719,7 @@ impl<'a> Resolver<'a> {
                         Applicability::MaybeIncorrect,
                     )),
                 )
-            } else if self.session.rust_2015() {
+            } else if self.session.is_rust_2015() {
                 (
                     format!("maybe a missing crate `{ident}`?"),
                     Some((
@@ -1996,7 +1998,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
         mut path: Vec<Segment>,
         parent_scope: &ParentScope<'b>,
     ) -> Option<(Vec<Segment>, Option<String>)> {
-        if path[1].ident.span.rust_2015() {
+        if path[1].ident.span.is_rust_2015() {
             return None;
         }
 

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -85,7 +85,7 @@ impl<'a> Resolver<'a> {
         // 4c. Standard library prelude (de-facto closed, controlled).
         // 6. Language prelude: builtin attributes (closed, controlled).
 
-        let rust_2015 = ctxt.edition().rust_2015();
+        let rust_2015 = ctxt.edition().is_rust_2015();
         let (ns, macro_kind, is_absolute_path) = match scope_set {
             ScopeSet::All(ns, _) => (ns, None, false),
             ScopeSet::AbsolutePath(ns) => (ns, None, true),
@@ -1397,7 +1397,8 @@ impl<'a> Resolver<'a> {
                         module = Some(ModuleOrUniformRoot::ExternPrelude);
                         continue;
                     }
-                    if name == kw::PathRoot && ident.span.rust_2015() && self.session.rust_2018() {
+                    if name == kw::PathRoot && ident.span.is_rust_2015() && self.session.rust_2018()
+                    {
                         // `::a::b` from 2015 macro on 2018 global edition
                         module = Some(ModuleOrUniformRoot::CrateRootAndExternPrelude);
                         continue;

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2145,7 +2145,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         let segments = &use_tree.prefix.segments;
         if !segments.is_empty() {
             let ident = segments[0].ident;
-            if ident.is_path_segment_keyword() || ident.span.rust_2015() {
+            if ident.is_path_segment_keyword() || ident.span.is_rust_2015() {
                 return;
             }
 

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1343,7 +1343,7 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                     "!",
                     Applicability::MaybeIncorrect,
                 );
-                if path_str == "try" && span.rust_2015() {
+                if path_str == "try" && span.is_rust_2015() {
                     err.note("if you want the `try` keyword, you need Rust 2018 or later");
                 }
             }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -919,8 +919,8 @@ impl Session {
     }
 
     /// Is this edition 2015?
-    pub fn rust_2015(&self) -> bool {
-        self.edition().rust_2015()
+    pub fn is_rust_2015(&self) -> bool {
+        self.edition().is_rust_2015()
     }
 
     /// Are we allowed to use features from the Rust 2018 edition?

--- a/compiler/rustc_span/src/edition.rs
+++ b/compiler/rustc_span/src/edition.rs
@@ -77,7 +77,7 @@ impl Edition {
     }
 
     /// Is this edition 2015?
-    pub fn rust_2015(self) -> bool {
+    pub fn is_rust_2015(self) -> bool {
         self == Edition::Edition2015
     }
 

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -705,8 +705,8 @@ impl Span {
     }
 
     #[inline]
-    pub fn rust_2015(self) -> bool {
-        self.edition().rust_2015()
+    pub fn is_rust_2015(self) -> bool {
+        self.edition().is_rust_2015()
     }
 
     #[inline]

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -133,7 +133,7 @@ impl<'tcx, 'a> GeneratorData<'tcx, 'a> {
                                         .cloned()
                                         .unwrap_or_else(|| {
                                             bug!(
-                                                "node_type: no type for node `{}`",
+                                                "node_type: no type for node {}",
                                                 ty::tls::with(|tcx| tcx
                                                     .hir()
                                                     .node_to_string(await_expr.hir_id))

--- a/tests/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/tests/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -56,11 +56,8 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/const_debuginfo.rs:+1:9: +1:10
           _1 = const 1_u8;                 // scope 0 at $DIR/const_debuginfo.rs:+1:13: +1:16
-          StorageLive(_2);                 // scope 1 at $DIR/const_debuginfo.rs:+2:9: +2:10
           _2 = const 2_u8;                 // scope 1 at $DIR/const_debuginfo.rs:+2:13: +2:16
-          StorageLive(_3);                 // scope 2 at $DIR/const_debuginfo.rs:+3:9: +3:10
           _3 = const 3_u8;                 // scope 2 at $DIR/const_debuginfo.rs:+3:13: +3:16
           StorageLive(_4);                 // scope 3 at $DIR/const_debuginfo.rs:+4:9: +4:12
           StorageLive(_5);                 // scope 3 at $DIR/const_debuginfo.rs:+4:15: +4:20

--- a/tests/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
@@ -18,7 +18,6 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/bad_op_mod_by_zero.rs:+1:9: +1:10
           _1 = const 0_i32;                // scope 0 at $DIR/bad_op_mod_by_zero.rs:+1:13: +1:14
           StorageLive(_2);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:9: +2:11
 -         _4 = Eq(_1, const 0_i32);        // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19

--- a/tests/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
@@ -11,7 +11,6 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/scalar_literal_propagation.rs:+1:9: +1:10
           _1 = const 1_u32;                // scope 0 at $DIR/scalar_literal_propagation.rs:+1:13: +1:14
           StorageLive(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
 -         _2 = consume(_1) -> bb1;         // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15

--- a/tests/mir-opt/copy-prop/cycle.main.CopyProp.diff
+++ b/tests/mir-opt/copy-prop/cycle.main.CopyProp.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-          StorageLive(_2);                 // scope 1 at $DIR/cycle.rs:+2:9: +2:10
+-         StorageLive(_2);                 // scope 1 at $DIR/cycle.rs:+2:9: +2:10
           _2 = _1;                         // scope 1 at $DIR/cycle.rs:+2:13: +2:14
 -         StorageLive(_3);                 // scope 2 at $DIR/cycle.rs:+3:9: +3:10
 -         _3 = _2;                         // scope 2 at $DIR/cycle.rs:+3:13: +3:14

--- a/tests/mir-opt/copy-prop/dead_stores_79191.f.CopyProp.after.mir
+++ b/tests/mir-opt/copy-prop/dead_stores_79191.f.CopyProp.after.mir
@@ -11,7 +11,6 @@ fn f(_1: usize) -> usize {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/dead_stores_79191.rs:+1:9: +1:10
         _2 = _1;                         // scope 0 at $DIR/dead_stores_79191.rs:+1:13: +1:14
         _1 = const 5_usize;              // scope 1 at $DIR/dead_stores_79191.rs:+2:5: +2:10
         _1 = _2;                         // scope 1 at $DIR/dead_stores_79191.rs:+3:5: +3:10

--- a/tests/mir-opt/copy-prop/dead_stores_better.f.CopyProp.after.mir
+++ b/tests/mir-opt/copy-prop/dead_stores_better.f.CopyProp.after.mir
@@ -11,7 +11,6 @@ fn f(_1: usize) -> usize {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/dead_stores_better.rs:+1:9: +1:10
         _2 = _1;                         // scope 0 at $DIR/dead_stores_better.rs:+1:13: +1:14
         _1 = const 5_usize;              // scope 1 at $DIR/dead_stores_better.rs:+2:5: +2:10
         _1 = _2;                         // scope 1 at $DIR/dead_stores_better.rs:+3:5: +3:10

--- a/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.diff
+++ b/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.diff
@@ -98,7 +98,7 @@
       }
   
       bb5: {
-          StorageLive(_17);                // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+-         StorageLive(_17);                // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
           _17 = ((_12 as Some).0: usize);  // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
           StorageLive(_18);                // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
 -         StorageLive(_19);                // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19

--- a/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.diff
+++ b/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.diff
@@ -1,0 +1,146 @@
+- // MIR for `main` before CopyProp
++ // MIR for `main` after CopyProp
+  
+  fn main() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue_107511.rs:+0:11: +0:11
+      let mut _1: i32;                     // in scope 0 at $DIR/issue_107511.rs:+1:9: +1:16
+      let _3: ();                          // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
+      let mut _4: std::ops::Range<usize>;  // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _5: std::ops::Range<usize>;  // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _6: usize;                   // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
+      let mut _7: &[i32];                  // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
+      let mut _8: &[i32; 4];               // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
+      let mut _10: ();                     // in scope 0 at $DIR/issue_107511.rs:+0:1: +11:2
+      let _11: ();                         // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _12: std::option::Option<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _13: &mut std::ops::Range<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _14: &mut std::ops::Range<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _15: isize;                  // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
+      let mut _16: !;                      // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
+      let mut _18: i32;                    // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
+      let _19: usize;                      // in scope 0 at $DIR/issue_107511.rs:+7:18: +7:19
+      let mut _20: usize;                  // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
+      let mut _21: bool;                   // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
+      scope 1 {
+          debug sum => _1;                 // in scope 1 at $DIR/issue_107511.rs:+1:9: +1:16
+          let _2: [i32; 4];                // in scope 1 at $DIR/issue_107511.rs:+2:9: +2:10
+          scope 2 {
+              debug a => _2;               // in scope 2 at $DIR/issue_107511.rs:+2:9: +2:10
+              let mut _9: std::ops::Range<usize>; // in scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+              scope 3 {
+                  debug iter => _9;        // in scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+                  let _17: usize;          // in scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+                  scope 4 {
+                      debug i => _17;      // in scope 4 at $DIR/issue_107511.rs:+6:9: +6:10
+                  }
+              }
+              scope 5 {
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/issue_107511.rs:+1:9: +1:16
+          _1 = const 0_i32;                // scope 0 at $DIR/issue_107511.rs:+1:19: +1:20
+          StorageLive(_2);                 // scope 1 at $DIR/issue_107511.rs:+2:9: +2:10
+          _2 = [const 0_i32, const 10_i32, const 20_i32, const 30_i32]; // scope 1 at $DIR/issue_107511.rs:+2:13: +2:28
+-         StorageLive(_3);                 // scope 2 at $DIR/issue_107511.rs:+6:5: +8:6
+          StorageLive(_4);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_5);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_6);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          StorageLive(_7);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          StorageLive(_8);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          _8 = &_2;                        // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          _7 = move _8 as &[i32] (Pointer(Unsize)); // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          StorageDead(_8);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:18
+          _6 = core::slice::<impl [i32]>::len(move _7) -> bb1; // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+                                           // mir::Constant
+                                           // + span: $DIR/issue_107511.rs:10:19: 10:22
+                                           // + literal: Const { ty: for<'a> fn(&'a [i32]) -> usize {core::slice::<impl [i32]>::len}, val: Value(<ZST>) }
+      }
+  
+      bb1: {
+          StorageDead(_7);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
+          Deinit(_5);                      // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          (_5.0: usize) = const 0_usize;   // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          (_5.1: usize) = move _6;         // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageDead(_6);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
+          _4 = <std::ops::Range<usize> as IntoIterator>::into_iter(move _5) -> bb2; // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+                                           // mir::Constant
+                                           // + span: $DIR/issue_107511.rs:10:14: 10:24
+                                           // + literal: Const { ty: fn(std::ops::Range<usize>) -> <std::ops::Range<usize> as IntoIterator>::IntoIter {<std::ops::Range<usize> as IntoIterator>::into_iter}, val: Value(<ZST>) }
+      }
+  
+      bb2: {
+          StorageDead(_5);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
+          StorageLive(_9);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          _9 = move _4;                    // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          goto -> bb3;                     // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
+      }
+  
+      bb3: {
+-         StorageLive(_11);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_12);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_13);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_14);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          _14 = &mut _9;                   // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          _13 = &mut (*_14);               // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          _12 = <std::ops::Range<usize> as Iterator>::next(move _13) -> bb4; // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+                                           // mir::Constant
+                                           // + span: $DIR/issue_107511.rs:10:14: 10:24
+                                           // + literal: Const { ty: for<'a> fn(&'a mut std::ops::Range<usize>) -> Option<<std::ops::Range<usize> as Iterator>::Item> {<std::ops::Range<usize> as Iterator>::next}, val: Value(<ZST>) }
+      }
+  
+      bb4: {
+          StorageDead(_13);                // scope 3 at $DIR/issue_107511.rs:+6:23: +6:24
+          _15 = discriminant(_12);         // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          switchInt(move _15) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+      }
+  
+      bb5: {
+          StorageLive(_17);                // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+          _17 = ((_12 as Some).0: usize);  // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+          StorageLive(_18);                // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         StorageLive(_19);                // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19
+-         _19 = _17;                       // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19
+          _20 = Len(_2);                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         _21 = Lt(_19, _20);              // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         assert(move _21, "index out of bounds: the length is {} but the index is {}", move _20, _19) -> bb8; // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
++         _21 = Lt(_17, _20);              // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
++         assert(move _21, "index out of bounds: the length is {} but the index is {}", move _20, _17) -> bb8; // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+      }
+  
+      bb6: {
+          unreachable;                     // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+      }
+  
+      bb7: {
+-         _3 = const ();                   // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
+          StorageDead(_14);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_12);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+-         StorageDead(_11);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_9);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_4);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
+-         StorageDead(_3);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
+          _0 = const ();                   // scope 0 at $DIR/issue_107511.rs:+0:11: +11:2
+          StorageDead(_2);                 // scope 1 at $DIR/issue_107511.rs:+11:1: +11:2
+          StorageDead(_1);                 // scope 0 at $DIR/issue_107511.rs:+11:1: +11:2
+          return;                          // scope 0 at $DIR/issue_107511.rs:+11:2: +11:2
+      }
+  
+      bb8: {
+-         _18 = _2[_19];                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
++         _18 = _2[_17];                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+          _1 = Add(_1, move _18);          // scope 4 at $DIR/issue_107511.rs:+7:9: +7:20
+          StorageDead(_18);                // scope 4 at $DIR/issue_107511.rs:+7:19: +7:20
+-         StorageDead(_19);                // scope 4 at $DIR/issue_107511.rs:+7:20: +7:21
+-         _11 = const ();                  // scope 4 at $DIR/issue_107511.rs:+6:25: +8:6
+-         StorageDead(_17);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_14);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_12);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+-         StorageDead(_11);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+-         _10 = const ();                  // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
+          goto -> bb3;                     // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
+      }
+  }
+  

--- a/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.diff
+++ b/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.diff
@@ -4,37 +4,34 @@
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/issue_107511.rs:+0:11: +0:11
       let mut _1: i32;                     // in scope 0 at $DIR/issue_107511.rs:+1:9: +1:16
-      let _3: ();                          // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
+      let mut _3: std::ops::Range<usize>;  // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
       let mut _4: std::ops::Range<usize>;  // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
-      let mut _5: std::ops::Range<usize>;  // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
-      let mut _6: usize;                   // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
-      let mut _7: &[i32];                  // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
-      let mut _8: &[i32; 4];               // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
-      let mut _10: ();                     // in scope 0 at $DIR/issue_107511.rs:+0:1: +11:2
-      let _11: ();                         // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
-      let mut _12: std::option::Option<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _5: usize;                   // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
+      let mut _6: &[i32];                  // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
+      let mut _7: &[i32; 4];               // in scope 0 at $DIR/issue_107511.rs:+6:17: +6:24
+      let mut _9: ();                      // in scope 0 at $DIR/issue_107511.rs:+0:1: +9:2
+      let _10: ();                         // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _11: std::option::Option<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
+      let mut _12: &mut std::ops::Range<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
       let mut _13: &mut std::ops::Range<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
-      let mut _14: &mut std::ops::Range<usize>; // in scope 0 at $DIR/issue_107511.rs:+6:14: +6:24
-      let mut _15: isize;                  // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
-      let mut _16: !;                      // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
-      let mut _18: i32;                    // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
-      let _19: usize;                      // in scope 0 at $DIR/issue_107511.rs:+7:18: +7:19
-      let mut _20: usize;                  // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
-      let mut _21: bool;                   // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
+      let mut _14: isize;                  // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
+      let mut _15: !;                      // in scope 0 at $DIR/issue_107511.rs:+6:5: +8:6
+      let mut _17: i32;                    // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
+      let _18: usize;                      // in scope 0 at $DIR/issue_107511.rs:+7:18: +7:19
+      let mut _19: usize;                  // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
+      let mut _20: bool;                   // in scope 0 at $DIR/issue_107511.rs:+7:16: +7:20
       scope 1 {
           debug sum => _1;                 // in scope 1 at $DIR/issue_107511.rs:+1:9: +1:16
           let _2: [i32; 4];                // in scope 1 at $DIR/issue_107511.rs:+2:9: +2:10
           scope 2 {
               debug a => _2;               // in scope 2 at $DIR/issue_107511.rs:+2:9: +2:10
-              let mut _9: std::ops::Range<usize>; // in scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+              let mut _8: std::ops::Range<usize>; // in scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
               scope 3 {
-                  debug iter => _9;        // in scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
-                  let _17: usize;          // in scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+                  debug iter => _8;        // in scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+                  let _16: usize;          // in scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
                   scope 4 {
-                      debug i => _17;      // in scope 4 at $DIR/issue_107511.rs:+6:9: +6:10
+                      debug i => _16;      // in scope 4 at $DIR/issue_107511.rs:+6:9: +6:10
                   }
-              }
-              scope 5 {
               }
           }
       }
@@ -44,70 +41,69 @@
           _1 = const 0_i32;                // scope 0 at $DIR/issue_107511.rs:+1:19: +1:20
           StorageLive(_2);                 // scope 1 at $DIR/issue_107511.rs:+2:9: +2:10
           _2 = [const 0_i32, const 10_i32, const 20_i32, const 30_i32]; // scope 1 at $DIR/issue_107511.rs:+2:13: +2:28
--         StorageLive(_3);                 // scope 2 at $DIR/issue_107511.rs:+6:5: +8:6
+          StorageLive(_3);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
           StorageLive(_4);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
-          StorageLive(_5);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_5);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
           StorageLive(_6);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
           StorageLive(_7);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
-          StorageLive(_8);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
-          _8 = &_2;                        // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
-          _7 = move _8 as &[i32] (Pointer(Unsize)); // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
-          StorageDead(_8);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:18
-          _6 = core::slice::<impl [i32]>::len(move _7) -> bb1; // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          _7 = &_2;                        // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          _6 = move _7 as &[i32] (Pointer(Unsize)); // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
+          StorageDead(_7);                 // scope 2 at $DIR/issue_107511.rs:+6:17: +6:18
+          _5 = core::slice::<impl [i32]>::len(move _6) -> bb1; // scope 2 at $DIR/issue_107511.rs:+6:17: +6:24
                                            // mir::Constant
                                            // + span: $DIR/issue_107511.rs:10:19: 10:22
                                            // + literal: Const { ty: for<'a> fn(&'a [i32]) -> usize {core::slice::<impl [i32]>::len}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_7);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
-          Deinit(_5);                      // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
-          (_5.0: usize) = const 0_usize;   // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
-          (_5.1: usize) = move _6;         // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
           StorageDead(_6);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
-          _4 = <std::ops::Range<usize> as IntoIterator>::into_iter(move _5) -> bb2; // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          Deinit(_4);                      // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          (_4.0: usize) = const 0_usize;   // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          (_4.1: usize) = move _5;         // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageDead(_5);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
+          _3 = <std::ops::Range<usize> as IntoIterator>::into_iter(move _4) -> bb2; // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
                                            // mir::Constant
                                            // + span: $DIR/issue_107511.rs:10:14: 10:24
                                            // + literal: Const { ty: fn(std::ops::Range<usize>) -> <std::ops::Range<usize> as IntoIterator>::IntoIter {<std::ops::Range<usize> as IntoIterator>::into_iter}, val: Value(<ZST>) }
       }
   
       bb2: {
-          StorageDead(_5);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
-          StorageLive(_9);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
-          _9 = move _4;                    // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageDead(_4);                 // scope 2 at $DIR/issue_107511.rs:+6:23: +6:24
+          StorageLive(_8);                 // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
+          _8 = move _3;                    // scope 2 at $DIR/issue_107511.rs:+6:14: +6:24
           goto -> bb3;                     // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
       }
   
       bb3: {
--         StorageLive(_11);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+-         StorageLive(_10);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageLive(_11);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
           StorageLive(_12);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
           StorageLive(_13);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
-          StorageLive(_14);                // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
-          _14 = &mut _9;                   // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
-          _13 = &mut (*_14);               // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
-          _12 = <std::ops::Range<usize> as Iterator>::next(move _13) -> bb4; // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          _13 = &mut _8;                   // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          _12 = &mut (*_13);               // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          _11 = <std::ops::Range<usize> as Iterator>::next(move _12) -> bb4; // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
                                            // mir::Constant
                                            // + span: $DIR/issue_107511.rs:10:14: 10:24
                                            // + literal: Const { ty: for<'a> fn(&'a mut std::ops::Range<usize>) -> Option<<std::ops::Range<usize> as Iterator>::Item> {<std::ops::Range<usize> as Iterator>::next}, val: Value(<ZST>) }
       }
   
       bb4: {
-          StorageDead(_13);                // scope 3 at $DIR/issue_107511.rs:+6:23: +6:24
-          _15 = discriminant(_12);         // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
-          switchInt(move _15) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          StorageDead(_12);                // scope 3 at $DIR/issue_107511.rs:+6:23: +6:24
+          _14 = discriminant(_11);         // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
+          switchInt(move _14) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 3 at $DIR/issue_107511.rs:+6:14: +6:24
       }
   
       bb5: {
--         StorageLive(_17);                // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
-          _17 = ((_12 as Some).0: usize);  // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
-          StorageLive(_18);                // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
--         StorageLive(_19);                // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19
--         _19 = _17;                       // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19
-          _20 = Len(_2);                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
--         _21 = Lt(_19, _20);              // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
--         assert(move _21, "index out of bounds: the length is {} but the index is {}", move _20, _19) -> bb8; // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
-+         _21 = Lt(_17, _20);              // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
-+         assert(move _21, "index out of bounds: the length is {} but the index is {}", move _20, _17) -> bb8; // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         StorageLive(_16);                // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+          _16 = ((_11 as Some).0: usize);  // scope 3 at $DIR/issue_107511.rs:+6:9: +6:10
+          StorageLive(_17);                // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         StorageLive(_18);                // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19
+-         _18 = _16;                       // scope 4 at $DIR/issue_107511.rs:+7:18: +7:19
+          _19 = Len(_2);                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         _20 = Lt(_18, _19);              // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+-         assert(move _20, "index out of bounds: the length is {} but the index is {}", move _19, _18) -> bb8; // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
++         _20 = Lt(_16, _19);              // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
++         assert(move _20, "index out of bounds: the length is {} but the index is {}", move _19, _16) -> bb8; // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
       }
   
       bb6: {
@@ -115,31 +111,29 @@
       }
   
       bb7: {
--         _3 = const ();                   // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
-          StorageDead(_14);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
-          StorageDead(_12);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
--         StorageDead(_11);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
-          StorageDead(_9);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
-          StorageDead(_4);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
--         StorageDead(_3);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
-          _0 = const ();                   // scope 0 at $DIR/issue_107511.rs:+0:11: +11:2
-          StorageDead(_2);                 // scope 1 at $DIR/issue_107511.rs:+11:1: +11:2
-          StorageDead(_1);                 // scope 0 at $DIR/issue_107511.rs:+11:1: +11:2
-          return;                          // scope 0 at $DIR/issue_107511.rs:+11:2: +11:2
+          _0 = const ();                   // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
+          StorageDead(_13);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_11);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+-         StorageDead(_10);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_8);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_3);                 // scope 2 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_2);                 // scope 1 at $DIR/issue_107511.rs:+9:1: +9:2
+          StorageDead(_1);                 // scope 0 at $DIR/issue_107511.rs:+9:1: +9:2
+          return;                          // scope 0 at $DIR/issue_107511.rs:+9:2: +9:2
       }
   
       bb8: {
--         _18 = _2[_19];                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
-+         _18 = _2[_17];                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
-          _1 = Add(_1, move _18);          // scope 4 at $DIR/issue_107511.rs:+7:9: +7:20
-          StorageDead(_18);                // scope 4 at $DIR/issue_107511.rs:+7:19: +7:20
--         StorageDead(_19);                // scope 4 at $DIR/issue_107511.rs:+7:20: +7:21
--         _11 = const ();                  // scope 4 at $DIR/issue_107511.rs:+6:25: +8:6
--         StorageDead(_17);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
-          StorageDead(_14);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
-          StorageDead(_12);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
--         StorageDead(_11);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
--         _10 = const ();                  // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
+-         _17 = _2[_18];                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
++         _17 = _2[_16];                   // scope 4 at $DIR/issue_107511.rs:+7:16: +7:20
+          _1 = Add(_1, move _17);          // scope 4 at $DIR/issue_107511.rs:+7:9: +7:20
+          StorageDead(_17);                // scope 4 at $DIR/issue_107511.rs:+7:19: +7:20
+-         StorageDead(_18);                // scope 4 at $DIR/issue_107511.rs:+7:20: +7:21
+-         _10 = const ();                  // scope 4 at $DIR/issue_107511.rs:+6:25: +8:6
+-         StorageDead(_16);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_13);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+          StorageDead(_11);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+-         StorageDead(_10);                // scope 3 at $DIR/issue_107511.rs:+8:5: +8:6
+-         _9 = const ();                   // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
           goto -> bb3;                     // scope 3 at $DIR/issue_107511.rs:+6:5: +8:6
       }
   }

--- a/tests/mir-opt/copy-prop/issue_107511.rs
+++ b/tests/mir-opt/copy-prop/issue_107511.rs
@@ -1,0 +1,15 @@
+// unit-test: CopyProp
+
+// EMIT_MIR issue_107511.main.CopyProp.diff
+fn main() {
+    let mut sum = 0;
+    let a = [0, 10, 20, 30];
+
+    // `i` is assigned in a loop. Only removing its `StorageDead` would mean that
+    // execution sees repeated `StorageLive`. This would be UB.
+    for i in 0..a.len() {
+        sum += a[i];
+    }
+
+    let _ = sum;
+}

--- a/tests/mir-opt/copy-prop/issue_107511.rs
+++ b/tests/mir-opt/copy-prop/issue_107511.rs
@@ -10,6 +10,4 @@ fn main() {
     for i in 0..a.len() {
         sum += a[i];
     }
-
-    let _ = sum;
 }

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.diff
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.diff
@@ -16,9 +16,7 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
           _1 = const u8::MAX;              // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
-          StorageLive(_2);                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
           _2 = const 1_u8;                 // scope 0 at $DIR/inherit_overflow.rs:+3:13: +3:47
           _5 = CheckedAdd(const u8::MAX, const 1_u8); // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL
           assert(!move (_5.1: bool), "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> bb1; // scope 2 at $SRC_DIR/core/src/ops/arith.rs:LL:COL

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -79,7 +79,6 @@
       }
   
       bb6: {
-          StorageLive(_10);                // scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
           _10 = ((_7 as Some).0: usize);   // scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
           StorageLive(_11);                // scope 3 at $DIR/funky_arms.rs:+15:43: +15:46
           _11 = &mut (*_1);                // scope 3 at $DIR/funky_arms.rs:+15:43: +15:46

--- a/tests/mir-opt/issue_101973.inner.ConstProp.diff
+++ b/tests/mir-opt/issue_101973.inner.ConstProp.diff
@@ -33,7 +33,6 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/issue_101973.rs:+1:5: +1:65
           StorageLive(_3);                 // scope 0 at $DIR/issue_101973.rs:+1:5: +1:58
-          StorageLive(_4);                 // scope 0 at $DIR/issue_101973.rs:+1:5: +1:17
           StorageLive(_12);                // scope 2 at $DIR/issue_101973.rs:7:12: 7:27
           StorageLive(_13);                // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
           _14 = CheckedShr(_1, const 0_i32); // scope 2 at $DIR/issue_101973.rs:7:12: 7:20
@@ -63,7 +62,6 @@
           StorageDead(_13);                // scope 2 at $DIR/issue_101973.rs:7:26: 7:27
           _4 = BitOr(const 0_u32, move _12); // scope 2 at $DIR/issue_101973.rs:7:5: 7:27
           StorageDead(_12);                // scope 2 at $DIR/issue_101973.rs:7:26: 7:27
-          StorageLive(_6);                 // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
           StorageLive(_7);                 // scope 0 at $DIR/issue_101973.rs:+1:31: +1:52
           StorageLive(_8);                 // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45
           _10 = CheckedShr(_1, const 8_i32); // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -29,7 +29,6 @@
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/issue_76432.rs:+1:9: +1:10
-          StorageLive(_4);                 // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
           StorageLive(_5);                 // scope 0 at $DIR/issue_76432.rs:+1:20: +1:29
           _5 = [_1, _1, _1];               // scope 0 at $DIR/issue_76432.rs:+1:20: +1:29
           _4 = &_5;                        // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29

--- a/tests/mir-opt/simplify_match.main.ConstProp.diff
+++ b/tests/mir-opt/simplify_match.main.ConstProp.diff
@@ -10,7 +10,6 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify_match.rs:+1:17: +1:18
           _2 = const false;                // scope 0 at $DIR/simplify_match.rs:+1:21: +1:26
 -         switchInt(_2) -> [0: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:+1:5: +1:31
 +         switchInt(const false) -> [0: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:+1:5: +1:31

--- a/tests/mir-opt/slice_filter.variant_a-{closure#0}.CopyProp.diff
+++ b/tests/mir-opt/slice_filter.variant_a-{closure#0}.CopyProp.diff
@@ -101,16 +101,16 @@
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
+-         StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
           _25 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
           _3 = &((*_25).0: usize);         // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
-          StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
+-         StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
           _26 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
           _4 = &((*_26).1: usize);         // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
-          StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
+-         StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
           _27 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
           _5 = &((*_27).2: usize);         // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
-          StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
+-         StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           _28 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           _6 = &((*_28).3: usize);         // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56

--- a/tests/mir-opt/slice_filter.variant_a-{closure#0}.DestinationPropagation.diff
+++ b/tests/mir-opt/slice_filter.variant_a-{closure#0}.DestinationPropagation.diff
@@ -85,16 +85,12 @@
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
           _25 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
           _3 = &((*_25).0: usize);         // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
-          StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
           _26 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
           _4 = &((*_26).1: usize);         // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
-          StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
           _27 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
           _5 = &((*_27).2: usize);         // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
-          StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           _28 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           _6 = &((*_28).3: usize);         // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
 -         StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56

--- a/tests/mir-opt/slice_filter.variant_b-{closure#0}.CopyProp.diff
+++ b/tests/mir-opt/slice_filter.variant_b-{closure#0}.CopyProp.diff
@@ -33,16 +33,16 @@
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
+-         StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
           _21 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
           _3 = ((*_21).0: usize);          // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
-          StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
+-         StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
           _22 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
           _4 = ((*_22).1: usize);          // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
-          StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
+-         StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
           _23 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
           _5 = ((*_23).2: usize);          // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
-          StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
+-         StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
           _24 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
           _6 = ((*_24).3: usize);          // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
           StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:42: +0:58

--- a/tests/mir-opt/slice_filter.variant_b-{closure#0}.DestinationPropagation.diff
+++ b/tests/mir-opt/slice_filter.variant_b-{closure#0}.DestinationPropagation.diff
@@ -25,16 +25,12 @@
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
           _13 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
           _3 = ((*_13).0: usize);          // scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
-          StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
           _14 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
           _4 = ((*_14).1: usize);          // scope 0 at $DIR/slice_filter.rs:+0:32: +0:33
-          StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
           _15 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
           _5 = ((*_15).2: usize);          // scope 0 at $DIR/slice_filter.rs:+0:35: +0:36
-          StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
           _16 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
           _6 = ((*_16).3: usize);          // scope 0 at $DIR/slice_filter.rs:+0:38: +0:39
 -         StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:42: +0:58

--- a/tests/mir-opt/try_identity_e2e.new.PreCodegen.after.mir
+++ b/tests/mir-opt/try_identity_e2e.new.PreCodegen.after.mir
@@ -30,7 +30,6 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb1: {
-        StorageLive(_5);                 // scope 0 at $DIR/try_identity_e2e.rs:+5:21: +5:22
         _5 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity_e2e.rs:+5:21: +5:22
         Deinit(_2);                      // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
         ((_2 as Break).0: E) = move _5;  // scope 2 at $DIR/try_identity_e2e.rs:+5:27: +5:48
@@ -40,7 +39,6 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb2: {
-        StorageLive(_4);                 // scope 0 at $DIR/try_identity_e2e.rs:+4:20: +4:21
         _4 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity_e2e.rs:+4:20: +4:21
         Deinit(_2);                      // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
         ((_2 as Continue).0: T) = move _4; // scope 1 at $DIR/try_identity_e2e.rs:+4:26: +4:50
@@ -50,7 +48,6 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb3: {
-        StorageLive(_8);                 // scope 0 at $DIR/try_identity_e2e.rs:+9:32: +9:33
         _8 = move ((_2 as Break).0: E);  // scope 0 at $DIR/try_identity_e2e.rs:+9:32: +9:33
         Deinit(_0);                      // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
         ((_0 as Err).0: E) = move _8;    // scope 4 at $DIR/try_identity_e2e.rs:+9:45: +9:51
@@ -64,7 +61,6 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb5: {
-        StorageLive(_7);                 // scope 0 at $DIR/try_identity_e2e.rs:+8:35: +8:36
         _7 = move ((_2 as Continue).0: T); // scope 0 at $DIR/try_identity_e2e.rs:+8:35: +8:36
         Deinit(_0);                      // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +11:6
         ((_0 as Ok).0: T) = move _7;     // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +11:6

--- a/tests/mir-opt/try_identity_e2e.old.PreCodegen.after.mir
+++ b/tests/mir-opt/try_identity_e2e.old.PreCodegen.after.mir
@@ -19,7 +19,6 @@ fn old(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb1: {
-        StorageLive(_4);                 // scope 0 at $DIR/try_identity_e2e.rs:+4:17: +4:18
         _4 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity_e2e.rs:+4:17: +4:18
         Deinit(_0);                      // scope 2 at $DIR/try_identity_e2e.rs:+4:30: +4:36
         ((_0 as Err).0: E) = move _4;    // scope 2 at $DIR/try_identity_e2e.rs:+4:30: +4:36
@@ -32,7 +31,6 @@ fn old(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb3: {
-        StorageLive(_3);                 // scope 0 at $DIR/try_identity_e2e.rs:+3:16: +3:17
         _3 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity_e2e.rs:+3:16: +3:17
         Deinit(_0);                      // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +6:6
         ((_0 as Ok).0: T) = move _3;     // scope 0 at $DIR/try_identity_e2e.rs:+1:5: +6:6

--- a/tests/ui/borrowck/issue-95079-missing-move-in-nested-closure.fixed
+++ b/tests/ui/borrowck/issue-95079-missing-move-in-nested-closure.fixed
@@ -2,13 +2,13 @@
 #![allow(dead_code, path_statements)]
 fn foo1(s: &str) -> impl Iterator<Item = String> + '_ {
     None.into_iter()
-        .flat_map(move |()| s.chars().map(|c| format!("{}{}", c, s)))
+        .flat_map(move |()| s.chars().map(move |c| format!("{}{}", c, s)))
         //~^ ERROR captured variable cannot escape `FnMut` closure body
         //~| HELP consider adding 'move' keyword before the nested closure
 }
 
 fn foo2(s: &str) -> impl Sized + '_ {
-    move |()| s.chars().map(|c| format!("{}{}", c, s))
+    move |()| s.chars().map(move |c| format!("{}{}", c, s))
     //~^ ERROR lifetime may not live long enough
     //~| HELP consider adding 'move' keyword before the nested closure
 }
@@ -18,7 +18,7 @@ pub fn foo3<'a>(
     bar: &'a X,
 ) -> impl Iterator<Item = ()> + 'a {
     Some(()).iter().flat_map(move |()| {
-        Some(()).iter().map(|()| { bar; }) //~ ERROR captured variable cannot escape
+        Some(()).iter().map(move |()| { bar; }) //~ ERROR captured variable cannot escape
         //~^ HELP consider adding 'move' keyword before the nested closure
     })
 }

--- a/tests/ui/borrowck/issue-95079-missing-move-in-nested-closure.stderr
+++ b/tests/ui/borrowck/issue-95079-missing-move-in-nested-closure.stderr
@@ -1,5 +1,5 @@
 error: captured variable cannot escape `FnMut` closure body
-  --> $DIR/issue-95079-missing-move-in-nested-closure.rs:3:29
+  --> $DIR/issue-95079-missing-move-in-nested-closure.rs:5:29
    |
 LL | fn foo1(s: &str) -> impl Iterator<Item = String> + '_ {
    |         - variable defined here
@@ -7,7 +7,7 @@ LL |     None.into_iter()
 LL |         .flat_map(move |()| s.chars().map(|c| format!("{}{}", c, s)))
    |                           - -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                           | |
-   |                           | returns a reference to a captured variable which escapes the closure body
+   |                           | returns a closure that contains a reference to a captured variable, which then escapes the closure body
    |                           | variable captured here
    |                           inferred to be a `FnMut` closure
    |
@@ -19,12 +19,12 @@ LL |         .flat_map(move |()| s.chars().map(move |c| format!("{}{}", c, s)))
    |                                           ++++
 
 error: lifetime may not live long enough
-  --> $DIR/issue-95079-missing-move-in-nested-closure.rs:9:15
+  --> $DIR/issue-95079-missing-move-in-nested-closure.rs:11:15
    |
 LL |     move |()| s.chars().map(|c| format!("{}{}", c, s))
    |     --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
    |     |       |
-   |     |       return type of closure `Map<Chars<'_>, [closure@$DIR/issue-95079-missing-move-in-nested-closure.rs:9:29: 9:32]>` contains a lifetime `'2`
+   |     |       return type of closure `Map<Chars<'_>, [closure@$DIR/issue-95079-missing-move-in-nested-closure.rs:11:29: 11:32]>` contains a lifetime `'2`
    |     lifetime `'1` represents this closure's body
    |
    = note: closure implements `Fn`, so references to captured variables can't escape the closure
@@ -33,5 +33,26 @@ help: consider adding 'move' keyword before the nested closure
 LL |     move |()| s.chars().map(move |c| format!("{}{}", c, s))
    |                             ++++
 
-error: aborting due to 2 previous errors
+error: captured variable cannot escape `FnMut` closure body
+  --> $DIR/issue-95079-missing-move-in-nested-closure.rs:21:9
+   |
+LL |     bar: &'a X,
+   |     --- variable defined here
+LL | ) -> impl Iterator<Item = ()> + 'a {
+LL |     Some(()).iter().flat_map(move |()| {
+   |                                      - inferred to be a `FnMut` closure
+LL |         Some(()).iter().map(|()| { bar; })
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^^^
+   |         |                          |
+   |         |                          variable captured here
+   |         returns a closure that contains a reference to a captured variable, which then escapes the closure body
+   |
+   = note: `FnMut` closures only have access to their captured variables while they are executing...
+   = note: ...therefore, they cannot allow references to captured variables to escape
+help: consider adding 'move' keyword before the nested closure
+   |
+LL |         Some(()).iter().map(move |()| { bar; })
+   |                             ++++
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/did_you_mean/issue-46718-struct-pattern-dotdotdot.stderr
+++ b/tests/ui/did_you_mean/issue-46718-struct-pattern-dotdotdot.stderr
@@ -2,7 +2,12 @@ error: expected field pattern, found `...`
   --> $DIR/issue-46718-struct-pattern-dotdotdot.rs:11:55
    |
 LL |             PersonalityInventory { expressivity: exp, ... } => exp
-   |                                                       ^^^ help: to omit remaining fields, use one fewer `.`: `..`
+   |                                                       ^^^
+   |
+help: to omit remaining fields, use `..`
+   |
+LL |             PersonalityInventory { expressivity: exp, .. } => exp
+   |                                                       ~~
 
 error: aborting due to previous error
 

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.rs
@@ -2,7 +2,8 @@ fn main() {
     let x = 42;
     match x {
         0..=73 => {},
-        74..=> {},   //~ ERROR unexpected `=>` after open range
-                     //~^ ERROR expected one of `=>`, `if`, or `|`, found `>`
+        74..=> {},
+        //~^ ERROR unexpected `>` after inclusive range
+        //~| NOTE this is parsed as an inclusive range `..=`
     }
 }

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.stderr
@@ -1,19 +1,15 @@
-error: unexpected `=>` after open range
-  --> $DIR/half-open-range-pats-inclusive-match-arrow.rs:5:11
+error: unexpected `>` after inclusive range
+  --> $DIR/half-open-range-pats-inclusive-match-arrow.rs:5:14
    |
 LL |         74..=> {},
-   |           ^^^
+   |           ---^
+   |           |
+   |           this is parsed as an inclusive range `..=`
    |
 help: add a space between the pattern and `=>`
    |
 LL |         74.. => {},
    |             +
 
-error: expected one of `=>`, `if`, or `|`, found `>`
-  --> $DIR/half-open-range-pats-inclusive-match-arrow.rs:5:14
-   |
-LL |         74..=> {},
-   |              ^ expected one of `=>`, `if`, or `|`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/tests/ui/parser/issue-102806.stderr
+++ b/tests/ui/parser/issue-102806.stderr
@@ -32,7 +32,12 @@ error: expected field pattern, found `...`
   --> $DIR/issue-102806.rs:21:22
    |
 LL |     let V3 { z: val, ... } = v;
-   |                      ^^^ help: to omit remaining fields, use one fewer `.`: `..`
+   |                      ^^^
+   |
+help: to omit remaining fields, use `..`
+   |
+LL |     let V3 { z: val, .. } = v;
+   |                      ~~
 
 error[E0063]: missing fields `x` and `y` in initializer of `V3`
   --> $DIR/issue-102806.rs:17:13

--- a/tests/ui/parser/issues/issue-63135.stderr
+++ b/tests/ui/parser/issues/issue-63135.stderr
@@ -20,7 +20,12 @@ error: expected field pattern, found `...`
   --> $DIR/issue-63135.rs:3:8
    |
 LL | fn i(n{...,f #
-   |        ^^^ help: to omit remaining fields, use one fewer `.`: `..`
+   |        ^^^
+   |
+help: to omit remaining fields, use `..`
+   |
+LL | fn i(n{..,f #
+   |        ~~
 
 error: expected `}`, found `,`
   --> $DIR/issue-63135.rs:3:11

--- a/tests/ui/stats/hir-stats.rs
+++ b/tests/ui/stats/hir-stats.rs
@@ -1,7 +1,11 @@
 // check-pass
 // compile-flags: -Zhir-stats
 // only-x86_64
-// ignore-stage1  FIXME: remove after next bootstrap bump
+
+// Type layouts sometimes change. When that happens, until the next bootstrap
+// bump occurs, stage1 and stage2 will give different outputs for this test.
+// Add an `ignore-stage1` comment marker to work around that problem during
+// that time.
 
 // The aim here is to include at least one of every different type of top-level
 // AST/HIR node reported by `-Zhir-stats`.

--- a/tests/ui/structs-enums/struct-enum-ignoring-field-with-underscore.rs
+++ b/tests/ui/structs-enums/struct-enum-ignoring-field-with-underscore.rs
@@ -7,6 +7,5 @@ fn main() {
     let foo = Some(Foo::Other);
 
     if let Some(Foo::Bar {_}) = foo {}
-    //~^ ERROR expected identifier, found reserved identifier `_`
-    //~| ERROR pattern does not mention field `bar` [E0027]
+    //~^ ERROR expected field pattern, found `_`
 }

--- a/tests/ui/structs-enums/struct-enum-ignoring-field-with-underscore.stderr
+++ b/tests/ui/structs-enums/struct-enum-ignoring-field-with-underscore.stderr
@@ -1,24 +1,13 @@
-error: expected identifier, found reserved identifier `_`
+error: expected field pattern, found `_`
   --> $DIR/struct-enum-ignoring-field-with-underscore.rs:9:27
    |
 LL |     if let Some(Foo::Bar {_}) = foo {}
-   |                           ^ expected identifier, found reserved identifier
+   |                           ^
+   |
+help: to omit remaining fields, use `..`
+   |
+LL |     if let Some(Foo::Bar {..}) = foo {}
+   |                           ~~
 
-error[E0027]: pattern does not mention field `bar`
-  --> $DIR/struct-enum-ignoring-field-with-underscore.rs:9:17
-   |
-LL |     if let Some(Foo::Bar {_}) = foo {}
-   |                 ^^^^^^^^^^^^ missing field `bar`
-   |
-help: include the missing field in the pattern
-   |
-LL |     if let Some(Foo::Bar {_, bar }) = foo {}
-   |                            ~~~~~~~
-help: if you don't care about this missing field, you can explicitly ignore it
-   |
-LL |     if let Some(Foo::Bar {_, .. }) = foo {}
-   |                            ~~~~~~
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0027`.

--- a/tests/ui/uninhabited/issue-107505.rs
+++ b/tests/ui/uninhabited/issue-107505.rs
@@ -1,0 +1,18 @@
+// compile-flags: --crate-type=lib
+// check-pass
+
+// Make sure we don't pass inference variables to uninhabitedness checks in borrowck
+
+struct Command<'s> {
+    session: &'s (),
+    imp: std::convert::Infallible,
+}
+
+fn command(_: &()) -> Command<'_> {
+    unreachable!()
+}
+
+fn with_session<'s>(a: &std::process::Command, b: &'s ()) -> Command<'s> {
+    a.get_program();
+    command(b)
+}


### PR DESCRIPTION
Successful merges:

 - #106575 (Suggest `move` in nested closure when appropriate)
 - #106919 (Recover `_` as `..` in field pattern)
 - #107493 (Improve diagnostic for missing space in range pattern)
 - #107515 (Improve pretty-printing of `HirIdValidator` errors)
 - #107524 (Remove both StorageLive and StorageDead in CopyProp.)
 - #107532 (Erase regions before doing uninhabited check in borrowck)
 - #107559 (Rename `rust_2015` → `is_rust_2015`)
 - #107577 (Reinstate the `hir-stats.rs` tests on stage 1.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=106575,106919,107493,107515,107524,107532,107559,107577)
<!-- homu-ignore:end -->