### PR TITLE
create dummy placeholder crate to prevent compiler from panicing

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -5,6 +5,7 @@ use crate::expand::{self, AstFragment, Invocation};
 use crate::module::DirOwnership;
 
 use rustc_ast::attr::MarkedAttrs;
+use rustc_ast::mut_visit::DummyAstNode;
 use rustc_ast::ptr::P;
 use rustc_ast::token::{self, Nonterminal};
 use rustc_ast::tokenstream::TokenStream;
@@ -639,6 +640,10 @@ impl MacResult for DummyResult {
 
     fn make_variants(self: Box<DummyResult>) -> Option<SmallVec<[ast::Variant; 1]>> {
         Some(SmallVec::new())
+    }
+
+    fn make_crate(self: Box<DummyResult>) -> Option<ast::Crate> {
+        Some(DummyAstNode::dummy())
     }
 }
 

--- a/tests/ui/recursion_limit/issue_21102.rs
+++ b/tests/ui/recursion_limit/issue_21102.rs
@@ -1,0 +1,9 @@
+#![recursion_limit="4"]
+#![invalid_attribute]
+#![invalid_attribute]
+#![invalid_attribute]
+#![invalid_attribute]
+#![invalid_attribute]
+//~^ERROR recursion limit reached while expanding
+
+fn main() {}

--- a/tests/ui/recursion_limit/issue_21102.stderr
+++ b/tests/ui/recursion_limit/issue_21102.stderr
@@ -1,0 +1,10 @@
+error: recursion limit reached while expanding `#[invalid_attribute]`
+  --> $DIR/issue_21102.rs:6:1
+   |
+LL | #![invalid_attribute]
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "8"]` attribute to your crate (`issue_21102`)
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This PR is to address the panic found in https://github.com/rust-lang/rust/issues/105700.

There are 2 separate things going on with this panic.
First the code could not generate a dummy response for crate fragment types when it hits the recursion limit.
This PR adds the method to the trait implementation for `DymmyResult` to be able to create a dummy crate node.
This stops the panic from happening.

The second thing that is not addressed (and maybe does not need addressing? 🤷🏻) 
is that when you have multiple attributes it ends up treating attributes that follow another as being the result of expanding the former (maybe there is a better way to say that). So you end up hitting the recursion limit. Even though you would think there is no expansion happening here.

If you did not hit the recursion limit the compiler would output that `invalid_attribute` does not exists. But it currently exits before the resolution step when the recursion limit is reached here.