### PR TITLE
Add missing tracking issue for `RawOsError`

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -102,7 +102,7 @@ enum ErrorData<C> {
 /// portability.
 ///
 /// [`into`]: Into::into
-#[unstable(feature = "raw_os_error_ty", issue = "none")]
+#[unstable(feature = "raw_os_error_ty", issue = "107792")]
 pub type RawOsError = i32;
 
 // `#[repr(align(4))]` is probably redundant, it should have that value or

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -262,7 +262,7 @@ use crate::sys_common::memchr;
 
 #[stable(feature = "bufwriter_into_parts", since = "1.56.0")]
 pub use self::buffered::WriterPanicked;
-#[unstable(feature = "raw_os_error_ty", issue = "none")]
+#[unstable(feature = "raw_os_error_ty", issue = "107792")]
 pub use self::error::RawOsError;
 pub(crate) use self::stdio::attempt_print_to_stderr;
 #[unstable(feature = "internal_output_capture", issue = "none")]


### PR DESCRIPTION
I forgot to add it in the original PR…

See #107792.

@rustbot label +T-libs-api -T-libs