### PR TITLE
rustdoc: change the +/- icons

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1451,9 +1451,9 @@ details.toggle > summary.hideme > span {
 
 details.toggle > summary::before {
 	/* toggle plus */
-	background: url('data:image/svg+xml,<svg width="17" height="17" \
-shape-rendering="crispEdges" stroke="black" fill="none" xmlns="http://www.w3.org/2000/svg"><path \
-d="M5 2.5H2.5v12H5m7-12h2.5v12H12M5 8.5h7M8.5 12V8.625v0V5"/></svg>') no-repeat top left;
+	background: url('data:image/svg+xml,<svg width="17" height="17" fill="gray" \
+	stroke="gray"	xmlns="http://www.w3.org/2000/svg"><path d="M13 8.5L4 14L4 3L13 8.5Z"/> \
+	</svg>') no-repeat top left;
 	content: "";
 	cursor: pointer;
 	width: 16px;
@@ -1532,9 +1532,9 @@ details.toggle[open] > summary.hideme > span {
 
 details.toggle[open] > summary::before {
 	/* toggle minus */
-	background: url('data:image/svg+xml,<svg width="17" height="17" \
-shape-rendering="crispEdges" stroke="black" fill="none" xmlns="http://www.w3.org/2000/svg"><path \
-d="M5 2.5H2.5v12H5m7-12h2.5v12H12M5 8.5h7"/></svg>') no-repeat top left;
+	background: url('data:image/svg+xml,<svg width="17" height="17" fill="gray" \
+	stroke="gray"	xmlns="http://www.w3.org/2000/svg"><path d="M8.5 13L3 4L14 4L8.5 13Z"/> \
+	</svg>') no-repeat top left;
 }
 
 details.toggle[open] > summary::after {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -297,11 +297,27 @@ button {
 
 button#toggle-all-docs {
 	padding: 0;
-	background: none;
+	margin-bottom: 2px;
 	border: none;
+	outline: none;
 	/* iOS button gradient: https://stackoverflow.com/q/5438567 */
 	-webkit-appearance: none;
+	opacity: 0.5;
+	cursor: pointer;
+	width: 17px;
+	height: 17px;
+	vertical-align: middle;
+
+	background: url('data:image/svg+xml,<svg width="17" height="17" viewBox="0 0 17 17" \
+fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4.32143 8L8.5 12.5L12.6786 8H15L8.5 15L2 8H4.32143Z" \
+fill="gray"/><path d="M8.5 11L2 4L15 4L8.5 11Z" fill="gray"/></svg>') no-repeat top left;
+}
+button#toggle-all-docs:hover,
+button#toggle-all-docs:focus {
 	opacity: 1;
+}
+button#toggle-all-docs.will-expand {
+	transform: rotate(180deg);
 }
 
 .rustdoc {
@@ -1451,9 +1467,8 @@ details.toggle > summary.hideme > span {
 
 details.toggle > summary::before {
 	/* toggle plus */
-	background: url('data:image/svg+xml,<svg width="17" height="17" fill="gray" \
-	stroke="gray"	xmlns="http://www.w3.org/2000/svg"><path d="M13 8.5L4 14L4 3L13 8.5Z"/> \
-	</svg>') no-repeat top left;
+	background: url('data:image/svg+xml,<svg width="17" height="17" fill="gray" stroke="gray" \
+xmlns="http://www.w3.org/2000/svg"><path d="M13 8.5L4 14L4 3L13 8.5Z"/></svg>') no-repeat top left;
 	content: "";
 	cursor: pointer;
 	width: 16px;
@@ -1532,9 +1547,8 @@ details.toggle[open] > summary.hideme > span {
 
 details.toggle[open] > summary::before {
 	/* toggle minus */
-	background: url('data:image/svg+xml,<svg width="17" height="17" fill="gray" \
-	stroke="gray"	xmlns="http://www.w3.org/2000/svg"><path d="M8.5 13L3 4L14 4L8.5 13Z"/> \
-	</svg>') no-repeat top left;
+	background: url('data:image/svg+xml,<svg width="17" height="17" fill="gray" stroke="gray" \
+xmlns="http://www.w3.org/2000/svg"><path d="M8.5 13L3 4L14 4L8.5 13Z"/></svg>') no-repeat top left;
 }
 
 details.toggle[open] > summary::after {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -308,9 +308,9 @@ button#toggle-all-docs {
 	height: 17px;
 	vertical-align: middle;
 
-	background: url('data:image/svg+xml,<svg width="17" height="17" viewBox="0 0 17 17" \
-fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4.32143 8L8.5 12.5L12.6786 8H15L8.5 15L2 8H4.32143Z" \
-fill="gray"/><path d="M8.5 11L2 4L15 4L8.5 11Z" fill="gray"/></svg>') no-repeat top left;
+	background: url('data:image/svg+xml,<svg width="17" height="17" viewBox="0 0 17 17" fill="none" \
+xmlns="http://www.w3.org/2000/svg"><path d="M4.32143 7L8.5 11.5L12.6786 7H15L8.5 14L2 7H4.32143Z" \
+fill="gray"/><path d="M8.5 10L2 3L15 3L8.5 10Z" fill="gray"/></svg>') no-repeat top left;
 }
 button#toggle-all-docs:hover,
 button#toggle-all-docs:focus {
@@ -1467,8 +1467,9 @@ details.toggle > summary.hideme > span {
 
 details.toggle > summary::before {
 	/* toggle plus */
-	background: url('data:image/svg+xml,<svg width="17" height="17" fill="gray" stroke="gray" \
-xmlns="http://www.w3.org/2000/svg"><path d="M13 8.5L4 14L4 3L13 8.5Z"/></svg>') no-repeat top left;
+	background: url('data:image/svg+xml,<svg width="17" height="17" fill="gray" \
+xmlns="http://www.w3.org/2000/svg"><path d="M13.75 9.5L5.25 14.5L5.25 4.5L13.75 9.5Z"/> \
+</svg>') no-repeat top left;
 	content: "";
 	cursor: pointer;
 	width: 16px;
@@ -1524,7 +1525,7 @@ details.toggle > summary.hideme::before {
 details.toggle > summary:not(.hideme)::before {
 	position: absolute;
 	left: -24px;
-	top: 4px;
+	top: 3px;
 }
 
 .impl-items > details.toggle > summary:not(.hideme)::before {
@@ -1547,12 +1548,18 @@ details.toggle[open] > summary.hideme > span {
 
 details.toggle[open] > summary::before {
 	/* toggle minus */
-	background: url('data:image/svg+xml,<svg width="17" height="17" fill="gray" stroke="gray" \
-xmlns="http://www.w3.org/2000/svg"><path d="M8.5 13L3 4L14 4L8.5 13Z"/></svg>') no-repeat top left;
+	background: url('data:image/svg+xml,<svg width="17" height="17" fill="gray" \
+xmlns="http://www.w3.org/2000/svg"><path d="M9.5 13.75L4.5 5.25L14.5 5.25L9.5 13.75Z"/> \
+</svg>') no-repeat top left;
 }
 
 details.toggle[open] > summary::after {
 	content: "Collapse";
+}
+
+details.toggle.type-contents-toggle > summary::before,
+details.toggle.top-doc > summary::before {
+	margin-bottom: 5px;
 }
 
 /* This is needed in docblocks to have the "▶" element to be on the same line. */

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -22,7 +22,6 @@
             {%- else -%}
         {%- endmatch -%}
         <button id="toggle-all-docs" title="collapse all docs"> {#- -#}
-            [<span>&#x2212;</span>] {#- -#}
         </button> {#- -#}
     </span> {#- -#}
 </div> {#- -#}


### PR DESCRIPTION
The `[+]` and `[-]` icons to expand/collapse parts of the documentation are really difficult to tell apart. This tries to replace them with something simpler.

Old
<img width="600" alt="image" src="https://user-images.githubusercontent.com/29011024/216741660-d6988572-32b1-4149-a051-18243719431d.png">

New
<img width="600" alt="image" src="https://user-images.githubusercontent.com/29011024/216917973-fb772c7f-6cc8-4c95-81b6-be471060d81e.png">
<img width="600" alt="image" src="https://user-images.githubusercontent.com/29011024/216917781-96a62cdf-f5ad-4056-b677-9c96697cc55d.png">
<img width="600" alt="image" src="https://user-images.githubusercontent.com/29011024/216917834-c4b14f43-358c-43a5-bb74-b41ea7e2e34a.png">

Demo: https://host-7e0a2.web.app/sample-2/std/iter/trait.Iterator.html

Also discussed here: #59851