### PR TITLE
create symlink for legacy rustfmt path

### DIFF
--- a/src/bootstrap/download.rs
+++ b/src/bootstrap/download.rs
@@ -2,7 +2,7 @@ use std::{
     env,
     ffi::{OsStr, OsString},
     fs::{self, File},
-    io::{BufRead, BufReader, ErrorKind},
+    io::{self, BufRead, BufReader, ErrorKind},
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
@@ -24,6 +24,14 @@ static SHOULD_FIX_BINS_AND_DYLIBS: OnceCell<bool> = OnceCell::new();
 impl Config {
     pub fn is_verbose(&self) -> bool {
         self.verbose > 0
+    }
+
+    pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, link: Q) -> io::Result<()> {
+        #[cfg(unix)]
+        use std::os::unix::fs::symlink as symlink_file;
+        #[cfg(windows)]
+        use std::os::windows::fs::symlink_file;
+        if !self.dry_run() { symlink_file(src.as_ref(), link.as_ref()) } else { Ok(()) }
     }
 
     pub(crate) fn create(&self, path: &Path, s: &str) {
@@ -331,6 +339,12 @@ impl Config {
         let bin_root = self.out.join(host.triple).join("rustfmt");
         let rustfmt_path = bin_root.join("bin").join(exe("rustfmt", host));
         let rustfmt_stamp = bin_root.join(".rustfmt-stamp");
+
+        let legacy_rustfmt = self.initial_rustc.with_file_name(exe("rustfmt", host));
+        if !legacy_rustfmt.exists() {
+            t!(self.symlink_file(&rustfmt_path, &legacy_rustfmt));
+        }
+
         if rustfmt_path.exists() && !program_out_of_date(&rustfmt_stamp, &channel) {
             return Some(rustfmt_path);
         }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -20,7 +20,6 @@ use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File};
-use std::io;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -1407,7 +1406,7 @@ impl Build {
                 src = t!(fs::canonicalize(src));
             } else {
                 let link = t!(fs::read_link(src));
-                t!(self.symlink_file(link, dst));
+                t!(self.config.symlink_file(link, dst));
                 return;
             }
         }
@@ -1523,14 +1522,6 @@ impl Build {
             Err(err) => panic!("could not read dir {:?}: {:?}", dir, err),
         };
         iter.map(|e| t!(e)).collect::<Vec<_>>().into_iter()
-    }
-
-    fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, link: Q) -> io::Result<()> {
-        #[cfg(unix)]
-        use std::os::unix::fs::symlink as symlink_file;
-        #[cfg(windows)]
-        use std::os::windows::fs::symlink_file;
-        if !self.config.dry_run() { symlink_file(src.as_ref(), link.as_ref()) } else { Ok(()) }
     }
 
     /// Returns if config.ninja is enabled, and checks for ninja existence,

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -516,7 +516,7 @@ impl Step for Llvm {
 
             let lib_llvm = out_dir.join("build").join("lib").join(lib_name);
             if !lib_llvm.exists() {
-                t!(builder.symlink_file("libLLVM.dylib", &lib_llvm));
+                t!(builder.build.config.symlink_file("libLLVM.dylib", &lib_llvm));
             }
         }
 


### PR DESCRIPTION
Fixes #107547 .
Main change is in the `download.rs` file. Created a symlink for the legacy rustfmt path to the new rustfmt path. Other file changes are simply as a result of porting over the symlink_file function from the Build struct to the config Struct