### PR TITLE
Fix some more `non_lifetime_binders` stuff with higher-ranked trait bounds

### DIFF
--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -418,10 +418,15 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'cx, 'tcx> {
                 bug!("encountered a fresh type during canonicalization")
             }
 
-            ty::Placeholder(placeholder) => self.canonicalize_ty_var(
-                CanonicalVarInfo { kind: CanonicalVarKind::PlaceholderTy(placeholder) },
-                t,
-            ),
+            ty::Placeholder(mut placeholder) => {
+                if !self.canonicalize_mode.preserve_universes() {
+                    placeholder.universe = ty::UniverseIndex::ROOT;
+                }
+                self.canonicalize_ty_var(
+                    CanonicalVarInfo { kind: CanonicalVarKind::PlaceholderTy(placeholder) },
+                    t,
+                )
+            }
 
             ty::Bound(debruijn, _) => {
                 if debruijn >= self.binder_index {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -735,7 +735,10 @@ pub trait PrettyPrinter<'tcx>:
                     p!(print(data))
                 }
             }
-            ty::Placeholder(placeholder) => p!(write("Placeholder({:?})", placeholder)),
+            ty::Placeholder(placeholder) => match placeholder.name {
+                ty::BoundTyKind::Anon(_) => p!(write("Placeholder({:?})", placeholder)),
+                ty::BoundTyKind::Param(_, name) => p!(write("{}", name)),
+            },
             ty::Alias(ty::Opaque, ty::AliasTy { def_id, substs, .. }) => {
                 // We use verbose printing in 'NO_QUERIES' mode, to
                 // avoid needing to call `predicates_of`. This should

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2148,12 +2148,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 }))
             }
 
-            ty::Alias(..) | ty::Param(_) => None,
+            ty::Alias(..) | ty::Param(_) | ty::Placeholder(..) => None,
             ty::Infer(ty::TyVar(_)) => Ambiguous,
 
-            ty::Placeholder(..)
-            | ty::Bound(..)
-            | ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            // We can make this an ICE if/once we actually instantiate the trait obligation.
+            ty::Bound(..) => None,
+
+            ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
                 bug!("asked to assemble builtin bounds of unexpected type: {:?}", self_ty);
             }
         }

--- a/tests/ui/traits/non_lifetime_binders/bad-sized-cond.rs
+++ b/tests/ui/traits/non_lifetime_binders/bad-sized-cond.rs
@@ -18,4 +18,6 @@ fn main() {
     //~^ ERROR the size for values of type `V` cannot be known at compilation time
 
     bar();
+    //~^ ERROR the size for values of type `V` cannot be known at compilation time
+    //~| ERROR `V` is not an iterator
 }

--- a/tests/ui/traits/non_lifetime_binders/bad-sized-cond.rs
+++ b/tests/ui/traits/non_lifetime_binders/bad-sized-cond.rs
@@ -7,7 +7,15 @@ where
 {
 }
 
+pub fn bar()
+where
+    for<V> V: IntoIterator,
+{
+}
+
 fn main() {
     foo();
     //~^ ERROR the size for values of type `V` cannot be known at compilation time
+
+    bar();
 }

--- a/tests/ui/traits/non_lifetime_binders/bad-sized-cond.rs
+++ b/tests/ui/traits/non_lifetime_binders/bad-sized-cond.rs
@@ -1,0 +1,13 @@
+#![feature(non_lifetime_binders)]
+//~^ WARN is incomplete and may not be safe
+
+pub fn foo()
+where
+    for<V> V: Sized,
+{
+}
+
+fn main() {
+    foo();
+    //~^ ERROR the size for values of type `V` cannot be known at compilation time
+}

--- a/tests/ui/traits/non_lifetime_binders/bad-sized-cond.stderr
+++ b/tests/ui/traits/non_lifetime_binders/bad-sized-cond.stderr
@@ -23,13 +23,13 @@ LL | where
 LL |     for<V> V: Sized,
    |               ^^^^^ required by this bound in `foo`
 
-error[E0277]: the size for values of type `Placeholder(Placeholder { universe: U3, name: Param(DefId(0:6 ~ bad_sized_cond[9450]::bar::V), "V") })` cannot be known at compilation time
+error[E0277]: the size for values of type `V` cannot be known at compilation time
   --> $DIR/bad-sized-cond.rs:20:5
    |
 LL |     bar();
    |     ^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `Placeholder(Placeholder { universe: U3, name: Param(DefId(0:6 ~ bad_sized_cond[9450]::bar::V), "V") })`
+   = help: the trait `Sized` is not implemented for `V`
    = note: required for `V` to implement `IntoIterator`
 note: required by a bound in `bar`
   --> $DIR/bad-sized-cond.rs:12:15
