### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
  "declare_clippy_lint",
  "if_chain",
  "itertools",
- "pulldown-cmark 0.9.2",
+ "pulldown-cmark",
  "quine-mc_cluskey",
  "regex-syntax",
  "rustc-semver",
@@ -2555,7 +2555,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "opener",
- "pulldown-cmark 0.9.2",
+ "pulldown-cmark",
  "regex",
  "serde",
  "serde_json",
@@ -2572,7 +2572,7 @@ dependencies = [
  "anyhow",
  "handlebars 3.5.5",
  "pretty_assertions",
- "pulldown-cmark 0.7.2",
+ "pulldown-cmark",
  "same-file",
  "serde_json",
  "url",
@@ -3267,17 +3267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca36dea94d187597e104a5c8e4b07576a8a45aa5db48a65e12940d3eb7461f55"
-dependencies = [
- "bitflags",
- "memchr",
- "unicase",
 ]
 
 [[package]]
@@ -4583,7 +4572,7 @@ name = "rustc_resolve"
 version = "0.0.0"
 dependencies = [
  "bitflags",
- "pulldown-cmark 0.9.2",
+ "pulldown-cmark",
  "rustc_arena",
  "rustc_ast",
  "rustc_ast_pretty",


### PR DESCRIPTION
10 commits in 39c13e67a5962466cc7253d41bc1099bbcb224c3..17b3d0de0897e1c6b8ca347bd39f850bb0a5b9f6 2023-02-12 02:01:08 +0000 to 2023-02-17 19:45:09 +0000

- fix: unsupported protocol error on old macos version (rust-lang/cargo#11733)
- Error on invalid alphanumeric token for crates.io (rust-lang/cargo#11600)
- Add clippy lints (rust-lang/cargo#11722)
- chore: Make dependencies alphabetical order (rust-lang/cargo#11719)
- chore: bump mdbook to 0.4.27 (rust-lang/cargo#11716)
- Amend `mdman` tests. (rust-lang/cargo#11715)
- Run CI for macOS on nightly (rust-lang/cargo#11712)
- doc: doc comments and intra-doc links for `core::compiler` (rust-lang/cargo#11711)
- Ensure em dashes are recognizable in markup (rust-lang/cargo#11646)
- Set CARGO_BIN_NAME environment variable also for binary examples (rust-lang/cargo#11705)

r? @ghost