### PR TITLE
Reduce some function calls in the query system

### DIFF
--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -124,9 +124,7 @@ impl QueryContext for QueryCtxt<'_> {
             };
 
             // Use the `ImplicitCtxt` while we execute the query.
-            tls::enter_context(&new_icx, || {
-                rustc_data_structures::stack::ensure_sufficient_stack(compute)
-            })
+            tls::enter_context(&new_icx, compute)
         })
     }
 


### PR DESCRIPTION
This reduces size of `rustc_driver` by 0.54% and seems to be a minor performance improvement.

<table><tr><td rowspan="2">Benchmark</td><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th></tr><tr><td align="right">Time</td><td align="right">Time</td><td align="right">%</th></tr><tr><td>🟣 <b>clap</b>:check</td><td align="right">1.8112s</td><td align="right">1.8054s</td><td align="right"> -0.32%</td></tr><tr><td>🟣 <b>hyper</b>:check</td><td align="right">0.2649s</td><td align="right">0.2653s</td><td align="right"> 0.14%</td></tr><tr><td>🟣 <b>regex</b>:check</td><td align="right">1.0065s</td><td align="right">1.0048s</td><td align="right"> -0.17%</td></tr><tr><td>🟣 <b>syn</b>:check</td><td align="right">1.6226s</td><td align="right">1.6235s</td><td align="right"> 0.05%</td></tr><tr><td>🟣 <b>syntex_syntax</b>:check</td><td align="right">6.3298s</td><td align="right">6.3087s</td><td align="right"> -0.33%</td></tr><tr><td>Total</td><td align="right">11.0351s</td><td align="right">11.0077s</td><td align="right"> -0.25%</td></tr><tr><td>Summary</td><td align="right">1.0000s</td><td align="right">0.9987s</td><td align="right"> -0.13%</td></tr></table>

r? @cjgillot 