### PR TITLE
Do not ICE on unmet trait alias bounds

### DIFF
--- a/tests/ui/traits/alias/issue-108072-unmet-trait-alias-bound.rs
+++ b/tests/ui/traits/alias/issue-108072-unmet-trait-alias-bound.rs
@@ -1,0 +1,11 @@
+// Regression test for #108072: do not ICE upon unmet trait alias constraint
+
+#![feature(trait_alias)]
+
+trait IteratorAlias = Iterator;
+
+fn f(_: impl IteratorAlias) {}
+
+fn main() {
+    f(()) //~ `()` is not an iterator
+}

--- a/tests/ui/traits/alias/issue-108072-unmet-trait-alias-bound.stderr
+++ b/tests/ui/traits/alias/issue-108072-unmet-trait-alias-bound.stderr
@@ -1,0 +1,18 @@
+error[E0277]: `()` is not an iterator
+  --> $DIR/issue-108072-unmet-trait-alias-bound.rs:10:7
+   |
+LL |     f(())
+   |     - ^^ `()` is not an iterator
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Iterator` is not implemented for `()`
+note: required by a bound in `f`
+  --> $DIR/issue-108072-unmet-trait-alias-bound.rs:7:14
+   |
+LL | fn f(_: impl IteratorAlias) {}
+   |              ^^^^^^^^^^^^^ required by this bound in `f`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Obligations derived from trait alias predicates are not from any `impl` and therefore should be `DerivedObligation` rather than `ImplDerivedObligation`.

Fixes #108072

r? compiler