### PR TITLE
Add ui test for implementation on projection

### DIFF
--- a/tests/ui/const-generics/wrong-normalization.rs
+++ b/tests/ui/const-generics/wrong-normalization.rs
@@ -1,0 +1,19 @@
+// This test ensures that if implementation on projections is supported,
+// it doesn't end in very weird cycle error.
+
+#![crate_type = "lib"]
+
+pub trait Identity {
+    type Identity: ?Sized;
+}
+
+impl<T: ?Sized> Identity for T {
+    type Identity = Self;
+}
+
+pub struct I8<const F: i8>;
+
+impl <I8<{i8::MIN}> as Identity>::Identity {
+//~^ ERROR no nominal type found for inherent implementation
+    pub fn foo(&self) {}
+}

--- a/tests/ui/const-generics/wrong-normalization.stderr
+++ b/tests/ui/const-generics/wrong-normalization.stderr
@@ -1,0 +1,11 @@
+error[E0118]: no nominal type found for inherent implementation
+  --> $DIR/wrong-normalization.rs:16:6
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl requires a nominal type
+   |
+   = note: either implement a trait on it or create a newtype to wrap it instead
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0118`.


### PR DESCRIPTION
The error in full can be seen in https://github.com/rust-lang/rust/pull/107263 and is part of why the PR is blocked (it still requires the approval from the team for supporting it).

r? @oli-obk 