### PR TITLE
Change src/etc/vscode_settings.json to always treat ./library as the sysroot source

### DIFF
--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -29,6 +29,7 @@ pub enum Profile {
 static SETTINGS_HASHES: &[&str] = &[
     "ea67e259dedf60d4429b6c349a564ffcd1563cf41c920a856d1f5b16b4701ac8",
     "56e7bf011c71c5d81e0bf42e84938111847a810eee69d906bba494ea90b51922",
+    "af1b5efe196aed007577899db9dae15d6dbc923d6fa42fa0934e68617ba9bbe0",
 ];
 static VSCODE_SETTINGS: &str = include_str!("../etc/vscode_settings.json");
 

--- a/src/etc/vscode_settings.json
+++ b/src/etc/vscode_settings.json
@@ -1,7 +1,7 @@
 {
     "rust-analyzer.check.invocationLocation": "root",
     "rust-analyzer.check.invocationStrategy": "once",
-    "rust-analyzer.checkOnSave.overrideCommand": [
+    "rust-analyzer.check.overrideCommand": [
         "python3",
         "x.py",
         "check",
@@ -23,6 +23,6 @@
         "check",
         "--json-output"
     ],
-    "rust-analyzer.cargo.sysroot": "./build/host/stage0-sysroot",
+    "rust-analyzer.cargo.sysrootSrc": "./library",
     "rust-analyzer.rustc.source": "./Cargo.toml"
 }


### PR DESCRIPTION
See
https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer/topic/False.20error.20report.20for.20.60rust-analyzer.28private-field.29.60 for further discussion; previously this had various bugs.

I tested go-to-definition on:
- `use std::io::Write` in `src/bootstrap/setup.rs`
- `use std::cell::RefCell` in `src/librustdoc/core.rs`
- `use rustc_span::symbol::sym` in `src/librustdoc/core.rs`
- `use std::fmt` in `compiler/rustc_span/src/symbol.rs`
- `Global` in `library/alloc/src/alloc/tests.rs`

The following things still don't work:
- `Global.deallocate` in alloc/tests.rs. This function is under `cfg(not(test))`, so it can't be enabled without disabling RA in `tests.rs` altogether. I think this might be fixable by moving `library/alloc/src/alloc/tests.rs` to `library/alloc/tests/alloc/lib.rs`, so it's in a different crate, but I'd like to avoid blocking this improvement on that change.

cc @thomcc @BoxyUwU @spastorino - you've had issues with RA in the past, does this fix them? Are there any other use cases I should test? You can try these changes out by running `cp src/etc/vscode_settings.json .vscode/settings.json`, or running `x setup` and picking a random profile (it won't overwrite config.toml if it already exists). See https://github.com/rust-lang/rust/pull/108135 for plans to make updating the config easier.

r? @Veykril