### PR TITLE
Fix overlapping spans in removing extra arguments

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -932,25 +932,22 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     labels
                         .push((provided_span, format!("unexpected argument{}", provided_ty_name)));
                     let mut span = provided_span;
-                    if arg_idx.index() > 0
+                    if span.can_be_used_for_suggestions() {
+                        if arg_idx.index() > 0
                         && let Some((_, prev)) = provided_arg_tys
                             .get(ProvidedIdx::from_usize(arg_idx.index() - 1)
                     ) {
                         // Include previous comma
-                        span = span.with_lo(prev.hi());
-                    } else if let Some((_, next)) = provided_arg_tys.get(
-                        ProvidedIdx::from_usize(arg_idx.index() + 1),
-                    ) {
-                        // Include next comma
-                        span = span.until(*next);
+                        span = prev.shrink_to_hi().to(span);
                     }
-                    suggestions.push((span, String::new()));
+                        suggestions.push((span, String::new()));
 
-                    suggestion_text = match suggestion_text {
-                        SuggestionText::None => SuggestionText::Remove(false),
-                        SuggestionText::Remove(_) => SuggestionText::Remove(true),
-                        _ => SuggestionText::DidYouMean,
-                    };
+                        suggestion_text = match suggestion_text {
+                            SuggestionText::None => SuggestionText::Remove(false),
+                            SuggestionText::Remove(_) => SuggestionText::Remove(true),
+                            _ => SuggestionText::DidYouMean,
+                        };
+                    }
                 }
                 Error::Missing(expected_idx) => {
                     // If there are multiple missing arguments adjacent to each other,

--- a/tests/ui/alloc-error/alloc-error-handler-bad-signature-3.stderr
+++ b/tests/ui/alloc-error/alloc-error-handler-bad-signature-3.stderr
@@ -7,10 +7,7 @@ LL |   fn oom() -> ! {
    |  _-^^^^^^^^^^^^
 LL | |     loop {}
 LL | | }
-   | | -
-   | | |
-   | |_unexpected argument of type `core::alloc::Layout`
-   |   help: remove the extra argument
+   | |_- unexpected argument of type `core::alloc::Layout`
    |
 note: function defined here
   --> $DIR/alloc-error-handler-bad-signature-3.rs:10:4

--- a/tests/ui/argument-suggestions/extra_arguments.rs
+++ b/tests/ui/argument-suggestions/extra_arguments.rs
@@ -3,8 +3,15 @@ fn one_arg(_a: i32) {}
 fn two_arg_same(_a: i32, _b: i32) {}
 fn two_arg_diff(_a: i32, _b: &str) {}
 
+macro_rules! foo {
+    ($x:expr) => {
+        empty($x, 1); //~ ERROR function takes
+    }
+}
+
 fn main() {
   empty(""); //~ ERROR function takes
+  empty(1, 1); //~ ERROR function takes
 
   one_arg(1, 1); //~ ERROR function takes
   one_arg(1, ""); //~ ERROR function takes
@@ -32,4 +39,5 @@ fn main() {
     1,
     ""
   );
+  foo!(1);
 }

--- a/tests/ui/argument-suggestions/extra_arguments.stderr
+++ b/tests/ui/argument-suggestions/extra_arguments.stderr
@@ -1,5 +1,5 @@
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
-  --> $DIR/extra_arguments.rs:7:3
+  --> $DIR/extra_arguments.rs:13:3
    |
 LL |   empty("");
    |   ^^^^^ --
@@ -13,8 +13,27 @@ note: function defined here
 LL | fn empty() {}
    |    ^^^^^
 
+error[E0061]: this function takes 0 arguments but 2 arguments were supplied
+  --> $DIR/extra_arguments.rs:14:3
+   |
+LL |   empty(1, 1);
+   |   ^^^^^ -  - unexpected argument of type `{integer}`
+   |         |
+   |         unexpected argument of type `{integer}`
+   |
+note: function defined here
+  --> $DIR/extra_arguments.rs:1:4
+   |
+LL | fn empty() {}
+   |    ^^^^^
+help: remove the extra arguments
+   |
+LL -   empty(1, 1);
+LL +   empty();
+   |
+
 error[E0061]: this function takes 1 argument but 2 arguments were supplied
-  --> $DIR/extra_arguments.rs:9:3
+  --> $DIR/extra_arguments.rs:16:3
    |
 LL |   one_arg(1, 1);
    |   ^^^^^^^  ---
@@ -29,7 +48,7 @@ LL | fn one_arg(_a: i32) {}
    |    ^^^^^^^ -------
 
 error[E0061]: this function takes 1 argument but 2 arguments were supplied
-  --> $DIR/extra_arguments.rs:10:3
+  --> $DIR/extra_arguments.rs:17:3
    |
 LL |   one_arg(1, "");
    |   ^^^^^^^  ----
@@ -44,7 +63,7 @@ LL | fn one_arg(_a: i32) {}
    |    ^^^^^^^ -------
 
 error[E0061]: this function takes 1 argument but 3 arguments were supplied
-  --> $DIR/extra_arguments.rs:11:3
+  --> $DIR/extra_arguments.rs:18:3
    |
 LL |   one_arg(1, "", 1.0);
    |   ^^^^^^^    --  --- unexpected argument of type `{float}`
@@ -63,7 +82,7 @@ LL +   one_arg(1);
    |
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
-  --> $DIR/extra_arguments.rs:13:3
+  --> $DIR/extra_arguments.rs:20:3
    |
 LL |   two_arg_same(1, 1, 1);
    |   ^^^^^^^^^^^^     ---
@@ -78,7 +97,7 @@ LL | fn two_arg_same(_a: i32, _b: i32) {}
    |    ^^^^^^^^^^^^ -------  -------
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
-  --> $DIR/extra_arguments.rs:14:3
+  --> $DIR/extra_arguments.rs:21:3
    |
 LL |   two_arg_same(1, 1, 1.0);
    |   ^^^^^^^^^^^^     -----
@@ -93,7 +112,7 @@ LL | fn two_arg_same(_a: i32, _b: i32) {}
    |    ^^^^^^^^^^^^ -------  -------
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
-  --> $DIR/extra_arguments.rs:16:3
+  --> $DIR/extra_arguments.rs:23:3
    |
 LL |   two_arg_diff(1, 1, "");
    |   ^^^^^^^^^^^^  ---
@@ -108,7 +127,7 @@ LL | fn two_arg_diff(_a: i32, _b: &str) {}
    |    ^^^^^^^^^^^^ -------  --------
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
-  --> $DIR/extra_arguments.rs:17:3
+  --> $DIR/extra_arguments.rs:24:3
    |
 LL |   two_arg_diff(1, "", "");
    |   ^^^^^^^^^^^^      ----
@@ -123,7 +142,7 @@ LL | fn two_arg_diff(_a: i32, _b: &str) {}
    |    ^^^^^^^^^^^^ -------  --------
 
 error[E0061]: this function takes 2 arguments but 4 arguments were supplied
-  --> $DIR/extra_arguments.rs:18:3
+  --> $DIR/extra_arguments.rs:25:3
    |
 LL |   two_arg_diff(1, 1, "", "");
    |   ^^^^^^^^^^^^    -      -- unexpected argument of type `&'static str`
@@ -142,7 +161,7 @@ LL +   two_arg_diff(1, "");
    |
 
 error[E0061]: this function takes 2 arguments but 4 arguments were supplied
-  --> $DIR/extra_arguments.rs:19:3
+  --> $DIR/extra_arguments.rs:26:3
    |
 LL |   two_arg_diff(1, "", 1, "");
    |   ^^^^^^^^^^^^        -  -- unexpected argument of type `&'static str`
@@ -161,7 +180,7 @@ LL +   two_arg_diff(1, "");
    |
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
-  --> $DIR/extra_arguments.rs:22:3
+  --> $DIR/extra_arguments.rs:29:3
    |
 LL |   two_arg_same(1, 1,     "");
    |   ^^^^^^^^^^^^     --------
@@ -176,7 +195,7 @@ LL | fn two_arg_same(_a: i32, _b: i32) {}
    |    ^^^^^^^^^^^^ -------  -------
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
-  --> $DIR/extra_arguments.rs:23:3
+  --> $DIR/extra_arguments.rs:30:3
    |
 LL |   two_arg_diff(1, 1,     "");
    |   ^^^^^^^^^^^^  ---
@@ -191,7 +210,7 @@ LL | fn two_arg_diff(_a: i32, _b: &str) {}
    |    ^^^^^^^^^^^^ -------  --------
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
-  --> $DIR/extra_arguments.rs:24:3
+  --> $DIR/extra_arguments.rs:31:3
    |
 LL |     two_arg_same(
    |     ^^^^^^^^^^^^
@@ -211,7 +230,7 @@ LL | fn two_arg_same(_a: i32, _b: i32) {}
    |    ^^^^^^^^^^^^ -------  -------
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
-  --> $DIR/extra_arguments.rs:30:3
+  --> $DIR/extra_arguments.rs:37:3
    |
 LL |     two_arg_diff(
    |     ^^^^^^^^^^^^
@@ -229,6 +248,26 @@ note: function defined here
 LL | fn two_arg_diff(_a: i32, _b: &str) {}
    |    ^^^^^^^^^^^^ -------  --------
 
-error: aborting due to 14 previous errors
+error[E0061]: this function takes 0 arguments but 2 arguments were supplied
+  --> $DIR/extra_arguments.rs:8:9
+   |
+LL |         empty($x, 1);
+   |         ^^^^^     - unexpected argument of type `{integer}`
+...
+LL |   foo!(1);
+   |   -------
+   |   |    |
+   |   |    unexpected argument of type `{integer}`
+   |   |    help: remove the extra argument
+   |   in this macro invocation
+   |
+note: function defined here
+  --> $DIR/extra_arguments.rs:1:4
+   |
+LL | fn empty() {}
+   |    ^^^^^
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 16 previous errors
 
 For more information about this error, try `rustc --explain E0061`.

--- a/tests/ui/issues/issue-26094.rs
+++ b/tests/ui/issues/issue-26094.rs
@@ -1,7 +1,7 @@
 macro_rules! some_macro {
-    ($other: expr) => ({
+    ($other: expr) => {{
         $other(None) //~ NOTE unexpected argument of type `Option<_>`
-    })
+    }};
 }
 
 fn some_function() {} //~ NOTE defined here
@@ -9,5 +9,4 @@ fn some_function() {} //~ NOTE defined here
 fn main() {
     some_macro!(some_function);
     //~^ ERROR function takes 0 arguments but 1 argument was supplied
-    //~| NOTE in this expansion of some_macro!
 }

--- a/tests/ui/issues/issue-26094.stderr
+++ b/tests/ui/issues/issue-26094.stderr
@@ -2,10 +2,7 @@ error[E0061]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/issue-26094.rs:10:17
    |
 LL |         $other(None)
-   |                ----
-   |                |
-   |                unexpected argument of type `Option<_>`
-   |                help: remove the extra argument
+   |                ---- unexpected argument of type `Option<_>`
 ...
 LL |     some_macro!(some_function);
    |                 ^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #108225 

Each span is already extended to include the previous comma, so extending to the *next* comma is unecessary and causes an ICE with assertions on.

@rustbot label +A-diagnostics