### PR TITLE
Don't delay `ReError` bug during lexical region resolve

### DIFF
--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -1046,7 +1046,7 @@ impl<'tcx> LexicalRegionResolutions<'tcx> {
             ty::ReVar(rid) => match self.values[rid] {
                 VarValue::Empty(_) => r,
                 VarValue::Value(r) => r,
-                VarValue::ErrorValue => tcx.mk_re_error_misc(),
+                VarValue::ErrorValue => tcx.lifetimes.re_static,
             },
             _ => r,
         };

--- a/tests/ui/regions/resolve-re-error-ice.rs
+++ b/tests/ui/regions/resolve-re-error-ice.rs
@@ -1,0 +1,22 @@
+// check-pass
+
+// Allow this for now, can remove this UI test when this becomes a hard error.
+#![allow(implied_bounds_entailment)]
+
+use std::collections::hash_map::{Keys, HashMap};
+use std::marker::PhantomData;
+
+trait MapAssertion<'a, K, V, R> {
+    fn key_set(&self) -> Subject<Keys<K, V>, (), R>;
+}
+
+struct Subject<'a, T, V, R>(PhantomData<(&'a T, V, R)>);
+
+impl<'a, K, V, R> MapAssertion<'a, K, V, R> for Subject<'a, HashMap<K, V>, (), R>
+{
+    fn key_set(&self) -> Subject<'a, Keys<K, V>, (), R> {
+        todo!()
+    }
+}
+
+fn main() {}

--- a/tests/ui/regions/resolve-re-error-ice.stderr
+++ b/tests/ui/regions/resolve-re-error-ice.stderr
@@ -1,0 +1,15 @@
+Future incompatibility report: Future breakage diagnostic:
+warning: impl method assumes more implied bounds than the corresponding trait method
+  --> $DIR/resolve-re-error-ice.rs:17:16
+   |
+LL |     fn key_set(&self) -> Subject<'a, Keys<K, V>, (), R> {
+   |                ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this type to make the impl signature compatible: `Subject<'_, std::collections::hash_map::Keys<'_, K, V>, (), R>`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #105572 <https://github.com/rust-lang/rust/issues/105572>
+note: the lint level is defined here
+  --> $DIR/resolve-re-error-ice.rs:4:10
+   |
+LL | #![allow(implied_bounds_entailment)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^
+


### PR DESCRIPTION
Lexical region resolution returns a list of `RegionResolutionError` which don't necessarily correspond to diagnostics being emitted. The compiler may, validly, throw away these resolution errors and do something else. Therefore it's not valid to use `ReError` during lifetime resolution, since we may actually be on a totally fine compilation path.

For example, the `implied_bounds_entailment` lint runs region resolution twice, and only emits an error if it fails both times. If we delay a bug and create a `ReError` during this first run, then we will ICE.

Fixes #108170

----

Side-note: this is conceptually equivalent to how we can't necessarily delay bugs or create `ty::Error` during trait solving/fulfillment, since the compiler is allowed to throw away these fulfillment errors to do other things. It's only once we actually emit an error (`report_region_errors` / `report_fulfillment_errors`)