### PR TITLE
[107049] Recognise top level keys in config.toml.example

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -379,8 +379,14 @@ cur_section = None
 sections[None] = []
 section_order = [None]
 targets = {}
+top_level_keys = []
 
 for line in open(rust_dir + '/config.toml.example').read().split("\n"):
+    if cur_section == None: 
+        if line.count('=') == 1: 
+            top_level_key = line.split('=')[0]
+            top_level_key = top_level_key.strip(' #')
+            top_level_keys.append(top_level_key)
     if line.startswith('['):
         cur_section = line[1:-1]
         if cur_section.startswith('target'):
@@ -459,12 +465,23 @@ def configure_section(lines, config):
                 raise RuntimeError("failed to find config line for {}".format(key))
 
 
-for section_key in config:
-    section_config = config[section_key]
-    if section_key not in sections:
-        raise RuntimeError("config key {} not in sections".format(section_key))
+def configure_top_level_key(lines, top_level_key, value): 
+    for i, line in enumerate(lines): 
+        if line.startswith('#' + top_level_key + ' = ') or line.startswith(top_level_key + ' = '): 
+            lines[i] = "{} = {}".format(top_level_key, value)
+            return 
+        
+    raise RuntimeError("failed to find config line for {}".format(top_level_key))
 
-    if section_key == 'target':
+      
+for section_key, section_config in config.items():
+    if section_key not in sections and section_key not in top_level_keys: 
+        raise RuntimeError("config key {} not in sections or top_level_keys".format(section_key))
+    
+    if section_key in top_level_keys: 
+        configure_top_level_key(sections[None], section_key, section_config)
+
+    elif  section_key == 'target':
         for target in section_config:
             configure_section(targets[target], section_config[target])
     else:

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -382,8 +382,8 @@ targets = {}
 top_level_keys = []
 
 for line in open(rust_dir + '/config.toml.example').read().split("\n"):
-    if cur_section == None: 
-        if line.count('=') == 1: 
+    if cur_section == None:
+        if line.count('=') == 1:
             top_level_key = line.split('=')[0]
             top_level_key = top_level_key.strip(' #')
             top_level_keys.append(top_level_key)
@@ -465,20 +465,19 @@ def configure_section(lines, config):
                 raise RuntimeError("failed to find config line for {}".format(key))
 
 
-def configure_top_level_key(lines, top_level_key, value): 
-    for i, line in enumerate(lines): 
-        if line.startswith('#' + top_level_key + ' = ') or line.startswith(top_level_key + ' = '): 
+def configure_top_level_key(lines, top_level_key, value):
+    for i, line in enumerate(lines):
+        if line.startswith('#' + top_level_key + ' = ') or line.startswith(top_level_key + ' = '):
             lines[i] = "{} = {}".format(top_level_key, value)
-            return 
-        
+            return
+
     raise RuntimeError("failed to find config line for {}".format(top_level_key))
 
-      
+
 for section_key, section_config in config.items():
-    if section_key not in sections and section_key not in top_level_keys: 
+    if section_key not in sections and section_key not in top_level_keys:
         raise RuntimeError("config key {} not in sections or top_level_keys".format(section_key))
-    
-    if section_key in top_level_keys: 
+    if section_key in top_level_keys:
         configure_top_level_key(sections[None], section_key, section_config)
 
     elif  section_key == 'target':


### PR DESCRIPTION
Closes #107049

Test Plan

Configure changelog-seen
```
lionellloh@lionellloh-mbp rust % ./configure --set changelog-seen=1
configure: processing command line
configure:
configure: changelog-seen       := 1
configure: build.configure-args := ['--set', 'changelog-seen=1']
configure:
configure: writing `config.toml` in current directory
configure:
configure: run `python /Users/lionellloh/rust/x.py --help`
lionellloh@lionellloh-mbp rust % diff config.toml config.toml.example
16c16
< changelog-seen = 1
---
> changelog-seen = 2
331c331
< configure-args = ['--set', 'changelog-seen=1']
---
> #configure-args = []
675c675
< [target.x86_64-apple-darwin]
---
> [target.x86_64-unknown-linux-gnu]
809d808
<
```

Configure profile

```
lionellloh@lionellloh-mbp rust % ./configure --set profile=xyz
configure: processing command line
configure:
configure: profile              := xyz
configure: build.configure-args := ['--set', 'profile=xyz']
configure:
configure: writing `config.toml` in current directory
configure:
configure: run `python /Users/lionellloh/rust/x.py --help`
lionellloh@lionellloh-mbp rust % diff config.toml config.toml.example
26c26
< profile = xyz
---
> #profile = <none>
331c331
< configure-args = ['--set', 'profile=xyz']
---
> #configure-args = []
675c675
< [target.x86_64-apple-darwin]
---
> [target.x86_64-unknown-linux-gnu]
809d808
<
```