### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -628,7 +628,10 @@ fn print_crate_info(
                 println!("{}", serde_json::to_string_pretty(&sess.target.to_json()).unwrap());
             }
             FileNames | CrateName => {
-                let Some(attrs) = attrs.as_ref() else { return Compilation::Continue; };
+                let Some(attrs) = attrs.as_ref() else {
+                    // no crate attributes, print out an error and exit
+                    return Compilation::Continue;
+                };
                 let t_outputs = rustc_interface::util::build_output_filenames(attrs, sess);
                 let id = rustc_session::output::find_crate_name(sess, attrs);
                 if *req == PrintRequest::CrateName {

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -628,7 +628,7 @@ fn print_crate_info(
                 println!("{}", serde_json::to_string_pretty(&sess.target.to_json()).unwrap());
             }
             FileNames | CrateName => {
-                let attrs = attrs.as_ref().unwrap();
+                let Some(attrs) = attrs.as_ref() else { return Compilation::Continue; };
                 let t_outputs = rustc_interface::util::build_output_filenames(attrs, sess);
                 let id = rustc_session::output::find_crate_name(sess, attrs);
                 if *req == PrintRequest::CrateName {

--- a/compiler/rustc_error_messages/locales/en-US/borrowck.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/borrowck.ftl
@@ -18,7 +18,7 @@ borrowck_generic_does_not_live_long_enough =
     `{$kind}` does not live long enough
 
 borrowck_move_borrowed =
-    cannot move out of `{$desc}` beacause it is borrowed
+    cannot move out of `{$desc}` because it is borrowed
 
 borrowck_var_does_not_need_mut =
     variable does not need to be mutable
@@ -87,10 +87,10 @@ borrowck_use_due_to_use_closure =
     use occurs due to use in closure
 
 borrowck_assign_due_to_use_closure =
-    assign occurs due to use in closure
+    assignment occurs due to use in closure
 
 borrowck_assign_part_due_to_use_closure =
-    assign to part occurs due to use in closure
+    assignment to part occurs due to use in closure
 
 borrowck_capture_immute =
     capture is immutable because of use here

--- a/compiler/rustc_log/src/lib.rs
+++ b/compiler/rustc_log/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! ```
 //! fn main() {
-//!     rustc_log::init_rustc_env_logger().unwrap();
+//!     rustc_log::init_env_logger("LOG").unwrap();
 //!
 //!     let edition = rustc_span::edition::Edition::Edition2021;
 //!     rustc_span::create_session_globals_then(edition, || {
@@ -23,9 +23,9 @@
 //! }
 //! ```
 //!
-//! Now `RUSTC_LOG=debug cargo run` will run your minimal main.rs and show
+//! Now `LOG=debug cargo run` will run your minimal main.rs and show
 //! rustc's debug logging. In a workflow like this, one might also add
-//! `std::env::set_var("RUSTC_LOG", "debug")` to the top of main so that `cargo
+//! `std::env::set_var("LOG", "debug")` to the top of main so that `cargo
 //! run` by itself is sufficient to get logs.
 //!
 //! The reason rustc_log is a tiny separate crate, as opposed to exposing the

--- a/compiler/rustc_log/src/lib.rs
+++ b/compiler/rustc_log/src/lib.rs
@@ -53,12 +53,6 @@ use tracing_subscriber::fmt::{
 };
 use tracing_subscriber::layer::SubscriberExt;
 
-pub fn init_rustc_env_logger() -> Result<(), Error> {
-    init_env_logger("RUSTC_LOG")
-}
-
-/// In contrast to `init_rustc_env_logger` this allows you to choose an env var
-/// other than `RUSTC_LOG`.
 pub fn init_env_logger(env: &str) -> Result<(), Error> {
     let filter = match env::var(env) {
         Ok(env) => EnvFilter::new(env),

--- a/src/bootstrap/download.rs
+++ b/src/bootstrap/download.rs
@@ -340,9 +340,12 @@ impl Config {
         let rustfmt_path = bin_root.join("bin").join(exe("rustfmt", host));
         let rustfmt_stamp = bin_root.join(".rustfmt-stamp");
 
-        let legacy_rustfmt = self.initial_rustc.with_file_name(exe("rustfmt", host));
-        if !legacy_rustfmt.exists() {
-            t!(self.symlink_file(&rustfmt_path, &legacy_rustfmt));
+        #[cfg(not(windows))]
+        {
+            let legacy_rustfmt = self.initial_rustc.with_file_name(exe("rustfmt", host));
+            if !legacy_rustfmt.exists() {
+                t!(self.symlink_file(&rustfmt_path, &legacy_rustfmt));
+            }
         }
 
         if rustfmt_path.exists() && !program_out_of_date(&rustfmt_stamp, &channel) {

--- a/tests/run-make/no-input-file/Makefile
+++ b/tests/run-make/no-input-file/Makefile
@@ -1,0 +1,4 @@
+include ../../run-make-fulldeps/tools.mk
+
+all:
+	$(RUSTC) --print crate-name 2>&1 | diff - no-input-file.stderr

--- a/tests/run-make/no-input-file/no-input-file.stderr
+++ b/tests/run-make/no-input-file/no-input-file.stderr
@@ -1,0 +1,2 @@
+error: no input filename given
+

--- a/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.rs
+++ b/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.rs
@@ -1,0 +1,19 @@
+// ignore-tidy-linelength
+
+// Regression test for #107745.
+// Previously need_type_info::update_infer_source will consider expressions originating from
+// macro expressions as candiate "previous sources". This unfortunately can mean that
+// for macros expansions such as `format!()` internal implementation details can leak, such as:
+//
+// ```
+// error[E0282]: type annotations needed
+// --> src/main.rs:2:22
+//  |
+//2 |     println!("{:?}", []);
+//  |                      ^^ cannot infer type of the type parameter `T` declared on the associated function `new_debug`
+// ```
+
+fn main() {
+    println!("{:?}", []);
+    //~^ ERROR type annotations needed
+}

--- a/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.stderr
+++ b/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.stderr
@@ -1,0 +1,11 @@
+error[E0282]: type annotations needed
+  --> $DIR/issue-107745-avoid-expr-from-macro-expansion.rs:17:22
+   |
+LL |     println!("{:?}", []);
+   |                      ^^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/issues/issue-16966.stderr
+++ b/tests/ui/issues/issue-16966.stderr
@@ -1,10 +1,8 @@
 error[E0282]: type annotations needed
-  --> $DIR/issue-16966.rs:2:5
+  --> $DIR/issue-16966.rs:2:12
    |
 LL |     panic!(std::default::Default::default());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `M` declared on the function `begin_panic`
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.rs
+++ b/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.rs
@@ -17,7 +17,7 @@ fn test2<T1, T2>(arg1 : T1, arg2 : T2) {
 fn test3<'a>(arg : &'a u32) {
   let v : Vec<'a = vec![];
     //~^ ERROR: expected one of
-    //~| ERROR: type annotations needed for `Vec<T>`
+    //~| ERROR: type annotations needed for `Vec<_>`
 }
 
 fn main() {}

--- a/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.stderr
+++ b/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.stderr
@@ -39,26 +39,26 @@ help: you might have meant to end the type parameters here
 LL |   let v : Vec<'a> = vec![];
    |                 +
 
-error[E0282]: type annotations needed for `Vec<T>`
+error[E0282]: type annotations needed for `Vec<_>`
   --> $DIR/missing-closing-angle-bracket-eq-constraint.rs:7:7
    |
 LL |   let v : Vec<(u32,_) = vec![];
    |       ^
    |
-help: consider giving `v` an explicit type, where the type for type parameter `T` is specified
+help: consider giving `v` an explicit type, where the placeholders `_` are specified
    |
-LL |   let v: Vec<T> : Vec<(u32,_) = vec![];
+LL |   let v: Vec<_> : Vec<(u32,_) = vec![];
    |        ++++++++
 
-error[E0282]: type annotations needed for `Vec<T>`
+error[E0282]: type annotations needed for `Vec<_>`
   --> $DIR/missing-closing-angle-bracket-eq-constraint.rs:18:7
    |
 LL |   let v : Vec<'a = vec![];
    |       ^
    |
-help: consider giving `v` an explicit type, where the type for type parameter `T` is specified
+help: consider giving `v` an explicit type, where the placeholders `_` are specified
    |
-LL |   let v: Vec<T> : Vec<'a = vec![];
+LL |   let v: Vec<_> : Vec<'a = vec![];
    |        ++++++++
 
 error: aborting due to 5 previous errors

--- a/tests/ui/type/type-check/cannot_infer_local_or_vec.stderr
+++ b/tests/ui/type/type-check/cannot_infer_local_or_vec.stderr
@@ -1,12 +1,12 @@
-error[E0282]: type annotations needed for `Vec<T>`
+error[E0282]: type annotations needed for `Vec<_>`
   --> $DIR/cannot_infer_local_or_vec.rs:2:9
    |
 LL |     let x = vec![];
    |         ^
    |
-help: consider giving `x` an explicit type, where the type for type parameter `T` is specified
+help: consider giving `x` an explicit type, where the placeholders `_` are specified
    |
-LL |     let x: Vec<T> = vec![];
+LL |     let x: Vec<_> = vec![];
    |          ++++++++
 
 error: aborting due to previous error

--- a/tests/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
+++ b/tests/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
@@ -1,12 +1,12 @@
-error[E0282]: type annotations needed for `(Vec<T>,)`
+error[E0282]: type annotations needed for `(Vec<_>,)`
   --> $DIR/cannot_infer_local_or_vec_in_tuples.rs:2:9
    |
 LL |     let (x, ) = (vec![], );
    |         ^^^^^   ---------- type must be known at this point
    |
-help: consider giving this pattern a type, where the type for type parameter `T` is specified
+help: consider giving this pattern a type, where the placeholders `_` are specified
    |
-LL |     let (x, ): (Vec<T>,) = (vec![], );
+LL |     let (x, ): (Vec<_>,) = (vec![], );
    |              +++++++++++
 
 error: aborting due to previous error


### PR DESCRIPTION
Successful merges:

 - #107789 (Avoid exposing type parameters and implementation details sourced from macro expansions)
 - #107836 (Handle properly when there is no crate attrs)
 - #107839 (avoid duplicating the RUSTC_LOG env var name)
 - #107866 (Allow wasi-libc to initialize its environment variables lazily.)
 - #107876 (create symlink only for non-windows operating systems)
 - #107882 (Cleanup typos in en_US/borrowck.ftl)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=107789,107836,107839,107866,107876,107882)
<!-- homu-ignore:end -->