### PR TITLE
Deny non-lifetime bound vars in `for<..> ||` closure binders

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -474,7 +474,7 @@ declare_features! (
     /// Allows using the `non_exhaustive_omitted_patterns` lint.
     (active, non_exhaustive_omitted_patterns_lint, "1.57.0", Some(89554), None),
     /// Allows `for<T>` binders in where-clauses
-    (incomplete, non_lifetime_binders, "CURRENT_RUSTC_VERSION", Some(1), None),
+    (incomplete, non_lifetime_binders, "CURRENT_RUSTC_VERSION", Some(108185), None),
     /// Allows making `dyn Trait` well-formed even if `Trait` is not object safe.
     /// In that case, `dyn Trait: Trait` does not hold. Moreover, coercions and
     /// casts in safe Rust to `dyn Trait` for such a `Trait` is also forbidden.

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -398,7 +398,12 @@ fn has_late_bound_regions<'tcx>(tcx: TyCtxt<'tcx>, node: Node<'tcx>) -> Option<S
                 Some(rbv::ResolvedArg::StaticLifetime | rbv::ResolvedArg::EarlyBound(..)) => {}
                 Some(rbv::ResolvedArg::LateBound(debruijn, _, _))
                     if debruijn < self.outer_index => {}
-                Some(rbv::ResolvedArg::LateBound(..) | rbv::ResolvedArg::Free(..)) | None => {
+                Some(
+                    rbv::ResolvedArg::LateBound(..)
+                    | rbv::ResolvedArg::Free(..)
+                    | rbv::ResolvedArg::Error(_),
+                )
+                | None => {
                     self.has_late_bound_regions = Some(lt.ident.span);
                 }
             }

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -134,7 +134,8 @@ impl<'tcx> Visitor<'tcx> for FindNestedTypeVisitor<'tcx> {
                             rbv::ResolvedArg::StaticLifetime
                             | rbv::ResolvedArg::Free(_, _)
                             | rbv::ResolvedArg::EarlyBound(_)
-                            | rbv::ResolvedArg::LateBound(_, _, _),
+                            | rbv::ResolvedArg::LateBound(_, _, _)
+                            | rbv::ResolvedArg::Error(_),
                         )
                         | None,
                         _,
@@ -211,7 +212,8 @@ impl<'tcx> Visitor<'tcx> for TyPathVisitor<'tcx> {
                     rbv::ResolvedArg::StaticLifetime
                     | rbv::ResolvedArg::EarlyBound(_)
                     | rbv::ResolvedArg::LateBound(_, _, _)
-                    | rbv::ResolvedArg::Free(_, _),
+                    | rbv::ResolvedArg::Free(_, _)
+                    | rbv::ResolvedArg::Error(_),
                 )
                 | None,
                 _,

--- a/compiler/rustc_middle/src/middle/resolve_bound_vars.rs
+++ b/compiler/rustc_middle/src/middle/resolve_bound_vars.rs
@@ -3,6 +3,7 @@
 use crate::ty;
 
 use rustc_data_structures::fx::FxHashMap;
+use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{ItemLocalId, OwnerId};
 use rustc_macros::HashStable;
@@ -13,6 +14,7 @@ pub enum ResolvedArg {
     EarlyBound(/* decl */ DefId),
     LateBound(ty::DebruijnIndex, /* late-bound index */ u32, /* decl */ DefId),
     Free(DefId, /* lifetime decl */ DefId),
+    Error(ErrorGuaranteed),
 }
 
 /// A set containing, at most, one known element.

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -149,6 +149,9 @@ impl<'tcx> Const<'tcx> {
                         ty::ConstKind::Bound(debruijn, ty::BoundVar::from_u32(index)),
                         ty,
                     )),
+                    Some(rbv::ResolvedArg::Error(guar)) => {
+                        Some(tcx.const_error_with_guaranteed(ty, guar))
+                    }
                     arg => bug!("unexpected bound var resolution for {:?}: {arg:?}", expr.hir_id),
                 }
             }

--- a/tests/ui/bounds-lifetime.stderr
+++ b/tests/ui/bounds-lifetime.stderr
@@ -22,7 +22,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | type D = for<'a, T> fn();
    |                  ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error[E0658]: only lifetime parameters can be used in this context
@@ -31,7 +31,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | type E = dyn for<T> Fn();
    |                  ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors

--- a/tests/ui/closures/binder/const-bound.rs
+++ b/tests/ui/closures/binder/const-bound.rs
@@ -1,0 +1,7 @@
+#![feature(closure_lifetime_binder, non_lifetime_binders)]
+//~^ WARN  is incomplete and may not be safe to use
+
+fn main()  {
+    for<const N: i32> || -> () {};
+    //~^ ERROR late-bound const parameter not allowed on closures
+}

--- a/tests/ui/closures/binder/const-bound.stderr
+++ b/tests/ui/closures/binder/const-bound.stderr
@@ -1,0 +1,17 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/const-bound.rs:1:37
+   |
+LL | #![feature(closure_lifetime_binder, non_lifetime_binders)]
+   |                                     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: late-bound const parameter not allowed on closures
+  --> $DIR/const-bound.rs:5:9
+   |
+LL |     for<const N: i32> || -> () {};
+   |         ^^^^^^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/closures/binder/disallow-const.stderr
+++ b/tests/ui/closures/binder/disallow-const.stderr
@@ -4,7 +4,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL |     for<const N: i32> || -> () {};
    |               ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/tests/ui/closures/binder/disallow-ty.stderr