@@ -40,13 +40,13 @@ LL | where
 LL |     for<V> V: IntoIterator,
    |               ^^^^^^^^^^^^ required by this bound in `bar`
 
-error[E0277]: `Placeholder(Placeholder { universe: U3, name: Param(DefId(0:6 ~ bad_sized_cond[9450]::bar::V), "V") })` is not an iterator
+error[E0277]: `V` is not an iterator
   --> $DIR/bad-sized-cond.rs:20:5
    |
 LL |     bar();
-   |     ^^^ `Placeholder(Placeholder { universe: U3, name: Param(DefId(0:6 ~ bad_sized_cond[9450]::bar::V), "V") })` is not an iterator
+   |     ^^^ `V` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `Placeholder(Placeholder { universe: U3, name: Param(DefId(0:6 ~ bad_sized_cond[9450]::bar::V), "V") })`
+   = help: the trait `Iterator` is not implemented for `V`
    = note: required for `V` to implement `IntoIterator`
 note: required by a bound in `bar`
   --> $DIR/bad-sized-cond.rs:12:15

--- a/tests/ui/traits/non_lifetime_binders/bad-sized-cond.stderr
+++ b/tests/ui/traits/non_lifetime_binders/bad-sized-cond.stderr
@@ -8,7 +8,7 @@ LL | #![feature(non_lifetime_binders)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0277]: the size for values of type `V` cannot be known at compilation time
-  --> $DIR/bad-sized-cond.rs:11:5
+  --> $DIR/bad-sized-cond.rs:17:5
    |
 LL |     foo();
    |     ^^^ doesn't have a size known at compile-time
@@ -23,6 +23,40 @@ LL | where
 LL |     for<V> V: Sized,
    |               ^^^^^ required by this bound in `foo`
 
-error: aborting due to previous error; 1 warning emitted
+error[E0277]: the size for values of type `Placeholder(Placeholder { universe: U3, name: Param(DefId(0:6 ~ bad_sized_cond[9450]::bar::V), "V") })` cannot be known at compilation time
+  --> $DIR/bad-sized-cond.rs:20:5
+   |
+LL |     bar();
+   |     ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `Placeholder(Placeholder { universe: U3, name: Param(DefId(0:6 ~ bad_sized_cond[9450]::bar::V), "V") })`
+   = note: required for `V` to implement `IntoIterator`
+note: required by a bound in `bar`
+  --> $DIR/bad-sized-cond.rs:12:15
+   |
+LL | pub fn bar()
+   |        --- required by a bound in this
+LL | where
+LL |     for<V> V: IntoIterator,
+   |               ^^^^^^^^^^^^ required by this bound in `bar`
+
+error[E0277]: `Placeholder(Placeholder { universe: U3, name: Param(DefId(0:6 ~ bad_sized_cond[9450]::bar::V), "V") })` is not an iterator
+  --> $DIR/bad-sized-cond.rs:20:5
+   |
+LL |     bar();
+   |     ^^^ `Placeholder(Placeholder { universe: U3, name: Param(DefId(0:6 ~ bad_sized_cond[9450]::bar::V), "V") })` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `Placeholder(Placeholder { universe: U3, name: Param(DefId(0:6 ~ bad_sized_cond[9450]::bar::V), "V") })`
+   = note: required for `V` to implement `IntoIterator`
+note: required by a bound in `bar`
+  --> $DIR/bad-sized-cond.rs:12:15
+   |
+LL | pub fn bar()
+   |        --- required by a bound in this
+LL | where
+LL |     for<V> V: IntoIterator,
+   |               ^^^^^^^^^^^^ required by this bound in `bar`
+
+error: aborting due to 3 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/non_lifetime_binders/bad-sized-cond.stderr
+++ b/tests/ui/traits/non_lifetime_binders/bad-sized-cond.stderr
@@ -1,0 +1,28 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/bad-sized-cond.rs:1:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0277]: the size for values of type `V` cannot be known at compilation time
+  --> $DIR/bad-sized-cond.rs:11:5
+   |
+LL |     foo();
+   |     ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `V`
+note: required by a bound in `foo`
+  --> $DIR/bad-sized-cond.rs:6:15
+   |
+LL | pub fn foo()
+   |        --- required by a bound in this
+LL | where
+LL |     for<V> V: Sized,
+   |               ^^^^^ required by this bound in `foo`
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
1. When assembling candidates for `for<T> T: Sized`, we can't ICE because the self-type is a bound type.
2. Fix an issue where, when canonicalizing in non-universe preserving mode, we don't actually set the universe for placeholders to the root even though we do the same for region vars.
3. Make `Placeholder("T")` format like `T` in error messages.

Fixes #108180
Fixes #108182

r? types