### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
  "declare_clippy_lint",
  "if_chain",
  "itertools",
- "pulldown-cmark 0.9.2",
+ "pulldown-cmark",
  "quine-mc_cluskey",
  "regex-syntax",
  "rustc-semver",
@@ -2555,7 +2555,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "opener",
- "pulldown-cmark 0.9.2",
+ "pulldown-cmark",
  "regex",
  "serde",
  "serde_json",
@@ -2572,7 +2572,7 @@ dependencies = [
  "anyhow",
  "handlebars 3.5.5",
  "pretty_assertions",
- "pulldown-cmark 0.7.2",
+ "pulldown-cmark",
  "same-file",
  "serde_json",
  "url",
@@ -3267,17 +3267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca36dea94d187597e104a5c8e4b07576a8a45aa5db48a65e12940d3eb7461f55"
-dependencies = [
- "bitflags",
- "memchr",
- "unicase",
 ]
 
 [[package]]
@@ -4583,7 +4572,7 @@ name = "rustc_resolve"
 version = "0.0.0"
 dependencies = [
  "bitflags",
- "pulldown-cmark 0.9.2",
+ "pulldown-cmark",
  "rustc_arena",
  "rustc_ast",
  "rustc_ast_pretty",

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -145,10 +145,13 @@ pub unsafe fn create_module<'ll>(
     let llvm_version = llvm_util::get_version();
     if llvm_version < (16, 0, 0) {
         if sess.target.arch == "s390x" {
-            // See https://reviews.llvm.org/D131158
+            // LLVM 16 data layout changed to always set 64-bit vector alignment,
+            // which is conditional in earlier LLVM versions.
+            // https://reviews.llvm.org/D131158 for the discussion.
             target_data_layout = target_data_layout.replace("-v128:64", "");
         } else if sess.target.arch == "riscv64" {
-            // See https://reviews.llvm.org/D116735
+            // LLVM 16 introduced this change so as to produce more efficient code.
+            // See https://reviews.llvm.org/D116735 for the discussion.
             target_data_layout = target_data_layout.replace("-n32:64-", "-n64-");
         }
     }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -145,8 +145,10 @@ pub unsafe fn create_module<'ll>(
     let llvm_version = llvm_util::get_version();
     if llvm_version < (16, 0, 0) {
         if sess.target.arch == "s390x" {
+            // See https://reviews.llvm.org/D131158
             target_data_layout = target_data_layout.replace("-v128:64", "");
         } else if sess.target.arch == "riscv64" {
+            // See https://reviews.llvm.org/D116735
             target_data_layout = target_data_layout.replace("-n32:64-", "-n64-");
         }
     }

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -471,6 +471,8 @@ pub enum StashKey {
     /// When an invalid lifetime e.g. `'2` should be reinterpreted
     /// as a char literal in the parser
     LifetimeIsChar,
+    /// When an invalid lifetime e.g. `'🐱` contains emoji.
+    LifetimeContainsEmoji,
     /// Maybe there was a typo where a comma was forgotten before
     /// FRU syntax
     MaybeFruTypo,

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -474,7 +474,7 @@ declare_features! (
     /// Allows using the `non_exhaustive_omitted_patterns` lint.
     (active, non_exhaustive_omitted_patterns_lint, "1.57.0", Some(89554), None),
     /// Allows `for<T>` binders in where-clauses
-    (incomplete, non_lifetime_binders, "CURRENT_RUSTC_VERSION", Some(1), None),
+    (incomplete, non_lifetime_binders, "CURRENT_RUSTC_VERSION", Some(108185), None),
     /// Allows making `dyn Trait` well-formed even if `Trait` is not object safe.
     /// In that case, `dyn Trait: Trait` does not hold. Moreover, coercions and
     /// casts in safe Rust to `dyn Trait` for such a `Trait` is also forbidden.

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -398,7 +398,12 @@ fn has_late_bound_regions<'tcx>(tcx: TyCtxt<'tcx>, node: Node<'tcx>) -> Option<S
                 Some(rbv::ResolvedArg::StaticLifetime | rbv::ResolvedArg::EarlyBound(..)) => {}
                 Some(rbv::ResolvedArg::LateBound(debruijn, _, _))
                     if debruijn < self.outer_index => {}
-                Some(rbv::ResolvedArg::LateBound(..) | rbv::ResolvedArg::Free(..)) | None => {
+                Some(
+                    rbv::ResolvedArg::LateBound(..)
+                    | rbv::ResolvedArg::Free(..)
+                    | rbv::ResolvedArg::Error(_),
+                )
+                | None => {
                     self.has_late_bound_regions = Some(lt.ident.span);
                 }
             }

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -134,7 +134,8 @@ impl<'tcx> Visitor<'tcx> for FindNestedTypeVisitor<'tcx> {
                             rbv::ResolvedArg::StaticLifetime
                             | rbv::ResolvedArg::Free(_, _)
                             | rbv::ResolvedArg::EarlyBound(_)
-                            | rbv::ResolvedArg::LateBound(_, _, _),
+                            | rbv::ResolvedArg::LateBound(_, _, _)
+                            | rbv::ResolvedArg::Error(_),
                         )
                         | None,
                         _,
@@ -211,7 +212,8 @@ impl<'tcx> Visitor<'tcx> for TyPathVisitor<'tcx> {
                     rbv::ResolvedArg::StaticLifetime
                     | rbv::ResolvedArg::EarlyBound(_)
                     | rbv::ResolvedArg::LateBound(_, _, _)
-                    | rbv::ResolvedArg::Free(_, _),
+                    | rbv::ResolvedArg::Free(_, _)
+                    | rbv::ResolvedArg::Error(_),
                 )
                 | None,
                 _,

--- a/compiler/rustc_lexer/src/tests.rs
+++ b/compiler/rustc_lexer/src/tests.rs
@@ -235,7 +235,7 @@ fn lifetime() {
     check_lexing(
         "'abc",
         expect![[r#"
-            Token { kind: Lifetime { starts_with_number: false }, len: 4 }
+            Token { kind: Lifetime { starts_with_number: false, contains_emoji: false }, len: 4 }
         "#]],
     );
 }

--- a/compiler/rustc_lint/src/deref_into_dyn_supertrait.rs
+++ b/compiler/rustc_lint/src/deref_into_dyn_supertrait.rs
@@ -78,7 +78,7 @@ impl<'tcx> LateLintPass<'tcx> for DerefIntoDynSupertrait {
             });
             cx.emit_spanned_lint(DEREF_INTO_DYN_SUPERTRAIT, cx.tcx.def_span(item.owner_id.def_id), SupertraitAsDerefTarget {
                 t,
-                target_principal: target_principal.to_string(),
+                target_principal,
                 label,
             });
         }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -8,7 +8,7 @@ use rustc_errors::{
 };
 use rustc_hir::def_id::DefId;
 use rustc_macros::{LintDiagnostic, Subdiagnostic};
-use rustc_middle::ty::{Predicate, Ty, TyCtxt};
+use rustc_middle::ty::{PolyExistentialTraitRef, Predicate, Ty, TyCtxt};
 use rustc_session::parse::ParseSess;
 use rustc_span::{edition::Edition, sym, symbol::Ident, Span, Symbol};
 
@@ -556,8 +556,7 @@ pub struct BuiltinUnexpectedCliConfigValue {
 #[diag(lint_supertrait_as_deref_target)]
 pub struct SupertraitAsDerefTarget<'a> {
     pub t: Ty<'a>,
-    pub target_principal: String,
-    // pub target_principal: Binder<'a, ExistentialTraitRef<'b>>,
+    pub target_principal: PolyExistentialTraitRef<'a>,
     #[subdiagnostic]
     pub label: Option<SupertraitAsDerefTargetLabel>,
 }

--- a/compiler/rustc_middle/src/middle/resolve_bound_vars.rs
+++ b/compiler/rustc_middle/src/middle/resolve_bound_vars.rs
@@ -3,6 +3,7 @@
 use crate::ty;
 
 use rustc_data_structures::fx::FxHashMap;
+use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{ItemLocalId, OwnerId};
 use rustc_macros::HashStable;
@@ -13,6 +14,7 @@ pub enum ResolvedArg {
     EarlyBound(/* decl */ DefId),
     LateBound(ty::DebruijnIndex, /* late-bound index */ u32, /* decl */ DefId),
     Free(DefId, /* lifetime decl */ DefId),
+    Error(ErrorGuaranteed),
 }
 
 /// A set containing, at most, one known element.

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -149,6 +149,9 @@ impl<'tcx> Const<'tcx> {
                         ty::ConstKind::Bound(debruijn, ty::BoundVar::from_u32(index)),
                         ty,
                     )),
+                    Some(rbv::ResolvedArg::Error(guar)) => {
+                        Some(tcx.const_error_with_guaranteed(ty, guar))
+                    }
                     arg => bug!("unexpected bound var resolution for {:?}: {arg:?}", expr.hir_id),
                 }
             }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -933,6 +933,12 @@ impl<'tcx> PolyExistentialTraitRef<'tcx> {
     }
 }
 
