### PR TITLE
rustdoc: simplify DOM for `.item-table`

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -39,10 +39,10 @@ use crate::html::{highlight, static_files};
 use askama::Template;
 use itertools::Itertools;
 
-const ITEM_TABLE_OPEN: &str = "<div class=\"item-table\">";
-const ITEM_TABLE_CLOSE: &str = "</div>";
-const ITEM_TABLE_ROW_OPEN: &str = "<div class=\"item-row\">";
-const ITEM_TABLE_ROW_CLOSE: &str = "</div>";
+const ITEM_TABLE_OPEN: &str = "<ul class=\"item-table\">";
+const ITEM_TABLE_CLOSE: &str = "</ul>";
+const ITEM_TABLE_ROW_OPEN: &str = "<li>";
+const ITEM_TABLE_ROW_CLOSE: &str = "</li>";
 
 // A component in a `use` path, like `string` in std::string::ToString
 struct PathComponent {
@@ -338,14 +338,14 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                 match *src {
                     Some(src) => write!(
                         w,
-                        "<div class=\"item-left\"><code>{}extern crate {} as {};",
+                        "<div class=\"item-name\"><code>{}extern crate {} as {};",
                         visibility_print_with_space(myitem.visibility(tcx), myitem.item_id, cx),
                         anchor(myitem.item_id.expect_def_id(), src, cx),
                         myitem.name.unwrap(),
                     ),
                     None => write!(
                         w,
-                        "<div class=\"item-left\"><code>{}extern crate {};",
+                        "<div class=\"item-name\"><code>{}extern crate {};",
                         visibility_print_with_space(myitem.visibility(tcx), myitem.item_id, cx),
                         anchor(myitem.item_id.expect_def_id(), myitem.name.unwrap(), cx),
                     ),
@@ -384,11 +384,11 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                 let (stab_tags_before, stab_tags_after) = if stab_tags.is_empty() {
                     ("", "")
                 } else {
-                    ("<div class=\"item-right docblock-short\">", "</div>")
+                    ("<div class=\"desc docblock-short\">", "</div>")
                 };
                 write!(
                     w,
-                    "<div class=\"item-left\"{id}>\
+                    "<div class=\"item-name\"{id}>\
                          <code>{vis}{imp}</code>\
                      </div>\
                      {stab_tags_before}{stab_tags}{stab_tags_after}",
@@ -426,11 +426,11 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                 let (docs_before, docs_after) = if docs.is_empty() {
                     ("", "")
                 } else {
-                    ("<div class=\"item-right docblock-short\">", "</div>")
+                    ("<div class=\"desc docblock-short\">", "</div>")
                 };
                 write!(
                     w,
-                    "<div class=\"item-left\">\
+                    "<div class=\"item-name\">\
                         <a class=\"{class}\" href=\"{href}\" title=\"{title}\">{name}</a>\
                         {visibility_emoji}\
                         {unsafety_flag}\

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -193,7 +193,7 @@ h1, h2, h3, h4, h5, h6,
 .mobile-topbar,
 .search-input,
 .search-results .result-name,
-.item-left > a,
+.item-name > a,
 .out-of-band,
 span.since,
 a.srclink,
@@ -742,14 +742,16 @@ table,
 
 .item-table {
 	display: table;
+	padding: 0;
+	margin: 0;
 }
-.item-row {
+.item-table > li {
 	display: table-row;
 }
-.item-left, .item-right {
+.item-table > li > div {
 	display: table-cell;
 }
-.item-left {
+.item-table > li > .item-name {
 	padding-right: 1.25rem;
 }
 
@@ -954,7 +956,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	padding: 3px;
 	margin-bottom: 5px;
 }
-.item-left .stab {
+.item-name .stab {
 	margin-left: 0.3125em;
 }
 .stab {
@@ -1723,7 +1725,7 @@ in storage.js
 	}
 
 	/* Display an alternating layout on tablets and phones */
-	.item-table, .item-row, .item-left, .item-right,
+	.item-table, .item-row, .item-table > li, .item-table > li > div,
 	.search-results > a, .search-results > a > div {
 		display: block;
 	}
@@ -1732,7 +1734,7 @@ in storage.js
 	.search-results > a {
 		padding: 5px 0px;
 	}
-	.search-results > a > div.desc, .item-right {
+	.search-results > a > div.desc, .item-table > li > div.desc {
 		padding-left: 2em;
 	}
 

--- a/tests/rustdoc-gui/huge-collection-of-constants.goml
+++ b/tests/rustdoc-gui/huge-collection-of-constants.goml
@@ -3,7 +3,7 @@
 goto: "file://" + |DOC_PATH| + "/test_docs/huge_amount_of_consts/index.html"
 
 compare-elements-position-near-false: (
-    "//*[@class='item-table']//div[last()-1]",
-    "//*[@class='item-table']//div[last()-3]",
+    "//ul[@class='item-table']/li[last()-1]",
+    "//ul[@class='item-table']/li[last()-3]",
     {"y": 12},
 )

--- a/tests/rustdoc-gui/item-summary-table.goml
+++ b/tests/rustdoc-gui/item-summary-table.goml
@@ -1,6 +1,6 @@
 // This test ensures that <table> elements aren't display in items summary.
 goto: "file://" + |DOC_PATH| + "/lib2/summary_table/index.html"
 // We check that we picked the right item first.
-assert-text: (".item-table .item-left", "Foo")
+assert-text: (".item-table .item-name", "Foo")
 // Then we check that its summary is empty.
-assert-false: ".item-table .item-right"
+assert-false: ".item-table .desc"

--- a/tests/rustdoc-gui/label-next-to-symbol.goml
+++ b/tests/rustdoc-gui/label-next-to-symbol.goml
@@ -9,31 +9,31 @@ assert: (".stab.portability")
 
 // make sure that deprecated and portability have the right colors
 assert-css: (
-    ".item-table .item-left .stab.deprecated",
+    ".item-table .item-name .stab.deprecated",
     { "background-color": "rgb(255, 245, 214)" },
 )
 assert-css: (
-    ".item-table .item-left .stab.portability",
+    ".item-table .item-name .stab.portability",
     { "background-color": "rgb(255, 245, 214)" },
 )
 
 // table like view
-assert-css: (".item-right.docblock-short", { "padding-left": "0px" })
+assert-css: (".desc.docblock-short", { "padding-left": "0px" })
 compare-elements-position-near: (
-    "//*[@class='item-left']//a[text()='replaced_function']",
-    ".item-left .stab.deprecated",
+    "//*[@class='item-name']//a[text()='replaced_function']",
+    ".item-name .stab.deprecated",
     {"y": 2},
 )
 compare-elements-position: (
-    ".item-left .stab.deprecated",
-    ".item-left .stab.portability",
+    ".item-name .stab.deprecated",
+    ".item-name .stab.portability",
     ("y"),
 )
 
 // Ensure no wrap
 compare-elements-position: (
-    "//*[@class='item-left']//a[text()='replaced_function']/..",
-    "//*[@class='item-right docblock-short'][text()='a thing with a label']",
+    "//*[@class='item-name']//a[text()='replaced_function']/..",
+    "//*[@class='desc docblock-short'][text()='a thing with a label']",
     ("y"),
 )
 
@@ -41,26 +41,26 @@ compare-elements-position: (
 // Mobile view
 size: (600, 600)
 // staggered layout with 2em spacing
-assert-css: (".item-right.docblock-short", { "padding-left": "32px" })
+assert-css: (".desc.docblock-short", { "padding-left": "32px" })
 compare-elements-position-near: (
-    "//*[@class='item-left']//a[text()='replaced_function']",
-    ".item-left .stab.deprecated",
+    "//*[@class='item-name']//a[text()='replaced_function']",
+    ".item-name .stab.deprecated",
     {"y": 2},
 )
 compare-elements-position: (
-    ".item-left .stab.deprecated",
-    ".item-left .stab.portability",
+    ".item-name .stab.deprecated",
+    ".item-name .stab.portability",
     ("y"),
 )
 
 // Ensure wrap
 compare-elements-position-false: (
-    "//*[@class='item-left']//a[text()='replaced_function']/..",
-    "//*[@class='item-right docblock-short'][text()='a thing with a label']",
+    "//*[@class='item-name']//a[text()='replaced_function']/..",
+    "//*[@class='desc docblock-short'][text()='a thing with a label']",
     ("y"),
 )
 compare-elements-position-false: (
-    ".item-left .stab.deprecated",
-    "//*[@class='item-right docblock-short'][text()='a thing with a label']",
+    ".item-name .stab.deprecated",
+    "//*[@class='desc docblock-short'][text()='a thing with a label']",
     ("y"),
 )

--- a/tests/rustdoc-gui/module-items-font.goml
+++ b/tests/rustdoc-gui/module-items-font.goml
@@ -1,7 +1,7 @@
 // This test checks that the correct font is used on module items (in index.html pages).
 goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
 assert-css: (
-    ".item-table .item-left > a",
+    ".item-table .item-name > a",
     {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
     ALL,
 )
@@ -13,55 +13,55 @@ assert-css: (
 
 // modules
 assert-css: (
-    "#modules + .item-table .item-left a",
+    "#modules + .item-table .item-name a",
     {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
 )
 assert-css: (
-    "#modules + .item-table .item-right.docblock-short",
+    "#modules + .item-table .desc.docblock-short",
     {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
 )
 // structs
 assert-css: (
-    "#structs + .item-table .item-left a",
+    "#structs + .item-table .item-name a",
     {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
 )
 assert-css: (
-    "#structs + .item-table .item-right.docblock-short",
+    "#structs + .item-table .desc.docblock-short",
     {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
 )
 // enums
 assert-css: (
-    "#enums + .item-table .item-left a",
+    "#enums + .item-table .item-name a",
     {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
 )
 assert-css: (
-    "#enums + .item-table .item-right.docblock-short",
+    "#enums + .item-table .desc.docblock-short",
     {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
 )
 // traits
 assert-css: (
-    "#traits + .item-table .item-left a",
+    "#traits + .item-table .item-name a",
     {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
 )
 assert-css: (
-    "#traits + .item-table .item-right.docblock-short",
+    "#traits + .item-table .desc.docblock-short",
     {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
 )
 // functions
 assert-css: (
-    "#functions + .item-table .item-left a",
+    "#functions + .item-table .item-name a",
     {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
 )
 assert-css: (
-    "#functions + .item-table .item-right.docblock-short",
+    "#functions + .item-table .desc.docblock-short",
     {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
 )
 // keywords
 assert-css: (
-    "#keywords + .item-table .item-left a",
+    "#keywords + .item-table .item-name a",
     {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
 )
 assert-css: (
-    "#keywords + .item-table .item-right.docblock-short",
+    "#keywords + .item-table .desc.docblock-short",
     {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
 )

--- a/tests/rustdoc-gui/sidebar.goml
+++ b/tests/rustdoc-gui/sidebar.goml
@@ -70,8 +70,8 @@ assert-text: (".sidebar-elems section ul > li:nth-child(8)", "Functions")
 assert-text: (".sidebar-elems section ul > li:nth-child(9)", "Type Definitions")
 assert-text: (".sidebar-elems section ul > li:nth-child(10)", "Unions")
 assert-text: (".sidebar-elems section ul > li:nth-child(11)", "Keywords")
-assert-text: ("#structs + .item-table .item-left > a", "Foo")
-click: "#structs + .item-table .item-left > a"
+assert-text: ("#structs + .item-table .item-name > a", "Foo")
+click: "#structs + .item-table .item-name > a"
 
 // PAGE: struct.Foo.html
 assert-count: (".sidebar .location", 1)
@@ -103,8 +103,8 @@ assert-text: (".sidebar-elems > section ul.block > li:nth-child(2)", "Structs")
 assert-text: (".sidebar-elems > section ul.block > li:nth-child(3)", "Traits")
 assert-text: (".sidebar-elems > section ul.block > li:nth-child(4)", "Functions")
 assert-text: (".sidebar-elems > section ul.block > li:nth-child(5)", "Type Definitions")
-assert-text: ("#functions + .item-table .item-left > a", "foobar")
-click: "#functions + .item-table .item-left > a"
+assert-text: ("#functions + .item-table .item-name > a", "foobar")
+click: "#functions + .item-table .item-name > a"
 
 // PAGE: fn.foobar.html
 // In items containing no items (like functions or constants) and in modules, we have no
@@ -127,7 +127,7 @@ assert-text: (".sidebar > .location", "Module sub_sub_module")
 // We check that we don't have the crate list.
 assert-false: ".sidebar-elems .crate"
 assert-text: (".sidebar-elems > section ul > li:nth-child(1)", "Functions")
-assert-text: ("#functions + .item-table .item-left > a", "foo")
+assert-text: ("#functions + .item-table .item-name > a", "foo")
 
 // Links to trait implementations in the sidebar should not wrap even if they are long.
 goto: "file://" + |DOC_PATH| + "/lib2/struct.HasALongTraitWithParams.html"

--- a/tests/rustdoc-gui/unsafe-fn.goml
+++ b/tests/rustdoc-gui/unsafe-fn.goml
@@ -19,7 +19,7 @@ define-function: (
         local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
         // We reload the page so the local storage settings are being used.
         reload:
-        assert-css: (".item-left sup", {"color": |color|})
+        assert-css: (".item-name sup", {"color": |color|})
     },
 )
 

--- a/tests/rustdoc/cfg_doc_reexport.rs
+++ b/tests/rustdoc/cfg_doc_reexport.rs
@@ -5,8 +5,8 @@
 #![no_core]
 
 // @has 'foo/index.html'
-// @has - '//*[@class="item-left"]/*[@class="stab portability"]' 'foobar'
-// @has - '//*[@class="item-left"]/*[@class="stab portability"]' 'bar'
+// @has - '//*[@class="item-name"]/*[@class="stab portability"]' 'foobar'
+// @has - '//*[@class="item-name"]/*[@class="stab portability"]' 'bar'
 
 #[doc(cfg(feature = "foobar"))]
 mod imp_priv {

--- a/tests/rustdoc/deprecated.rs
+++ b/tests/rustdoc/deprecated.rs
@@ -1,6 +1,6 @@
-// @has deprecated/index.html '//*[@class="item-left"]/span[@class="stab deprecated"]' \
+// @has deprecated/index.html '//*[@class="item-name"]/span[@class="stab deprecated"]' \
 //      'Deprecated'
-// @has - '//*[@class="item-right docblock-short"]' 'Deprecated docs'
+// @has - '//*[@class="desc docblock-short"]' 'Deprecated docs'
 
 // @has deprecated/struct.S.html '//*[@class="stab deprecated"]' \
 //      'Deprecated since 1.0.0: text'
@@ -8,7 +8,7 @@
 #[deprecated(since = "1.0.0", note = "text")]
 pub struct S;
 
-// @matches deprecated/index.html '//*[@class="item-right docblock-short"]' '^Docs'
+// @matches deprecated/index.html '//*[@class="desc docblock-short"]' '^Docs'
 /// Docs
 pub struct T;
 

--- a/tests/rustdoc/doc-cfg.rs
+++ b/tests/rustdoc/doc-cfg.rs
@@ -12,7 +12,7 @@ pub struct Portable;
 // @has doc_cfg/unix_only/index.html \
 //  '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \
 //  'Available on Unix only.'
-// @matches - '//*[@class="item-left"]//*[@class="stab portability"]' '\AARM\Z'
+// @matches - '//*[@class="item-name"]//*[@class="stab portability"]' '\AARM\Z'
 // @count - '//*[@class="stab portability"]' 2
 #[doc(cfg(unix))]
 pub mod unix_only {
@@ -42,7 +42,7 @@ pub mod unix_only {
 // @has doc_cfg/wasi_only/index.html \
 //  '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \
 //  'Available on WASI only.'
-// @matches - '//*[@class="item-left"]//*[@class="stab portability"]' '\AWebAssembly\Z'
+// @matches - '//*[@class="item-name"]//*[@class="stab portability"]' '\AWebAssembly\Z'
 // @count - '//*[@class="stab portability"]' 2
 #[doc(cfg(target_os = "wasi"))]
 pub mod wasi_only {
@@ -74,7 +74,7 @@ pub mod wasi_only {
 
 // the portability header is different on the module view versus the full view
 // @has doc_cfg/index.html
-// @matches - '//*[@class="item-left"]//*[@class="stab portability"]' '\Aavx\Z'
+// @matches - '//*[@class="item-name"]//*[@class="stab portability"]' '\Aavx\Z'
 
 // @has doc_cfg/fn.uses_target_feature.html
 // @has - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \

--- a/tests/rustdoc/duplicate-cfg.rs
+++ b/tests/rustdoc/duplicate-cfg.rs
@@ -2,8 +2,8 @@
 #![feature(doc_cfg)]
 
 // @has 'foo/index.html'
-// @matches '-' '//*[@class="item-left"]//*[@class="stab portability"]' '^sync$'
-// @has '-' '//*[@class="item-left"]//*[@class="stab portability"]/@title' 'Available on crate feature `sync` only'
+// @matches '-' '//*[@class="item-name"]//*[@class="stab portability"]' '^sync$'
+// @has '-' '//*[@class="item-name"]//*[@class="stab portability"]/@title' 'Available on crate feature `sync` only'
 
 // @has 'foo/struct.Foo.html'
 // @has '-' '//*[@class="stab portability"]' 'sync'

--- a/tests/rustdoc/glob-shadowing-const.rs
+++ b/tests/rustdoc/glob-shadowing-const.rs
@@ -15,6 +15,6 @@ mod sub4 {
 pub use sub4::inner::*;
 
 // @has 'foo/index.html'
-// @has - '//div[@class="item-right docblock-short"]' '1'
-// @!has - '//div[@class="item-right docblock-short"]' '0'
+// @has - '//div[@class="desc docblock-short"]' '1'
+// @!has - '//div[@class="desc docblock-short"]' '0'
 fn main() { assert_eq!(X, 1); }

--- a/tests/rustdoc/glob-shadowing.rs
+++ b/tests/rustdoc/glob-shadowing.rs
@@ -1,17 +1,17 @@
 // @has 'glob_shadowing/index.html'
-// @count - '//div[@class="item-left"]' 6
-// @!has - '//div[@class="item-right docblock-short"]' 'sub1::describe'
-// @has - '//div[@class="item-right docblock-short"]' 'sub2::describe'
+// @count - '//div[@class="item-name"]' 6
+// @!has - '//div[@class="desc docblock-short"]' 'sub1::describe'
+// @has - '//div[@class="desc docblock-short"]' 'sub2::describe'
 
-// @!has - '//div[@class="item-right docblock-short"]' 'sub1::describe2'
+// @!has - '//div[@class="desc docblock-short"]' 'sub1::describe2'
 
-// @!has - '//div[@class="item-right docblock-short"]' 'sub1::prelude'
-// @has - '//div[@class="item-right docblock-short"]' 'mod::prelude'
+// @!has - '//div[@class="desc docblock-short"]' 'sub1::prelude'
+// @has - '//div[@class="desc docblock-short"]' 'mod::prelude'
 
-// @has - '//div[@class="item-right docblock-short"]' 'sub1::Foo (struct)'
-// @has - '//div[@class="item-right docblock-short"]' 'mod::Foo (function)'
+// @has - '//div[@class="desc docblock-short"]' 'sub1::Foo (struct)'
+// @has - '//div[@class="desc docblock-short"]' 'mod::Foo (function)'
 
-// @has - '//div[@class="item-right docblock-short"]' 'sub4::inner::X'
+// @has - '//div[@class="desc docblock-short"]' 'sub4::inner::X'
 
 // @has 'glob_shadowing/fn.describe.html'
 // @has - '//div[@class="docblock"]' 'sub2::describe'

--- a/tests/rustdoc/inline_cross/macros.rs
+++ b/tests/rustdoc/inline_cross/macros.rs
@@ -6,9 +6,9 @@
 
 extern crate macros;
 
-// @has foo/index.html '//*[@class="item-left"]/span[@class="stab deprecated"]' \
+// @has foo/index.html '//*[@class="item-name"]/span[@class="stab deprecated"]' \
 //         Deprecated
-// @has - '//*[@class="item-left"]/span[@class="stab unstable"]' \
+// @has - '//*[@class="item-name"]/span[@class="stab unstable"]' \
 //         Experimental
 
 // @has foo/macro.my_macro.html

--- a/tests/rustdoc/internal.rs
+++ b/tests/rustdoc/internal.rs
@@ -3,12 +3,12 @@
 // Check that the unstable marker is not added for "rustc_private".
 
 // @!matches internal/index.html \
-//      '//*[@class="item-right docblock-short"]/span[@class="stab unstable"]' \
+//      '//*[@class="desc docblock-short"]/span[@class="stab unstable"]' \
 //      ''
 // @!matches internal/index.html \
-//      '//*[@class="item-right docblock-short"]/span[@class="stab internal"]' \
+//      '//*[@class="desc docblock-short"]/span[@class="stab internal"]' \
 //      ''
-// @matches - '//*[@class="item-right docblock-short"]' 'Docs'
+// @matches - '//*[@class="desc docblock-short"]' 'Docs'
 
 // @!has internal/struct.S.html '//*[@class="stab unstable"]' ''
 // @!has internal/struct.S.html '//*[@class="stab internal"]' ''

--- a/tests/rustdoc/issue-32374.rs
+++ b/tests/rustdoc/issue-32374.rs
@@ -2,11 +2,11 @@
 #![doc(issue_tracker_base_url = "https://issue_url/")]
 #![unstable(feature = "test", issue = "32374")]
 
-// @matches issue_32374/index.html '//*[@class="item-left"]/span[@class="stab deprecated"]' \
+// @matches issue_32374/index.html '//*[@class="item-name"]/span[@class="stab deprecated"]' \
 //      'Deprecated'
-// @matches issue_32374/index.html '//*[@class="item-left"]/span[@class="stab unstable"]' \
+// @matches issue_32374/index.html '//*[@class="item-name"]/span[@class="stab unstable"]' \
 //      'Experimental'
-// @matches issue_32374/index.html '//*[@class="item-right docblock-short"]/text()' 'Docs'
+// @matches issue_32374/index.html '//*[@class="desc docblock-short"]/text()' 'Docs'
 
 // @has issue_32374/struct.T.html '//*[@class="stab deprecated"]/span' '👎'
 // @has issue_32374/struct.T.html '//*[@class="stab deprecated"]/span' \

--- a/tests/rustdoc/issue-46377.rs
+++ b/tests/rustdoc/issue-46377.rs
@@ -1,3 +1,3 @@
-// @has 'issue_46377/index.html' '//*[@class="item-right docblock-short"]' 'Check out this struct!'
+// @has 'issue_46377/index.html' '//*[@class="desc docblock-short"]' 'Check out this struct!'
 /// # Check out this struct!
 pub struct SomeStruct;

--- a/tests/rustdoc/issue-55364.rs
+++ b/tests/rustdoc/issue-55364.rs
@@ -29,8 +29,8 @@ pub mod subone {
 // @has - '//section[@id="main-content"]/details/div[@class="docblock"]//a[@href="../fn.foo.html"]' 'foo'
 // @has - '//section[@id="main-content"]/details/div[@class="docblock"]//a[@href="../fn.bar.html"]' 'bar'
 // Though there should be such links later
-// @has - '//section[@id="main-content"]/div[@class="item-table"]//div[@class="item-left"]/a[@class="fn"][@href="fn.foo.html"]' 'foo'
-// @has - '//section[@id="main-content"]/div[@class="item-table"]//div[@class="item-left"]/a[@class="fn"][@href="fn.bar.html"]' 'bar'
+// @has - '//section[@id="main-content"]/ul[@class="item-table"]//div[@class="item-name"]/a[@class="fn"][@href="fn.foo.html"]' 'foo'
+// @has - '//section[@id="main-content"]/ul[@class="item-table"]//div[@class="item-name"]/a[@class="fn"][@href="fn.bar.html"]' 'bar'
 /// See either [foo] or [bar].
 pub mod subtwo {
 
@@ -68,8 +68,8 @@ pub mod subthree {
 // Next we go *deeper* - In order to ensure it's not just "this or parent"
 // we test `crate::` and a `super::super::...` chain
 // @has issue_55364/subfour/subfive/subsix/subseven/subeight/index.html
-// @has - '//section[@id="main-content"]/div[@class="item-table"]//div[@class="item-right docblock-short"]//a[@href="../../../../../subone/fn.foo.html"]' 'other foo'
-// @has - '//section[@id="main-content"]/div[@class="item-table"]//div[@class="item-right docblock-short"]//a[@href="../../../../../subtwo/fn.bar.html"]' 'other bar'
+// @has - '//section[@id="main-content"]/ul[@class="item-table"]//div[@class="desc docblock-short"]//a[@href="../../../../../subone/fn.foo.html"]' 'other foo'
+// @has - '//section[@id="main-content"]/ul[@class="item-table"]//div[@class="desc docblock-short"]//a[@href="../../../../../subtwo/fn.bar.html"]' 'other bar'
 pub mod subfour {
     pub mod subfive {
         pub mod subsix {

--- a/tests/rustdoc/issue-95873.rs
+++ b/tests/rustdoc/issue-95873.rs
@@ -1,2 +1,2 @@
-// @has issue_95873/index.html "//*[@class='item-left']" "pub use ::std as x;"
+// @has issue_95873/index.html "//*[@class='item-name']" "pub use ::std as x;"
 pub use ::std as x;

--- a/tests/rustdoc/reexport-check.rs
+++ b/tests/rustdoc/reexport-check.rs
@@ -8,13 +8,13 @@ extern crate reexport_check;
 #[allow(deprecated, deprecated_in_future)]
 pub use std::i32;
 // @!has 'foo/index.html' '//code' 'pub use self::string::String;'
-// @has 'foo/index.html' '//div[@class="item-left"]' 'String'
+// @has 'foo/index.html' '//div[@class="item-name"]' 'String'
 pub use std::string::String;
 
 // i32 is deprecated, String is not
 // @count 'foo/index.html' '//span[@class="stab deprecated"]' 1
 
-// @has 'foo/index.html' '//div[@class="item-right docblock-short"]' 'Docs in original'
+// @has 'foo/index.html' '//div[@class="desc docblock-short"]' 'Docs in original'
 // this is a no-op, but shows what happens if there's an attribute that isn't a doc-comment
 #[doc(inline)]
 pub use reexport_check::S;

--- a/tests/rustdoc/short-docblock-codeblock.rs
+++ b/tests/rustdoc/short-docblock-codeblock.rs
@@ -1,6 +1,6 @@
 #![crate_name = "foo"]
 
-// @count foo/index.html '//*[@class="item-right docblock-short"]' 0
+// @count foo/index.html '//*[@class="desc docblock-short"]' 0
 
 /// ```
 /// let x = 12;

--- a/tests/rustdoc/short-docblock.rs
+++ b/tests/rustdoc/short-docblock.rs
@@ -1,7 +1,7 @@
 #![crate_name = "foo"]
 
-// @has foo/index.html '//*[@class="item-right docblock-short"]' 'fooo'
-// @!has foo/index.html '//*[@class="item-right docblock-short"]/h1' 'fooo'
+// @has foo/index.html '//*[@class="desc docblock-short"]' 'fooo'
+// @!has foo/index.html '//*[@class="desc docblock-short"]/h1' 'fooo'
 // @has foo/fn.foo.html '//h2[@id="fooo"]/a[@href="#fooo"]' 'fooo'
 
 /// # fooo
@@ -9,8 +9,8 @@
 /// foo
 pub fn foo() {}
 
-// @has foo/index.html '//*[@class="item-right docblock-short"]' 'mooood'
-// @!has foo/index.html '//*[@class="item-right docblock-short"]/h2' 'mooood'
+// @has foo/index.html '//*[@class="desc docblock-short"]' 'mooood'
+// @!has foo/index.html '//*[@class="desc docblock-short"]/h2' 'mooood'
 // @has foo/foo/index.html '//h3[@id="mooood"]/a[@href="#mooood"]' 'mooood'
 
 /// ## mooood
@@ -18,7 +18,7 @@ pub fn foo() {}
 /// foo mod
 pub mod foo {}
 
-// @has foo/index.html '//*[@class="item-right docblock-short"]/a[@href=\
+// @has foo/index.html '//*[@class="desc docblock-short"]/a[@href=\
 //                      "https://nougat.world"]/code' 'nougat'
 
 /// [`nougat`](https://nougat.world)


### PR DESCRIPTION
This switches from using `<div>` to the more semantic `<ul>`, and using class names that rhyme with the classes the search results table uses.