### PR TITLE
correctly update goals in the cache

### DIFF
--- a/tests/ui/traits/new-solver/provisional-result-done.rs
+++ b/tests/ui/traits/new-solver/provisional-result-done.rs
@@ -1,0 +1,37 @@
+// known-bug: unknown
+// compile-flags: -Ztrait-solver=next
+// failure-status: 101
+// normalize-stderr-test "note: .*\n\n" -> ""
+// normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
+// rustc-env:RUST_BACKTRACE=0
+
+// This tests checks that we update results in the provisional cache when
+// we pop a goal from the stack.
+#![feature(auto_traits)]
+auto trait Coinductive {}
+struct Foo<T>(T);
+struct Bar<T>(T);
+
+impl<T> Coinductive for Foo<T>
+where
+    Bar<T>: Coinductive
+{}
+
+impl<T> Coinductive for Bar<T>
+where
+    Foo<T>: Coinductive,
+    Bar<T>: ConstrainInfer,
+{}
+
+trait ConstrainInfer {}
+impl ConstrainInfer for Bar<u8> {}
+impl ConstrainInfer for Foo<u16> {}
+
+fn impls<T: Coinductive>() -> T { todo!() }
+
+fn constrain<T: ConstrainInfer>(_: T) {}
+
+fn main() {
+    // This should constrain `_` to `u8`.
+    impls::<Foo<_>>();
+}

--- a/tests/ui/traits/new-solver/provisional-result-done.stderr
+++ b/tests/ui/traits/new-solver/provisional-result-done.stderr
@@ -1,0 +1,6 @@
+error: the compiler unexpectedly panicked. this is a bug.
+
+query stack during panic:
+#0 [check_well_formed] checking that `<impl at $DIR/provisional-result-done.rs:20:1: 20:31>` is well-formed
+#1 [check_mod_type_wf] checking that types are well-formed in top-level module
+end of query stack


### PR DESCRIPTION
we may want to actually write the response for our goal into the provisional or global cache instead of simply using the result from the last iteration '^^

r? @rust-lang/initiative-trait-system-refactor 