### PR TITLE
fix UB in ancient test

### DIFF
--- a/tests/ui/regions/regions-mock-codegen.rs
+++ b/tests/ui/regions/regions-mock-codegen.rs
@@ -22,15 +22,15 @@ struct Ccx {
     x: isize,
 }
 
-fn allocate(_bcx: &arena) -> &Bcx<'_> {
+fn allocate(_bcx: &arena) -> &mut Bcx<'_> {
     unsafe {
         let layout = Layout::new::<Bcx>();
         let ptr = Global.allocate(layout).unwrap_or_else(|_| handle_alloc_error(layout));
-        &*(ptr.as_ptr() as *const _)
+        &mut *ptr.as_ptr().cast()
     }
 }
 
-fn h<'a>(bcx: &'a Bcx<'a>) -> &'a Bcx<'a> {
+fn h<'a>(bcx: &'a Bcx<'a>) -> &'a mut Bcx<'a> {
     return allocate(bcx.fcx.arena);
 }
 
@@ -38,7 +38,7 @@ fn g(fcx: &Fcx) {
     let bcx = Bcx { fcx };
     let bcx2 = h(&bcx);
     unsafe {
-        Global.deallocate(NonNull::new_unchecked(bcx2 as *const _ as *mut _), Layout::new::<Bcx>());
+        Global.deallocate(NonNull::new_unchecked(bcx2 as *mut _ as *mut _), Layout::new::<Bcx>());
     }
 }
 


### PR DESCRIPTION
This seems to go back all the way to the [original version of this test](https://github.com/rust-lang/rust/blob/b9aa9def858cfc66d411972b10ce3d98479acd78/src/test/run-pass/regions-mock-trans.rs) from ten years ago... @nikomatsakis trip down memory lane? ;)

Clearly deallocation is a form of mutation so doing it to a (pointer derived from a) shared reference cannot be legal. Let's use mutable references instead.