### PR TITLE
Iteratively simplify const conditions

### DIFF
--- a/compiler/rustc_mir_transform/src/simplify_branches.rs
+++ b/compiler/rustc_mir_transform/src/simplify_branches.rs
@@ -1,3 +1,4 @@
+use crate::dataflow_const_prop::DataflowConstProp;
 use crate::MirPass;
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
@@ -19,29 +20,42 @@ impl<'tcx> MirPass<'tcx> for SimplifyConstCondition {
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        let param_env = tcx.param_env(body.source.def_id());
-        for block in body.basic_blocks_mut() {
-            let terminator = block.terminator_mut();
-            terminator.kind = match terminator.kind {
-                TerminatorKind::SwitchInt {
-                    discr: Operand::Constant(ref c), ref targets, ..
-                } => {
-                    let constant = c.literal.try_eval_bits(tcx, param_env, c.ty());
-                    if let Some(constant) = constant {
-                        let target = targets.target_for_value(constant);
-                        TerminatorKind::Goto { target }
-                    } else {
-                        continue;
+        loop {
+            let mut changed = false;
+            let param_env = tcx.param_env(body.source.def_id());
+            for block in body.basic_blocks_mut() {
+                let terminator = block.terminator_mut();
+                terminator.kind = match terminator.kind {
+                    TerminatorKind::SwitchInt {
+                        discr: Operand::Constant(ref c),
+                        ref targets,
+                        ..
+                    } => {
+                        let constant = c.literal.try_eval_bits(tcx, param_env, c.ty());
+                        if let Some(constant) = constant {
+                            changed = true;
+                            let target = targets.target_for_value(constant);
+                            TerminatorKind::Goto { target }
+                        } else {
+                            continue;
+                        }
                     }
-                }
-                TerminatorKind::Assert {
-                    target, cond: Operand::Constant(ref c), expected, ..
-                } => match c.literal.try_eval_bool(tcx, param_env) {
-                    Some(v) if v == expected => TerminatorKind::Goto { target },
+                    TerminatorKind::Assert {
+                        target,
+                        cond: Operand::Constant(ref c),
+                        expected,
+                        ..
+                    } => match c.literal.try_eval_bool(tcx, param_env) {
+                        Some(v) if v == expected => {
+                            changed = true;
+                            TerminatorKind::Goto { target }
+                        }
+                        _ => continue,
+                    },
                     _ => continue,
-                },
-                _ => continue,
-            };
+                };
+            }
+            if !changed { break } else { DataflowConstProp.run_pass(tcx, body) }
         }
     }
 }


### PR DESCRIPTION
cc @est31 

It turns out that the drop flags are correctly inserted. However, the intermediate MIR transformation `SimplifyConstCondition` does not clean up the unreachable blocks. In addition, MIR validation understandably does not apply const analysis when tracking storage liveness, despite the fact that the "violating" block is apparently unreachable after applying a few rounds of data-flow const analysis.

We shall take the example from the description of #104843. After applying `SimplifyConstCondition` once, we have the following control flow graph.

![SimplifyConstCondition](https://user-images.githubusercontent.com/6884440/216842440-bfec2666-dc2d-479d-99c9-5184d76ada36.svg)

Note that Block 10 is only reachable if the drop flag `_5` is set to `true`, except that `_5` is always `false`.

There are open questions. Is it desirable to apply `DataflowConstProp` iteratively? Is it the right way to apply this transformation given that we need to perform the patching a few times?

Unfortunately, this will not provide answer to #103108.
