### PR TITLE
Hermit: Remove floor symbol

### DIFF
--- a/library/std/src/sys/hermit/mod.rs
+++ b/library/std/src/sys/hermit/mod.rs
@@ -72,11 +72,6 @@ pub fn unsupported_err() -> crate::io::Error {
     )
 }
 
-#[no_mangle]
-pub extern "C" fn floor(x: f64) -> f64 {
-    unsafe { intrinsics::floorf64(x) }
-}
-
 pub fn abort_internal() -> ! {
     unsafe {
         abi::abort();


### PR DESCRIPTION
This symbol should be provided by Hermit.

It was introduced in 2019 (https://github.com/rust-lang/rust/pull/65167). Since 2020, Hermit provides these math functions on its own (https://github.com/hermitcore/rusty-hermit/pull/37). I think forgetting to move this to Hermit was merely an oversight.

Related:
* https://github.com/hermitcore/libhermit-rs/pull/654
* https://github.com/hermitcore/rusty-hermit/pull/406

CC: @stlankes