### PR TITLE
llvm-16: Use Triple.h from new header location.

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
+++ b/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
@@ -4,7 +4,6 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/Triple.h"
 #include "llvm/Analysis/Lint.h"
 #include "llvm/Analysis/Passes.h"
 #include "llvm/IR/IRBuilder.h"
@@ -43,6 +42,12 @@
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/IRPrintingPasses.h"
 #include "llvm/Linker/Linker.h"
+
+#if LLVM_VERSION_GE(16, 0)
+#include "llvm/TargetParser/Triple.h"
+#else
+#include "llvm/ADT/Triple.h"
+#endif
 
 extern "C" void LLVMRustSetLastError(const char *);
 


### PR DESCRIPTION
LLVM 16 has moved Triple.h from ADT and into TargetParser.

LLVM [landed a commit](https://github.com/llvm/llvm-project/commit/62c7f035b4392c1933550eead6ddab35122720bc) this morning moving the header. This change should make rustc continue to build against LLVM main.