### PR TITLE
Make query keys `Copy`

### DIFF
--- a/compiler/rustc_query_system/src/query/caches.rs
+++ b/compiler/rustc_query_system/src/query/caches.rs
@@ -21,7 +21,7 @@ pub trait QueryStorage {
 }
 
 pub trait QueryCache: QueryStorage + Sized {
-    type Key: Hash + Eq + Clone + Debug;
+    type Key: Hash + Eq + Copy + Debug;
 
     /// Checks if the query is already computed and in the cache.
     /// It returns the shard index and a lock guard to the shard,
@@ -61,7 +61,7 @@ impl<K: Eq + Hash, V: Copy + Debug> QueryStorage for DefaultCache<K, V> {
 
 impl<K, V> QueryCache for DefaultCache<K, V>
 where
-    K: Eq + Hash + Clone + Debug,
+    K: Eq + Hash + Copy + Debug,
     V: Copy + Debug,
 {
     type Key = K;
@@ -179,7 +179,7 @@ impl<K: Eq + Idx, V: Copy + Debug> QueryStorage for VecCache<K, V> {
 
 impl<K, V> QueryCache for VecCache<K, V>
 where
-    K: Eq + Idx + Clone + Debug,
+    K: Eq + Idx + Copy + Debug,
     V: Copy + Debug,
 {
     type Key = K;

--- a/compiler/rustc_query_system/src/query/config.rs
+++ b/compiler/rustc_query_system/src/query/config.rs
@@ -19,7 +19,9 @@ pub type TryLoadFromDisk<Qcx, Q> =
 pub trait QueryConfig<Qcx: QueryContext> {
     const NAME: &'static str;
 
-    type Key: DepNodeParams<Qcx::DepContext> + Eq + Hash + Clone + Debug;
+    // `Key` and `Value` are `Copy` instead of `Clone` to ensure copying them stays cheap,
+    // but it isn't necessary.
+    type Key: DepNodeParams<Qcx::DepContext> + Eq + Hash + Copy + Debug;
     type Value: Debug + Copy;
 
     type Cache: QueryCache<Key = Self::Key, Value = Self::Value>;


### PR DESCRIPTION
This regressed compiler performance locally, so I'm curious what perf will say about it.

<table><tr><td rowspan="2">Benchmark</td><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th></tr><tr><td align="right">Time</td><td align="right">Time</td><td align="right">%</th></tr><tr><td>🟣 <b>clap</b>:check</td><td align="right">1.7566s</td><td align="right">1.7657s</td><td align="right"> 0.52%</td></tr><tr><td>🟣 <b>hyper</b>:check</td><td align="right">0.2572s</td><td align="right">0.2578s</td><td align="right"> 0.20%</td></tr><tr><td>🟣 <b>regex</b>:check</td><td align="right">0.9863s</td><td align="right">0.9900s</td><td align="right"> 0.37%</td></tr><tr><td>🟣 <b>syn</b>:check</td><td align="right">1.6018s</td><td align="right">1.6073s</td><td align="right"> 0.34%</td></tr><tr><td>🟣 <b>syntex_syntax</b>:check</td><td align="right">6.2493s</td><td align="right">6.2920s</td><td align="right"> 0.68%</td></tr><tr><td>Total</td><td align="right">10.8512s</td><td align="right">10.9127s</td><td align="right"> 0.57%</td></tr><tr><td>Summary</td><td align="right">1.0000s</td><td align="right">1.0042s</td><td align="right"> 0.42%</td></tr></table>