### PR TITLE
Move query accessor code into functions

### DIFF
--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -202,7 +202,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 }
 
-#[inline]
+#[inline(always)]
 fn query_get_at<'tcx, Cache>(
     tcx: TyCtxt<'tcx>,
     execute_query: fn(TyCtxt<'tcx>, Span, Cache::Key, QueryMode) -> Option<Cache::Value>,
@@ -220,7 +220,7 @@ where
     }
 }
 
-#[inline]
+#[inline(always)]
 fn query_ensure<'tcx, Cache>(
     tcx: TyCtxt<'tcx>,
     execute_query: fn(TyCtxt<'tcx>, Span, Cache::Key, QueryMode) -> Option<Cache::Value>,


### PR DESCRIPTION
This reduces the amount of code generated by the macros, which I think is the last item on https://github.com/rust-lang/rust/issues/96524.

It also improves performance.
<table><tr><td rowspan="2">Benchmark</td><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th></tr><tr><td align="right">Time</td><td align="right">Time</td><td align="right">%</th></tr><tr><td>🟣 <b>clap</b>:check</td><td align="right">1.8271s</td><td align="right">1.8163s</td><td align="right"> -0.59%</td></tr><tr><td>🟣 <b>hyper</b>:check</td><td align="right">0.2611s</td><td align="right">0.2597s</td><td align="right"> -0.57%</td></tr><tr><td>🟣 <b>regex</b>:check</td><td align="right">1.0206s</td><td align="right">1.0124s</td><td align="right"> -0.80%</td></tr><tr><td>🟣 <b>syn</b>:check</td><td align="right">1.6329s</td><td align="right">1.6158s</td><td align="right">💚  -1.05%</td></tr><tr><td>🟣 <b>syntex_syntax</b>:check</td><td align="right">6.3299s</td><td align="right">6.2816s</td><td align="right"> -0.76%</td></tr><tr><td>Total</td><td align="right">11.0717s</td><td align="right">10.9858s</td><td align="right"> -0.78%</td></tr><tr><td>Summary</td><td align="right">1.0000s</td><td align="right">0.9925s</td><td align="right"> -0.75%</td></tr></table>

r? @cjgillot 