### PR TITLE
Set `rust-analyzer.check.invocationLocation` to `root`

### DIFF
--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -24,10 +24,12 @@ pub enum Profile {
 }
 
 /// A list of historical hashes of `src/etc/vscode_settings.json`.
-/// New entries should be appended whenever this is updated so we can detected
+/// New entries should be appended whenever this is updated so we can detect
 /// outdated vs. user-modified settings files.
-static SETTINGS_HASHES: &[&str] =
-    &["ea67e259dedf60d4429b6c349a564ffcd1563cf41c920a856d1f5b16b4701ac8"];
+static SETTINGS_HASHES: &[&str] = &[
+    "ea67e259dedf60d4429b6c349a564ffcd1563cf41c920a856d1f5b16b4701ac8",
+    "56e7bf011c71c5d81e0bf42e84938111847a810eee69d906bba494ea90b51922",
+];
 static VSCODE_SETTINGS: &str = include_str!("../etc/vscode_settings.json");
 
 impl Profile {

--- a/src/etc/vscode_settings.json
+++ b/src/etc/vscode_settings.json
@@ -1,4 +1,6 @@
 {
+    "rust-analyzer.check.invocationLocation": "root",
+    "rust-analyzer.check.invocationStrategy": "once",
     "rust-analyzer.checkOnSave.overrideCommand": [
         "python3",
         "x.py",


### PR DESCRIPTION
Add
```json
    "rust-analyzer.check.invocationLocation": "root",
    "rust-analyzer.check.invocationStrategy": "once",
```
to the bundled VS code config. This prevents an error with r-a invoking `python3 x.py` in `src/bootstrap` where `x.py` does not exist.

r? @jyn514 