### PR TITLE
reuse allocation for always_storage_live_locals bitset

### DIFF
--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -1552,6 +1552,17 @@ impl<T: Idx> GrowableBitSet<T> {
     pub fn len(&self) -> usize {
         self.bit_set.count()
     }
+
+    // reuse allocation, set domain_size and fill
+    pub fn fill(&mut self, domain_size: usize) {
+        self.ensure(domain_size);
+        self.bit_set.domain_size = domain_size;
+        self.bit_set.insert_all();
+    }
+
+    pub fn as_bitset(&self) -> &BitSet<T> {
+        &self.bit_set
+    }
 }
 
 impl<T: Idx> From<BitSet<T>> for GrowableBitSet<T> {

--- a/compiler/rustc_mir_dataflow/src/storage.rs
+++ b/compiler/rustc_mir_dataflow/src/storage.rs
@@ -1,11 +1,12 @@
-use rustc_index::bit_set::BitSet;
+use rustc_index::bit_set::GrowableBitSet;
 use rustc_middle::mir::{self, Local};
 
 /// The set of locals in a MIR body that do not have `StorageLive`/`StorageDead` annotations.
 ///
 /// These locals have fixed storage for the duration of the body.
-pub fn always_storage_live_locals(body: &mir::Body<'_>) -> BitSet<Local> {
-    let mut always_live_locals = BitSet::new_filled(body.local_decls.len());
+pub fn always_storage_live_locals(body: &mir::Body<'_>, locals: &mut GrowableBitSet<Local>) {
+    locals.fill(body.local_decls.len());
+    let always_live_locals = locals;
 
     for block in &*body.basic_blocks {
         for statement in &block.statements {
@@ -15,6 +16,4 @@ pub fn always_storage_live_locals(body: &mir::Body<'_>) -> BitSet<Local> {
             }
         }
     }
-
-    always_live_locals
 }


### PR DESCRIPTION
This allows to reduce allocated block count about ~30% for `ctfe-stress-5`.