### PR TITLE
Require TAIT flag when using associated type bounds that lower to TAIT

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -133,6 +133,18 @@ impl<'a> PostExpansionVisitor<'a> {
                 }
                 visit::walk_ty(self, ty);
             }
+            fn visit_assoc_constraint(&mut self, constraint: &AssocConstraint) {
+                if let AssocConstraintKind::Bound { .. } = constraint.kind {
+                    gate_feature_post!(
+                        &self.vis,
+                        type_alias_impl_trait,
+                        constraint.span,
+                        "associated type bounds are unstable in this position",
+                        "the bound lowers to a type alias `impl Trait` here, which is unstable"
+                    )
+                }
+                visit::walk_assoc_constraint(self, constraint)
+            }
         }
         ImplTraitVisitor { vis: self }.visit_ty(ty);
     }

--- a/tests/ui/associated-type-bounds/assoc-type-eq-with-dyn-atb-fail.rs
+++ b/tests/ui/associated-type-bounds/assoc-type-eq-with-dyn-atb-fail.rs
@@ -9,6 +9,7 @@
 // we check that the spans for the error message are sane here.
 
 #![feature(associated_type_bounds)]
+#![feature(type_alias_impl_trait)]
 
 fn main() {}
 

--- a/tests/ui/associated-type-bounds/assoc-type-eq-with-dyn-atb-fail.stderr
+++ b/tests/ui/associated-type-bounds/assoc-type-eq-with-dyn-atb-fail.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `String: Copy` is not satisfied
-  --> $DIR/assoc-type-eq-with-dyn-atb-fail.rs:32:18
+  --> $DIR/assoc-type-eq-with-dyn-atb-fail.rs:33:18
    |
 LL |     fn func() -> Self::Out {
    |                  ^^^^^^^^^ the trait `Copy` is not implemented for `String`

--- a/tests/ui/associated-type-bounds/bound-in-type-alias-is-tait.rs
+++ b/tests/ui/associated-type-bounds/bound-in-type-alias-is-tait.rs
@@ -1,0 +1,11 @@
+#![feature(associated_type_bounds)]
+
+trait Foo {
+    type Assoc;
+}
+
+type X = dyn Foo<Assoc: Send>;
+//~^ ERROR associated type bounds are unstable in this position
+//~| ERROR unconstrained opaque type
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/bound-in-type-alias-is-tait.stderr
+++ b/tests/ui/associated-type-bounds/bound-in-type-alias-is-tait.stderr
@@ -1,0 +1,21 @@
+error[E0658]: associated type bounds are unstable in this position
+  --> $DIR/bound-in-type-alias-is-tait.rs:7:18
+   |
+LL | type X = dyn Foo<Assoc: Send>;
+   |                  ^^^^^^^^^^^
+   |
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+   = help: the bound lowers to a type alias `impl Trait` here, which is unstable
+
+error: unconstrained opaque type
+  --> $DIR/bound-in-type-alias-is-tait.rs:7:18
+   |
+LL | type X = dyn Foo<Assoc: Send>;
+   |                  ^^^^^^^^^^^
+   |
+   = note: `X` must be used in combination with a concrete type within the same module
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/associated-type-bounds/dyn-impl-trait-type.rs
+++ b/tests/ui/associated-type-bounds/dyn-impl-trait-type.rs
@@ -1,6 +1,7 @@
 // run-pass
 
 #![feature(associated_type_bounds)]
+#![feature(type_alias_impl_trait)]
 
 use std::ops::Add;
 


### PR DESCRIPTION
Sometimes `associated_type_bounds` lower into TAITs. These are fine, but we should additionally require the user to *acknowledge* this by adding the TAIT feature flag (at least until TAITs are stabilized, which may be soon..)

r? @oli-obk maybe, though this may need lang discussion, and feel free to reassign to someone else.