### PR TITLE
Add zsh and bash completions for `x`

### DIFF
--- a/src/etc/completions/x.bash
+++ b/src/etc/completions/x.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+_x_completions()
+{
+  if [ "${#COMP_WORDS[@]}" -le "2" ]; then
+	COMPREPLY=($(compgen -W "build check clippy fix fmt test bench doc clean dist install run setup" "${COMP_WORDS[1]}"))
+    return
+  else
+    compopt -o nospace
+    local cur=${COMP_WORDS[COMP_CWORD]}
+    local top=$(git rev-parse --show-toplevel 2>/dev/null || return)
+    COMPREPLY=$(cd $top && compgen -f -- "$cur")
+  fi
+}
+complete -F _x_completions x

--- a/src/etc/completions/x.zsh
+++ b/src/etc/completions/x.zsh
@@ -1,0 +1,13 @@
+#!/usr/bin/env zsh
+
+_x_completions()
+{
+  local line
+  local top=$(git rev-parse --show-toplevel 2>/dev/null || return)
+  cd "${top}"
+  _arguments -C \
+    "1:subcommand:(build check clippy fix fmt test bench doc clean dist install run setup)" \
+    "*:files:_files"
+  cd "${OLDPWD}"
+}
+compdef _x_completions x


### PR DESCRIPTION
Suggest the `x` subcommands, then suggest the paths they may be invoked with. We can then point users to these scripts in the dev guide. There is probably a better way to implement these, but I'm unfamiliar with shell completion APIs.

The content of `src/etc/completions/*_paths` is from the output of `x <cmd> -h -v`, hardcoded to avoid the shell having to invoke `x` whenever the completion script is loaded.

@rustbot label +T-bootstrap