### PR TITLE
Avoid using a dead email address as the main email address

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -419,18 +419,18 @@ Nixon Enraght-Moony <nixon.emoony@gmail.com>
 NODA Kai <nodakai@gmail.com>
 oliver <16816606+o752d@users.noreply.github.com>
 Oliver Middleton <olliemail27@gmail.com> <ollie27@users.noreply.github.com>
-Oliver Scherer <oliver.schneider@kit.edu> <git-spam-no-reply9815368754983@oli-obk.de>
-Oliver Scherer <oliver.schneider@kit.edu> <git-spam9815368754983@oli-obk.de>
-Oliver Scherer <oliver.schneider@kit.edu> <github333195615777966@oli-obk.de>
-Oliver Scherer <oliver.schneider@kit.edu> <rust19446194516@oli-obk.de>
-Oliver Scherer <oliver.schneider@kit.edu> <git-no-reply-9879165716479413131@oli-obk.de>
-Oliver Scherer <oliver.schneider@kit.edu> <git1984941651981@oli-obk.de>
-Oliver Scherer <oliver.schneider@kit.edu> <github35764891676564198441@oli-obk.de>
-Oliver Scherer <oliver.schneider@kit.edu> <github6541940@oli-obk.de>
-Oliver Scherer <oliver.schneider@kit.edu> <oli-obk@users.noreply.github.com>
-Oliver Scherer <oliver.schneider@kit.edu> <public.oliver.schneider@kit.edu>
-Oliver Scherer <oliver.schneider@kit.edu> <obk8176014uqher834@olio-obk.de>
-Oliver Scherer <oliver.schneider@kit.edu>
+Oliver Scherer <oli-obk@users.noreply.github.com> <git-spam-no-reply9815368754983@oli-obk.de>
+Oliver Scherer <oli-obk@users.noreply.github.com> <git-spam9815368754983@oli-obk.de>
+Oliver Scherer <oli-obk@users.noreply.github.com> <github333195615777966@oli-obk.de>
+Oliver Scherer <oli-obk@users.noreply.github.com> <rust19446194516@oli-obk.de>
+Oliver Scherer <oli-obk@users.noreply.github.com> <git-no-reply-9879165716479413131@oli-obk.de>
+Oliver Scherer <oli-obk@users.noreply.github.com> <git1984941651981@oli-obk.de>
+Oliver Scherer <oli-obk@users.noreply.github.com> <github35764891676564198441@oli-obk.de>
+Oliver Scherer <oli-obk@users.noreply.github.com> <github6541940@oli-obk.de>
+Oliver Scherer <oli-obk@users.noreply.github.com> <public.oliver.schneider@kit.edu>
+Oliver Scherer <oli-obk@users.noreply.github.com> <oliver.schneider@kit.edu>
+Oliver Scherer <oli-obk@users.noreply.github.com> <obk8176014uqher834@olio-obk.de>
+Oliver Scherer <oli-obk@users.noreply.github.com>
 Ömer Sinan Ağacan <omeragacan@gmail.com>
 Ophir LOJKINE <pere.jobs@gmail.com>
 Ožbolt Menegatti <ozbolt.menegatti@gmail.com> gareins <ozbolt.menegatti@gmail.com>


### PR DESCRIPTION
This caused highfive to welcome me as a new contributor on every PR, because it couldn't find any commits of mine.