### PR TITLE
loudly tell people when they change `Cargo.lock`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -459,6 +459,14 @@ These commits modify **compiler targets**.
 [mentions."src/doc/style-guide"]
 cc = ["@rust-lang/style"]
 
+[mentions."Cargo.lock"]
+message = """
+These commits modify the `Cargo.lock` file. Random changes to `Cargo.lock` can be introduced when switching branches and rebasing PRs. 
+This was probably unintentional and should be reverted before this PR is merged. 
+
+If this was intentional then you can ignore this comment.
+"""
+
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/contributing.html"


### PR DESCRIPTION
It keeps happening that people accidentally commit changes to `Cargo.lock` and then have to be told by a reviewer to undo this. I've also seen cases where PRs are merged that accidentally changed `Cargo.lock` during a rebase.. I figure that purposeful changes to `Cargo.lock` are likely rarer than these accidental ones?