### PR TITLE
Avoid exposing type parameters and implementation details sourced from macro expansions

### DIFF
--- a/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.rs
+++ b/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.rs
@@ -1,0 +1,19 @@
+// ignore-tidy-linelength
+
+// Regression test for #107745.
+// Previously need_type_info::update_infer_source will consider expressions originating from
+// macro expressions as candiate "previous sources". This unfortunately can mean that
+// for macros expansions such as `format!()` internal implementation details can leak, such as:
+//
+// ```
+// error[E0282]: type annotations needed
+// --> src/main.rs:2:22
+//  |
+//2 |     println!("{:?}", []);
+//  |                      ^^ cannot infer type of the type parameter `T` declared on the associated function `new_debug`
+// ```
+
+fn main() {
+    println!("{:?}", []);
+    //~^ ERROR type annotations needed
+}

--- a/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.stderr
+++ b/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.stderr
@@ -1,0 +1,11 @@
+error[E0282]: type annotations needed
+  --> $DIR/issue-107745-avoid-expr-from-macro-expansion.rs:17:22
+   |
+LL |     println!("{:?}", []);
+   |                      ^^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/issues/issue-16966.stderr
+++ b/tests/ui/issues/issue-16966.stderr
@@ -1,10 +1,8 @@
 error[E0282]: type annotations needed
-  --> $DIR/issue-16966.rs:2:5
+  --> $DIR/issue-16966.rs:2:12
    |
 LL |     panic!(std::default::Default::default());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `M` declared on the function `begin_panic`
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.rs
+++ b/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.rs
@@ -17,7 +17,7 @@ fn test2<T1, T2>(arg1 : T1, arg2 : T2) {
 fn test3<'a>(arg : &'a u32) {
   let v : Vec<'a = vec![];
     //~^ ERROR: expected one of
-    //~| ERROR: type annotations needed for `Vec<T>`
+    //~| ERROR: type annotations needed for `Vec<_>`
 }
 
 fn main() {}

--- a/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.stderr
+++ b/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.stderr
@@ -39,26 +39,26 @@ help: you might have meant to end the type parameters here
 LL |   let v : Vec<'a> = vec![];
    |                 +
 
-error[E0282]: type annotations needed for `Vec<T>`
+error[E0282]: type annotations needed for `Vec<_>`
   --> $DIR/missing-closing-angle-bracket-eq-constraint.rs:7:7
    |
 LL |   let v : Vec<(u32,_) = vec![];
    |       ^
    |
-help: consider giving `v` an explicit type, where the type for type parameter `T` is specified
+help: consider giving `v` an explicit type, where the placeholders `_` are specified
    |
-LL |   let v: Vec<T> : Vec<(u32,_) = vec![];
+LL |   let v: Vec<_> : Vec<(u32,_) = vec![];
    |        ++++++++
 
-error[E0282]: type annotations needed for `Vec<T>`
+error[E0282]: type annotations needed for `Vec<_>`
   --> $DIR/missing-closing-angle-bracket-eq-constraint.rs:18:7
    |
 LL |   let v : Vec<'a = vec![];
    |       ^
    |
-help: consider giving `v` an explicit type, where the type for type parameter `T` is specified
+help: consider giving `v` an explicit type, where the placeholders `_` are specified
    |
-LL |   let v: Vec<T> : Vec<'a = vec![];
+LL |   let v: Vec<_> : Vec<'a = vec![];
    |        ++++++++
 
 error: aborting due to 5 previous errors

--- a/tests/ui/type/type-check/cannot_infer_local_or_vec.stderr
+++ b/tests/ui/type/type-check/cannot_infer_local_or_vec.stderr
@@ -1,12 +1,12 @@
-error[E0282]: type annotations needed for `Vec<T>`
+error[E0282]: type annotations needed for `Vec<_>`
   --> $DIR/cannot_infer_local_or_vec.rs:2:9
    |
 LL |     let x = vec![];
    |         ^
    |
-help: consider giving `x` an explicit type, where the type for type parameter `T` is specified
+help: consider giving `x` an explicit type, where the placeholders `_` are specified
    |
-LL |     let x: Vec<T> = vec![];
+LL |     let x: Vec<_> = vec![];
    |          ++++++++
 
 error: aborting due to previous error

--- a/tests/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
+++ b/tests/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
@@ -1,12 +1,12 @@
-error[E0282]: type annotations needed for `(Vec<T>,)`
+error[E0282]: type annotations needed for `(Vec<_>,)`
   --> $DIR/cannot_infer_local_or_vec_in_tuples.rs:2:9
    |
 LL |     let (x, ) = (vec![], );
    |         ^^^^^   ---------- type must be known at this point
    |
-help: consider giving this pattern a type, where the type for type parameter `T` is specified
+help: consider giving this pattern a type, where the placeholders `_` are specified
    |
-LL |     let (x, ): (Vec<T>,) = (vec![], );
+LL |     let (x, ): (Vec<_>,) = (vec![], );
    |              +++++++++++
 
 error: aborting due to previous error


### PR DESCRIPTION
Fixes #107745.

~~I would like to **request some guidance** for this issue, because I don't think this is a good fix (a band-aid at best).~~

### The Problem

The code

```rust
fn main() {
    println!("{:?}", []);
}
```

gets desugared into (`rustc +nightly --edition=2018 issue-107745.rs -Z unpretty=hir`):

```rust
#[prelude_import]
use std::prelude::rust_2018::*;
#[macro_use]
extern crate std;
fn main() {
        {
                ::std::io::_print(<#[lang = "format_arguments"]>::new_v1(&["",
                                    "\n"], &[<#[lang = "format_argument"]>::new_debug(&[])]));
            };
    }
```

so the diagnostics code tries to be as specific and helpful as possible, and I think it finds that `[]` needs a type parameter and so does `new_debug`. But since `[]` doesn't have an origin for the type parameter definition, it points to `new_debug` instead and leaks the internal implementation detail since all `[]` has is an type inference variable.

### ~~The Bad Fix~~

~~This PR currently tries to fix the problem by bypassing the generated function `<#[lang = "format_argument"]>::new_debug` to avoid its generic parameter (I think it is auto-generated from the argument `[_; 0]`?) from getting collected as an `InsertableGenericArg`. This is problematic because it also prevents the help from getting displayed.~~

~~I think this fix is not ideal and hard-codes the format generated code pattern, but I can't think of a better fix. I have tried asking on Zulip but no responses there yet.~~
