### PR TITLE
Miri: basic dyn* support

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -632,7 +632,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 }
                 Ok(Some((size, align)))
             }
-            ty::Dynamic(..) => {
+            ty::Dynamic(_, _, ty::Dyn) => {
                 let vtable = metadata.unwrap_meta().to_pointer(self)?;
                 // Read size and align from vtable (already checks size).
                 Ok(Some(self.get_vtable_size_and_align(vtable)?))

--- a/compiler/rustc_const_eval/src/interpret/intern.rs
+++ b/compiler/rustc_const_eval/src/interpret/intern.rs
@@ -242,7 +242,7 @@ impl<'rt, 'mir, 'tcx: 'mir, M: CompileTimeMachine<'mir, 'tcx, const_eval::Memory
             let mplace = self.ecx.ref_to_mplace(&value)?;
             assert_eq!(mplace.layout.ty, referenced_ty);
             // Handle trait object vtables.
-            if let ty::Dynamic(..) =
+            if let ty::Dynamic(_, _, ty::Dyn) =
                 tcx.struct_tail_erasing_lifetimes(referenced_ty, self.ecx.param_env).kind()
             {
                 let ptr = mplace.meta.unwrap_meta().to_pointer(&tcx)?;

--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -567,8 +567,6 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     }
                 };
 
-                //         break self.deref_operand(&receiver)?.into();
-
                 // Obtain the underlying trait we are working on, and the adjusted receiver argument.
                 let recv_ty = receiver.layout.ty;
                 let receiver_place = match recv_ty.kind() {

--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -538,10 +538,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 // pointer or `dyn Trait` type, but it could be wrapped in newtypes. So recursively
                 // unwrap those newtypes until we are there.
                 let mut receiver = args[0].clone();
-                let receiver_place = loop {
+                let receiver = loop {
                     match receiver.layout.ty.kind() {
-                        ty::Ref(..) | ty::RawPtr(..) => break self.deref_operand(&receiver)?,
-                        ty::Dynamic(..) => break receiver.assert_mem_place(), // no immediate unsized values
+                        ty::Dynamic(..) | ty::Ref(..) | ty::RawPtr(..) => break receiver,
                         _ => {
                             // Not there yet, search for the only non-ZST field.
                             let mut non_zst_field = None;
@@ -567,39 +566,83 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         }
                     }
                 };
-                // Obtain the underlying trait we are working on.
-                let receiver_tail = self
-                    .tcx
-                    .struct_tail_erasing_lifetimes(receiver_place.layout.ty, self.param_env);
-                let ty::Dynamic(data, ..) = receiver_tail.kind() else {
-                    span_bug!(self.cur_span(), "dynamic call on non-`dyn` type {}", receiver_tail)
-                };
 
-                // Get the required information from the vtable.
-                let vptr = receiver_place.meta.unwrap_meta().to_pointer(self)?;
-                let (dyn_ty, dyn_trait) = self.get_ptr_vtable(vptr)?;
-                if dyn_trait != data.principal() {
-                    throw_ub_format!(
-                        "`dyn` call on a pointer whose vtable does not match its type"
-                    );
-                }
+                //         break self.deref_operand(&receiver)?.into();
+
+                // Obtain the underlying trait we are working on, and the adjusted receiver argument.
+                let recv_ty = receiver.layout.ty;
+                let (vptr, dyn_ty, adjusted_receiver) = match recv_ty.kind() {
+                    ty::Ref(..) | ty::RawPtr(..)
+                        if matches!(
+                            recv_ty.builtin_deref(true).unwrap().ty.kind(),
+                            ty::Dynamic(_, _, ty::DynStar)
+                        ) =>
+                    {
+                        let receiver = self.deref_operand(&receiver)?;
+                        let ty::Dynamic(data, ..) = receiver.layout.ty.kind() else { bug!() };
+                        let (recv, vptr) = self.unpack_dyn_star(&receiver.into())?;
+                        let (dyn_ty, dyn_trait) = self.get_ptr_vtable(vptr)?;
+                        if dyn_trait != data.principal() {
+                            throw_ub_format!(
+                                "`dyn*` call on a pointer whose vtable does not match its type"
+                            );
+                        }
+                        let recv = recv.assert_mem_place(); // we passed an MPlaceTy to `unpack_dyn_star` so we definitely still have one
+
+                        (vptr, dyn_ty, recv.ptr)
+                    }
+                    ty::Dynamic(_, _, ty::DynStar) => {
+                        // Not clear how to handle this, so far we assume the receiver is always a pointer.
+                        span_bug!(
+                            self.cur_span(),
+                            "by-value calls on a `dyn*`... are those a thing?"
+                        );
+                    }
+                    _ => {
+                        let receiver_place = match recv_ty.kind() {
+                            ty::Ref(..) | ty::RawPtr(..) => self.deref_operand(&receiver)?,
+                            ty::Dynamic(_, _, ty::Dyn) => receiver.assert_mem_place(), // unsized (`dyn`) cannot be immediate
+                            _ => bug!(),
+                        };
+                        // Doesn't have to be a `dyn Trait`, but the unsized tail must be `dyn Trait`.
+                        // (For that reason we also cannot use `unpack_dyn_trait`.)
+                        let receiver_tail = self.tcx.struct_tail_erasing_lifetimes(
+                            receiver_place.layout.ty,
+                            self.param_env,
+                        );
+                        let ty::Dynamic(data, _, ty::Dyn) = receiver_tail.kind() else {
+                            span_bug!(self.cur_span(), "dynamic call on non-`dyn` type {}", receiver_tail)
+                        };
+                        assert!(receiver_place.layout.is_unsized());
+
+                        // Get the required information from the vtable.
+                        let vptr = receiver_place.meta.unwrap_meta().to_pointer(self)?;
+                        let (dyn_ty, dyn_trait) = self.get_ptr_vtable(vptr)?;
+                        if dyn_trait != data.principal() {
+                            throw_ub_format!(
+                                "`dyn` call on a pointer whose vtable does not match its type"
+                            );
+                        }
+
+                        // It might be surprising that we use a pointer as the receiver even if this
+                        // is a by-val case; this works because by-val passing of an unsized `dyn
+                        // Trait` to a function is actually desugared to a pointer.
+                        (vptr, dyn_ty, receiver_place.ptr)
+                    }
+                };
 
                 // Now determine the actual method to call. We can do that in two different ways and
                 // compare them to ensure everything fits.
                 let Some(ty::VtblEntry::Method(fn_inst)) = self.get_vtable_entries(vptr)?.get(idx).copied() else {
                     throw_ub_format!("`dyn` call trying to call something that is not a method")
                 };
+                trace!("Virtual call dispatches to {fn_inst:#?}");
                 if cfg!(debug_assertions) {
                     let tcx = *self.tcx;
 
                     let trait_def_id = tcx.trait_of_item(def_id).unwrap();
                     let virtual_trait_ref =
                         ty::TraitRef::from_method(tcx, trait_def_id, instance.substs);
-                    assert_eq!(
-                        receiver_tail,
-                        virtual_trait_ref.self_ty(),
-                        "mismatch in underlying dyn trait computation within Miri and MIR building",
-                    );
                     let existential_trait_ref =
                         ty::ExistentialTraitRef::erase_self_ty(tcx, virtual_trait_ref);
                     let concrete_trait_ref = existential_trait_ref.with_self_ty(tcx, dyn_ty);
@@ -614,17 +657,12 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     assert_eq!(fn_inst, concrete_method);
                 }
 
-                // `*mut receiver_place.layout.ty` is almost the layout that we
-                // want for args[0]: We have to project to field 0 because we want
-                // a thin pointer.
-                assert!(receiver_place.layout.is_unsized());
-                let receiver_ptr_ty = self.tcx.mk_mut_ptr(receiver_place.layout.ty);
-                let this_receiver_ptr = self.layout_of(receiver_ptr_ty)?.field(self, 0);
-                // Adjust receiver argument.
-                args[0] = OpTy::from(ImmTy::from_immediate(
-                    Scalar::from_maybe_pointer(receiver_place.ptr, self).into(),
-                    this_receiver_ptr,
-                ));
+                // Adjust receiver argument. Layout can be any (thin) ptr.
+                args[0] = ImmTy::from_immediate(
+                    Scalar::from_maybe_pointer(adjusted_receiver, self).into(),
+                    self.layout_of(self.tcx.mk_mut_ptr(dyn_ty))?,
+                )
+                .into();
                 trace!("Patched receiver operand to {:#?}", args[0]);
                 // recurse with concrete function
                 self.eval_fn_call(
@@ -653,15 +691,24 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         // implementation fail -- a problem shared by rustc.
         let place = self.force_allocation(place)?;
 
-        let (instance, place) = match place.layout.ty.kind() {
-            ty::Dynamic(..) => {
+        let place = match place.layout.ty.kind() {
+            ty::Dynamic(_, _, ty::Dyn) => {
                 // Dropping a trait object. Need to find actual drop fn.
-                let place = self.unpack_dyn_trait(&place)?;
-                let instance = ty::Instance::resolve_drop_in_place(*self.tcx, place.layout.ty);
-                (instance, place)
+                self.unpack_dyn_trait(&place)?.0
             }
-            _ => (instance, place),
+            ty::Dynamic(_, _, ty::DynStar) => {
+                // Dropping a `dyn*`. Need to find actual drop fn.
+                self.unpack_dyn_star(&place.into())?.0.assert_mem_place()
+            }
+            _ => {
+                debug_assert_eq!(
+                    instance,
+                    ty::Instance::resolve_drop_in_place(*self.tcx, place.layout.ty)
+                );
+                place
+            }
         };
+        let instance = ty::Instance::resolve_drop_in_place(*self.tcx, place.layout.ty);
         let fn_abi = self.fn_abi_of_instance(instance, ty::List::empty())?;
 
         let arg = ImmTy::from_immediate(

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -478,6 +478,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 } else if matches!(v.layout.fields, FieldsShape::Union(..)) {
                     // A (non-frozen) union. We fall back to whatever the type says.
                     (self.unsafe_cell_action)(v)
+                } else if matches!(v.layout.ty.kind(), ty::Dynamic(_, _, ty::DynStar)) {
+                    // This needs to read the vtable pointer to proceed type-driven, but we don't
+                    // want to reentrantly read from memory here.
+                    (self.unsafe_cell_action)(v)
                 } else {
                     // We want to not actually read from memory for this visit. So, before
                     // walking this value, we have to make sure it is not a

--- a/src/tools/miri/tests/fail/branchless-select-i128-pointer.stderr
+++ b/src/tools/miri/tests/fail/branchless-select-i128-pointer.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference (address $HEX is unallocated)
+error: Undefined Behavior: constructing invalid value: encountered a dangling reference ($HEX[noalloc] has no provenance)
   --> $DIR/branchless-select-i128-pointer.rs:LL:CC
    |
 LL | /             transmute::<_, &str>(
@@ -6,7 +6,7 @@ LL | |
 LL | |                 !mask & transmute::<_, TwoPtrs>("false !")
 LL | |                     | mask & transmute::<_, TwoPtrs>("true !"),
 LL | |             )
-   | |_____________^ constructing invalid value: encountered a dangling reference (address $HEX is unallocated)
+   | |_____________^ constructing invalid value: encountered a dangling reference ($HEX[noalloc] has no provenance)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/dangling_ref1.rs
+++ b/src/tools/miri/tests/fail/validity/dangling_ref1.rs
@@ -3,5 +3,5 @@
 use std::mem;
 
 fn main() {
-    let _x: &i32 = unsafe { mem::transmute(16usize) }; //~ ERROR: encountered a dangling reference (address 0x10 is unallocated)
+    let _x: &i32 = unsafe { mem::transmute(16usize) }; //~ ERROR: encountered a dangling reference
 }

--- a/src/tools/miri/tests/fail/validity/dangling_ref1.stderr
+++ b/src/tools/miri/tests/fail/validity/dangling_ref1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference (address 0x10 is unallocated)
+error: Undefined Behavior: constructing invalid value: encountered a dangling reference (0x10[noalloc] has no provenance)
   --> $DIR/dangling_ref1.rs:LL:CC
    |
 LL |     let _x: &i32 = unsafe { mem::transmute(16usize) };
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (address 0x10 is unallocated)
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (0x10[noalloc] has no provenance)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/pass/dyn-star.rs
+++ b/src/tools/miri/tests/pass/dyn-star.rs
@@ -1,5 +1,3 @@
-// Dyn* handling leads to some funky reentrancy in Stacked Borrows, for some reason
-//@compile-flags: -Zmiri-disable-stacked-borrows
 #![feature(dyn_star)]
 #![allow(incomplete_features)]
 

--- a/src/tools/miri/tests/pass/dyn-star.rs
+++ b/src/tools/miri/tests/pass/dyn-star.rs
@@ -1,0 +1,118 @@
+// Dyn* handling leads to some funky reentrancy in Stacked Borrows, for some reason
+//@compile-flags: -Zmiri-disable-stacked-borrows
+#![feature(dyn_star)]
+#![allow(incomplete_features)]
+
+use std::fmt::{Debug, Display};
+
+fn main() {
+    make_dyn_star();
+    method();
+    box_();
+    dispatch_on_pin_mut();
+    dyn_star_to_dyn();
+    dyn_to_dyn_star();
+}
+
+fn dyn_star_to_dyn() {
+    let x: dyn* Debug = &42;
+    let x = Box::new(x) as Box<dyn Debug>;
+    assert_eq!("42", format!("{x:?}"));
+}
+
+fn dyn_to_dyn_star() {
+    let x: Box<dyn Debug> = Box::new(42);
+    let x = &x as dyn* Debug;
+    assert_eq!("42", format!("{x:?}"));
+}
+
+fn make_dyn_star() {
+    fn make_dyn_star_coercion(i: usize) {
+        let _dyn_i: dyn* Debug = i;
+    }
+
+    fn make_dyn_star_explicit(i: usize) {
+        let _dyn_i: dyn* Debug = i as dyn* Debug;
+    }
+
+    make_dyn_star_coercion(42);
+    make_dyn_star_explicit(42);
+}
+
+fn method() {
+    trait Foo {
+        fn get(&self) -> usize;
+    }
+    
+    impl Foo for usize {
+        fn get(&self) -> usize {
+            *self
+        }
+    }
+    
+    fn invoke_dyn_star(i: dyn* Foo) -> usize {
+        i.get()
+    }
+    
+    fn make_and_invoke_dyn_star(i: usize) -> usize {
+        let dyn_i: dyn* Foo = i;
+        invoke_dyn_star(dyn_i)
+    }
+    
+    assert_eq!(make_and_invoke_dyn_star(42), 42);
+}
+
+fn box_() {
+    fn make_dyn_star() -> dyn* Display {
+        Box::new(42) as dyn* Display
+    }
+    
+    let x = make_dyn_star();
+    assert_eq!(format!("{x}"), "42");
+}
+
+fn dispatch_on_pin_mut() {
+    use std::future::Future;
+
+    async fn foo(f: dyn* Future<Output = i32>) {
+        println!("dispatch_on_pin_mut: value: {}", f.await);
+    }
+
+    async fn async_main() {
+        foo(Box::pin(async { 1 })).await
+    }
+
+    // ------------------------------------------------------------------------- //
+    // Implementation Details Below...
+
+    use std::pin::Pin;
+    use std::task::*;
+
+    pub fn noop_waker() -> Waker {
+        let raw = RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE);
+
+        // SAFETY: the contracts for RawWaker and RawWakerVTable are upheld
+        unsafe { Waker::from_raw(raw) }
+    }
+
+    const NOOP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
+
+    unsafe fn noop_clone(_p: *const ()) -> RawWaker {
+        RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE)
+    }
+
+    unsafe fn noop(_p: *const ()) {}
+
+    let mut fut = async_main();
+
+    // Poll loop, just to test the future...
+    let waker = noop_waker();
+    let ctx = &mut Context::from_waker(&waker);
+
+    loop {
+        match unsafe { Pin::new_unchecked(&mut fut).poll(ctx) } {
+            Poll::Pending => {}
+            Poll::Ready(()) => break,
+        }
+    }
+}

--- a/src/tools/miri/tests/pass/dyn-star.stdout
+++ b/src/tools/miri/tests/pass/dyn-star.stdout
@@ -1,0 +1,1 @@
+dispatch_on_pin_mut: value: 1

--- a/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
@@ -167,7 +167,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/raw-bytes.rs:96:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (address 0x539 is unallocated)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (0x539[noalloc] has no provenance)
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
@@ -178,7 +178,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/raw-bytes.rs:99:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (address 0x539 is unallocated)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (0x539[noalloc] has no provenance)
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {

--- a/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
@@ -167,7 +167,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/raw-bytes.rs:96:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (address 0x539 is unallocated)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (0x539[noalloc] has no provenance)
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
@@ -178,7 +178,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/raw-bytes.rs:99:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (address 0x539 is unallocated)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (0x539[noalloc] has no provenance)
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {

--- a/tests/ui/consts/const-eval/ub-ref-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.stderr
@@ -85,7 +85,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref-ptr.rs:43:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (address 0x539 is unallocated)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (0x539[noalloc] has no provenance)
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
@@ -96,7 +96,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref-ptr.rs:46:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (address 0x539 is unallocated)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (0x539[noalloc] has no provenance)
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {

--- a/tests/ui/dyn-star/dyn-star-to-dyn.rs
+++ b/tests/ui/dyn-star/dyn-star-to-dyn.rs
@@ -1,9 +1,17 @@
-// build-pass
+// run-pass
 
 #![feature(dyn_star)]
 //~^ WARN the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
 
+use std::fmt::Debug;
+
 fn main() {
-    let x: dyn* Send = &();
-    let x = Box::new(x) as Box<dyn Send>;
+    let x: dyn* Debug = &42;
+    let x = Box::new(x) as Box<dyn Debug>;
+    assert_eq!("42", format!("{x:?}"));
+
+    // Also test opposite direction.
+    let x: Box<dyn Debug> = Box::new(42);
+    let x = &x as dyn* Debug;
+    assert_eq!("42", format!("{x:?}"));
 }


### PR DESCRIPTION
As usual I am very unsure about the dynamic dispatch stuff, but it passes even the `Pin<&mut dyn* Trait>` test so that is something.

TBH I think it was a mistake to make `dyn Trait` and `dyn* Trait` part of the same `TyKind` variant. Almost everywhere in Miri this lead to the wrong default behavior, resulting in strange ICEs instead of nice "unimplemented" messages. The two types describe pretty different runtime data layout after all.

Strangely I did not need to do the equivalent of [this diff](https://github.com/rust-lang/rust/pull/106532#discussion_r1087095963) in Miri. Maybe that is because the unsizing logic matches on `ty::Dynamic(.., ty::Dyn)` already? In `unsized_info` I don't think the `target_dyn_kind` can be `DynStar`, since then it wouldn't be unsized!

r? @oli-obk Cc @eholk (dyn-star) https://github.com/rust-lang/rust/issues/102425