### PR TITLE
Implement `PartialEq` for all function pointers via a shim

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -381,6 +381,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             | ty::InstanceDef::ReifyShim(..)
             | ty::InstanceDef::ClosureOnceShim { .. }
             | ty::InstanceDef::FnPtrShim(..)
+            | ty::InstanceDef::FnPtrEqShim(..)
             | ty::InstanceDef::DropGlue(..)
             | ty::InstanceDef::CloneShim(..)
             | ty::InstanceDef::Item(_) => {

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -597,7 +597,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                     }
                     CastKind::FnPtrToPtr | CastKind::PtrToPtr => {
                         if !(op_ty.is_any_ptr() && target_type.is_unsafe_ptr()) {
-                            self.fail(location, "Can't cast {op_ty} into 'Ptr'");
+                            self.fail(location, format!("Can't cast {op_ty} into 'Ptr'"));
                         }
                     }
                     CastKind::FloatToFloat | CastKind::FloatToInt => {

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -378,6 +378,7 @@ impl<'tcx> CodegenUnit<'tcx> {
                             | InstanceDef::ReifyShim(..)
                             | InstanceDef::Intrinsic(..)
                             | InstanceDef::FnPtrShim(..)
+                            | InstanceDef::FnPtrEqShim(..)
                             | InstanceDef::Virtual(..)
                             | InstanceDef::ClosureOnceShim { .. }
                             | InstanceDef::DropGlue(..)

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -340,6 +340,7 @@ macro_rules! make_mir_visitor {
 
                         ty::InstanceDef::FnPtrShim(_def_id, ty) |
                         ty::InstanceDef::DropGlue(_def_id, Some(ty)) |
+                        ty::InstanceDef::FnPtrEqShim(_def_id, ty) |
                         ty::InstanceDef::CloneShim(_def_id, ty) => {
                             // FIXME(eddyb) use a better `TyContext` here.
                             self.visit_ty($(& $mutability)? *ty, TyContext::Location(location));

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -96,6 +96,11 @@ pub enum InstanceDef<'tcx> {
     ///
     /// The `DefId` is for `Clone::clone`, the `Ty` is the type `T` with the builtin `Clone` impl.
     CloneShim(DefId, Ty<'tcx>),
+
+    /// `<fn() as PartialEq>::eq` (generated `PartialEq` implementation for `fn()` pointers).
+    ///
+    /// `DefId` is `PartialEq::eq`.
+    FnPtrEqShim(DefId, Ty<'tcx>),
 }
 
 impl<'tcx> Instance<'tcx> {
@@ -147,6 +152,7 @@ impl<'tcx> InstanceDef<'tcx> {
             InstanceDef::VTableShim(def_id)
             | InstanceDef::ReifyShim(def_id)
             | InstanceDef::FnPtrShim(def_id, _)
+            | InstanceDef::FnPtrEqShim(def_id, _)
             | InstanceDef::Virtual(def_id, _)
             | InstanceDef::Intrinsic(def_id)
             | InstanceDef::ClosureOnceShim { call_once: def_id, track_caller: _ }
@@ -163,6 +169,7 @@ impl<'tcx> InstanceDef<'tcx> {
             InstanceDef::VTableShim(..)
             | InstanceDef::ReifyShim(..)
             | InstanceDef::FnPtrShim(..)
+            | InstanceDef::FnPtrEqShim(..)
             | InstanceDef::Virtual(..)
             | InstanceDef::Intrinsic(..)
             | InstanceDef::ClosureOnceShim { .. }
@@ -178,6 +185,7 @@ impl<'tcx> InstanceDef<'tcx> {
             InstanceDef::VTableShim(def_id)
             | InstanceDef::ReifyShim(def_id)
             | InstanceDef::FnPtrShim(def_id, _)
+            | InstanceDef::FnPtrEqShim(def_id, _)
             | InstanceDef::Virtual(def_id, _)
             | InstanceDef::Intrinsic(def_id)
             | InstanceDef::ClosureOnceShim { call_once: def_id, track_caller: _ }
@@ -265,6 +273,7 @@ impl<'tcx> InstanceDef<'tcx> {
         match *self {
             InstanceDef::CloneShim(..)
             | InstanceDef::FnPtrShim(..)
+            | InstanceDef::FnPtrEqShim(..)
             | InstanceDef::DropGlue(_, Some(_)) => false,
             InstanceDef::ClosureOnceShim { .. }
             | InstanceDef::DropGlue(..)
@@ -298,6 +307,7 @@ fn fmt_instance(
         InstanceDef::Intrinsic(_) => write!(f, " - intrinsic"),
         InstanceDef::Virtual(_, num) => write!(f, " - virtual#{}", num),
         InstanceDef::FnPtrShim(_, ty) => write!(f, " - shim({})", ty),
+        InstanceDef::FnPtrEqShim(_, ty) => write!(f, " - shim({ty})"),
         InstanceDef::ClosureOnceShim { .. } => write!(f, " - shim"),
         InstanceDef::DropGlue(_, None) => write!(f, " - shim(None)"),
         InstanceDef::DropGlue(_, Some(ty)) => write!(f, " - shim(Some({}))", ty),

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2293,6 +2293,7 @@ impl<'tcx> TyCtxt<'tcx> {
             ty::InstanceDef::VTableShim(..)
             | ty::InstanceDef::ReifyShim(..)
             | ty::InstanceDef::Intrinsic(..)
+            | ty::InstanceDef::FnPtrEqShim(..)
             | ty::InstanceDef::FnPtrShim(..)
             | ty::InstanceDef::Virtual(..)
             | ty::InstanceDef::ClosureOnceShim { .. }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2301,6 +2301,16 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
+    pub fn trait_method(self, trait_def_id: DefId, method_name: Symbol) -> DefId {
+        // The unhygienic comparison here is acceptable because this is only
+        // used on known traits.
+        self.associated_items(trait_def_id)
+            .filter_by_name_unhygienic(method_name)
+            .find(|item| item.kind == ty::AssocKind::Fn)
+            .expect("trait method not found")
+            .def_id
+    }
+
     // FIXME(@lcnr): Remove this function.
     pub fn get_attrs_unchecked(self, did: DefId) -> &'tcx [ast::Attribute] {
         if let Some(did) = did.as_local() {

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2088,6 +2088,7 @@ impl<'tcx> Ty<'tcx> {
         }
     }
 
+    #[track_caller]
     pub fn fn_sig(self, tcx: TyCtxt<'tcx>) -> PolyFnSig<'tcx> {
         match self.kind() {
             FnDef(def_id, substs) => tcx.fn_sig(*def_id).subst(tcx, substs),

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -837,15 +837,9 @@ fn trait_method<'tcx>(
     method_name: Symbol,
     substs: impl IntoIterator<Item = impl Into<GenericArg<'tcx>>>,
 ) -> ConstantKind<'tcx> {
-    // The unhygienic comparison here is acceptable because this is only
-    // used on known traits.
-    let item = tcx
-        .associated_items(trait_def_id)
-        .filter_by_name_unhygienic(method_name)
-        .find(|item| item.kind == ty::AssocKind::Fn)
-        .expect("trait method not found");
+    let def_id = tcx.trait_method(trait_def_id, method_name);
 
-    let method_ty = tcx.mk_fn_def(item.def_id, substs);
+    let method_ty = tcx.mk_fn_def(def_id, substs);
 
     ConstantKind::zero_sized(method_ty)
 }

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -268,6 +268,7 @@ impl<'tcx> Inliner<'tcx> {
             InstanceDef::VTableShim(_)
             | InstanceDef::ReifyShim(_)
             | InstanceDef::FnPtrShim(..)
+            | InstanceDef::FnPtrEqShim(..)
             | InstanceDef::ClosureOnceShim { .. }
             | InstanceDef::DropGlue(..)
             | InstanceDef::CloneShim(..) => return Ok(()),

--- a/compiler/rustc_mir_transform/src/inline/cycle.rs
+++ b/compiler/rustc_mir_transform/src/inline/cycle.rs
@@ -82,6 +82,7 @@ pub(crate) fn mir_callgraph_reachable<'tcx>(
                 InstanceDef::VTableShim(_)
                 | InstanceDef::ReifyShim(_)
                 | InstanceDef::FnPtrShim(..)
+                | InstanceDef::FnPtrEqShim(..)
                 | InstanceDef::ClosureOnceShim { .. }
                 | InstanceDef::CloneShim(..) => {}
                 InstanceDef::DropGlue(..) => {

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -975,6 +975,7 @@ fn visit_instance_use<'tcx>(
         | ty::InstanceDef::ClosureOnceShim { .. }
         | ty::InstanceDef::Item(..)
         | ty::InstanceDef::FnPtrShim(..)
+        | ty::InstanceDef::FnPtrEqShim(..)
         | ty::InstanceDef::CloneShim(..) => {
             output.push(create_fn_mono_item(tcx, instance, source));
         }

--- a/compiler/rustc_monomorphize/src/partitioning/default.rs
+++ b/compiler/rustc_monomorphize/src/partitioning/default.rs
@@ -274,6 +274,7 @@ fn characteristic_def_id_of_mono_item<'tcx>(
                 ty::InstanceDef::VTableShim(..)
                 | ty::InstanceDef::ReifyShim(..)
                 | ty::InstanceDef::FnPtrShim(..)
+                | ty::InstanceDef::FnPtrEqShim(..)
                 | ty::InstanceDef::ClosureOnceShim { .. }
                 | ty::InstanceDef::Intrinsic(..)
                 | ty::InstanceDef::DropGlue(..)
@@ -428,6 +429,7 @@ fn mono_item_visibility<'tcx>(
         InstanceDef::VTableShim(..)
         | InstanceDef::ReifyShim(..)
         | InstanceDef::FnPtrShim(..)
+        | InstanceDef::FnPtrEqShim(..)
         | InstanceDef::Virtual(..)
         | InstanceDef::Intrinsic(..)
         | InstanceDef::ClosureOnceShim { .. }

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -269,6 +269,22 @@ fn resolve_associated_item<'tcx>(
                     let substs = tcx.erase_regions(rcvr_substs);
                     Some(ty::Instance::new(trait_item_id, substs))
                 }
+            } else if Some(trait_ref.def_id) == tcx.lang_items().eq_trait() {
+                // FIXME(eddyb) use lang items for methods instead of names.
+                let name = tcx.item_name(trait_item_id);
+                if name == sym::eq {
+                    let self_ty = trait_ref.self_ty();
+                    Some(Instance {
+                        def: ty::InstanceDef::FnPtrEqShim(trait_item_id, self_ty),
+                        substs: rcvr_substs,
+                    })
+                } else {
+                    assert_eq!(name, sym::ne);
+
+                    // Use the default `fn ne` from `trait PartialEq`.
+                    let substs = tcx.erase_regions(rcvr_substs);
+                    Some(ty::Instance::new(trait_item_id, substs))
+                }
             } else {
                 None
             }

--- a/tests/ui/fn/fn-ptr-eq-op.rs
+++ b/tests/ui/fn/fn-ptr-eq-op.rs
@@ -1,0 +1,33 @@
+fn foo(_: &()) {}
+
+fn main() {
+    let x: for<'a> fn(&'a ()) = foo;
+    let y: for<'a> fn(&'a ()) = foo;
+    x == y; //~ ERROR: `==` cannot be applied
+
+    let x: for<'a> fn(&'a ()) = foo;
+    let y: fn(&()) = foo;
+    x == y; //~ ERROR: `==` cannot be applied
+
+    let x: fn(&()) = foo;
+    let y: for<'a> fn(&'a ()) = foo;
+    x == y; //~ ERROR: `==` cannot be applied
+
+    let x: for<'a> fn(&'a ()) = foo;
+    let y: for<'a> fn(&'a ()) = foo;
+    x == foo; //~ ERROR: `==` cannot be applied
+    y == foo; //~ ERROR: `==` cannot be applied
+    foo == x; //~ ERROR: `==` cannot be applied
+    //~^ ERROR mismatched types
+    foo == y; //~ ERROR: `==` cannot be applied
+    //~^ ERROR mismatched types
+
+    let x: for<'a> fn(&'a ()) = foo;
+    let y: fn(&'static ()) = foo;
+    x == y; //~ ERROR: `==` cannot be applied
+
+    let x: fn(&'static ()) = foo;
+    let y: fn(&'static ()) = foo;
+    foo == x; //~ ERROR: `==` cannot be applied
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/fn/fn-ptr-eq-op.stderr
+++ b/tests/ui/fn/fn-ptr-eq-op.stderr
@@ -1,0 +1,148 @@
+error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a ())`
+  --> $DIR/fn-ptr-eq-op.rs:6:7
+   |
+LL |     x == y;
+   |     - ^^ - fn(&())
+   |     |
+   |     for<'a> fn(&'a ())
+   |
+help: use parentheses to call these
+   |
+LL |     x(/* &() */) == y(/* &() */);
+   |      +++++++++++     +++++++++++
+
+error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a ())`
+  --> $DIR/fn-ptr-eq-op.rs:10:7
+   |
+LL |     x == y;
+   |     - ^^ - fn(&())
+   |     |
+   |     for<'a> fn(&'a ())
+   |
+help: use parentheses to call these
+   |
+LL |     x(/* &() */) == y(/* &() */);
+   |      +++++++++++     +++++++++++
+
+error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a ())`
+  --> $DIR/fn-ptr-eq-op.rs:14:7
+   |
+LL |     x == y;
+   |     - ^^ - fn(&())
+   |     |
+   |     for<'a> fn(&'a ())
+   |
+help: use parentheses to call these
+   |
+LL |     x(/* &() */) == y(/* &() */);
+   |      +++++++++++     +++++++++++
+
+error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a ())`
+  --> $DIR/fn-ptr-eq-op.rs:18:7
+   |
+LL |     x == foo;
+   |     - ^^ --- fn(&())
+   |     |
+   |     for<'a> fn(&'a ())
+   |
+help: use parentheses to call these
+   |
+LL |     x(/* &() */) == foo(/* &() */);
+   |      +++++++++++       +++++++++++
+
+error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a ())`
+  --> $DIR/fn-ptr-eq-op.rs:19:7
+   |
+LL |     y == foo;
+   |     - ^^ --- fn(&())
+   |     |
+   |     for<'a> fn(&'a ())
+   |
+help: use parentheses to call these
+   |
+LL |     y(/* &() */) == foo(/* &() */);
+   |      +++++++++++       +++++++++++
+
+error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a ()) {foo}`
+  --> $DIR/fn-ptr-eq-op.rs:20:9
+   |
+LL |     foo == x;
+   |     --- ^^ - for<'a> fn(&'a ())
+   |     |
+   |     for<'a> fn(&'a ()) {foo}
+   |
+help: use parentheses to call these
+   |
+LL |     foo(/* &() */) == x(/* &() */);
+   |        +++++++++++     +++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/fn-ptr-eq-op.rs:20:12
+   |
+LL |     foo == x;
+   |            ^ expected fn item, found fn pointer
+   |
+   = note: expected fn item `for<'a> fn(&'a ()) {foo}`
+           found fn pointer `for<'a> fn(&'a ())`
+
+error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a ()) {foo}`
+  --> $DIR/fn-ptr-eq-op.rs:22:9
+   |
+LL |     foo == y;
+   |     --- ^^ - for<'a> fn(&'a ())
+   |     |
+   |     for<'a> fn(&'a ()) {foo}
+   |
+help: use parentheses to call these
+   |
+LL |     foo(/* &() */) == y(/* &() */);
+   |        +++++++++++     +++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/fn-ptr-eq-op.rs:22:12
+   |
+LL |     foo == y;
+   |            ^ expected fn item, found fn pointer
+   |
+   = note: expected fn item `for<'a> fn(&'a ()) {foo}`
+           found fn pointer `for<'a> fn(&'a ())`
+
+error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a ())`
+  --> $DIR/fn-ptr-eq-op.rs:27:7
+   |
+LL |     x == y;
+   |     - ^^ - fn(&())
+   |     |
+   |     for<'a> fn(&'a ())
+   |
+help: use parentheses to call these
+   |
+LL |     x(/* &() */) == y(/* &() */);
+   |      +++++++++++     +++++++++++
+
+error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a ()) {foo}`
+  --> $DIR/fn-ptr-eq-op.rs:32:9
+   |
+LL |     foo == x;
+   |     --- ^^ - fn(&())
+   |     |
+   |     for<'a> fn(&'a ()) {foo}
+   |
+help: use parentheses to call these
+   |
+LL |     foo(/* &() */) == x(/* &() */);
+   |        +++++++++++     +++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/fn-ptr-eq-op.rs:32:12
+   |
+LL |     foo == x;
+   |            ^ expected fn item, found fn pointer
+   |
+   = note: expected fn item `for<'a> fn(&'a ()) {foo}`
+           found fn pointer `fn(&())`
+
+error: aborting due to 12 previous errors
+
+Some errors have detailed explanations: E0308, E0369.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/fn/fn-ptr-eq.rs
+++ b/tests/ui/fn/fn-ptr-eq.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+fn foo(_: &()) {}
+
+fn main() {
+    let x: for<'a> fn(&'a ()) = foo;
+    let y: for<'a> fn(&'a ()) = foo;
+    bar(x, y);
+
+    let x: fn(&'static ()) = foo;
+    let y: for<'a> fn(&'a ()) = foo;
+    x == y;
+    let x: fn(&'static ()) = foo;
+    let y: fn(&'static ()) = foo;
+    x == y;
+    x == foo;
+}
+
+fn bar<T: PartialEq>(_: T, _: T) {}


### PR DESCRIPTION
This allows comparing higher kinded function pointers, at least directly via `PartialEq`. `==` has too much magic to work with this.

We can implement this in libstd without needing a shim once https://github.com/rust-lang/rust/pull/99531 lands

this unblocks https://github.com/rust-lang/rust/pull/105750

r? types