### PR TITLE
Reexported macros docs

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2206,10 +2206,12 @@ fn clean_maybe_renamed_item<'tcx>(
         };
 
         let mut extra_attrs = Vec::new();
-        if let Some(hir::Node::Item(use_node)) =
-            import_id.and_then(|def_id| cx.tcx.hir().find_by_def_id(def_id))
+        if let Some(import_id) = import_id &&
+            let Some(hir::Node::Item(use_node)) = cx.tcx.hir().find_by_def_id(import_id)
         {
-            // We get all the various imports' attributes.
+            // First, we add the attributes from the current import.
+            extra_attrs.extend_from_slice(inline::load_attrs(cx, import_id.to_def_id()));
+            // Then we get all the various imports' attributes.
             get_all_import_attributes(use_node, cx.tcx, item.owner_id.def_id, &mut extra_attrs);
         }
 

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -378,7 +378,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 let nonexported = !tcx.has_attr(def_id, sym::macro_export);
 
                 if is_macro_2_0 || nonexported || self.inlining {
-                    self.add_to_current_mod(item, renamed, None);
+                    self.add_to_current_mod(item, renamed, import_id);
                 }
             }
             hir::ItemKind::Mod(ref m) => {

--- a/tests/rustdoc/reexport-macro.rs
+++ b/tests/rustdoc/reexport-macro.rs
@@ -1,0 +1,23 @@
+// Ensure that macros are correctly reexported and that they get both the comment from the
+// `pub use` and from the macro.
+
+#![crate_name = "foo"]
+
+// @has 'foo/macro.foo.html'
+// @!has - '//*[@class="toggle top-doc"]/*[@class="docblock"]' 'x y'
+// @has - '//*[@class="toggle top-doc"]/*[@class="docblock"]' 'y'
+#[macro_use]
+mod my_module {
+    /// y
+    #[macro_export]
+    macro_rules! foo {
+        () => ();
+    }
+}
+
+// @has 'foo/another_mod/macro.bar.html'
+// @has - '//*[@class="toggle top-doc"]/*[@class="docblock"]' 'x y'
+pub mod another_mod {
+    /// x
+    pub use crate::foo as bar;
+}


### PR DESCRIPTION
Part of #59368 (doesn't fix it, only improve the current situation a bit).

Macros were not correctly handled in reexports and the reexport attributes were not merged with the item either. This PR fixes both.

r? @notriddle 