### PR TITLE
Use tracked `cstore` queries instead of untracked data

### DIFF
--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -128,10 +128,7 @@ impl<'a> std::fmt::Debug for CrateDump<'a> {
 
 impl CStore {
     pub fn from_tcx(tcx: TyCtxt<'_>) -> &CStore {
-        tcx.cstore_untracked()
-            .as_any()
-            .downcast_ref::<CStore>()
-            .expect("`tcx.cstore` is not a `CStore`")
+        tcx.cstore(()).as_any().downcast_ref::<CStore>().expect("`tcx.cstore` is not a `CStore`")
     }
 
     fn alloc_new_crate_num(&mut self) -> CrateNum {

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -16,7 +16,7 @@ use rustc_middle::middle::stability::DeprecationEntry;
 use rustc_middle::ty::fast_reject::SimplifiedType;
 use rustc_middle::ty::query::{ExternProviders, Providers};
 use rustc_middle::ty::{self, TyCtxt, Visibility};
-use rustc_session::cstore::{CrateSource, CrateStore};
+use rustc_session::cstore::CrateStore;
 use rustc_session::{Session, StableCrateId};
 use rustc_span::hygiene::{ExpnHash, ExpnId};
 use rustc_span::source_map::{Span, Spanned};
@@ -562,10 +562,6 @@ impl CStore {
         self.get_crate_data(def.krate).get_fn_has_self_parameter(def.index, sess)
     }
 
-    pub fn crate_source_untracked(&self, cnum: CrateNum) -> Lrc<CrateSource> {
-        self.get_crate_data(cnum).source.clone()
-    }
-
     pub fn get_span_untracked(&self, def_id: DefId, sess: &Session) -> Span {
         self.get_crate_data(def_id.krate).get_span(def_id.index, sess)
     }
@@ -574,7 +570,7 @@ impl CStore {
         self.get_crate_data(def.krate).def_kind(def.index)
     }
 
-    pub fn crates_untracked(&self) -> impl Iterator<Item = CrateNum> + '_ {
+    fn crates_untracked(&self) -> impl Iterator<Item = CrateNum> + '_ {
         self.iter_crate_data().map(|(cnum, _)| cnum)
     }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -48,6 +48,13 @@ rustc_queries! {
         desc { "getting the source span" }
     }
 
+    query cstore(key: ()) -> &'tcx rustc_session::cstore::CrateStoreDyn {
+        // Accesses untracked data
+        eval_always
+        no_hash
+        desc { "getting the crate store" }
+    }
+
     /// Represents crate as a whole (as distinct from the top-level crate module).
     /// If you call `hir_crate` (e.g., indirectly by calling `tcx.hir().krate()`),
     /// we will have to assume that any change means that you need to be recompiled.

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -55,7 +55,7 @@ use rustc_query_system::dep_graph::DepNodeIndex;
 use rustc_query_system::ich::StableHashingContext;
 use rustc_serialize::opaque::{FileEncodeResult, FileEncoder};
 use rustc_session::config::CrateType;
-use rustc_session::cstore::{CrateStoreDyn, Untracked};
+use rustc_session::cstore::Untracked;
 use rustc_session::lint::Lint;
 use rustc_session::Limit;
 use rustc_session::Session;

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2408,4 +2408,5 @@ pub fn provide(providers: &mut ty::query::Providers) {
     };
     providers.source_span =
         |tcx, def_id| tcx.untracked.source_span.get(def_id).copied().unwrap_or(DUMMY_SP);
+    providers.cstore = |tcx, ()| &*tcx.untracked.cstore;
 }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -970,12 +970,6 @@ impl<'tcx> TyCtxt<'tcx> {
 
     /// Note that this is *untracked* and should only be used within the query
     /// system if the result is otherwise tracked through queries
-    pub fn cstore_untracked(self) -> &'tcx CrateStoreDyn {
-        &*self.untracked.cstore
-    }
-
-    /// Note that this is *untracked* and should only be used within the query
-    /// system if the result is otherwise tracked through queries
     #[inline]
     pub fn definitions_untracked(self) -> ReadGuard<'tcx, Definitions> {
         self.untracked.definitions.read()

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -502,7 +502,7 @@ impl<'a, 'tcx> CacheDecoder<'a, 'tcx> {
                 // expansion, so we use `import_source_files` to ensure that the foreign
                 // source files are actually imported before we call `source_file_by_stable_id`.
                 if stable_id.cnum != LOCAL_CRATE {
-                    self.tcx.cstore_untracked().import_source_files(self.tcx.sess, stable_id.cnum);
+                    self.tcx.cstore(()).import_source_files(self.tcx.sess, stable_id.cnum);
                 }
 
                 source_map
@@ -670,7 +670,7 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for ExpnId {
             expn_id
         } else {
             let index_guess = decoder.foreign_expn_data[&hash];
-            decoder.tcx.cstore_untracked().expn_hash_to_expn_id(
+            decoder.tcx.cstore(()).expn_hash_to_expn_id(
                 decoder.tcx.sess,
                 krate,
                 index_guess,

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -502,7 +502,9 @@ impl<'a, 'tcx> CacheDecoder<'a, 'tcx> {
                 // expansion, so we use `import_source_files` to ensure that the foreign
                 // source files are actually imported before we call `source_file_by_stable_id`.
                 if stable_id.cnum != LOCAL_CRATE {
-                    self.tcx.cstore(()).import_source_files(self.tcx.sess, stable_id.cnum);
+                    self.tcx.dep_graph.with_ignore(|| {
+                        self.tcx.cstore(()).import_source_files(self.tcx.sess, stable_id.cnum)
+                    });
                 }
 
                 source_map
@@ -670,12 +672,7 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for ExpnId {
             expn_id
         } else {
             let index_guess = decoder.foreign_expn_data[&hash];
-            decoder.tcx.cstore(()).expn_hash_to_expn_id(
-                decoder.tcx.sess,
-                krate,
-                index_guess,
-                hash,
-            )
+            decoder.tcx.cstore(()).expn_hash_to_expn_id(decoder.tcx.sess, krate, index_guess, hash)
         };
 
         debug_assert_eq!(expn_id.krate, krate);


### PR DESCRIPTION
The less untracked cases we have, the easier it is to keep incremental from ICEing. Also helps work towards https://github.com/rust-lang/rust/pull/105462