### PR TITLE
no python in shell scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
             os: ubuntu-20.04-8core-32gb
           - name: dist-x86_64-apple
             env:
-              SCRIPT: "./x.py dist bootstrap --include-default-paths --host=x86_64-apple-darwin --target=x86_64-apple-darwin"
+              SCRIPT: "./x.py dist bootstrap bootstrap-shim --include-default-paths --host=x86_64-apple-darwin --target=x86_64-apple-darwin"
               RUST_CONFIGURE_ARGS: "--enable-full-tools --enable-sanitizers --enable-profiler --set rust.jemalloc --set llvm.ninja=false --set rust.lto=thin"
               RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
               MACOSX_DEPLOYMENT_TARGET: 10.7
@@ -323,7 +323,7 @@ jobs:
             os: macos-latest
           - name: dist-apple-various
             env:
-              SCRIPT: "./x.py dist bootstrap --include-default-paths --host='' --target=aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim"
+              SCRIPT: "./x.py dist bootstrap bootstrap-shim --include-default-paths --host='' --target=aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim"
               RUST_CONFIGURE_ARGS: "--enable-sanitizers --enable-profiler --set rust.jemalloc --set llvm.ninja=false"
               RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
               MACOSX_DEPLOYMENT_TARGET: 10.7
@@ -334,7 +334,7 @@ jobs:
             os: macos-latest
           - name: dist-x86_64-apple-alt
             env:
-              SCRIPT: "./x.py dist bootstrap --include-default-paths"
+              SCRIPT: "./x.py dist bootstrap bootstrap-shim --include-default-paths"
               RUST_CONFIGURE_ARGS: "--enable-extended --enable-profiler --set rust.jemalloc --set llvm.ninja=false"
               RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
               MACOSX_DEPLOYMENT_TARGET: 10.7
@@ -367,7 +367,7 @@ jobs:
             os: macos-latest
           - name: dist-aarch64-apple
             env:
-              SCRIPT: "./x.py dist bootstrap --include-default-paths --stage 2"
+              SCRIPT: "./x.py dist bootstrap bootstrap-shim --include-default-paths --stage 2"
               RUST_CONFIGURE_ARGS: "--build=x86_64-apple-darwin --host=aarch64-apple-darwin --target=aarch64-apple-darwin --enable-full-tools --enable-sanitizers --enable-profiler --disable-docs --set rust.jemalloc --set llvm.ninja=false"
               RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
               SELECT_XCODE: /Applications/Xcode_13.4.1.app
@@ -442,19 +442,19 @@ jobs:
           - name: dist-x86_64-msvc
             env:
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --host=x86_64-pc-windows-msvc --target=x86_64-pc-windows-msvc --enable-full-tools --enable-profiler"
-              SCRIPT: PGO_HOST=x86_64-pc-windows-msvc python src/ci/stage-build.py python x.py dist bootstrap --include-default-paths
+              SCRIPT: PGO_HOST=x86_64-pc-windows-msvc python src/ci/stage-build.py python x.py dist bootstrap bootstrap-shim --include-default-paths
               DIST_REQUIRE_ALL_TOOLS: 1
             os: windows-2019-8core-32gb
           - name: dist-i686-msvc
             env:
               RUST_CONFIGURE_ARGS: "--build=i686-pc-windows-msvc --host=i686-pc-windows-msvc --target=i686-pc-windows-msvc,i586-pc-windows-msvc --enable-full-tools --enable-profiler"
-              SCRIPT: python x.py dist bootstrap --include-default-paths
+              SCRIPT: python x.py dist bootstrap bootstrap-shim --include-default-paths
               DIST_REQUIRE_ALL_TOOLS: 1
             os: windows-2019-8core-32gb
           - name: dist-aarch64-msvc
             env:
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --host=aarch64-pc-windows-msvc --enable-full-tools --enable-profiler"
-              SCRIPT: python x.py dist bootstrap --include-default-paths
+              SCRIPT: python x.py dist bootstrap bootstrap-shim --include-default-paths
               DIST_REQUIRE_ALL_TOOLS: 1
               WINDOWS_SDK_20348_HACK: 1
             os: windows-2019-8core-32gb
@@ -462,13 +462,13 @@ jobs:
             env:
               RUST_CONFIGURE_ARGS: "--build=i686-pc-windows-gnu --enable-full-tools --enable-profiler"
               NO_DOWNLOAD_CI_LLVM: 1
-              SCRIPT: python x.py dist bootstrap --include-default-paths
+              SCRIPT: python x.py dist bootstrap bootstrap-shim --include-default-paths
               CUSTOM_MINGW: 1
               DIST_REQUIRE_ALL_TOOLS: 1
             os: windows-2019-8core-32gb
           - name: dist-x86_64-mingw
             env:
-              SCRIPT: python x.py dist bootstrap --include-default-paths
+              SCRIPT: python x.py dist bootstrap bootstrap-shim --include-default-paths
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu --enable-full-tools --enable-profiler"
               NO_DOWNLOAD_CI_LLVM: 1
               CUSTOM_MINGW: 1
@@ -477,7 +477,7 @@ jobs:
           - name: dist-x86_64-msvc-alt
             env:
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --enable-extended --enable-profiler"
-              SCRIPT: python x.py dist bootstrap --include-default-paths
+              SCRIPT: python x.py dist bootstrap bootstrap-shim --include-default-paths
             os: windows-2019-8core-32gb
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "cmake",
  "fd-lock",
  "filetime",
+ "getopts",
  "hex",
  "ignore",
  "is-terminal",
@@ -315,6 +316,15 @@ checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -777,6 +787,12 @@ name = "unicode-ident"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "version_check"

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -15,6 +15,11 @@ path = "bin/main.rs"
 test = false
 
 [[bin]]
+name = "bootstrap-shim"
+path = "bin/bootstrap-shim.rs"
+test = false
+
+[[bin]]
 name = "rustc"
 path = "bin/rustc.rs"
 test = false
@@ -35,6 +40,7 @@ build_helper = { path = "../tools/build_helper" }
 cmake = "0.1.38"
 filetime = "0.2"
 cc = "1.0.69"
+getopts = "0.2"
 libc = "0.2"
 hex = "0.4"
 object = { version = "0.29.0", default-features = false, features = ["archive", "coff", "read_core", "unaligned"] }

