### PR TITLE
Require TAITs to appear in the signature of items that register a hidden type

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -524,6 +524,8 @@ declare_features! (
     (active, try_blocks, "1.29.0", Some(31436), None),
     /// Allows `impl Trait` to be used inside type aliases (RFC 2515).
     (active, type_alias_impl_trait, "1.38.0", Some(63063), None),
+    /// Allows functions with TAITs in their where bounds to register hidden types.
+    (active, type_alias_impl_trait_in_where_bounds, "CURRENT_RUSTC_VERSION", Some(63063), None),
     /// Allows the use of type ascription in expressions.
     (active, type_ascription, "1.6.0", Some(23416), None),
     /// Allows creation of instances of a struct by moving fields that have

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -69,6 +69,9 @@ hir_analysis_trait_object_declared_with_no_traits =
     at least one trait is required for an object type
     .alias_span = this alias does not contain a trait
 
+hir_analysis_opaque_type_constrained_bug_not_in_sig = opaque type constrained without being represented in the signature
+    .item_label = this item must mention the opaque type in its signature or where bounds
+
 hir_analysis_missing_type_params =
     the type {$parameterCount ->
         [one] parameter

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -69,7 +69,7 @@ hir_analysis_trait_object_declared_with_no_traits =
     at least one trait is required for an object type
     .alias_span = this alias does not contain a trait
 
-hir_analysis_opaque_type_constrained_bug_not_in_sig = opaque type constrained without being represented in the signature
+hir_analysis_opaque_type_constrained_but_not_in_sig = opaque type constrained without being represented in the signature
     .item_label = this item must mention the opaque type in its signature or where bounds
 
 hir_analysis_missing_type_params =

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -72,6 +72,9 @@ hir_analysis_trait_object_declared_with_no_traits =
 hir_analysis_opaque_type_constrained_but_not_in_sig = opaque type constrained without being represented in the signature
     .item_label = this item must mention the opaque type in its signature or where bounds
 
+hir_analysis_opaque_type_constrained_but_not_in_sibling = opaque type constrained in nested item
+    .item_label = this item is not a sibling of the opaque type
+
 hir_analysis_missing_type_params =
     the type {$parameterCount ->
         [one] parameter

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -177,7 +177,7 @@ pub struct UnconstrainedOpaqueType {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis_opaque_type_constrained_bug_not_in_sig)]
+#[diag(hir_analysis_opaque_type_constrained_but_not_in_sig)]
 pub struct OpaqueTypeConstrainedButNotInSig {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -176,6 +176,15 @@ pub struct UnconstrainedOpaqueType {
     pub what: &'static str,
 }
 
+#[derive(Diagnostic)]
+#[diag(hir_analysis_opaque_type_constrained_bug_not_in_sig)]
+pub struct OpaqueTypeConstrainedButNotInSig {
+    #[primary_span]
+    pub span: Span,
+    #[label(hir_analysis_item_label)]
+    pub item_span: Span,
+}
+
 pub struct MissingTypeParams {
     pub span: Span,
     pub def_span: Span,

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -184,6 +184,14 @@ pub struct OpaqueTypeConstrainedButNotInSig {
     #[label(hir_analysis_item_label)]
     pub item_span: Span,
 }
+#[derive(Diagnostic)]
+#[diag(hir_analysis_opaque_type_constrained_but_not_in_sibling)]
+pub struct OpaqueTypeConstrainedInNonSibling {
+    #[primary_span]
+    pub span: Span,
+    #[label(hir_analysis_item_label)]
+    pub item_span: Span,
+}
 
 pub struct MissingTypeParams {
     pub span: Span,

--- a/compiler/rustc_hir_typeck/src/inherited.rs
+++ b/compiler/rustc_hir_typeck/src/inherited.rs
@@ -73,13 +73,17 @@ impl<'tcx> Deref for Inherited<'tcx> {
 }
 
 impl<'tcx> Inherited<'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Self {
+    pub fn new(
+        tcx: TyCtxt<'tcx>,
+        def_id: LocalDefId,
+        mk_defining_use_anchor: impl FnOnce(LocalDefId) -> DefiningAnchor,
+    ) -> Self {
         let hir_owner = tcx.hir().local_def_id_to_hir_id(def_id).owner;
 
         let infcx = tcx
             .infer_ctxt()
             .ignoring_regions()
-            .with_opaque_type_inference(DefiningAnchor::Bind(hir_owner.def_id))
+            .with_opaque_type_inference(mk_defining_use_anchor(hir_owner.def_id))
             .build();
         let typeck_results = RefCell::new(ty::TypeckResults::new(hir_owner));
 

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -372,7 +372,6 @@ impl<'tcx> InferCtxt<'tcx> {
     /// in its defining scope.
     #[instrument(skip(self), level = "trace", ret)]
     pub fn opaque_type_origin(&self, def_id: LocalDefId) -> Option<OpaqueTyOrigin> {
-        let opaque_hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id);
         let parent_def_id = match self.defining_use_anchor {
             DefiningAnchor::Bubble | DefiningAnchor::Error => return None,
             DefiningAnchor::Bind(bind) => bind,
@@ -385,9 +384,7 @@ impl<'tcx> InferCtxt<'tcx> {
             // Anonymous `impl Trait`
             hir::OpaqueTyOrigin::FnReturn(parent) => parent == parent_def_id,
             // Named `type Foo = impl Bar;`
-            hir::OpaqueTyOrigin::TyAlias => {
-                may_define_opaque_type(self.tcx, parent_def_id, opaque_hir_id)
-            }
+            hir::OpaqueTyOrigin::TyAlias => may_define_opaque_type(self.tcx, parent_def_id, def_id),
         };
         in_definition_scope.then_some(origin)
     }
@@ -634,7 +631,13 @@ impl<'tcx> InferCtxt<'tcx> {
 /// Here, `def_id` is the `LocalDefId` of the defining use of the opaque type (e.g., `f1` or `f2`),
 /// and `opaque_hir_id` is the `HirId` of the definition of the opaque type `Baz`.
 /// For the above example, this function returns `true` for `f1` and `false` for `f2`.
-fn may_define_opaque_type(tcx: TyCtxt<'_>, def_id: LocalDefId, opaque_hir_id: hir::HirId) -> bool {
+#[instrument(skip(tcx), level = "trace", ret)]
+fn may_define_opaque_type<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+    opaque_def_id: LocalDefId,
+) -> bool {
+    let opaque_hir_id = tcx.hir().local_def_id_to_hir_id(opaque_def_id);
     let mut hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
 
     // Named opaque types can be defined by any siblings or children of siblings.

--- a/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
+++ b/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
@@ -223,7 +223,7 @@ impl<'tcx> TryNormalizeAfterErasingRegionsFolder<'tcx> {
         TryNormalizeAfterErasingRegionsFolder { tcx, param_env }
     }
 
-    #[instrument(skip(self), level = "debug")]
+    #[instrument(skip(self), level = "debug", ret)]
     fn try_normalize_generic_arg_after_erasing_regions(
         &self,
         arg: ty::GenericArg<'tcx>,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1509,6 +1509,7 @@ symbols! {
         ty,
         type_alias_enum_variants,
         type_alias_impl_trait,
+        type_alias_impl_trait_in_where_bounds,
         type_ascribe,
         type_ascription,
         type_changing_struct_update,

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
@@ -17,6 +17,7 @@ use rustc_middle::ty::subst::{GenericArg, GenericArgKind, SubstsRef};
 use rustc_middle::ty::{self, Clause, EarlyBinder, ParamTy, PredicateKind, ProjectionPredicate, TraitPredicate, Ty};
 use rustc_span::{sym, Symbol};
 use rustc_trait_selection::traits::{query::evaluate_obligation::InferCtxtExt as _, Obligation, ObligationCause};
+use rustc_infer::infer::DefiningAnchor;
 
 use super::UNNECESSARY_TO_OWNED;
 
@@ -369,7 +370,7 @@ fn can_change_type<'a>(cx: &LateContext<'a>, mut expr: &'a Expr<'a>, mut ty: Ty<
             Node::Item(item) => {
                 if let ItemKind::Fn(_, _, body_id) = &item.kind
                 && let output_ty = return_ty(cx, item.owner_id)
-                && let inherited = Inherited::new(cx.tcx, item.owner_id.def_id)
+                && let inherited = Inherited::new(cx.tcx, item.owner_id.def_id, DefiningAnchor::Bind)
                 && let fn_ctxt = FnCtxt::new(&inherited, cx.param_env, item.owner_id.def_id)
                 && fn_ctxt.can_coerce(ty, output_ty)
                 {

--- a/src/tools/clippy/clippy_lints/src/transmute/utils.rs
+++ b/src/tools/clippy/clippy_lints/src/transmute/utils.rs
@@ -4,6 +4,7 @@ use rustc_hir_typeck::{cast, FnCtxt, Inherited};
 use rustc_lint::LateContext;
 use rustc_middle::ty::{cast::CastKind, Ty};
 use rustc_span::DUMMY_SP;
+use rustc_infer::infer::DefiningAnchor;
 
 // check if the component types of the transmuted collection and the result have different ABI,
 // size or alignment
@@ -33,7 +34,7 @@ pub(super) fn check_cast<'tcx>(
     let hir_id = e.hir_id;
     let local_def_id = hir_id.owner.def_id;
 
-    let inherited = Inherited::new(cx.tcx, local_def_id);
+    let inherited = Inherited::new(cx.tcx, local_def_id, DefiningAnchor::Bind);
     let fn_ctxt = FnCtxt::new(&inherited, cx.param_env, local_def_id);
 
     // If we already have errors, we can't be sure we can pointer cast.

--- a/tests/codegen/sanitizer-cfi-emit-type-metadata-id-itanium-cxx-abi.rs
+++ b/tests/codegen/sanitizer-cfi-emit-type-metadata-id-itanium-cxx-abi.rs
@@ -104,9 +104,7 @@ where
     // Type in const path
     const {
         pub struct Foo;
-        fn foo() -> Type5 {
-            Foo
-        }
+        let _: Type5 = Foo;
     };
 
     // Type in impl path

--- a/tests/codegen/sanitizer-cfi-emit-type-metadata-id-itanium-cxx-abi.rs
+++ b/tests/codegen/sanitizer-cfi-emit-type-metadata-id-itanium-cxx-abi.rs
@@ -3,7 +3,7 @@
 // needs-sanitizer-cfi
 // compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi
 
-#![crate_type="lib"]
+#![crate_type = "lib"]
 #![allow(dead_code)]
 #![allow(incomplete_features)]
 #![allow(unused_must_use)]
@@ -29,23 +29,23 @@ pub union Union1<T> {
 }
 
 // Extern type
-extern {
+extern "C" {
     pub type type1;
 }
 
 // Trait
 pub trait Trait1<T> {
-    fn foo(&self) { }
+    fn foo(&self) {}
 }
 
 // Trait implementation
 impl<T> Trait1<T> for i32 {
-    fn foo(&self) { }
+    fn foo(&self) {}
 }
 
 // Trait implementation
 impl<T> Trait1<T> for Struct1<T> {
-    fn foo(&self) { }
+    fn foo(&self) {}
 }
 
 // impl Trait type aliases for helping with defining other types (see below)
@@ -61,9 +61,22 @@ pub type Type9 = impl Send;
 pub type Type10 = impl Send;
 pub type Type11 = impl Send;
 
-pub fn fn1<'a>() {
+pub fn fn1<'a>()
+where
+    Type1:,
+    Type2:,
+    Type3:,
+    Type4:,
+    Type5:,
+    Type6:,
+    Type7:,
+    Type8:,
+    Type9:,
+    Type10:,
+    Type11:,
+{
     // Closure
-    let closure1 = || { };
+    let closure1 = || {};
     let _: Type1 = closure1;
 
     // Constructor
@@ -71,7 +84,7 @@ pub fn fn1<'a>() {
     let _: Type2 = Foo;
 
     // Type in extern path
-    extern {
+    extern "C" {
         fn foo();
     }
     let _: Type3 = foo;
@@ -85,12 +98,14 @@ pub fn fn1<'a>() {
     // Type in const path
     const {
         pub struct Foo;
-        fn foo() -> Type5 { Foo }
+        fn foo() -> Type5 {
+            Foo
+        }
     };
 
     // Type in impl path
     impl<T> Struct1<T> {
-        fn foo(&self) { }
+        fn foo(&self) {}
     }
     let _: Type6 = <Struct1<i32>>::foo;
 
@@ -138,305 +153,305 @@ pub struct Bar;
 #[repr(transparent)]
 pub struct Type14<T>(T);
 
-pub fn foo0(_: ()) { }
+pub fn foo0(_: ()) {}
 // CHECK: define{{.*}}foo0{{.*}}!type ![[TYPE0:[0-9]+]]
-pub fn foo1(_: c_void, _: ()) { }
+pub fn foo1(_: c_void, _: ()) {}
 // CHECK: define{{.*}}foo1{{.*}}!type ![[TYPE1:[0-9]+]]
-pub fn foo2(_: (), _: c_void, _: c_void) { }
+pub fn foo2(_: (), _: c_void, _: c_void) {}
 // CHECK: define{{.*}}foo2{{.*}}!type ![[TYPE2:[0-9]+]]
-pub fn foo3(_: *mut c_void) { }
+pub fn foo3(_: *mut c_void) {}
 // CHECK: define{{.*}}foo3{{.*}}!type ![[TYPE3:[0-9]+]]
-pub fn foo4(_: *mut c_void, _: *mut ()) { }
+pub fn foo4(_: *mut c_void, _: *mut ()) {}
 // CHECK: define{{.*}}foo4{{.*}}!type ![[TYPE4:[0-9]+]]
-pub fn foo5(_: *mut (), _: *mut c_void, _: *mut c_void) { }
+pub fn foo5(_: *mut (), _: *mut c_void, _: *mut c_void) {}
 // CHECK: define{{.*}}foo5{{.*}}!type ![[TYPE5:[0-9]+]]
-pub fn foo6(_: *const c_void) { }
+pub fn foo6(_: *const c_void) {}
 // CHECK: define{{.*}}foo6{{.*}}!type ![[TYPE6:[0-9]+]]
-pub fn foo7(_: *const c_void, _: *const ()) { }
+pub fn foo7(_: *const c_void, _: *const ()) {}
 // CHECK: define{{.*}}foo7{{.*}}!type ![[TYPE7:[0-9]+]]
-pub fn foo8(_: *const (), _: *const c_void, _: *const c_void) { }
+pub fn foo8(_: *const (), _: *const c_void, _: *const c_void) {}
 // CHECK: define{{.*}}foo8{{.*}}!type ![[TYPE8:[0-9]+]]
-pub fn foo9(_: bool) { }
+pub fn foo9(_: bool) {}
 // CHECK: define{{.*}}foo9{{.*}}!type ![[TYPE9:[0-9]+]]
-pub fn foo10(_: bool, _: bool) { }
+pub fn foo10(_: bool, _: bool) {}
 // CHECK: define{{.*}}foo10{{.*}}!type ![[TYPE10:[0-9]+]]
-pub fn foo11(_: bool, _: bool, _: bool) { }
+pub fn foo11(_: bool, _: bool, _: bool) {}
 // CHECK: define{{.*}}foo11{{.*}}!type ![[TYPE11:[0-9]+]]
-pub fn foo12(_: i8) { }
+pub fn foo12(_: i8) {}
 // CHECK: define{{.*}}foo12{{.*}}!type ![[TYPE12:[0-9]+]]
-pub fn foo13(_: i8, _: i8) { }
+pub fn foo13(_: i8, _: i8) {}
 // CHECK: define{{.*}}foo13{{.*}}!type ![[TYPE13:[0-9]+]]
-pub fn foo14(_: i8, _: i8, _: i8) { }
+pub fn foo14(_: i8, _: i8, _: i8) {}
 // CHECK: define{{.*}}foo14{{.*}}!type ![[TYPE14:[0-9]+]]
-pub fn foo15(_: i16) { }
+pub fn foo15(_: i16) {}
 // CHECK: define{{.*}}foo15{{.*}}!type ![[TYPE15:[0-9]+]]
-pub fn foo16(_: i16, _: i16) { }
+pub fn foo16(_: i16, _: i16) {}
 // CHECK: define{{.*}}foo16{{.*}}!type ![[TYPE16:[0-9]+]]
-pub fn foo17(_: i16, _: i16, _: i16) { }
+pub fn foo17(_: i16, _: i16, _: i16) {}
 // CHECK: define{{.*}}foo17{{.*}}!type ![[TYPE17:[0-9]+]]
-pub fn foo18(_: i32) { }
+pub fn foo18(_: i32) {}
 // CHECK: define{{.*}}foo18{{.*}}!type ![[TYPE18:[0-9]+]]
-pub fn foo19(_: i32, _: i32) { }
+pub fn foo19(_: i32, _: i32) {}
 // CHECK: define{{.*}}foo19{{.*}}!type ![[TYPE19:[0-9]+]]
-pub fn foo20(_: i32, _: i32, _: i32) { }
+pub fn foo20(_: i32, _: i32, _: i32) {}
 // CHECK: define{{.*}}foo20{{.*}}!type ![[TYPE20:[0-9]+]]
-pub fn foo21(_: i64) { }
+pub fn foo21(_: i64) {}
 // CHECK: define{{.*}}foo21{{.*}}!type ![[TYPE21:[0-9]+]]
-pub fn foo22(_: i64, _: i64) { }
+pub fn foo22(_: i64, _: i64) {}
 // CHECK: define{{.*}}foo22{{.*}}!type ![[TYPE22:[0-9]+]]
-pub fn foo23(_: i64, _: i64, _: i64) { }
+pub fn foo23(_: i64, _: i64, _: i64) {}
 // CHECK: define{{.*}}foo23{{.*}}!type ![[TYPE23:[0-9]+]]
-pub fn foo24(_: i128) { }
+pub fn foo24(_: i128) {}
 // CHECK: define{{.*}}foo24{{.*}}!type ![[TYPE24:[0-9]+]]
-pub fn foo25(_: i128, _: i128) { }
+pub fn foo25(_: i128, _: i128) {}
 // CHECK: define{{.*}}foo25{{.*}}!type ![[TYPE25:[0-9]+]]
-pub fn foo26(_: i128, _: i128, _: i128) { }
+pub fn foo26(_: i128, _: i128, _: i128) {}
 // CHECK: define{{.*}}foo26{{.*}}!type ![[TYPE26:[0-9]+]]
-pub fn foo27(_: isize) { }
+pub fn foo27(_: isize) {}
 // CHECK: define{{.*}}foo27{{.*}}!type ![[TYPE27:[0-9]+]]
-pub fn foo28(_: isize, _: isize) { }
+pub fn foo28(_: isize, _: isize) {}
 // CHECK: define{{.*}}foo28{{.*}}!type ![[TYPE28:[0-9]+]]
-pub fn foo29(_: isize, _: isize, _: isize) { }
+pub fn foo29(_: isize, _: isize, _: isize) {}
 // CHECK: define{{.*}}foo29{{.*}}!type ![[TYPE29:[0-9]+]]
-pub fn foo30(_: u8) { }
+pub fn foo30(_: u8) {}
 // CHECK: define{{.*}}foo30{{.*}}!type ![[TYPE30:[0-9]+]]
-pub fn foo31(_: u8, _: u8) { }
+pub fn foo31(_: u8, _: u8) {}
 // CHECK: define{{.*}}foo31{{.*}}!type ![[TYPE31:[0-9]+]]
-pub fn foo32(_: u8, _: u8, _: u8) { }
+pub fn foo32(_: u8, _: u8, _: u8) {}
 // CHECK: define{{.*}}foo32{{.*}}!type ![[TYPE32:[0-9]+]]
-pub fn foo33(_: u16) { }
+pub fn foo33(_: u16) {}
 // CHECK: define{{.*}}foo33{{.*}}!type ![[TYPE33:[0-9]+]]
-pub fn foo34(_: u16, _: u16) { }
+pub fn foo34(_: u16, _: u16) {}
 // CHECK: define{{.*}}foo34{{.*}}!type ![[TYPE34:[0-9]+]]
-pub fn foo35(_: u16, _: u16, _: u16) { }
+pub fn foo35(_: u16, _: u16, _: u16) {}
 // CHECK: define{{.*}}foo35{{.*}}!type ![[TYPE35:[0-9]+]]
-pub fn foo36(_: u32) { }
+pub fn foo36(_: u32) {}
 // CHECK: define{{.*}}foo36{{.*}}!type ![[TYPE36:[0-9]+]]
-pub fn foo37(_: u32, _: u32) { }
+pub fn foo37(_: u32, _: u32) {}
 // CHECK: define{{.*}}foo37{{.*}}!type ![[TYPE37:[0-9]+]]
-pub fn foo38(_: u32, _: u32, _: u32) { }
+pub fn foo38(_: u32, _: u32, _: u32) {}
 // CHECK: define{{.*}}foo38{{.*}}!type ![[TYPE38:[0-9]+]]
-pub fn foo39(_: u64) { }
+pub fn foo39(_: u64) {}
 // CHECK: define{{.*}}foo39{{.*}}!type ![[TYPE39:[0-9]+]]
-pub fn foo40(_: u64, _: u64) { }
+pub fn foo40(_: u64, _: u64) {}
 // CHECK: define{{.*}}foo40{{.*}}!type ![[TYPE40:[0-9]+]]
-pub fn foo41(_: u64, _: u64, _: u64) { }
+pub fn foo41(_: u64, _: u64, _: u64) {}
 // CHECK: define{{.*}}foo41{{.*}}!type ![[TYPE41:[0-9]+]]
-pub fn foo42(_: u128) { }
+pub fn foo42(_: u128) {}
 // CHECK: define{{.*}}foo42{{.*}}!type ![[TYPE42:[0-9]+]]
-pub fn foo43(_: u128, _: u128) { }
+pub fn foo43(_: u128, _: u128) {}
 // CHECK: define{{.*}}foo43{{.*}}!type ![[TYPE43:[0-9]+]]
-pub fn foo44(_: u128, _: u128, _: u128) { }
+pub fn foo44(_: u128, _: u128, _: u128) {}
 // CHECK: define{{.*}}foo44{{.*}}!type ![[TYPE44:[0-9]+]]
-pub fn foo45(_: usize) { }
+pub fn foo45(_: usize) {}
 // CHECK: define{{.*}}foo45{{.*}}!type ![[TYPE45:[0-9]+]]
-pub fn foo46(_: usize, _: usize) { }
+pub fn foo46(_: usize, _: usize) {}
 // CHECK: define{{.*}}foo46{{.*}}!type ![[TYPE46:[0-9]+]]
-pub fn foo47(_: usize, _: usize, _: usize) { }
+pub fn foo47(_: usize, _: usize, _: usize) {}
 // CHECK: define{{.*}}foo47{{.*}}!type ![[TYPE47:[0-9]+]]
-pub fn foo48(_: f32) { }
+pub fn foo48(_: f32) {}
 // CHECK: define{{.*}}foo48{{.*}}!type ![[TYPE48:[0-9]+]]
-pub fn foo49(_: f32, _: f32) { }
+pub fn foo49(_: f32, _: f32) {}
 // CHECK: define{{.*}}foo49{{.*}}!type ![[TYPE49:[0-9]+]]
-pub fn foo50(_: f32, _: f32, _: f32) { }
+pub fn foo50(_: f32, _: f32, _: f32) {}
 // CHECK: define{{.*}}foo50{{.*}}!type ![[TYPE50:[0-9]+]]
-pub fn foo51(_: f64) { }
+pub fn foo51(_: f64) {}
 // CHECK: define{{.*}}foo51{{.*}}!type ![[TYPE51:[0-9]+]]
-pub fn foo52(_: f64, _: f64) { }
+pub fn foo52(_: f64, _: f64) {}
 // CHECK: define{{.*}}foo52{{.*}}!type ![[TYPE52:[0-9]+]]
-pub fn foo53(_: f64, _: f64, _: f64) { }
+pub fn foo53(_: f64, _: f64, _: f64) {}
 // CHECK: define{{.*}}foo53{{.*}}!type ![[TYPE53:[0-9]+]]
-pub fn foo54(_: char) { }
+pub fn foo54(_: char) {}
 // CHECK: define{{.*}}foo54{{.*}}!type ![[TYPE54:[0-9]+]]
-pub fn foo55(_: char, _: char) { }
+pub fn foo55(_: char, _: char) {}
 // CHECK: define{{.*}}foo55{{.*}}!type ![[TYPE55:[0-9]+]]
-pub fn foo56(_: char, _: char, _: char) { }
+pub fn foo56(_: char, _: char, _: char) {}
 // CHECK: define{{.*}}foo56{{.*}}!type ![[TYPE56:[0-9]+]]
-pub fn foo57(_: &str) { }
+pub fn foo57(_: &str) {}
 // CHECK: define{{.*}}foo57{{.*}}!type ![[TYPE57:[0-9]+]]
-pub fn foo58(_: &str, _: &str) { }
+pub fn foo58(_: &str, _: &str) {}
 // CHECK: define{{.*}}foo58{{.*}}!type ![[TYPE58:[0-9]+]]
-pub fn foo59(_: &str, _: &str, _: &str) { }
+pub fn foo59(_: &str, _: &str, _: &str) {}
 // CHECK: define{{.*}}foo59{{.*}}!type ![[TYPE59:[0-9]+]]
-pub fn foo60(_: (i32, i32)) { }
+pub fn foo60(_: (i32, i32)) {}
 // CHECK: define{{.*}}foo60{{.*}}!type ![[TYPE60:[0-9]+]]
-pub fn foo61(_: (i32, i32), _: (i32, i32)) { }
+pub fn foo61(_: (i32, i32), _: (i32, i32)) {}
 // CHECK: define{{.*}}foo61{{.*}}!type ![[TYPE61:[0-9]+]]
-pub fn foo62(_: (i32, i32), _: (i32, i32), _: (i32, i32)) { }
+pub fn foo62(_: (i32, i32), _: (i32, i32), _: (i32, i32)) {}
 // CHECK: define{{.*}}foo62{{.*}}!type ![[TYPE62:[0-9]+]]
-pub fn foo63(_: [i32; 32]) { }
+pub fn foo63(_: [i32; 32]) {}
 // CHECK: define{{.*}}foo63{{.*}}!type ![[TYPE63:[0-9]+]]
-pub fn foo64(_: [i32; 32], _: [i32; 32]) { }
+pub fn foo64(_: [i32; 32], _: [i32; 32]) {}
 // CHECK: define{{.*}}foo64{{.*}}!type ![[TYPE64:[0-9]+]]
-pub fn foo65(_: [i32; 32], _: [i32; 32], _: [i32; 32]) { }
+pub fn foo65(_: [i32; 32], _: [i32; 32], _: [i32; 32]) {}
 // CHECK: define{{.*}}foo65{{.*}}!type ![[TYPE65:[0-9]+]]
-pub fn foo66(_: &[i32]) { }
+pub fn foo66(_: &[i32]) {}
 // CHECK: define{{.*}}foo66{{.*}}!type ![[TYPE66:[0-9]+]]
-pub fn foo67(_: &[i32], _: &[i32]) { }
+pub fn foo67(_: &[i32], _: &[i32]) {}
 // CHECK: define{{.*}}foo67{{.*}}!type ![[TYPE67:[0-9]+]]
-pub fn foo68(_: &[i32], _: &[i32], _: &[i32]) { }
+pub fn foo68(_: &[i32], _: &[i32], _: &[i32]) {}
 // CHECK: define{{.*}}foo68{{.*}}!type ![[TYPE68:[0-9]+]]
-pub fn foo69(_: &Struct1::<i32>) { }
+pub fn foo69(_: &Struct1<i32>) {}
 // CHECK: define{{.*}}foo69{{.*}}!type ![[TYPE69:[0-9]+]]
-pub fn foo70(_: &Struct1::<i32>, _: &Struct1::<i32>) { }
+pub fn foo70(_: &Struct1<i32>, _: &Struct1<i32>) {}
 // CHECK: define{{.*}}foo70{{.*}}!type ![[TYPE70:[0-9]+]]
-pub fn foo71(_: &Struct1::<i32>, _: &Struct1::<i32>, _: &Struct1::<i32>) { }
+pub fn foo71(_: &Struct1<i32>, _: &Struct1<i32>, _: &Struct1<i32>) {}
 // CHECK: define{{.*}}foo71{{.*}}!type ![[TYPE71:[0-9]+]]
-pub fn foo72(_: &Enum1::<i32>) { }
+pub fn foo72(_: &Enum1<i32>) {}
 // CHECK: define{{.*}}foo72{{.*}}!type ![[TYPE72:[0-9]+]]
-pub fn foo73(_: &Enum1::<i32>, _: &Enum1::<i32>) { }
+pub fn foo73(_: &Enum1<i32>, _: &Enum1<i32>) {}
 // CHECK: define{{.*}}foo73{{.*}}!type ![[TYPE73:[0-9]+]]
-pub fn foo74(_: &Enum1::<i32>, _: &Enum1::<i32>, _: &Enum1::<i32>) { }
+pub fn foo74(_: &Enum1<i32>, _: &Enum1<i32>, _: &Enum1<i32>) {}
 // CHECK: define{{.*}}foo74{{.*}}!type ![[TYPE74:[0-9]+]]
-pub fn foo75(_: &Union1::<i32>) { }
+pub fn foo75(_: &Union1<i32>) {}
 // CHECK: define{{.*}}foo75{{.*}}!type ![[TYPE75:[0-9]+]]
-pub fn foo76(_: &Union1::<i32>, _: &Union1::<i32>) { }
+pub fn foo76(_: &Union1<i32>, _: &Union1<i32>) {}
 // CHECK: define{{.*}}foo76{{.*}}!type ![[TYPE76:[0-9]+]]
-pub fn foo77(_: &Union1::<i32>, _: &Union1::<i32>, _: &Union1::<i32>) { }
+pub fn foo77(_: &Union1<i32>, _: &Union1<i32>, _: &Union1<i32>) {}
 // CHECK: define{{.*}}foo77{{.*}}!type ![[TYPE77:[0-9]+]]
-pub fn foo78(_: *mut type1) { }
+pub fn foo78(_: *mut type1) {}
 // CHECK: define{{.*}}foo78{{.*}}!type ![[TYPE78:[0-9]+]]
-pub fn foo79(_: *mut type1, _: *mut type1) { }
+pub fn foo79(_: *mut type1, _: *mut type1) {}
 // CHECK: define{{.*}}foo79{{.*}}!type ![[TYPE79:[0-9]+]]
-pub fn foo80(_: *mut type1, _: *mut type1, _: *mut type1) { }
+pub fn foo80(_: *mut type1, _: *mut type1, _: *mut type1) {}
 // CHECK: define{{.*}}foo80{{.*}}!type ![[TYPE80:[0-9]+]]
-pub fn foo81(_: &mut i32) { }
+pub fn foo81(_: &mut i32) {}
 // CHECK: define{{.*}}foo81{{.*}}!type ![[TYPE81:[0-9]+]]
-pub fn foo82(_: &mut i32, _: &i32) { }
+pub fn foo82(_: &mut i32, _: &i32) {}
 // CHECK: define{{.*}}foo82{{.*}}!type ![[TYPE82:[0-9]+]]
-pub fn foo83(_: &mut i32, _: &i32, _: &i32) { }
+pub fn foo83(_: &mut i32, _: &i32, _: &i32) {}
 // CHECK: define{{.*}}foo83{{.*}}!type ![[TYPE83:[0-9]+]]
-pub fn foo84(_: &i32) { }
+pub fn foo84(_: &i32) {}
 // CHECK: define{{.*}}foo84{{.*}}!type ![[TYPE84:[0-9]+]]
-pub fn foo85(_: &i32, _: &mut i32) { }
+pub fn foo85(_: &i32, _: &mut i32) {}
 // CHECK: define{{.*}}foo85{{.*}}!type ![[TYPE85:[0-9]+]]
-pub fn foo86(_: &i32, _: &mut i32, _: &mut i32) { }
+pub fn foo86(_: &i32, _: &mut i32, _: &mut i32) {}
 // CHECK: define{{.*}}foo86{{.*}}!type ![[TYPE86:[0-9]+]]
-pub fn foo87(_: *mut i32) { }
+pub fn foo87(_: *mut i32) {}
 // CHECK: define{{.*}}foo87{{.*}}!type ![[TYPE87:[0-9]+]]
-pub fn foo88(_: *mut i32, _: *const i32) { }
+pub fn foo88(_: *mut i32, _: *const i32) {}
 // CHECK: define{{.*}}foo88{{.*}}!type ![[TYPE88:[0-9]+]]
-pub fn foo89(_: *mut i32, _: *const i32, _: *const i32) { }
+pub fn foo89(_: *mut i32, _: *const i32, _: *const i32) {}
 // CHECK: define{{.*}}foo89{{.*}}!type ![[TYPE89:[0-9]+]]
-pub fn foo90(_: *const i32) { }
+pub fn foo90(_: *const i32) {}
 // CHECK: define{{.*}}foo90{{.*}}!type ![[TYPE90:[0-9]+]]
-pub fn foo91(_: *const i32, _: *mut i32) { }
+pub fn foo91(_: *const i32, _: *mut i32) {}
 // CHECK: define{{.*}}foo91{{.*}}!type ![[TYPE91:[0-9]+]]
-pub fn foo92(_: *const i32, _: *mut i32, _: *mut i32) { }
+pub fn foo92(_: *const i32, _: *mut i32, _: *mut i32) {}
 // CHECK: define{{.*}}foo92{{.*}}!type ![[TYPE92:[0-9]+]]
-pub fn foo93(_: fn(i32) -> i32) { }
+pub fn foo93(_: fn(i32) -> i32) {}
 // CHECK: define{{.*}}foo93{{.*}}!type ![[TYPE93:[0-9]+]]
-pub fn foo94(_: fn(i32) -> i32, _: fn(i32) -> i32) { }
+pub fn foo94(_: fn(i32) -> i32, _: fn(i32) -> i32) {}
 // CHECK: define{{.*}}foo94{{.*}}!type ![[TYPE94:[0-9]+]]
-pub fn foo95(_: fn(i32) -> i32, _: fn(i32) -> i32, _: fn(i32) -> i32) { }
+pub fn foo95(_: fn(i32) -> i32, _: fn(i32) -> i32, _: fn(i32) -> i32) {}
 // CHECK: define{{.*}}foo95{{.*}}!type ![[TYPE95:[0-9]+]]
-pub fn foo96(_: &dyn Fn(i32) -> i32) { }
+pub fn foo96(_: &dyn Fn(i32) -> i32) {}
 // CHECK: define{{.*}}foo96{{.*}}!type ![[TYPE96:[0-9]+]]
-pub fn foo97(_: &dyn Fn(i32) -> i32, _: &dyn Fn(i32) -> i32) { }
+pub fn foo97(_: &dyn Fn(i32) -> i32, _: &dyn Fn(i32) -> i32) {}
 // CHECK: define{{.*}}foo97{{.*}}!type ![[TYPE97:[0-9]+]]
-pub fn foo98(_: &dyn Fn(i32) -> i32, _: &dyn Fn(i32) -> i32, _: &dyn Fn(i32) -> i32) { }
+pub fn foo98(_: &dyn Fn(i32) -> i32, _: &dyn Fn(i32) -> i32, _: &dyn Fn(i32) -> i32) {}
 // CHECK: define{{.*}}foo98{{.*}}!type ![[TYPE98:[0-9]+]]
-pub fn foo99(_: &dyn FnMut(i32) -> i32) { }
+pub fn foo99(_: &dyn FnMut(i32) -> i32) {}
 // CHECK: define{{.*}}foo99{{.*}}!type ![[TYPE99:[0-9]+]]
-pub fn foo100(_: &dyn FnMut(i32) -> i32, _: &dyn FnMut(i32) -> i32) { }
+pub fn foo100(_: &dyn FnMut(i32) -> i32, _: &dyn FnMut(i32) -> i32) {}
 // CHECK: define{{.*}}foo100{{.*}}!type ![[TYPE100:[0-9]+]]
-pub fn foo101(_: &dyn FnMut(i32) -> i32, _: &dyn FnMut(i32) -> i32, _: &dyn FnMut(i32) -> i32) { }
+pub fn foo101(_: &dyn FnMut(i32) -> i32, _: &dyn FnMut(i32) -> i32, _: &dyn FnMut(i32) -> i32) {}
 // CHECK: define{{.*}}foo101{{.*}}!type ![[TYPE101:[0-9]+]]
-pub fn foo102(_: &dyn FnOnce(i32) -> i32) { }
+pub fn foo102(_: &dyn FnOnce(i32) -> i32) {}
 // CHECK: define{{.*}}foo102{{.*}}!type ![[TYPE102:[0-9]+]]
-pub fn foo103(_: &dyn FnOnce(i32) -> i32, _: &dyn FnOnce(i32) -> i32) { }
+pub fn foo103(_: &dyn FnOnce(i32) -> i32, _: &dyn FnOnce(i32) -> i32) {}
 // CHECK: define{{.*}}foo103{{.*}}!type ![[TYPE103:[0-9]+]]
 pub fn foo104(_: &dyn FnOnce(i32) -> i32, _: &dyn FnOnce(i32) -> i32, _: &dyn FnOnce(i32) -> i32) {}
 // CHECK: define{{.*}}foo104{{.*}}!type ![[TYPE104:[0-9]+]]
-pub fn foo105(_: &dyn Send) { }
+pub fn foo105(_: &dyn Send) {}
 // CHECK: define{{.*}}foo105{{.*}}!type ![[TYPE105:[0-9]+]]
-pub fn foo106(_: &dyn Send, _: &dyn Send) { }
+pub fn foo106(_: &dyn Send, _: &dyn Send) {}
 // CHECK: define{{.*}}foo106{{.*}}!type ![[TYPE106:[0-9]+]]
-pub fn foo107(_: &dyn Send, _: &dyn Send, _: &dyn Send) { }
+pub fn foo107(_: &dyn Send, _: &dyn Send, _: &dyn Send) {}
 // CHECK: define{{.*}}foo107{{.*}}!type ![[TYPE107:[0-9]+]]
-pub fn foo108(_: Type1) { }
+pub fn foo108(_: Type1) {}
 // CHECK: define{{.*}}foo108{{.*}}!type ![[TYPE108:[0-9]+]]
-pub fn foo109(_: Type1, _: Type1) { }
+pub fn foo109(_: Type1, _: Type1) {}
 // CHECK: define{{.*}}foo109{{.*}}!type ![[TYPE109:[0-9]+]]
-pub fn foo110(_: Type1, _: Type1, _: Type1) { }
+pub fn foo110(_: Type1, _: Type1, _: Type1) {}
 // CHECK: define{{.*}}foo110{{.*}}!type ![[TYPE110:[0-9]+]]
-pub fn foo111(_: Type2) { }
+pub fn foo111(_: Type2) {}
 // CHECK: define{{.*}}foo111{{.*}}!type ![[TYPE111:[0-9]+]]
-pub fn foo112(_: Type2, _: Type2) { }
+pub fn foo112(_: Type2, _: Type2) {}
 // CHECK: define{{.*}}foo112{{.*}}!type ![[TYPE112:[0-9]+]]
-pub fn foo113(_: Type2, _: Type2, _: Type2) { }
+pub fn foo113(_: Type2, _: Type2, _: Type2) {}
 // CHECK: define{{.*}}foo113{{.*}}!type ![[TYPE113:[0-9]+]]
-pub fn foo114(_: Type3) { }
+pub fn foo114(_: Type3) {}
 // CHECK: define{{.*}}foo114{{.*}}!type ![[TYPE114:[0-9]+]]
-pub fn foo115(_: Type3, _: Type3) { }
+pub fn foo115(_: Type3, _: Type3) {}
 // CHECK: define{{.*}}foo115{{.*}}!type ![[TYPE115:[0-9]+]]
-pub fn foo116(_: Type3, _: Type3, _: Type3) { }
+pub fn foo116(_: Type3, _: Type3, _: Type3) {}
 // CHECK: define{{.*}}foo116{{.*}}!type ![[TYPE116:[0-9]+]]
-pub fn foo117(_: Type4) { }
+pub fn foo117(_: Type4) {}
 // CHECK: define{{.*}}foo117{{.*}}!type ![[TYPE117:[0-9]+]]
-pub fn foo118(_: Type4, _: Type4) { }
+pub fn foo118(_: Type4, _: Type4) {}
 // CHECK: define{{.*}}foo118{{.*}}!type ![[TYPE118:[0-9]+]]
-pub fn foo119(_: Type4, _: Type4, _: Type4) { }
+pub fn foo119(_: Type4, _: Type4, _: Type4) {}
 // CHECK: define{{.*}}foo119{{.*}}!type ![[TYPE119:[0-9]+]]
-pub fn foo120(_: Type5) { }
+pub fn foo120(_: Type5) {}
 // CHECK: define{{.*}}foo120{{.*}}!type ![[TYPE120:[0-9]+]]
-pub fn foo121(_: Type5, _: Type5) { }
+pub fn foo121(_: Type5, _: Type5) {}
 // CHECK: define{{.*}}foo121{{.*}}!type ![[TYPE121:[0-9]+]]
-pub fn foo122(_: Type5, _: Type5, _: Type5) { }
+pub fn foo122(_: Type5, _: Type5, _: Type5) {}
 // CHECK: define{{.*}}foo122{{.*}}!type ![[TYPE122:[0-9]+]]
-pub fn foo123(_: Type6) { }
+pub fn foo123(_: Type6) {}
 // CHECK: define{{.*}}foo123{{.*}}!type ![[TYPE123:[0-9]+]]
-pub fn foo124(_: Type6, _: Type6) { }
+pub fn foo124(_: Type6, _: Type6) {}
 // CHECK: define{{.*}}foo124{{.*}}!type ![[TYPE124:[0-9]+]]
-pub fn foo125(_: Type6, _: Type6, _: Type6) { }
+pub fn foo125(_: Type6, _: Type6, _: Type6) {}
 // CHECK: define{{.*}}foo125{{.*}}!type ![[TYPE125:[0-9]+]]
-pub fn foo126(_: Type7) { }
+pub fn foo126(_: Type7) {}
 // CHECK: define{{.*}}foo126{{.*}}!type ![[TYPE126:[0-9]+]]
-pub fn foo127(_: Type7, _: Type7) { }
+pub fn foo127(_: Type7, _: Type7) {}
 // CHECK: define{{.*}}foo127{{.*}}!type ![[TYPE127:[0-9]+]]
-pub fn foo128(_: Type7, _: Type7, _: Type7) { }
+pub fn foo128(_: Type7, _: Type7, _: Type7) {}
 // CHECK: define{{.*}}foo128{{.*}}!type ![[TYPE128:[0-9]+]]
-pub fn foo129(_: Type8) { }
+pub fn foo129(_: Type8) {}
 // CHECK: define{{.*}}foo129{{.*}}!type ![[TYPE129:[0-9]+]]
-pub fn foo130(_: Type8, _: Type8) { }
+pub fn foo130(_: Type8, _: Type8) {}
 // CHECK: define{{.*}}foo130{{.*}}!type ![[TYPE130:[0-9]+]]
-pub fn foo131(_: Type8, _: Type8, _: Type8) { }
+pub fn foo131(_: Type8, _: Type8, _: Type8) {}
 // CHECK: define{{.*}}foo131{{.*}}!type ![[TYPE131:[0-9]+]]
-pub fn foo132(_: Type9) { }
+pub fn foo132(_: Type9) {}
 // CHECK: define{{.*}}foo132{{.*}}!type ![[TYPE132:[0-9]+]]
-pub fn foo133(_: Type9, _: Type9) { }
+pub fn foo133(_: Type9, _: Type9) {}
 // CHECK: define{{.*}}foo133{{.*}}!type ![[TYPE133:[0-9]+]]
-pub fn foo134(_: Type9, _: Type9, _: Type9) { }
+pub fn foo134(_: Type9, _: Type9, _: Type9) {}
 // CHECK: define{{.*}}foo134{{.*}}!type ![[TYPE134:[0-9]+]]
-pub fn foo135(_: Type10) { }
+pub fn foo135(_: Type10) {}
 // CHECK: define{{.*}}foo135{{.*}}!type ![[TYPE135:[0-9]+]]
-pub fn foo136(_: Type10, _: Type10) { }
+pub fn foo136(_: Type10, _: Type10) {}
 // CHECK: define{{.*}}foo136{{.*}}!type ![[TYPE136:[0-9]+]]
-pub fn foo137(_: Type10, _: Type10, _: Type10) { }
+pub fn foo137(_: Type10, _: Type10, _: Type10) {}
 // CHECK: define{{.*}}foo137{{.*}}!type ![[TYPE137:[0-9]+]]
-pub fn foo138(_: Type11) { }
+pub fn foo138(_: Type11) {}
 // CHECK: define{{.*}}foo138{{.*}}!type ![[TYPE138:[0-9]+]]
-pub fn foo139(_: Type11, _: Type11) { }
+pub fn foo139(_: Type11, _: Type11) {}
 // CHECK: define{{.*}}foo139{{.*}}!type ![[TYPE139:[0-9]+]]
-pub fn foo140(_: Type11, _: Type11, _: Type11) { }
+pub fn foo140(_: Type11, _: Type11, _: Type11) {}
 // CHECK: define{{.*}}foo140{{.*}}!type ![[TYPE140:[0-9]+]]
-pub fn foo141(_: Type12) { }
+pub fn foo141(_: Type12) {}
 // CHECK: define{{.*}}foo141{{.*}}!type ![[TYPE141:[0-9]+]]
-pub fn foo142(_: Type12, _: Type12) { }
+pub fn foo142(_: Type12, _: Type12) {}
 // CHECK: define{{.*}}foo142{{.*}}!type ![[TYPE142:[0-9]+]]
-pub fn foo143(_: Type12, _: Type12, _: Type12) { }
+pub fn foo143(_: Type12, _: Type12, _: Type12) {}
 // CHECK: define{{.*}}foo143{{.*}}!type ![[TYPE143:[0-9]+]]
-pub fn foo144(_: Type13) { }
+pub fn foo144(_: Type13) {}
 // CHECK: define{{.*}}foo144{{.*}}!type ![[TYPE144:[0-9]+]]
-pub fn foo145(_: Type13, _: Type13) { }
+pub fn foo145(_: Type13, _: Type13) {}
 // CHECK: define{{.*}}foo145{{.*}}!type ![[TYPE145:[0-9]+]]
-pub fn foo146(_: Type13, _: Type13, _: Type13) { }
+pub fn foo146(_: Type13, _: Type13, _: Type13) {}
 // CHECK: define{{.*}}foo146{{.*}}!type ![[TYPE146:[0-9]+]]
-pub fn foo147(_: Type14<Bar>) { }
+pub fn foo147(_: Type14<Bar>) {}
 // CHECK: define{{.*}}foo147{{.*}}!type ![[TYPE147:[0-9]+]]
-pub fn foo148(_: Type14<Bar>, _: Type14<Bar>) { }
+pub fn foo148(_: Type14<Bar>, _: Type14<Bar>) {}
 // CHECK: define{{.*}}foo148{{.*}}!type ![[TYPE148:[0-9]+]]
-pub fn foo149(_: Type14<Bar>, _: Type14<Bar>, _: Type14<Bar>) { }
+pub fn foo149(_: Type14<Bar>, _: Type14<Bar>, _: Type14<Bar>) {}
 // CHECK: define{{.*}}foo149{{.*}}!type ![[TYPE149:[0-9]+]]
 
 // CHECK: ![[TYPE0]] = !{i64 0, !"_ZTSFvvE"}

--- a/tests/codegen/sanitizer-cfi-emit-type-metadata-id-itanium-cxx-abi.rs
+++ b/tests/codegen/sanitizer-cfi-emit-type-metadata-id-itanium-cxx-abi.rs
@@ -7,7 +7,13 @@
 #![allow(dead_code)]
 #![allow(incomplete_features)]
 #![allow(unused_must_use)]
-#![feature(adt_const_params, extern_types, inline_const, type_alias_impl_trait)]
+#![feature(
+    adt_const_params,
+    extern_types,
+    inline_const,
+    type_alias_impl_trait,
+    type_alias_impl_trait_in_where_bounds
+)]
 
 extern crate core;
 use core::ffi::c_void;

--- a/tests/ui/feature-gates/feature-gate-type_alias_impl_trait.rs
+++ b/tests/ui/feature-gates/feature-gate-type_alias_impl_trait.rs
@@ -12,7 +12,10 @@ fn define() -> Bar {
 
 type Foo2 = impl Debug;
 
-fn define2() {
+fn define2()
+where
+    Foo2: Debug,
+{
     let x = || -> Foo2 { 42 };
 }
 
@@ -21,13 +24,19 @@ type Foo3 = impl Debug;
 fn define3(x: Foo3) {
     let y: i32 = x;
 }
-fn define3_1() {
+fn define3_1()
+where
+    Foo3: Debug,
+{
     define3(42)
 }
 
 type Foo4 = impl Debug;
 
-fn define4() {
+fn define4()
+where
+    Foo4: Debug,
+{
     let y: Foo4 = 42;
 }
 

--- a/tests/ui/feature-gates/feature-gate-type_alias_impl_trait_in_where_bounds.rs
+++ b/tests/ui/feature-gates/feature-gate-type_alias_impl_trait_in_where_bounds.rs
@@ -1,6 +1,6 @@
 // ignore-compare-mode-chalk
 // check-pass
-#![feature(type_alias_impl_trait)]
+#![feature(type_alias_impl_trait, type_alias_impl_trait_in_where_bounds)]
 use std::fmt::Debug;
 
 type Foo = impl Debug;
@@ -10,8 +10,12 @@ fn define() -> Bar {
     Bar(42)
 }
 
-fn define2() {
-    type Foo2 = impl Debug;
+type Foo2 = impl Debug;
+
+fn define2()
+where
+    Foo2: Debug,
+{
     let x = || -> Foo2 { 42 };
 }
 
@@ -20,9 +24,19 @@ type Foo3 = impl Debug;
 fn define3(x: Foo3) {
     let y: i32 = x;
 }
+fn define3_1()
+where
+    Foo3: Debug,
+{
+    define3(42)
+}
 
-fn define4() {
-    type Foo4 = impl Debug;
+type Foo4 = impl Debug;
+
+fn define4()
+where
+    Foo4: Debug,
+{
     let y: Foo4 = 42;
 }
 

--- a/tests/ui/impl-trait/deduce-signature-from-supertrait.rs
+++ b/tests/ui/impl-trait/deduce-signature-from-supertrait.rs
@@ -8,8 +8,13 @@ impl<T: Fn(i32)> SuperExpectation for T {}
 
 type Foo = impl SuperExpectation;
 
-fn main() {
+fn foo()
+where
+    Foo: SuperExpectation,
+{
     let _: Foo = |x| {
         let _ = x.to_string();
     };
 }
+
+fn main() {}

--- a/tests/ui/impl-trait/deduce-signature-from-supertrait.rs
+++ b/tests/ui/impl-trait/deduce-signature-from-supertrait.rs
@@ -1,6 +1,6 @@
 // check-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(type_alias_impl_trait, type_alias_impl_trait_in_where_bounds)]
 
 trait SuperExpectation: Fn(i32) {}
 

--- a/tests/ui/impl-trait/issue-55872-2.stderr
+++ b/tests/ui/impl-trait/issue-55872-2.stderr
@@ -1,8 +1,0 @@
-error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
-  --> $DIR/issue-55872-2.rs:17:9
-   |
-LL |         async {}
-   |         ^^^^^^^^
-
-error: aborting due to previous error
-

--- a/tests/ui/impl-trait/issues/issue-74282.rs
+++ b/tests/ui/impl-trait/issues/issue-74282.rs
@@ -1,11 +1,12 @@
 #![feature(type_alias_impl_trait)]
 
-type Closure = impl Fn() -> u64;
-struct Anonymous(Closure);
-
 fn main() {
+    type Closure = impl Fn() -> u64;
+    struct Anonymous(Closure);
     let y = || -> Closure { || 3 };
-    Anonymous(|| { //~ ERROR mismatched types
-        3 //~^ ERROR mismatched types
+    Anonymous(|| {
+        //~^ ERROR mismatched types
+        //~| ERROR mismatched types
+        3
     })
 }

--- a/tests/ui/impl-trait/issues/issue-74282.stderr
+++ b/tests/ui/impl-trait/issues/issue-74282.stderr
@@ -1,34 +1,38 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-74282.rs:8:15
+  --> $DIR/issue-74282.rs:7:15
    |
-LL |   type Closure = impl Fn() -> u64;
-   |                  ---------------- the expected opaque type
+LL |       type Closure = impl Fn() -> u64;
+   |                      ---------------- the expected opaque type
 ...
 LL |       Anonymous(|| {
    |  _____---------_^
    | |     |
    | |     arguments to this struct are incorrect
+LL | |
+LL | |
 LL | |         3
 LL | |     })
    | |_____^ expected opaque type, found closure
    |
    = note: expected opaque type `Closure`
-                  found closure `[closure@$DIR/issue-74282.rs:8:15: 8:17]`
+                  found closure `[closure@$DIR/issue-74282.rs:7:15: 7:17]`
    = note: no two closures, even if identical, have the same type
    = help: consider boxing your closure and/or using it as a trait object
 note: tuple struct defined here
-  --> $DIR/issue-74282.rs:4:8
+  --> $DIR/issue-74282.rs:5:12
    |
-LL | struct Anonymous(Closure);
-   |        ^^^^^^^^^
+LL |     struct Anonymous(Closure);
+   |            ^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/issue-74282.rs:8:5
+  --> $DIR/issue-74282.rs:7:5
    |
 LL |   fn main() {
    |             - expected `()` because of default return type
-LL |       let y = || -> Closure { || 3 };
+...
 LL | /     Anonymous(|| {
+LL | |
+LL | |
 LL | |         3
 LL | |     })
    | |      ^- help: consider using a semicolon here: `;`

--- a/tests/ui/impl-trait/issues/issue-78722.global.stderr
+++ b/tests/ui/impl-trait/issues/issue-78722.global.stderr
@@ -1,5 +1,5 @@
 error[E0658]: `async` blocks are not allowed in constants
-  --> $DIR/issue-78722.rs:13:20
+  --> $DIR/issue-78722.rs:18:20
    |
 LL |         let f: F = async { 1 };
    |                    ^^^^^^^^^^^
@@ -7,8 +7,8 @@ LL |         let f: F = async { 1 };
    = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
    = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
 
-error[E0271]: expected `[async block@$DIR/issue-78722.rs:11:13: 11:21]` to be a future that resolves to `u8`, but it resolves to `()`
-  --> $DIR/issue-78722.rs:9:30
+error[E0271]: expected `[async block@$DIR/issue-78722.rs:16:13: 16:21]` to be a future that resolves to `u8`, but it resolves to `()`
+  --> $DIR/issue-78722.rs:14:30
    |
 LL |         fn concrete_use() -> F {
    |                              ^ expected `()`, found `u8`

--- a/tests/ui/impl-trait/issues/issue-78722.in_const.stderr
+++ b/tests/ui/impl-trait/issues/issue-78722.in_const.stderr
@@ -1,0 +1,19 @@
+error[E0658]: `async` blocks are not allowed in constants
+  --> $DIR/issue-78722.rs:18:20
+   |
+LL |         let f: F = async { 1 };
+   |                    ^^^^^^^^^^^
+   |
+   = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
+   = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
+
+error[E0271]: expected `[async block@$DIR/issue-78722.rs:16:13: 16:21]` to be a future that resolves to `u8`, but it resolves to `()`
+  --> $DIR/issue-78722.rs:14:30
+   |
+LL |         fn concrete_use() -> F {
+   |                              ^ expected `()`, found `u8`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0271, E0658.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/impl-trait/issues/issue-78722.rs
+++ b/tests/ui/impl-trait/issues/issue-78722.rs
@@ -1,11 +1,16 @@
 // edition:2018
 
+// revisions: global in_const
+
 #![feature(type_alias_impl_trait)]
 
+#[cfg(global)]
 type F = impl core::future::Future<Output = u8>;
 
 struct Bug {
     V1: [(); {
+        #[cfg(in_const)]
+        type F = impl core::future::Future<Output = u8>;
         fn concrete_use() -> F {
             //~^ ERROR to be a future that resolves to `u8`, but it resolves to `()`
             async {}

--- a/tests/ui/type-alias-impl-trait/almost_in_scope.rs
+++ b/tests/ui/type-alias-impl-trait/almost_in_scope.rs
@@ -1,0 +1,18 @@
+#![feature(type_alias_impl_trait)]
+
+type Foo = impl std::fmt::Debug;
+
+trait Blah {
+    type Output;
+    fn method();
+}
+
+impl Blah for u32 {
+    type Output = Foo;
+    fn method() {
+        let x: Foo = 22_u32;
+        //~^ ERROR: opaque type constrained without being represented in the signature
+    }
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/almost_in_scope.stderr
+++ b/tests/ui/type-alias-impl-trait/almost_in_scope.stderr
@@ -1,0 +1,10 @@
+error: opaque type constrained without being represented in the signature
+  --> $DIR/almost_in_scope.rs:13:22
+   |
+LL |     fn method() {
+   |     ----------- this item must mention the opaque type in its signature or where bounds
+LL |         let x: Foo = 22_u32;
+   |                      ^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/type-alias-impl-trait/associated-type-impl-trait-lifetime.rs
+++ b/tests/ui/type-alias-impl-trait/associated-type-impl-trait-lifetime.rs
@@ -5,15 +5,14 @@
 trait Trait {
     type Opaque1;
     type Opaque2;
-    fn constrain(self);
+    fn constrain(self) -> (Self::Opaque1, Self::Opaque2);
 }
 
 impl<'a> Trait for &'a () {
     type Opaque1 = impl Sized;
     type Opaque2 = impl Sized + 'a;
-    fn constrain(self) {
-        let _: Self::Opaque1 = ();
-        let _: Self::Opaque2 = self;
+    fn constrain(self) -> (Self::Opaque1, Self::Opaque2) {
+        ((), self)
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/closure_args.rs
+++ b/tests/ui/type-alias-impl-trait/closure_args.rs
@@ -2,7 +2,7 @@
 
 // regression test for https://github.com/rust-lang/rust/issues/100800
 
-#![feature(type_alias_impl_trait)]
+#![feature(type_alias_impl_trait, type_alias_impl_trait_in_where_bounds)]
 
 trait Anything {}
 impl<T> Anything for T {}

--- a/tests/ui/type-alias-impl-trait/closure_args.rs
+++ b/tests/ui/type-alias-impl-trait/closure_args.rs
@@ -11,6 +11,18 @@ fn run<F: FnOnce(Input) -> ()>(f: F, i: Input) {
     f(i);
 }
 
+fn foo()
+where
+    Input: Anything,
+{
+    run(
+        |x: u32| {
+            println!("{x}");
+        },
+        0,
+    );
+}
+
 fn main() {
-    run(|x: u32| {println!("{x}");}, 0);
+    foo();
 }

--- a/tests/ui/type-alias-impl-trait/closure_args2.rs
+++ b/tests/ui/type-alias-impl-trait/closure_args2.rs
@@ -4,7 +4,9 @@
 
 trait Foo {
     // This was reachable in https://github.com/rust-lang/rust/issues/100800
-    fn foo(&self) { unreachable!() }
+    fn foo(&self) {
+        unreachable!()
+    }
 }
 impl<T> Foo for T {}
 
@@ -14,10 +16,21 @@ impl B {
 }
 
 type Input = impl Foo;
-fn run1<F: FnOnce(Input)>(f: F, i: Input) {f(i)}
-fn run2<F: FnOnce(B)>(f: F, i: B) {f(i)}
+fn run1<F: FnOnce(Input)>(f: F, i: Input) {
+    f(i)
+}
+fn run2<F: FnOnce(B)>(f: F, i: B) {
+    f(i)
+}
+
+fn foo()
+where
+    Input: Foo,
+{
+    run1(|x: B| x.foo(), B);
+    run2(|x: B| x.foo(), B);
+}
 
 fn main() {
-    run1(|x: B| {x.foo()}, B);
-    run2(|x: B| {x.foo()}, B);
+    foo();
 }

--- a/tests/ui/type-alias-impl-trait/closure_args2.rs
+++ b/tests/ui/type-alias-impl-trait/closure_args2.rs
@@ -1,6 +1,6 @@
 // run-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(type_alias_impl_trait, type_alias_impl_trait_in_where_bounds)]
 
 trait Foo {
     // This was reachable in https://github.com/rust-lang/rust/issues/100800

--- a/tests/ui/type-alias-impl-trait/defining-scope-self.rs
+++ b/tests/ui/type-alias-impl-trait/defining-scope-self.rs
@@ -1,0 +1,21 @@
+#![feature(type_alias_impl_trait)]
+
+// edition: 2021
+// check-pass
+
+type MyIter = impl Iterator<Item = i32>;
+
+struct Foo {
+    iter: MyIter,
+}
+
+// ensure that `self` is seen as `Foo` and thus
+// counts as a defining use for `MyIter` due to the
+// struct field.
+impl Foo {
+    fn set_iter(&mut self) {
+        self.iter = [1, 2, 3].into_iter();
+    }
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/defining-scopes-in_type.rs
+++ b/tests/ui/type-alias-impl-trait/defining-scopes-in_type.rs
@@ -1,0 +1,16 @@
+#![feature(type_alias_impl_trait)]
+
+// check that we don't allow defining hidden types of TAITs in
+// const generic defaults.
+type Foo = impl Send;
+//~^ ERROR unconstrained opaque type
+
+#[rustfmt::skip]
+struct Struct<
+    const C: usize = {
+        let _: Foo = ();
+        0
+    },
+>;
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/defining-scopes-in_type.stderr
+++ b/tests/ui/type-alias-impl-trait/defining-scopes-in_type.stderr
@@ -1,0 +1,10 @@
+error: unconstrained opaque type
+  --> $DIR/defining-scopes-in_type.rs:5:12
+   |
+LL | type Foo = impl Send;
+   |            ^^^^^^^^^
+   |
+   = note: `Foo` must be used in combination with a concrete type within the same module
+
+error: aborting due to previous error
+

--- a/tests/ui/type-alias-impl-trait/defining-scopes-semantic.rs
+++ b/tests/ui/type-alias-impl-trait/defining-scopes-semantic.rs
@@ -1,0 +1,14 @@
+#![feature(type_alias_impl_trait)]
+
+// check-pass
+
+type Foo = impl std::fmt::Debug;
+
+struct Wrap(Foo);
+
+// Check that fields count as defining uses, too
+fn h() -> Wrap {
+    Wrap(42)
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/defining-scopes-syntactic.rs
+++ b/tests/ui/type-alias-impl-trait/defining-scopes-syntactic.rs
@@ -1,0 +1,19 @@
+#![feature(type_alias_impl_trait)]
+
+// Check that we cannot syntactically mention a TAIT without
+// it also being part of the type.
+
+type DropType<T> = ();
+//~^ ERROR type parameter `T` is unused
+
+type Foo = impl std::fmt::Debug;
+
+// Check that, even though `Foo` is not part
+// of the actual type, we do allow this to be a defining scope
+fn g() -> DropType<Foo> {
+    let _: Foo = 42;
+    //~^ ERROR: constrained without being represented in the signature
+    ()
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/defining-scopes-syntactic.stderr
+++ b/tests/ui/type-alias-impl-trait/defining-scopes-syntactic.stderr
@@ -1,0 +1,17 @@
+error[E0091]: type parameter `T` is unused
+  --> $DIR/defining-scopes-syntactic.rs:6:15
+   |
+LL | type DropType<T> = ();
+   |               ^ unused type parameter
+
+error: opaque type constrained without being represented in the signature
+  --> $DIR/defining-scopes-syntactic.rs:14:12
+   |
+LL | fn g() -> DropType<Foo> {
+   | ----------------------- this item must mention the opaque type in its signature or where bounds
+LL |     let _: Foo = 42;
+   |            ^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0091`.

--- a/tests/ui/type-alias-impl-trait/defining-scopes-syntacticish.rs
+++ b/tests/ui/type-alias-impl-trait/defining-scopes-syntacticish.rs
@@ -1,0 +1,18 @@
+#![feature(type_alias_impl_trait)]
+
+// check-pass
+
+// Check that we cannot syntactically mention a TAIT without
+// it also being part of the type.
+
+struct DropType<T>(std::marker::PhantomData<T>);
+
+type Foo = impl std::fmt::Debug;
+// Check that, even though `Foo` is not part
+// of the actual type, we do allow this to be a defining scope
+fn g() -> DropType<Foo> {
+    let _: Foo = 42;
+    DropType(std::marker::PhantomData)
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/defining-use-item-child.rs
+++ b/tests/ui/type-alias-impl-trait/defining-use-item-child.rs
@@ -1,0 +1,30 @@
+#![feature(type_alias_impl_trait)]
+
+fn main() {}
+
+type Foo = impl std::fmt::Display;
+
+fn bar() {
+    pub fn foo() -> Foo {
+        "foo"
+        //~^ ERROR: opaque type constrained in nested item
+    }
+}
+
+fn baz() -> Foo {
+    pub fn foo() -> Foo {
+        "foo"
+        //~^ ERROR: opaque type constrained in nested item
+    }
+    "baz"
+}
+
+struct Bak {
+    x: [u8; {
+        fn blob() -> Foo {
+            "blob"
+            //~^ ERROR: opaque type constrained in nested item
+        }
+        5
+    }],
+}

--- a/tests/ui/type-alias-impl-trait/defining-use-item-child.stderr
+++ b/tests/ui/type-alias-impl-trait/defining-use-item-child.stderr
@@ -1,0 +1,26 @@
+error: opaque type constrained in nested item
+  --> $DIR/defining-use-item-child.rs:9:9
+   |
+LL |     pub fn foo() -> Foo {
+   |     ------------------- this item is not a sibling of the opaque type
+LL |         "foo"
+   |         ^^^^^
+
+error: opaque type constrained in nested item
+  --> $DIR/defining-use-item-child.rs:16:9
+   |
+LL |     pub fn foo() -> Foo {
+   |     ------------------- this item is not a sibling of the opaque type
+LL |         "foo"
+   |         ^^^^^
+
+error: opaque type constrained in nested item
+  --> $DIR/defining-use-item-child.rs:25:13
+   |
+LL |         fn blob() -> Foo {
+   |         ---------------- this item is not a sibling of the opaque type
+LL |             "blob"
+   |             ^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.rs
+++ b/tests/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.rs
@@ -1,6 +1,9 @@
 #![feature(type_alias_impl_trait)]
 
-fn main() {
+fn foo()
+where
+    WrongGeneric<i32>: 'static,
+{
     let y = 42;
     let x = wrong_generic(&y);
     let z: i32 = x;
@@ -13,4 +16,8 @@ type WrongGeneric<T> = impl 'static;
 fn wrong_generic<T>(t: T) -> WrongGeneric<T> {
     t
     //~^ ERROR the parameter type `T` may not live long enough
+}
+
+fn main() {
+    foo();
 }

--- a/tests/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.rs
+++ b/tests/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(type_alias_impl_trait, type_alias_impl_trait_in_where_bounds)]
 
 fn foo()
 where

--- a/tests/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.stderr
@@ -1,11 +1,11 @@
 error: at least one trait must be specified
-  --> $DIR/generic_type_does_not_live_long_enough.rs:10:24
+  --> $DIR/generic_type_does_not_live_long_enough.rs:13:24
    |
 LL | type WrongGeneric<T> = impl 'static;
    |                        ^^^^^^^^^^^^
 
 error[E0792]: expected generic type parameter, found `&i32`
-  --> $DIR/generic_type_does_not_live_long_enough.rs:6:18
+  --> $DIR/generic_type_does_not_live_long_enough.rs:9:18
    |
 LL |     let z: i32 = x;
    |                  ^
@@ -14,7 +14,7 @@ LL | type WrongGeneric<T> = impl 'static;
    |                   - this generic parameter must be used with a generic type parameter
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/generic_type_does_not_live_long_enough.rs:14:5
+  --> $DIR/generic_type_does_not_live_long_enough.rs:17:5
    |
 LL |     t
    |     ^ ...so that the type `T` will meet its required lifetime bounds

--- a/tests/ui/type-alias-impl-trait/impl_trait_for_tait_bound.rs
+++ b/tests/ui/type-alias-impl-trait/impl_trait_for_tait_bound.rs
@@ -3,17 +3,20 @@
 use std::fmt::Debug;
 
 type Foo = impl Debug;
-pub trait Yay { }
-impl Yay for Foo { }
+pub trait Yay {}
+impl Yay for Foo {}
 
-fn foo() {
-    is_yay::<u32>();   //~ ERROR: the trait bound `u32: Yay` is not satisfied
+fn foo()
+where
+    Foo: Debug,
+{
+    is_yay::<u32>(); //~ ERROR: the trait bound `u32: Yay` is not satisfied
     is_debug::<u32>(); // OK
-    is_yay::<Foo>();   // OK
+    is_yay::<Foo>(); // OK
     is_debug::<Foo>(); // OK
 }
 
-fn is_yay<T: Yay>() { }
-fn is_debug<T: Debug>() { }
+fn is_yay<T: Yay>() {}
+fn is_debug<T: Debug>() {}
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/impl_trait_for_tait_bound.stderr
+++ b/tests/ui/type-alias-impl-trait/impl_trait_for_tait_bound.stderr
@@ -1,14 +1,14 @@
 error[E0277]: the trait bound `u32: Yay` is not satisfied
-  --> $DIR/impl_trait_for_tait_bound.rs:10:14
+  --> $DIR/impl_trait_for_tait_bound.rs:13:14
    |
 LL |     is_yay::<u32>();
    |              ^^^ the trait `Yay` is not implemented for `u32`
    |
    = help: the trait `Yay` is implemented for `Foo`
 note: required by a bound in `is_yay`
-  --> $DIR/impl_trait_for_tait_bound.rs:16:14
+  --> $DIR/impl_trait_for_tait_bound.rs:19:14
    |
-LL | fn is_yay<T: Yay>() { }
+LL | fn is_yay<T: Yay>() {}
    |              ^^^ required by this bound in `is_yay`
 
 error: aborting due to previous error

--- a/tests/ui/type-alias-impl-trait/impl_trait_for_tait_bound2.rs
+++ b/tests/ui/type-alias-impl-trait/impl_trait_for_tait_bound2.rs
@@ -2,15 +2,14 @@
 
 use std::fmt::Debug;
 
-type Foo = impl Debug;
-
-pub trait Yay { }
-impl Yay for u32 { }
+pub trait Yay {}
+impl Yay for u32 {}
 
 fn foo() {
+    type Foo = impl Debug;
     is_yay::<Foo>(); //~ ERROR: the trait bound `Foo: Yay` is not satisfied
 }
 
-fn is_yay<T: Yay>() { }
+fn is_yay<T: Yay>() {}
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/impl_trait_for_tait_bound2.stderr
+++ b/tests/ui/type-alias-impl-trait/impl_trait_for_tait_bound2.stderr
@@ -1,14 +1,14 @@
 error[E0277]: the trait bound `Foo: Yay` is not satisfied
-  --> $DIR/impl_trait_for_tait_bound2.rs:11:14
+  --> $DIR/impl_trait_for_tait_bound2.rs:10:14
    |
 LL |     is_yay::<Foo>();
    |              ^^^ the trait `Yay` is not implemented for `Foo`
    |
    = help: the trait `Yay` is implemented for `u32`
 note: required by a bound in `is_yay`
-  --> $DIR/impl_trait_for_tait_bound2.rs:14:14
+  --> $DIR/impl_trait_for_tait_bound2.rs:13:14
    |
-LL | fn is_yay<T: Yay>() { }
+LL | fn is_yay<T: Yay>() {}
    |              ^^^ required by this bound in `is_yay`
 
 error: aborting due to previous error

--- a/tests/ui/type-alias-impl-trait/inference-cycle.rs
+++ b/tests/ui/type-alias-impl-trait/inference-cycle.rs
@@ -15,8 +15,14 @@ mod m {
         is_send(foo()); // Today: error
     }
 
-    fn baz() {
+    fn baz() -> Foo {
         let f: Foo = 22_u32;
+        f
+    }
+
+    fn bak() {
+        let f: Foo = 22_u32;
+        //~^ ERROR constrained without being represented in the signature
     }
 
     fn is_send<T: Send>(_: T) {}

--- a/tests/ui/type-alias-impl-trait/inference-cycle.stderr
+++ b/tests/ui/type-alias-impl-trait/inference-cycle.stderr
@@ -17,6 +17,14 @@ note: cycle used when checking item types in module `m`
 LL | mod m {
    | ^^^^^
 
-error: aborting due to previous error
+error: opaque type constrained without being represented in the signature
+  --> $DIR/inference-cycle.rs:24:22
+   |
+LL |     fn bak() {
+   |     -------- this item must mention the opaque type in its signature or where bounds
+LL |         let f: Foo = 22_u32;
+   |                      ^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/type-alias-impl-trait/issue-57961.rs
+++ b/tests/ui/type-alias-impl-trait/issue-57961.rs
@@ -11,8 +11,8 @@ impl Foo for () {
     //~^ ERROR expected `IntoIter<u32>` to be an iterator that yields `X`, but it yields `u32`
 }
 
-fn incoherent() {
-    let f: X = 22_i32;
+fn incoherent() -> X {
+    22_i32;
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/issue-63263-anon-const-fail.rs
+++ b/tests/ui/type-alias-impl-trait/issue-63263-anon-const-fail.rs
@@ -1,0 +1,14 @@
+// Regression test for issue #63263.
+// Tests that we properly handle closures with an explicit return type
+// that return an opaque type.
+
+#![feature(type_alias_impl_trait, inline_const)]
+
+pub type Closure = impl FnOnce();
+
+fn main() {
+    const {
+        let x: Closure = || {};
+        //~^ ERROR: opaque type constrained without being represented in the signature
+    }
+}

--- a/tests/ui/type-alias-impl-trait/issue-63263-anon-const-fail.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-63263-anon-const-fail.stderr
@@ -1,0 +1,11 @@
+error: opaque type constrained without being represented in the signature
+  --> $DIR/issue-63263-anon-const-fail.rs:11:26
+   |
+LL | fn main() {
+   | --------- this item must mention the opaque type in its signature or where bounds
+LL |     const {
+LL |         let x: Closure = || {};
+   |                          ^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/type-alias-impl-trait/issue-63263-anon-const.rs
+++ b/tests/ui/type-alias-impl-trait/issue-63263-anon-const.rs
@@ -1,0 +1,14 @@
+// Regression test for issue #63263.
+// Tests that we properly handle closures with an explicit return type
+// that return an opaque type.
+
+// check-pass
+
+#![feature(type_alias_impl_trait, inline_const)]
+
+fn main() {
+    pub type Closure = impl FnOnce();
+    const {
+        let x: Closure = || {};
+    }
+}

--- a/tests/ui/type-alias-impl-trait/issue-63263-closure-return-fail.rs
+++ b/tests/ui/type-alias-impl-trait/issue-63263-closure-return-fail.rs
@@ -1,0 +1,11 @@
+// Tests that we don't allow closures to constrain opaque types
+// unless their surrounding item has the opaque type in its signature.
+
+#![feature(type_alias_impl_trait)]
+
+pub type Closure = impl FnOnce();
+
+fn main() {
+    || -> Closure { || () };
+    //~^ ERROR: opaque type constrained without being represented in the signature
+}

--- a/tests/ui/type-alias-impl-trait/issue-63263-closure-return-fail.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-63263-closure-return-fail.stderr
@@ -1,0 +1,10 @@
+error: opaque type constrained without being represented in the signature
+  --> $DIR/issue-63263-closure-return-fail.rs:9:21
+   |
+LL | fn main() {
+   | --------- this item must mention the opaque type in its signature or where bounds
+LL |     || -> Closure { || () };
+   |                     ^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/type-alias-impl-trait/issue-63263-closure-return.rs
+++ b/tests/ui/type-alias-impl-trait/issue-63263-closure-return.rs
@@ -6,8 +6,7 @@
 
 #![feature(type_alias_impl_trait)]
 
-pub type Closure = impl FnOnce();
-
 fn main() {
+    pub type Closure = impl FnOnce();
     || -> Closure { || () };
 }

--- a/tests/ui/type-alias-impl-trait/issue-65679-inst-opaque-ty-from-val-twice.rs
+++ b/tests/ui/type-alias-impl-trait/issue-65679-inst-opaque-ty-from-val-twice.rs
@@ -11,7 +11,12 @@ type T = impl Sized;
 
 fn take(_: fn() -> T) {}
 
-fn main() {
+fn foo()
+where
+    T: Sized,
+{
     take(|| {});
     take(|| {});
 }
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/issue-65679-inst-opaque-ty-from-val-twice.rs
+++ b/tests/ui/type-alias-impl-trait/issue-65679-inst-opaque-ty-from-val-twice.rs
@@ -1,6 +1,6 @@
 // check-pass
 
-#![feature(type_alias_impl_trait, rustc_attrs)]
+#![feature(type_alias_impl_trait, rustc_attrs, type_alias_impl_trait_in_where_bounds)]
 
 type T = impl Sized;
 // The concrete type referred by impl-trait-type-alias(`T`) is guaranteed

--- a/tests/ui/type-alias-impl-trait/reveal_local.rs
+++ b/tests/ui/type-alias-impl-trait/reveal_local.rs
@@ -4,8 +4,9 @@ use std::fmt::Debug;
 
 type Foo = impl Debug;
 //~^ ERROR cycle detected
+//~| ERROR cycle detected
 
-fn is_send<T: Send>() { }
+fn is_send<T: Send>() {}
 
 fn not_good() {
     // Error: this function does not constrain `Foo` to any particular
@@ -13,7 +14,10 @@ fn not_good() {
     is_send::<Foo>();
 }
 
-fn not_gooder() {
+fn not_gooder()
+where
+    Foo: Debug,
+{
     // Constrain `Foo = u32`
     let x: Foo = 22_u32;
 

--- a/tests/ui/type-alias-impl-trait/reveal_local.stderr
+++ b/tests/ui/type-alias-impl-trait/reveal_local.stderr
@@ -5,7 +5,7 @@ LL | type Foo = impl Debug;
    |            ^^^^^^^^^^
    |
 note: ...which requires type-checking `not_good`...
-  --> $DIR/reveal_local.rs:13:5
+  --> $DIR/reveal_local.rs:14:5
    |
 LL |     is_send::<Foo>();
    |     ^^^^^^^^^^^^^^
@@ -23,6 +23,31 @@ LL | |
 LL | | fn main() {}
    | |____________^
 
-error: aborting due to previous error
+error[E0391]: cycle detected when computing type of `Foo::{opaque#0}`
+  --> $DIR/reveal_local.rs:5:12
+   |
+LL | type Foo = impl Debug;
+   |            ^^^^^^^^^^
+   |
+note: ...which requires type-checking `not_gooder`...
+  --> $DIR/reveal_local.rs:26:5
+   |
+LL |     is_send::<Foo>();
+   |     ^^^^^^^^^^^^^^
+   = note: ...which requires evaluating trait selection obligation `Foo: core::marker::Send`...
+   = note: ...which again requires computing type of `Foo::{opaque#0}`, completing the cycle
+note: cycle used when checking item types in top-level module
+  --> $DIR/reveal_local.rs:1:1
+   |
+LL | / #![feature(type_alias_impl_trait)]
+LL | |
+LL | | use std::fmt::Debug;
+LL | |
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/type-alias-impl-trait/type_of_a_let.rs
+++ b/tests/ui/type-alias-impl-trait/type_of_a_let.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(type_alias_impl_trait, type_alias_impl_trait_in_where_bounds)]
 #![allow(dead_code)]
 
 use std::fmt::Debug;

--- a/tests/ui/type-alias-impl-trait/type_of_a_let.rs
+++ b/tests/ui/type-alias-impl-trait/type_of_a_let.rs
@@ -5,12 +5,18 @@ use std::fmt::Debug;
 
 type Foo = impl Debug;
 
-fn foo1() -> u32 {
+fn foo1() -> u32
+where
+    Foo: Debug,
+{
     let x: Foo = 22_u32;
     x
 }
 
-fn foo2() -> u32 {
+fn foo2() -> u32
+where
+    Foo: Debug,
+{
     let x: Foo = 22_u32;
     let y: Foo = x;
     same_type((x, y)); //~ ERROR use of moved value

--- a/tests/ui/type-alias-impl-trait/type_of_a_let.stderr
+++ b/tests/ui/type-alias-impl-trait/type_of_a_let.stderr
@@ -1,5 +1,5 @@
 error[E0382]: use of moved value: `x`
-  --> $DIR/type_of_a_let.rs:16:16
+  --> $DIR/type_of_a_let.rs:22:16
    |
 LL |     let x: Foo = 22_u32;
    |         - move occurs because `x` has type `Foo`, which does not implement the `Copy` trait
@@ -9,7 +9,7 @@ LL |     same_type((x, y));
    |                ^ value used here after move
 
 error[E0382]: use of moved value: `y`
-  --> $DIR/type_of_a_let.rs:17:5
+  --> $DIR/type_of_a_let.rs:23:5
    |
 LL |     let y: Foo = x;
    |         - move occurs because `y` has type `Foo`, which does not implement the `Copy` trait


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/107645

We now error in case an opaque type gets constrained in a function/item that doesn't have the opaque type in its return type or argument types (Option 5 of #107645):

Any item in the defining scope can register hidden types, but we error out if the TAIT is not in the return type or argument types (post normalization, see below).
We still look at all functions in the defining scope, there's no change in cycle errors.

This is forward compatible to all other designs.

We normalize the argument types and return type before checking for opaque types in order to allow cases like

```rust
impl Iterator for Foo {
    type Item = impl Debug;
    fn next(&mut self) -> Option<Self::Item> {
        ...
    }
}
```

This means if you have a `-> <TAIT as Trait>::AssocType` that is not a constraining use and will error for now. We can later check both pre and post-normalization to allow that, too. The current design is entirely forward compatible with it.