### PR TITLE
Speedup heapsort by 1.8x by making it branchless

### DIFF
--- a/library/core/src/slice/sort.rs
+++ b/library/core/src/slice/sort.rs
@@ -198,7 +198,12 @@ where
             }
 
             // Choose the greater child.
-            child += (child + 1 < v.len() && is_less(&v[child], &v[child + 1])) as usize;
+            if child + 1 < v.len() {
+                // We need a branch to be sure not to out-of-bounds index,
+                // but it's highly predictable.  The comparison, however,
+                // is better done branchless, especially for primitives.
+                child += is_less(&v[child], &v[child + 1]) as usize;
+            }
 
             // Stop if the invariant holds at `node`.
             if !is_less(&v[node], &v[child]) {

--- a/library/core/src/slice/sort.rs
+++ b/library/core/src/slice/sort.rs
@@ -198,9 +198,7 @@ where
             }
 
             // Choose the greater child.
-            if child + 1 < v.len() && is_less(&v[child], &v[child + 1]) {
-                child += 1;
-            }
+            child += (child + 1 < v.len() && is_less(&v[child], &v[child + 1])) as usize;
 
             // Stop if the invariant holds at `node`.
             if !is_less(&v[node], &v[child]) {


### PR DESCRIPTION
`slice::sort_unstable` will fall back to heapsort if it repeatedly fails to find a good pivot. By making the core child update code branchless it is much faster. On Zen3 sorting 10k `u64` and forcing the sort to pick heapsort, results in:

~455us -> 278us~

455us -> 249us