### PR TITLE
Inline `copied` and `next` methods

### DIFF
--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -43,6 +43,7 @@ where
 {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<T> {
         self.it.next().copied()
     }

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1794,6 +1794,7 @@ impl<T> Option<&T> {
     /// let copied = opt_x.copied();
     /// assert_eq!(copied, Some(12));
     /// ```
+    #[inline]
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "copied", since = "1.35.0")]
     #[rustc_const_unstable(feature = "const_option", issue = "67441")]

--- a/tests/codegen/issue-107681-unwrap_unchecked-optimized.rs
+++ b/tests/codegen/issue-107681-unwrap_unchecked-optimized.rs
@@ -1,0 +1,13 @@
+// compile-flags: -C opt-level=3
+
+#![crate_type = "lib"]
+
+extern crate core;
+use core::{iter::Copied, slice::Iter};
+
+// Make sure that the use of unwrap_unchecked is optimized accordingly.
+// i.e., there are no branch jumps.
+pub unsafe fn unwrap_unchecked_optimized(x: &mut Copied<Iter<'_, u32>>) -> u32 {
+    // CHECK-NOT: br
+    x.next().unwrap_unchecked()
+}


### PR DESCRIPTION
This should fix #107681.