### PR TITLE
fix: mock ConstParm when encounter LateBound during convert path expr

### DIFF
--- a/tests/ui/traits/non_lifetime_binders/path-expr.rs
+++ b/tests/ui/traits/non_lifetime_binders/path-expr.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+#![feature(non_lifetime_binders)]
+//~^ WARN the feature `non_lifetime_binders` is incomplete
+
+fn b() where for<const C: usize> [(); C]: Clone {}
+
+fn main() {
+    b();
+}

--- a/tests/ui/traits/non_lifetime_binders/path-expr.stderr
+++ b/tests/ui/traits/non_lifetime_binders/path-expr.stderr
@@ -1,0 +1,11 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/path-expr.rs:3:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
close #108194 