### PR TITLE
Change some `pub` to `pub(crate)` in `std`

### DIFF
--- a/library/std/src/collections/hash/mod.rs
+++ b/library/std/src/collections/hash/mod.rs
@@ -1,4 +1,4 @@
 //! Unordered containers, implemented as hash-tables
 
-pub mod map;
-pub mod set;
+pub(crate) mod map;
+pub(crate) mod set;

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -15,7 +15,7 @@ mod private {
     // implementations, since that can enable unsound downcasting.
     #[unstable(feature = "error_type_id", issue = "60784")]
     #[derive(Debug)]
-    pub struct Internal;
+    pub(crate) struct Internal;
 }
 
 /// An error reporter that prints an error and its sources.

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -72,7 +72,7 @@ macro_rules! error_contains {
 // have permission, and return otherwise. This way, we still don't run these
 // tests most of the time, but at least we do if the user has the right
 // permissions.
-pub fn got_symlink_permission(tmpdir: &TempDir) -> bool {
+pub(crate) fn got_symlink_permission(tmpdir: &TempDir) -> bool {
     if cfg!(unix) {
         return true;
     }

--- a/library/std/src/io/buffered/linewritershim.rs
+++ b/library/std/src/io/buffered/linewritershim.rs
@@ -11,12 +11,12 @@ use crate::sys_common::memchr;
 /// `BufWriters` to be temporarily given line-buffering logic; this is what
 /// enables Stdout to be alternately in line-buffered or block-buffered mode.
 #[derive(Debug)]
-pub struct LineWriterShim<'a, W: Write> {
+pub(crate) struct LineWriterShim<'a, W: Write> {
     buffer: &'a mut BufWriter<W>,
 }
 
 impl<'a, W: Write> LineWriterShim<'a, W> {
-    pub fn new(buffer: &'a mut BufWriter<W>) -> Self {
+    pub(crate) fn new(buffer: &'a mut BufWriter<W>) -> Self {
         Self { buffer }
     }
 

--- a/library/std/src/io/buffered/tests.rs
+++ b/library/std/src/io/buffered/tests.rs
@@ -8,7 +8,7 @@ use crate::sync::atomic::{AtomicUsize, Ordering};
 use crate::thread;
 
 /// A dummy reader intended at testing short-reads propagation.
-pub struct ShortReader {
+pub(crate) struct ShortReader {
     lengths: Vec<usize>,
 }
 
@@ -541,25 +541,25 @@ fn bench_buffered_writer(b: &mut test::Bencher) {
 #[derive(Default, Clone)]
 struct ProgrammableSink {
     // Writes append to this slice
-    pub buffer: Vec<u8>,
+    pub(crate) buffer: Vec<u8>,
 
     // If true, writes will always be an error
-    pub always_write_error: bool,
+    pub(crate) always_write_error: bool,
 
     // If true, flushes will always be an error
-    pub always_flush_error: bool,
+    pub(crate) always_flush_error: bool,
 
     // If set, only up to this number of bytes will be written in a single
     // call to `write`
-    pub accept_prefix: Option<usize>,
+    pub(crate) accept_prefix: Option<usize>,
 
     // If set, counts down with each write, and writes return an error
     // when it hits 0
-    pub max_writes: Option<usize>,
+    pub(crate) max_writes: Option<usize>,
 
     // If set, attempting to write when max_writes == Some(0) will be an
     // error; otherwise, it will return Ok(0).
-    pub error_after_max_writes: bool,
+    pub(crate) error_after_max_writes: bool,
 }
 
 impl Write for ProgrammableSink {
@@ -1006,7 +1006,7 @@ enum RecordedEvent {
 
 #[derive(Debug, Clone, Default)]
 struct WriteRecorder {
-    pub events: Vec<RecordedEvent>,
+    pub(crate) events: Vec<RecordedEvent>,
 }
 
 impl Write for WriteRecorder {

--- a/library/std/src/io/cursor/tests.rs
+++ b/library/std/src/io/cursor/tests.rs
@@ -518,7 +518,7 @@ fn test_partial_eq() {
 
 #[test]
 fn test_eq() {
-    struct AssertEq<T: Eq>(pub T);
+    struct AssertEq<T: Eq>(pub(crate) T);
 
     let _: AssertEq<Cursor<Vec<u8>>> = AssertEq(Cursor::new(Vec::new()));
 }

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -610,7 +610,7 @@ pub fn stdout() -> Stdout {
 // Flush the data and disable buffering during shutdown
 // by replacing the line writer by one with zero
 // buffering capacity.
-pub fn cleanup() {
+pub(crate) fn cleanup() {
     let mut initialized = false;
     let stdout = STDOUT.get_or_init(|| {
         initialized = true;

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -221,6 +221,7 @@
 #![allow(unused_lifetimes)]
 #![deny(rustc::existing_doc_keyword)]
 #![deny(fuzzy_provenance_casts)]
+#![cfg_attr(not(test), warn(unreachable_pub))]
 // Ensure that std can be linked against panic_abort despite compiled with `-C panic=unwind`
 #![deny(ffi_unwind_calls)]
 // std may use features in a platform-specific way
@@ -518,6 +519,8 @@ pub mod fs;
 pub mod io;
 pub mod net;
 pub mod num;
+// os-specific code may be incorrectly detected as unreachable
+#[allow(unreachable_pub)]
 pub mod os;
 pub mod panic;
 pub mod path;
@@ -582,7 +585,10 @@ pub mod arch {
 pub use std_detect::is_x86_feature_detected;
 
 // Platform-abstraction modules
+// platform-specific code may be incorrectly detected as unreachable
+#[allow(unreachable_pub)]
 mod sys;
+#[allow(unreachable_pub)]
 mod sys_common;
 
 pub mod alloc;
@@ -592,7 +598,7 @@ mod panicking;
 mod personality;
 
 #[path = "../../backtrace/src/lib.rs"]
-#[allow(dead_code, unused_attributes, fuzzy_provenance_casts)]
+#[allow(dead_code, unused_attributes, fuzzy_provenance_casts, unreachable_pub)]
 mod backtrace_rs;
 
 // Re-export macros defined in core.

--- a/library/std/src/net/display_buffer.rs
+++ b/library/std/src/net/display_buffer.rs
@@ -3,19 +3,19 @@ use crate::mem::MaybeUninit;
 use crate::str;
 
 /// Used for slow path in `Display` implementations when alignment is required.
-pub struct DisplayBuffer<const SIZE: usize> {
+pub(crate) struct DisplayBuffer<const SIZE: usize> {
     buf: [MaybeUninit<u8>; SIZE],
     len: usize,
 }
 
 impl<const SIZE: usize> DisplayBuffer<SIZE> {
     #[inline]
-    pub const fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self { buf: MaybeUninit::uninit_array(), len: 0 }
     }
 
     #[inline]
-    pub fn as_str(&self) -> &str {
+    pub(crate) fn as_str(&self) -> &str {
         // SAFETY: `buf` is only written to by the `fmt::Write::write_str` implementation
         // which writes a valid UTF-8 string to `buf` and correctly sets `len`.
         unsafe {

--- a/library/std/src/net/test.rs
+++ b/library/std/src/net/test.rs
@@ -6,25 +6,25 @@ use crate::sync::atomic::{AtomicUsize, Ordering};
 
 static PORT: AtomicUsize = AtomicUsize::new(0);
 
-pub fn next_test_ip4() -> SocketAddr {
+pub(crate) fn next_test_ip4() -> SocketAddr {
     let port = PORT.fetch_add(1, Ordering::SeqCst) as u16 + base_port();
     SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port))
 }
 
-pub fn next_test_ip6() -> SocketAddr {
+pub(crate) fn next_test_ip6() -> SocketAddr {
     let port = PORT.fetch_add(1, Ordering::SeqCst) as u16 + base_port();
     SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), port, 0, 0))
 }
 
-pub fn sa4(a: Ipv4Addr, p: u16) -> SocketAddr {
+pub(crate) fn sa4(a: Ipv4Addr, p: u16) -> SocketAddr {
     SocketAddr::V4(SocketAddrV4::new(a, p))
 }
 
-pub fn sa6(a: Ipv6Addr, p: u16) -> SocketAddr {
+pub(crate) fn sa6(a: Ipv6Addr, p: u16) -> SocketAddr {
     SocketAddr::V6(SocketAddrV6::new(a, p, 0, 0))
 }
 
-pub fn tsa<A: ToSocketAddrs>(a: A) -> Result<Vec<SocketAddr>, String> {
+pub(crate) fn tsa<A: ToSocketAddrs>(a: A) -> Result<Vec<SocketAddr>, String> {
     match a.to_socket_addrs() {
         Ok(a) => Ok(a.collect()),
         Err(e) => Err(e.to_string()),

--- a/library/std/src/os/unix/mod.rs
+++ b/library/std/src/os/unix/mod.rs
@@ -60,7 +60,7 @@ mod platform {
     #[cfg(target_os = "l4re")]
     pub use crate::os::l4re::*;
     #[cfg(target_os = "linux")]
-    pub use crate::os::linux::*;
+    pub(crate) use crate::os::linux::*;
     #[cfg(target_os = "macos")]
     pub use crate::os::macos::*;
     #[cfg(target_os = "netbsd")]

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -404,7 +404,7 @@ pub mod panic_count {
 pub use realstd::rt::panic_count;
 
 /// Invoke a closure, capturing the cause of an unwinding panic if one occurs.
-pub unsafe fn r#try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>> {
+pub(crate) unsafe fn r#try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>> {
     union Data<F, R> {
         f: ManuallyDrop<F>,
         r: ManuallyDrop<R>,
@@ -517,14 +517,14 @@ pub unsafe fn r#try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>>
 
 /// Determines whether the current thread is unwinding because of panic.
 #[inline]
-pub fn panicking() -> bool {
+pub(crate) fn panicking() -> bool {
     !panic_count::count_is_zero()
 }
 
 /// Entry point of panics from the core crate (`panic_impl` lang item).
 #[cfg(not(test))]
 #[panic_handler]
-pub fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
+pub(crate) fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
     struct PanicPayload<'a> {
         inner: &'a fmt::Arguments<'a>,
         string: Option<String>,
@@ -716,7 +716,7 @@ fn rust_panic_with_hook(
 
 /// This is the entry point for `resume_unwind`.
 /// It just forwards the payload to the panic runtime.
-pub fn rust_panic_without_hook(payload: Box<dyn Any + Send>) -> ! {
+pub(crate) fn rust_panic_without_hook(payload: Box<dyn Any + Send>) -> ! {
     panic_count::increase();
 
     struct RewrapBox(Box<dyn Any + Send>);

--- a/library/std/src/path/tests.rs
+++ b/library/std/src/path/tests.rs
@@ -131,7 +131,7 @@ fn into() {
 
 #[test]
 #[cfg(unix)]
-pub fn test_decompositions_unix() {
+pub(crate) fn test_decompositions_unix() {
     t!("",
     iter: [],
     has_root: false,
@@ -465,7 +465,7 @@ pub fn test_decompositions_unix() {
 
 #[test]
 #[cfg(windows)]
-pub fn test_decompositions_windows() {
+pub(crate) fn test_decompositions_windows() {
     t!("",
     iter: [],
     has_root: false,
@@ -1095,7 +1095,7 @@ pub fn test_decompositions_windows() {
 }
 
 #[test]
-pub fn test_stem_ext() {
+pub(crate) fn test_stem_ext() {
     t!("foo",
     file_stem: Some("foo"),
     extension: None
@@ -1138,7 +1138,7 @@ pub fn test_stem_ext() {
 }
 
 #[test]
-pub fn test_prefix_ext() {
+pub(crate) fn test_prefix_ext() {
     t!("foo",
     file_prefix: Some("foo"),
     extension: None
@@ -1181,7 +1181,7 @@ pub fn test_prefix_ext() {
 }
 
 #[test]
-pub fn test_push() {
+pub(crate) fn test_push() {
     macro_rules! tp (
         ($path:expr, $push:expr, $expected:expr) => ( {
             let mut actual = PathBuf::from($path);
@@ -1279,7 +1279,7 @@ pub fn test_push() {
 }
 
 #[test]
-pub fn test_pop() {
+pub(crate) fn test_pop() {
     macro_rules! tp (
         ($path:expr, $expected:expr, $output:expr) => ( {
             let mut actual = PathBuf::from($path);
@@ -1333,7 +1333,7 @@ pub fn test_pop() {
 }
 
 #[test]
-pub fn test_set_file_name() {
+pub(crate) fn test_set_file_name() {
     macro_rules! tfn (
             ($path:expr, $file:expr, $expected:expr) => ( {
             let mut p = PathBuf::from($path);
@@ -1367,7 +1367,7 @@ pub fn test_set_file_name() {
 }
 
 #[test]
-pub fn test_set_extension() {
+pub(crate) fn test_set_extension() {
     macro_rules! tfe (
             ($path:expr, $ext:expr, $expected:expr, $output:expr) => ( {
             let mut p = PathBuf::from($path);
@@ -1420,7 +1420,7 @@ fn test_eq_receivers() {
 }
 
 #[test]
-pub fn test_compare() {
+pub(crate) fn test_compare() {
     use crate::collections::hash_map::DefaultHasher;
     use crate::hash::{Hash, Hasher};
 

--- a/library/std/src/personality/dwarf/eh.rs
+++ b/library/std/src/personality/dwarf/eh.rs
@@ -15,44 +15,47 @@ use super::DwarfReader;
 use core::mem;
 use core::ptr;
 
-pub const DW_EH_PE_omit: u8 = 0xFF;
-pub const DW_EH_PE_absptr: u8 = 0x00;
+pub(crate) const DW_EH_PE_omit: u8 = 0xFF;
+pub(crate) const DW_EH_PE_absptr: u8 = 0x00;
 
-pub const DW_EH_PE_uleb128: u8 = 0x01;
-pub const DW_EH_PE_udata2: u8 = 0x02;
-pub const DW_EH_PE_udata4: u8 = 0x03;
-pub const DW_EH_PE_udata8: u8 = 0x04;
-pub const DW_EH_PE_sleb128: u8 = 0x09;
-pub const DW_EH_PE_sdata2: u8 = 0x0A;
-pub const DW_EH_PE_sdata4: u8 = 0x0B;
-pub const DW_EH_PE_sdata8: u8 = 0x0C;
+pub(crate) const DW_EH_PE_uleb128: u8 = 0x01;
+pub(crate) const DW_EH_PE_udata2: u8 = 0x02;
+pub(crate) const DW_EH_PE_udata4: u8 = 0x03;
+pub(crate) const DW_EH_PE_udata8: u8 = 0x04;
+pub(crate) const DW_EH_PE_sleb128: u8 = 0x09;
+pub(crate) const DW_EH_PE_sdata2: u8 = 0x0A;
+pub(crate) const DW_EH_PE_sdata4: u8 = 0x0B;
+pub(crate) const DW_EH_PE_sdata8: u8 = 0x0C;
 
-pub const DW_EH_PE_pcrel: u8 = 0x10;
-pub const DW_EH_PE_textrel: u8 = 0x20;
-pub const DW_EH_PE_datarel: u8 = 0x30;
-pub const DW_EH_PE_funcrel: u8 = 0x40;
-pub const DW_EH_PE_aligned: u8 = 0x50;
+pub(crate) const DW_EH_PE_pcrel: u8 = 0x10;
+pub(crate) const DW_EH_PE_textrel: u8 = 0x20;
+pub(crate) const DW_EH_PE_datarel: u8 = 0x30;
+pub(crate) const DW_EH_PE_funcrel: u8 = 0x40;
+pub(crate) const DW_EH_PE_aligned: u8 = 0x50;
 
-pub const DW_EH_PE_indirect: u8 = 0x80;
+pub(crate) const DW_EH_PE_indirect: u8 = 0x80;
 
 #[derive(Copy, Clone)]
-pub struct EHContext<'a> {
-    pub ip: usize,                             // Current instruction pointer
-    pub func_start: usize,                     // Address of the current function
-    pub get_text_start: &'a dyn Fn() -> usize, // Get address of the code section
-    pub get_data_start: &'a dyn Fn() -> usize, // Get address of the data section
+pub(crate) struct EHContext<'a> {
+    pub(crate) ip: usize,                             // Current instruction pointer
+    pub(crate) func_start: usize,                     // Address of the current function
+    pub(crate) get_text_start: &'a dyn Fn() -> usize, // Get address of the code section
+    pub(crate) get_data_start: &'a dyn Fn() -> usize, // Get address of the data section
 }
 
-pub enum EHAction {
+pub(crate) enum EHAction {
     None,
     Cleanup(usize),
     Catch(usize),
     Terminate,
 }
 
-pub const USING_SJLJ_EXCEPTIONS: bool = cfg!(all(target_os = "ios", target_arch = "arm"));
+pub(crate) const USING_SJLJ_EXCEPTIONS: bool = cfg!(all(target_os = "ios", target_arch = "arm"));
 
-pub unsafe fn find_eh_action(lsda: *const u8, context: &EHContext<'_>) -> Result<EHAction, ()> {
+pub(crate) unsafe fn find_eh_action(
+    lsda: *const u8,
+    context: &EHContext<'_>,
+) -> Result<EHAction, ()> {
     if lsda.is_null() {
         return Ok(EHAction::None);
     }

--- a/library/std/src/personality/dwarf/mod.rs
+++ b/library/std/src/personality/dwarf/mod.rs
@@ -9,19 +9,19 @@
 #[cfg(test)]
 mod tests;
 
-pub mod eh;
+pub(crate) mod eh;
 
 use core::mem;
 
-pub struct DwarfReader {
-    pub ptr: *const u8,
+pub(crate) struct DwarfReader {
+    pub(crate) ptr: *const u8,
 }
 
 #[repr(C, packed)]
 struct Unaligned<T>(T);
 
 impl DwarfReader {
-    pub fn new(ptr: *const u8) -> DwarfReader {
+    pub(crate) fn new(ptr: *const u8) -> DwarfReader {
         DwarfReader { ptr }
     }
 
@@ -29,7 +29,7 @@ impl DwarfReader {
     // on a 4-byte boundary. This may cause problems on platforms with strict
     // alignment requirements. By wrapping data in a "packed" struct, we are
     // telling the backend to generate "misalignment-safe" code.
-    pub unsafe fn read<T: Copy>(&mut self) -> T {
+    pub(crate) unsafe fn read<T: Copy>(&mut self) -> T {
         let Unaligned(result) = *(self.ptr as *const Unaligned<T>);
         self.ptr = self.ptr.add(mem::size_of::<T>());
         result
@@ -37,7 +37,7 @@ impl DwarfReader {
 
     // ULEB128 and SLEB128 encodings are defined in Section 7.6 - "Variable
     // Length Data".
-    pub unsafe fn read_uleb128(&mut self) -> u64 {
+    pub(crate) unsafe fn read_uleb128(&mut self) -> u64 {
         let mut shift: usize = 0;
         let mut result: u64 = 0;
         let mut byte: u8;
@@ -52,7 +52,7 @@ impl DwarfReader {
         result
     }
 
-    pub unsafe fn read_sleb128(&mut self) -> i64 {
+    pub(crate) unsafe fn read_sleb128(&mut self) -> i64 {
         let mut shift: u32 = 0;
         let mut result: u64 = 0;
         let mut byte: u8;

--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -68,7 +68,7 @@ fn signal_reported_right() {
     }
 }
 
-pub fn run_output(mut cmd: Command) -> String {
+pub(crate) fn run_output(mut cmd: Command) -> String {
     let p = cmd.spawn();
     assert!(p.is_ok());
     let mut p = p.unwrap();
@@ -216,18 +216,18 @@ fn test_wait_with_output_once() {
 }
 
 #[cfg(all(unix, not(target_os = "android")))]
-pub fn env_cmd() -> Command {
+pub(crate) fn env_cmd() -> Command {
     Command::new("env")
 }
 #[cfg(target_os = "android")]
-pub fn env_cmd() -> Command {
+pub(crate) fn env_cmd() -> Command {
     let mut cmd = Command::new("/system/bin/sh");
     cmd.arg("-c").arg("set");
     cmd
 }
 
 #[cfg(windows)]
-pub fn env_cmd() -> Command {
+pub(crate) fn env_cmd() -> Command {
     let mut cmd = Command::new("cmd");
     cmd.arg("/c").arg("set");
     cmd

--- a/library/std/src/sync/mpmc/error.rs
+++ b/library/std/src/sync/mpmc/error.rs
@@ -1,7 +1,9 @@
 use crate::error;
 use crate::fmt;
 
-pub use crate::sync::mpsc::{RecvError, RecvTimeoutError, SendError, TryRecvError, TrySendError};
+pub(crate) use crate::sync::mpsc::{
+    RecvError, RecvTimeoutError, SendError, TryRecvError, TrySendError,
+};
 
 /// An error returned from the [`send_timeout`] method.
 ///
@@ -9,7 +11,7 @@ pub use crate::sync::mpsc::{RecvError, RecvTimeoutError, SendError, TryRecvError
 ///
 /// [`send_timeout`]: super::Sender::send_timeout
 #[derive(PartialEq, Eq, Clone, Copy)]
-pub enum SendTimeoutError<T> {
+pub(crate) enum SendTimeoutError<T> {
     /// The message could not be sent because the channel is full and the operation timed out.
     ///
     /// If this is a zero-capacity channel, then the error indicates that there was no receiver

--- a/library/std/src/sync/mpmc/select.rs
+++ b/library/std/src/sync/mpmc/select.rs
@@ -3,7 +3,7 @@
 ///
 /// Each field contains data associated with a specific channel flavor.
 #[derive(Debug, Default)]
-pub struct Token {
+pub(crate) struct Token {
     pub(crate) array: super::array::ArrayToken,
     pub(crate) list: super::list::ListToken,
     #[allow(dead_code)]
@@ -12,7 +12,7 @@ pub struct Token {
 
 /// Identifier associated with an operation by a specific thread on a specific channel.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Operation(usize);
+pub(crate) struct Operation(usize);
 
 impl Operation {
     /// Creates an operation identifier from a mutable reference.
@@ -21,7 +21,7 @@ impl Operation {
     /// reference should point to a variable that is specific to the thread and the operation,
     /// and is alive for the entire duration of a blocking operation.
     #[inline]
-    pub fn hook<T>(r: &mut T) -> Operation {
+    pub(crate) fn hook<T>(r: &mut T) -> Operation {
         let val = r as *mut T as usize;
         // Make sure that the pointer address doesn't equal the numerical representation of
         // `Selected::{Waiting, Aborted, Disconnected}`.
@@ -32,7 +32,7 @@ impl Operation {
 
 /// Current state of a blocking operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Selected {
+pub(crate) enum Selected {
     /// Still waiting for an operation.
     Waiting,
 

--- a/library/std/src/sync/mpmc/utils.rs
+++ b/library/std/src/sync/mpmc/utils.rs
@@ -65,13 +65,13 @@ use crate::ops::{Deref, DerefMut};
     )),
     repr(align(64))
 )]
-pub struct CachePadded<T> {
+pub(crate) struct CachePadded<T> {
     value: T,
 }
 
 impl<T> CachePadded<T> {
     /// Pads and aligns a value to the length of a cache line.
-    pub fn new(value: T) -> CachePadded<T> {
+    pub(crate) fn new(value: T) -> CachePadded<T> {
         CachePadded::<T> { value }
     }
 }
@@ -93,13 +93,13 @@ impl<T> DerefMut for CachePadded<T> {
 const SPIN_LIMIT: u32 = 6;
 
 /// Performs quadratic backoff in spin loops.
-pub struct Backoff {
+pub(crate) struct Backoff {
     step: Cell<u32>,
 }
 
 impl Backoff {
     /// Creates a new `Backoff`.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Backoff { step: Cell::new(0) }
     }
 
@@ -108,7 +108,7 @@ impl Backoff {
     /// This method should be used for retrying an operation because another thread made
     /// progress. i.e. on CAS failure.
     #[inline]
-    pub fn spin_light(&self) {
+    pub(crate) fn spin_light(&self) {
         let step = self.step.get().min(SPIN_LIMIT);
         for _ in 0..step.pow(2) {
             crate::hint::spin_loop();
@@ -121,7 +121,7 @@ impl Backoff {
     ///
     /// This method should be used in blocking loops where parking the thread is not an option.
     #[inline]
-    pub fn spin_heavy(&self) {
+    pub(crate) fn spin_heavy(&self) {
         if self.step.get() <= SPIN_LIMIT {
             for _ in 0..self.step.get().pow(2) {
                 crate::hint::spin_loop()

--- a/library/std/src/sync/mpmc/waker.rs
+++ b/library/std/src/sync/mpmc/waker.rs
@@ -196,7 +196,7 @@ impl Drop for SyncWaker {
 
 /// Returns a unique id for the current thread.
 #[inline]
-pub fn current_thread_id() -> usize {
+pub(crate) fn current_thread_id() -> usize {
     // `u8` is not drop so this variable will be available during thread destruction,
     // whereas `thread::current()` would not be
     thread_local! { static DUMMY: u8 = 0 }

--- a/library/std/src/sync/mpsc/sync_tests.rs
+++ b/library/std/src/sync/mpsc/sync_tests.rs
@@ -4,7 +4,7 @@ use crate::sync::mpmc::SendTimeoutError;
 use crate::thread;
 use crate::time::Duration;
 
-pub fn stress_factor() -> usize {
+pub(crate) fn stress_factor() -> usize {
     match env::var("RUST_TEST_STRESS") {
         Ok(val) => val.parse().unwrap(),
         Err(..) => 1,

--- a/library/std/src/sync/mpsc/tests.rs
+++ b/library/std/src/sync/mpsc/tests.rs
@@ -3,7 +3,7 @@ use crate::env;
 use crate::thread;
 use crate::time::{Duration, Instant};
 
-pub fn stress_factor() -> usize {
+pub(crate) fn stress_factor() -> usize {
     match env::var("RUST_TEST_STRESS") {
         Ok(val) => val.parse().unwrap(),
         Err(..) => 1,

--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -541,10 +541,10 @@ impl<T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'_, T> {
     }
 }
 
-pub fn guard_lock<'a, T: ?Sized>(guard: &MutexGuard<'a, T>) -> &'a sys::Mutex {
+pub(crate) fn guard_lock<'a, T: ?Sized>(guard: &MutexGuard<'a, T>) -> &'a sys::Mutex {
     &guard.lock.inner
 }
 
-pub fn guard_poison<'a, T: ?Sized>(guard: &MutexGuard<'a, T>) -> &'a poison::Flag {
+pub(crate) fn guard_poison<'a, T: ?Sized>(guard: &MutexGuard<'a, T>) -> &'a poison::Flag {
     &guard.lock.poison
 }

--- a/library/std/src/sync/remutex/tests.rs
+++ b/library/std/src/sync/remutex/tests.rs
@@ -52,7 +52,7 @@ fn trylock_works() {
     let _lock3 = m.try_lock();
 }
 
-pub struct Answer<'a>(pub ReentrantMutexGuard<'a, RefCell<u32>>);
+pub(crate) struct Answer<'a>(pub(crate) ReentrantMutexGuard<'a, RefCell<u32>>);
 impl Drop for Answer<'_> {
     fn drop(&mut self) {
         *self.0.borrow_mut() = 42;

--- a/library/std/src/sys_common/backtrace.rs
+++ b/library/std/src/sys_common/backtrace.rs
@@ -12,13 +12,13 @@ use crate::sync::{Mutex, PoisonError};
 /// Max number of frames to print.
 const MAX_NB_FRAMES: usize = 100;
 
-pub fn lock() -> impl Drop {
+pub(crate) fn lock() -> impl Drop {
     static LOCK: Mutex<()> = Mutex::new(());
     LOCK.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
 /// Prints the current backtrace.
-pub fn print(w: &mut dyn Write, format: PrintFmt) -> io::Result<()> {
+pub(crate) fn print(w: &mut dyn Write, format: PrintFmt) -> io::Result<()> {
     // There are issues currently linking libbacktrace into tests, and in
     // general during std's own unit tests we're not testing this path. In
     // test mode immediately return here to optimize away any references to the
@@ -114,7 +114,7 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
 /// this is only inline(never) when backtraces in std are enabled, otherwise
 /// it's fine to optimize away.
 #[cfg_attr(feature = "backtrace", inline(never))]
-pub fn __rust_begin_short_backtrace<F, T>(f: F) -> T
+pub(crate) fn __rust_begin_short_backtrace<F, T>(f: F) -> T
 where
     F: FnOnce() -> T,
 {
@@ -130,7 +130,7 @@ where
 /// this is only inline(never) when backtraces in std are enabled, otherwise
 /// it's fine to optimize away.
 #[cfg_attr(feature = "backtrace", inline(never))]
-pub fn __rust_end_short_backtrace<F, T>(f: F) -> T
+pub(crate) fn __rust_end_short_backtrace<F, T>(f: F) -> T
 where
     F: FnOnce() -> T,
 {
@@ -145,7 +145,7 @@ where
 /// Prints the filename of the backtrace frame.
 ///
 /// See also `output`.
-pub fn output_filename(
+pub(crate) fn output_filename(
     fmt: &mut fmt::Formatter<'_>,
     bows: BytesOrWideString<'_>,
     print_fmt: PrintFmt,

--- a/library/std/src/sys_common/io.rs
+++ b/library/std/src/sys_common/io.rs
@@ -1,6 +1,6 @@
 // Bare metal platforms usually have very small amounts of RAM
 // (in the order of hundreds of KB)
-pub const DEFAULT_BUF_SIZE: usize = if cfg!(target_os = "espidf") { 512 } else { 8 * 1024 };
+pub(crate) const DEFAULT_BUF_SIZE: usize = if cfg!(target_os = "espidf") { 512 } else { 8 * 1024 };
 
 #[cfg(test)]
 #[allow(dead_code)] // not used on emscripten

--- a/library/std/src/sys_common/lazy_box.rs
+++ b/library/std/src/sys_common/lazy_box.rs
@@ -40,7 +40,7 @@ pub(crate) trait LazyInit {
 
 impl<T: LazyInit> LazyBox<T> {
     #[inline]
-    pub const fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self { ptr: AtomicPtr::new(null_mut()), _phantom: PhantomData }
     }
 

--- a/library/std/src/sys_common/memchr.rs
+++ b/library/std/src/sys_common/memchr.rs
@@ -26,7 +26,7 @@ mod tests;
 /// assert_eq!(memchr(b'k', haystack), Some(8));
 /// ```
 #[inline]
-pub fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
+pub(crate) fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
     sys::memchr(needle, haystack)
 }
 
@@ -46,6 +46,6 @@ pub fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
 /// assert_eq!(memrchr(b'o', haystack), Some(17));
 /// ```
 #[inline]
-pub fn memrchr(needle: u8, haystack: &[u8]) -> Option<usize> {
+pub(crate) fn memrchr(needle: u8, haystack: &[u8]) -> Option<usize> {
     sys::memrchr(needle, haystack)
 }

--- a/library/std/src/sys_common/mod.rs
+++ b/library/std/src/sys_common/mod.rs
@@ -20,25 +20,25 @@
 #[cfg(test)]
 mod tests;
 
-pub mod backtrace;
-pub mod fs;
-pub mod io;
-pub mod lazy_box;
-pub mod memchr;
-pub mod once;
-pub mod process;
-pub mod thread;
-pub mod thread_info;
-pub mod thread_local_dtor;
-pub mod thread_parking;
-pub mod wstr;
-pub mod wtf8;
+pub(crate) mod backtrace;
+pub(crate) mod fs;
+pub(crate) mod io;
+pub(crate) mod lazy_box;
+pub(crate) mod memchr;
+pub(crate) mod once;
+pub(crate) mod process;
+pub(crate) mod thread;
+pub(crate) mod thread_info;
+pub(crate) mod thread_local_dtor;
+pub(crate) mod thread_parking;
+pub(crate) mod wstr;
+pub(crate) mod wtf8;
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {
         pub use crate::sys::thread_local_key;
     } else {
-        pub mod thread_local_key;
+        pub(crate) mod thread_local_key;
     }
 }
 
@@ -50,7 +50,7 @@ cfg_if::cfg_if! {
                  all(target_vendor = "fortanix", target_env = "sgx")))] {
         pub use crate::sys::net;
     } else {
-        pub mod net;
+        pub(crate) mod net;
     }
 }
 
@@ -58,25 +58,25 @@ cfg_if::cfg_if! {
 
 /// A trait for viewing representations from std types
 #[doc(hidden)]
-pub trait AsInner<Inner: ?Sized> {
+pub(crate) trait AsInner<Inner: ?Sized> {
     fn as_inner(&self) -> &Inner;
 }
 
 /// A trait for viewing representations from std types
 #[doc(hidden)]
-pub trait AsInnerMut<Inner: ?Sized> {
+pub(crate) trait AsInnerMut<Inner: ?Sized> {
     fn as_inner_mut(&mut self) -> &mut Inner;
 }
 
 /// A trait for extracting representations from std types
 #[doc(hidden)]
-pub trait IntoInner<Inner> {
+pub(crate) trait IntoInner<Inner> {
     fn into_inner(self) -> Inner;
 }
 
 /// A trait for creating std types from internal representations
 #[doc(hidden)]
-pub trait FromInner<Inner> {
+pub(crate) trait FromInner<Inner> {
     fn from_inner(inner: Inner) -> Self;
 }
 
@@ -84,7 +84,7 @@ pub trait FromInner<Inner> {
 // (numer*denom) and the overall result fit into i64 (which is the case
 // for our time conversions).
 #[allow(dead_code)] // not used on all platforms
-pub fn mul_div_u64(value: u64, numer: u64, denom: u64) -> u64 {
+pub(crate) fn mul_div_u64(value: u64, numer: u64, denom: u64) -> u64 {
     let q = value / denom;
     let r = value % denom;
     // Decompose value as (value/denom*denom + value%denom),

--- a/library/std/src/sys_common/once/futex.rs
+++ b/library/std/src/sys_common/once/futex.rs
@@ -29,19 +29,19 @@ const COMPLETE: u32 = 4;
 // variable. When the running thread finishes, it will wake all waiting threads using
 // `futex_wake_all`.
 
-pub struct OnceState {
+pub(crate) struct OnceState {
     poisoned: bool,
     set_state_to: Cell<u32>,
 }
 
 impl OnceState {
     #[inline]
-    pub fn is_poisoned(&self) -> bool {
+    pub(crate) fn is_poisoned(&self) -> bool {
         self.poisoned
     }
 
     #[inline]
-    pub fn poison(&self) {
+    pub(crate) fn poison(&self) {
         self.set_state_to.set(POISONED);
     }
 }
@@ -62,18 +62,18 @@ impl<'a> Drop for CompletionGuard<'a> {
     }
 }
 
-pub struct Once {
+pub(crate) struct Once {
     state: AtomicU32,
 }
 
 impl Once {
     #[inline]
-    pub const fn new() -> Once {
+    pub(crate) const fn new() -> Once {
         Once { state: AtomicU32::new(INCOMPLETE) }
     }
 
     #[inline]
-    pub fn is_completed(&self) -> bool {
+    pub(crate) fn is_completed(&self) -> bool {
         // Use acquire ordering to make all initialization changes visible to the
         // current thread.
         self.state.load(Acquire) == COMPLETE
@@ -94,7 +94,7 @@ impl Once {
     // so avoids the cost of dynamic dispatch.
     #[cold]
     #[track_caller]
-    pub fn call(&self, ignore_poisoning: bool, f: &mut impl FnMut(&public::OnceState)) {
+    pub(crate) fn call(&self, ignore_poisoning: bool, f: &mut impl FnMut(&public::OnceState)) {
         let mut state = self.state.load(Acquire);
         loop {
             match state {

--- a/library/std/src/sys_common/once/mod.rs
+++ b/library/std/src/sys_common/once/mod.rs
@@ -19,7 +19,7 @@ cfg_if::cfg_if! {
         target_os = "hermit",
     ))] {
         mod futex;
-        pub use futex::{Once, OnceState};
+        pub(crate) use futex::{Once, OnceState};
     } else if #[cfg(any(
         windows,
         target_family = "unix",

--- a/library/std/src/sys_common/process.rs
+++ b/library/std/src/sys_common/process.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code)] // not used on all platforms
 #![unstable(feature = "process_internals", issue = "none")]
 
 use crate::collections::BTreeMap;

--- a/library/std/src/sys_common/thread.rs
+++ b/library/std/src/sys_common/thread.rs
@@ -2,7 +2,7 @@ use crate::env;
 use crate::sync::atomic::{self, Ordering};
 use crate::sys::thread as imp;
 
-pub fn min_stack() -> usize {
+pub(crate) fn min_stack() -> usize {
     static MIN: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
     match MIN.load(Ordering::Relaxed) {
         0 => {}

--- a/library/std/src/sys_common/thread_info.rs
+++ b/library/std/src/sys_common/thread_info.rs
@@ -30,15 +30,15 @@ impl ThreadInfo {
     }
 }
 
-pub fn current_thread() -> Option<Thread> {
+pub(crate) fn current_thread() -> Option<Thread> {
     ThreadInfo::with(|info| info.thread.clone())
 }
 
-pub fn stack_guard() -> Option<Guard> {
+pub(crate) fn stack_guard() -> Option<Guard> {
     ThreadInfo::with(|info| info.stack_guard.clone()).and_then(|o| o)
 }
 
-pub fn set(stack_guard: Option<Guard>, thread: Thread) {
+pub(crate) fn set(stack_guard: Option<Guard>, thread: Thread) {
     THREAD_INFO.with(move |thread_info| {
         let mut thread_info = thread_info.borrow_mut();
         rtassert!(thread_info.is_none());

--- a/library/std/src/sys_common/thread_local_dtor.rs
+++ b/library/std/src/sys_common/thread_local_dtor.rs
@@ -16,7 +16,7 @@
 use crate::ptr;
 use crate::sys_common::thread_local_key::StaticKey;
 
-pub unsafe fn register_dtor_fallback(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
+pub(crate) unsafe fn register_dtor_fallback(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
     // The fallback implementation uses a vanilla OS-based TLS key to track
     // the list of destructors that need to be run for this thread. The key
     // then has its own destructor which runs all the other destructors.

--- a/library/std/src/sys_common/thread_parking/mod.rs
+++ b/library/std/src/sys_common/thread_parking/mod.rs
@@ -10,7 +10,7 @@ cfg_if::cfg_if! {
         target_os = "hermit",
     ))] {
         mod futex;
-        pub use futex::Parker;
+        pub(crate) use futex::Parker;
     } else if #[cfg(any(
         target_os = "netbsd",
         all(target_vendor = "fortanix", target_env = "sgx"),

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -785,16 +785,16 @@ mod lazy {
     use crate::hint;
     use crate::mem;
 
-    pub struct LazyKeyInner<T> {
+    pub(crate) struct LazyKeyInner<T> {
         inner: UnsafeCell<Option<T>>,
     }
 
     impl<T> LazyKeyInner<T> {
-        pub const fn new() -> LazyKeyInner<T> {
+        pub(crate) const fn new() -> LazyKeyInner<T> {
             LazyKeyInner { inner: UnsafeCell::new(None) }
         }
 
-        pub unsafe fn get(&self) -> Option<&'static T> {
+        pub(crate) unsafe fn get(&self) -> Option<&'static T> {
             // SAFETY: The caller must ensure no reference is ever handed out to
             // the inner cell nor mutable reference to the Option<T> inside said
             // cell. This make it safe to hand a reference, though the lifetime
@@ -804,7 +804,7 @@ mod lazy {
 
         /// The caller must ensure that no reference is active: this method
         /// needs unique access.
-        pub unsafe fn initialize<F: FnOnce() -> T>(&self, init: F) -> &'static T {
+        pub(crate) unsafe fn initialize<F: FnOnce() -> T>(&self, init: F) -> &'static T {
             // Execute the initialization up front, *then* move it into our slot,
             // just in case initialization fails.
             let value = init();
@@ -851,7 +851,7 @@ mod lazy {
         /// As such, callers of this method must ensure no `&` and `&mut` are
         /// available and used at the same time.
         #[allow(unused)]
-        pub unsafe fn take(&mut self) -> Option<T> {
+        pub(crate) unsafe fn take(&mut self) -> Option<T> {
             // SAFETY: See doc comment for this method.
             unsafe { (*self.inner.get()).take() }
         }
@@ -902,7 +902,7 @@ pub mod statik {
 
 #[doc(hidden)]
 #[cfg(all(target_thread_local, not(all(target_family = "wasm", not(target_feature = "atomics"))),))]
-pub mod fast {
+pub(crate) mod fast {
     use super::lazy::LazyKeyInner;
     use crate::cell::Cell;
     use crate::sys::thread_local_dtor::register_dtor;
@@ -1045,7 +1045,7 @@ pub mod fast {
     not(target_thread_local),
     not(all(target_family = "wasm", not(target_feature = "atomics"))),
 ))]
-pub mod os {
+pub(crate) mod os {
     use super::lazy::LazyKeyInner;
     use crate::cell::Cell;
     use crate::sys_common::thread_local_key::StaticKey as OsStaticKey;


### PR DESCRIPTION
Most of this was done by enabling `warn(unreachable_pub)` and using `x fix library/std`. It's incomplete and doesn't leave the lint enabled as `cargo fix` doesn't recurse through path dependencies, and only covers items which trigger on my system (`x86-64 GNU Linux`).

EDIT: Just wanted to note that the motivation for this was #107884, where a very unsound function, only used in tests, was both `pub` and not marked `unsafe`