### PR TITLE
Check that built-in callable types validate their output type is `Sized` (in new solver)

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/assembly.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly.rs
@@ -96,10 +96,22 @@ pub(super) trait GoalKind<'tcx>: TypeFoldable<'tcx> + Copy + Eq {
         impl_def_id: DefId,
     ) -> QueryResult<'tcx>;
 
+    // Consider a predicate we know holds (`assumption`) against a goal we're trying to prove.
     fn consider_assumption(
         ecx: &mut EvalCtxt<'_, 'tcx>,
         goal: Goal<'tcx, Self>,
         assumption: ty::Predicate<'tcx>,
+    ) -> QueryResult<'tcx> {
+        Self::consider_assumption_with_certainty(ecx, goal, assumption, Certainty::Yes)
+    }
+
+    // Consider a predicate we know holds (`assumption`) against a goal, unifying with
+    // the `assumption_certainty` if it satisfies the goal.
+    fn consider_assumption_with_certainty(
+        ecx: &mut EvalCtxt<'_, 'tcx>,
+        goal: Goal<'tcx, Self>,
+        assumption: ty::Predicate<'tcx>,
+        assumption_certainty: Certainty,
     ) -> QueryResult<'tcx>;
 
     // A type implements an `auto trait` if its components do as well. These components

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -260,10 +260,11 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
         })
     }
 
-    fn consider_assumption(
+    fn consider_assumption_with_certainty(
         ecx: &mut EvalCtxt<'_, 'tcx>,
         goal: Goal<'tcx, Self>,
         assumption: ty::Predicate<'tcx>,
+        assumption_certainty: Certainty,
     ) -> QueryResult<'tcx> {
         if let Some(poly_projection_pred) = assumption.to_opt_poly_projection_pred()
             && poly_projection_pred.projection_def_id() == goal.predicate.def_id()
@@ -280,7 +281,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
 
                 ecx.eq_term_and_make_canonical_response(
                     goal,
-                    subst_certainty,
+                    subst_certainty.unify_and(assumption_certainty),
                     assumption_projection_pred.term,
                 )
             })
@@ -329,22 +330,29 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
         goal: Goal<'tcx, Self>,
         goal_kind: ty::ClosureKind,
     ) -> QueryResult<'tcx> {
+        let tcx = ecx.tcx();
         if let Some(tupled_inputs_and_output) =
             structural_traits::extract_tupled_inputs_and_output_from_callable(
-                ecx.tcx(),
+                tcx,
                 goal.predicate.self_ty(),
                 goal_kind,
             )?
         {
+            // A built-in `Fn` trait needs to check that its output is `Sized`
+            // (FIXME: technically we only need to check this if the type is a fn ptr...)
+            let output_is_sized_pred = tupled_inputs_and_output
+                .map_bound(|(_, output)| tcx.at(DUMMY_SP).mk_trait_ref(LangItem::Sized, [output]));
+            let (_, output_is_sized_certainty) =
+                ecx.evaluate_goal(goal.with(tcx, output_is_sized_pred))?;
+
             let pred = tupled_inputs_and_output
                 .map_bound(|(inputs, output)| ty::ProjectionPredicate {
-                    projection_ty: ecx
-                        .tcx()
+                    projection_ty: tcx
                         .mk_alias_ty(goal.predicate.def_id(), [goal.predicate.self_ty(), inputs]),
                     term: output.into(),
                 })
-                .to_predicate(ecx.tcx());
-            Self::consider_assumption(ecx, goal, pred)
+                .to_predicate(tcx);
+            Self::consider_assumption_with_certainty(ecx, goal, pred, output_is_sized_certainty)
         } else {
             ecx.make_canonical_response(Certainty::AMBIGUOUS)
         }

--- a/compiler/rustc_trait_selection/src/solve/trait_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals.rs
@@ -62,11 +62,11 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
         })
     }
 
