### PR TITLE
Improve niche placement by trying two strategies and picking the better result

### DIFF
--- a/tests/codegen/issues/issue-103840.rs
+++ b/tests/codegen/issues/issue-103840.rs
@@ -1,4 +1,5 @@
 // compile-flags: -O
+// min-llvm-version: 16.0
 #![crate_type = "lib"]
 
 pub fn foo(t: &mut Vec<usize>) {

--- a/tests/codegen/issues/issue-105386-ub-in-debuginfo.rs
+++ b/tests/codegen/issues/issue-105386-ub-in-debuginfo.rs
@@ -19,4 +19,5 @@ pub fn outer_function(x: S, y: S) -> usize {
 // CHECK-NOT: [[ptr_tmp:%.*]] = getelementptr inbounds %"[closure@{{.*.rs}}:9:23: 9:25]", ptr [[spill]]
 // CHECK-NOT: [[load:%.*]] = load ptr, ptr
 // CHECK: call void @llvm.lifetime.start{{.*}}({{.*}}, ptr [[spill]])
-// CHECK: call void @llvm.memcpy{{.*}}(ptr {{align .*}} [[spill]], ptr {{align .*}} %x
+// CHECK: [[inner:%.*]] = getelementptr inbounds %"{{.*}}", ptr [[spill]]
+// CHECK: call void @llvm.memcpy{{.*}}(ptr {{align .*}} [[inner]], ptr {{align .*}} %x

--- a/tests/codegen/issues/issue-86106.rs
+++ b/tests/codegen/issues/issue-86106.rs
@@ -1,4 +1,5 @@
 // min-llvm-version: 15.0
+// only-64bit llvm appears to use stores instead of memset on 32bit
 // compile-flags: -C opt-level=3 -Z merge-functions=disabled
 
 // The below two functions ensure that both `String::new()` and `"".to_string()`
@@ -19,9 +20,9 @@ pub fn string_new() -> String {
 // CHECK-LABEL: define void @empty_to_string
 #[no_mangle]
 pub fn empty_to_string() -> String {
-    // CHECK: getelementptr
+    // CHECK: store ptr inttoptr
+    // CHECK-NEXT: getelementptr
     // CHECK-NEXT: call void @llvm.memset
-    // CHECK-NEXT: store ptr inttoptr
     // CHECK-NEXT: ret void
     "".to_string()
 }

--- a/tests/codegen/issues/issue-86106.rs
+++ b/tests/codegen/issues/issue-86106.rs
@@ -9,12 +9,9 @@
 // CHECK-LABEL: define void @string_new
 #[no_mangle]
 pub fn string_new() -> String {
-    // CHECK-NOT: load i8
-    // CHECK: store i{{32|64}}
+    // CHECK: store ptr inttoptr
     // CHECK-NEXT: getelementptr
-    // CHECK-NEXT: store ptr
-    // CHECK-NEXT: getelementptr
-    // CHECK-NEXT: store i{{32|64}}
+    // CHECK-NEXT: call void @llvm.memset
     // CHECK-NEXT: ret void
     String::new()
 }
@@ -22,12 +19,9 @@ pub fn string_new() -> String {
 // CHECK-LABEL: define void @empty_to_string
 #[no_mangle]
 pub fn empty_to_string() -> String {
-    // CHECK-NOT: load i8
-    // CHECK: store i{{32|64}}
-    // CHECK-NEXT: getelementptr
-    // CHECK-NEXT: store ptr
-    // CHECK-NEXT: getelementptr
-    // CHECK-NEXT: store i{{32|64}}
+    // CHECK: getelementptr
+    // CHECK-NEXT: call void @llvm.memset
+    // CHECK-NEXT: store ptr inttoptr
     // CHECK-NEXT: ret void
     "".to_string()
 }
@@ -38,12 +32,9 @@ pub fn empty_to_string() -> String {
 // CHECK-LABEL: @empty_vec
 #[no_mangle]
 pub fn empty_vec() -> Vec<u8> {
-    // CHECK: store i{{32|64}}
-    // CHECK-NOT: load i8
+    // CHECK: store ptr inttoptr
     // CHECK-NEXT: getelementptr
-    // CHECK-NEXT: store ptr
-    // CHECK-NEXT: getelementptr
-    // CHECK-NEXT: store i{{32|64}}
+    // CHECK-NEXT: call void @llvm.memset
     // CHECK-NEXT: ret void
     vec![]
 }
@@ -51,12 +42,9 @@ pub fn empty_vec() -> Vec<u8> {
 // CHECK-LABEL: @empty_vec_clone
 #[no_mangle]
 pub fn empty_vec_clone() -> Vec<u8> {
-    // CHECK: store i{{32|64}}
-    // CHECK-NOT: load i8
+    // CHECK: store ptr inttoptr
     // CHECK-NEXT: getelementptr
-    // CHECK-NEXT: store ptr
-    // CHECK-NEXT: getelementptr
-    // CHECK-NEXT: store i{{32|64}}
+    // CHECK-NEXT: call void @llvm.memset
     // CHECK-NEXT: ret void
     vec![].clone()
 }

--- a/tests/ui/async-await/future-sizes/async-awaiting-fut.stdout
+++ b/tests/ui/async-await/future-sizes/async-awaiting-fut.stdout
@@ -2,38 +2,34 @@ print-type-size type: `[async fn body@$DIR/async-awaiting-fut.rs:21:21: 24:2]`: 
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 0 bytes
 print-type-size     variant `Suspend0`: 3077 bytes
-print-type-size         local `.__awaitee`: 3077 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         local `.__awaitee`: 3077 bytes
 print-type-size     variant `Returned`: 0 bytes
 print-type-size     variant `Panicked`: 0 bytes
 print-type-size type: `[async fn body@$DIR/async-awaiting-fut.rs:10:64: 19:2]`: 3077 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
-print-type-size     variant `Unresumed`: 2051 bytes
-print-type-size         padding: 1026 bytes
-print-type-size         upvar `.fut`: 1025 bytes, alignment: 1 bytes
+print-type-size     variant `Unresumed`: 1025 bytes
+print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
 print-type-size     variant `Suspend0`: 2052 bytes
-print-type-size         local `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
-print-type-size         local `..generator_field4`: 1 bytes
+print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
 print-type-size         padding: 1 bytes
-print-type-size         upvar `.fut`: 1025 bytes, alignment: 1 bytes
+print-type-size         local `.fut`: 1025 bytes, alignment: 1 bytes
+print-type-size         local `..generator_field4`: 1 bytes
 print-type-size         local `.__awaitee`: 1 bytes
 print-type-size     variant `Suspend1`: 3076 bytes
-print-type-size         padding: 1024 bytes
+print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         padding: 1026 bytes
 print-type-size         local `..generator_field4`: 1 bytes, alignment: 1 bytes
-print-type-size         padding: 1 bytes
-print-type-size         upvar `.fut`: 1025 bytes, alignment: 1 bytes
 print-type-size         local `.__awaitee`: 1025 bytes
 print-type-size     variant `Suspend2`: 2052 bytes
-print-type-size         local `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
-print-type-size         local `..generator_field4`: 1 bytes
+print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
 print-type-size         padding: 1 bytes
-print-type-size         upvar `.fut`: 1025 bytes, alignment: 1 bytes
+print-type-size         local `.fut`: 1025 bytes, alignment: 1 bytes
+print-type-size         local `..generator_field4`: 1 bytes
 print-type-size         local `.__awaitee`: 1 bytes
-print-type-size     variant `Returned`: 2051 bytes
-print-type-size         padding: 1026 bytes
-print-type-size         upvar `.fut`: 1025 bytes, alignment: 1 bytes
-print-type-size     variant `Panicked`: 2051 bytes
-print-type-size         padding: 1026 bytes
-print-type-size         upvar `.fut`: 1025 bytes, alignment: 1 bytes
+print-type-size     variant `Returned`: 1025 bytes
+print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size     variant `Panicked`: 1025 bytes
+print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
 print-type-size type: `std::mem::ManuallyDrop<[async fn body@$DIR/async-awaiting-fut.rs:10:64: 19:2]>`: 3077 bytes, alignment: 1 bytes
 print-type-size     field `.value`: 3077 bytes
 print-type-size type: `std::mem::MaybeUninit<[async fn body@$DIR/async-awaiting-fut.rs:10:64: 19:2]>`: 3077 bytes, alignment: 1 bytes
@@ -43,11 +39,11 @@ print-type-size         field `.value`: 3077 bytes
 print-type-size type: `[async fn body@$DIR/async-awaiting-fut.rs:8:35: 8:37]`: 1025 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 1024 bytes
-print-type-size         upvar `.arg`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.arg`: 1024 bytes
 print-type-size     variant `Returned`: 1024 bytes
-print-type-size         upvar `.arg`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.arg`: 1024 bytes
 print-type-size     variant `Panicked`: 1024 bytes
-print-type-size         upvar `.arg`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.arg`: 1024 bytes
 print-type-size type: `std::mem::ManuallyDrop<[async fn body@$DIR/async-awaiting-fut.rs:8:35: 8:37]>`: 1025 bytes, alignment: 1 bytes
 print-type-size     field `.value`: 1025 bytes
 print-type-size type: `std::mem::MaybeUninit<[async fn body@$DIR/async-awaiting-fut.rs:8:35: 8:37]>`: 1025 bytes, alignment: 1 bytes

--- a/tests/ui/async-await/future-sizes/large-arg.stdout
+++ b/tests/ui/async-await/future-sizes/large-arg.stdout
@@ -2,20 +2,20 @@ print-type-size type: `[async fn body@$DIR/large-arg.rs:6:21: 8:2]`: 3076 bytes,
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 0 bytes
 print-type-size     variant `Suspend0`: 3075 bytes
-print-type-size         local `.__awaitee`: 3075 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         local `.__awaitee`: 3075 bytes
 print-type-size     variant `Returned`: 0 bytes
 print-type-size     variant `Panicked`: 0 bytes
 print-type-size type: `[async fn body@$DIR/large-arg.rs:10:30: 12:2]`: 3075 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.t`: 1024 bytes
 print-type-size     variant `Suspend0`: 3074 bytes
-print-type-size         upvar `.t`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.t`: 1024 bytes
 print-type-size         local `.__awaitee`: 2050 bytes
 print-type-size     variant `Returned`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.t`: 1024 bytes
 print-type-size     variant `Panicked`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.t`: 1024 bytes
 print-type-size type: `std::mem::ManuallyDrop<[async fn body@$DIR/large-arg.rs:10:30: 12:2]>`: 3075 bytes, alignment: 1 bytes
 print-type-size     field `.value`: 3075 bytes
 print-type-size type: `std::mem::MaybeUninit<[async fn body@$DIR/large-arg.rs:10:30: 12:2]>`: 3075 bytes, alignment: 1 bytes
@@ -25,14 +25,14 @@ print-type-size         field `.value`: 3075 bytes
 print-type-size type: `[async fn body@$DIR/large-arg.rs:13:26: 15:2]`: 2050 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.t`: 1024 bytes
 print-type-size     variant `Suspend0`: 2049 bytes
-print-type-size         upvar `.t`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.t`: 1024 bytes
 print-type-size         local `.__awaitee`: 1025 bytes
 print-type-size     variant `Returned`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.t`: 1024 bytes
 print-type-size     variant `Panicked`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.t`: 1024 bytes
 print-type-size type: `std::mem::ManuallyDrop<[async fn body@$DIR/large-arg.rs:13:26: 15:2]>`: 2050 bytes, alignment: 1 bytes
 print-type-size     field `.value`: 2050 bytes
 print-type-size type: `std::mem::MaybeUninit<[async fn body@$DIR/large-arg.rs:13:26: 15:2]>`: 2050 bytes, alignment: 1 bytes
@@ -42,11 +42,11 @@ print-type-size         field `.value`: 2050 bytes
 print-type-size type: `[async fn body@$DIR/large-arg.rs:16:26: 18:2]`: 1025 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.t`: 1024 bytes
 print-type-size     variant `Returned`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.t`: 1024 bytes
 print-type-size     variant `Panicked`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.t`: 1024 bytes
 print-type-size type: `std::mem::ManuallyDrop<[async fn body@$DIR/large-arg.rs:16:26: 18:2]>`: 1025 bytes, alignment: 1 bytes
 print-type-size     field `.value`: 1025 bytes
 print-type-size type: `std::mem::MaybeUninit<[async fn body@$DIR/large-arg.rs:16:26: 18:2]>`: 1025 bytes, alignment: 1 bytes

--- a/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
@@ -465,7 +465,7 @@ LL | const LAYOUT_INVALID_ZERO: Layout = unsafe { Layout::from_size_align_unchec
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               00 10 00 00 00 00 00 00                         │ ........
+               00 00 00 00 00 10 00 00                         │ ........
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -476,7 +476,7 @@ LL | const LAYOUT_INVALID_THREE: Layout = unsafe { Layout::from_size_align_unche
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               09 00 00 00 03 00 00 00                         │ ........
+               03 00 00 00 09 00 00 00                         │ ........
            }
 
 error[E0080]: it is undefined behavior to use this value

--- a/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
@@ -465,7 +465,7 @@ LL | const LAYOUT_INVALID_ZERO: Layout = unsafe { Layout::from_size_align_unchec
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               00 10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+               00 00 00 00 00 00 00 00 00 10 00 00 00 00 00 00 │ ................
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -476,7 +476,7 @@ LL | const LAYOUT_INVALID_THREE: Layout = unsafe { Layout::from_size_align_unche
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               09 00 00 00 00 00 00 00 03 00 00 00 00 00 00 00 │ ................
+               03 00 00 00 00 00 00 00 09 00 00 00 00 00 00 00 │ ................
            }
 
 error[E0080]: it is undefined behavior to use this value

--- a/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
+++ b/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
@@ -370,12 +370,6 @@ error: layout_of(NicheFirst) = Layout {
                pref: $PREF_ALIGN,
            },
            abi: ScalarPair(
-               Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
                Initialized {
                    value: Int(
                        I8,
@@ -383,10 +377,16 @@ error: layout_of(NicheFirst) = Layout {
                    ),
                    valid_range: 0..=4,
                },
+               Union {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+               },
            ),
            fields: Arbitrary {
                offsets: [
-                   Size(1 bytes),
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -394,7 +394,7 @@ error: layout_of(NicheFirst) = Layout {
            },
            largest_niche: Some(
                Niche {
-                   offset: Size(1 bytes),
+                   offset: Size(0 bytes),
                    value: Int(
                        I8,
                        false,
@@ -429,29 +429,29 @@ error: layout_of(NicheFirst) = Layout {
                                    I8,
                                    false,
                                ),
-                               valid_range: 0..=255,
+                               valid_range: 0..=2,
                            },
                            Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
-                               valid_range: 0..=2,
+                               valid_range: 0..=255,
                            },
                        ),
                        fields: Arbitrary {
                            offsets: [
-                               Size(1 bytes),
                                Size(0 bytes),
+                               Size(1 bytes),
                            ],
                            memory_index: [
-                               1,
                                0,
+                               1,
                            ],
                        },
                        largest_niche: Some(
                            Niche {
-                               offset: Size(1 bytes),
+                               offset: Size(0 bytes),
                                value: Int(
                                    I8,
                                    false,
@@ -514,12 +514,6 @@ error: layout_of(NicheSecond) = Layout {
                pref: $PREF_ALIGN,
            },
            abi: ScalarPair(
-               Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
                Initialized {
                    value: Int(
                        I8,
@@ -527,10 +521,16 @@ error: layout_of(NicheSecond) = Layout {
                    ),
                    valid_range: 0..=4,
                },
+               Union {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+               },
            ),
            fields: Arbitrary {
                offsets: [
-                   Size(1 bytes),
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -538,7 +538,7 @@ error: layout_of(NicheSecond) = Layout {
            },
            largest_niche: Some(
                Niche {
-                   offset: Size(1 bytes),
+                   offset: Size(0 bytes),
                    value: Int(
                        I8,
                        false,
@@ -573,29 +573,29 @@ error: layout_of(NicheSecond) = Layout {
                                    I8,
                                    false,
                                ),
-                               valid_range: 0..=255,
+                               valid_range: 0..=2,
                            },
                            Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
-                               valid_range: 0..=2,
+                               valid_range: 0..=255,
                            },
                        ),
                        fields: Arbitrary {
                            offsets: [
-                               Size(0 bytes),
                                Size(1 bytes),
+                               Size(0 bytes),
                            ],
                            memory_index: [
-                               0,
                                1,
+                               0,
                            ],
                        },
                        largest_niche: Some(
                            Niche {
-                               offset: Size(1 bytes),
+                               offset: Size(0 bytes),
                                value: Int(
                                    I8,
                                    false,

--- a/tests/ui/print_type_sizes/async.stdout
+++ b/tests/ui/print_type_sizes/async.stdout
@@ -1,15 +1,15 @@
 print-type-size type: `[async fn body@$DIR/async.rs:8:36: 11:2]`: 16386 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 8192 bytes
-print-type-size         upvar `.arg`: 8192 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.arg`: 8192 bytes
 print-type-size     variant `Suspend0`: 16385 bytes
-print-type-size         upvar `.arg`: 8192 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.arg`: 8192 bytes
 print-type-size         local `.arg`: 8192 bytes
 print-type-size         local `.__awaitee`: 1 bytes
 print-type-size     variant `Returned`: 8192 bytes
-print-type-size         upvar `.arg`: 8192 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.arg`: 8192 bytes
 print-type-size     variant `Panicked`: 8192 bytes
-print-type-size         upvar `.arg`: 8192 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.arg`: 8192 bytes
 print-type-size type: `std::mem::ManuallyDrop<[u8; 8192]>`: 8192 bytes, alignment: 1 bytes
 print-type-size     field `.value`: 8192 bytes
 print-type-size type: `std::mem::MaybeUninit<[u8; 8192]>`: 8192 bytes, alignment: 1 bytes

--- a/tests/ui/print_type_sizes/generator.stdout
+++ b/tests/ui/print_type_sizes/generator.stdout
@@ -1,10 +1,10 @@
 print-type-size type: `[generator@$DIR/generator.rs:10:5: 10:14]`: 8193 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 8192 bytes
-print-type-size         upvar `.array`: 8192 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.array`: 8192 bytes
 print-type-size     variant `Suspend0`: 8192 bytes
-print-type-size         upvar `.array`: 8192 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.array`: 8192 bytes
 print-type-size     variant `Returned`: 8192 bytes
-print-type-size         upvar `.array`: 8192 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.array`: 8192 bytes
 print-type-size     variant `Panicked`: 8192 bytes
-print-type-size         upvar `.array`: 8192 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size         upvar `.array`: 8192 bytes


### PR DESCRIPTION
Fixes #104807
Fixes #105371

Determining which sort order is better requires calculating the struct size (so we can calculate the niche offset). But that in turn depends on the field order, so happens after sorting. So the simple way to solve that is to run the whole thing twice and pick the better result.

1st commit is just code motion, the meat is in the later ones.