+impl rustc_errors::IntoDiagnosticArg for PolyExistentialTraitRef<'_> {
+    fn into_diagnostic_arg(self) -> rustc_errors::DiagnosticArgValue<'static> {
+        self.to_string().into_diagnostic_arg()
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, TyEncodable, TyDecodable)]
 #[derive(HashStable)]
 pub enum BoundVariableKind {

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -19,7 +19,6 @@ use rustc_data_structures::sync::Lock;
 use rustc_errors::{DiagnosticBuilder, ErrorGuaranteed, FatalError};
 use rustc_session::Session;
 use rustc_span::{Span, DUMMY_SP};
-use std::borrow::Borrow;
 use std::cell::Cell;
 use std::collections::hash_map::Entry;
 use std::fmt::Debug;
@@ -364,25 +363,13 @@ where
             let (result, dep_node_index) =
                 execute_job::<Q, Qcx>(qcx, key.clone(), dep_node, job.id);
             if Q::FEEDABLE {
-                // We may have put a value inside the cache from inside the execution.
-                // Verify that it has the same hash as what we have now, to ensure consistency.
+                // We should not compute queries that also got a value via feeding.
+                // This can't happen, as query feeding adds the very dependencies to the fed query
+                // as its feeding query had. So if the fed query is red, so is its feeder, which will
+                // get evaluated first, and re-feed the query.
                 if let Some((cached_result, _)) = cache.lookup(&key) {
-                    let hasher = Q::HASH_RESULT.expect("feedable forbids no_hash");
-
-                    let old_hash = qcx.dep_context().with_stable_hashing_context(|mut hcx| {
-                        hasher(&mut hcx, cached_result.borrow())
-                    });
-                    let new_hash = qcx
-                        .dep_context()
-                        .with_stable_hashing_context(|mut hcx| hasher(&mut hcx, &result));
-                    debug_assert_eq!(
-                        old_hash,
-                        new_hash,
-                        "Computed query value for {:?}({:?}) is inconsistent with fed value,\ncomputed={:#?}\nfed={:#?}",
-                        Q::DEP_KIND,
-                        key,
-                        result,
-                        cached_result,
+                    panic!(
+                        "fed query later has its value computed. The already cached value: {cached_result:?}"
                     );
                 }
             }

--- a/tests/ui/bounds-lifetime.stderr
+++ b/tests/ui/bounds-lifetime.stderr
@@ -22,7 +22,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | type D = for<'a, T> fn();
    |                  ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error[E0658]: only lifetime parameters can be used in this context
@@ -31,7 +31,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | type E = dyn for<T> Fn();
    |                  ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors

--- a/tests/ui/closures/binder/const-bound.rs
+++ b/tests/ui/closures/binder/const-bound.rs
@@ -1,0 +1,7 @@
+#![feature(closure_lifetime_binder, non_lifetime_binders)]
+//~^ WARN  is incomplete and may not be safe to use
+
+fn main()  {
+    for<const N: i32> || -> () {};
+    //~^ ERROR late-bound const parameter not allowed on closures
+}

--- a/tests/ui/closures/binder/const-bound.stderr
+++ b/tests/ui/closures/binder/const-bound.stderr
@@ -1,0 +1,17 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/const-bound.rs:1:37
+   |
+LL | #![feature(closure_lifetime_binder, non_lifetime_binders)]
+   |                                     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: late-bound const parameter not allowed on closures
+  --> $DIR/const-bound.rs:5:9
+   |
+LL |     for<const N: i32> || -> () {};
+   |         ^^^^^^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/closures/binder/disallow-const.stderr
+++ b/tests/ui/closures/binder/disallow-const.stderr
@@ -4,7 +4,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL |     for<const N: i32> || -> () {};
    |               ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/tests/ui/closures/binder/disallow-ty.stderr
+++ b/tests/ui/closures/binder/disallow-ty.stderr
@@ -4,7 +4,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL |     for<T> || -> () {};
    |         ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/tests/ui/closures/binder/type-bound-2.rs
+++ b/tests/ui/closures/binder/type-bound-2.rs
@@ -1,0 +1,7 @@
+#![feature(closure_lifetime_binder, non_lifetime_binders)]
+//~^ WARN  is incomplete and may not be safe to use
+
+fn main() {
+    for<T> || -> () {};
+    //~^ ERROR late-bound type parameter not allowed on closures
+}

--- a/tests/ui/closures/binder/type-bound-2.stderr
+++ b/tests/ui/closures/binder/type-bound-2.stderr
@@ -1,0 +1,17 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/type-bound-2.rs:1:37
+   |
+LL | #![feature(closure_lifetime_binder, non_lifetime_binders)]
+   |                                     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: late-bound type parameter not allowed on closures
+  --> $DIR/type-bound-2.rs:5:9
+   |
+LL |     for<T> || -> () {};
+   |         ^
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/closures/binder/type-bound.rs
+++ b/tests/ui/closures/binder/type-bound.rs
@@ -1,0 +1,7 @@
+#![feature(closure_lifetime_binder, non_lifetime_binders)]
+//~^ WARN  is incomplete and may not be safe to use
+
+fn main()  {
+    for<T> || -> T {};
+    //~^ ERROR late-bound type parameter not allowed on closures
+}

--- a/tests/ui/closures/binder/type-bound.stderr
+++ b/tests/ui/closures/binder/type-bound.stderr
@@ -1,0 +1,17 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/type-bound.rs:1:37
+   |
+LL | #![feature(closure_lifetime_binder, non_lifetime_binders)]
+   |                                     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: late-bound type parameter not allowed on closures
+  --> $DIR/type-bound.rs:5:9
+   |
+LL |     for<T> || -> T {};
+   |         ^
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/conditional-compilation/cfg-generic-params.stderr
+++ b/tests/ui/conditional-compilation/cfg-generic-params.stderr
@@ -34,7 +34,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | type FnBad = for<#[cfg(no)] 'a, #[cfg(yes)] T> fn();
    |                                             ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error[E0658]: only lifetime parameters can be used in this context
@@ -43,7 +43,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | type PolyBad = dyn for<#[cfg(no)] 'a, #[cfg(yes)] T> Copy;
    |                                                   ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error[E0658]: only lifetime parameters can be used in this context
@@ -52,7 +52,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | struct WhereBad where for<#[cfg(no)] 'a, #[cfg(yes)] T> u8: Copy;
    |                                                      ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error: aborting due to 8 previous errors

--- a/tests/ui/feature-gates/feature-gate-non_lifetime_binders.stderr
+++ b/tests/ui/feature-gates/feature-gate-non_lifetime_binders.stderr
@@ -4,7 +4,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | fn foo() where for<T> T:, {}
    |                    ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/tests/ui/higher-rank-trait-bounds/hrtb-wrong-kind.stderr
+++ b/tests/ui/higher-rank-trait-bounds/hrtb-wrong-kind.stderr
@@ -4,7 +4,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | fn a() where for<T> T: Copy {}
    |                  ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error[E0658]: only lifetime parameters can be used in this context
@@ -13,7 +13,7 @@ error[E0658]: only lifetime parameters can be used in this context
 LL | fn b() where for<const C: usize> [(); C]: Copy {}
    |                        ^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/tests/ui/lexer/issue-108019-bad-emoji-recovery.rs
+++ b/tests/ui/lexer/issue-108019-bad-emoji-recovery.rs
@@ -1,0 +1,45 @@
+#![allow(unused_labels)]
+
+// FIXME(#108019): outdated Unicode table
+// fn foo() {
+//     '🥺 loop {
+//         break
+//     }
+// }
+
+fn bar() {
+    '🐱 loop {
+    //~^ ERROR labeled expression must be followed by `:`
+    //~| ERROR lifetimes or labels cannot contain emojis
+        break
+    }
+}
+
+fn qux() {
+    'a🐱 loop {
+    //~^ ERROR labeled expression must be followed by `:`
+    //~| ERROR lifetimes or labels cannot contain emojis
+        break
+    }
+}
+
+fn quux() {
+    '1🐱 loop {
+    //~^ ERROR labeled expression must be followed by `:`
+    //~| ERROR lifetimes or labels cannot start with a number
+        break
+    }
+}
+
+fn x<'🐱>() -> &'🐱 () {
+    //~^ ERROR lifetimes or labels cannot contain emojis
+    //~| ERROR lifetimes or labels cannot contain emojis
+    &()
+}
+
+fn y() {
+    'a🐱: loop {}
+    //~^ ERROR lifetimes or labels cannot contain emojis
+}
+
+fn main() {}

