### PR TITLE
rustdoc: use a string with one-character codes for search index types

### DIFF
--- a/src/librustdoc/formats/item_type.rs
+++ b/src/librustdoc/formats/item_type.rs
@@ -21,6 +21,7 @@ use crate::clean;
 /// a heading, edit the listing in `html/render.rs`, function `sidebar_module`. This uses an
 /// ordering based on a helper function inside `item_module`, in the same file.
 #[derive(Copy, PartialEq, Eq, Hash, Clone, Debug, PartialOrd, Ord)]
+#[repr(u8)]
 pub(crate) enum ItemType {
     Module = 0,
     ExternCrate = 1,

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -236,7 +236,16 @@ pub(crate) fn build_index<'tcx>(
             crate_data.serialize_field("doc", &self.doc)?;
             crate_data.serialize_field(
                 "t",
-                &self.items.iter().map(|item| &item.ty).collect::<Vec<_>>(),
+                &self
+                    .items
+                    .iter()
+                    .map(|item| {
+                        let n = item.ty as u8;
+                        let c = char::try_from(n + b'A').expect("item types must fit in ASCII");
+                        assert!(c <= 'z', "item types must fit within ASCII printables");
+                        c
+                    })
+                    .collect::<String>(),
             )?;
             crate_data.serialize_field(
                 "n",

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1939,6 +1939,7 @@ function initSearch(rawSearchIndex) {
          * @type {Array<string>}
          */
         const searchWords = [];
+        const charA = "A".charCodeAt(0);
         let i, word;
         let currentIndex = 0;
         let id = 0;
@@ -1953,7 +1954,7 @@ function initSearch(rawSearchIndex) {
             /**
              * The raw search data for a given crate. `n`, `t`, `d`, and `q`, `i`, and `f`
              * are arrays with the same length. n[i] contains the name of an item.
-             * t[i] contains the type of that item (as a small integer that represents an
+             * t[i] contains the type of that item (as a string of characters that represent an
              * offset in `itemTypes`). d[i] contains the description of that item.
              *
              * q[i] contains the full path of the item, or an empty string indicating
@@ -1980,7 +1981,7 @@ function initSearch(rawSearchIndex) {
              *   doc: string,
              *   a: Object,
              *   n: Array<string>,
-             *   t: Array<Number>,
+             *   t: String,
              *   d: Array<string>,
              *   q: Array<string>,
              *   i: Array<Number>,
@@ -2009,7 +2010,7 @@ function initSearch(rawSearchIndex) {
             searchIndex.push(crateRow);
             currentIndex += 1;
 
-            // an array of (Number) item types
+            // a String of one character item type codes
             const itemTypes = crateCorpus.t;
             // an array of (String) item names
             const itemNames = crateCorpus.n;
@@ -2060,7 +2061,7 @@ function initSearch(rawSearchIndex) {
                 }
                 const row = {
                     crate: crate,
-                    ty: itemTypes[i],
+                    ty: itemTypes.charCodeAt(i) - charA,
                     name: itemNames[i],
                     path: itemPaths[i] ? itemPaths[i] : lastPath,
                     desc: itemDescs[i],


### PR DESCRIPTION
    $ wc -c search-index.old.js search-index.new.js
    3940530 search-index.old.js
    3843222 search-index.new.js

((3940530-3843222)/3940530)*100 = 2.47%

    $ wc -c search-index.old.js.gz search-index.new.js.gz
    380251 search-index.old.js.gz
    379434 search-index.new.js.gz

((380251-379434)/380251)*100 = 0.214%