### PR TITLE
Enable `#[thread_local]` on armv6k-nintendo-3ds

### DIFF
--- a/compiler/rustc_target/src/spec/armv6k_nintendo_3ds.rs
+++ b/compiler/rustc_target/src/spec/armv6k_nintendo_3ds.rs
@@ -29,8 +29,7 @@ pub fn target() -> Target {
             pre_link_args,
             exe_suffix: ".elf".into(),
             no_default_libraries: false,
-            // There are some issues in debug builds with this enabled in certain programs.
-            has_thread_local: false,
+            has_thread_local: true,
             ..Default::default()
         },
     }


### PR DESCRIPTION
Since [libctru 2.1.2](https://github.com/devkitPro/libctru/releases/tag/v2.1.2)  was released we should now be able to use real `#[thread_local]` without corruption issues on the 3DS target.

CC @Meziu @AzureMarker @Techie-Pi 
https://github.com/rust3ds/ctru-rs/issues/91#issuecomment-1426821450