### PR TITLE
Use triple rather than arch for fuchsia test-runner

### DIFF
--- a/src/doc/rustc/src/platform-support/fuchsia.md
+++ b/src/doc/rustc/src/platform-support/fuchsia.md
@@ -697,7 +697,7 @@ test environment with:
 src/ci/docker/scripts/fuchsia-test-runner.py start
     --rust ${RUST_SRC_PATH}/install
     --sdk ${SDK_PATH}
-    --target-arch {x64,arm64}
+    --target-triple {x86_64-unknown-fuchsia|aarch64-unknown-fuchsia}
 ```
 
 Where `${RUST_SRC_PATH}/install` is the `prefix` set in `config.toml` and


### PR DESCRIPTION
This allows the user of the test-runner script to specify a full triple rather than just an architecture which helps with the transition from the two component to three component target triples for fuchsia.