### PR TITLE
reword descriptions of the deprecated int modules

### DIFF
--- a/library/core/src/num/shells/i128.rs
+++ b/library/core/src/num/shells/i128.rs
@@ -1,6 +1,4 @@
-//! Constants for the 128-bit signed integer type.
-//!
-//! *[See also the `i128` primitive type][i128].*
+//! Redundant constants module for the [`i128` primitive type][i128].
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/i16.rs
+++ b/library/core/src/num/shells/i16.rs
@@ -1,6 +1,4 @@
-//! Constants for the 16-bit signed integer type.
-//!
-//! *[See also the `i16` primitive type][i16].*
+//! Redundant constants module for the [`i16` primitive type][i16].
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/i32.rs
+++ b/library/core/src/num/shells/i32.rs
@@ -1,6 +1,4 @@
-//! Constants for the 32-bit signed integer type.
-//!
-//! *[See also the `i32` primitive type][i32].*
+//! Redundant constants module for the [`i32` primitive type][i32].
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/i64.rs
+++ b/library/core/src/num/shells/i64.rs
@@ -1,6 +1,4 @@
-//! Constants for the 64-bit signed integer type.
-//!
-//! *[See also the `i64` primitive type][i64].*
+//! Redundant constants module for the [`i64` primitive type][i64].
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/i8.rs
+++ b/library/core/src/num/shells/i8.rs
@@ -1,6 +1,4 @@
-//! Constants for the 8-bit signed integer type.
-//!
-//! *[See also the `i8` primitive type][i8].*
+//! Redundant constants module for the [`i8` primitive type][i8].
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/isize.rs
+++ b/library/core/src/num/shells/isize.rs
@@ -1,6 +1,4 @@
-//! Constants for the pointer-sized signed integer type.
-//!
-//! *[See also the `isize` primitive type][isize].*
+//! Redundant constants module for the [`isize` primitive type][isize].
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/u128.rs
+++ b/library/core/src/num/shells/u128.rs
@@ -1,6 +1,4 @@
-//! Constants for the 128-bit unsigned integer type.
-//!
-//! *[See also the `u128` primitive type][u128].*
+//! Redundant constants module for the [`u128` primitive type][u128].
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/u16.rs
+++ b/library/core/src/num/shells/u16.rs
@@ -1,6 +1,4 @@
-//! Constants for the 16-bit unsigned integer type.
-//!
-//! *[See also the `u16` primitive type][u16].*
+//! Redundant constants module for the [`i16` primitive type][i16].
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/u32.rs
+++ b/library/core/src/num/shells/u32.rs
@@ -1,6 +1,4 @@
-//! Constants for the 32-bit unsigned integer type.
-//!
-//! *[See also the `u32` primitive type][u32].*
+//! Redundant constants module for the [`u32` primitive type][u32].
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/u64.rs
+++ b/library/core/src/num/shells/u64.rs
@@ -1,6 +1,4 @@
-//! Constants for the 64-bit unsigned integer type.
-//!
-//! *[See also the `u64` primitive type][u64].*
+//! Redundant constants module for the [`u64` primitive type][u64].
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/u8.rs
+++ b/library/core/src/num/shells/u8.rs
@@ -1,6 +1,4 @@
-//! Constants for the 8-bit unsigned integer type.
-//!
-//! *[See also the `u8` primitive type][u8].*
+//! Redundant constants module for the [`u8` primitive type][u8].
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/usize.rs
+++ b/library/core/src/num/shells/usize.rs
@@ -1,6 +1,4 @@
-//! Constants for the pointer-sized unsigned integer type.
-//!
-//! *[See also the `usize` primitive type][usize].*
+//! Redundant constants module for the [`usize` primitive type][usize].
 //!
 //! New code should use the associated constants directly on the primitive type.
 


### PR DESCRIPTION
Based on recommendation by @est31 here: https://github.com/rust-lang/rust/pull/107587#issuecomment-1416131590

This is meant to make it more clear, when looking at the `std` or `core` docs, that these are deprecated modules - not deprecated integer types (a common misunderstanding).

Before:
![image](https://user-images.githubusercontent.com/803701/216733011-fabc22e1-4e77-4a47-96e3-a765ac4690b6.png)

After:
![image](https://user-images.githubusercontent.com/803701/216733660-02071ced-883d-4ab5-8c0a-d28547d1d5db.png)
