### PR TITLE
Remove support for defaulted trait methods with `async` or return-position `impl Trait`

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
@@ -124,3 +124,10 @@ hir_analysis_linkage_type =
 hir_analysis_auto_deref_reached_recursion_limit = reached the recursion limit while auto-dereferencing `{$ty}`
     .label = deref recursion limit reached
     .help = consider increasing the recursion limit by adding a `#![recursion_limit = "{$suggested_limit}"]` attribute to your crate (`{$crate_name}`)
+
+hir_analysis_default_async_fn_not_allowed = default body not allowed on async trait method
+    .remove_label = remove this body, or move it to an impl instead
+
+hir_analysis_default_rpitit_fn_not_allowed = default body not allowed on trait method with `impl Trait`
+    .label = this `impl Trait`
+    .remove_label = remove this body, or move it to an impl instead

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -312,3 +312,21 @@ pub struct AutoDerefReachedRecursionLimit<'a> {
     pub suggested_limit: rustc_session::Limit,
     pub crate_name: Symbol,
 }
+
+#[derive(Diagnostic)]
+pub enum DefaultRpititMethodNotAllowed {
+    #[diag(hir_analysis_default_async_fn_not_allowed)]
+    AsyncFn {
+        #[primary_span]
+        #[label(remove_label)]
+        body_span: Span,
+    },
+    #[diag(hir_analysis_default_rpitit_fn_not_allowed)]
+    ReturnPositionImplTrait {
+        #[primary_span]
+        #[label(remove_label)]
+        body_span: Span,
+        #[label]
+        rpitit_span: Span,
+    },
+}

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -90,15 +90,7 @@ enum ProjectionCandidate<'tcx> {
     /// From an "impl" (or a "pseudo-impl" returned by select)
     Select(Selection<'tcx>),
 
-    ImplTraitInTrait(ImplTraitInTraitCandidate<'tcx>),
-}
-
-#[derive(PartialEq, Eq, Debug)]
-enum ImplTraitInTraitCandidate<'tcx> {
-    // The `impl Trait` from a trait function's default body
-    Trait,
-    // A concrete type provided from a trait's `impl Trait` from an impl
-    Impl(ImplSourceUserDefinedData<'tcx, PredicateObligation<'tcx>>),
+    ImplTraitInTrait(ImplSourceUserDefinedData<'tcx, PredicateObligation<'tcx>>),
 }
 
 enum ProjectionCandidateSet<'tcx> {
