### PR TITLE
resolve: Fix doc links referring to other crates when documenting proc macro crates directly

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4206,7 +4206,8 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 if let Some(res) = res
                     && let Some(def_id) = res.opt_def_id()
                     && !def_id.is_local()
-                    && self.r.session.crate_types().contains(&CrateType::ProcMacro) {
+                    && self.r.session.crate_types().contains(&CrateType::ProcMacro)
+                    && matches!(self.r.session.opts.resolve_doc_links, ResolveDocLinks::ExportedMetadata) {
                     // Encoding foreign def ids in proc macro crate metadata will ICE.
                     return None;
                 }
@@ -4276,6 +4277,10 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                         .filter_map(|tr| {
                             if !tr.def_id.is_local()
                                 && self.r.session.crate_types().contains(&CrateType::ProcMacro)
+                                && matches!(
+                                    self.r.session.opts.resolve_doc_links,
+                                    ResolveDocLinks::ExportedMetadata
+                                )
                             {
                                 // Encoding foreign def ids in proc macro crate metadata will ICE.
                                 return None;

--- a/tests/rustdoc-ui/intra-doc/proc-macro-doc.rs
+++ b/tests/rustdoc-ui/intra-doc/proc-macro-doc.rs
@@ -1,0 +1,27 @@
+// check-pass
+// force-host
+// no-prefer-dynamic
+// compile-flags: --crate-type proc-macro
+
+#![deny(rustdoc::broken_intra_doc_links)]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+/// [`Unpin`]
+#[proc_macro_derive(F)]
+pub fn derive_(t: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    t
+}
+
+/// [`Vec`]
+#[proc_macro_attribute]
+pub fn attr(t: proc_macro::TokenStream, _: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    t
+}
+
+/// [`std::fs::File`]
+#[proc_macro]
+pub fn func(t: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    t
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/107950