### PR TITLE
Specialize iter::Chain<A, B>::next when A==B

### DIFF
--- a/library/core/benches/iter.rs
+++ b/library/core/benches/iter.rs
@@ -201,7 +201,7 @@ fn bench_for_each_chain_ref_fold(b: &mut Bencher) {
 /// Helper to benchmark `sum` for iterators taken by value which
 /// can optimize `fold`, and by reference which cannot.
 macro_rules! bench_sums {
-    ($bench_sum:ident, $bench_ref_sum:ident, $iter:expr) => {
+    ($bench_sum:ident, $bench_ref_sum:ident, $bench_ext_sum:ident, $iter:expr) => {
         #[bench]
         fn $bench_sum(b: &mut Bencher) {
             b.iter(|| -> i64 { $iter.map(black_box).sum() });
@@ -211,144 +211,178 @@ macro_rules! bench_sums {
         fn $bench_ref_sum(b: &mut Bencher) {
             b.iter(|| -> i64 { $iter.map(black_box).by_ref().sum() });
         }
+
+        #[bench]
+        fn $bench_ext_sum(b: &mut Bencher) {
+            b.iter(|| -> i64 {
+                let mut sum = 0;
+                for i in $iter.map(black_box) {
+                    sum += i;
+                }
+                sum
+            });
+        }
     };
 }
 
 bench_sums! {
     bench_flat_map_sum,
     bench_flat_map_ref_sum,
+    bench_flat_map_ext_sum,
     (0i64..1000).flat_map(|x| x..x+1000)
 }
 
 bench_sums! {
     bench_flat_map_chain_sum,
     bench_flat_map_chain_ref_sum,
+    bench_flat_map_chain_ext_sum,
     (0i64..1000000).flat_map(|x| once(x).chain(once(x)))
 }
 
 bench_sums! {
     bench_enumerate_sum,
     bench_enumerate_ref_sum,
+    bench_enumerate_ext_sum,
     (0i64..1000000).enumerate().map(|(i, x)| x * i as i64)
 }
 
 bench_sums! {
     bench_enumerate_chain_sum,
     bench_enumerate_chain_ref_sum,
+    bench_enumerate_chain_ext_sum,
     (0i64..1000000).chain(0..1000000).enumerate().map(|(i, x)| x * i as i64)
 }
 
 bench_sums! {
     bench_filter_sum,
     bench_filter_ref_sum,
+    bench_filter_ext_sum,
     (0i64..1000000).filter(|x| x % 3 == 0)
 }
 
 bench_sums! {
     bench_filter_chain_sum,
     bench_filter_chain_ref_sum,
+    bench_filter_chain_ext_sum,
     (0i64..1000000).chain(0..1000000).filter(|x| x % 3 == 0)
 }
 
 bench_sums! {
     bench_filter_map_sum,
     bench_filter_map_ref_sum,
+    bench_filter_map_ext_sum,
     (0i64..1000000).filter_map(|x| x.checked_mul(x))
 }
 
 bench_sums! {
     bench_filter_map_chain_sum,
     bench_filter_map_chain_ref_sum,
+    bench_filter_map_chain_ext_sum,
     (0i64..1000000).chain(0..1000000).filter_map(|x| x.checked_mul(x))
 }
 
 bench_sums! {
     bench_fuse_sum,
     bench_fuse_ref_sum,
+    bench_fuse_ext_sum,
     (0i64..1000000).fuse()
 }
 
 bench_sums! {
     bench_fuse_chain_sum,
     bench_fuse_chain_ref_sum,
+    bench_fuse_chain_ext_sum,
     (0i64..1000000).chain(0..1000000).fuse()
 }
 
 bench_sums! {
     bench_inspect_sum,
     bench_inspect_ref_sum,
+    bench_inspect_ext_sum,
     (0i64..1000000).inspect(|_| {})
 }
 
 bench_sums! {
     bench_inspect_chain_sum,
     bench_inspect_chain_ref_sum,
+    bench_inspect_chain_ext_sum,
     (0i64..1000000).chain(0..1000000).inspect(|_| {})
 }
 
 bench_sums! {
     bench_peekable_sum,
     bench_peekable_ref_sum,
+    bench_peekable_ext_sum,
     (0i64..1000000).peekable()
 }
 
 bench_sums! {
     bench_peekable_chain_sum,
     bench_peekable_chain_ref_sum,
+    bench_peekable_chain_ext_sum,
     (0i64..1000000).chain(0..1000000).peekable()
 }
 
 bench_sums! {
     bench_skip_sum,
     bench_skip_ref_sum,
+    bench_skip_ext_sum,
     (0i64..1000000).skip(1000)
 }
 
 bench_sums! {
     bench_skip_chain_sum,
     bench_skip_chain_ref_sum,
+    bench_skip_chain_ext_sum,
     (0i64..1000000).chain(0..1000000).skip(1000)
 }
 
 bench_sums! {
     bench_skip_while_sum,
     bench_skip_while_ref_sum,
+    bench_skip_while_ext_sum,
     (0i64..1000000).skip_while(|&x| x < 1000)
 }
 
 bench_sums! {
     bench_skip_while_chain_sum,
     bench_skip_while_chain_ref_sum,
+    bench_skip_while_chain_ext_sum,
     (0i64..1000000).chain(0..1000000).skip_while(|&x| x < 1000)
 }
 
 bench_sums! {
     bench_take_while_chain_sum,
     bench_take_while_chain_ref_sum,
+    bench_take_while_chain_ext_sum,
     (0i64..1000000).chain(1000000..).take_while(|&x| x < 1111111)
 }
 
 bench_sums! {
     bench_cycle_take_sum,
     bench_cycle_take_ref_sum,
+    bench_cycle_take_ext_sum,
     (0..10000).cycle().take(1000000)
 }
 
 bench_sums! {
     bench_cycle_skip_take_sum,
     bench_cycle_skip_take_ref_sum,
+    bench_cycle_skip_take_ext_sum,
     (0..100000).cycle().skip(1000000).take(1000000)
 }
 
 bench_sums! {
     bench_cycle_take_skip_sum,
     bench_cycle_take_skip_ref_sum,
+    bench_cycle_take_skip_ext_sum,
     (0..100000).cycle().take(1000000).skip(100000)
 }
 
 bench_sums! {
     bench_skip_cycle_skip_zip_add_sum,
     bench_skip_cycle_skip_zip_add_ref_sum,
+    bench_skip_cycle_skip_zip_add_ext_sum,
     (0..100000).skip(100).cycle().skip(100)
       .zip((0..100000).cycle().skip(10))
       .map(|(a,b)| a+b)
@@ -359,6 +393,7 @@ bench_sums! {
 bench_sums! {
     bench_slice_chain_sum,
     bench_slice_chain_ref_sum,
+    bench_slice_chain_ext_sum,
     (&[0; 512]).iter().chain((&[1; 512]).iter())
 }
 

--- a/library/core/benches/iter.rs
+++ b/library/core/benches/iter.rs
@@ -356,6 +356,12 @@ bench_sums! {
       .take(1000000)
 }
 
+bench_sums! {
+    bench_slice_chain_sum,
+    bench_slice_chain_ref_sum,
+    (&[0; 512]).iter().chain((&[1; 512]).iter())
+}
+
 // Checks whether Skip<Zip<A,B>> is as fast as Zip<Skip<A>, Skip<B>>, from
 // https://users.rust-lang.org/t/performance-difference-between-iterator-zip-and-skip-order/15743
 #[bench]


### PR DESCRIPTION
This improves external iteration for `Chain` where both sides have the same type.

```
 iter::bench_chain_partial_cmp         337,514         338,658                  1,144    0.34%   x 1.00
 iter::bench_enumerate_chain_ref_sum   3,834,642       1,911,073           -1,923,569  -50.16%   x 2.01
 iter::bench_enumerate_chain_sum       2,393,149       2,405,145               11,996    0.50%   x 1.00
 iter::bench_filter_chain_count        1,769,977       2,020,882              250,905   14.18%   x 0.88
 iter::bench_filter_chain_ref_count    3,961,136       1,911,154           -2,049,982  -51.75%   x 2.07
 iter::bench_filter_chain_ref_sum      1,617,944       1,683,379               65,435    4.04%   x 0.96
 iter::bench_filter_chain_sum          1,663,256       2,104,894              441,638   26.55%   x 0.79
 iter::bench_filter_map_chain_ref_sum  3,646,401       3,638,193               -8,208   -0.23%   x 1.00
 iter::bench_filter_map_chain_sum      1,663,237       1,901,151              237,914   14.30%   x 0.87
 iter::bench_flat_map_chain_ref_sum    12,055,514      13,475,988           1,420,474   11.78%   x 0.89
 iter::bench_flat_map_chain_sum        1,900,258       1,912,229               11,971    0.63%   x 0.99
 iter::bench_for_each_chain_fold       2,205,688       2,218,132               12,444    0.56%   x 0.99
 iter::bench_for_each_chain_loop       4,110,058       2,471,585           -1,638,473  -39.86%   x 1.66
 iter::bench_for_each_chain_ref_fold   4,169,257       1,434,176           -2,735,081  -65.60%   x 2.91
 iter::bench_fuse_chain_ref_sum        3,811,904       3,874,261               62,357    1.64%   x 0.98
 iter::bench_fuse_chain_sum            473,010         476,363                  3,353    0.71%   x 0.99
 iter::bench_inspect_chain_ref_sum     3,981,137       1,075,046           -2,906,091  -73.00%   x 3.70
 iter::bench_inspect_chain_sum         474,636         475,986                  1,350    0.28%   x 1.00
 iter::bench_peekable_chain_ref_sum    3,932,644       1,433,588           -2,499,056  -63.55%   x 2.74
 iter::bench_peekable_chain_sum        475,751         475,416                   -335   -0.07%   x 1.00
 iter::bench_skip_chain_ref_sum        3,930,088       1,433,293           -2,496,795  -63.53%   x 2.74
 iter::bench_skip_chain_sum            478,383         474,852                 -3,531   -0.74%   x 1.01
 iter::bench_skip_while_chain_ref_sum  4,634,693       4,483,621             -151,072   -3.26%   x 1.03
 iter::bench_skip_while_chain_sum      477,349         464,687                -12,662   -2.65%   x 1.03
 iter::bench_slice_chain_ref_sum       842             492                       -350  -41.57%   x 1.71
 iter::bench_slice_chain_sum           443             338                       -105  -23.70%   x 1.31
 iter::bench_take_while_chain_ref_sum  2,194,655       2,126,616              -68,039   -3.10%   x 1.03
 iter::bench_take_while_chain_sum      1,732,017       1,213,209             -518,808  -29.95%   x 1.43
```

Similar to the [optimization in vec_deque::Iter::next](https://github.com/rust-lang/rust/blob/319b88c463fe6f51bb6badbbd3bb97252a60f3a5/library/alloc/src/collections/vec_deque/iter.rs#L43-L56)