### PR TITLE
Split implied and super predicate queries, then allow elaborator to filter only supertraits

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -64,8 +64,9 @@ pub fn provide(providers: &mut Providers) {
         predicates_defined_on,
         explicit_predicates_of: predicates_of::explicit_predicates_of,
         super_predicates_of: predicates_of::super_predicates_of,
-        super_predicates_that_define_assoc_type:
-            predicates_of::super_predicates_that_define_assoc_type,
+        super_predicates_that_define_assoc_type: |tcx, (def_id, assoc_name)| {
+            predicates_of::super_predicates_that_define_assoc_type(tcx, (def_id, Some(assoc_name)))
+        },
         trait_explicit_predicates_and_bounds: predicates_of::trait_explicit_predicates_and_bounds,
         type_param_predicates: predicates_of::type_param_predicates,
         trait_def,

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -64,9 +64,9 @@ pub fn provide(providers: &mut Providers) {
         predicates_defined_on,
         explicit_predicates_of: predicates_of::explicit_predicates_of,
         super_predicates_of: predicates_of::super_predicates_of,
-        super_predicates_that_define_assoc_type: |tcx, (def_id, assoc_name)| {
-            predicates_of::super_predicates_that_define_assoc_type(tcx, (def_id, Some(assoc_name)))
-        },
+        implied_predicates_of: predicates_of::implied_predicates_of,
+        super_predicates_that_define_assoc_type:
+            predicates_of::super_predicates_that_define_assoc_type,
         trait_explicit_predicates_and_bounds: predicates_of::trait_explicit_predicates_and_bounds,
         type_param_predicates: predicates_of::type_param_predicates,
         trait_def,
@@ -597,6 +597,7 @@ fn convert_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
         }
         hir::ItemKind::TraitAlias(..) => {
             tcx.ensure().generics_of(def_id);
+            tcx.at(it.span).implied_predicates_of(def_id);
             tcx.at(it.span).super_predicates_of(def_id);
             tcx.ensure().predicates_of(def_id);
         }

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -1749,8 +1749,7 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
             if trait_defines_associated_type_named(def_id) {
                 break Some(bound_vars.into_iter().collect());
             }
-            let predicates =
-                tcx.super_predicates_that_define_assoc_type((def_id, Some(assoc_name)));
+            let predicates = tcx.super_predicates_that_define_assoc_type((def_id, assoc_name));
             let obligations = predicates.predicates.iter().filter_map(|&(pred, _)| {
                 let bound_predicate = pred.kind();
                 match bound_predicate.skip_binder() {

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -210,7 +210,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // and we want to keep inference generally in the same order of
             // the registered obligations.
             predicates.rev(),
-        ) {
+        )
+        // We only care about self bounds
+        .filter_only_self()
+        {
             debug!(?pred);
             let bound_predicate = pred.kind();
 

--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -192,7 +192,7 @@ impl<'tcx, O: Elaboratable<'tcx>> Elaborator<'tcx, O> {
         match bound_predicate.skip_binder() {
             ty::PredicateKind::Clause(ty::Clause::Trait(data)) => {
                 // Get predicates declared on the trait.
-                let predicates = tcx.super_predicates_of(data.def_id());
+                let predicates = tcx.implied_predicates_of(data.def_id());
 
                 let obligations =
                     predicates.predicates.iter().enumerate().map(|(index, &(mut pred, span))| {

--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -381,10 +381,8 @@ pub fn transitive_bounds_that_define_assoc_type<'tcx>(
         while let Some(trait_ref) = stack.pop() {
             let anon_trait_ref = tcx.anonymize_bound_vars(trait_ref);
             if visited.insert(anon_trait_ref) {
-                let super_predicates = tcx.super_predicates_that_define_assoc_type((
-                    trait_ref.def_id(),
-                    Some(assoc_name),
-                ));
+                let super_predicates =
+                    tcx.super_predicates_that_define_assoc_type((trait_ref.def_id(), assoc_name));
                 for (super_predicate, _) in super_predicates.predicates {
                     let subst_predicate = super_predicate.subst_supertrait(tcx, &trait_ref);
                     if let Some(binder) = subst_predicate.to_opt_poly_trait_pred() {

--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -69,6 +69,7 @@ impl<'tcx> Extend<ty::Predicate<'tcx>> for PredicateSet<'tcx> {
 pub struct Elaborator<'tcx, O> {
     stack: Vec<O>,
     visited: PredicateSet<'tcx>,
+    only_self: bool,
 }
 
 /// Describes how to elaborate an obligation into a sub-obligation.
@@ -170,7 +171,8 @@ pub fn elaborate<'tcx, O: Elaboratable<'tcx>>(
     tcx: TyCtxt<'tcx>,
     obligations: impl IntoIterator<Item = O>,
 ) -> Elaborator<'tcx, O> {
-    let mut elaborator = Elaborator { stack: Vec::new(), visited: PredicateSet::new(tcx) };
+    let mut elaborator =
+        Elaborator { stack: Vec::new(), visited: PredicateSet::new(tcx), only_self: false };
     elaborator.extend_deduped(obligations);
     elaborator
 }
@@ -185,14 +187,25 @@ impl<'tcx, O: Elaboratable<'tcx>> Elaborator<'tcx, O> {
         self.stack.extend(obligations.into_iter().filter(|o| self.visited.insert(o.predicate())));
     }
 
+    /// Filter to only the supertraits of trait predicates, i.e. only the predicates
+    /// that have `Self` as their self type, instead of all implied predicates.
+    pub fn filter_only_self(mut self) -> Self {
+        self.only_self = true;
+        self
+    }
+
     fn elaborate(&mut self, elaboratable: &O) {
         let tcx = self.visited.tcx;
 
         let bound_predicate = elaboratable.predicate().kind();
         match bound_predicate.skip_binder() {
             ty::PredicateKind::Clause(ty::Clause::Trait(data)) => {
-                // Get predicates declared on the trait.
-                let predicates = tcx.implied_predicates_of(data.def_id());
+                // Get predicates implied by the trait, or only super predicates if we only care about self predicates.
+                let predicates = if self.only_self {
+                    tcx.super_predicates_of(data.def_id())
+                } else {
+                    tcx.implied_predicates_of(data.def_id())
+                };
 
                 let obligations =
                     predicates.predicates.iter().enumerate().map(|(index, &(mut pred, span))| {
@@ -350,18 +363,16 @@ pub fn supertraits<'tcx>(
     tcx: TyCtxt<'tcx>,
     trait_ref: ty::PolyTraitRef<'tcx>,
 ) -> impl Iterator<Item = ty::PolyTraitRef<'tcx>> {
-    let pred: ty::Predicate<'tcx> = trait_ref.to_predicate(tcx);
-    FilterToTraits::new(elaborate(tcx, [pred]))
+    elaborate(tcx, [trait_ref.to_predicate(tcx)]).filter_only_self().filter_to_traits()
 }
 
 pub fn transitive_bounds<'tcx>(
     tcx: TyCtxt<'tcx>,
     trait_refs: impl Iterator<Item = ty::PolyTraitRef<'tcx>>,
 ) -> impl Iterator<Item = ty::PolyTraitRef<'tcx>> {
-    FilterToTraits::new(elaborate(
-        tcx,
-        trait_refs.map(|trait_ref| -> ty::Predicate<'tcx> { trait_ref.to_predicate(tcx) }),
-    ))
+    elaborate(tcx, trait_refs.map(|trait_ref| trait_ref.to_predicate(tcx)))
+        .filter_only_self()
+        .filter_to_traits()
 }
 
 /// A specialized variant of `elaborate` that only elaborates trait references that may
@@ -402,16 +413,16 @@ pub fn transitive_bounds_that_define_assoc_type<'tcx>(
 // Other
 ///////////////////////////////////////////////////////////////////////////
 
+impl<'tcx> Elaborator<'tcx, ty::Predicate<'tcx>> {
+    fn filter_to_traits(self) -> FilterToTraits<Self> {
+        FilterToTraits { base_iterator: self }
+    }
+}
+
 /// A filter around an iterator of predicates that makes it yield up
 /// just trait references.
 pub struct FilterToTraits<I> {
     base_iterator: I,
-}
-
-impl<I> FilterToTraits<I> {
-    fn new(base: I) -> FilterToTraits<I> {
-        FilterToTraits { base_iterator: base }
-    }
 }
 
 impl<'tcx, I: Iterator<Item = ty::Predicate<'tcx>>> Iterator for FilterToTraits<I> {

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -255,6 +255,8 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
                 ty::Adt(def, _) => is_def_must_use(cx, def.did(), span),
                 ty::Alias(ty::Opaque, ty::AliasTy { def_id: def, .. }) => {
                     elaborate(cx.tcx, cx.tcx.explicit_item_bounds(def).iter().cloned())
+                        // We only care about self bounds for the impl-trait
+                        .filter_only_self()
                         .find_map(|(pred, _span)| {
                             // We only look at the `DefId`, so it is safe to skip the binder here.
                             if let ty::PredicateKind::Clause(ty::Clause::Trait(

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -253,7 +253,19 @@ provide! { tcx, def_id, other, cdata,
             .get(cdata, def_id.index)
             .map(|lazy| lazy.decode((cdata, tcx)))
             .process_decoded(tcx, || panic!("{def_id:?} does not have trait_impl_trait_tys")))
-     }
+    }
+    implied_predicates_of => {
+        cdata
+            .root
+            .tables
+            .implied_predicates_of
+            .get(cdata, def_id.index)
+            .map(|lazy| lazy.decode((cdata, tcx)))
+            .unwrap_or_else(|| {
+                debug_assert_eq!(tcx.def_kind(def_id), DefKind::Trait);
+                tcx.super_predicates_of(def_id)
+            })
+    }
 
     associated_types_for_impl_traits_in_associated_fn => { table_defaulted_array }
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1316,8 +1316,12 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 let default = self.tcx.object_lifetime_default(def_id);
                 record!(self.tables.object_lifetime_default[def_id] <- default);
             }
-            if let DefKind::Trait | DefKind::TraitAlias = def_kind {
+            if let DefKind::Trait = def_kind {
                 record!(self.tables.super_predicates_of[def_id] <- self.tcx.super_predicates_of(def_id));
+            }
+            if let DefKind::TraitAlias = def_kind {
+                record!(self.tables.super_predicates_of[def_id] <- self.tcx.super_predicates_of(def_id));
+                record!(self.tables.implied_predicates_of[def_id] <- self.tcx.implied_predicates_of(def_id));
             }
             if let DefKind::Enum | DefKind::Struct | DefKind::Union = def_kind {
                 self.encode_info_for_adt(def_id);

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -372,6 +372,9 @@ define_tables! {
     explicit_predicates_of: Table<DefIndex, LazyValue<ty::GenericPredicates<'static>>>,
     generics_of: Table<DefIndex, LazyValue<ty::Generics>>,
     super_predicates_of: Table<DefIndex, LazyValue<ty::GenericPredicates<'static>>>,
+    // As an optimization, we only store this for trait aliases,
+    // since it's identical to super_predicates_of for traits.
+    implied_predicates_of: Table<DefIndex, LazyValue<ty::GenericPredicates<'static>>>,
     type_of: Table<DefIndex, LazyValue<ty::EarlyBinder<Ty<'static>>>>,
     variances_of: Table<DefIndex, LazyArray<ty::Variance>>,
     fn_sig: Table<DefIndex, LazyValue<ty::EarlyBinder<ty::PolyFnSig<'static>>>>,
@@ -383,7 +386,6 @@ define_tables! {
     mir_for_ctfe: Table<DefIndex, LazyValue<mir::Body<'static>>>,
     mir_generator_witnesses: Table<DefIndex, LazyValue<mir::GeneratorLayout<'static>>>,
     promoted_mir: Table<DefIndex, LazyValue<IndexVec<mir::Promoted, mir::Body<'static>>>>,
-    // FIXME(compiler-errors): Why isn't this a LazyArray?
     thir_abstract_const: Table<DefIndex, LazyValue<ty::Const<'static>>>,
     impl_parent: Table<DefIndex, RawDefId>,
     impl_polarity: Table<DefIndex, ty::ImplPolarity>,

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -230,7 +230,7 @@ impl Key for (LocalDefId, LocalDefId) {
     }
 }
 
-impl Key for (DefId, Option<Ident>) {
+impl Key for (DefId, Ident) {
     type CacheSelector = DefaultCacheSelector<Self>;
 
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -631,10 +631,10 @@ rustc_queries! {
     /// returns the full set of predicates. If `Some<Ident>`, then the query returns only the
     /// subset of super-predicates that reference traits that define the given associated type.
     /// This is used to avoid cycles in resolving types like `T::Item`.
-    query super_predicates_that_define_assoc_type(key: (DefId, Option<rustc_span::symbol::Ident>)) -> ty::GenericPredicates<'tcx> {
-        desc { |tcx| "computing the super traits of `{}`{}",
+    query super_predicates_that_define_assoc_type(key: (DefId, rustc_span::symbol::Ident)) -> ty::GenericPredicates<'tcx> {
+        desc { |tcx| "computing the super traits of `{}` with associated type name `{}`",
             tcx.def_path_str(key.0),
-            if let Some(assoc_name) = key.1 { format!(" with associated type name `{}`", assoc_name) } else { "".to_string() },
+            key.1
         }
     }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -627,6 +627,12 @@ rustc_queries! {
         separate_provide_extern
     }
 
+    query implied_predicates_of(key: DefId) -> ty::GenericPredicates<'tcx> {
+        desc { |tcx| "computing the implied predicates of `{}`", tcx.def_path_str(key) }
+        cache_on_disk_if { key.is_local() }
+        separate_provide_extern
+    }
+
     /// The `Option<Ident>` is the name of an associated type. If it is `None`, then this query
     /// returns the full set of predicates. If `Some<Ident>`, then the query returns only the
     /// subset of super-predicates that reference traits that define the given associated type.

--- a/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
@@ -498,7 +498,10 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         let tcx = self.tcx();
         let own_bounds: FxIndexSet<_> =
             bounds.iter().map(|bound| bound.with_self_ty(tcx, self_ty)).collect();
-        for assumption in elaborate(tcx, own_bounds.iter().copied()) {
+        for assumption in elaborate(tcx, own_bounds.iter().copied())
+            // we only care about bounds that match the `Self` type
+            .filter_only_self()
+        {
             // FIXME: Predicates are fully elaborated in the object type's existential bounds
             // list. We want to only consider these pre-elaborated projections, and not other
             // projection predicates that we reach by elaborating the principal trait ref,

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -115,7 +115,7 @@ impl<'tcx> TraitAliasExpander<'tcx> {
         }
 
         // Get components of trait alias.
-        let predicates = tcx.super_predicates_of(trait_ref.def_id());
+        let predicates = tcx.implied_predicates_of(trait_ref.def_id());
         debug!(?predicates);
 
         let items = predicates.predicates.iter().rev().filter_map(|(pred, span)| {

--- a/tests/ui/associated-type-bounds/ambiguous-associated-type2.stderr
+++ b/tests/ui/associated-type-bounds/ambiguous-associated-type2.stderr
@@ -5,7 +5,7 @@ LL | trait Baz: Foo + Bar<Self::Item> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: ...which immediately requires computing the super traits of `Baz` with associated type name `Item` again
-note: cycle used when computing the super traits of `Baz`
+note: cycle used when computing the super predicates of `Baz`
   --> $DIR/ambiguous-associated-type2.rs:7:1
    |
 LL | trait Baz: Foo + Bar<Self::Item> {}

--- a/tests/ui/associated-types/issue-20825.stderr
+++ b/tests/ui/associated-types/issue-20825.stderr
@@ -5,7 +5,7 @@ LL | pub trait Processor: Subscriber<Input = Self::Input> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: ...which immediately requires computing the super traits of `Processor` with associated type name `Input` again
-note: cycle used when computing the super traits of `Processor`
+note: cycle used when computing the super predicates of `Processor`
   --> $DIR/issue-20825.rs:5:1
    |
 LL | pub trait Processor: Subscriber<Input = Self::Input> {

--- a/tests/ui/closures/self-supertrait-bounds.rs
+++ b/tests/ui/closures/self-supertrait-bounds.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+// Makes sure that we only consider `Self` supertrait predicates while
+// elaborating during closure signature deduction.
+
+#![feature(trait_alias)]
+
+trait Confusing<F> = Fn(i32) where F: Fn(u32);
+
+fn alias<T: Confusing<F>, F>(_: T, _: F) {}
+
+fn main() {
+    alias(|_| {}, |_| {});
+}

--- a/tests/ui/cycle-trait/cycle-trait-supertrait-direct.stderr
+++ b/tests/ui/cycle-trait/cycle-trait-supertrait-direct.stderr
@@ -1,15 +1,10 @@
 error[E0391]: cycle detected when computing the super predicates of `Chromosome`
-  --> $DIR/cycle-trait-supertrait-direct.rs:3:1
-   |
-LL | trait Chromosome: Chromosome {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: ...which requires computing the super traits of `Chromosome`...
   --> $DIR/cycle-trait-supertrait-direct.rs:3:19
    |
 LL | trait Chromosome: Chromosome {
    |                   ^^^^^^^^^^
-   = note: ...which again requires computing the super predicates of `Chromosome`, completing the cycle
+   |
+   = note: ...which immediately requires computing the super predicates of `Chromosome` again
 note: cycle used when collecting item types in top-level module
   --> $DIR/cycle-trait-supertrait-direct.rs:3:1
    |

--- a/tests/ui/cycle-trait/cycle-trait-supertrait-indirect.stderr
+++ b/tests/ui/cycle-trait/cycle-trait-supertrait-indirect.stderr
@@ -1,26 +1,16 @@
 error[E0391]: cycle detected when computing the super predicates of `B`
-  --> $DIR/cycle-trait-supertrait-indirect.rs:7:1
-   |
-LL | trait B: C {
-   | ^^^^^^^^^^
-   |
-note: ...which requires computing the super traits of `B`...
   --> $DIR/cycle-trait-supertrait-indirect.rs:7:10
    |
 LL | trait B: C {
    |          ^
-note: ...which requires computing the super predicates of `C`...
-  --> $DIR/cycle-trait-supertrait-indirect.rs:11:1
    |
-LL | trait C: B { }
-   | ^^^^^^^^^^
-note: ...which requires computing the super traits of `C`...
+note: ...which requires computing the super predicates of `C`...
   --> $DIR/cycle-trait-supertrait-indirect.rs:11:10
    |
 LL | trait C: B { }
    |          ^
    = note: ...which again requires computing the super predicates of `B`, completing the cycle
-note: cycle used when computing the super traits of `A`
+note: cycle used when computing the super predicates of `A`
   --> $DIR/cycle-trait-supertrait-indirect.rs:4:10
    |
 LL | trait A: B {

--- a/tests/ui/infinite/infinite-trait-alias-recursion.stderr
+++ b/tests/ui/infinite/infinite-trait-alias-recursion.stderr
@@ -1,30 +1,15 @@
 error[E0391]: cycle detected when computing the super predicates of `T1`
-  --> $DIR/infinite-trait-alias-recursion.rs:3:1
-   |
-LL | trait T1 = T2;
-   | ^^^^^^^^
-   |
-note: ...which requires computing the super traits of `T1`...
   --> $DIR/infinite-trait-alias-recursion.rs:3:12
    |
 LL | trait T1 = T2;
    |            ^^
-note: ...which requires computing the super predicates of `T2`...
-  --> $DIR/infinite-trait-alias-recursion.rs:6:1
    |
-LL | trait T2 = T3;
-   | ^^^^^^^^
-note: ...which requires computing the super traits of `T2`...
+note: ...which requires computing the super predicates of `T2`...
   --> $DIR/infinite-trait-alias-recursion.rs:6:12
    |
 LL | trait T2 = T3;
    |            ^^
 note: ...which requires computing the super predicates of `T3`...
-  --> $DIR/infinite-trait-alias-recursion.rs:8:1
-   |
-LL | trait T3 = T1 + T3;
-   | ^^^^^^^^
-note: ...which requires computing the super traits of `T3`...
   --> $DIR/infinite-trait-alias-recursion.rs:8:12
    |
 LL | trait T3 = T1 + T3;

--- a/tests/ui/issues/issue-12511.stderr
+++ b/tests/ui/issues/issue-12511.stderr
@@ -1,20 +1,10 @@
 error[E0391]: cycle detected when computing the super predicates of `T1`
-  --> $DIR/issue-12511.rs:1:1
-   |
-LL | trait T1 : T2 {
-   | ^^^^^^^^^^^^^
-   |
-note: ...which requires computing the super traits of `T1`...
   --> $DIR/issue-12511.rs:1:12
    |
 LL | trait T1 : T2 {
    |            ^^
-note: ...which requires computing the super predicates of `T2`...
-  --> $DIR/issue-12511.rs:5:1
    |
-LL | trait T2 : T1 {
-   | ^^^^^^^^^^^^^
-note: ...which requires computing the super traits of `T2`...
+note: ...which requires computing the super predicates of `T2`...
   --> $DIR/issue-12511.rs:5:12
    |
 LL | trait T2 : T1 {

--- a/tests/ui/issues/issue-20772.stderr
+++ b/tests/ui/issues/issue-20772.stderr
@@ -5,7 +5,7 @@ LL | trait T : Iterator<Item=Self::Item>
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: ...which immediately requires computing the super traits of `T` with associated type name `Item` again
-note: cycle used when computing the super traits of `T`
+note: cycle used when computing the super predicates of `T`
   --> $DIR/issue-20772.rs:1:1
    |
 LL | trait T : Iterator<Item=Self::Item>

--- a/tests/ui/lint/unused/trait-alias-supertrait.rs
+++ b/tests/ui/lint/unused/trait-alias-supertrait.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+// Make sure that we only consider *Self* supertrait predicates
+// in the `unused_must_use` lint.
+
+#![feature(trait_alias)]
+#![deny(unused_must_use)]
+
+trait Foo<T> = Sized where T: Iterator;
+
+fn test<T: Iterator>() -> impl Foo<T> {}
+
+fn main() {
+    test::<std::iter::Once<()>>();
+}

--- a/tests/ui/traits/alias/dont-elaborate-non-self.rs
+++ b/tests/ui/traits/alias/dont-elaborate-non-self.rs
@@ -1,0 +1,10 @@
+#![feature(trait_alias)]
+
+use std::future::Future;
+
+trait F<Fut: Future<Output = usize>> = Fn() -> Fut;
+
+fn f<Fut>(a: dyn F<Fut>) {}
+//~^ ERROR the size for values of type `(dyn Fn() -> Fut + 'static)` cannot be known at compilation time
+
+fn main() {}

--- a/tests/ui/traits/alias/dont-elaborate-non-self.stderr
+++ b/tests/ui/traits/alias/dont-elaborate-non-self.stderr
@@ -1,0 +1,20 @@
+error[E0277]: the size for values of type `(dyn Fn() -> Fut + 'static)` cannot be known at compilation time
+  --> $DIR/dont-elaborate-non-self.rs:7:11
+   |
+LL | fn f<Fut>(a: dyn F<Fut>) {}
+   |           ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Fn() -> Fut + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: you can use `impl Trait` as the argument type
+   |
+LL | fn f<Fut>(a: impl F<Fut>) {}
+   |              ~~~~
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn f<Fut>(a: &dyn F<Fut>) {}
+   |              +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/trait-upcasting/alias-where-clause-isnt-supertrait.rs
+++ b/tests/ui/traits/trait-upcasting/alias-where-clause-isnt-supertrait.rs
@@ -1,0 +1,33 @@
+#![feature(trait_upcasting)]
+#![feature(trait_alias)]
+
+// Although we *elaborate* `T: Alias` to `i32: B`, we should
+// not consider `B` to be a supertrait of the type.
+trait Alias = A where i32: B;
+
+trait A {}
+
+trait B {
+    fn test(&self);
+}
+
+trait C: Alias {}
+
+impl A for () {}
+
+impl C for () {}
+
+impl B for i32 {
+    fn test(&self) {
+        println!("hi {self}");
+    }
+}
+
+fn test(x: &dyn C) -> &dyn B {
+    x
+    //~^ ERROR mismatched types
+}
+
+fn main() {
+    let x: &dyn C = &();
+}

--- a/tests/ui/traits/trait-upcasting/alias-where-clause-isnt-supertrait.stderr
+++ b/tests/ui/traits/trait-upcasting/alias-where-clause-isnt-supertrait.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/alias-where-clause-isnt-supertrait.rs:27:5
+   |
+LL | fn test(x: &dyn C) -> &dyn B {
+   |                       ------ expected `&dyn B` because of return type
+LL |     x
+   |     ^ expected trait `B`, found trait `C`
+   |
+   = note: expected reference `&dyn B`
+              found reference `&dyn C`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/traits/trait-upcasting/cyclic-trait-resolution.stderr
+++ b/tests/ui/traits/trait-upcasting/cyclic-trait-resolution.stderr
@@ -1,15 +1,10 @@
 error[E0391]: cycle detected when computing the super predicates of `A`
-  --> $DIR/cyclic-trait-resolution.rs:1:1
-   |
-LL | trait A: B + A {}
-   | ^^^^^^^^^^^^^^
-   |
-note: ...which requires computing the super traits of `A`...
   --> $DIR/cyclic-trait-resolution.rs:1:14
    |
 LL | trait A: B + A {}
    |              ^
-   = note: ...which again requires computing the super predicates of `A`, completing the cycle
+   |
+   = note: ...which immediately requires computing the super predicates of `A` again
 note: cycle used when collecting item types in top-level module
   --> $DIR/cyclic-trait-resolution.rs:1:1
    |


### PR DESCRIPTION
Split the `super_predicates_of` query into a new `implied_predicates_of` query. The former now only returns the *real* supertraits of a trait alias, and the latter now returns the implied predicates (which include all of the `where` clauses of the trait alias). The behavior of these queries is identical for regular traits.

Now that the two queries are split, we can add a new filter method to the elaborator, `filter_only_self()`, which can be used in instances that we need only the *supertrait* predicates, such as during the elaboration used in closure signature deduction. This toggles the usage of `super_predicates_of` instead of `implied_predicates_of` during elaboration of a trait predicate.

This supersedes #104745, and fixes the four independent bugs identified in that PR.
Fixes #104719
Fixes #106238
Fixes #110023
Fixes #109514

r? types