--- a/tests/ui/lexer/issue-108019-bad-emoji-recovery.stderr
+++ b/tests/ui/lexer/issue-108019-bad-emoji-recovery.stderr
@@ -1,0 +1,86 @@
+error: labeled expression must be followed by `:`
+  --> $DIR/issue-108019-bad-emoji-recovery.rs:11:5
+   |
+LL |       '🐱 loop {
+   |       ^--- help: add `:` after the label
+   |       |
+   |  _____the label
+   | |
+LL | |
+LL | |
+LL | |         break
+LL | |     }
+   | |_____^
+   |
+   = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+
+error: labeled expression must be followed by `:`
+  --> $DIR/issue-108019-bad-emoji-recovery.rs:19:5
+   |
+LL |       'a🐱 loop {
+   |       ^---- help: add `:` after the label
+   |       |
+   |  _____the label
+   | |
+LL | |
+LL | |
+LL | |         break
+LL | |     }
+   | |_____^
+   |
+   = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+
+error: labeled expression must be followed by `:`
+  --> $DIR/issue-108019-bad-emoji-recovery.rs:27:5
+   |
+LL |       '1🐱 loop {
+   |       ^---- help: add `:` after the label
+   |       |
+   |  _____the label
+   | |
+LL | |
+LL | |
+LL | |         break
+LL | |     }
+   | |_____^
+   |
+   = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+
+error: lifetimes or labels cannot contain emojis
+  --> $DIR/issue-108019-bad-emoji-recovery.rs:11:5
+   |
+LL |     '🐱 loop {
+   |     ^^^
+
+error: lifetimes or labels cannot contain emojis
+  --> $DIR/issue-108019-bad-emoji-recovery.rs:19:5
+   |
+LL |     'a🐱 loop {
+   |     ^^^^
+
+error: lifetimes or labels cannot start with a number
+  --> $DIR/issue-108019-bad-emoji-recovery.rs:27:5
+   |
+LL |     '1🐱 loop {
+   |     ^^^^
+
+error: lifetimes or labels cannot contain emojis
+  --> $DIR/issue-108019-bad-emoji-recovery.rs:34:6
+   |
+LL | fn x<'🐱>() -> &'🐱 () {
+   |      ^^^
+
+error: lifetimes or labels cannot contain emojis
+  --> $DIR/issue-108019-bad-emoji-recovery.rs:34:16
+   |
+LL | fn x<'🐱>() -> &'🐱 () {
+   |                 ^^^
+
+error: lifetimes or labels cannot contain emojis
+  --> $DIR/issue-108019-bad-emoji-recovery.rs:41:5
+   |
+LL |     'a🐱: loop {}
+   |     ^^^^
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/lint/issue-108155.rs
+++ b/tests/ui/lint/issue-108155.rs
@@ -1,0 +1,15 @@
+// check-pass
+// check that `deref_into_dyn_supertrait` doesn't cause ICE by eagerly converting
+// a cancelled lint
+
+#![allow(deref_into_dyn_supertrait)]
+
+trait Trait {}
+impl std::ops::Deref for dyn Trait + Send + Sync {
+    type Target = dyn Trait;
+    fn deref(&self) -> &Self::Target {
+        self
+    }
+}
+
+fn main() {}

--- a/tests/ui/parser/numeric-lifetime.rs
+++ b/tests/ui/parser/numeric-lifetime.rs
@@ -1,6 +1,6 @@
 struct S<'1> { s: &'1 usize }
-//~^ ERROR lifetimes cannot start with a number
-//~| ERROR lifetimes cannot start with a number
+//~^ ERROR lifetimes or labels cannot start with a number
+//~| ERROR lifetimes or labels cannot start with a number
 fn main() {
     // verify that the parse error doesn't stop type checking
     let x: usize = "";

--- a/tests/ui/parser/numeric-lifetime.stderr
+++ b/tests/ui/parser/numeric-lifetime.stderr
@@ -6,13 +6,13 @@ LL |     let x: usize = "";
    |            |
    |            expected due to this
 
-error: lifetimes cannot start with a number
+error: lifetimes or labels cannot start with a number
   --> $DIR/numeric-lifetime.rs:1:10
    |
 LL | struct S<'1> { s: &'1 usize }
    |          ^^
 
-error: lifetimes cannot start with a number
+error: lifetimes or labels cannot start with a number
   --> $DIR/numeric-lifetime.rs:1:20
    |
 LL | struct S<'1> { s: &'1 usize }

