### PR TITLE
no-fail-fast support for tool testsuites

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -435,6 +435,10 @@ impl Step for Rustfmt {
             &[],
         );
 
+        if !builder.fail_fast {
+            cargo.arg("--no-fail-fast");
+        }
+
         let dir = testdir(builder, compiler.host);
         t!(fs::create_dir_all(&dir));
         cargo.env("RUSTFMT_TEST_DIR", dir);
@@ -615,6 +619,10 @@ impl Step for Miri {
         );
         cargo.add_rustc_lib_path(builder, compiler);
 
+        if !builder.fail_fast {
+            cargo.arg("--no-fail-fast");
+        }
+
         // miri tests need to know about the stage sysroot
         cargo.env("MIRI_SYSROOT", &miri_sysroot);
         cargo.env("MIRI_HOST_SYSROOT", sysroot);
@@ -745,6 +753,10 @@ impl Step for Clippy {
             SourceType::InTree,
             &[],
         );
+
+        if !builder.fail_fast {
+            cargo.arg("--no-fail-fast");
+        }
 
         cargo.env("RUSTC_TEST_SUITE", builder.rustc(compiler));
         cargo.env("RUSTC_LIB_PATH", builder.rustc_libdir(compiler));


### PR DESCRIPTION
~~This commit adds a change to pass "--no-fail-fast" flag to `cargo test` inside `tool::prepare_tool_cargo()` so there is no need to do it manually in each `Step` trait implementation in src/bootstrap/test.rs.~~

~~Also, removes the flag from test.rs where prepare_tool_cargo() is called so cargo doesn't complain because the flag has been passed twice.~~

This commit adds `--no-fail-fast` flag to each `cargo test`
command in each tool Step trait implementation (`miri`, `rustfmt` and `clippy`).


Fixes #108261