--- a/src/bootstrap/bin/bootstrap-shim.rs
+++ b/src/bootstrap/bin/bootstrap-shim.rs
@@ -1,0 +1,29 @@
+use std::{env, process::Command};
+
+use bootstrap::{t, MinimalConfig};
+
+#[path = "../../../src/tools/x/src/main.rs"]
+mod run_python;
+
+fn main() {
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    let mut opts = getopts::Options::new();
+    opts.optopt("", "config", "TOML configuration file for build", "FILE");
+    let matches = t!(opts.parse(args));
+
+    // If there are no untracked changes to bootstrap, download it from CI.
+    // Otherwise, build it from source. Use python to build to avoid duplicating the code between python and rust.
+    let config = MinimalConfig::parse(t!(matches.opt_get("config")));
+    let bootstrap_bin = if let Some(commit) = last_modified_bootstrap_commit(&config) {
+        config.download_bootstrap(&commit)
+    } else {
+        return run_python::main();
+    };
+
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    Command::new(bootstrap_bin).args(args).status().expect("failed to spawn bootstrap binairy");
+}
+
+fn last_modified_bootstrap_commit(config: &MinimalConfig) -> Option<String> {
+    config.last_modified_commit(&["src/bootstrap"], "download-bootstrap", true)
+}

--- a/src/bootstrap/bin/bootstrap-shim.rs
+++ b/src/bootstrap/bin/bootstrap-shim.rs
@@ -1,19 +1,17 @@
 use std::{env, process::Command};
 
-use bootstrap::{t, MinimalConfig};
+use bootstrap::{Flags, MinimalConfig};
 
 #[path = "../../../src/tools/x/src/main.rs"]
 mod run_python;
 
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
-    let mut opts = getopts::Options::new();
-    opts.optopt("", "config", "TOML configuration file for build", "FILE");
-    let matches = t!(opts.parse(args));
+    let flags = Flags::parse(&args);
 
     // If there are no untracked changes to bootstrap, download it from CI.
     // Otherwise, build it from source. Use python to build to avoid duplicating the code between python and rust.
