### PR TITLE
[WIP] Build `rustc` with a single CGU on x64 Linux

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -84,7 +84,8 @@ ENV RUST_CONFIGURE_ARGS \
       --set llvm.ninja=false \
       --set rust.jemalloc \
       --set rust.use-lld=true \
-      --set rust.lto=thin
+      --set rust.lto=thin \
+      --set rust.codegen-units=1
 
 ENV SCRIPT python3 ../x.py build --set rust.debug=true opt-dist && \
     ./build/$HOSTS/stage0-tools-bin/opt-dist linux-ci -- python3 ../x.py dist \


### PR DESCRIPTION
Follow-up attempt to https://github.com/rust-lang/rust/pull/87650. I wonder if anything changed with the addition of LTO.

I also enabled a single CGU only for the actual build of the compiler on CI, so that we can better see the perf. effects on the bootstrap benchmark.