### PR TITLE
rustdoc: hide `reference` methods in search index

### DIFF
--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -288,6 +288,12 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                         let last = self.cache.parent_stack.last().expect("parent_stack is empty 2");
                         let did = match &*last {
                             ParentStackItem::Impl {
+                                // impl Trait for &T { fn method(self); }
+                                //
+                                // When generating a function index with the above shape, we want it
+                                // associated with `T`, not with the primitive reference type. It should
+                                // show up as `T::method`, rather than `reference::method`, in the search
+                                // results page.
                                 for_: clean::Type::BorrowedRef { type_, .. },
                                 ..
                             } => type_.def_id(&self.cache),

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -287,6 +287,10 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                     } else {
                         let last = self.cache.parent_stack.last().expect("parent_stack is empty 2");
                         let did = match &*last {
+                            ParentStackItem::Impl {
+                                for_: clean::Type::BorrowedRef { type_, .. },
+                                ..
+                            } => type_.def_id(&self.cache),
                             ParentStackItem::Impl { for_, .. } => for_.def_id(&self.cache),
                             ParentStackItem::Type(item_id) => item_id.as_def_id(),
                         };

--- a/tests/rustdoc-js-std/reference-shrink.js
+++ b/tests/rustdoc-js-std/reference-shrink.js
@@ -1,0 +1,8 @@
+// exact-check
+
+const QUERY = 'reference::shrink';
+
+const EXPECTED = {
+    // avoid including the method that's not going to be in the HTML
+    'others': [],
+};


### PR DESCRIPTION
They're hidden in the HTML, so it makes no sense in the search engine for `reference::next` or `reference::shrink` to be shown.

https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/What.20is.20.60reference.3A.3Ashrink.60.3F