### PR TITLE
Add `where` to `borrowck_could_not_prove`

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/borrowck.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/borrowck.ftl
@@ -6,7 +6,7 @@ borrowck_higher_ranked_lifetime_error =
     higher-ranked lifetime error
 
 borrowck_could_not_prove =
-    could not prove `{$predicate}`
+    could not prove `where {$predicate}`
 
 borrowck_could_not_normalize =
     could not normalize `{$value}`

--- a/tests/ui/higher-rank-trait-bounds/issue-59311.stderr
+++ b/tests/ui/higher-rank-trait-bounds/issue-59311.stderr
@@ -4,7 +4,7 @@ error: higher-ranked lifetime error
 LL |     v.t(|| {});
    |     ^^^^^^^^^^
    |
-   = note: could not prove `[closure@$DIR/issue-59311.rs:17:9: 17:11] well-formed`
+   = note: could not prove `where [closure@$DIR/issue-59311.rs:17:9: 17:11] well-formed`
 
 error: higher-ranked lifetime error
   --> $DIR/issue-59311.rs:17:9
@@ -12,7 +12,7 @@ error: higher-ranked lifetime error
 LL |     v.t(|| {});
    |         ^^^^^
    |
-   = note: could not prove `for<'a> &'a V: 'static`
+   = note: could not prove `where for<'a> &'a V: 'static`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/re-empty-in-error.stderr
+++ b/tests/ui/lifetimes/re-empty-in-error.stderr
@@ -4,7 +4,7 @@ error: higher-ranked lifetime error
 LL |     foo(&10);
    |     ^^^^^^^^
    |
-   = note: could not prove `for<'b> &'b (): 'a`
+   = note: could not prove `where for<'b> &'b (): 'a`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This is a minute difference in an error message that generally should not be hit, but the meaning of the predicate's notation of `Type: Trait` is unclear when encountered in a random message, removed from surrounding Rust syntax, provoking remarks like a straight-up "What does this mean?" from people who have been programming in Rust for multiple years. We can use the `where` prefix, giving us `where Type: Trait`, which a more experienced Rust programmer is likely to recognize as using the format of a `where` clause and thus appropriately frame the notation of the predicate, even if the message remains fairly cryptic.