### PR TITLE
[perf] delete no-op caching optimization from (old) trait solver

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1002,17 +1002,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         previous_stack: TraitObligationStackList<'o, 'tcx>,
         mut obligation: TraitObligation<'tcx>,
     ) -> Result<EvaluationResult, OverflowError> {
-        if !self.is_intercrate()
-            && obligation.is_global()
-            && obligation.param_env.caller_bounds().iter().all(|bound| bound.needs_subst())
-        {
-            // If a param env has no global bounds, global obligations do not
-            // depend on its particular value in order to work, so we can clear
-            // out the param env and get better caching.
-            debug!("in global");
-            obligation.param_env = obligation.param_env.without_caller_bounds();
-        }
-
         let stack = self.push_stack(previous_stack, &obligation);
         let mut fresh_trait_pred = stack.fresh_trait_pred;
         let mut param_env = obligation.param_env;


### PR DESCRIPTION
This code path is only taken if the caller bounds are already empty. Found in https://github.com/rust-lang/rust/pull/107688#issuecomment-1419111616.

r? ghost