### PR TITLE
Ban associated type bounds in bad positions

### DIFF
--- a/compiler/rustc_ast_lowering/locales/en-US.ftl
+++ b/compiler/rustc_ast_lowering/locales/en-US.ftl
@@ -19,6 +19,9 @@ ast_lowering_remove_parentheses = remove these parentheses
 ast_lowering_misplaced_impl_trait =
     `impl Trait` only allowed in function and inherent method return types, not in {$position}
 
+ast_lowering_misplaced_assoc_ty_binding =
+    associated type bounds are only allowed in where clauses and function signatures, not in {$position}
+
 ast_lowering_rustc_box_attribute_error =
     #[rustc_box] requires precisely one argument and no other attributes are allowed
 

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -79,6 +79,14 @@ pub struct MisplacedImplTrait<'a> {
     pub position: DiagnosticArgFromDisplay<'a>,
 }
 
+#[derive(Diagnostic)]
+#[diag(ast_lowering_misplaced_assoc_ty_binding)]
+pub struct MisplacedAssocTyBinding<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub position: DiagnosticArgFromDisplay<'a>,
+}
+
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_rustc_box_attribute_error)]
 pub struct RustcBoxAttributeError {

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1011,8 +1011,14 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 hir::TypeBindingKind::Equality { term }
             }
             AssocConstraintKind::Bound { bounds } => {
+                enum DesugarKind<'a> {
+                    ImplTrait,
+                    Error(&'a ImplTraitPosition),
+                    Bound,
+                }
+
                 // Piggy-back on the `impl Trait` context to figure out the correct behavior.
-                let (desugar_to_impl_trait, itctx) = match itctx {
+                let desugar_kind = match itctx {
                     // We are in the return position:
                     //
                     //     fn foo() -> impl Iterator<Item: Debug>
@@ -1021,7 +1027,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     //
                     //     fn foo() -> impl Iterator<Item = impl Debug>
                     ImplTraitContext::ReturnPositionOpaqueTy { .. }
-                    | ImplTraitContext::TypeAliasesOpaqueTy { .. } => (true, itctx),
+                    | ImplTraitContext::TypeAliasesOpaqueTy { .. } => DesugarKind::ImplTrait,
 
                     // We are in the argument position, but within a dyn type:
                     //
@@ -1030,7 +1036,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     // so desugar to
                     //
                     //     fn foo(x: dyn Iterator<Item = impl Debug>)
-                    ImplTraitContext::Universal if self.is_in_dyn_type => (true, itctx),
+                    ImplTraitContext::Universal if self.is_in_dyn_type => DesugarKind::ImplTrait,
 
                     // In `type Foo = dyn Iterator<Item: Debug>` we desugar to
                     // `type Foo = dyn Iterator<Item = impl Debug>` but we have to override the
@@ -1039,11 +1045,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     //
                     // FIXME: this is only needed until `impl Trait` is allowed in type aliases.
                     ImplTraitContext::Disallowed(position) if self.is_in_dyn_type => {
-                        self.tcx.sess.emit_err(errors::MisplacedAssocTyBinding {
-                            span: constraint.span,
-                            position: DiagnosticArgFromDisplay(position),
-                        });
-                        (false, itctx)
+                        DesugarKind::Error(position)
                     }
 
                     // We are in the parameter position, but not within a dyn type:
@@ -1053,35 +1055,46 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     // so we leave it as is and this gets expanded in astconv to a bound like
                     // `<T as Iterator>::Item: Debug` where `T` is the type parameter for the
                     // `impl Iterator`.
-                    _ => (false, itctx),
+                    _ => DesugarKind::Bound,
                 };
 
-                if desugar_to_impl_trait {
-                    // Desugar `AssocTy: Bounds` into `AssocTy = impl Bounds`. We do this by
-                    // constructing the HIR for `impl bounds...` and then lowering that.
+                match desugar_kind {
+                    DesugarKind::ImplTrait => {
+                        // Desugar `AssocTy: Bounds` into `AssocTy = impl Bounds`. We do this by
+                        // constructing the HIR for `impl bounds...` and then lowering that.
 
-                    let impl_trait_node_id = self.next_node_id();
+                        let impl_trait_node_id = self.next_node_id();
 
-                    self.with_dyn_type_scope(false, |this| {
-                        let node_id = this.next_node_id();
-                        let ty = this.lower_ty(
-                            &Ty {
-                                id: node_id,
-                                kind: TyKind::ImplTrait(impl_trait_node_id, bounds.clone()),
-                                span: this.lower_span(constraint.span),
-                                tokens: None,
-                            },
-                            itctx,
-                        );
+                        self.with_dyn_type_scope(false, |this| {
+                            let node_id = this.next_node_id();
+                            let ty = this.lower_ty(
+                                &Ty {
+                                    id: node_id,
+                                    kind: TyKind::ImplTrait(impl_trait_node_id, bounds.clone()),
+                                    span: this.lower_span(constraint.span),
+                                    tokens: None,
+                                },
+                                itctx,
+                            );
 
-                        hir::TypeBindingKind::Equality { term: ty.into() }
-                    })
-                } else {
-                    // Desugar `AssocTy: Bounds` into a type binding where the
-                    // later desugars into a trait predicate.
-                    let bounds = self.lower_param_bounds(bounds, itctx);
+                            hir::TypeBindingKind::Equality { term: ty.into() }
+                        })
+                    }
+                    DesugarKind::Bound => {
+                        // Desugar `AssocTy: Bounds` into a type binding where the
+                        // later desugars into a trait predicate.
+                        let bounds = self.lower_param_bounds(bounds, itctx);
 
-                    hir::TypeBindingKind::Constraint { bounds }
+                        hir::TypeBindingKind::Constraint { bounds }
+                    }
+                    DesugarKind::Error(position) => {
+                        self.tcx.sess.emit_err(errors::MisplacedAssocTyBinding {
+                            span: constraint.span,
+                            position: DiagnosticArgFromDisplay(position),
+                        });
+                        let err_ty = &*self.arena.alloc(self.ty(constraint.span, hir::TyKind::Err));
+                        hir::TypeBindingKind::Equality { term: err_ty.into() }
+                    }
                 }
             }
         };

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -288,31 +288,31 @@ enum ImplTraitPosition {
 impl std::fmt::Display for ImplTraitPosition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match self {
-            ImplTraitPosition::Path => "path",
-            ImplTraitPosition::Variable => "variable binding",
-            ImplTraitPosition::Trait => "trait",
-            ImplTraitPosition::AsyncBlock => "async block",
-            ImplTraitPosition::Bound => "bound",
-            ImplTraitPosition::Generic => "generic",
-            ImplTraitPosition::ExternFnParam => "`extern fn` param",
-            ImplTraitPosition::ClosureParam => "closure param",
-            ImplTraitPosition::PointerParam => "`fn` pointer param",
-            ImplTraitPosition::FnTraitParam => "`Fn` trait param",
-            ImplTraitPosition::TraitParam => "trait method param",
-            ImplTraitPosition::ImplParam => "`impl` method param",
-            ImplTraitPosition::ExternFnReturn => "`extern fn` return",
-            ImplTraitPosition::ClosureReturn => "closure return",
-            ImplTraitPosition::PointerReturn => "`fn` pointer return",
-            ImplTraitPosition::FnTraitReturn => "`Fn` trait return",
-            ImplTraitPosition::TraitReturn => "trait method return",
-            ImplTraitPosition::ImplReturn => "`impl` method return",
-            ImplTraitPosition::GenericDefault => "generic parameter default",
-            ImplTraitPosition::ConstTy => "const type",
-            ImplTraitPosition::StaticTy => "static type",
-            ImplTraitPosition::AssocTy => "associated type",
-            ImplTraitPosition::FieldTy => "field type",
-            ImplTraitPosition::Cast => "cast type",
-            ImplTraitPosition::ImplSelf => "impl header",
+            ImplTraitPosition::Path => "paths",
+            ImplTraitPosition::Variable => "variable bindings",
+            ImplTraitPosition::Trait => "traits",
+            ImplTraitPosition::AsyncBlock => "async blocks",
+            ImplTraitPosition::Bound => "bounds",
+            ImplTraitPosition::Generic => "generics",
+            ImplTraitPosition::ExternFnParam => "`extern fn` params",
+            ImplTraitPosition::ClosureParam => "closure params",
+            ImplTraitPosition::PointerParam => "`fn` pointer params",
+            ImplTraitPosition::FnTraitParam => "`Fn` trait params",
+            ImplTraitPosition::TraitParam => "trait method params",
+            ImplTraitPosition::ImplParam => "`impl` method params",
+            ImplTraitPosition::ExternFnReturn => "`extern fn` return types",
+            ImplTraitPosition::ClosureReturn => "closure return types",
+            ImplTraitPosition::PointerReturn => "`fn` pointer return types",
+            ImplTraitPosition::FnTraitReturn => "`Fn` trait return types",
+            ImplTraitPosition::TraitReturn => "trait method return types",
+            ImplTraitPosition::ImplReturn => "`impl` method return types",
+            ImplTraitPosition::GenericDefault => "generic parameter defaults",
+            ImplTraitPosition::ConstTy => "const types",
+            ImplTraitPosition::StaticTy => "static types",
+            ImplTraitPosition::AssocTy => "associated types",
+            ImplTraitPosition::FieldTy => "field types",
+            ImplTraitPosition::Cast => "cast types",
+            ImplTraitPosition::ImplSelf => "impl headers",
         };
 
         write!(f, "{name}")
@@ -1038,12 +1038,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     //     fn foo(x: dyn Iterator<Item = impl Debug>)
                     ImplTraitContext::Universal if self.is_in_dyn_type => DesugarKind::ImplTrait,
 
-                    // In `type Foo = dyn Iterator<Item: Debug>` we desugar to
-                    // `type Foo = dyn Iterator<Item = impl Debug>` but we have to override the
-                    // "impl trait context" to permit `impl Debug` in this position (it desugars
-                    // then to an opaque type).
-                    //
-                    // FIXME: this is only needed until `impl Trait` is allowed in type aliases.
                     ImplTraitContext::Disallowed(position) if self.is_in_dyn_type => {
                         DesugarKind::Error(position)
                     }

--- a/compiler/rustc_ast_passes/locales/en-US.ftl
+++ b/compiler/rustc_ast_passes/locales/en-US.ftl
@@ -11,9 +11,6 @@ ast_passes_forbidden_let_stable =
 ast_passes_deprecated_where_clause_location =
     where clause not allowed here
 
-ast_passes_forbidden_assoc_constraint =
-    associated type bounds are not allowed within structs, enums, or unions
-
 ast_passes_keyword_lifetime =
     lifetimes cannot use keyword names
 

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -24,13 +24,6 @@ pub struct ForbiddenLetStable {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes_forbidden_assoc_constraint)]
-pub struct ForbiddenAssocConstraint {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(ast_passes_keyword_lifetime)]
 pub struct KeywordLifetime {
     #[primary_span]

--- a/tests/ui/associated-consts/issue-105330.stderr
+++ b/tests/ui/associated-consts/issue-105330.stderr
@@ -33,7 +33,7 @@ LL | fn main<A: TraitWAssocConst<A=32>>() {
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl header
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl headers
   --> $DIR/issue-105330.rs:6:27
    |
 LL | impl TraitWAssocConst for impl Demo {

--- a/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.rs
+++ b/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.rs
@@ -1,0 +1,15 @@
+#![feature(associated_type_bounds)]
+
+trait B {
+    type AssocType;
+}
+
+fn f()
+where
+    dyn for<'j> B<AssocType: 'j>:,
+    //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+    //~| ERROR the value of the associated type `AssocType` (from trait `B`) must be specified
+{
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.rs
+++ b/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.rs
@@ -8,7 +8,6 @@ fn f()
 where
     dyn for<'j> B<AssocType: 'j>:,
     //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-    //~| ERROR the value of the associated type `AssocType` (from trait `B`) must be specified
 {
 }
 

--- a/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.stderr
+++ b/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.stderr
@@ -4,15 +4,5 @@ error: associated type bounds are only allowed in where clauses and function sig
 LL |     dyn for<'j> B<AssocType: 'j>:,
    |                   ^^^^^^^^^^^^^
 
-error[E0191]: the value of the associated type `AssocType` (from trait `B`) must be specified
-  --> $DIR/bad-universal-in-dyn-in-where-clause.rs:9:9
-   |
-LL |     type AssocType;
-   |     -------------- `AssocType` defined here
-...
-LL |     dyn for<'j> B<AssocType: 'j>:,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `for<'j> B<AssocType: 'j, AssocType = Type>`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.stderr
+++ b/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.stderr
@@ -1,0 +1,18 @@
+error: associated type bounds are only allowed in where clauses and function signatures, not in bound
+  --> $DIR/bad-universal-in-dyn-in-where-clause.rs:9:19
+   |
+LL |     dyn for<'j> B<AssocType: 'j>:,
+   |                   ^^^^^^^^^^^^^
+
+error[E0191]: the value of the associated type `AssocType` (from trait `B`) must be specified
+  --> $DIR/bad-universal-in-dyn-in-where-clause.rs:9:9
+   |
+LL |     type AssocType;
+   |     -------------- `AssocType` defined here
+...
+LL |     dyn for<'j> B<AssocType: 'j>:,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `for<'j> B<AssocType: 'j, AssocType = Type>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.stderr
+++ b/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.stderr
@@ -1,4 +1,4 @@
-error: associated type bounds are only allowed in where clauses and function signatures, not in bound
+error: associated type bounds are only allowed in where clauses and function signatures, not in bounds
   --> $DIR/bad-universal-in-dyn-in-where-clause.rs:9:19
    |
 LL |     dyn for<'j> B<AssocType: 'j>:,

--- a/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.rs
+++ b/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.rs
@@ -1,0 +1,14 @@
+#![feature(associated_type_bounds)]
+
+trait Trait {
+    type Item;
+}
+
+trait Trait2 {}
+
+// It's not possible to insert a universal `impl Trait` here!
+impl dyn Trait<Item: Trait2> {}
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Trait`) must be specified
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.rs
+++ b/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.rs
@@ -9,6 +9,5 @@ trait Trait2 {}
 // It's not possible to insert a universal `impl Trait` here!
 impl dyn Trait<Item: Trait2> {}
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Trait`) must be specified
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.stderr
+++ b/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.stderr
@@ -1,0 +1,8 @@
+error: associated type bounds are only allowed in where clauses and function signatures, not in impl header
+  --> $DIR/bad-universal-in-impl-sig.rs:10:16
+   |
+LL | impl dyn Trait<Item: Trait2> {}
+   |                ^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.stderr
+++ b/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.stderr
@@ -1,4 +1,4 @@
-error: associated type bounds are only allowed in where clauses and function signatures, not in impl header
+error: associated type bounds are only allowed in where clauses and function signatures, not in impl headers
   --> $DIR/bad-universal-in-impl-sig.rs:10:16
    |
 LL | impl dyn Trait<Item: Trait2> {}

--- a/tests/ui/associated-type-bounds/inside-adt.rs
+++ b/tests/ui/associated-type-bounds/inside-adt.rs
@@ -4,32 +4,23 @@ use std::mem::ManuallyDrop;
 
 struct S1 { f: dyn Iterator<Item: Copy> }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 struct S2 { f: Box<dyn Iterator<Item: Copy>> }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 struct S3 { f: dyn Iterator<Item: 'static> }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 
 enum E1 { V(dyn Iterator<Item: Copy>) }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 enum E3 { V(dyn Iterator<Item: 'static>) }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 
 union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/inside-adt.rs
+++ b/tests/ui/associated-type-bounds/inside-adt.rs
@@ -3,28 +3,33 @@
 use std::mem::ManuallyDrop;
 
 struct S1 { f: dyn Iterator<Item: Copy> }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 struct S2 { f: Box<dyn Iterator<Item: Copy>> }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 struct S3 { f: dyn Iterator<Item: 'static> }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 
 enum E1 { V(dyn Iterator<Item: Copy>) }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
-//~| ERROR the size for values of type `(dyn Iterator<Item = impl Copy> + 'static)`
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 enum E3 { V(dyn Iterator<Item: 'static>) }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
-//~| ERROR the size for values of type `(dyn Iterator<Item = impl Sized + 'static> + 'static)`
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 
 union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
-//~| ERROR the size for values of type `(dyn Iterator<Item = impl Copy> + 'static)`
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
-//~| ERROR the size for values of type `(dyn Iterator<Item = impl Sized + 'static> + 'static)`
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/inside-adt.stderr
+++ b/tests/ui/associated-type-bounds/inside-adt.stderr
@@ -1,131 +1,129 @@
-error: associated type bounds are not allowed within structs, enums, or unions
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
   --> $DIR/inside-adt.rs:5:29
    |
 LL | struct S1 { f: dyn Iterator<Item: Copy> }
    |                             ^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:7:33
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:8:33
    |
 LL | struct S2 { f: Box<dyn Iterator<Item: Copy>> }
    |                                 ^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:9:29
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:11:29
    |
 LL | struct S3 { f: dyn Iterator<Item: 'static> }
    |                             ^^^^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:12:26
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:15:26
    |
 LL | enum E1 { V(dyn Iterator<Item: Copy>) }
    |                          ^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:15:30
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:18:30
    |
 LL | enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
    |                              ^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:17:26
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:21:26
    |
 LL | enum E3 { V(dyn Iterator<Item: 'static>) }
    |                          ^^^^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:21:41
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:25:41
    |
 LL | union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
    |                                         ^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:24:45
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:28:45
    |
 LL | union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
    |                                             ^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:26:41
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:31:41
    |
 LL | union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }
    |                                         ^^^^^^^^^^^^^
 
-error[E0277]: the size for values of type `(dyn Iterator<Item = impl Copy> + 'static)` cannot be known at compilation time
-  --> $DIR/inside-adt.rs:12:13
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:5:20
+   |
+LL | struct S1 { f: dyn Iterator<Item: Copy> }
+   |                    ^^^^^^^^^^^^^^^^^^^^
+   |                    |
+   |                    associated type `Item` must be specified
+   |                    help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
+
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:8:24
+   |
+LL | struct S2 { f: Box<dyn Iterator<Item: Copy>> }
+   |                        ^^^^^^^^^^^^^^^^^^^^
+   |                        |
+   |                        associated type `Item` must be specified
+   |                        help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
+
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:11:20
+   |
+LL | struct S3 { f: dyn Iterator<Item: 'static> }
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Iterator<Item: 'static, Item = Type>`
+
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:15:17
    |
 LL | enum E1 { V(dyn Iterator<Item: Copy>) }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `(dyn Iterator<Item = impl Copy> + 'static)`
-   = note: no field of an enum variant may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
-   |
-LL | enum E1 { V(&dyn Iterator<Item: Copy>) }
-   |             +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL | enum E1 { V(Box<dyn Iterator<Item: Copy>>) }
-   |             ++++                        +
+   |                 ^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 associated type `Item` must be specified
+   |                 help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
 
-error[E0277]: the size for values of type `(dyn Iterator<Item = impl Sized + 'static> + 'static)` cannot be known at compilation time
-  --> $DIR/inside-adt.rs:17:13
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:18:21
+   |
+LL | enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
+   |                     ^^^^^^^^^^^^^^^^^^^^
+   |                     |
+   |                     associated type `Item` must be specified
+   |                     help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
+
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:21:17
    |
 LL | enum E3 { V(dyn Iterator<Item: 'static>) }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `(dyn Iterator<Item = impl Sized + 'static> + 'static)`
-   = note: no field of an enum variant may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
-   |
-LL | enum E3 { V(&dyn Iterator<Item: 'static>) }
-   |             +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL | enum E3 { V(Box<dyn Iterator<Item: 'static>>) }
-   |             ++++                           +
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Iterator<Item: 'static, Item = Type>`
 
-error[E0277]: the size for values of type `(dyn Iterator<Item = impl Copy> + 'static)` cannot be known at compilation time
-  --> $DIR/inside-adt.rs:21:15
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:25:32
    |
 LL | union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: within `ManuallyDrop<(dyn Iterator<Item = impl Copy> + 'static)>`, the trait `Sized` is not implemented for `(dyn Iterator<Item = impl Copy> + 'static)`
-   = note: required because it appears within the type `ManuallyDrop<dyn Iterator<Item = impl Copy>>`
-   = note: no field of a union may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
-   |
-LL | union U1 { f: &ManuallyDrop<dyn Iterator<Item: Copy>> }
-   |               +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL | union U1 { f: Box<ManuallyDrop<dyn Iterator<Item: Copy>>> }
-   |               ++++                                      +
+   |                                ^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                associated type `Item` must be specified
+   |                                help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
 
-error[E0277]: the size for values of type `(dyn Iterator<Item = impl Sized + 'static> + 'static)` cannot be known at compilation time
-  --> $DIR/inside-adt.rs:26:15
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:28:36
+   |
+LL | union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
+   |                                    ^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    associated type `Item` must be specified
+   |                                    help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
+
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:31:32
    |
 LL | union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: within `ManuallyDrop<(dyn Iterator<Item = impl Sized + 'static> + 'static)>`, the trait `Sized` is not implemented for `(dyn Iterator<Item = impl Sized + 'static> + 'static)`
-   = note: required because it appears within the type `ManuallyDrop<dyn Iterator<Item = impl Sized>>`
-   = note: no field of a union may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
-   |
-LL | union U3 { f: &ManuallyDrop<dyn Iterator<Item: 'static>> }
-   |               +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL | union U3 { f: Box<ManuallyDrop<dyn Iterator<Item: 'static>>> }
-   |               ++++                                         +
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Iterator<Item: 'static, Item = Type>`
 
-error: aborting due to 13 previous errors
+error: aborting due to 18 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/associated-type-bounds/inside-adt.stderr
+++ b/tests/ui/associated-type-bounds/inside-adt.stderr
@@ -5,125 +5,52 @@ LL | struct S1 { f: dyn Iterator<Item: Copy> }
    |                             ^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:8:33
+  --> $DIR/inside-adt.rs:7:33
    |
 LL | struct S2 { f: Box<dyn Iterator<Item: Copy>> }
    |                                 ^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:11:29
+  --> $DIR/inside-adt.rs:9:29
    |
 LL | struct S3 { f: dyn Iterator<Item: 'static> }
    |                             ^^^^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:15:26
+  --> $DIR/inside-adt.rs:12:26
    |
 LL | enum E1 { V(dyn Iterator<Item: Copy>) }
    |                          ^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:18:30
+  --> $DIR/inside-adt.rs:14:30
    |
 LL | enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
    |                              ^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:21:26
+  --> $DIR/inside-adt.rs:16:26
    |
 LL | enum E3 { V(dyn Iterator<Item: 'static>) }
    |                          ^^^^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:25:41
+  --> $DIR/inside-adt.rs:19:41
    |
 LL | union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
    |                                         ^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:28:45
+  --> $DIR/inside-adt.rs:21:45
    |
 LL | union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
    |                                             ^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:31:41
+  --> $DIR/inside-adt.rs:23:41
    |
 LL | union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }
    |                                         ^^^^^^^^^^^^^
 
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:5:20
-   |
-LL | struct S1 { f: dyn Iterator<Item: Copy> }
-   |                    ^^^^^^^^^^^^^^^^^^^^
-   |                    |
-   |                    associated type `Item` must be specified
-   |                    help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
+error: aborting due to 9 previous errors
 
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:8:24
-   |
-LL | struct S2 { f: Box<dyn Iterator<Item: Copy>> }
-   |                        ^^^^^^^^^^^^^^^^^^^^
-   |                        |
-   |                        associated type `Item` must be specified
-   |                        help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:11:20
-   |
-LL | struct S3 { f: dyn Iterator<Item: 'static> }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Iterator<Item: 'static, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:15:17
-   |
-LL | enum E1 { V(dyn Iterator<Item: Copy>) }
-   |                 ^^^^^^^^^^^^^^^^^^^^
-   |                 |
-   |                 associated type `Item` must be specified
-   |                 help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:18:21
-   |
-LL | enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
-   |                     ^^^^^^^^^^^^^^^^^^^^
-   |                     |
-   |                     associated type `Item` must be specified
-   |                     help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:21:17
-   |
-LL | enum E3 { V(dyn Iterator<Item: 'static>) }
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Iterator<Item: 'static, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:25:32
-   |
-LL | union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
-   |                                ^^^^^^^^^^^^^^^^^^^^
-   |                                |
-   |                                associated type `Item` must be specified
-   |                                help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:28:36
-   |
-LL | union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
-   |                                    ^^^^^^^^^^^^^^^^^^^^
-   |                                    |
-   |                                    associated type `Item` must be specified
-   |                                    help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:31:32
-   |
-LL | union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Iterator<Item: 'static, Item = Type>`
-
-error: aborting due to 18 previous errors
-
-For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/associated-type-bounds/inside-adt.stderr
+++ b/tests/ui/associated-type-bounds/inside-adt.stderr
@@ -1,52 +1,52 @@
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:5:29
    |
 LL | struct S1 { f: dyn Iterator<Item: Copy> }
    |                             ^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:7:33
    |
 LL | struct S2 { f: Box<dyn Iterator<Item: Copy>> }
    |                                 ^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:9:29
    |
 LL | struct S3 { f: dyn Iterator<Item: 'static> }
    |                             ^^^^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:12:26
    |
 LL | enum E1 { V(dyn Iterator<Item: Copy>) }
    |                          ^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:14:30
    |
 LL | enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
    |                              ^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:16:26
    |
 LL | enum E3 { V(dyn Iterator<Item: 'static>) }
    |                          ^^^^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:19:41
    |
 LL | union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
    |                                         ^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:21:45
    |
 LL | union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
    |                                             ^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:23:41
    |
 LL | union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }

--- a/tests/ui/async-await/in-trait/fn-not-async-err2.rs
+++ b/tests/ui/async-await/in-trait/fn-not-async-err2.rs
@@ -11,7 +11,7 @@ trait MyTrait {
 
 impl MyTrait for i32 {
     fn foo(&self) -> impl Future<Output = i32> {
-        //~^ ERROR `impl Trait` only allowed in function and inherent method return types, not in `impl` method return [E0562]
+        //~^ ERROR `impl Trait` only allowed in function and inherent method return types, not in `impl` method return types
         async { *self }
     }
 }

--- a/tests/ui/async-await/in-trait/fn-not-async-err2.stderr
+++ b/tests/ui/async-await/in-trait/fn-not-async-err2.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `impl` method return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `impl` method return types
   --> $DIR/fn-not-async-err2.rs:13:22
    |
 LL |     fn foo(&self) -> impl Future<Output = i32> {

--- a/tests/ui/feature-gates/feature-gate-associated_type_bounds.stderr
+++ b/tests/ui/feature-gates/feature-gate-associated_type_bounds.stderr
@@ -115,19 +115,19 @@ LL |     let _: impl Tr1<As1: Copy> = S1;
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const types
   --> $DIR/feature-gate-associated_type_bounds.rs:55:14
    |
 LL | const _cdef: impl Tr1<As1: Copy> = S1;
    |              ^^^^^^^^^^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const types
   --> $DIR/feature-gate-associated_type_bounds.rs:61:15
    |
 LL | static _sdef: impl Tr1<As1: Copy> = S1;
    |               ^^^^^^^^^^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/feature-gate-associated_type_bounds.rs:68:12
    |
 LL |     let _: impl Tr1<As1: Copy> = S1;

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_fn_trait_return.stderr
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_fn_trait_return.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
   --> $DIR/feature-gate-impl_trait_in_fn_trait_return.rs:1:24
    |
 LL | fn f() -> impl Fn() -> impl Sized { || () }
@@ -7,7 +7,7 @@ LL | fn f() -> impl Fn() -> impl Sized { || () }
    = note: see issue #99697 <https://github.com/rust-lang/rust/issues/99697> for more information
    = help: add `#![feature(impl_trait_in_fn_trait_return)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
   --> $DIR/feature-gate-impl_trait_in_fn_trait_return.rs:3:32
    |
 LL | fn g() -> &'static dyn Fn() -> impl Sized { &|| () }

--- a/tests/ui/feature-gates/feature-gate-return_position_impl_trait_in_trait.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_position_impl_trait_in_trait.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
   --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:8:17
    |
 LL |     fn bar() -> impl Sized;
@@ -7,7 +7,7 @@ LL |     fn bar() -> impl Sized;
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
   --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:9:21
    |
 LL |     fn baz() -> Box<impl std::fmt::Display>;
@@ -16,7 +16,7 @@ LL |     fn baz() -> Box<impl std::fmt::Display>;
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
   --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:15:23
    |
 LL |     async fn bar() -> impl Sized;

--- a/tests/ui/impl-trait/issues/issue-54600.stderr
+++ b/tests/ui/impl-trait/issues/issue-54600.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-54600.rs:4:19
    |
 LL |     let x: Option<impl Debug> = Some(44_u32);

--- a/tests/ui/impl-trait/issues/issue-54840.stderr
+++ b/tests/ui/impl-trait/issues/issue-54840.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-54840.rs:5:13
    |
 LL |     let j: &impl Add = &i;

--- a/tests/ui/impl-trait/issues/issue-58504.stderr
+++ b/tests/ui/impl-trait/issues/issue-58504.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-58504.rs:10:16
    |
 LL |     let gens: [impl Generator<Return=!, Yield=()>;2] = [ mk_gen(), mk_gen() ];

--- a/tests/ui/impl-trait/issues/issue-58956.stderr
+++ b/tests/ui/impl-trait/issues/issue-58956.stderr
@@ -1,10 +1,10 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const types
   --> $DIR/issue-58956.rs:7:11
    |
 LL | const _A: impl Lam = {
    |           ^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-58956.rs:9:17
    |
 LL |     let x: Wrap<impl Lam> = Wrap(B);

--- a/tests/ui/impl-trait/issues/issue-70971.stderr
+++ b/tests/ui/impl-trait/issues/issue-70971.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-70971.rs:2:14
    |
 LL |     let x : (impl Copy,) = (true,);

--- a/tests/ui/impl-trait/issues/issue-79099.stderr
+++ b/tests/ui/impl-trait/issues/issue-79099.stderr
@@ -9,7 +9,7 @@ LL |         let f: impl core::future::Future<Output = u8> = async { 1 };
    = help: pass `--edition 2021` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-79099.rs:3:16
    |
 LL |         let f: impl core::future::Future<Output = u8> = async { 1 };

--- a/tests/ui/impl-trait/issues/issue-83929-impl-trait-in-generic-default.stderr
+++ b/tests/ui/impl-trait/issues/issue-83929-impl-trait-in-generic-default.stderr
@@ -1,10 +1,10 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/issue-83929-impl-trait-in-generic-default.rs:1:16
    |
 LL | struct Foo<T = impl Copy>(T);
    |                ^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/issue-83929-impl-trait-in-generic-default.rs:4:20
    |
 LL | type Result<T, E = impl std::error::Error> = std::result::Result<T, E>;

--- a/tests/ui/impl-trait/issues/issue-84919.stderr
+++ b/tests/ui/impl-trait/issues/issue-84919.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-84919.rs:5:13
    |
 LL |     let _x: impl Trait = ();

--- a/tests/ui/impl-trait/issues/issue-86642.stderr
+++ b/tests/ui/impl-trait/issues/issue-86642.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const types
   --> $DIR/issue-86642.rs:1:11
    |
 LL | static x: impl Fn(&str) -> Result<&str, ()> = move |source| {

--- a/tests/ui/impl-trait/issues/issue-87295.stderr
+++ b/tests/ui/impl-trait/issues/issue-87295.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-87295.rs:16:31
    |
 LL |     let _do_not_waste: Struct<impl Trait<Output = i32>> = Struct::new(());

--- a/tests/ui/impl-trait/nested_impl_trait.stderr
+++ b/tests/ui/impl-trait/nested_impl_trait.stderr
@@ -34,7 +34,7 @@ LL |     fn bad(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                  |         nested `impl Trait` here
    |                                  outer `impl Trait`
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
   --> $DIR/nested_impl_trait.rs:10:32
    |
 LL | fn bad_in_fn_syntax(x: fn() -> impl Into<impl Debug>) {}

--- a/tests/ui/impl-trait/where-allowed.stderr
+++ b/tests/ui/impl-trait/where-allowed.stderr
@@ -43,109 +43,109 @@ LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer params
   --> $DIR/where-allowed.rs:16:40
    |
 LL | fn in_fn_parameter_in_parameters(_: fn(impl Debug)) { panic!() }
    |                                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
   --> $DIR/where-allowed.rs:20:42
    |
 LL | fn in_fn_return_in_parameters(_: fn() -> impl Debug) { panic!() }
    |                                          ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer params
   --> $DIR/where-allowed.rs:24:38
    |
 LL | fn in_fn_parameter_in_return() -> fn(impl Debug) { panic!() }
    |                                      ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
   --> $DIR/where-allowed.rs:28:40
    |
 LL | fn in_fn_return_in_return() -> fn() -> impl Debug { panic!() }
    |                                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
   --> $DIR/where-allowed.rs:32:49
    |
 LL | fn in_dyn_Fn_parameter_in_parameters(_: &dyn Fn(impl Debug)) { panic!() }
    |                                                 ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
   --> $DIR/where-allowed.rs:36:51
    |
 LL | fn in_dyn_Fn_return_in_parameters(_: &dyn Fn() -> impl Debug) { panic!() }
    |                                                   ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
   --> $DIR/where-allowed.rs:40:55
    |
 LL | fn in_dyn_Fn_parameter_in_return() -> &'static dyn Fn(impl Debug) { panic!() }
    |                                                       ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
   --> $DIR/where-allowed.rs:47:51
    |
 LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                                   ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
   --> $DIR/where-allowed.rs:52:53
    |
 LL | fn in_impl_Fn_return_in_parameters(_: &impl Fn() -> impl Debug) { panic!() }
    |                                                     ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
   --> $DIR/where-allowed.rs:56:57
    |
 LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
    |                                                         ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
   --> $DIR/where-allowed.rs:64:38
    |
 LL | fn in_Fn_parameter_in_generics<F: Fn(impl Debug)> (_: F) { panic!() }
    |                                      ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
   --> $DIR/where-allowed.rs:68:40
    |
 LL | fn in_Fn_return_in_generics<F: Fn() -> impl Debug> (_: F) { panic!() }
    |                                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
   --> $DIR/where-allowed.rs:81:32
    |
 LL | struct InBraceStructField { x: impl Debug }
    |                                ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
   --> $DIR/where-allowed.rs:85:41
    |
 LL | struct InAdtInBraceStructField { x: Vec<impl Debug> }
    |                                         ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
   --> $DIR/where-allowed.rs:89:27
    |
 LL | struct InTupleStructField(impl Debug);
    |                           ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
   --> $DIR/where-allowed.rs:94:25
    |
 LL |     InBraceVariant { x: impl Debug },
    |                         ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
   --> $DIR/where-allowed.rs:96:20
    |
 LL |     InTupleVariant(impl Debug),
    |                    ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
   --> $DIR/where-allowed.rs:107:23
    |
 LL |     fn in_return() -> impl Debug;
@@ -154,7 +154,7 @@ LL |     fn in_return() -> impl Debug;
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `impl` method return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `impl` method return types
   --> $DIR/where-allowed.rs:124:34
    |
 LL |     fn in_trait_impl_return() -> impl Debug { () }
@@ -163,121 +163,121 @@ LL |     fn in_trait_impl_return() -> impl Debug { () }
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` params
   --> $DIR/where-allowed.rs:137:33
    |
 LL |     fn in_foreign_parameters(_: impl Debug);
    |                                 ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` return types
   --> $DIR/where-allowed.rs:140:31
    |
 LL |     fn in_foreign_return() -> impl Debug;
    |                               ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
   --> $DIR/where-allowed.rs:156:39
    |
 LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |                                       ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in traits
   --> $DIR/where-allowed.rs:161:16
    |
 LL | impl PartialEq<impl Debug> for () {
    |                ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl header
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl headers
   --> $DIR/where-allowed.rs:166:24
    |
 LL | impl PartialEq<()> for impl Debug {
    |                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl header
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl headers
   --> $DIR/where-allowed.rs:171:6
    |
 LL | impl impl Debug {
    |      ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl header
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl headers
   --> $DIR/where-allowed.rs:177:24
    |
 LL | impl InInherentImplAdt<impl Debug> {
    |                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bound
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bounds
   --> $DIR/where-allowed.rs:183:11
    |
 LL |     where impl Debug: Debug
    |           ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bound
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bounds
   --> $DIR/where-allowed.rs:190:15
    |
 LL |     where Vec<impl Debug>: Debug
    |               ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bound
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bounds
   --> $DIR/where-allowed.rs:197:24
    |
 LL |     where T: PartialEq<impl Debug>
    |                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
   --> $DIR/where-allowed.rs:204:17
    |
 LL |     where T: Fn(impl Debug)
    |                 ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
   --> $DIR/where-allowed.rs:211:22
    |
 LL |     where T: Fn() -> impl Debug
    |                      ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/where-allowed.rs:217:40
    |
 LL | struct InStructGenericParamDefault<T = impl Debug>(T);
    |                                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/where-allowed.rs:221:36
    |
 LL | enum InEnumGenericParamDefault<T = impl Debug> { Variant(T) }
    |                                    ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/where-allowed.rs:225:38
    |
 LL | trait InTraitGenericParamDefault<T = impl Debug> {}
    |                                      ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/where-allowed.rs:229:41
    |
 LL | type InTypeAliasGenericParamDefault<T = impl Debug> = T;
    |                                         ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/where-allowed.rs:233:11
    |
 LL | impl <T = impl Debug> T {}
    |           ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/where-allowed.rs:240:40
    |
 LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    |                                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/where-allowed.rs:246:29
    |
 LL |     let _in_local_variable: impl Fn() = || {};
    |                             ^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in closure return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in closure return types
   --> $DIR/where-allowed.rs:248:46
    |
 LL |     let _in_return_in_local_variable = || -> impl Fn() { || {} };

--- a/tests/ui/issues/issue-47715.stderr
+++ b/tests/ui/issues/issue-47715.stderr
@@ -1,22 +1,22 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generics
   --> $DIR/issue-47715.rs:9:37
    |
 LL | struct Container<T: Iterable<Item = impl Foo>> {
    |                                     ^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generics
   --> $DIR/issue-47715.rs:14:30
    |
 LL | enum Enum<T: Iterable<Item = impl Foo>> {
    |                              ^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generics
   --> $DIR/issue-47715.rs:19:32
    |
 LL | union Union<T: Iterable<Item = impl Foo> + Copy> {
    |                                ^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generics
   --> $DIR/issue-47715.rs:24:30
    |
 LL | type Type<T: Iterable<Item = impl Foo>> = T;

--- a/tests/ui/type-alias-impl-trait/type-alias-impl-trait-fn-type.stderr
+++ b/tests/ui/type-alias-impl-trait/type-alias-impl-trait-fn-type.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
   --> $DIR/type-alias-impl-trait-fn-type.rs:6:20
    |
 LL | type Foo = fn() -> impl Send;

--- a/tests/ui/typeck/issue-104513-ice.stderr
+++ b/tests/ui/typeck/issue-104513-ice.stderr
@@ -4,7 +4,7 @@ error[E0405]: cannot find trait `Oops` in this scope
 LL |     let _: S<impl Oops> = S;
    |                   ^^^^ not found in this scope
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-104513-ice.rs:3:14
    |
 LL |     let _: S<impl Oops> = S;


### PR DESCRIPTION
We should not try to lower associated type bounds into TAITs in positions where `impl Trait` is not allowed (except for in `where` clauses, like `where T: Trait<Assoc: Bound>`). 

This is achieved by using the same `rustc_ast_lowering` machinery as impl-trait does to characterize positions as universal/existential/disallowed.

Fixes #106077

Split out the first commit into #108066, since it's not really related.