### PR TITLE
Stabilize const slice::split_at

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1596,7 +1596,8 @@ impl<T> [T] {
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_slice_split_at_not_mut", issue = "101158")]
+    #[rustc_const_stable(feature = "const_slice_split_at_not_mut", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_allow_const_fn_unstable(slice_split_at_unchecked)]
     #[inline]
     #[track_caller]
     #[must_use]


### PR DESCRIPTION
This stabilizes the use of the following method in const context:

```rust
impl<T> [T] {
    pub const fn split_at(&self, mid: usize) -> (&[T], &[T]);
}
```

cc tracking issue #101158