+++ b/tests/ui/closures/binder/disallow-ty.stderr
@@ -4,7 +4,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL |     for<T> || -> () {};
    |         ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/tests/ui/closures/binder/type-bound-2.rs
+++ b/tests/ui/closures/binder/type-bound-2.rs
@@ -1,0 +1,7 @@
+#![feature(closure_lifetime_binder, non_lifetime_binders)]
+//~^ WARN  is incomplete and may not be safe to use
+
+fn main() {
+    for<T> || -> () {};
+    //~^ ERROR late-bound type parameter not allowed on closures
+}

--- a/tests/ui/closures/binder/type-bound-2.stderr
+++ b/tests/ui/closures/binder/type-bound-2.stderr
@@ -1,0 +1,17 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/type-bound-2.rs:1:37
+   |
+LL | #![feature(closure_lifetime_binder, non_lifetime_binders)]
+   |                                     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: late-bound type parameter not allowed on closures
+  --> $DIR/type-bound-2.rs:5:9
+   |
+LL |     for<T> || -> () {};
+   |         ^
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/closures/binder/type-bound.rs
+++ b/tests/ui/closures/binder/type-bound.rs
@@ -1,0 +1,7 @@
+#![feature(closure_lifetime_binder, non_lifetime_binders)]
+//~^ WARN  is incomplete and may not be safe to use
+
+fn main()  {
+    for<T> || -> T {};
+    //~^ ERROR late-bound type parameter not allowed on closures
+}

--- a/tests/ui/closures/binder/type-bound.stderr
+++ b/tests/ui/closures/binder/type-bound.stderr
@@ -1,0 +1,17 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/type-bound.rs:1:37
+   |
+LL | #![feature(closure_lifetime_binder, non_lifetime_binders)]
+   |                                     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: late-bound type parameter not allowed on closures
+  --> $DIR/type-bound.rs:5:9
+   |
+LL |     for<T> || -> T {};
+   |         ^
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/conditional-compilation/cfg-generic-params.stderr
+++ b/tests/ui/conditional-compilation/cfg-generic-params.stderr
@@ -34,7 +34,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | type FnBad = for<#[cfg(no)] 'a, #[cfg(yes)] T> fn();
    |                                             ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error[E0658]: only lifetime parameters can be used in this context
@@ -43,7 +43,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | type PolyBad = dyn for<#[cfg(no)] 'a, #[cfg(yes)] T> Copy;
    |                                                   ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error[E0658]: only lifetime parameters can be used in this context
@@ -52,7 +52,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | struct WhereBad where for<#[cfg(no)] 'a, #[cfg(yes)] T> u8: Copy;
    |                                                      ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error: aborting due to 8 previous errors

--- a/tests/ui/feature-gates/feature-gate-non_lifetime_binders.stderr
+++ b/tests/ui/feature-gates/feature-gate-non_lifetime_binders.stderr
@@ -4,7 +4,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | fn foo() where for<T> T:, {}
    |                    ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/tests/ui/higher-rank-trait-bounds/hrtb-wrong-kind.stderr
+++ b/tests/ui/higher-rank-trait-bounds/hrtb-wrong-kind.stderr
@@ -4,7 +4,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | fn a() where for<T> T: Copy {}
    |                  ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error[E0658]: only lifetime parameters can be used in this context
@@ -13,7 +13,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | fn b() where for<const C: usize> [(); C]: Copy {}
    |                        ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/tests/ui/traits/non_lifetime_binders/basic.stderr
+++ b/tests/ui/traits/non_lifetime_binders/basic.stderr
@@ -4,7 +4,7 @@ warning: the feature `non_lifetime_binders` is incomplete and may not be safe to
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/traits/non_lifetime_binders/fail.stderr
+++ b/tests/ui/traits/non_lifetime_binders/fail.stderr
@@ -4,7 +4,7 @@ warning: the feature `non_lifetime_binders` is incomplete and may not be safe to
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0277]: the trait bound `T: Trait` is not satisfied

--- a/tests/ui/traits/non_lifetime_binders/on-dyn.stderr
+++ b/tests/ui/traits/non_lifetime_binders/on-dyn.stderr
@@ -4,7 +4,7 @@ warning: the feature `non_lifetime_binders` is incomplete and may not be safe to
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 error: late-bound type parameter not allowed on trait object types

--- a/tests/ui/traits/non_lifetime_binders/on-ptr.stderr
+++ b/tests/ui/traits/non_lifetime_binders/on-ptr.stderr
@@ -4,7 +4,7 @@ warning: the feature `non_lifetime_binders` is incomplete and may not be safe to
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 error: late-bound type parameter not allowed on function pointer types


### PR DESCRIPTION
Moves the check for illegal bound var types from astconv to resolve_bound_vars. If a binder is defined to have a type or const late-bound var that's not allowed, we'll resolve any usages to ty error or const error values, so we shouldn't ever see late-bound types or consts in places they aren't expected.

Fixes #108184
Fixes #108181
Fixes #108192