-    fn consider_assumption_with_certainty(
+    fn consider_implied_clause(
         ecx: &mut EvalCtxt<'_, 'tcx>,
         goal: Goal<'tcx, Self>,
         assumption: ty::Predicate<'tcx>,
-        assumption_certainty: Certainty,
+        requirements: impl IntoIterator<Item = Goal<'tcx, ty::Predicate<'tcx>>>,
     ) -> QueryResult<'tcx> {
         if let Some(poly_trait_pred) = assumption.to_opt_poly_trait_pred()
             && poly_trait_pred.def_id() == goal.predicate.def_id()
@@ -75,14 +75,13 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
             ecx.infcx.probe(|_| {
                 let assumption_trait_pred =
                     ecx.infcx.instantiate_binder_with_infer(poly_trait_pred);
-                let nested_goals = ecx.infcx.eq(
+                let mut nested_goals = ecx.infcx.eq(
                     goal.param_env,
                     goal.predicate.trait_ref,
                     assumption_trait_pred.trait_ref,
                 )?;
-                ecx.evaluate_all(nested_goals).and_then(|certainty| {
-                    ecx.make_canonical_response(certainty.unify_and(assumption_certainty))
-                })
+                nested_goals.extend(requirements);
+                ecx.evaluate_all_and_make_canonical_response(nested_goals)
             })
         } else {
             Err(NoSolution)
@@ -178,29 +177,25 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
         goal_kind: ty::ClosureKind,
     ) -> QueryResult<'tcx> {
         let tcx = ecx.tcx();
-        if let Some(tupled_inputs_and_output) =
+        let Some(tupled_inputs_and_output) =
             structural_traits::extract_tupled_inputs_and_output_from_callable(
                 tcx,
                 goal.predicate.self_ty(),
                 goal_kind,
-            )?
-        {
-            // A built-in `Fn` trait needs to check that its output is `Sized`
-            // (FIXME: technically we only need to check this if the type is a fn ptr...)
-            let output_is_sized_pred = tupled_inputs_and_output
-                .map_bound(|(_, output)| tcx.at(DUMMY_SP).mk_trait_ref(LangItem::Sized, [output]));
-            let (_, output_is_sized_certainty) =
-                ecx.evaluate_goal(goal.with(tcx, output_is_sized_pred))?;
+            )? else {
+            return ecx.make_canonical_response(Certainty::AMBIGUOUS);
+        };
+        let output_is_sized_pred = tupled_inputs_and_output
+            .map_bound(|(_, output)| tcx.at(DUMMY_SP).mk_trait_ref(LangItem::Sized, [output]));
 
-            let pred = tupled_inputs_and_output
-                .map_bound(|(inputs, _)| {
-                    tcx.mk_trait_ref(goal.predicate.def_id(), [goal.predicate.self_ty(), inputs])
-                })
-                .to_predicate(tcx);
-            Self::consider_assumption_with_certainty(ecx, goal, pred, output_is_sized_certainty)
-        } else {
-            ecx.make_canonical_response(Certainty::AMBIGUOUS)
-        }
+        let pred = tupled_inputs_and_output
+            .map_bound(|(inputs, _)| {
+                tcx.mk_trait_ref(goal.predicate.def_id(), [goal.predicate.self_ty(), inputs])
+            })
+            .to_predicate(tcx);
+        // A built-in `Fn` impl only holds if the output is sized.
+        // (FIXME: technically we only need to check this if the type is a fn ptr...)
+        Self::consider_implied_clause(ecx, goal, pred, [goal.with(tcx, output_is_sized_pred)])
     }
 
     fn consider_builtin_tuple_candidate(
@@ -236,6 +231,8 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
         }
 
         // Async generator unconditionally implement `Future`
+        // Technically, we need to check that the future output type is Sized,
+        // but that's already proven by the generator being WF.
         ecx.make_canonical_response(Certainty::Yes)
     }
 
@@ -255,13 +252,16 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
         }
 
         let generator = substs.as_generator();
-        Self::consider_assumption(
+        Self::consider_implied_clause(
             ecx,
             goal,
             ty::Binder::dummy(
                 tcx.mk_trait_ref(goal.predicate.def_id(), [self_ty, generator.resume_ty()]),
             )
             .to_predicate(tcx),
+            // Technically, we need to check that the generator types are Sized,
+            // but that's already proven by the generator being WF.
+            [],
         )
     }
 

--- a/tests/ui/traits/new-solver/builtin-fn-must-return-sized.rs
+++ b/tests/ui/traits/new-solver/builtin-fn-must-return-sized.rs
@@ -1,0 +1,17 @@
+// compile-flags: -Ztrait-solver=next
+
+#![feature(fn_traits)]
+#![feature(unboxed_closures)]
+#![feature(tuple_trait)]
+
+use std::ops::Fn;
+use std::marker::Tuple;
+
+fn foo<F: Fn<T>, T: Tuple>(f: Option<F>, t: T) {
+    let y = (f.unwrap()).call(t);
+}
+
+fn main() {
+    foo::<fn() -> str, _>(None, ());
+    //~^ expected a `Fn<_>` closure, found `fn() -> str`
+}

--- a/tests/ui/traits/new-solver/builtin-fn-must-return-sized.stderr
+++ b/tests/ui/traits/new-solver/builtin-fn-must-return-sized.stderr
@@ -1,0 +1,18 @@
+error[E0277]: expected a `Fn<_>` closure, found `fn() -> str`
+  --> $DIR/builtin-fn-must-return-sized.rs:15:27
+   |
+LL |     foo::<fn() -> str, _>(None, ());
+   |     --------------------- ^^^^ expected an `Fn<_>` closure, found `fn() -> str`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Fn<_>` is not implemented for `fn() -> str`
+note: required by a bound in `foo`
+  --> $DIR/builtin-fn-must-return-sized.rs:10:11
+   |
+LL | fn foo<F: Fn<T>, T: Tuple>(f: Option<F>, t: T) {
+   |           ^^^^^ required by this bound in `foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Working on parity with old solver. Putting this up for consideration, it's not *really* needed or anything just yet. Maybe it's better to approach this from another direction (like always checking the item bounds when calling `consider_assumption`? we may need that for coinduction to be sound though?)

This basically implements #100096 for the new solver.