### PR TITLE
Do not eagerly recover for bad `impl Trait` types in macros

### DIFF
--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -694,8 +694,9 @@ impl<'a> Parser<'a> {
         // `where`, so stop if it's it.
         // We also continue if we find types (not traits), again for error recovery.
         while self.can_begin_bound()
-            || self.token.can_begin_type()
-            || (self.token.is_reserved_ident() && !self.token.is_keyword(kw::Where))
+            || (self.may_recover()
+                && (self.token.can_begin_type()
+                    || (self.token.is_reserved_ident() && !self.token.is_keyword(kw::Where))))
         {
             if self.token.is_keyword(kw::Dyn) {
                 // Account for `&dyn Trait + dyn Other`.

--- a/tests/ui/parser/bad-recover-kw-after-impl.rs
+++ b/tests/ui/parser/bad-recover-kw-after-impl.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+// edition:2021
+// for the `impl` + keyword test
+
+macro_rules! impl_primitive {
+    ($ty:ty) => {
+        compile_error!("whoops");
+    };
+    (impl async) => {};
+}
+
+impl_primitive!(impl async);
+
+fn main() {}

--- a/tests/ui/parser/bad-recover-ty-after-impl.rs
+++ b/tests/ui/parser/bad-recover-ty-after-impl.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+macro_rules! impl_primitive {
+    ($ty:ty) => { impl_primitive!(impl $ty); };
+    (impl $ty:ty) => { fn a(_: $ty) {} }
+}
+
+impl_primitive! { u8 }
+
+macro_rules! test {
+    ($ty:ty) => { compile_error!("oh no"); };
+    (impl &) => {};
+}
+
+test!(impl &);
+
+fn main() {}


### PR DESCRIPTION
Fixes #107796

cc #106712, @estebank and @Ezrashaw please make sure to use [`Parser::may_recover`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_parse/parser/struct.Parser.html#method.may_recover) for all eager-token-consuming parser recoveries.

This also fixes a separate regression from #99915, that was introduced before we added `may_recover` though.