### PR TITLE
spawn python with explicit arch for lldb_batchmode

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1149,8 +1149,7 @@ impl<'test> TestCx<'test> {
         rust_src_root: &Path,
     ) -> ProcRes {
         let mut cmd: Command;
-        if (self.config.matches_arch("aarch64")
-            || self.config.matches_arch("arm64"))
+        if (self.config.matches_arch("aarch64") || self.config.matches_arch("arm64"))
             && self.config.matches_os("macos")
         {
             cmd = Command::new("arch");
@@ -1161,8 +1160,7 @@ impl<'test> TestCx<'test> {
         // Prepare the lldb_batchmode which executes the debugger script
         let lldb_script_path = rust_src_root.join("src/etc/lldb_batchmode.py");
         self.cmd2procres(
-            cmd
-                .arg(&lldb_script_path)
+            cmd.arg(&lldb_script_path)
                 .arg(test_executable)
                 .arg(debugger_script)
                 .env("PYTHONUNBUFFERED", "1") // Help debugging #78665

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1148,10 +1148,20 @@ impl<'test> TestCx<'test> {
         debugger_script: &Path,
         rust_src_root: &Path,
     ) -> ProcRes {
+        let mut cmd: Command;
+        if (self.config.matches_arch("aarch64")
+            || self.config.matches_arch("arm64"))
+            && self.config.matches_os("macos")
+        {
+            cmd = Command::new("arch");
+            cmd.arg("-arm64").arg(&self.config.python);
+        } else {
+            cmd = Command::new(&self.config.python);
+        };
         // Prepare the lldb_batchmode which executes the debugger script
         let lldb_script_path = rust_src_root.join("src/etc/lldb_batchmode.py");
         self.cmd2procres(
-            Command::new(&self.config.python)
+            cmd
                 .arg(&lldb_script_path)
                 .arg(test_executable)
                 .arg(debugger_script)


### PR DESCRIPTION
On my arm64 Mac entire `tests/debuginfo/` suite is failing due to errors produced by lldb while invoking `run` debug commands
> run
error: the platform is not currently connected

It appears that _somehow_ platform information is not preserved when spawning python process. And given that python is a universal binary with both arm64 and x86_64 architectures (at least on my machine) latter is being incorrectly chosen and then it spawns improper lldb.

Another curious observation is that following program adapted from `run_lldb` works correctly when being compiled ie `cargo build && ./target/debug/runlldb` but fails when launched directly from cargo ie `cargo run`

<details>
  <summary>the program</summary>

```rust
use std::process::{Command, Output};

fn main() {
    run_lldb();
}

fn run_lldb() {
    cmd2procres(
        Command::new("/usr/bin/python3")
            .arg("./src/etc/lldb_batchmode.py")
            .arg("./build/aarch64-apple-darwin/test/debuginfo/basic-types.lldb/a")
            .arg("./build/aarch64-apple-darwin/test/debuginfo/basic-types.lldb/basic-types.debugger.script")
            .env("PYTHONUNBUFFERED", "1")
            .env("PYTHONPATH", "/Library/Developer/CommandLineTools/Library/PrivateFrameworks/LLDB.framework/Resources/Python"),
    )
}

fn cmd2procres(cmd: &mut Command) {
    match cmd.output() {
        Ok(Output { status, stdout, stderr }) => {
            println!("status: {}, stdout: {}, stderr: {}", status, String::from_utf8(stdout).unwrap(), String::from_utf8(stderr).unwrap());
        }
        Err(e) => {
            eprintln!("Failed to setup Python process for LLDB script: {}", e);
        }
    };
}

```
</details>

Which makes me think that there is a bug in cargo to be fixed as well.

I'm not sure that `runtest.rs` is the best place for such patch, perhaps I should look somewhere upstream, starting at `x.py`, and I'd appreciate it if someone could point me to the right place. So please consider this PR as an illustrative work. There is also the possibility that my setup is utterly broken, and these problems are not reproducible beyond my machine. 🙈 