### PR TITLE
 Rename atomic 'as_mut_ptr' to 'as_ptr' to match Cell (ref #66893) 

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -922,13 +922,13 @@ impl AtomicBool {
     ///
     /// let mut atomic = AtomicBool::new(true);
     /// unsafe {
-    ///     my_atomic_op(atomic.as_mut_ptr());
+    ///     my_atomic_op(atomic.as_ptr());
     /// }
     /// # }
     /// ```
     #[inline]
     #[unstable(feature = "atomic_mut_ptr", reason = "recently added", issue = "66893")]
-    pub const fn as_mut_ptr(&self) -> *mut bool {
+    pub const fn as_ptr(&self) -> *mut bool {
         self.v.get().cast()
     }
 
@@ -1814,12 +1814,12 @@ impl<T> AtomicPtr<T> {
     ///
     /// // SAFETY: Safe as long as `my_atomic_op` is atomic.
     /// unsafe {
-    ///     my_atomic_op(atomic.as_mut_ptr());
+    ///     my_atomic_op(atomic.as_ptr());
     /// }
     /// ```
     #[inline]
     #[unstable(feature = "atomic_mut_ptr", reason = "recently added", issue = "66893")]
-    pub const fn as_mut_ptr(&self) -> *mut *mut T {
+    pub const fn as_ptr(&self) -> *mut *mut T {
         self.p.get()
     }
 }
@@ -2719,7 +2719,7 @@ macro_rules! atomic_int {
             ///
             /// // SAFETY: Safe as long as `my_atomic_op` is atomic.
             /// unsafe {
-            ///     my_atomic_op(atomic.as_mut_ptr());
+            ///     my_atomic_op(atomic.as_ptr());
             /// }
             /// # }
             /// ```
@@ -2727,7 +2727,7 @@ macro_rules! atomic_int {
             #[unstable(feature = "atomic_mut_ptr",
                    reason = "recently added",
                    issue = "66893")]
-            pub const fn as_mut_ptr(&self) -> *mut $int_type {
+            pub const fn as_ptr(&self) -> *mut $int_type {
                 self.v.get()
             }
         }

--- a/library/std/src/sys_common/thread_parking/id.rs
+++ b/library/std/src/sys_common/thread_parking/id.rs
@@ -60,7 +60,7 @@ impl Parker {
         if state == PARKED {
             // Loop to guard against spurious wakeups.
             while state == PARKED {
-                park(self.state.as_mut_ptr().addr());
+                park(self.state.as_ptr().addr());
                 state = self.state.load(Acquire);
             }
 
@@ -76,7 +76,7 @@ impl Parker {
 
         let state = self.state.fetch_sub(1, Acquire).wrapping_sub(1);
         if state == PARKED {
-            park_timeout(dur, self.state.as_mut_ptr().addr());
+            park_timeout(dur, self.state.as_ptr().addr());
             // Swap to ensure that we observe all state changes with acquire
             // ordering, even if the state has been changed after the timeout
             // occured.
@@ -99,7 +99,7 @@ impl Parker {
             // and terminated before this call is made. This call then returns an
             // error or wakes up an unrelated thread. The platform API and
             // environment does allow this, however.
-            unpark(tid, self.state.as_mut_ptr().addr());
+            unpark(tid, self.state.as_ptr().addr());
         }
     }
 }


### PR DESCRIPTION
Originally discussed in https://github.com/rust-lang/rust/issues/66893#issuecomment-1419198623

~~This uses #107706 as a base to avoid a merge conflict once that gets rolled up (so disregard const changes in the diff until it does)~~ all merged & rebased

@rustbot label +T-libs-api
r? m-ou-se