### PR TITLE
Added sanity check to to catch empty `host` parameter in `./x.py test --host=''`

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -284,7 +284,7 @@ impl StepDescription {
         }
     }
 
-    /// This might run the builder. If the any of the `pathsets` are excluded by `self.is_excluded`
+    /// This might run `self`. If the any of the `pathsets` are excluded by `self.is_excluded`
     /// it will not run but will return true.
     /// If no target can be determined it will not run and will return false.
     /// Else it will run and return true.
@@ -341,8 +341,8 @@ impl StepDescription {
         if paths.is_empty() || builder.config.include_default_paths {
             for (desc, should_run) in v.iter().zip(&should_runs) {
                 if desc.default && should_run.is_really_default() {
-                    ran =
-                        desc.maybe_run(builder, should_run.paths.iter().cloned().collect()) || ran;
+                    ran |= desc.maybe_run(builder, should_run.paths.iter().cloned().collect());
+
                 }
             }
         }
@@ -356,7 +356,7 @@ impl StepDescription {
         paths.retain(|path| {
             for (desc, should_run) in v.iter().zip(&should_runs) {
                 if let Some(suite) = should_run.is_suite_path(&path) {
-                    ran = desc.maybe_run(builder, vec![suite.clone()]) || ran;
+                    ran |= desc.maybe_run(builder, vec![suite.clone()]);
                     return false;
                 }
             }
@@ -371,7 +371,7 @@ impl StepDescription {
         for (desc, should_run) in v.iter().zip(&should_runs) {
             let pathsets = should_run.pathset_for_paths_removing_matches(&mut paths, desc.kind);
             if !pathsets.is_empty() {
-                ran = desc.maybe_run(builder, pathsets) || ran;
+                ran |= desc.maybe_run(builder, pathsets);
             }
         }
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -284,8 +284,10 @@ impl StepDescription {
         }
     }
 
-    /// This might run the builder. Returns false if no targets can be determined indicating that
-    /// builder was not run
+    /// This might run the builder. If the any of the `pathsets` are excluded by `self.is_excluded`
+    /// it will not run but will return true.
+    /// If no target can be determined it will not run and will return false.
+    /// Else it will run and return true.
     fn maybe_run(&self, builder: &Builder<'_>, pathsets: Vec<PathSet>) -> bool {
         if pathsets.iter().any(|set| self.is_excluded(builder, set)) {
             return true;

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -284,6 +284,8 @@ impl StepDescription {
         }
     }
 
+    /// This might run the builder. Returns false if no targets can be determined indicating that
+    /// builder was not run
     fn maybe_run(&self, builder: &Builder<'_>, pathsets: Vec<PathSet>) -> bool {
         if pathsets.iter().any(|set| self.is_excluded(builder, set)) {
             return true;

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -342,7 +342,6 @@ impl StepDescription {
             for (desc, should_run) in v.iter().zip(&should_runs) {
                 if desc.default && should_run.is_really_default() {
                     ran |= desc.maybe_run(builder, should_run.paths.iter().cloned().collect());
-
                 }
             }
         }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -329,7 +329,10 @@ impl StepDescription {
         }
         // sanity checks on hosts
         if builder.hosts.is_empty() {
-            eprintln!("`x.py {}` run with empty `host` parameter. Either set it or leave it out for default value.", builder.kind.as_str());
+            eprintln!(
+                "`x.py {}` run with empty `host` parameter. Either set it or leave it out for default value.",
+                builder.kind.as_str()
+            );
             crate::detail_exit(1);
         }
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -327,6 +327,11 @@ impl StepDescription {
                 desc.name
             );
         }
+        // sanity checks on hosts
+        if builder.hosts.is_empty() {
+            eprintln!("`x.py {}` run with empty `host` parameter. Either set it or leave it out for default value.", builder.kind.as_str());
+            crate::detail_exit(1);
+        }
 
         if paths.is_empty() || builder.config.include_default_paths {
             for (desc, should_run) in v.iter().zip(&should_runs) {

--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -117,6 +117,16 @@ fn test_exclude() {
 }
 
 #[test]
+fn test_with_empty_host_and_empty_target() {
+    let config = configure("test", &[], &[]);
+    let cache = run_build(&[], config);
+
+    assert!(!cache.contains::<test::Tidy>());
+    assert!(!cache.contains::<test::Cargotest>());
+    assert!(!cache.contains::<test::RustdocUi>());
+}
+
+#[test]
 fn test_exclude_kind() {
     let path = PathBuf::from("src/tools/cargotest");
     let exclude = TaskPath::parse("test::src/tools/cargotest");
@@ -431,6 +441,16 @@ mod dist {
     }
 
     #[test]
+    fn dist_with_empty_host_and_empty_target() {
+        let config = configure(&[], &[]);
+        let mut cache = run_build(&[], config);
+
+        assert!(cache.all::<dist::Docs>().is_empty());
+        assert!(cache.all::<dist::Mingw>().is_empty());
+        assert!(cache.all::<dist::Std>().is_empty());
+    }
+
+    #[test]
     fn dist_with_same_targets_and_hosts() {
         let mut cache = run_build(&[], configure(&["A", "B"], &["A", "B"]));
 
@@ -539,6 +559,18 @@ mod dist {
             first(builder.cache.all::<compile::Rustc>()),
             &[rustc!(A => A, stage = 0), rustc!(A => A, stage = 1),]
         );
+    }
+
+    #[test]
+    fn build_with_empty_host_and_empty_target() {
+        let config = configure(&[], &[]);
+        let build = Build::new(config);
+        let mut builder = Builder::new(&build);
+        builder.run_step_descriptions(&Builder::get_step_descriptions(Kind::Build), &[]);
+
+        assert!(builder.cache.all::<compile::Std>().is_empty());
+        assert!(builder.cache.all::<compile::Assemble>().is_empty());
+        assert!(builder.cache.all::<compile::Rustc>().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
I have added this test to prematurely exit the bootstrapper before it running all its logic. This solves #77906

Fixes #77906