### PR TITLE
Add `array::map` benchmarks

### DIFF
--- a/library/core/benches/array.rs
+++ b/library/core/benches/array.rs
@@ -1,0 +1,19 @@
+use test::black_box;
+use test::Bencher;
+
+macro_rules! map_array {
+    ($func_name:ident, $start_item: expr, $map_item: expr, $arr_size: expr) => {
+        #[bench]
+        fn $func_name(b: &mut Bencher) {
+            let arr = [$start_item; $arr_size];
+            b.iter(|| black_box(arr).map(|_| black_box($map_item)));
+        }
+    };
+}
+
+map_array!(map_8byte_8byte_8, 0u64, 1u64, 800);
+map_array!(map_8byte_8byte_64, 0u64, 1u64, 6400);
+map_array!(map_8byte_8byte_256, 0u64, 1u64, 25600);
+
+map_array!(map_8byte_256byte_256, 0u64, [0u64; 4], 25600);
+map_array!(map_256byte_8byte_256, [0u64; 4], 0u64, 25600);

--- a/library/core/benches/lib.rs
+++ b/library/core/benches/lib.rs
@@ -9,6 +9,7 @@
 extern crate test;
 
 mod any;
+mod array;
 mod ascii;
 mod char;
 mod fmt;


### PR DESCRIPTION
Since there were no previous benchmarks for `array::map`, and it is known to have mediocre/poor performance, add some simple benchmarks. These benchmarks vary the length of the array and size of each item.