@@ -1292,17 +1284,6 @@ fn assemble_candidate_for_impl_trait_in_trait<'cx, 'tcx>(
     let tcx = selcx.tcx();
     if tcx.def_kind(obligation.predicate.def_id) == DefKind::ImplTraitPlaceholder {
         let trait_fn_def_id = tcx.impl_trait_in_trait_parent(obligation.predicate.def_id);
-        // If we are trying to project an RPITIT with trait's default `Self` parameter,
-        // then we must be within a default trait body.
-        if obligation.predicate.self_ty()
-            == ty::InternalSubsts::identity_for_item(tcx, obligation.predicate.def_id).type_at(0)
-            && tcx.associated_item(trait_fn_def_id).defaultness(tcx).has_value()
-        {
-            candidate_set.push_candidate(ProjectionCandidate::ImplTraitInTrait(
-                ImplTraitInTraitCandidate::Trait,
-            ));
-            return;
-        }
 
         let trait_def_id = tcx.parent(trait_fn_def_id);
         let trait_substs =
@@ -1313,9 +1294,7 @@ fn assemble_candidate_for_impl_trait_in_trait<'cx, 'tcx>(
         let _ = selcx.infcx.commit_if_ok(|_| {
             match selcx.select(&obligation.with(tcx, trait_predicate)) {
                 Ok(Some(super::ImplSource::UserDefined(data))) => {
-                    candidate_set.push_candidate(ProjectionCandidate::ImplTraitInTrait(
-                        ImplTraitInTraitCandidate::Impl(data),
-                    ));
+                    candidate_set.push_candidate(ProjectionCandidate::ImplTraitInTrait(data));
                     Ok(())
                 }
                 Ok(None) => {
@@ -1777,18 +1756,9 @@ fn confirm_candidate<'cx, 'tcx>(
         ProjectionCandidate::Select(impl_source) => {
             confirm_select_candidate(selcx, obligation, impl_source)
         }
-        ProjectionCandidate::ImplTraitInTrait(ImplTraitInTraitCandidate::Impl(data)) => {
+        ProjectionCandidate::ImplTraitInTrait(data) => {
             confirm_impl_trait_in_trait_candidate(selcx, obligation, data)
         }
-        // If we're projecting an RPITIT for a default trait body, that's just
-        // the same def-id, but as an opaque type (with regular RPIT semantics).
-        ProjectionCandidate::ImplTraitInTrait(ImplTraitInTraitCandidate::Trait) => Progress {
-            term: selcx
-                .tcx()
-                .mk_opaque(obligation.predicate.def_id, obligation.predicate.substs)
-                .into(),
-            obligations: vec![],
-        },
     };
 
     // When checking for cycle during evaluation, we compare predicates with

--- a/tests/ui/async-await/async-trait-fn.rs
+++ b/tests/ui/async-await/async-trait-fn.rs
@@ -1,8 +1,11 @@
 // edition:2018
 trait T {
     async fn foo() {} //~ ERROR functions in traits cannot be declared `async`
+    //~^ ERROR mismatched types
     async fn bar(&self) {} //~ ERROR functions in traits cannot be declared `async`
+    //~^ ERROR mismatched types
     async fn baz() { //~ ERROR functions in traits cannot be declared `async`
+        //~^ ERROR mismatched types
         // Nested item must not ICE.
         fn a() {}
     }

--- a/tests/ui/async-await/async-trait-fn.stderr
+++ b/tests/ui/async-await/async-trait-fn.stderr
@@ -12,7 +12,7 @@ LL |     async fn foo() {}
    = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
-  --> $DIR/async-trait-fn.rs:4:5
+  --> $DIR/async-trait-fn.rs:5:5
    |
 LL |     async fn bar(&self) {}
    |     -----^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     async fn bar(&self) {}
    = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
-  --> $DIR/async-trait-fn.rs:5:5
+  --> $DIR/async-trait-fn.rs:7:5
    |
 LL |     async fn baz() {
    |     -----^^^^^^^^^
@@ -37,6 +37,54 @@ LL |     async fn baz() {
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error[E0308]: mismatched types
+  --> $DIR/async-trait-fn.rs:3:20
+   |
+LL |     async fn foo() {}
+   |                    ^^
+   |                    |
+   |                    expected associated type, found `async fn` body
+   |                    arguments to this function are incorrect
+   |
+   = note: expected associated type `impl Future<Output = ()>`
+              found `async fn` body `[async fn body@$DIR/async-trait-fn.rs:3:20: 3:22]`
+note: function defined here
+  --> $SRC_DIR/core/src/future/mod.rs:LL:COL
 
-For more information about this error, try `rustc --explain E0706`.
+error[E0308]: mismatched types
+  --> $DIR/async-trait-fn.rs:5:25
+   |
+LL |     async fn bar(&self) {}
+   |                         ^^
+   |                         |
+   |                         expected associated type, found `async fn` body
+   |                         arguments to this function are incorrect
+   |
+   = note: expected associated type `impl Future<Output = ()>`
+              found `async fn` body `[async fn body@$DIR/async-trait-fn.rs:5:25: 5:27]`
+note: function defined here
+  --> $SRC_DIR/core/src/future/mod.rs:LL:COL
+
+error[E0308]: mismatched types
+  --> $DIR/async-trait-fn.rs:7:20
+   |
+LL |       async fn baz() {
+   |  ____________________-
+LL | |
+LL | |         // Nested item must not ICE.
+LL | |         fn a() {}
+LL | |     }
+   | |     ^
+   | |     |
+   | |_____expected associated type, found `async fn` body
+   |       arguments to this function are incorrect
+   |
+   = note: expected associated type `impl Future<Output = ()>`
+              found `async fn` body `[async fn body@$DIR/async-trait-fn.rs:7:20: 11:6]`
+note: function defined here
+  --> $SRC_DIR/core/src/future/mod.rs:LL:COL
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0308, E0706.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/edition-deny-async-fns-2015.rs
+++ b/tests/ui/async-await/edition-deny-async-fns-2015.rs
@@ -17,6 +17,7 @@ impl Foo {
 trait Bar {
     async fn foo() {} //~ ERROR `async fn` is not permitted in Rust 2015
     //~^ ERROR functions in traits cannot be declared `async`
+    //~| ERROR mismatched types
 }
 
 fn main() {

--- a/tests/ui/async-await/edition-deny-async-fns-2015.stderr
+++ b/tests/ui/async-await/edition-deny-async-fns-2015.stderr
@@ -53,7 +53,7 @@ LL |     async fn foo() {}
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/edition-deny-async-fns-2015.rs:36:9
+  --> $DIR/edition-deny-async-fns-2015.rs:37:9
    |
 LL |         async fn bar() {}
    |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -62,7 +62,7 @@ LL |         async fn bar() {}
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/edition-deny-async-fns-2015.rs:26:9
+  --> $DIR/edition-deny-async-fns-2015.rs:27:9
    |
 LL |         async fn foo() {}
    |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -71,7 +71,7 @@ LL |         async fn foo() {}
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/edition-deny-async-fns-2015.rs:31:13
+  --> $DIR/edition-deny-async-fns-2015.rs:32:13
    |
 LL |             async fn bar() {}
    |             ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -92,7 +92,21 @@ LL |     async fn foo() {}
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
-error: aborting due to 10 previous errors
+error[E0308]: mismatched types
+  --> $DIR/edition-deny-async-fns-2015.rs:18:20
+   |
+LL |     async fn foo() {}
+   |                    ^^
+   |                    |
+   |                    expected associated type, found `async fn` body
+   |                    arguments to this function are incorrect
+   |
+   = note: expected associated type `impl Future<Output = ()>`
+              found `async fn` body `[async fn body@$DIR/edition-deny-async-fns-2015.rs:18:20: 18:22]`
+note: function defined here
+  --> $SRC_DIR/core/src/future/mod.rs:LL:COL
 
-Some errors have detailed explanations: E0670, E0706.
-For more information about an error, try `rustc --explain E0670`.
+error: aborting due to 11 previous errors
+
+Some errors have detailed explanations: E0308, E0670, E0706.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/in-trait/return-type-suggestion.rs
+++ b/tests/ui/async-await/in-trait/return-type-suggestion.rs
@@ -1,13 +1,11 @@
 // edition: 2021
+// known-bug: #108142
 
 #![feature(async_fn_in_trait)]
-//~^ WARN the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
 
 trait A {
     async fn e() {
         Ok(())
-        //~^ ERROR mismatched types
-        //~| HELP consider using a semicolon here
     }
 }
 

--- a/tests/ui/async-await/in-trait/return-type-suggestion.stderr
+++ b/tests/ui/async-await/in-trait/return-type-suggestion.stderr
@@ -1,5 +1,5 @@
 warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/return-type-suggestion.rs:3:12
+  --> $DIR/return-type-suggestion.rs:4:12
    |
 LL | #![feature(async_fn_in_trait)]
    |            ^^^^^^^^^^^^^^^^^
@@ -7,17 +7,11 @@ LL | #![feature(async_fn_in_trait)]
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0308]: mismatched types
-  --> $DIR/return-type-suggestion.rs:8:9
+error: default body not allowed on async trait method
+  --> $DIR/return-type-suggestion.rs:7:18
    |
-LL |         Ok(())
-   |         ^^^^^^- help: consider using a semicolon here: `;`
-   |         |
-   |         expected `()`, found `Result<(), _>`
-   |
-   = note: expected unit type `()`
-                   found enum `Result<(), _>`
+LL |     async fn e() {
+   |                  ^ remove this body, or move it to an impl instead
 
 error: aborting due to previous error; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/in-trait/box-coerce-span-in-default.rs
+++ b/tests/ui/impl-trait/in-trait/box-coerce-span-in-default.rs
@@ -1,7 +1,6 @@
-// check-pass
+// known-bug: #108142
 
 #![feature(return_position_impl_trait_in_trait)]
-//~^ WARN the feature `return_position_impl_trait_in_trait` is incomplete
 
 struct TestA {}
 struct TestB {}

--- a/tests/ui/impl-trait/in-trait/box-coerce-span-in-default.stderr
+++ b/tests/ui/impl-trait/in-trait/box-coerce-span-in-default.stderr
@@ -7,5 +7,13 @@ LL | #![feature(return_position_impl_trait_in_trait)]
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-warning: 1 warning emitted
+error: default body not allowed on trait method with `impl Trait`
+  --> $DIR/box-coerce-span-in-default.rs:37:68
+   |
+LL |     fn test_func(&self, func: &str) -> impl TestTrait<Output = ()> {
+   |                                        --------------------------- ^ remove this body, or move it to an impl instead
+   |                                        |
+   |                                        this `impl Trait`
+
+error: aborting due to previous error; 1 warning emitted
 

--- a/tests/ui/impl-trait/in-trait/default-body-type-err-2.rs
+++ b/tests/ui/impl-trait/in-trait/default-body-type-err-2.rs
@@ -1,4 +1,5 @@
 // edition:2021
+// known-bug: #108142
 
 #![allow(incomplete_features)]
 #![feature(async_fn_in_trait)]
@@ -6,7 +7,6 @@
 pub trait Foo {
     async fn woopsie_async(&self) -> String {
         42
-        //~^ ERROR mismatched types
     }
 }
 

--- a/tests/ui/impl-trait/in-trait/default-body-type-err-2.stderr
+++ b/tests/ui/impl-trait/in-trait/default-body-type-err-2.stderr
@@ -1,11 +1,8 @@
-error[E0308]: mismatched types
-  --> $DIR/default-body-type-err-2.rs:8:9
+error: default body not allowed on async trait method
+  --> $DIR/default-body-type-err-2.rs:8:45
    |
-LL |         42
-   |         ^^- help: try using a conversion method: `.to_string()`
-   |         |
-   |         expected `String`, found integer
+LL |     async fn woopsie_async(&self) -> String {
+   |                                             ^ remove this body, or move it to an impl instead
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/in-trait/default-body-type-err.rs
+++ b/tests/ui/impl-trait/in-trait/default-body-type-err.rs
@@ -1,3 +1,5 @@
+// known-bug: #108142
+
 #![allow(incomplete_features)]
 #![feature(return_position_impl_trait_in_trait)]
 
@@ -5,7 +7,6 @@ use std::ops::Deref;
 
 pub trait Foo {
     fn lol(&self) -> impl Deref<Target = String> {
-        //~^ type mismatch resolving `<&i32 as Deref>::Target == String`
         &1i32
     }
 }

--- a/tests/ui/impl-trait/in-trait/default-body-type-err.stderr
+++ b/tests/ui/impl-trait/in-trait/default-body-type-err.stderr
@@ -1,12 +1,10 @@
-error[E0271]: type mismatch resolving `<&i32 as Deref>::Target == String`
-  --> $DIR/default-body-type-err.rs:7:22
+error: default body not allowed on trait method with `impl Trait`
+  --> $DIR/default-body-type-err.rs:9:50
    |
 LL |     fn lol(&self) -> impl Deref<Target = String> {
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `String`
-LL |
-LL |         &1i32
-   |         ----- return type was inferred to be `&i32` here
+   |                      --------------------------- ^ remove this body, or move it to an impl instead
+   |                      |
+   |                      this `impl Trait`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/impl-trait/in-trait/default-body-with-rpit.rs
+++ b/tests/ui/impl-trait/in-trait/default-body-with-rpit.rs
@@ -1,5 +1,5 @@
-// check-pass
 // edition:2021
+// known-bug: #108142
 
 #![feature(async_fn_in_trait, return_position_impl_trait_in_trait)]
 #![allow(incomplete_features)]

--- a/tests/ui/impl-trait/in-trait/default-body-with-rpit.stderr
+++ b/tests/ui/impl-trait/in-trait/default-body-with-rpit.stderr
@@ -1,0 +1,8 @@
+error: default body not allowed on async trait method
+  --> $DIR/default-body-with-rpit.rs:10:39
+   |
+LL |     async fn baz(&self) -> impl Debug {
+   |                                       ^ remove this body, or move it to an impl instead
+
+error: aborting due to previous error
+

--- a/tests/ui/impl-trait/in-trait/default-body.rs
+++ b/tests/ui/impl-trait/in-trait/default-body.rs
@@ -1,5 +1,5 @@
-// check-pass
 // edition:2021
+// known-bug: #108142
 
 #![feature(async_fn_in_trait, return_position_impl_trait_in_trait)]
 #![allow(incomplete_features)]

--- a/tests/ui/impl-trait/in-trait/default-body.stderr
+++ b/tests/ui/impl-trait/in-trait/default-body.stderr
@@ -1,0 +1,8 @@
+error: default body not allowed on async trait method
+  --> $DIR/default-body.rs:10:33
+   |
+LL |     async fn baz(&self) -> &str {
+   |                                 ^ remove this body, or move it to an impl instead
+
+error: aborting due to previous error
+

--- a/tests/ui/impl-trait/in-trait/method-signature-matches.rs
+++ b/tests/ui/impl-trait/in-trait/method-signature-matches.rs
@@ -13,7 +13,7 @@ impl Uwu for () {
 }
 
 trait AsyncUwu {
-    async fn owo(x: ()) {}
+    async fn owo(x: ());
 }
 
 impl AsyncUwu for () {

--- a/tests/ui/impl-trait/in-trait/method-signature-matches.stderr
+++ b/tests/ui/impl-trait/in-trait/method-signature-matches.stderr
@@ -27,7 +27,7 @@ LL |     async fn owo(_: u8) {}
 note: type in trait
   --> $DIR/method-signature-matches.rs:16:21
    |
-LL |     async fn owo(x: ()) {}
+LL |     async fn owo(x: ());
    |                     ^^
    = note: expected signature `fn(()) -> _`
               found signature `fn(u8) -> _`

--- a/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs
+++ b/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs
@@ -12,6 +12,7 @@ impl A {
 
 trait C{async fn new(val: T) {} //~ ERROR  `async fn` is not permitted in Rust 2015
 //~^ ERROR functions in traits cannot be declared `async`
+//~| ERROR mismatched types
 //~| ERROR cannot find type `T` in this scope
 //~| WARN changes to closure capture in Rust 2021 will affect drop order [rust_2021_incompatible_closure_captures]
 

--- a/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.stderr
+++ b/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.stderr
@@ -1,5 +1,5 @@
 error: this file contains an unclosed delimiter
-  --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs:18:53
+  --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs:19:53
    |
 LL | trait C{async fn new(val: T) {}
    |        - unclosed delimiter
@@ -74,6 +74,20 @@ help: add a dummy let to cause `path` to be fully captured
 LL |     async fn create(path: impl AsRef<std::path::Path>)  { let _ = &path;
    |                                                           ++++++++++++++
 
+error[E0308]: mismatched types
+  --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs:13:30
+   |
+LL | trait C{async fn new(val: T) {}
+   |                              ^^
+   |                              |
+   |                              expected associated type, found `async fn` body
+   |                              arguments to this function are incorrect
+   |
+   = note: expected associated type `impl Future<Output = ()>`
+              found `async fn` body `[async fn body@$DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs:13:30: 13:32]`
+note: function defined here
+  --> $SRC_DIR/core/src/future/mod.rs:LL:COL
+
 warning: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs:13:30
    |
@@ -89,7 +103,7 @@ help: add a dummy let to cause `val` to be fully captured
 LL | trait C{async fn new(val: T) { let _ = &val;}
    |                                +++++++++++++
 
-error: aborting due to 6 previous errors; 2 warnings emitted
+error: aborting due to 7 previous errors; 2 warnings emitted
 
-Some errors have detailed explanations: E0412, E0423, E0670, E0706.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0308, E0412, E0423, E0670, E0706.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Unfortunately, default methods on `async fn` and return-position `impl Trait` in traits are unsound and pretty unworkable in their current state. To put it in perspective, given the code:

```rust
trait Foo {
  async fn foo();
}
```

The above code cannot bbe desugared like:

```rust
#![feature(type_alias_impl_trait, associated_type_defaults)]

use std::future::Future;

trait Foo {
    type FooRPIT = impl Future<Output = ()>;
    
    fn foo() -> Self::FooRPIT {
        async {}
    }
}
```

because we shouldn't be able to observe the `Self::FooRPIT` -> `impl Future` projection.

Ideally, we *could* observe this inside the body of `Foo::foo`, but the way that our projection logic implements this is not correct, leading to issues like #107002. Fixing it leads to weird cycles or committing to really nasty hacks in HIR and MIR typeck (#107013).

---

To discourage users from relying on this behavior and hitting issues like #107002, let's just deny this behavior for now. Maybe I can revisit this feature in the future with a clearer mind. I may have some tricks up my sleeve to fix this, but for now, let's not commit to supporting this.

cc @rust-lang/wg-async and @rust-lang/types who may have thoughts about this.

r? @lcnr

Fixes #107002 (not really, but at least closes it)