### PR TITLE
unused-lifetimes: don't warn about lifetimes originating from expanded code

### DIFF
--- a/tests/ui/lifetimes/issue-104432-unused-lifetimes-in-expansion.rs
+++ b/tests/ui/lifetimes/issue-104432-unused-lifetimes-in-expansion.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+#![deny(unused_lifetimes)]
+trait Trait2 {
+    type As;
+}
+
+// we should not warn about an unused lifetime about code generated from this proc macro here
+#[derive(Clone)]
+struct ShimMethod4<T: Trait2 + 'static>(pub &'static dyn for<'s> Fn(&'s mut T::As));
+
+pub fn main() {}


### PR DESCRIPTION
previously, we would warn like this:

````
warning: lifetime parameter `'s` never used
 --> /tmp/unusedlif/code.rs:6:62
  |
5 | #[derive(Clone)]
  |          - help: elide the unused lifetime
6 | struct ShimMethod4<T: Trait2 + 'static>(pub &'static dyn for<'s> Fn(&'s mut T::As));
  |                                                              ^^
  |
  = note: requested on the command line with `-W unused-lifetimes`
````

Fixes #104432