### PR TITLE
Add test for bad cast with deferred projection equality

### DIFF
--- a/tests/ui/typeck/lazy-norm/cast-checks-handling-projections.rs
+++ b/tests/ui/typeck/lazy-norm/cast-checks-handling-projections.rs
@@ -1,0 +1,6 @@
+// compile-flags: -Ztrait-solver=next
+// known-bug: unknown
+
+fn main() {
+    (0u8 + 0u8) as char;
+}

--- a/tests/ui/typeck/lazy-norm/cast-checks-handling-projections.stderr
+++ b/tests/ui/typeck/lazy-norm/cast-checks-handling-projections.stderr
@@ -1,0 +1,9 @@
+error[E0271]: type mismatch resolving `char == <u8 as Add>::Output`
+  --> $DIR/cast-checks-handling-projections.rs:5:5
+   |
+LL |     (0u8 + 0u8) as char;
+   |     ^^^^^^^^^^^ types differ
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
1. Unification during coercion (`Coerce::unify`) needs to consider deferred projection obligations (at least pass over them with `predicate_may_hold` or something, to disqualify any totally wrong unifications) -- otherwise, we'll shallowly consider `<u8 as Add>::Output` and `char` as coercible during `FnCtxt::try_coerce`, which will fail later when the nested obligations are registered and processed.

2. Cast checking needs to be able to structurally normalize types so it sees `u8` instead of `<u8 as Add>::Output`. Otherwise it'll always consider the latter as part of a non-primitive cast. Currently `FnCtxt::normalize` doesn't do anything useful here, interestingly.

I tried looking into both of these and it's not immediately clear where to refactor existing typeck code to fix this (at least the latter), but I'm gonna commit a test for it at least so we don't forget. This is one of the issues that's keeping us from building larger projects.