### PR TITLE
fix ICE `const parameters cannot be generic` in generic_const_exprs

### DIFF
--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -73,10 +73,7 @@ impl<'tcx> Const<'tcx> {
         let expr = &tcx.hir().body(body_id).value;
         debug!(?expr);
 
-        let ty = tcx
-            .type_of(def.def_id_for_type_of())
-            .no_bound_vars()
-            .expect("const parameter types cannot be generic");
+        let ty = tcx.type_of(def.def_id_for_type_of()).subst_identity();
 
         match Self::try_eval_lit_or_param(tcx, ty, expr) {
             Some(v) => v,

--- a/tests/ui/const-generics/generic_const_exprs/issue-108165.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-108165.rs
@@ -1,0 +1,10 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+pub trait TraitWAssocConst {
+    const A: dyn TraitWAssocConst<A=0>; //~ ERROR: associated const equality is incomplete
+    //~^ ERROR: cycle detected when computing type
+}
+
+fn main<A: TraitWAssocConst<A=0>>() {}
+//~^ ERROR: associated const equality is incomplete

--- a/tests/ui/const-generics/generic_const_exprs/issue-108165.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-108165.stderr
@@ -1,0 +1,40 @@
+error[E0658]: associated const equality is incomplete
+  --> $DIR/issue-108165.rs:5:35
+   |
+LL |     const A: dyn TraitWAssocConst<A=0>;
+   |                                   ^^^
+   |
+   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
+   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+
+error[E0658]: associated const equality is incomplete
+  --> $DIR/issue-108165.rs:9:29
+   |
+LL | fn main<A: TraitWAssocConst<A=0>>() {}
+   |                             ^^^
+   |
+   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
+   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+
+error[E0391]: cycle detected when computing type of `TraitWAssocConst::A`
+  --> $DIR/issue-108165.rs:5:5
+   |
+LL |     const A: dyn TraitWAssocConst<A=0>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires computing type of `TraitWAssocConst::A::{constant#0}`...
+  --> $DIR/issue-108165.rs:5:37
+   |
+LL |     const A: dyn TraitWAssocConst<A=0>;
+   |                                     ^
+   = note: ...which again requires computing type of `TraitWAssocConst::A`, completing the cycle
+note: cycle used when computing type of `main::{constant#0}`
+  --> $DIR/issue-108165.rs:9:31
+   |
+LL | fn main<A: TraitWAssocConst<A=0>>() {}
+   |                               ^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0391, E0658.
+For more information about an error, try `rustc --explain E0391`.


### PR DESCRIPTION
Fixes #108165.

In #107753, we changed several uses of `tcx.type_of(did)` on consts to `tcx.type_of(did).no_bound_vars().expect(..)` after adding `EarlyBinder`, one of which is causing this ICE.

r? @BoxyUwU 