### PR TITLE
Remove `source_span_untracked`

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -981,13 +981,6 @@ impl<'tcx> TyCtxt<'tcx> {
         self.untracked.definitions.read()
     }
 
-    /// Note that this is *untracked* and should only be used within the query
-    /// system if the result is otherwise tracked through queries
-    #[inline]
-    pub fn source_span_untracked(self, def_id: LocalDefId) -> Span {
-        self.untracked.source_span.get(def_id).copied().unwrap_or(DUMMY_SP)
-    }
-
     #[inline(always)]
     pub fn with_stable_hashing_context<R>(
         self,

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -695,7 +695,11 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for Span {
             let dlo = u32::decode(decoder);
             let dto = u32::decode(decoder);
 
-            let enclosing = decoder.tcx.source_span_untracked(parent.unwrap()).data_untracked();
+            let enclosing = decoder
+                .tcx
+                .dep_graph
+                .with_ignore(|| decoder.tcx.source_span(parent.unwrap()))
+                .data_untracked();
             let span = Span::new(
                 enclosing.lo + BytePos::from_u32(dlo),
                 enclosing.lo + BytePos::from_u32(dto),


### PR DESCRIPTION
it only has one caller, and we can avoid query dep tracking and still call the query

r? @ghost (I want to perf test this first)