### PR TITLE
Prevent some attributes from being merged with others on reexports

### DIFF
--- a/tests/rustdoc/reexport-attr-merge.rs
+++ b/tests/rustdoc/reexport-attr-merge.rs
@@ -1,0 +1,26 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/59368>.
+// The goal is to ensure that `doc(hidden)`, `doc(inline)` and `doc(no_inline`)
+
+#![crate_name = "foo"]
+#![feature(doc_cfg)]
+
+// @has 'foo/index.html'
+
+#[doc(hidden, cfg(feature = "foo"))]
+pub struct Foo;
+
+#[doc(hidden, no_inline, cfg(feature = "bar"))]
+pub use Foo as Foo1;
+
+#[doc(hidden, inline)]
+pub use Foo1 as Foo2;
+
+// First we ensure that none of the other items are generated.
+// @count - '//a[@class="struct"]' 1
+// Then we check that both `cfg` are displayed.
+// @has - '//*[@class="stab portability"]' 'foo'
+// @has - '//*[@class="stab portability"]' 'bar'
+// And finally we check that the only element displayed is `Bar`.
+// @has - '//a[@class="struct"]' 'Bar'
+#[doc(inline)]
+pub use Foo2 as Bar;

--- a/tests/rustdoc/reexport-attr-merge.rs
+++ b/tests/rustdoc/reexport-attr-merge.rs
@@ -1,5 +1,6 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/59368>.
-// The goal is to ensure that `doc(hidden)`, `doc(inline)` and `doc(no_inline`)
+// The goal is to ensure that `doc(hidden)`, `doc(inline)` and `doc(no_inline)`
+// are not copied from an item when inlined.
 
 #![crate_name = "foo"]
 #![feature(doc_cfg)]
@@ -15,8 +16,9 @@ pub use Foo as Foo1;
 #[doc(hidden, inline)]
 pub use Foo1 as Foo2;
 
-// First we ensure that none of the other items are generated.
-// @count - '//a[@class="struct"]' 1
+// First we ensure that only the reexport `Bar2` and the inlined struct `Bar`
+// are inlined.
+// @count - '//a[@class="struct"]' 2
 // Then we check that both `cfg` are displayed.
 // @has - '//*[@class="stab portability"]' 'foo'
 // @has - '//*[@class="stab portability"]' 'bar'
@@ -24,3 +26,8 @@ pub use Foo1 as Foo2;
 // @has - '//a[@class="struct"]' 'Bar'
 #[doc(inline)]
 pub use Foo2 as Bar;
+
+// This one should appear but `Bar2` won't be linked because there is no
+// `#[doc(inline)]`.
+// @has - '//*[@id="reexport.Bar2"]' 'pub use Foo2 as Bar2;'
+pub use Foo2 as Bar2;


### PR DESCRIPTION
Final fix for https://github.com/rust-lang/rust/issues/59368.

As discussed on zulip [here](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Filtering.20sub.20attributes.20in.20ast.3A.3AAttribute), we need to clone the `Attribute` to be able to filter some parts of it. Then we need to go through the attributes to be able to only keep what we want (everything except a few attributes in short).

As for the second commit, when I wrote the test, I realized that the code to traverse all reexports one by one to collect all their attributes was not completely working so I fixed the few issues remaining.

r? @notriddle 