### PR TITLE
Simplify `Iterator::next` for `GenericShunt` used in `iter::try_process`

### DIFF
--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -175,7 +175,16 @@ where
     type Item = <I::Item as Try>::Output;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.try_for_each(ControlFlow::Break).break_value()
+        if let Some(value) = self.iter.next() {
+            match Try::branch(value) {
+                ControlFlow::Continue(output) => return Some(output),
+                ControlFlow::Break(residual) => {
+                    *self.residual = Some(residual);
+                    return None;
+                }
+            }
+        }
+        None
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {


### PR DESCRIPTION
This pull request simplifies the iterator implementation for the GenericShunt structure used in iter::try_process. Although the old implementation commands respect and admiration, but:

1. To be honest, it is not clear not at first sight, nor from the second. And although it is delightful in its conciseness, I spent half a day trying to get through the wilds of mutual function calls.
2. Uses too many unnecessary branches and function calls (see code below). Also, using an implicit for + return loop instead of a direct iter.next() seems odd. While the compiler will likely optimize all of this, the implementation proposed in this pull request will probably compile faster.

In any case, feel free to just close this PR if you think it's redundant.

cc @scottmcm.

P.S. More explicit old code:

```rust
impl<I, R> Iterator for GenericShunt<'_, I, R>
where
    I: Iterator<Item: Try<Residual = R>>,
{
    type Item = <I::Item as Try>::Output;

    fn next(&mut self) -> Option<Self::Item> {
        let result = self.iter.try_fold((), |acc, x| match <I::Item as Try>::branch(x) {
            ControlFlow::Continue(x) => ControlFlow::Break(ControlFlow::Break(x)),
            ControlFlow::Break(r) => {
                *self.residual = Some(r);
                ControlFlow::Break(ControlFlow::Continue(acc))
            }
        });

        let out = match result {
            ControlFlow::Continue(val) => return None,
            ControlFlow::Break(val) => match val {
                ControlFlow::Continue(_) => return None,
                ControlFlow::Break(val) => val,
            },
        };
        Some(out)
    }
}
```