### PR TITLE
rustdoc: Indicate struct can be created + fn

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1507,6 +1507,11 @@ impl FnDecl {
             _ => panic!("unexpected desugaring of async function"),
         }
     }
+
+    /// Indicates id this function declaration can be used to create the type
+    pub(crate) fn type_builder(&self) -> bool {
+        self.inputs.values.get(0).and_then(|v| v.to_self())
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -845,11 +845,12 @@ fn assoc_method(
         render_attributes_in_code(w, meth);
         (0, "", Ending::Newline)
     };
+    let takes_self = d.inputs.values.iter().filter(|v| v.to_self().is_some()).count() > 0;
     w.reserve(header_len + "<a href=\"\" class=\"fn\">{".len() + "</a>".len());
     write!(
         w,
         "{indent}{vis}{constness}{asyncness}{unsafety}{defaultness}{abi}fn <a{href} class=\"fn\">{name}</a>\
-         {generics}{decl}{notable_traits}{where_clause}",
+         {generics}{decl}{notable_traits}{where_clause}{no_self}",
         indent = indent_str,
         vis = vis,
         constness = constness,
@@ -863,7 +864,19 @@ fn assoc_method(
         decl = d.full_print(header_len, indent, cx),
         notable_traits = notable_traits.unwrap_or_default(),
         where_clause = print_where_clause(g, cx, indent, end_newline),
+        no_self = if !takes_self {
+            "<span class=\"stab\" title=\"Can be used to construct this type\">⚒️</span>"
+        } else {
+            ""
+        }
     );
+}
+
+/// Returns true if the given function can be used to construct the type.
+///
+/// This means the function does not take `self` ad returns the given type (including if Option or Result)
+fn fn_is_to_build_type(ty: &clean::Item, fn_item: &clean::FnDecl) -> bool {
+    todo!()
 }
 
 /// Writes a span containing the versions at which an item became stable and/or const-stable. For

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -431,7 +431,7 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                 write!(
                     w,
                     "<div class=\"item-left\">\
-                        <a class=\"{class}\" href=\"{href}\" title=\"{title}\">{name}</a>\
+                        <a class=\"{class}\" href=\"{href}\" title=\"{title}\">{name} {ind}</a>\
                         {visibility_emoji}\
                         {unsafety_flag}\
                         {stab_tags}\
@@ -448,6 +448,11 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                         .filter_map(|s| if !s.is_empty() { Some(s.as_str()) } else { None })
                         .collect::<Vec<_>>()
                         .join(" "),
+                    ind = if myitem.is_struct() {
+                        "*" // ToDo: indicate if can be constructed
+                    } else {
+                        ""
+                    }
                 );
                 w.write_str(ITEM_TABLE_ROW_CLOSE);
             }


### PR DESCRIPTION
Visual hint to indicate the `Struct` that can be created from outside as well as highlight the functions that can be used as well (function that does not take `self` and returns the type, `Option` or `Result`)

Signed-off-by: Mohammad Mustakim Ali <mustakimali@users.noreply.github.com>