### PR TITLE
layout: deal with placeholders, ICE on bound types

### DIFF
--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -470,14 +470,11 @@ fn layout_of_uncached<'tcx>(
             return Err(LayoutError::Unknown(ty));
         }
 
-        ty::Placeholder(..)
-        | ty::GeneratorWitness(..)
-        | ty::GeneratorWitnessMIR(..)
-        | ty::Infer(_) => {
+        ty::Bound(..) | ty::GeneratorWitness(..) | ty::GeneratorWitnessMIR(..) | ty::Infer(_) => {
             bug!("Layout::compute: unexpected type `{}`", ty)
         }
 
-        ty::Bound(..) | ty::Param(_) | ty::Error(_) => {
+        ty::Placeholder(..) | ty::Param(_) | ty::Error(_) => {
             return Err(LayoutError::Unknown(ty));
         }
     })


### PR DESCRIPTION
A placeholder type is the same as a param as they represent "this could be any type". A bound type represents a type inside of a `for<T>` or `exists<T>`. When entering a forall or exists `T` should be instantiated as a existential (inference var) or universal (placeholder). You should never observe a bound variable without its binder.