### PR TITLE
[WIP] Move drop elaboration before borrowck

### DIFF
--- a/compiler/rustc_borrowck/src/def_use.rs
+++ b/compiler/rustc_borrowck/src/def_use.rs
@@ -54,7 +54,7 @@ pub fn categorize(context: PlaceContext) -> Option<DefUse> {
 
         PlaceContext::MutatingUse(MutatingUseContext::AddressOf) |
         PlaceContext::NonMutatingUse(NonMutatingUseContext::AddressOf) |
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::Inspect) |
+        PlaceContext::NonMutatingUse(NonMutatingUseContext::Inspect(_)) |
         PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy) |
         PlaceContext::NonMutatingUse(NonMutatingUseContext::Move) |
         PlaceContext::NonUse(NonUseContext::AscribeUserTy) |

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -939,7 +939,22 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             return OtherUse(use_span);
         }
 
-        for stmt in &self.body[location.block].statements[location.statement_index + 1..] {
+        // drop and replace might have moved the assignment to the next block
+        let maybe_additional_statement = if let Some(Terminator {
+            kind: TerminatorKind::Drop { target: drop_target, .. },
+            ..
+        }) = self.body[location.block].terminator
+        {
+            self.body[drop_target].statements.iter().take(1)
+        } else {
+            [].iter().take(0)
+        };
+
+        let statements = self.body[location.block].statements[location.statement_index + 1..]
+            .iter()
+            .chain(maybe_additional_statement);
+
+        for stmt in statements {
             if let StatementKind::Assign(box (_, Rvalue::Aggregate(kind, places))) = &stmt.kind {
                 let (&def_id, is_generator) = match kind {
                     box AggregateKind::Closure(def_id, _) => (def_id, false),

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -828,7 +828,13 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             let Some(hir::Node::Item(item)) = node else { return; };
             let hir::ItemKind::Fn(.., body_id) = item.kind else { return; };
             let body = self.infcx.tcx.hir().body(body_id);
-            let mut v = V { assign_span: span, err, ty, suggested: false };
+            let mut assign_span = span;
+            // Drop desugaring is done at MIR build so it's not in the HIR
+            if let Some(DesugaringKind::Replace) = span.desugaring_kind() {
+                assign_span.remove_mark();
+            }
+
+            let mut v = V { assign_span, err, ty, suggested: false };
             v.visit_body(body);
             if !v.suggested {
                 err.help(&format!(

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -36,7 +36,7 @@ use rustc_middle::mir::{InlineAsmOperand, Terminator, TerminatorKind};
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, CapturedPlace, ParamEnv, RegionVid, TyCtxt};
 use rustc_session::lint::builtin::UNUSED_MUT;
-use rustc_span::{Span, Symbol};
+use rustc_span::{DesugaringKind, Span, Symbol};
 
 use either::Either;
 use smallvec::SmallVec;
@@ -578,7 +578,7 @@ impl<'cx, 'tcx> rustc_mir_dataflow::ResultsVisitor<'cx, 'tcx> for MirBorrowckCtx
             StatementKind::Assign(box (lhs, rhs)) => {
                 // FIXME: drop-elaboration checks the discriminant of an enum after it has been
                 // moved out. This is a known isses and should be fixed in the future.
-                if !matches!(rhs, Rvalue::Discriminant(_)) {
+                if !(matches!(rhs, Rvalue::Discriminant(_)) && span.desugaring_kind() == Some(DesugaringKind::Drop)) {
                     self.consume_rvalue(location, (rhs, span), flow_state);
                 }
 

--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -230,7 +230,7 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
                 | MutatingUseContext::Projection,
             )
             | PlaceContext::NonMutatingUse(
-                NonMutatingUseContext::Inspect
+                NonMutatingUseContext::Inspect(_)
                 | NonMutatingUseContext::SharedBorrow
                 | NonMutatingUseContext::UniqueBorrow
                 | NonMutatingUseContext::ShallowBorrow

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -3,7 +3,6 @@ use rustc_hir::lang_items::LangItem;
 use rustc_index::vec::Idx;
 use rustc_middle::mir::patch::MirPatch;
 use rustc_middle::mir::*;
-use rustc_middle::traits::Reveal;
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::util::IntTypeExt;
 use rustc_middle::ty::{self, Ty, TyCtxt};
@@ -273,7 +272,6 @@ where
                 let subpath = self.elaborator.field_subpath(variant_path, field);
                 let tcx = self.tcx();
 
-                assert_eq!(self.elaborator.param_env().reveal(), Reveal::All);
                 let field_ty =
                     tcx.normalize_erasing_regions(self.elaborator.param_env(), f.ty(tcx, substs));
                 (tcx.mk_place_field(base_place, field, field_ty), subpath)

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -185,6 +185,16 @@ pub fn elaborate_drop<'b, 'tcx, D>(
     D: DropElaborator<'b, 'tcx>,
     'tcx: 'b,
 {
+    use rustc_span::DesugaringKind;
+    let span = elaborator.tcx().with_stable_hashing_context(|hcx| {
+        source_info.span.mark_with_reason(
+            None,
+            DesugaringKind::Drop,
+            elaborator.tcx().sess.edition(),
+            hcx,
+        )
+    });
+    let source_info = SourceInfo { span, ..source_info };
     DropCtxt { elaborator, source_info, place, path, succ, unwind }.elaborate_drop(bb)
 }
 

--- a/compiler/rustc_mir_dataflow/src/impls/liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/liveness.rs
@@ -195,7 +195,7 @@ impl DefUse {
             | PlaceContext::NonMutatingUse(
                 NonMutatingUseContext::AddressOf
                 | NonMutatingUseContext::Copy
-                | NonMutatingUseContext::Inspect
+                | NonMutatingUseContext::Inspect(_)
                 | NonMutatingUseContext::Move
                 | NonMutatingUseContext::ShallowBorrow
                 | NonMutatingUseContext::SharedBorrow

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -934,7 +934,7 @@ impl Visitor<'_> for CanConstProp {
             // Reading constants is allowed an arbitrary number of times
             NonMutatingUse(NonMutatingUseContext::Copy)
             | NonMutatingUse(NonMutatingUseContext::Move)
-            | NonMutatingUse(NonMutatingUseContext::Inspect)
+            | NonMutatingUse(NonMutatingUseContext::Inspect(_))
             | NonMutatingUse(NonMutatingUseContext::Projection)
             | NonUse(_) => {}
 

--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -1,3 +1,4 @@
+use crate::simplify::remove_dead_blocks;
 use crate::MirPass;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_index::bit_set::BitSet;
@@ -68,6 +69,9 @@ impl<'tcx> MirPass<'tcx> for ElaborateDrops {
             .elaborate()
         };
         elaborate_patch.apply(body);
+
+        remove_dead_blocks(tcx, body);
+        body.basic_blocks_mut().raw.shrink_to_fit();
     }
 }
 

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -342,7 +342,6 @@ fn mir_promoted(
             // These next passes must be executed together
             &add_call_guards::CriticalCallEdges,
             &elaborate_drops::ElaborateDrops,
-            &simplify::SimplifyCfg::new("elaborate-drops"),
             &coverage::InstrumentCoverage,
         ],
         Some(MirPhase::Analysis(AnalysisPhase::Initial)),

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -1151,6 +1151,7 @@ pub enum DesugaringKind {
     Await,
     ForLoop,
     WhileLoop,
+    Replace,
 }
 
 impl DesugaringKind {
@@ -1166,6 +1167,7 @@ impl DesugaringKind {
             DesugaringKind::OpaqueTy => "`impl Trait`",
             DesugaringKind::ForLoop => "`for` loop",
             DesugaringKind::WhileLoop => "`while` loop",
+            DesugaringKind::Replace => "drop and replace",
         }
     }
 }

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -1152,6 +1152,8 @@ pub enum DesugaringKind {
     ForLoop,
     WhileLoop,
     Replace,
+    /// Code inserted by the compiler as part of drop elaboration
+    Drop,
 }
 
 impl DesugaringKind {
@@ -1168,6 +1170,7 @@ impl DesugaringKind {
             DesugaringKind::ForLoop => "`for` loop",
             DesugaringKind::WhileLoop => "`while` loop",
             DesugaringKind::Replace => "drop and replace",
+            DesugaringKind::Drop => "drop elaboration",
         }
     }
 }

--- a/tests/ui/borrowck/borrowck-vec-pattern-nesting.rs
+++ b/tests/ui/borrowck/borrowck-vec-pattern-nesting.rs
@@ -1,6 +1,5 @@
 #![feature(box_patterns)]
 
-
 fn a() {
     let mut vec = [Box::new(1), Box::new(2), Box::new(3)];
     match vec {
@@ -8,6 +7,7 @@ fn a() {
         //~^ NOTE `vec[_]` is borrowed here
             vec[0] = Box::new(4); //~ ERROR cannot assign
             //~^ NOTE `vec[_]` is assigned to here
+            //~| NOTE in this expansion of desugaring of drop and replace
             _a.use_ref();
             //~^ NOTE borrow later used here
         }
@@ -22,6 +22,7 @@ fn b() {
         //~^ `vec[_]` is borrowed here
             vec[0] = Box::new(4); //~ ERROR cannot assign
             //~^ NOTE `vec[_]` is assigned to here
+            //~| NOTE in this expansion of desugaring of drop and replace
             _b.use_ref();
             //~^ NOTE borrow later used here
         }
@@ -44,9 +45,9 @@ fn c() {
         _ => {}
     }
     let a = vec[0]; //~ ERROR cannot move out
-    //~| NOTE cannot move out of here
-    //~| NOTE move occurs because
-    //~| HELP consider borrowing here
+                    //~| NOTE cannot move out of here
+                    //~| NOTE move occurs because
+                    //~| HELP consider borrowing here
 }
 
 fn d() {
@@ -63,9 +64,9 @@ fn d() {
         _ => {}
     }
     let a = vec[0]; //~ ERROR cannot move out
-    //~| NOTE cannot move out of here
-    //~| NOTE move occurs because
-    //~| HELP consider borrowing here
+                    //~| NOTE cannot move out of here
+                    //~| NOTE move occurs because
+                    //~| HELP consider borrowing here
 }
 
 fn e() {
@@ -83,12 +84,15 @@ fn e() {
         _ => {}
     }
     let a = vec[0]; //~ ERROR cannot move out
-    //~| NOTE cannot move out of here
-    //~| NOTE move occurs because
-    //~| HELP consider borrowing here
+                    //~| NOTE cannot move out of here
+                    //~| NOTE move occurs because
+                    //~| HELP consider borrowing here
 }
 
 fn main() {}
 
-trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
-impl<T> Fake for T { }
+trait Fake {
+    fn use_mut(&mut self) {}
+    fn use_ref(&self) {}
+}
+impl<T> Fake for T {}

--- a/tests/ui/borrowck/borrowck-vec-pattern-nesting.stderr
+++ b/tests/ui/borrowck/borrowck-vec-pattern-nesting.stderr
@@ -1,12 +1,12 @@
 error[E0506]: cannot assign to `vec[_]` because it is borrowed
-  --> $DIR/borrowck-vec-pattern-nesting.rs:9:13
+  --> $DIR/borrowck-vec-pattern-nesting.rs:8:13
    |
 LL |         [box ref _a, _, _] => {
    |              ------ `vec[_]` is borrowed here
 LL |
 LL |             vec[0] = Box::new(4);
    |             ^^^^^^ `vec[_]` is assigned to here but it was already borrowed
-LL |
+...
 LL |             _a.use_ref();
    |             ------------ borrow later used here
 
@@ -18,12 +18,12 @@ LL |         &mut [ref _b @ ..] => {
 LL |
 LL |             vec[0] = Box::new(4);
    |             ^^^^^^ `vec[_]` is assigned to here but it was already borrowed
-LL |
+...
 LL |             _b.use_ref();
    |             ------------ borrow later used here
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
-  --> $DIR/borrowck-vec-pattern-nesting.rs:34:11
+  --> $DIR/borrowck-vec-pattern-nesting.rs:35:11
    |
 LL |     match vec {
    |           ^^^ cannot move out of here
@@ -41,7 +41,7 @@ LL +         [_a,
    |
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
-  --> $DIR/borrowck-vec-pattern-nesting.rs:46:13
+  --> $DIR/borrowck-vec-pattern-nesting.rs:47:13
    |
 LL |     let a = vec[0];
    |             ^^^^^^
@@ -55,7 +55,7 @@ LL |     let a = &vec[0];
    |             +
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
-  --> $DIR/borrowck-vec-pattern-nesting.rs:55:11
+  --> $DIR/borrowck-vec-pattern-nesting.rs:56:11
    |
 LL |     match vec {
    |           ^^^ cannot move out of here
@@ -73,7 +73,7 @@ LL +         [
    |
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
-  --> $DIR/borrowck-vec-pattern-nesting.rs:65:13
+  --> $DIR/borrowck-vec-pattern-nesting.rs:66:13
    |
 LL |     let a = vec[0];
    |             ^^^^^^
@@ -87,7 +87,7 @@ LL |     let a = &vec[0];
    |             +
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
-  --> $DIR/borrowck-vec-pattern-nesting.rs:74:11
+  --> $DIR/borrowck-vec-pattern-nesting.rs:75:11
    |
 LL |     match vec {
    |           ^^^ cannot move out of here
@@ -106,7 +106,7 @@ LL +         [_a, _b, _c] => {}
    |
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
-  --> $DIR/borrowck-vec-pattern-nesting.rs:85:13
+  --> $DIR/borrowck-vec-pattern-nesting.rs:86:13
    |
 LL |     let a = vec[0];
    |             ^^^^^^

--- a/tests/ui/borrowck/issue-45199.rs
+++ b/tests/ui/borrowck/issue-45199.rs
@@ -2,23 +2,27 @@ fn test_drop_replace() {
     let b: Box<isize>;
     //~^ HELP consider making this binding mutable
     //~| SUGGESTION mut b
-    b = Box::new(1);    //~ NOTE first assignment
-    b = Box::new(2);    //~ ERROR cannot assign twice to immutable variable `b`
-                        //~| NOTE cannot assign twice to immutable
+    b = Box::new(1); //~ NOTE first assignment
+    b = Box::new(2); //~ ERROR cannot assign twice to immutable variable `b`
+                     //~| NOTE cannot assign twice to immutable
+                     //~| NOTE in this expansion of desugaring of drop and replace
 }
 
 fn test_call() {
-    let b = Box::new(1);    //~ NOTE first assignment
-                            //~| HELP consider making this binding mutable
-                            //~| SUGGESTION mut b
-    b = Box::new(2);        //~ ERROR cannot assign twice to immutable variable `b`
-                            //~| NOTE cannot assign twice to immutable
+    let b = Box::new(1); //~ NOTE first assignment
+                         //~| HELP consider making this binding mutable
+                         //~| SUGGESTION mut b
+    b = Box::new(2); //~ ERROR cannot assign twice to immutable variable `b`
+                     //~| NOTE cannot assign twice to immutable
+                     //~| NOTE in this expansion of desugaring of drop and replace
 }
 
-fn test_args(b: Box<i32>) {  //~ HELP consider making this binding mutable
-                                //~| SUGGESTION mut b
-    b = Box::new(2);            //~ ERROR cannot assign to immutable argument `b`
-                                //~| NOTE cannot assign to immutable argument
+fn test_args(b: Box<i32>) { //~ HELP consider making this binding mutable
+                            //~| SUGGESTION mut b
+
+    b = Box::new(2); //~ ERROR cannot assign to immutable argument `b`
+                     //~| NOTE cannot assign to immutable argument
+                     //~| NOTE in this expansion of desugaring of drop and replace
 }
 
 fn main() {}

--- a/tests/ui/borrowck/issue-45199.stderr
+++ b/tests/ui/borrowck/issue-45199.stderr
@@ -10,7 +10,7 @@ LL |     b = Box::new(2);
    |     ^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/issue-45199.rs:14:5
+  --> $DIR/issue-45199.rs:15:5
    |
 LL |     let b = Box::new(1);
    |         -
@@ -22,11 +22,11 @@ LL |     b = Box::new(2);
    |     ^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign to immutable argument `b`
-  --> $DIR/issue-45199.rs:20:5
+  --> $DIR/issue-45199.rs:23:5
    |
 LL | fn test_args(b: Box<i32>) {
    |              - help: consider making this binding mutable: `mut b`
-LL |
+...
 LL |     b = Box::new(2);
    |     ^ cannot assign to immutable argument
 

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.rs
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.rs
@@ -5,8 +5,8 @@ fn test() {
     drop(b);
     b = Box::new(2); //~ ERROR cannot assign twice to immutable variable `b`
                      //~| NOTE cannot assign twice to immutable
+                     //~| NOTE in this expansion of desugaring of drop and replace
     drop(b);
 }
 
-fn main() {
-}
+fn main() {}


### PR DESCRIPTION
Proof of concept to show what's needed to move drop elaboration before borrow checking. Ideally we could have it right after MIR build, but this tries to be as minimal as possible.

There are a few hacks, mostly around drop-elaboration code that does not pass borrowck / move analysis.

I plan to work on the remaining failing tests in the coming days