### PR TITLE
Don't suggest `#[doc(hidden)]` trait methods with matching return type

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
@@ -504,7 +504,9 @@ fn foo(&self) -> Self::T { String::new() }
         let methods: Vec<(Span, String)> = items
             .in_definition_order()
             .filter(|item| {
-                ty::AssocKind::Fn == item.kind && Some(item.name) != current_method_ident
+                ty::AssocKind::Fn == item.kind
+                    && Some(item.name) != current_method_ident
+                    && !tcx.is_doc_hidden(item.def_id)
             })
             .filter_map(|item| {
                 let method = tcx.fn_sig(item.def_id).subst_identity();

--- a/tests/ui/suggestions/trait-hidden-method.rs
+++ b/tests/ui/suggestions/trait-hidden-method.rs
@@ -1,0 +1,11 @@
+// #107983 - testing that `__iterator_get_unchecked` isn't suggested
+// HELP included so that compiletest errors on the bad suggestion
+pub fn i_can_has_iterator() -> impl Iterator<Item = u32> {
+    //~^ ERROR expected `Box<dyn Iterator>`
+    //~| HELP consider constraining the associated type
+    Box::new(1..=10) as Box<dyn Iterator>
+    //~^ ERROR the value of the associated type `Item`
+    //~| HELP specify the associated type
+}
+
+fn main() {}

--- a/tests/ui/suggestions/trait-hidden-method.stderr
+++ b/tests/ui/suggestions/trait-hidden-method.stderr
@@ -1,0 +1,24 @@
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/trait-hidden-method.rs:6:33
+   |
+LL |     Box::new(1..=10) as Box<dyn Iterator>
+   |                                 ^^^^^^^^ help: specify the associated type: `Iterator<Item = Type>`
+
+error[E0271]: expected `Box<dyn Iterator>` to be an iterator that yields `u32`, but it yields `<dyn Iterator as Iterator>::Item`
+  --> $DIR/trait-hidden-method.rs:3:32
+   |
+LL | pub fn i_can_has_iterator() -> impl Iterator<Item = u32> {
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^ expected associated type, found `u32`
+...
+LL |     Box::new(1..=10) as Box<dyn Iterator>
+   |     ------------------------------------- return type was inferred to be `Box<dyn Iterator>` here
+   |
+   = note: expected associated type `<dyn Iterator as Iterator>::Item`
+                         found type `u32`
+   = help: consider constraining the associated type `<dyn Iterator as Iterator>::Item` to `u32` or calling a method that returns `<dyn Iterator as Iterator>::Item`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0191, E0271.
+For more information about an error, try `rustc --explain E0191`.


### PR DESCRIPTION
Fixes #107983, addressing the bad suggestion.
The test can probably be made more specific to this  case, but I'm unsure how.

@rustbot label +A-diagnostics