### PR TITLE
don't point at nonexisting code beyond EOF when warning about delims

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -661,6 +661,10 @@ trait UnusedDelimLint {
         keep_space: (bool, bool),
     ) {
         let primary_span = if let Some((lo, hi)) = spans {
+            if hi.is_empty() {
+                // do not point at delims that do not exist
+                return;
+            }
             MultiSpan::from(vec![lo, hi])
         } else {
             MultiSpan::from(value_span)

--- a/tests/ui/malformed/issue-107423-unused-delim-only-one-no-pair.rs
+++ b/tests/ui/malformed/issue-107423-unused-delim-only-one-no-pair.rs
@@ -1,0 +1,7 @@
+// check that we don't generate a span that points beyond EOF
+
+// error-pattern: unclosed delimiter
+// error-pattern: unclosed delimiter
+// error-pattern: unclosed delimiter
+
+fn a(){{{

--- a/tests/ui/malformed/issue-107423-unused-delim-only-one-no-pair.stderr
+++ b/tests/ui/malformed/issue-107423-unused-delim-only-one-no-pair.stderr
@@ -1,0 +1,32 @@
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-107423-unused-delim-only-one-no-pair.rs:7:11
+   |
+LL | fn a(){{{
+   |       --- ^
+   |       |||
+   |       ||unclosed delimiter
+   |       |unclosed delimiter
+   |       unclosed delimiter
+
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-107423-unused-delim-only-one-no-pair.rs:7:11
+   |
+LL | fn a(){{{
+   |       --- ^
+   |       |||
+   |       ||unclosed delimiter
+   |       |unclosed delimiter
+   |       unclosed delimiter
+
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-107423-unused-delim-only-one-no-pair.rs:7:11
+   |
+LL | fn a(){{{
+   |       --- ^
+   |       |||
+   |       ||unclosed delimiter
+   |       |unclosed delimiter
+   |       unclosed delimiter
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Previously we would show this:
```
warning: unnecessary braces around block return value
 --> /tmp/bad.rs:1:8
  |
1 | fn a(){{{
  |        ^  ^
  |
  = note: `#[warn(unused_braces)]` on by default
help: remove these braces
  |
1 - fn a(){{{
1 + fn a(){{
  |
```

which is now hidden in this case.
We would create a span spanning between the pair of redundant {}s but there is only EOF instead of the `}` so we would previously point at nothing. This would cause the debug assertion ice to trigger. I would have loved to just only point at the second delim and say "you can remove that" but I'm not sure how to do that without refactoring the entire diagnostic which seems tricky. :( But given that this does not seem to regress any other tests we have, I think this edge-casey enough be acceptable.

Fixes https://github.com/rust-lang/rust/issues/107423

r? @compiler-errors