### PR TITLE
Use `TyCtxt::mk_str` instead of interned str

### DIFF
--- a/compiler/rustc_codegen_gcc/src/common.rs
+++ b/compiler/rustc_codegen_gcc/src/common.rs
@@ -133,7 +133,7 @@ impl<'gcc, 'tcx> ConstMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
             .1;
         let len = s.len();
         let cs = self.const_ptrcast(str_global.get_address(None),
-            self.type_ptr_to(self.layout_of(self.tcx.types.str_).gcc_type(self, true)),
+            self.type_ptr_to(self.layout_of(self.tcx.mk_str()).gcc_type(self, true)),
         );
         (cs, self.const_usize(len as u64))
     }

--- a/compiler/rustc_codegen_llvm/src/common.rs
+++ b/compiler/rustc_codegen_llvm/src/common.rs
@@ -205,7 +205,7 @@ impl<'ll, 'tcx> ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         let len = s.len();
         let cs = consts::ptrcast(
             str_global,
-            self.type_ptr_to(self.layout_of(self.tcx.types.str_).llvm_type(self)),
+            self.type_ptr_to(self.layout_of(self.tcx.mk_str()).llvm_type(self)),
         );
         (cs, self.const_usize(len as u64))
     }

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -759,10 +759,9 @@ where
         let meta = Scalar::from_machine_usize(u64::try_from(str.len()).unwrap(), self);
         let mplace = MemPlace { ptr: ptr.into(), meta: MemPlaceMeta::Meta(meta) };
 
-        let ty = self.tcx.mk_ref(
-            self.tcx.lifetimes.re_static,
-            ty::TypeAndMut { ty: self.tcx.types.str_, mutbl },
-        );
+        let ty = self
+            .tcx
+            .mk_ref(self.tcx.lifetimes.re_static, ty::TypeAndMut { ty: self.tcx.mk_str(), mutbl });
         let layout = self.layout_of(ty).unwrap();
         Ok(MPlaceTy { mplace, layout, align: layout.align.abi })
     }

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -2819,7 +2819,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     hir::PrimTy::Int(it) => tcx.mk_mach_int(ty::int_ty(it)),
                     hir::PrimTy::Uint(uit) => tcx.mk_mach_uint(ty::uint_ty(uit)),
                     hir::PrimTy::Float(ft) => tcx.mk_mach_float(ty::float_ty(ft)),
-                    hir::PrimTy::Str => tcx.types.str_,
+                    hir::PrimTy::Str => tcx.mk_str(),
                 }
             }
             Res::Err => {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -264,7 +264,6 @@ pub struct CommonTypes<'tcx> {
     pub u128: Ty<'tcx>,
     pub f32: Ty<'tcx>,
     pub f64: Ty<'tcx>,
-    pub str_: Ty<'tcx>,
     pub never: Ty<'tcx>,
     pub self_param: Ty<'tcx>,
 
@@ -335,7 +334,6 @@ impl<'tcx> CommonTypes<'tcx> {
             u128: mk(Uint(ty::UintTy::U128)),
             f32: mk(Float(ty::FloatTy::F32)),
             f64: mk(Float(ty::FloatTy::F64)),
-            str_: mk(Str),
             self_param: mk(ty::Param(ty::ParamTy { index: 0, name: kw::SelfUpper })),
 
             trait_object_dummy_self: fresh_tys[0],
@@ -1696,9 +1694,13 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
+    pub fn mk_str(self) -> Ty<'tcx> {
+        self.mk_ty(ty::Str)
+    }
+
     #[inline]
     pub fn mk_static_str(self) -> Ty<'tcx> {
-        self.mk_imm_ref(self.lifetimes.re_static, self.types.str_)
+        self.mk_imm_ref(self.lifetimes.re_static, self.mk_str())
     }
 
     #[inline]

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -245,7 +245,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     }
                     let re_erased = tcx.lifetimes.re_erased;
                     let ref_string = self.temp(tcx.mk_imm_ref(re_erased, ty), test.span);
-                    let ref_str_ty = tcx.mk_imm_ref(re_erased, tcx.types.str_);
+                    let ref_str_ty = tcx.mk_imm_ref(re_erased, tcx.mk_str());
                     let ref_str = self.temp(ref_str_ty, test.span);
                     let deref = tcx.require_lang_item(LangItem::Deref, None);
                     let method = trait_method(tcx, deref, sym::deref, [ty]);

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -518,7 +518,7 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
         // See https://github.com/rust-lang/rust/issues/90703#issuecomment-1004263455
         Some(match prim {
             Bool => tcx.types.bool,
-            Str => tcx.types.str_,
+            Str => tcx.mk_str(),
             Char => tcx.types.char,
             Never => tcx.types.never,
             I8 => tcx.types.i8,

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
@@ -497,8 +497,8 @@ fn is_to_string_on_string_like<'a>(
         && let GenericArgKind::Type(ty) = generic_arg.unpack()
         && let Some(deref_trait_id) = cx.tcx.get_diagnostic_item(sym::Deref)
         && let Some(as_ref_trait_id) = cx.tcx.get_diagnostic_item(sym::AsRef)
-        && (cx.get_associated_type(ty, deref_trait_id, "Target") == Some(cx.tcx.types.str_) ||
-            implements_trait(cx, ty, as_ref_trait_id, &[cx.tcx.types.str_.into()])) {
+        && (cx.get_associated_type(ty, deref_trait_id, "Target").map_or(false, |ty| ty.is_str()) ||
+            implements_trait(cx, ty, as_ref_trait_id, &[cx.tcx.mk_str().into()])) {
             true
         } else {
             false

--- a/src/tools/clippy/clippy_lints/src/ptr.rs
+++ b/src/tools/clippy/clippy_lints/src/ptr.rs
@@ -385,7 +385,7 @@ enum DerefTy<'tcx> {
 impl<'tcx> DerefTy<'tcx> {
     fn ty(&self, cx: &LateContext<'tcx>) -> Ty<'tcx> {
         match *self {
-            Self::Str => cx.tcx.types.str_,
+            Self::Str => cx.tcx.mk_str(),
             Self::Path => cx.tcx.mk_adt(
                 cx.tcx.adt_def(cx.tcx.get_diagnostic_item(sym::Path).unwrap()),
                 List::empty(),


### PR DESCRIPTION
Split out of #107939. Hopefully the usages of the interned str type aren't so hot that this is a perf regression. Guess we'll see..

r? @oli-obk