### PR TITLE
 x.py fails all downloads that use a tempdir with snap curl #107722

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -87,14 +87,16 @@ def _download(path, url, probably_big, verbose, exception):
         # If curl is not present on Win32, we should not sys.exit
         #   but raise `CalledProcessError` or `OSError` instead
         require(["curl", "--version"], exception=platform_is_win32)
-        run(["curl", option,
-             "-L", # Follow redirect.
-             "-y", "30", "-Y", "10",    # timeout if speed is < 10 bytes/sec for > 30 seconds
-             "--connect-timeout", "30",  # timeout if cannot connect within 30 seconds
-             "--retry", "3", "-Sf", "-o", path, url],
-            verbose=verbose,
-            exception=True, # Will raise RuntimeError on failure
-        )
+        with open(path, "wb") as outfile:
+            run(["curl", option,
+                "-L", # Follow redirect.
+                "-y", "30", "-Y", "10",    # timeout if speed is < 10 bytes/sec for > 30 seconds
+                "--connect-timeout", "30",  # timeout if cannot connect within 30 seconds
+                "--retry", "3", "-Sf", url],
+                stdout=outfile,    #Implements cli redirect operator '>'
+                verbose=verbose,
+                exception=True, # Will raise RuntimeError on failure
+            )
     except (subprocess.CalledProcessError, OSError, RuntimeError):
         # see http://serverfault.com/questions/301128/how-to-download
         if platform_is_win32:


### PR DESCRIPTION
Have used the open() library from python to capture the binary output of the curl command and write it to a file using stdout of the subprocess. Added a single-line comment mentioning the redirect operator. 