-    let config = MinimalConfig::parse(t!(matches.opt_get("config")));
+    let config = MinimalConfig::parse(&flags, None);
     let bootstrap_bin = if let Some(commit) = last_modified_bootstrap_commit(&config) {
         config.download_bootstrap(&commit)
     } else {

--- a/src/bootstrap/bin/bootstrap-shim.rs
+++ b/src/bootstrap/bin/bootstrap-shim.rs
@@ -1,9 +1,56 @@
-use std::{env, process::Command};
+use std::{
+    env, io,
+    process::{self, Command, ExitStatus},
+};
 
 use bootstrap::{Flags, MinimalConfig};
 
 #[path = "../../../src/tools/x/src/main.rs"]
-mod run_python;
+mod x;
+
+/// We are planning to exclude python logic from x script by executing bootstrap-shim
+/// immediately. Since `find_and_run_available_bootstrap_script` executes x script first,
+/// any changes on bootstrap will not be seen. To prevent this problem, in bootstrap-shim
+/// we want to call the python script directly.
+fn find_and_run_py_bootstrap_script() {
+    #[cfg(unix)]
+    fn exec_or_status(command: &mut Command) -> io::Result<ExitStatus> {
+        use std::os::unix::process::CommandExt;
+        Err(command.exec())
+    }
+
+    #[cfg(not(unix))]
+    fn exec_or_status(command: &mut Command) -> io::Result<ExitStatus> {
+        command.status()
+    }
+
+    let current_path = match env::current_dir() {
+        Ok(dir) => dir,
+        Err(err) => {
+            eprintln!("Failed to get current directory: {err}");
+            process::exit(1);
+        }
+    };
+
+    for dir in current_path.ancestors() {
+        let candidate = dir.join("x.py");
+        if candidate.exists() {
+            let mut cmd: Command;
+            cmd = Command::new(x::python());
+            cmd.arg(&candidate).args(env::args().skip(1)).current_dir(dir);
+            let result = exec_or_status(&mut cmd);
+
+            match result {
+                Err(error) => {
+                    eprintln!("Failed to invoke `{:?}`: {}", cmd, error);
+                }
+                Ok(status) => {
+                    process::exit(status.code().unwrap_or(1));
+                }
+            }
+        }
+    }
+}
 
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
@@ -15,16 +62,17 @@ fn main() {
     let bootstrap_bin = if let Some(commit) = last_modified_bootstrap_commit(&config) {
         config.download_bootstrap(&commit)
     } else {
-        return run_python::main();
+        return find_and_run_py_bootstrap_script();
     };
 
     let args: Vec<_> = std::env::args().skip(1).collect();
+    println!("Running pre-compiled bootstrap binary");
     Command::new(bootstrap_bin).args(args).status().expect("failed to spawn bootstrap binairy");
 }
 
 fn last_modified_bootstrap_commit(config: &MinimalConfig) -> Option<String> {
     config.last_modified_commit(
-        &["src/bootstrap", "src/tools/build_helper"],
+        &["src/bootstrap", "src/tools/build_helper", "src/tools/x"],
         "download-bootstrap",
         true,
     )

--- a/src/bootstrap/bin/bootstrap-shim.rs
+++ b/src/bootstrap/bin/bootstrap-shim.rs
@@ -25,5 +25,9 @@ fn main() {
 }
 
 fn last_modified_bootstrap_commit(config: &MinimalConfig) -> Option<String> {
-    config.last_modified_commit(&["src/bootstrap"], "download-bootstrap", true)
+    config.last_modified_commit(
+        &["src/bootstrap", "src/tools/build_helper"],
+        "download-bootstrap",
+        true,
+    )
 }

--- a/src/bootstrap/bin/main.rs
+++ b/src/bootstrap/bin/main.rs
@@ -13,7 +13,7 @@ use bootstrap::{Build, Config, Subcommand, VERSION};
 
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
-    let config = Config::parse(&args);
+    let config = Config::parse(&args, None);
 
     #[cfg(all(any(unix, windows), not(target_os = "solaris")))]
     let mut build_lock;

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -703,7 +703,8 @@ impl<'a> Builder<'a> {
                 check::Rls,
                 check::RustAnalyzer,
                 check::Rustfmt,
-                check::Bootstrap
+                check::Bootstrap,
+                check::BootstrapShim,
             ),
             Kind::Test => describe!(
                 crate::toolstate::ToolStateCheck,
@@ -808,6 +809,7 @@ impl<'a> Builder<'a> {
                 dist::LlvmTools,
                 dist::RustDev,
                 dist::Bootstrap,
+                dist::BootstrapShim,
                 dist::Extended,
                 // It seems that PlainSourceTarball somehow changes how some of the tools
                 // perceive their dependencies (see #93033) which would invalidate fingerprints

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -704,7 +704,6 @@ impl<'a> Builder<'a> {
                 check::RustAnalyzer,
                 check::Rustfmt,
                 check::Bootstrap,
-                check::BootstrapShim,
             ),
             Kind::Test => describe!(
                 crate::toolstate::ToolStateCheck,

--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -7,7 +7,7 @@ fn configure(cmd: &str, host: &[&str], target: &[&str]) -> Config {
 }
 
 fn configure_with_args(cmd: &[String], host: &[&str], target: &[&str]) -> Config {
-    let mut config = Config::parse(cmd);
+    let mut config = Config::parse(cmd, None);
     // don't save toolstates
     config.save_toolstates = None;
     config.dry_run = DryRun::SelfCheck;
@@ -18,7 +18,7 @@ fn configure_with_args(cmd: &[String], host: &[&str], target: &[&str]) -> Config
     let submodule_build = Build::new(Config {
         // don't include LLVM, so CI doesn't require ninja/cmake to be installed
         rust_codegen_backends: vec![],
-        ..Config::parse(&["check".to_owned()])
+        ..Config::parse(&["check".to_owned()], None)
     });
     submodule_build.update_submodule(Path::new("src/doc/book"));
     submodule_build.update_submodule(Path::new("src/tools/rust-analyzer"));

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -448,7 +448,9 @@ tool_check_step!(Rls, "src/tools/rls", SourceType::InTree);
 tool_check_step!(Rustfmt, "src/tools/rustfmt", SourceType::InTree);
 tool_check_step!(MiroptTestTools, "src/tools/miropt-test-tools", SourceType::InTree);
 
+// FIXME: currently  these are marked as ToolRustc, but they should be ToolBootstrap instead to avoid having to build the compiler first
 tool_check_step!(Bootstrap, "src/bootstrap", SourceType::InTree, false);
+tool_check_step!(BootstrapShim, "src/bootstrap/bin/bootstrap-shim", SourceType::InTree, false);
 
 /// Cargo's output path for the standard library in a given stage, compiled
 /// by a particular compiler for the specified target.

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -450,7 +450,6 @@ tool_check_step!(MiroptTestTools, "src/tools/miropt-test-tools", SourceType::InT
 
 // FIXME: currently  these are marked as ToolRustc, but they should be ToolBootstrap instead to avoid having to build the compiler first
 tool_check_step!(Bootstrap, "src/bootstrap", SourceType::InTree, false);
-tool_check_step!(BootstrapShim, "src/bootstrap/bin/bootstrap-shim", SourceType::InTree, false);
 
 /// Cargo's output path for the standard library in a given stage, compiled
 /// by a particular compiler for the specified target.

--- a/src/bootstrap/config/tests.rs
+++ b/src/bootstrap/config/tests.rs
@@ -1,13 +1,9 @@
-use super::{Config, Flags, TomlConfig};
+use super::{Config, Flags};
 use clap::CommandFactory;
 use std::{env, path::Path};
 
-fn toml(config: &str) -> TomlConfig {
-    toml::from_str(config).unwrap()
-}
-
 fn parse(config: &str) -> Config {
-    Config::parse(&["check".to_owned(), "--config=/does/not/exist".to_owned()], Some(toml(config)))
+    Config::parse(&["check".to_owned(), "--config=/does/not/exist".to_owned()], Some(config))
 }
 
 #[test]

--- a/src/bootstrap/config/tests.rs
+++ b/src/bootstrap/config/tests.rs
@@ -2,12 +2,12 @@ use super::{Config, Flags, TomlConfig};
 use clap::CommandFactory;
 use std::{env, path::Path};
 
-fn toml(config: &str) -> impl '_ + Fn(&Path) -> TomlConfig {
-    |&_| toml::from_str(config).unwrap()
+fn toml(config: &str) -> TomlConfig {
+    toml::from_str(config).unwrap()
 }
 
 fn parse(config: &str) -> Config {
-    Config::parse_inner(&["check".to_owned(), "--config=/does/not/exist".to_owned()], toml(config))
+    Config::parse(&["check".to_owned(), "--config=/does/not/exist".to_owned()], Some(toml(config)))
 }
 
 #[test]

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -2327,7 +2327,6 @@ impl Step for BootstrapShim {
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        // Create this even with only `dist bootstrap` to avoid having to update all CI builders.
         run.alias("bootstrap-shim")
     }
 

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -183,7 +183,7 @@ impl Flags {
             HelpVerboseOnly::try_parse_from(it.clone())
         {
             println!("note: updating submodules before printing available paths");
-            let config = Config::parse(&[String::from("build")]);
+            let config = Config::parse(&[String::from("build")], None);
             let build = Build::new(config);
             let paths = Builder::get_help(&build, subcommand);
             if let Some(s) = paths {

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -8,7 +8,8 @@ use std::path::{Path, PathBuf};
 use clap::{CommandFactory, Parser, ValueEnum};
 
 use crate::builder::{Builder, Kind};
-use crate::config::{target_selection_list, Config, TargetSelectionList};
+use crate::config::Config;
+use crate::min_config::{target_selection_list, TargetSelectionList};
 use crate::setup::Profile;
 use crate::{Build, DocTests};
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -90,6 +90,7 @@ mod job {
 pub use crate::builder::PathSet;
 use crate::cache::{Interned, INTERNER};
 pub use crate::config::Config;
+pub use crate::flags::Flags;
 pub use crate::flags::Subcommand;
 pub use crate::min_config::MinimalConfig;
 use termcolor::{ColorChoice, StandardStream, WriteColor};

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -55,6 +55,7 @@ mod format;
 mod install;
 mod llvm;
 mod metadata;
+mod min_config;
 mod render_tests;
 mod run;
 mod sanity;
@@ -90,6 +91,7 @@ pub use crate::builder::PathSet;
 use crate::cache::{Interned, INTERNER};
 pub use crate::config::Config;
 pub use crate::flags::Subcommand;
+pub use crate::min_config::MinimalConfig;
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
 const LLVM_TOOLS: &[&str] = &[

--- a/src/bootstrap/min_config.rs
+++ b/src/bootstrap/min_config.rs
@@ -1,0 +1,393 @@
+use core::fmt;
+use std::{
+    collections::HashMap,
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use serde::Deserialize;
+use serde_derive::Deserialize;
+
+use crate::{
+    cache::{Interned, INTERNER},
+    t,
+    util::output,
+};
+
+/// The bare minimum config, suitable for `bootstrap-shim`, but sharing code with the main `bootstrap` binary.
+#[derive(Default, Clone)]
+pub struct MinimalConfig {
+    // Needed so we know where to store the unpacked bootstrap binary.
+    pub build: TargetSelection,
+    // Needed so we know where to load `src/stage0.json`
+    pub src: PathBuf,
+    // Needed so we know where to store the cache.
+    pub out: PathBuf,
+    pub patch_binaries_for_nix: bool,
+    // Needed to know which commit to download.
+    pub stage0_metadata: Stage0Metadata,
+
+    // This isn't currently used, but will eventually let people configure whether to download or build bootstrap.
+    pub config: Option<PathBuf>,
+    // Not currently used in the shim.
+    pub verbose: usize,
+    // Not currently used in the shim.
+    pub dry_run: DryRun,
+}
+
+#[derive(Default, Deserialize, Clone)]
+pub struct Stage0Metadata {
+    pub compiler: CompilerMetadata,
+    pub config: Stage0Config,
+    pub checksums_sha256: HashMap<String, String>,
+    pub rustfmt: Option<RustfmtMetadata>,
+}
+#[derive(Clone, Default, Deserialize)]
+pub struct CompilerMetadata {
+    pub date: String,
+    pub version: String,
+}
+#[derive(Default, Deserialize, Clone)]
+pub struct Stage0Config {
+    pub dist_server: String,
+    pub artifacts_server: String,
+    pub artifacts_with_llvm_assertions_server: String,
+    pub git_merge_commit_email: String,
+    pub nightly_branch: String,
+}
+
+#[derive(Default, Deserialize, Clone)]
+pub struct RustfmtMetadata {
+    pub date: String,
+    pub version: String,
+}
+
+impl MinimalConfig {
+    fn default_opts() -> Self {
+        let dry_run = DryRun::default();
+        let config = None;
+        let verbose = 0;
+        let patch_binaries_for_nix = false;
+        let stage0_metadata = Stage0Metadata::default();
+
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        // Undo `src/bootstrap`
+        let src = manifest_dir.parent().unwrap().parent().unwrap().to_owned();
+        let out = PathBuf::from("build");
+
+        // set by build.rs
+        let build = TargetSelection::from_user(&env!("BUILD_TRIPLE"));
+
+        MinimalConfig {
+            build,
+            src,
+            out,
+            config,
+            dry_run,
+            verbose,
+            patch_binaries_for_nix,
+            stage0_metadata,
+        }
+    }
+
+    pub fn parse(config_flag: Option<PathBuf>) -> MinimalConfig {
+        let mut config = Self::default_opts();
+
+        if let Some(src) = src() {
+            config.src = src;
+        }
+
+        if cfg!(test) {
+            // Use the build directory of the original x.py invocation, so that we can set `initial_rustc` properly.
+            config.out = Path::new(
+                &env::var_os("CARGO_TARGET_DIR").expect("cargo test directly is not supported"),
+            )
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        }
+
+        let toml = if let Some(toml_path) = Self::config_path(config.src.clone(), config_flag) {
+            config.config = Some(toml_path.clone());
+            get_toml(&toml_path)
+        } else {
+            config.config = None;
+            TomlConfig::default()
+        };
+        if let Some(build) = toml.build.unwrap_or_default().build {
+            config.build = TargetSelection::from_user(&build);
+        }
+
+        // NOTE: Bootstrap spawns various commands with different working directories.
+        // To avoid writing to random places on the file system, `config.out` needs to be an absolute path.
+        if !config.out.is_absolute() {
+            // `canonicalize` requires the path to already exist. Use our vendored copy of `absolute` instead.
+            config.out = crate::util::absolute(&config.out);
+        }
+
+        if config.dry_run() {
+            let dir = config.out.join("tmp-dry-run");
+            t!(fs::create_dir_all(&dir));
+            config.out = dir;
+        }
+
+        let stage0_json = t!(std::fs::read(&config.src.join("src").join("stage0.json")));
+        config.stage0_metadata = t!(serde_json::from_slice::<Stage0Metadata>(&stage0_json));
+
+        config
+    }
+
+    /// Read from `--config`, then `RUST_BOOTSTRAP_CONFIG`, then `./config.toml`, then `config.toml` in the root directory.
+    ///
+    /// Give a hard error if `--config` or `RUST_BOOTSTRAP_CONFIG` are set to a missing path,
+    /// but not if `config.toml` hasn't been created.
+    fn config_path(src: PathBuf, config_flag: Option<PathBuf>) -> Option<PathBuf> {
+        let toml_path =
+            config_flag.or_else(|| env::var_os("RUST_BOOTSTRAP_CONFIG").map(PathBuf::from));
+        let using_default_path = toml_path.is_none();
+        let mut toml_path = toml_path.unwrap_or_else(|| PathBuf::from("config.toml"));
+        if using_default_path && !toml_path.exists() {
+            toml_path = src.join(toml_path);
+        }
+
+        if !using_default_path || toml_path.exists() { Some(toml_path) } else { None }
+    }
+}
+
+impl MinimalConfig {
+    pub fn verbose(&self, msg: &str) {
+        if self.verbose > 0 {
+            println!("{}", msg);
+        }
+    }
+
+    pub(crate) fn dry_run(&self) -> bool {
+        match self.dry_run {
+            DryRun::Disabled => false,
+            DryRun::SelfCheck | DryRun::UserSelected => true,
+        }
+    }
+
+    /// A git invocation which runs inside the source directory.
+    ///
+    /// Use this rather than `Command::new("git")` in order to support out-of-tree builds.
+    pub(crate) fn git(&self) -> Command {
+        let mut git = Command::new("git");
+        git.current_dir(&self.src);
+        git
+    }
+
+    /// Returns the last commit in which any of `modified_paths` were changed,
+    /// or `None` if there are untracked changes in the working directory and `if_unchanged` is true.
+    pub fn last_modified_commit(
+        &self,
+        modified_paths: &[&str],
+        option_name: &str,
+        if_unchanged: bool,
+    ) -> Option<String> {
+        // Handle running from a directory other than the top level
+        let top_level = output(self.git().args(&["rev-parse", "--show-toplevel"]));
+        let top_level = top_level.trim_end();
+
+        // Look for a version to compare to based on the current commit.
+        // Only commits merged by bors will have CI artifacts.
+        let merge_base = output(
+            self.git()
+                .arg("rev-list")
+                .arg(format!("--author={}", self.stage0_metadata.config.git_merge_commit_email))
+                .args(&["-n1", "--first-parent", "HEAD"]),
+        );
+        let commit = merge_base.trim_end();
+        if commit.is_empty() {
+            println!("error: could not find commit hash for downloading components from CI");
+            println!("help: maybe your repository history is too shallow?");
+            println!("help: consider disabling `{option_name}`");
+            println!("help: or fetch enough history to include one upstream commit");
+            crate::detail_exit(1);
+        }
+
+        // Warn if there were changes to the compiler or standard library since the ancestor commit.
+        let mut git = self.git();
+        git.args(&["diff-index", "--quiet", &commit, "--"]);
+
+        for path in modified_paths {
+            git.arg(format!("{top_level}/{path}"));
+        }
+
+        let has_changes = !t!(git.status()).success();
+        if has_changes {
+            if if_unchanged {
+                if self.verbose > 0 {
+                    println!(
+                        "warning: saw changes to one of {modified_paths:?} since {commit}; \
+                            ignoring `{option_name}`"
+                    );
+                }
+                return None;
+            }
+            println!(
+                "warning: `{option_name}` is enabled, but there are changes to one of {modified_paths:?}"
+            );
+        }
+
+        Some(commit.to_string())
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn get_toml<T: Deserialize<'static> + Default>(_file: &Path) -> T {
+    T::default()
+}
+#[cfg(not(test))]
+pub(crate) fn get_toml<T: Deserialize<'static> + Default>(file: &Path) -> T {
+    let contents =
+        t!(fs::read_to_string(file), format!("config file {} not found", file.display()));
+    // Deserialize to Value and then TomlConfig to prevent the Deserialize impl of
+    // TomlConfig and sub types to be monomorphized 5x by toml.
+    match toml::from_str(&contents).and_then(|table: toml::Value| T::deserialize(table)) {
+        Ok(table) => table,
+        Err(err) => {
+            eprintln!("failed to parse TOML configuration '{}': {}", file.display(), err);
+            crate::detail_exit(2);
+        }
+    }
+}
+
+fn src() -> Option<PathBuf> {
+    // Infer the source directory. This is non-trivial because we want to support a downloaded bootstrap binary,
+    // running on a completely machine from where it was compiled.
+    let mut cmd = Command::new("git");
+    // NOTE: we cannot support running from outside the repository because the only path we have available
+    // is set at compile time, which can be wrong if bootstrap was downloaded from source.
+    // We still support running outside the repository if we find we aren't in a git directory.
+    cmd.arg("rev-parse").arg("--show-toplevel");
+    // Discard stderr because we expect this to fail when building from a tarball.
+    let output = cmd
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()
+        .and_then(|output| if output.status.success() { Some(output) } else { None });
+    if let Some(output) = output {
+        let git_root = String::from_utf8(output.stdout).unwrap();
+        // We need to canonicalize this path to make sure it uses backslashes instead of forward slashes.
+        let git_root = PathBuf::from(git_root.trim()).canonicalize().unwrap();
+        let s = git_root.to_str().unwrap();
+
+        // Bootstrap is quite bad at handling /? in front of paths
+        let src = match s.strip_prefix("\\\\?\\") {
+            Some(p) => PathBuf::from(p),
+            None => PathBuf::from(git_root),
+        };
+        // If this doesn't have at least `stage0.json`, we guessed wrong. This can happen when,
+        // for example, the build directory is inside of another unrelated git directory.
+        // In that case keep the original `CARGO_MANIFEST_DIR` handling.
+        //
+        // NOTE: this implies that downloadable bootstrap isn't supported when the build directory is outside
+        // the source directory. We could fix that by setting a variable from all three of python, ./x, and x.ps1.
+        if src.join("src").join("stage0.json").exists() { Some(src) } else { None }
+    } else {
+        // We're building from a tarball, not git sources.
+        // We don't support pre-downloaded bootstrap in this case.
+        None
+    }
+}
+
+#[derive(Clone, Default)]
+pub enum DryRun {
+    /// This isn't a dry run.
+    #[default]
+    Disabled,
+    /// This is a dry run enabled by bootstrap itself, so it can verify that no work is done.
+    SelfCheck,
+    /// This is a dry run enabled by the `--dry-run` flag.
+    UserSelected,
+}
+
+#[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TargetSelection {
+    pub triple: Interned<String>,
+    file: Option<Interned<String>>,
+}
+
+/// Newtype over `Vec<TargetSelection>` so we can implement custom parsing logic
+#[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct TargetSelectionList(pub(crate) Vec<TargetSelection>);
+
+pub fn target_selection_list(s: &str) -> Result<TargetSelectionList, String> {
+    Ok(TargetSelectionList(
+        s.split(",").filter(|s| !s.is_empty()).map(TargetSelection::from_user).collect(),
+    ))
+}
+
+impl TargetSelection {
+    pub fn from_user(selection: &str) -> Self {
+        let path = Path::new(selection);
+
+        let (triple, file) = if path.exists() {
+            let triple = path
+                .file_stem()
+                .expect("Target specification file has no file stem")
+                .to_str()
+                .expect("Target specification file stem is not UTF-8");
+
+            (triple, Some(selection))
+        } else {
+            (selection, None)
+        };
+
+        let triple = INTERNER.intern_str(triple);
+        let file = file.map(|f| INTERNER.intern_str(f));
+
+        Self { triple, file }
+    }
+
+    pub fn rustc_target_arg(&self) -> &str {
+        self.file.as_ref().unwrap_or(&self.triple)
+    }
+
+    pub fn contains(&self, needle: &str) -> bool {
+        self.triple.contains(needle)
+    }
+
+    pub fn starts_with(&self, needle: &str) -> bool {
+        self.triple.starts_with(needle)
+    }
+
+    pub fn ends_with(&self, needle: &str) -> bool {
+        self.triple.ends_with(needle)
+    }
+}
+
+impl fmt::Display for TargetSelection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.triple)?;
+        if let Some(file) = self.file {
+            write!(f, "({})", file)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for TargetSelection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl PartialEq<&str> for TargetSelection {
+    fn eq(&self, other: &&str) -> bool {
+        self.triple == *other
+    }
+}
+
+#[derive(Deserialize, Default)]
+struct TomlConfig {
+    build: Option<Build>,
+}
+
+/// TOML representation of various global build decisions.
+#[derive(Deserialize, Default)]
+struct Build {
+    build: Option<String>,
+}

--- a/src/bootstrap/min_config.rs
+++ b/src/bootstrap/min_config.rs
@@ -7,7 +7,6 @@ use std::{
     process::Command,
 };
 
-use serde::Deserialize;
 use serde_derive::Deserialize;
 
 use crate::{
@@ -19,6 +18,12 @@ use crate::{
 };
 
 /// The bare minimum config, suitable for `bootstrap-shim`, but sharing code with the main `bootstrap` binary.
+/// Unlike bootstrap itself, bootstrap-shim needs to be compatible across multiple versions of the Rust repo.
+///
+/// FIXME: Update the following information once bootstrap-shim is default in shell scripts
+///
+/// Once bootstrap-shim is used as default(today it's opt in) in shell scripts, DO NOT CHANGE this configuration
+/// without the version bump for the pinned nightly version of bootstrap-shim.
 #[derive(Default, Clone)]
 pub struct MinimalConfig {
     // Needed so we know where to store the unpacked bootstrap binary.
@@ -30,12 +35,11 @@ pub struct MinimalConfig {
     pub patch_binaries_for_nix: bool,
     // Needed to know which commit to download.
     pub stage0_metadata: Stage0Metadata,
-
     // This isn't currently used, but will eventually let people configure whether to download or build bootstrap.
     pub config: Option<PathBuf>,
-    // Not currently used in the shim.
+    // General need for verbose mode logging in `bootstrap-shim`.
     pub verbose: usize,
-    // Not currently used in the shim.
+    // Needed for `bootstrap::download` module
     pub dry_run: DryRun,
 }
 
@@ -46,11 +50,13 @@ pub struct Stage0Metadata {
     pub checksums_sha256: HashMap<String, String>,
     pub rustfmt: Option<RustfmtMetadata>,
 }
+
 #[derive(Clone, Default, Deserialize)]
 pub struct CompilerMetadata {
     pub date: String,
     pub version: String,
 }
+
 #[derive(Default, Deserialize, Clone)]
 pub struct Stage0Config {
     pub dist_server: String,
@@ -228,12 +234,12 @@ impl MinimalConfig {
 
 #[cfg(test)]
 /// Shared helper function to be used in `MinimalConfig::parse` and `bootstrap::config::Config::parse`
-pub(crate) fn get_toml<T: Deserialize<'static> + Default>(_file: &Path) -> T {
+pub(crate) fn get_toml<T: serde::Deserialize<'static> + Default>(_file: &Path) -> T {
     T::default()
 }
 #[cfg(not(test))]
 /// Shared helper function to be used in `MinimalConfig::parse` and `bootstrap::config::Config::parse`
-pub(crate) fn get_toml<T: Deserialize<'static> + Default>(file: &Path) -> T {
+pub(crate) fn get_toml<T: serde::Deserialize<'static> + Default>(file: &Path) -> T {
     let contents =
         t!(fs::read_to_string(file), format!("config file {} not found", file.display()));
     // Deserialize to Value and then TomlConfig to prevent the Deserialize impl of
@@ -262,7 +268,7 @@ fn set_config_output_dir(output_path: &mut PathBuf) {
 }
 
 /// Shared helper function to be used in `MinimalConfig::parse` and `bootstrap::config::Config::parse`
-pub(crate) fn set_cfg_path_and_return_toml_cfg<T: Deserialize<'static> + Default>(
+pub(crate) fn set_cfg_path_and_return_toml_cfg<T: serde::Deserialize<'static> + Default>(
     src: PathBuf,
     config_flag: Option<PathBuf>,
     cfg_path: &mut Option<PathBuf>,

--- a/src/bootstrap/min_config.rs
+++ b/src/bootstrap/min_config.rs
@@ -98,32 +98,13 @@ impl MinimalConfig {
             config.src = src;
         }
 
-        if cfg!(test) {
-            // Use the build directory of the original x.py invocation, so that we can set `initial_rustc` properly.
-            config.out = Path::new(
-                &env::var_os("CARGO_TARGET_DIR").expect("cargo test directly is not supported"),
-            )
-            .parent()
-            .unwrap()
-            .to_path_buf();
-        }
+        set_config_output_dir(&mut config.out);
 
-        let toml = if let Some(toml_path) = Self::config_path(config.src.clone(), config_flag) {
-            config.config = Some(toml_path.clone());
-            get_toml(&toml_path)
-        } else {
-            config.config = None;
-            TomlConfig::default()
-        };
+        let toml: TomlConfig =
+            set_and_return_toml_config(config.src.clone(), config_flag, &mut config.config);
+
         if let Some(build) = toml.build.unwrap_or_default().build {
             config.build = TargetSelection::from_user(&build);
-        }
-
-        // NOTE: Bootstrap spawns various commands with different working directories.
-        // To avoid writing to random places on the file system, `config.out` needs to be an absolute path.
-        if !config.out.is_absolute() {
-            // `canonicalize` requires the path to already exist. Use our vendored copy of `absolute` instead.
-            config.out = crate::util::absolute(&config.out);
         }
 
         if config.dry_run() {
@@ -131,27 +112,16 @@ impl MinimalConfig {
             t!(fs::create_dir_all(&dir));
             config.out = dir;
         }
-
-        let stage0_json = t!(std::fs::read(&config.src.join("src").join("stage0.json")));
-        config.stage0_metadata = t!(serde_json::from_slice::<Stage0Metadata>(&stage0_json));
-
-        config
-    }
-
-    /// Read from `--config`, then `RUST_BOOTSTRAP_CONFIG`, then `./config.toml`, then `config.toml` in the root directory.
-    ///
-    /// Give a hard error if `--config` or `RUST_BOOTSTRAP_CONFIG` are set to a missing path,
-    /// but not if `config.toml` hasn't been created.
-    fn config_path(src: PathBuf, config_flag: Option<PathBuf>) -> Option<PathBuf> {
-        let toml_path =
-            config_flag.or_else(|| env::var_os("RUST_BOOTSTRAP_CONFIG").map(PathBuf::from));
-        let using_default_path = toml_path.is_none();
-        let mut toml_path = toml_path.unwrap_or_else(|| PathBuf::from("config.toml"));
-        if using_default_path && !toml_path.exists() {
-            toml_path = src.join(toml_path);
+        // NOTE: Bootstrap spawns various commands with different working directories.
+        // To avoid writing to random places on the file system, `config.out` needs to be an absolute path.
+        else if !config.out.is_absolute() {
+            // `canonicalize` requires the path to already exist. Use our vendored copy of `absolute` instead.
+            config.out = crate::util::absolute(&config.out);
         }
 
-        if !using_default_path || toml_path.exists() { Some(toml_path) } else { None }
+        config.stage0_metadata = deserialize_stage0_metadata(&config.src);
+
+        config
     }
 }
 
@@ -236,10 +206,12 @@ impl MinimalConfig {
 }
 
 #[cfg(test)]
+/// Shared helper function to be used in `MinimalConfig::parse` and `bootstrap::config::Config::parse`
 pub(crate) fn get_toml<T: Deserialize<'static> + Default>(_file: &Path) -> T {
     T::default()
 }
 #[cfg(not(test))]
+/// Shared helper function to be used in `MinimalConfig::parse` and `bootstrap::config::Config::parse`
 pub(crate) fn get_toml<T: Deserialize<'static> + Default>(file: &Path) -> T {
     let contents =
         t!(fs::read_to_string(file), format!("config file {} not found", file.display()));
@@ -252,6 +224,59 @@ pub(crate) fn get_toml<T: Deserialize<'static> + Default>(file: &Path) -> T {
             crate::detail_exit(2);
         }
     }
+}
+
+/// Shared helper function to be used in `MinimalConfig::parse` and `bootstrap::config::Config::parse`
+///
+/// Use the build directory of the original x.py invocation, so that we can set `initial_rustc` properly.
+#[allow(unused_variables)]
+pub(crate) fn set_config_output_dir(output_path: &mut PathBuf) {
+    #[cfg(test)]
+    {
+        *output_path = Path::new(
+            &env::var_os("CARGO_TARGET_DIR").expect("cargo test directly is not supported"),
+        )
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    }
+}
+
+/// Shared helper function to be used in `MinimalConfig::parse` and `bootstrap::config::Config::parse`
+pub(crate) fn set_and_return_toml_config<T: Deserialize<'static> + Default>(
+    src: PathBuf,
+    config_flag: Option<PathBuf>,
+    cfg_path: &mut Option<PathBuf>,
+) -> T {
+    /// Read from `--config`, then `RUST_BOOTSTRAP_CONFIG`, then `./config.toml`, then `config.toml` in the root directory.
+    ///
+    /// Give a hard error if `--config` or `RUST_BOOTSTRAP_CONFIG` are set to a missing path,
+    /// but not if `config.toml` hasn't been created.
+    fn config_path(src: &PathBuf, config_flag: Option<PathBuf>) -> Option<PathBuf> {
+        let toml_path =
+            config_flag.or_else(|| env::var_os("RUST_BOOTSTRAP_CONFIG").map(PathBuf::from));
+        let using_default_path = toml_path.is_none();
+        let mut toml_path = toml_path.unwrap_or_else(|| PathBuf::from("config.toml"));
+        if using_default_path && !toml_path.exists() {
+            toml_path = src.join(toml_path);
+        }
+
+        if !using_default_path || toml_path.exists() { Some(toml_path) } else { None }
+    }
+
+    if let Some(toml_path) = config_path(&src, config_flag) {
+        *cfg_path = Some(toml_path.clone());
+        get_toml(&toml_path)
+    } else {
+        *cfg_path = None;
+        T::default()
+    }
+}
+
+/// Shared helper function to be used in `MinimalConfig::parse` and `bootstrap::config::Config::parse`
+pub(crate) fn deserialize_stage0_metadata(stage0_metadata_path: &PathBuf) -> Stage0Metadata {
+    let stage0_json = t!(std::fs::read(stage0_metadata_path.join("src").join("stage0.json")));
+    t!(serde_json::from_slice::<Stage0Metadata>(&stage0_json))
 }
 
 fn src() -> Option<PathBuf> {

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -84,7 +84,7 @@ ENV RUST_CONFIGURE_ARGS \
 ENV SCRIPT python3 ../src/ci/stage-build.py python3 ../x.py dist \
     --host $HOSTS --target $HOSTS \
     --include-default-paths \
-    build-manifest bootstrap
+    build-manifest bootstrap bootstrap-shim
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang
 
 # This is the only builder which will create source tarballs

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -489,7 +489,7 @@ jobs:
 
           - name: dist-x86_64-apple
             env:
-              SCRIPT: ./x.py dist bootstrap --include-default-paths --host=x86_64-apple-darwin --target=x86_64-apple-darwin
+              SCRIPT: ./x.py dist bootstrap bootstrap-shim --include-default-paths --host=x86_64-apple-darwin --target=x86_64-apple-darwin
               RUST_CONFIGURE_ARGS: --enable-full-tools --enable-sanitizers --enable-profiler --set rust.jemalloc --set llvm.ninja=false --set rust.lto=thin
               RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
               MACOSX_DEPLOYMENT_TARGET: 10.7
@@ -502,7 +502,7 @@ jobs:
 
           - name: dist-apple-various
             env:
-              SCRIPT: ./x.py dist bootstrap --include-default-paths --host='' --target=aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim
+              SCRIPT: ./x.py dist bootstrap bootstrap-shim --include-default-paths --host='' --target=aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim
               RUST_CONFIGURE_ARGS: --enable-sanitizers --enable-profiler --set rust.jemalloc --set llvm.ninja=false
               RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
               MACOSX_DEPLOYMENT_TARGET: 10.7
@@ -514,7 +514,7 @@ jobs:
 
           - name: dist-x86_64-apple-alt
             env:
-              SCRIPT: ./x.py dist bootstrap --include-default-paths
+              SCRIPT: ./x.py dist bootstrap bootstrap-shim --include-default-paths
               RUST_CONFIGURE_ARGS: --enable-extended --enable-profiler --set rust.jemalloc --set llvm.ninja=false
               RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
               MACOSX_DEPLOYMENT_TARGET: 10.7
@@ -545,7 +545,7 @@ jobs:
           # This target only needs to support 11.0 and up as nothing else supports the hardware
           - name: dist-aarch64-apple
             env:
-              SCRIPT: ./x.py dist bootstrap --include-default-paths --stage 2
+              SCRIPT: ./x.py dist bootstrap bootstrap-shim --include-default-paths --stage 2
               RUST_CONFIGURE_ARGS: >-
                 --build=x86_64-apple-darwin
                 --host=aarch64-apple-darwin
@@ -684,7 +684,7 @@ jobs:
                 --target=x86_64-pc-windows-msvc
                 --enable-full-tools
                 --enable-profiler
-              SCRIPT: PGO_HOST=x86_64-pc-windows-msvc python src/ci/stage-build.py python x.py dist bootstrap --include-default-paths
+              SCRIPT: PGO_HOST=x86_64-pc-windows-msvc python src/ci/stage-build.py python x.py dist bootstrap bootstrap-shim --include-default-paths
               DIST_REQUIRE_ALL_TOOLS: 1
             <<: *job-windows-8c
 
@@ -696,7 +696,7 @@ jobs:
                 --target=i686-pc-windows-msvc,i586-pc-windows-msvc
                 --enable-full-tools
                 --enable-profiler
-              SCRIPT: python x.py dist bootstrap --include-default-paths
+              SCRIPT: python x.py dist bootstrap bootstrap-shim --include-default-paths
               DIST_REQUIRE_ALL_TOOLS: 1
             <<: *job-windows-8c
 
@@ -707,7 +707,7 @@ jobs:
                 --host=aarch64-pc-windows-msvc
                 --enable-full-tools
                 --enable-profiler
-              SCRIPT: python x.py dist bootstrap --include-default-paths
+              SCRIPT: python x.py dist bootstrap bootstrap-shim --include-default-paths
               DIST_REQUIRE_ALL_TOOLS: 1
               # Hack around this SDK version, because it doesn't work with clang.
               # See https://github.com/rust-lang/rust/issues/88796
@@ -723,14 +723,14 @@ jobs:
               # We are intentionally allowing an old toolchain on this builder (and that's
               # incompatible with LLVM downloads today).
               NO_DOWNLOAD_CI_LLVM: 1
-              SCRIPT: python x.py dist bootstrap --include-default-paths
+              SCRIPT: python x.py dist bootstrap bootstrap-shim --include-default-paths
               CUSTOM_MINGW: 1
               DIST_REQUIRE_ALL_TOOLS: 1
             <<: *job-windows-8c
 
           - name: dist-x86_64-mingw
             env:
-              SCRIPT: python x.py dist bootstrap --include-default-paths
+              SCRIPT: python x.py dist bootstrap bootstrap-shim --include-default-paths
               RUST_CONFIGURE_ARGS: >-
                 --build=x86_64-pc-windows-gnu
                 --enable-full-tools
@@ -745,7 +745,7 @@ jobs:
           - name: dist-x86_64-msvc-alt
             env:
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
-              SCRIPT: python x.py dist bootstrap --include-default-paths
+              SCRIPT: python x.py dist bootstrap bootstrap-shim --include-default-paths
             <<: *job-windows-8c
 
   try:

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -183,7 +183,8 @@ static PKG_INSTALLERS: &[&str] = &["x86_64-apple-darwin", "aarch64-apple-darwin"
 
 static MINGW: &[&str] = &["i686-pc-windows-gnu", "x86_64-pc-windows-gnu"];
 
-static NIGHTLY_ONLY_COMPONENTS: &[PkgType] = &[PkgType::Miri, PkgType::JsonDocs];
+static NIGHTLY_ONLY_COMPONENTS: &[PkgType] =
+    &[PkgType::Miri, PkgType::JsonDocs, PkgType::BootstrapShim];
 
 macro_rules! t {
     ($e:expr) => {
@@ -414,7 +415,8 @@ impl Builder {
                 | PkgType::Rustfmt
                 | PkgType::LlvmTools
                 | PkgType::RustAnalysis
-                | PkgType::JsonDocs => {
+                | PkgType::JsonDocs
+                | PkgType::BootstrapShim => {
                     extensions.push(host_component(pkg));
                 }
                 PkgType::RustcDev | PkgType::RustcDocs => {

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -57,6 +57,7 @@ pkg_type! {
     LlvmTools = "llvm-tools"; preview = true,
     Miri = "miri"; preview = true,
     JsonDocs = "rust-docs-json"; preview = true,
+    BootstrapShim = "bootstrap-shim"; preview = true,
 }
 
 impl PkgType {
@@ -92,6 +93,7 @@ impl PkgType {
             PkgType::ReproducibleArtifacts => true,
             PkgType::RustMingw => true,
             PkgType::RustAnalysis => true,
+            PkgType::BootstrapShim => true,
         }
     }
 
@@ -115,6 +117,7 @@ impl PkgType {
             RustAnalyzer => HOSTS,
             Clippy => HOSTS,
             Miri => HOSTS,
+            BootstrapShim => HOSTS,
             Rustfmt => HOSTS,
             RustAnalysis => TARGETS,
             LlvmTools => TARGETS,

--- a/src/tools/x/src/main.rs
+++ b/src/tools/x/src/main.rs
@@ -98,7 +98,7 @@ fn handle_result(result: io::Result<ExitStatus>, cmd: Command) {
     }
 }
 
-fn main() {
+pub fn main() {
     match env::args().skip(1).next().as_deref() {
         Some("--wrapper-version") => {
             let version = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
Helps with #94829.

For now this needs you to manually opt in with `cargo run --manifest-path src/bootstrap/Cargo.toml -p bootstrap-shim`.