### PR TITLE
make x look for x.py if shell script does not exist

### DIFF
--- a/src/tools/x/Cargo.toml
+++ b/src/tools/x/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x"
-version = "0.1.0"
+version = "0.1.1"
 description = "Run x.py slightly more conveniently"
 edition = "2021"
 publish = false


### PR DESCRIPTION
Fixes #107907

Manually tested by doing the following after changes were made:
1. `cargo install --path src/tools/x`
2. checked out old version:  commit hash `775c3c0` from https://github.com/rust-lang/rust/pull/99992
3. Ran `x --help` and it works. Previously, it was giving the error `x.py not found`