### PR TITLE
Add a test for default trait method with RPITITs

### DIFF
--- a/tests/ui/impl-trait/in-trait/default-method-constraint.rs
+++ b/tests/ui/impl-trait/in-trait/default-method-constraint.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+// This didn't work in the previous default RPITIT method hack attempt
+
+#![feature(return_position_impl_trait_in_trait)]
+//~^ WARN the feature `return_position_impl_trait_in_trait` is incomplete
+
+trait Foo {
+    fn bar(x: bool) -> impl Sized {
+        if x {
+            let _: u32 = Self::bar(!x);
+        }
+        Default::default()
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/default-method-constraint.stderr
+++ b/tests/ui/impl-trait/in-trait/default-method-constraint.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_position_impl_trait_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/default-method-constraint.rs:5:12
+   |
+LL | #![feature(return_position_impl_trait_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
This didn't work in #107013, but now that #108203 has landed, let's make sure we don't regress it.

r? types