### PR TITLE
Remove implicit total orderings

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -776,10 +776,9 @@ pub enum PatKind {
     MacCall(P<MacCall>),
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Copy)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Copy)]
 #[derive(HashStable_Generic, Encodable, Decodable)]
 pub enum Mutability {
-    // N.B. Order is deliberate, so that Not < Mut
     Not,
     Mut,
 }

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -435,6 +435,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
 
         // Check if we can use one of the "nice region errors".
         if let (Some(f), Some(o)) = (self.to_error_region(fr), self.to_error_region(outlived_fr)) {
+            debug!("report_region_error: nice report");
             let infer_err = self.infcx.err_ctxt();
             let nice = NiceRegionError::new_from_span(&infer_err, cause.span, o, f);
             if let Some(diag) = nice.try_report_from_nll() {

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -2173,7 +2173,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // is in the same SCC or something. In that case, find what
         // appears to be the most interesting point to report to the
         // user via an even more ad-hoc guess.
-        categorized_path.sort_by(|p0, p1| p0.category.cmp(&p1.category));
+        categorized_path.sort_by_key(|p| p.category.cmp_discr());
         debug!("sorted_path={:#?}", categorized_path);
 
         (categorized_path.remove(0), extra_info)

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -389,7 +389,7 @@ pub fn coerce_unsized_info<'tcx>(tcx: TyCtxt<'tcx>, impl_did: DefId) -> CoerceUn
     let check_mutbl = |mt_a: ty::TypeAndMut<'tcx>,
                        mt_b: ty::TypeAndMut<'tcx>,
                        mk_ptr: &dyn Fn(Ty<'tcx>) -> Ty<'tcx>| {
-        if mt_a.mutbl < mt_b.mutbl {
+        if let (hir::Mutability::Not, hir::Mutability::Mut) = (mt_a.mutbl, mt_b.mutbl) {
             infcx
                 .err_ctxt()
                 .report_mismatched_types(

--- a/compiler/rustc_hir_analysis/src/outlives/utils.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/utils.rs
@@ -1,14 +1,14 @@
+use rustc_data_structures::fx::FxHashMap;
 use rustc_infer::infer::outlives::components::{push_outlives_components, Component};
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind};
 use rustc_middle::ty::{self, Region, Ty, TyCtxt};
 use rustc_span::Span;
 use smallvec::smallvec;
-use std::collections::BTreeMap;
 
 /// Tracks the `T: 'a` or `'a: 'a` predicates that we have inferred
 /// must be added to the struct header.
 pub(crate) type RequiredPredicates<'tcx> =
-    BTreeMap<ty::OutlivesPredicate<GenericArg<'tcx>, ty::Region<'tcx>>, Span>;
+    FxHashMap<ty::OutlivesPredicate<GenericArg<'tcx>, ty::Region<'tcx>>, Span>;
 
 /// Given a requirement `T: 'a` or `'b: 'a`, deduce the
 /// outlives_component and add it to `required_predicates`

--- a/compiler/rustc_hir_typeck/src/_match.rs
+++ b/compiler/rustc_hir_typeck/src/_match.rs
@@ -575,5 +575,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 }
 
 fn arms_contain_ref_bindings<'tcx>(arms: &'tcx [hir::Arm<'tcx>]) -> Option<hir::Mutability> {
-    arms.iter().filter_map(|a| a.pat.contains_explicit_ref_binding()).max()
+    arms.iter().filter_map(|a| a.pat.contains_explicit_ref_binding()).max_by_key(|m| match m {
+        hir::Mutability::Not => 0u8,
+        hir::Mutability::Mut => 1,
+    })
 }

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -947,7 +947,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         m_cast: ty::TypeAndMut<'tcx>,
     ) -> Result<CastKind, CastError> {
         // array-ptr-cast: allow mut-to-mut, mut-to-const, const-to-const
-        if m_expr.mutbl >= m_cast.mutbl {
+        if m_expr.mutbl == m_cast.mutbl || m_expr.mutbl == hir::Mutability::Mut {
             if let ty::Array(ety, _) = m_expr.ty.kind() {
                 // Due to the limitations of LLVM global constants,
                 // region pointers end up pointing at copies of

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -110,7 +110,11 @@ fn coerce_mutbls<'tcx>(
     from_mutbl: hir::Mutability,
     to_mutbl: hir::Mutability,
 ) -> RelateResult<'tcx, ()> {
-    if from_mutbl >= to_mutbl { Ok(()) } else { Err(TypeError::Mutability) }
+    if from_mutbl == to_mutbl || from_mutbl == hir::Mutability::Mut {
+        Ok(())
+    } else {
+        Err(TypeError::Mutability)
+    }
 }
 
 /// Do not require any adjustments, i.e. coerce `x -> x`.

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -1420,7 +1420,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         (
                             sp,
                             format!("{}{derefs}", if mutbl_a != mutbl_b { mutbl_b.prefix_str() } else { "" }),
-                            if mutbl_b <= mutbl_a { Applicability::MachineApplicable } else { Applicability::MaybeIncorrect }
+                            if mutbl_b == mutbl_a || mutbl_b == hir::Mutability::Not { Applicability::MachineApplicable } else { Applicability::MaybeIncorrect }
                         )
                     });
 

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1936,7 +1936,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 _ => None,
             })
             .collect();
-        preds.sort_by_key(|pred| (pred.def_id(), pred.self_ty()));
+        preds.sort_by_key(|pred| pred.def_id());
         let def_ids = preds
             .iter()
             .filter_map(|pred| match pred.self_ty().kind() {

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
@@ -60,6 +60,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
     pub(super) fn try_report_placeholder_conflict(
         &self,
     ) -> Option<DiagnosticBuilder<'tcx, ErrorGuaranteed>> {
+        debug!(?self.error, "try_report_placeholder_conflict");
         match &self.error {
             ///////////////////////////////////////////////////////////////////////////
             // NB. The ordering of cases in this match is very

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -238,8 +238,14 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
         // later use this to expand across vids.
         let mut constraints = IndexVec::from_elem_n(Vec::new(), var_values.values.len());
         // Tracks the changed region vids.
-        let mut changes = Vec::new();
-        for constraint in self.data.constraints.keys() {
+        let mut changes = vec![];
+        let mut input_constraints: Vec<_> = self.data.constraints.keys().collect();
+        input_constraints.sort_by_key(|c| match c {
+            Constraint::VarSubVar(..) => 0u8,
+            Constraint::RegSubVar(..) => 1,
+            Constraint::VarSubReg(..) | Constraint::RegSubReg(..) => 2,
+        });
+        for constraint in input_constraints {
             match *constraint {
                 Constraint::RegSubVar(a_region, b_vid) => {
                     let b_data = var_values.value_mut(b_vid);

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -7,7 +7,9 @@ use super::{
     InferCtxtUndoLogs, MiscVariable, RegionVariableOrigin, Rollback, Snapshot, SubregionOrigin,
 };
 
-use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
+use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::fx::FxIndexMap;
+use rustc_data_structures::fx::FxIndexSet;
 use rustc_data_structures::intern::Interned;
 use rustc_data_structures::sync::Lrc;
 use rustc_data_structures::undo_log::UndoLogs;
@@ -20,7 +22,6 @@ use rustc_middle::ty::{ReLateBound, ReVar};
 use rustc_middle::ty::{Region, RegionVid};
 use rustc_span::Span;
 
-use std::collections::BTreeMap;
 use std::ops::Range;
 use std::{cmp, fmt, mem};
 
@@ -90,7 +91,7 @@ pub type VarInfos = IndexVec<RegionVid, RegionVariableInfo>;
 pub struct RegionConstraintData<'tcx> {
     /// Constraints of the form `A <= B`, where either `A` or `B` can
     /// be a region variable (or neither, as it happens).
-    pub constraints: BTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>,
+    pub constraints: FxIndexMap<Constraint<'tcx>, SubregionOrigin<'tcx>>,
 
     /// Constraints of the form `R0 member of [R1, ..., Rn]`, meaning that
     /// `R0` must be equal to one of the regions `R1..Rn`. These occur
@@ -127,7 +128,7 @@ pub struct RegionConstraintData<'tcx> {
 }
 
 /// Represents a constraint that influences the inference process.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum Constraint<'tcx> {
     /// A region variable is a subregion of another.
     VarSubVar(RegionVid, RegionVid),

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1200,7 +1200,7 @@ impl<'tcx> LateLintPass<'tcx> for MutableTransmutes {
         if let Some((&ty::Ref(_, _, from_mutbl), &ty::Ref(_, _, to_mutbl))) =
             get_transmute_from_to(cx, expr).map(|(ty1, ty2)| (ty1.kind(), ty2.kind()))
         {
-            if from_mutbl < to_mutbl {
+            if let (hir::Mutability::Not, hir::Mutability::Mut) = (from_mutbl, to_mutbl) {
                 cx.emit_spanned_lint(MUTABLE_TRANSMUTES, expr.span, BuiltinMutablesTransmutes);
             }
         }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2580,7 +2580,7 @@ impl<'tcx> ConstantKind<'tcx> {
 }
 
 /// An unevaluated (potentially generic) constant used in MIR.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, TyEncodable, TyDecodable, Lift)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, TyEncodable, TyDecodable, Lift)]
 #[derive(Hash, HashStable, TypeFoldable, TypeVisitable)]
 pub struct UnevaluatedConst<'tcx> {
     pub def: ty::WithOptConstParam<DefId>,

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -17,6 +17,8 @@ use std::fmt::{self, Debug};
 
 use super::{Field, SourceInfo};
 
+mod order;
+
 #[derive(Copy, Clone, PartialEq, TyEncodable, TyDecodable, HashStable, Debug)]
 pub enum UnsafetyViolationKind {
     /// Unsafe operation outside `unsafe`.
@@ -336,7 +338,7 @@ rustc_data_structures::static_assert_size!(ConstraintCategory<'_>, 16);
 /// order of the category, thereby influencing diagnostic output.
 ///
 /// See also `rustc_const_eval::borrow_check::constraints`.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[derive(TyEncodable, TyDecodable, HashStable, Lift, TypeVisitable, TypeFoldable)]
 pub enum ConstraintCategory<'tcx> {
     Return(ReturnConstraint),

--- a/compiler/rustc_middle/src/mir/query/order.rs
+++ b/compiler/rustc_middle/src/mir/query/order.rs
@@ -1,0 +1,27 @@
+use super::ConstraintCategory;
+
+impl<'tcx> ConstraintCategory<'tcx> {
+    pub fn cmp_discr(&self) -> u8 {
+        use ConstraintCategory::*;
+        match self {
+            Return(_) => 0,
+            Yield => 1,
+            UseAsConst => 2,
+            UseAsStatic => 3,
+            TypeAnnotation => 4,
+            Cast => 5,
+            ClosureBounds => 6,
+            CallArgument(_) => 7,
+            CopyBound => 8,
+            SizedBound => 9,
+            Assignment => 10,
+            Usage => 11,
+            OpaqueType => 12,
+            ClosureUpvar(_) => 13,
+            Predicate(_) => 14,
+            Boring => 15,
+            BoringNoLocation => 16,
+            Internal => 17,
+        }
+    }
+}

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -15,7 +15,7 @@ pub use kind::*;
 pub use valtree::*;
 
 /// Use this rather than `ConstData, whenever possible.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, HashStable)]
 #[rustc_pass_by_value]
 pub struct Const<'tcx>(pub(super) Interned<'tcx, ConstData<'tcx>>);
 
@@ -29,7 +29,7 @@ impl<'tcx> fmt::Debug for Const<'tcx> {
 }
 
 /// Typed constant value.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, HashStable, TyEncodable, TyDecodable)]
+#[derive(PartialEq, Eq, Hash, HashStable, TyEncodable, TyDecodable)]
 pub struct ConstData<'tcx> {
     pub ty: Ty<'tcx>,
     pub kind: ConstKind<'tcx>,

--- a/compiler/rustc_middle/src/ty/consts/kind.rs
+++ b/compiler/rustc_middle/src/ty/consts/kind.rs
@@ -14,7 +14,7 @@ use rustc_target::abi::Size;
 use super::ScalarInt;
 
 /// An unevaluated (potentially generic) constant used in the type-system.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, TyEncodable, TyDecodable, Lift)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, TyEncodable, TyDecodable, Lift)]
 #[derive(Hash, HashStable, TypeFoldable, TypeVisitable)]
 pub struct UnevaluatedConst<'tcx> {
     pub def: ty::WithOptConstParam<DefId>,
@@ -45,7 +45,7 @@ impl<'tcx> UnevaluatedConst<'tcx> {
 }
 
 /// Represents a constant in Rust.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, TyEncodable, TyDecodable)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, TyEncodable, TyDecodable)]
 #[derive(Hash, HashStable, TypeFoldable, TypeVisitable)]
 #[derive(derive_more::From)]
 pub enum ConstKind<'tcx> {
@@ -83,7 +83,7 @@ impl<'tcx> From<ty::ConstVid<'tcx>> for ConstKind<'tcx> {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[derive(HashStable, TyEncodable, TyDecodable, TypeVisitable, TypeFoldable)]
 pub enum Expr<'tcx> {
     Binop(mir::BinOp, Const<'tcx>, Const<'tcx>),
@@ -131,7 +131,7 @@ impl<'tcx> ConstKind<'tcx> {
 }
 
 /// An inference variable for a const, for use in const generics.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, TyEncodable, TyDecodable, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, TyEncodable, TyDecodable, Hash)]
 pub enum InferConst<'tcx> {
     /// Infer the value of the const.
     Var(ty::ConstVid<'tcx>),

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -25,7 +25,7 @@ pub struct Instance<'tcx> {
     pub substs: SubstsRef<'tcx>,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 #[derive(TyEncodable, TyDecodable, HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub enum InstanceDef<'tcx> {
     /// A user-defined callable item.

--- a/compiler/rustc_middle/src/ty/list.rs
+++ b/compiler/rustc_middle/src/ty/list.rs
@@ -1,7 +1,6 @@
 use crate::arena::Arena;
 use rustc_serialize::{Encodable, Encoder};
 use std::alloc::Layout;
-use std::cmp::Ordering;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::iter;
@@ -136,32 +135,6 @@ impl<T: PartialEq> PartialEq for List<T> {
 }
 
 impl<T: Eq> Eq for List<T> {}
-
-impl<T> Ord for List<T>
-where
-    T: Ord,
-{
-    fn cmp(&self, other: &List<T>) -> Ordering {
-        // Pointer equality implies list equality (due to the unique contents
-        // assumption), but the contents must be compared otherwise.
-        if self == other { Ordering::Equal } else { <[T] as Ord>::cmp(&**self, &**other) }
-    }
-}
-
-impl<T> PartialOrd for List<T>
-where
-    T: PartialOrd,
-{
-    fn partial_cmp(&self, other: &List<T>) -> Option<Ordering> {
-        // Pointer equality implies list equality (due to the unique contents
-        // assumption), but the contents must be compared otherwise.
-        if self == other {
-            Some(Ordering::Equal)
-        } else {
-            <[T] as PartialOrd>::partial_cmp(&**self, &**other)
-        }
-    }
-}
 
 impl<T> Hash for List<T> {
     #[inline]

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -454,7 +454,7 @@ pub struct CReaderCacheKey {
 }
 
 /// Use this rather than `TyKind`, whenever possible.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, HashStable)]
 #[rustc_diagnostic_item = "Ty"]
 #[rustc_pass_by_value]
 pub struct Ty<'tcx>(Interned<'tcx, WithCachedTypeInfo<TyKind<'tcx>>>);
@@ -852,7 +852,7 @@ impl<'tcx> PolyTraitPredicate<'tcx> {
 }
 
 /// `A: B`
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, TyEncodable, TyDecodable)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, TyEncodable, TyDecodable)]
 #[derive(HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub struct OutlivesPredicate<A, B>(pub A, pub B);
 pub type RegionOutlivesPredicate<'tcx> = OutlivesPredicate<ty::Region<'tcx>, ty::Region<'tcx>>;
@@ -881,7 +881,7 @@ pub struct CoercePredicate<'tcx> {
 }
 pub type PolyCoercePredicate<'tcx> = ty::Binder<'tcx, CoercePredicate<'tcx>>;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Term<'tcx> {
     ptr: NonZeroUsize,
     marker: PhantomData<(Ty<'tcx>, Const<'tcx>)>,
@@ -1010,7 +1010,7 @@ const TAG_MASK: usize = 0b11;
 const TYPE_TAG: usize = 0b00;
 const CONST_TAG: usize = 0b01;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, TyEncodable, TyDecodable)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 #[derive(HashStable, TypeFoldable, TypeVisitable)]
 pub enum TermKind<'tcx> {
     Ty(Ty<'tcx>),
@@ -1404,7 +1404,7 @@ impl<'tcx> OpaqueHiddenType<'tcx> {
 /// identified by both a universe, as well as a name residing within that universe. Distinct bound
 /// regions/types/consts within the same universe simply have an unknown relationship to one
 /// another.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[derive(HashStable, TyEncodable, TyDecodable)]
 pub struct Placeholder<T> {
     pub universe: UniverseIndex,
@@ -1416,7 +1416,7 @@ pub type PlaceholderRegion = Placeholder<BoundRegionKind>;
 pub type PlaceholderType = Placeholder<BoundTyKind>;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, HashStable)]
-#[derive(TyEncodable, TyDecodable, PartialOrd, Ord)]
+#[derive(TyEncodable, TyDecodable)]
 pub struct BoundConst<'tcx> {
     pub var: BoundVar,
     pub ty: Ty<'tcx>,
@@ -1476,7 +1476,7 @@ pub type PlaceholderConst<'tcx> = Placeholder<BoundVar>;
 /// Meaning that we need to use `type_of(const_param_did)` if `const_param_did` is `Some`
 /// to get the type of `did`.
 #[derive(Copy, Clone, Debug, TypeFoldable, TypeVisitable, Lift, TyEncodable, TyDecodable)]
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(PartialEq, Eq)]
 #[derive(Hash, HashStable)]
 pub struct WithOptConstParam<T> {
     pub did: T,

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -42,7 +42,7 @@ use rustc_type_ir::TyKind as IrTyKind;
 pub type TyKind<'tcx> = IrTyKind<TyCtxt<'tcx>>;
 pub type RegionKind<'tcx> = IrRegionKind<TyCtxt<'tcx>>;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, TyEncodable, TyDecodable)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, TyEncodable, TyDecodable)]
 #[derive(HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub struct TypeAndMut<'tcx> {
     pub ty: Ty<'tcx>,
@@ -683,7 +683,7 @@ impl<'tcx> InlineConstSubsts<'tcx> {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Hash, TyEncodable, TyDecodable)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 #[derive(HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub enum ExistentialPredicate<'tcx> {
     /// E.g., `Iterator`.
@@ -820,7 +820,7 @@ impl<'tcx> List<ty::PolyExistentialPredicate<'tcx>> {
 ///
 /// Trait references also appear in object types like `Foo<U>`, but in
 /// that case the `Self` parameter is absent from the substitutions.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, TyEncodable, TyDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 #[derive(HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub struct TraitRef<'tcx> {
     pub def_id: DefId,
@@ -884,7 +884,7 @@ impl rustc_errors::IntoDiagnosticArg for PolyTraitRef<'_> {
 /// ```
 /// The substitutions don't include the erased `Self`, only trait
 /// type and lifetime parameters (`[X, Y]` and `['a, 'b]` above).
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, TyEncodable, TyDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 #[derive(HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub struct ExistentialTraitRef<'tcx> {
     pub def_id: DefId,
@@ -933,7 +933,7 @@ impl<'tcx> PolyExistentialTraitRef<'tcx> {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, TyEncodable, TyDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, TyEncodable, TyDecodable)]
 #[derive(HashStable)]
 pub enum BoundVariableKind {
     Ty(BoundTyKind),
@@ -973,7 +973,7 @@ impl BoundVariableKind {
 /// e.g., `liberate_late_bound_regions`).
 ///
 /// `Decodable` and `Encodable` are implemented for `Binder<T>` using the `impl_binder_encode_decode!` macro.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 #[derive(HashStable, Lift)]
 pub struct Binder<'tcx, T>(T, &'tcx List<BoundVariableKind>);
 
@@ -1224,7 +1224,7 @@ impl<'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for SkipBindersAt<'tcx> {
 /// For a projection, this would be `<Ty as Trait<...>>::N`.
 ///
 /// For an opaque type, there is no explicit syntax.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, TyEncodable, TyDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 #[derive(HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub struct AliasTy<'tcx> {
     /// The parameters of the associated or opaque item.
@@ -1330,7 +1330,7 @@ pub type PolyGenSig<'tcx> = Binder<'tcx, GenSig<'tcx>>;
 /// - `inputs`: is the list of arguments and their modes.
 /// - `output`: is the return type.
 /// - `c_variadic`: indicates whether this is a C-variadic function.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, TyEncodable, TyDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 #[derive(HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub struct FnSig<'tcx> {
     pub inputs_and_output: &'tcx List<Ty<'tcx>>,
@@ -1437,7 +1437,7 @@ impl ParamConst {
 }
 
 /// Use this rather than `RegionKind`, whenever possible.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, HashStable)]
 #[rustc_pass_by_value]
 pub struct Region<'tcx>(pub Interned<'tcx, RegionKind<'tcx>>);
 
@@ -1526,7 +1526,7 @@ impl From<BoundVar> for BoundTy {
 }
 
 /// A `ProjectionPredicate` for an `ExistentialTraitRef`.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, TyEncodable, TyDecodable)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, TyEncodable, TyDecodable)]
 #[derive(HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub struct ExistentialProjection<'tcx> {
     pub def_id: DefId,
@@ -2456,7 +2456,7 @@ impl<'tcx> Ty<'tcx> {
 /// a miscompilation or unsoundness.
 ///
 /// When in doubt, use `VarianceDiagInfo::default()`
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum VarianceDiagInfo<'tcx> {
     /// No additional information - this is the default.
     /// We will not add any additional information to error messages.

--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -15,7 +15,6 @@ use rustc_type_ir::WithCachedTypeInfo;
 use smallvec::SmallVec;
 
 use core::intrinsics;
-use std::cmp::Ordering;
 use std::fmt;
 use std::marker::PhantomData;
 use std::mem;
@@ -48,7 +47,7 @@ const TYPE_TAG: usize = 0b00;
 const REGION_TAG: usize = 0b01;
 const CONST_TAG: usize = 0b10;
 
-#[derive(Debug, TyEncodable, TyDecodable, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, TyEncodable, TyDecodable, PartialEq, Eq)]
 pub enum GenericArgKind<'tcx> {
     Lifetime(ty::Region<'tcx>),
     Type(Ty<'tcx>),
@@ -112,18 +111,6 @@ impl<'tcx> fmt::Debug for GenericArg<'tcx> {
             GenericArgKind::Type(ty) => ty.fmt(f),
             GenericArgKind::Const(ct) => ct.fmt(f),
         }
-    }
-}
-
-impl<'tcx> Ord for GenericArg<'tcx> {
-    fn cmp(&self, other: &GenericArg<'tcx>) -> Ordering {
-        self.unpack().cmp(&other.unpack())
-    }
-}
-
-impl<'tcx> PartialOrd for GenericArg<'tcx> {
-    fn partial_cmp(&self, other: &GenericArg<'tcx>) -> Option<Ordering> {
-        Some(self.cmp(&other))
     }
 }
 
@@ -552,7 +539,7 @@ impl<'tcx, T: TypeVisitable<'tcx>> ir::TypeVisitable<TyCtxt<'tcx>> for &'tcx ty:
 ///
 /// If you don't have anything to `subst`, you may be looking for
 /// [`subst_identity`](EarlyBinder::subst_identity) or [`skip_binder`](EarlyBinder::skip_binder).
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 #[derive(Encodable, Decodable, HashStable)]
 pub struct EarlyBinder<T>(pub T);
 

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -21,6 +21,7 @@ use crate::infer::{InferCtxt, InferOk, LateBoundRegionConversionTime};
 use crate::traits::error_reporting::TypeErrCtxtExt as _;
 use crate::traits::query::evaluate_obligation::InferCtxtExt as _;
 use crate::traits::select::ProjectionMatchesProjection;
+use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::sso::SsoHashSet;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::ErrorGuaranteed;
@@ -35,8 +36,6 @@ use rustc_middle::ty::visit::{MaxUniverse, TypeVisitable};
 use rustc_middle::ty::DefIdTree;
 use rustc_middle::ty::{self, Term, ToPredicate, Ty, TyCtxt};
 use rustc_span::symbol::sym;
-
-use std::collections::BTreeMap;
 
 pub use rustc_middle::traits::Reveal;
 
@@ -649,9 +648,9 @@ pub struct BoundVarReplacer<'me, 'tcx> {
     // These three maps track the bound variable that were replaced by placeholders. It might be
     // nice to remove these since we already have the `kind` in the placeholder; we really just need
     // the `var` (but we *could* bring that into scope if we were to track them as we pass them).
-    mapped_regions: BTreeMap<ty::PlaceholderRegion, ty::BoundRegion>,
-    mapped_types: BTreeMap<ty::PlaceholderType, ty::BoundTy>,
-    mapped_consts: BTreeMap<ty::PlaceholderConst<'tcx>, ty::BoundVar>,
+    mapped_regions: FxIndexMap<ty::PlaceholderRegion, ty::BoundRegion>,
+    mapped_types: FxIndexMap<ty::PlaceholderType, ty::BoundTy>,
+    mapped_consts: FxIndexMap<ty::PlaceholderConst<'tcx>, ty::BoundVar>,
     // The current depth relative to *this* folding, *not* the entire normalization. In other words,
     // the depth of binders we've passed here.
     current_index: ty::DebruijnIndex,
@@ -704,19 +703,15 @@ impl<'me, 'tcx> BoundVarReplacer<'me, 'tcx> {
         value: T,
     ) -> (
         T,
-        BTreeMap<ty::PlaceholderRegion, ty::BoundRegion>,
-        BTreeMap<ty::PlaceholderType, ty::BoundTy>,
-        BTreeMap<ty::PlaceholderConst<'tcx>, ty::BoundVar>,
+        FxIndexMap<ty::PlaceholderRegion, ty::BoundRegion>,
+        FxIndexMap<ty::PlaceholderType, ty::BoundTy>,
+        FxIndexMap<ty::PlaceholderConst<'tcx>, ty::BoundVar>,
     ) {
-        let mapped_regions: BTreeMap<ty::PlaceholderRegion, ty::BoundRegion> = BTreeMap::new();
-        let mapped_types: BTreeMap<ty::PlaceholderType, ty::BoundTy> = BTreeMap::new();
-        let mapped_consts: BTreeMap<ty::PlaceholderConst<'tcx>, ty::BoundVar> = BTreeMap::new();
-
         let mut replacer = BoundVarReplacer {
             infcx,
-            mapped_regions,
-            mapped_types,
-            mapped_consts,
+            mapped_regions: <_>::default(),
+            mapped_types: <_>::default(),
+            mapped_consts: <_>::default(),
             current_index: ty::INNERMOST,
             universe_indices,
         };
@@ -818,9 +813,9 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for BoundVarReplacer<'_, 'tcx> {
 /// The inverse of [`BoundVarReplacer`]: replaces placeholders with the bound vars from which they came.
 pub struct PlaceholderReplacer<'me, 'tcx> {
     infcx: &'me InferCtxt<'tcx>,
-    mapped_regions: BTreeMap<ty::PlaceholderRegion, ty::BoundRegion>,
-    mapped_types: BTreeMap<ty::PlaceholderType, ty::BoundTy>,
-    mapped_consts: BTreeMap<ty::PlaceholderConst<'tcx>, ty::BoundVar>,
+    mapped_regions: FxIndexMap<ty::PlaceholderRegion, ty::BoundRegion>,
+    mapped_types: FxIndexMap<ty::PlaceholderType, ty::BoundTy>,
+    mapped_consts: FxIndexMap<ty::PlaceholderConst<'tcx>, ty::BoundVar>,
     universe_indices: &'me [Option<ty::UniverseIndex>],
     current_index: ty::DebruijnIndex,
 }
@@ -828,9 +823,9 @@ pub struct PlaceholderReplacer<'me, 'tcx> {
 impl<'me, 'tcx> PlaceholderReplacer<'me, 'tcx> {
     pub fn replace_placeholders<T: TypeFoldable<'tcx>>(
         infcx: &'me InferCtxt<'tcx>,
-        mapped_regions: BTreeMap<ty::PlaceholderRegion, ty::BoundRegion>,
-        mapped_types: BTreeMap<ty::PlaceholderType, ty::BoundTy>,
-        mapped_consts: BTreeMap<ty::PlaceholderConst<'tcx>, ty::BoundVar>,
+        mapped_regions: FxIndexMap<ty::PlaceholderRegion, ty::BoundRegion>,
+        mapped_types: FxIndexMap<ty::PlaceholderType, ty::BoundTy>,
+        mapped_consts: FxIndexMap<ty::PlaceholderConst<'tcx>, ty::BoundVar>,
         universe_indices: &'me [Option<ty::UniverseIndex>],
         value: T,
     ) -> T {

--- a/compiler/rustc_transmute/src/layout/mod.rs
+++ b/compiler/rustc_transmute/src/layout/mod.rs
@@ -43,7 +43,7 @@ pub(crate) mod rustc {
     use rustc_middle::ty::Ty;
 
     /// A reference in the layout.
-    #[derive(Debug, Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Copy)]
+    #[derive(Debug, Hash, Eq, PartialEq, Clone, Copy)]
     pub struct Ref<'tcx> {
         lifetime: Region<'tcx>,
         ty: Ty<'tcx>,

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -38,35 +38,35 @@ pub use ty_info::*;
 pub trait HashStableContext {}
 
 pub trait Interner: Sized {
-    type AdtDef: Clone + Debug + Hash + Ord;
-    type SubstsRef: Clone + Debug + Hash + Ord;
-    type DefId: Clone + Debug + Hash + Ord;
+    type AdtDef: Clone + Debug + Hash + Eq;
+    type SubstsRef: Clone + Debug + Hash + Eq;
+    type DefId: Clone + Debug + Hash + Eq;
     type Binder<T>;
-    type Ty: Clone + Debug + Hash + Ord;
-    type Const: Clone + Debug + Hash + Ord;
-    type Region: Clone + Debug + Hash + Ord;
+    type Ty: Clone + Debug + Hash + Eq;
+    type Const: Clone + Debug + Hash + Eq;
+    type Region: Clone + Debug + Hash + Eq;
     type Predicate;
-    type TypeAndMut: Clone + Debug + Hash + Ord;
-    type Mutability: Clone + Debug + Hash + Ord;
-    type Movability: Clone + Debug + Hash + Ord;
-    type PolyFnSig: Clone + Debug + Hash + Ord;
-    type ListBinderExistentialPredicate: Clone + Debug + Hash + Ord;
-    type BinderListTy: Clone + Debug + Hash + Ord;
-    type ListTy: Clone + Debug + Hash + Ord;
-    type AliasTy: Clone + Debug + Hash + Ord;
-    type ParamTy: Clone + Debug + Hash + Ord;
-    type BoundTy: Clone + Debug + Hash + Ord;
-    type PlaceholderType: Clone + Debug + Hash + Ord;
-    type InferTy: Clone + Debug + Hash + Ord;
-    type ErrorGuaranteed: Clone + Debug + Hash + Ord;
+    type TypeAndMut: Clone + Debug + Hash + Eq;
+    type Mutability: Clone + Debug + Hash + Eq;
+    type Movability: Clone + Debug + Hash + Eq;
+    type PolyFnSig: Clone + Debug + Hash + Eq;
+    type ListBinderExistentialPredicate: Clone + Debug + Hash + Eq;
+    type BinderListTy: Clone + Debug + Hash + Eq;
+    type ListTy: Clone + Debug + Hash + Eq;
+    type AliasTy: Clone + Debug + Hash + Eq;
+    type ParamTy: Clone + Debug + Hash + Eq;
+    type BoundTy: Clone + Debug + Hash + Eq;
+    type PlaceholderType: Clone + Debug + Hash + PartialEq + Eq;
+    type InferTy: Clone + Debug + Hash + Eq;
+    type ErrorGuaranteed: Clone + Debug + Hash + Eq;
     type PredicateKind: Clone + Debug + Hash + PartialEq + Eq;
-    type AllocId: Clone + Debug + Hash + Ord;
+    type AllocId: Clone + Debug + Hash + Eq;
 
-    type EarlyBoundRegion: Clone + Debug + Hash + Ord;
-    type BoundRegion: Clone + Debug + Hash + Ord;
-    type FreeRegion: Clone + Debug + Hash + Ord;
-    type RegionVid: Clone + Debug + Hash + Ord;
-    type PlaceholderRegion: Clone + Debug + Hash + Ord;
+    type EarlyBoundRegion: Clone + Debug + Hash + PartialEq + Eq;
+    type BoundRegion: Clone + Debug + Hash + PartialEq + Eq;
+    type FreeRegion: Clone + Debug + Hash + PartialEq + Eq;
+    type RegionVid: Clone + Debug + Hash + PartialEq + Eq;
+    type PlaceholderRegion: Clone + Debug + Hash + PartialEq + Eq;
 }
 
 pub trait InternAs<T: ?Sized, R> {

--- a/tests/ui/async-await/issues/issue-72312.stderr
+++ b/tests/ui/async-await/issues/issue-72312.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of associated function
-  --> $DIR/issue-72312.rs:12:9
+  --> $DIR/issue-72312.rs:12:24
    |
 LL |       pub async fn start(&self) {
    |                          -----
@@ -7,16 +7,17 @@ LL |       pub async fn start(&self) {
    |                          `self` is a reference that is only valid in the associated function body
    |                          let's call the lifetime of this reference `'1`
 ...
-LL | /         require_static(async move {
+LL |           require_static(async move {
+   |  ________________________^
 LL | |
 LL | |
 LL | |
 LL | |             &self;
 LL | |         });
-   | |          ^
-   | |          |
-   | |__________`self` escapes the associated function body here
-   |            argument requires that `'1` must outlive `'static`
+   | |         ^
+   | |         |
+   | |_________`self` escapes the associated function body here
+   |           argument requires that `'1` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -53,17 +53,16 @@ LL | fn case2() {
 error[E0597]: `a` does not live long enough
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:30:26
    |
-LL |       let a = 0;
-   |           - binding `a` declared here
-LL |       let cell = Cell::new(&a);
-   |                            ^^ borrowed value does not live long enough
+LL |     let a = 0;
+   |         - binding `a` declared here
+LL |     let cell = Cell::new(&a);
+   |                ----------^^-
+   |                |         |
+   |                |         borrowed value does not live long enough
+   |                argument requires that `a` is borrowed for `'static`
 ...
-LL | /     foo(cell, |cell_a, cell_x| {
-LL | |         cell_x.set(cell_a.get()); // forces 'a: 'x, implies 'a = 'static -> borrow error
-LL | |     })
-   | |______- argument requires that `a` is borrowed for `'static`
-LL |   }
-   |   - `a` dropped here while still borrowed
+LL | }
+   | - `a` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/user-annotations/adt-nullary-enums.stderr
+++ b/tests/ui/nll/user-annotations/adt-nullary-enums.stderr
@@ -1,16 +1,17 @@
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:33:41
    |
-LL |       let c = 66;
-   |           - binding `c` declared here
-LL | /     combine(
-LL | |         SomeEnum::SomeVariant(Cell::new(&c)),
-   | |                                         ^^ borrowed value does not live long enough
-LL | |         SomeEnum::SomeOtherVariant::<Cell<&'static u32>>,
-LL | |     );
-   | |_____- argument requires that `c` is borrowed for `'static`
-LL |   }
-   |   - `c` dropped here while still borrowed
+LL |     let c = 66;
+   |         - binding `c` declared here
+LL |     combine(
+LL |         SomeEnum::SomeVariant(Cell::new(&c)),
+   |                               ----------^^-
+   |                               |         |
+   |                               |         borrowed value does not live long enough
+   |                               argument requires that `c` is borrowed for `'static`
+...
+LL | }
+   | - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:41:41

--- a/tests/ui/traits/impl-of-supertrait-has-wrong-lifetime-parameters.stderr
+++ b/tests/ui/traits/impl-of-supertrait-has-wrong-lifetime-parameters.stderr
@@ -4,16 +4,16 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'b` d
 LL | impl<'a,'b> T2<'a, 'b> for S<'a, 'b> {
    |                            ^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
-  --> $DIR/impl-of-supertrait-has-wrong-lifetime-parameters.rs:24:6
-   |
-LL | impl<'a,'b> T2<'a, 'b> for S<'a, 'b> {
-   |      ^^
-note: ...but the lifetime must also be valid for the lifetime `'b` as defined here...
+note: first, the lifetime cannot outlive the lifetime `'b` as defined here...
   --> $DIR/impl-of-supertrait-has-wrong-lifetime-parameters.rs:24:9
    |
 LL | impl<'a,'b> T2<'a, 'b> for S<'a, 'b> {
    |         ^^
+note: ...but the lifetime must also be valid for the lifetime `'a` as defined here...
+  --> $DIR/impl-of-supertrait-has-wrong-lifetime-parameters.rs:24:6
+   |
+LL | impl<'a,'b> T2<'a, 'b> for S<'a, 'b> {
+   |      ^^
 note: ...so that the types are compatible
   --> $DIR/impl-of-supertrait-has-wrong-lifetime-parameters.rs:24:28
    |

--- a/tests/ui/traits/matching-lifetimes.stderr
+++ b/tests/ui/traits/matching-lifetimes.stderr
@@ -6,25 +6,6 @@ LL |     fn foo(x: Foo<'b,'a>) {
    |
    = note: expected signature `fn(Foo<'a, 'b>)`
               found signature `fn(Foo<'b, 'a>)`
-note: the lifetime `'b` as defined here...
-  --> $DIR/matching-lifetimes.rs:13:9
-   |
-LL | impl<'a,'b> Tr for Foo<'a,'b> {
-   |         ^^
-note: ...does not necessarily outlive the lifetime `'a` as defined here
-  --> $DIR/matching-lifetimes.rs:13:6
-   |
-LL | impl<'a,'b> Tr for Foo<'a,'b> {
-   |      ^^
-
-error[E0308]: method not compatible with trait
-  --> $DIR/matching-lifetimes.rs:14:5
-   |
-LL |     fn foo(x: Foo<'b,'a>) {
-   |     ^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
-   |
-   = note: expected signature `fn(Foo<'a, 'b>)`
-              found signature `fn(Foo<'b, 'a>)`
 note: the lifetime `'a` as defined here...
   --> $DIR/matching-lifetimes.rs:13:6
    |
@@ -35,6 +16,25 @@ note: ...does not necessarily outlive the lifetime `'b` as defined here
    |
 LL | impl<'a,'b> Tr for Foo<'a,'b> {
    |         ^^
+
+error[E0308]: method not compatible with trait
+  --> $DIR/matching-lifetimes.rs:14:5
+   |
+LL |     fn foo(x: Foo<'b,'a>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
+   |
+   = note: expected signature `fn(Foo<'a, 'b>)`
+              found signature `fn(Foo<'b, 'a>)`
+note: the lifetime `'b` as defined here...
+  --> $DIR/matching-lifetimes.rs:13:9
+   |
+LL | impl<'a,'b> Tr for Foo<'a,'b> {
+   |         ^^
+note: ...does not necessarily outlive the lifetime `'a` as defined here
+  --> $DIR/matching-lifetimes.rs:13:6
+   |
+LL | impl<'a,'b> Tr for Foo<'a,'b> {
+   |      ^^
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This PR will attempt to remove implicit orderings on `sty` data that are not naturally bestowed with either total or partial ordering.

It has come to attention specifically that a subtle mis-compilation was introduced in #104786 causing segfaults. By transposing the order of the variants in `Mutability`, in rare cases ADT constructors are miscompiled with incorrect memory layout. More details will come as the investigation into making a MVCE is underway.