### PR TITLE
for-loop recovery tweak

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2472,17 +2472,17 @@ impl<'a> Parser<'a> {
         let pat = self.recover_parens_around_for_head(pat, begin_paren);
 
         // Recover from missing expression in `for` loop
-        if matches!(expr.kind, ExprKind::Block(..))
+        if let ExprKind::Block(block, _) = &expr.kind
             && !matches!(self.token.kind, token::OpenDelim(token::Delimiter::Brace))
             && self.may_recover()
         {
+            let span = expr.span.shrink_to_lo();
             self.sess
-                .emit_err(errors::MissingExpressionInForLoop { span: expr.span.shrink_to_lo() });
+                .emit_err(errors::MissingExpressionInForLoop { span });
             let err_expr = self.mk_expr(expr.span, ExprKind::Err);
-            let block = self.mk_block(vec![], BlockCheckMode::Default, self.prev_token.span);
             return Ok(self.mk_expr(
                 lo.to(self.prev_token.span),
-                ExprKind::ForLoop(pat, err_expr, block, opt_label),
+                ExprKind::ForLoop(pat, err_expr, block.clone(), opt_label),
             ));
         }
 


### PR DESCRIPTION
Recover a bit more faithfully, with `for PAT in { BLOCK }` being recovered as `for PAT in <ERR_EXPR> { BLOCK }`, instead of `for PAT IN <ERR_EXPR> { }`.