### PR TITLE
Make Compare traits have ~const super traits.

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -662,8 +662,8 @@ impl dyn Any + Send + Sync {
 /// While `TypeId` implements `Hash`, `PartialOrd`, and `Ord`, it is worth
 /// noting that the hashes and ordering will vary between Rust releases. Beware
 /// of relying on them inside of your code!
-#[derive(Clone, Copy, Debug, Hash, Eq)]
-#[derive_const(PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash)]
+#[derive_const(PartialEq, Eq, PartialOrd, Ord)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {
     t: u64,

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -9,8 +9,8 @@ use crate::{cmp, fmt, hash, mem, num};
 /// Note that particularly large alignments, while representable in this type,
 /// are likely not to be supported by actual allocators and linkers.
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-#[derive(Copy, Clone, Eq)]
-#[derive_const(PartialEq)]
+#[derive(Copy, Clone)]
+#[derive_const(PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Alignment(AlignmentEnum);
 

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -41,7 +41,8 @@ macro_rules! tuple_impls {
         maybe_tuple_doc! {
             $($T)+ @
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl<$($T: Eq),+> Eq for ($($T,)+)
+            #[rustc_const_unstable(feature = "const_cmp", issue = "92391")]
+            impl<$($T: ~const Eq),+> const Eq for ($($T,)+)
             where
                 last_type!($($T,)+): ?Sized
             {}
@@ -51,7 +52,7 @@ macro_rules! tuple_impls {
             $($T)+ @
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_unstable(feature = "const_cmp", issue = "92391")]
-            impl<$($T: ~const PartialOrd + ~const PartialEq),+> const PartialOrd for ($($T,)+)
+            impl<$($T: ~const PartialOrd),+> const PartialOrd for ($($T,)+)
             where
                 last_type!($($T,)+): ?Sized
             {

--- a/tests/ui/consts/issue-25826.stderr
+++ b/tests/ui/consts/issue-25826.stderr
@@ -1,11 +1,11 @@
-error[E0277]: can't compare `*const ()` with `*const ()` in const contexts
+error[E0277]: can't compare `*const ()` with `_` in const contexts
   --> $DIR/issue-25826.rs:3:52
    |
 LL |     const A: bool = unsafe { id::<u8> as *const () < id::<u16> as *const () };
-   |                                                    ^ no implementation for `*const () < *const ()` and `*const () > *const ()`
+   |                                                    ^ no implementation for `*const () < _` and `*const () > _`
    |
-   = help: the trait `~const PartialOrd` is not implemented for `*const ()`
-note: the trait `PartialOrd` is implemented for `*const ()`, but that implementation is not `const`
+   = help: the trait `~const PartialOrd<_>` is not implemented for `*const ()`
+note: the trait `PartialOrd<_>` is implemented for `*const ()`, but that implementation is not `const`
   --> $DIR/issue-25826.rs:3:52
    |
 LL |     const A: bool = unsafe { id::<u8> as *const () < id::<u16> as *const () };


### PR DESCRIPTION
This changes the trait definitions for `Eq`, `PartialOrd` and `Ord` to have ~const super trait bounds.

This simplifies const code that uses (for example) both the `Ord` and `PartialEq` Traits since no additional trait bounds will have to be added for those (only the existing ones changed to ~const).

cc @fee1-dead 