### PR TITLE
Make sure `test_type_match` doesn't ICE with late-bound types

### DIFF
--- a/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
+++ b/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
@@ -186,7 +186,8 @@ impl<'tcx> TypeRelation<'tcx> for Match<'tcx> {
 
     #[instrument(skip(self), level = "debug")]
     fn tys(&mut self, pattern: Ty<'tcx>, value: Ty<'tcx>) -> RelateResult<'tcx, Ty<'tcx>> {
-        if let ty::Error(_) = pattern.kind() {
+        // FIXME(non_lifetime_binders): What to do here?
+        if matches!(pattern.kind(), ty::Error(_) | ty::Bound(..)) {
             // Unlike normal `TypeRelation` rules, `ty::Error` does not equal any type.
             self.no_match()
         } else if pattern == value {

--- a/tests/ui/traits/non_lifetime_binders/type-match-with-late-bound.rs
+++ b/tests/ui/traits/non_lifetime_binders/type-match-with-late-bound.rs
@@ -1,0 +1,14 @@
+// edition:2021
+// check-pass
+
+// Checks that test_type_match code doesn't ICE when predicates have late-bound types
+
+#![feature(non_lifetime_binders)]
+//~^ WARN is incomplete and may not be safe to use
+
+async fn walk2<'a, T: 'a>(_: T)
+where
+    for<F> F: 'a,
+{}
+
+fn main() {}

--- a/tests/ui/traits/non_lifetime_binders/type-match-with-late-bound.stderr
+++ b/tests/ui/traits/non_lifetime_binders/type-match-with-late-bound.stderr
@@ -1,0 +1,11 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/type-match-with-late-bound.rs:6:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes #108190 (in a kind of hacky way, anyways doesn't really matter)