### PR TITLE
Use custom implementation of read_buf in Read for &'a FileDesc

### DIFF
--- a/library/std/src/sys/unix/fd.rs
+++ b/library/std/src/sys/unix/fd.rs
@@ -284,6 +284,10 @@ impl<'a> Read for &'a FileDesc {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (**self).read(buf)
     }
+
+    fn read_buf(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+        (**self).read_buf(cursor)
+    }
 }
 
 impl AsInner<OwnedFd> for FileDesc {


### PR DESCRIPTION
This allows to skip an unnecessary buffer initialization.

Fixes #108223.