--- a/tests/ui/traits/non_lifetime_binders/basic.stderr
+++ b/tests/ui/traits/non_lifetime_binders/basic.stderr
@@ -4,7 +4,7 @@ warning: the feature `non_lifetime_binders` is incomplete and may not be safe to
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/traits/non_lifetime_binders/fail.stderr
+++ b/tests/ui/traits/non_lifetime_binders/fail.stderr
@@ -4,7 +4,7 @@ warning: the feature `non_lifetime_binders` is incomplete and may not be safe to
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0277]: the trait bound `T: Trait` is not satisfied

--- a/tests/ui/traits/non_lifetime_binders/on-dyn.stderr
+++ b/tests/ui/traits/non_lifetime_binders/on-dyn.stderr
@@ -4,7 +4,7 @@ warning: the feature `non_lifetime_binders` is incomplete and may not be safe to
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 error: late-bound type parameter not allowed on trait object types

--- a/tests/ui/traits/non_lifetime_binders/on-ptr.stderr
+++ b/tests/ui/traits/non_lifetime_binders/on-ptr.stderr
@@ -4,7 +4,7 @@ warning: the feature `non_lifetime_binders` is incomplete and may not be safe to
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 error: late-bound type parameter not allowed on function pointer types


### PR DESCRIPTION
Successful merges:

 - #108031 (Don't recover lifetimes/labels containing emojis as character literals)
 - #108046 (Don't allow evaluating queries that were fed in a previous compiler run)
 - #108162 (Don't eagerly convert principal to string)
 - #108186 (Deny non-lifetime bound vars in `for<..> ||` closure binders)
 - #108197 (Update cargo)
 - #108205 (link to llvm changes that prompted the special cases)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=108031,108046,108162,108186,108197,108205)
<!-- homu-ignore:end -->