### PR TITLE
Build only X86 architecture for all temporary LLVM builds in Linux x64 `dist` builder

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1329,6 +1329,9 @@ impl Config {
         config.llvm_tests = llvm_tests.unwrap_or(false);
         config.llvm_plugins = llvm_plugins.unwrap_or(false);
         config.rust_optimize = optimize.unwrap_or(true);
+        if flags.llvm_targets.is_some() {
+            config.llvm_targets = flags.llvm_targets;
+        }
 
         let default = debug == Some(true);
         config.rust_debug_assertions = debug_assertions.unwrap_or(default);

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -80,6 +80,7 @@ pub struct Flags {
     pub llvm_profile_generate: bool,
     pub llvm_bolt_profile_generate: bool,
     pub llvm_bolt_profile_use: Option<String>,
+    pub llvm_targets: Option<String>
 }
 
 #[derive(Debug)]
@@ -261,6 +262,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`",
         opts.optmulti("F", "", "forbid certain clippy lints", "OPT");
         opts.optflag("", "llvm-bolt-profile-generate", "generate BOLT profile for LLVM build");
         opts.optopt("", "llvm-bolt-profile-use", "use BOLT profile for LLVM build", "PROFILE");
+        opts.optopt("", "llvm-targets", "set LLVM targets", "TARGETS");
 
         // We can't use getopt to parse the options until we have completed specifying which
         // options are valid, but under the current implementation, some options are conditional on
@@ -706,6 +708,7 @@ Arguments:
             llvm_profile_generate: matches.opt_present("llvm-profile-generate"),
             llvm_bolt_profile_generate: matches.opt_present("llvm-bolt-profile-generate"),
             llvm_bolt_profile_use: matches.opt_str("llvm-bolt-profile-use"),
+            llvm_targets: matches.opt_str("llvm-targets"),
         }
     }
 }

--- a/src/ci/stage-build.py
+++ b/src/ci/stage-build.py
@@ -587,7 +587,8 @@ def execute_build_pipeline(timer: Timer, pipeline: Pipeline, final_build_args: L
     # Stage 1: Build rustc + PGO instrumented LLVM
     with timer.stage("Build rustc (LLVM PGO)"):
         build_rustc(pipeline, args=[
-            "--llvm-profile-generate"
+            "--llvm-profile-generate",
+            "--llvm-targets", "X86"
         ], env=dict(
             LLVM_PROFILE_DIR=str(pipeline.llvm_profile_dir_root() / "prof-%p")
         ))
@@ -605,7 +606,8 @@ def execute_build_pipeline(timer: Timer, pipeline: Pipeline, final_build_args: L
     with timer.stage("Build rustc (rustc PGO)"):
         build_rustc(pipeline, args=[
             "--rust-profile-generate",
-            pipeline.rustc_profile_dir_root()
+            pipeline.rustc_profile_dir_root(),
+            "--llvm-targets", "X86"
         ])
 
     with timer.stage("Gather profiles (rustc PGO)"):
@@ -624,6 +626,7 @@ def execute_build_pipeline(timer: Timer, pipeline: Pipeline, final_build_args: L
                 "--llvm-profile-use",
                 pipeline.llvm_profile_merged_file(),
                 "--llvm-bolt-profile-generate",
+                "--llvm-targets", "X86"
             ])
         with timer.stage("Gather profiles (LLVM BOLT)"):
             gather_llvm_bolt_profiles(pipeline)


### PR DESCRIPTION
Trying to see how much (if at all) Linux `dist` CI speeds up if we reduce the amount of LLVM targets that we add support for.

r? @ghost