### PR TITLE
rustdoc: Remove cache for preprocessed markdown links

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -27,13 +27,11 @@ use crate::clean::inline::build_external_trait;
 use crate::clean::{self, ItemId};
 use crate::config::{Options as RustdocOptions, OutputFormat, RenderOptions};
 use crate::formats::cache::Cache;
-use crate::passes::collect_intra_doc_links::PreprocessedMarkdownLink;
 use crate::passes::{self, Condition::*};
 
 pub(crate) use rustc_session::config::{Input, Options, UnstableOptions};
 
 pub(crate) struct ResolverCaches {
-    pub(crate) markdown_links: Option<FxHashMap<String, Vec<PreprocessedMarkdownLink>>>,
     pub(crate) all_trait_impls: Option<Vec<DefId>>,
     pub(crate) all_macro_rules: FxHashMap<Symbol, Res<NodeId>>,
     pub(crate) extern_doc_reachable: DefIdSet,

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -806,22 +806,12 @@ impl<'a, 'tcx> DocVisitor for LinkCollector<'a, 'tcx> {
             // NOTE: if there are links that start in one crate and end in another, this will not resolve them.
             // This is a degenerate case and it's not supported by rustdoc.
             let parent_node = parent_module.or(parent_node);
-            let mut tmp_links = self
-                .cx
-                .resolver_caches
-                .markdown_links
-                .take()
-                .expect("`markdown_links` are already borrowed");
-            if !tmp_links.contains_key(&doc) {
-                tmp_links.insert(doc.clone(), preprocessed_markdown_links(&doc));
-            }
-            for md_link in &tmp_links[&doc] {
-                let link = self.resolve_link(item, &doc, parent_node, md_link);
+            for md_link in preprocessed_markdown_links(&doc) {
+                let link = self.resolve_link(item, &doc, parent_node, &md_link);
                 if let Some(link) = link {
                     self.cx.cache.intra_doc_links.entry(item.item_id).or_default().push(link);
                 }
             }
-            self.cx.resolver_caches.markdown_links = Some(tmp_links);
         }
 
         if item.is_mod() {

--- a/src/librustdoc/passes/collect_intra_doc_links/early.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links/early.rs
@@ -24,7 +24,6 @@ pub(crate) fn early_resolve_intra_doc_links(
     link_resolver.process_extern_impls();
 
     ResolverCaches {
-        markdown_links: Some(Default::default()),
         all_trait_impls: Some(link_resolver.all_trait_impls),
         all_macro_rules: link_resolver.all_macro_rules,
         extern_doc_reachable: link_resolver.extern_doc_reachable,


### PR DESCRIPTION
It's quite possible that it's no longer useful after https://github.com/rust-lang/rust/pull/94857 is merged.