### PR TITLE
Patch `build/rustfmt/lib/*.so` for NixOS

### DIFF
--- a/src/bootstrap/download.rs
+++ b/src/bootstrap/download.rs
@@ -173,8 +173,7 @@ impl Config {
             // appear to have this (even when `../lib` is redundant).
             // NOTE: there are only two paths here, delimited by a `:`
             let mut entries = OsString::from("$ORIGIN/../lib:");
-            entries.push(t!(fs::canonicalize(nix_deps_dir)));
-            entries.push("/lib");
+            entries.push(t!(fs::canonicalize(nix_deps_dir)).join("lib"));
             entries
         };
         patchelf.args(&[OsString::from("--set-rpath"), rpath_entries]);
@@ -353,6 +352,13 @@ impl Config {
         if self.should_fix_bins_and_dylibs() {
             self.fix_bin_or_dylib(&bin_root.join("bin").join("rustfmt"));
             self.fix_bin_or_dylib(&bin_root.join("bin").join("cargo-fmt"));
+            let lib_dir = bin_root.join("lib");
+            for lib in t!(fs::read_dir(&lib_dir), lib_dir.display().to_string()) {
+                let lib = t!(lib);
+                if lib.path().extension() == Some(OsStr::new("so")) {
+                    self.fix_bin_or_dylib(&lib.path());
+                }
+            }
         }
 
         self.create(&rustfmt_stamp, &channel);


### PR DESCRIPTION
fixes #107676.