### PR TITLE
Label opaque type for 'captures lifetime' error message

### DIFF
--- a/compiler/rustc_infer/locales/en-US.ftl
+++ b/compiler/rustc_infer/locales/en-US.ftl
@@ -345,3 +345,6 @@ infer_prlf_defined_without_sub = the lifetime defined here...
 infer_prlf_must_oultive_with_sup = ...must outlive the lifetime `{$sup_symbol}` defined here
 infer_prlf_must_oultive_without_sup = ...must outlive the lifetime defined here
 infer_prlf_known_limitation = this is a known limitation that will be removed in the future (see issue #100013 <https://github.com/rust-lang/rust/issues/100013> for more information)
+
+infer_opaque_captures_lifetime = hidden type for `{$opaque_ty}` captures lifetime that does not appear in bounds
+    .label = opaque type defined here

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -1147,3 +1147,13 @@ pub enum PlaceholderRelationLfNotSatisfied {
         note: (),
     },
 }
+
+#[derive(Diagnostic)]
+#[diag(infer_opaque_captures_lifetime, code = "E0700")]
+pub struct OpaqueCapturesLifetime<'tcx> {
+    #[primary_span]
+    pub span: Span,
+    #[label]
+    pub opaque_ty_span: Span,
+    pub opaque_ty: Ty<'tcx>,
+}

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -281,15 +281,19 @@ pub fn unexpected_hidden_region_diagnostic<'tcx>(
     span: Span,
     hidden_ty: Ty<'tcx>,
     hidden_region: ty::Region<'tcx>,
-    opaque_ty: ty::OpaqueTypeKey<'tcx>,
+    opaque_ty_key: ty::OpaqueTypeKey<'tcx>,
 ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-    let opaque_ty = tcx.mk_opaque(opaque_ty.def_id.to_def_id(), opaque_ty.substs);
+    let opaque_ty = tcx.mk_opaque(opaque_ty_key.def_id.to_def_id(), opaque_ty_key.substs);
+
     let mut err = struct_span_err!(
         tcx.sess,
         span,
         E0700,
         "hidden type for `{opaque_ty}` captures lifetime that does not appear in bounds",
     );
+
+    let opaque_ty_span = tcx.def_span(opaque_ty_key.def_id);
+    err.span_label(opaque_ty_span, "opaque type defined here");
 
     // Explain the region we are capturing.
     match *hidden_region {

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -49,6 +49,7 @@ use super::lexical_region_resolve::RegionResolutionError;
 use super::region_constraints::GenericKind;
 use super::{InferCtxt, RegionVariableOrigin, SubregionOrigin, TypeTrace, ValuePairs};
 
+use crate::errors;
 use crate::infer;
 use crate::infer::error_reporting::nice_region_error::find_anon_type::find_anon_type;
 use crate::infer::ExpectedFound;
@@ -283,17 +284,11 @@ pub fn unexpected_hidden_region_diagnostic<'tcx>(
     hidden_region: ty::Region<'tcx>,
     opaque_ty_key: ty::OpaqueTypeKey<'tcx>,
 ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-    let opaque_ty = tcx.mk_opaque(opaque_ty_key.def_id.to_def_id(), opaque_ty_key.substs);
-
-    let mut err = struct_span_err!(
-        tcx.sess,
+    let mut err = tcx.sess.create_err(errors::OpaqueCapturesLifetime {
         span,
-        E0700,
-        "hidden type for `{opaque_ty}` captures lifetime that does not appear in bounds",
-    );
-
-    let opaque_ty_span = tcx.def_span(opaque_ty_key.def_id);
-    err.span_label(opaque_ty_span, "opaque type defined here");
+        opaque_ty: tcx.mk_opaque(opaque_ty_key.def_id.to_def_id(), opaque_ty_key.substs),
+        opaque_ty_span: tcx.def_span(opaque_ty_key.def_id),
+    });
 
     // Explain the region we are capturing.
     match *hidden_region {

--- a/tests/ui/async-await/multiple-lifetimes/ret-impl-trait-one.stderr
+++ b/tests/ui/async-await/multiple-lifetimes/ret-impl-trait-one.stderr
@@ -17,8 +17,9 @@ error[E0700]: hidden type for `impl Trait<'a>` captures lifetime that does not a
   --> $DIR/ret-impl-trait-one.rs:16:80
    |
 LL |   async fn async_ret_impl_trait1<'a, 'b>(a: &'a u8, b: &'b u8) -> impl Trait<'a> {
-   |  ____________________________________--__________________________________________^
-   | |                                    |
+   |  ____________________________________--___________________________--------------_^
+   | |                                    |                            |
+   | |                                    |                            opaque type defined here
    | |                                    hidden type `(&'a u8, &'b u8)` captures the lifetime `'b` as defined here
 LL | |
 LL | |     (a, b)

--- a/tests/ui/impl-trait/hidden-lifetimes.stderr
+++ b/tests/ui/impl-trait/hidden-lifetimes.stderr
@@ -2,7 +2,9 @@ error[E0700]: hidden type for `impl Swap + 'a` captures lifetime that does not a
   --> $DIR/hidden-lifetimes.rs:29:5
    |
 LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a {
-   |                 -- hidden type `&'a mut &'b T` captures the lifetime `'b` as defined here
+   |                 --                                   -------------- opaque type defined here
+   |                 |
+   |                 hidden type `&'a mut &'b T` captures the lifetime `'b` as defined here
 LL |     x
    |     ^
    |
@@ -15,7 +17,9 @@ error[E0700]: hidden type for `impl Swap + 'a` captures lifetime that does not a
   --> $DIR/hidden-lifetimes.rs:46:5
    |
 LL | fn hide_rc_refcell<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a {
-   |                        -- hidden type `Rc<RefCell<&'b T>>` captures the lifetime `'b` as defined here
+   |                        --                                            -------------- opaque type defined here
+   |                        |
+   |                        hidden type `Rc<RefCell<&'b T>>` captures the lifetime `'b` as defined here
 LL |     x
    |     ^
    |

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds-2.stderr
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds-2.stderr
@@ -1,6 +1,8 @@
 error[E0700]: hidden type for `impl Debug` captures lifetime that does not appear in bounds
   --> $DIR/impl-fn-hrtb-bounds-2.rs:5:9
    |
+LL | fn a() -> impl Fn(&u8) -> impl Debug {
+   |                           ---------- opaque type defined here
 LL |     |x| x
    |     --- ^
    |     |

--- a/tests/ui/impl-trait/multiple-lifetimes/error-handling-2.stderr
+++ b/tests/ui/impl-trait/multiple-lifetimes/error-handling-2.stderr
@@ -1,6 +1,9 @@
 error[E0700]: hidden type for `E<'b, 'c>` captures lifetime that does not appear in bounds
   --> $DIR/error-handling-2.rs:22:5
    |
+LL | type E<'a, 'b> = impl Sized;
+   |                  ---------- opaque type defined here
+LL |
 LL | fn foo<'a: 'b, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {
    |        -- hidden type `*mut &'a i32` captures the lifetime `'a` as defined here
 ...

--- a/tests/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unrelated.stderr
+++ b/tests/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unrelated.stderr
@@ -2,7 +2,9 @@ error[E0700]: hidden type for `impl Trait<'d, 'e>` captures lifetime that does n
   --> $DIR/ordinary-bounds-unrelated.rs:28:33
    |
 LL | fn upper_bounds<'a, 'b, 'c, 'd, 'e>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'d, 'e>
-   |                     -- hidden type `Ordinary<'b>` captures the lifetime `'b` as defined here
+   |                     --                                                   ------------------ opaque type defined here
+   |                     |
+   |                     hidden type `Ordinary<'b>` captures the lifetime `'b` as defined here
 ...
 LL |     if condition() { a } else { b }
    |                                 ^

--- a/tests/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unsuited.stderr
+++ b/tests/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unsuited.stderr
@@ -2,7 +2,9 @@ error[E0700]: hidden type for `impl Trait<'a, 'b>` captures lifetime that does n
   --> $DIR/ordinary-bounds-unsuited.rs:31:33
    |
 LL | fn upper_bounds<'a, 'b>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'a, 'b>
-   |                     -- hidden type `Ordinary<'b>` captures the lifetime `'b` as defined here
+   |                     --                                       ------------------ opaque type defined here
+   |                     |
+   |                     hidden type `Ordinary<'b>` captures the lifetime `'b` as defined here
 ...
 LL |     if condition() { a } else { b }
    |                                 ^

--- a/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
+++ b/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
@@ -2,8 +2,9 @@ error[E0700]: hidden type for `impl Copy` captures lifetime that does not appear
   --> $DIR/must_outlive_least_region_or_bound.rs:3:35
    |
 LL | fn elided(x: &i32) -> impl Copy { x }
-   |              ----                 ^
-   |              |
+   |              ----     ---------   ^
+   |              |        |
+   |              |        opaque type defined here
    |              hidden type `&i32` captures the anonymous lifetime defined here
    |
 help: to declare that `impl Copy` captures `'_`, you can add an explicit `'_` lifetime bound
@@ -15,8 +16,9 @@ error[E0700]: hidden type for `impl Copy` captures lifetime that does not appear
   --> $DIR/must_outlive_least_region_or_bound.rs:6:44
    |
 LL | fn explicit<'a>(x: &'a i32) -> impl Copy { x }
-   |             --                             ^
-   |             |
+   |             --                 ---------   ^
+   |             |                  |
+   |             |                  opaque type defined here
    |             hidden type `&'a i32` captures the lifetime `'a` as defined here
    |
 help: to declare that `impl Copy` captures `'a`, you can add an explicit `'a` lifetime bound
@@ -100,7 +102,9 @@ error[E0700]: hidden type for `impl Fn(&'a u32)` captures lifetime that does not
   --> $DIR/must_outlive_least_region_or_bound.rs:38:5
    |
 LL | fn move_lifetime_into_fn<'a, 'b>(x: &'a u32, y: &'b u32) -> impl Fn(&'a u32) {
-   |                              -- hidden type `[closure@$DIR/must_outlive_least_region_or_bound.rs:38:5: 38:13]` captures the lifetime `'b` as defined here
+   |                              --                             ---------------- opaque type defined here
+   |                              |
+   |                              hidden type `[closure@$DIR/must_outlive_least_region_or_bound.rs:38:5: 38:13]` captures the lifetime `'b` as defined here
 LL |     move |_| println!("{}", y)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |

--- a/tests/ui/impl-trait/nested-return-type4.stderr
+++ b/tests/ui/impl-trait/nested-return-type4.stderr
@@ -2,7 +2,9 @@ error[E0700]: hidden type for `impl Future<Output = impl Sized>` captures lifeti
   --> $DIR/nested-return-type4.rs:4:5
    |
 LL | fn test<'s: 's>(s: &'s str) -> impl std::future::Future<Output = impl Sized> {
-   |         -- hidden type `[async block@$DIR/nested-return-type4.rs:4:5: 4:31]` captures the lifetime `'s` as defined here
+   |         --                     --------------------------------------------- opaque type defined here
+   |         |
+   |         hidden type `[async block@$DIR/nested-return-type4.rs:4:5: 4:31]` captures the lifetime `'s` as defined here
 LL |     async move { let _s = s; }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |

--- a/tests/ui/impl-trait/region-escape-via-bound.stderr
+++ b/tests/ui/impl-trait/region-escape-via-bound.stderr
@@ -2,7 +2,9 @@ error[E0700]: hidden type for `impl Trait<'y>` captures lifetime that does not a
   --> $DIR/region-escape-via-bound.rs:17:5
    |
 LL | fn foo<'x, 'y>(x: Cell<&'x u32>) -> impl Trait<'y>
-   |        -- hidden type `Cell<&'x u32>` captures the lifetime `'x` as defined here
+   |        --                           -------------- opaque type defined here
+   |        |
+   |        hidden type `Cell<&'x u32>` captures the lifetime `'x` as defined here
 ...
 LL |     x
    |     ^

--- a/tests/ui/impl-trait/static-return-lifetime-infered.stderr
+++ b/tests/ui/impl-trait/static-return-lifetime-infered.stderr
@@ -2,7 +2,9 @@ error[E0700]: hidden type for `impl Iterator<Item = u32>` captures lifetime that
   --> $DIR/static-return-lifetime-infered.rs:7:9
    |
 LL |     fn iter_values_anon(&self) -> impl Iterator<Item=u32> {
-   |                         ----- hidden type `Map<std::slice::Iter<'_, (u32, u32)>, [closure@$DIR/static-return-lifetime-infered.rs:7:27: 7:30]>` captures the anonymous lifetime defined here
+   |                         -----     ----------------------- opaque type defined here
+   |                         |
+   |                         hidden type `Map<std::slice::Iter<'_, (u32, u32)>, [closure@$DIR/static-return-lifetime-infered.rs:7:27: 7:30]>` captures the anonymous lifetime defined here
 LL |         self.x.iter().map(|a| a.0)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -15,7 +17,9 @@ error[E0700]: hidden type for `impl Iterator<Item = u32>` captures lifetime that
   --> $DIR/static-return-lifetime-infered.rs:11:9
    |
 LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> {
-   |                    -- hidden type `Map<std::slice::Iter<'a, (u32, u32)>, [closure@$DIR/static-return-lifetime-infered.rs:11:27: 11:30]>` captures the lifetime `'a` as defined here
+   |                    --               ----------------------- opaque type defined here
+   |                    |
+   |                    hidden type `Map<std::slice::Iter<'a, (u32, u32)>, [closure@$DIR/static-return-lifetime-infered.rs:11:27: 11:30]>` captures the lifetime `'a` as defined here
 LL |         self.x.iter().map(|a| a.0)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |

--- a/tests/ui/lifetimes/issue-105227.stderr
+++ b/tests/ui/lifetimes/issue-105227.stderr
@@ -2,7 +2,9 @@ error[E0700]: hidden type for `impl Iterator<Item = char>` captures lifetime tha
   --> $DIR/issue-105227.rs:7:5
    |
 LL | fn chars0(v :(& str, &str)) -> impl Iterator<Item = char> {
-   |               ----- hidden type `std::iter::Chain<Chars<'_>, Chars<'_>>` captures the anonymous lifetime defined here
+   |               -----            -------------------------- opaque type defined here
+   |               |
+   |               hidden type `std::iter::Chain<Chars<'_>, Chars<'_>>` captures the anonymous lifetime defined here
 LL |
 LL |     v.0.chars().chain(v.1.chars())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +18,9 @@ error[E0700]: hidden type for `impl Iterator<Item = char>` captures lifetime tha
   --> $DIR/issue-105227.rs:13:5
    |
 LL | fn chars1(v0 : & str, v1 : &str) -> impl Iterator<Item = char> {
-   |                ----- hidden type `std::iter::Chain<Chars<'_>, Chars<'_>>` captures the anonymous lifetime defined here
+   |                -----                -------------------------- opaque type defined here
+   |                |
+   |                hidden type `std::iter::Chain<Chars<'_>, Chars<'_>>` captures the anonymous lifetime defined here
 LL |
 LL |     v0.chars().chain(v1.chars())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -31,7 +35,10 @@ error[E0700]: hidden type for `impl Iterator<Item = char>` captures lifetime tha
    |
 LL | fn chars2<'b>(v0 : &str, v1 : &'_ str, v2 : &'b str) ->
    |                    ---- hidden type `std::iter::Chain<Chars<'_>, Chars<'_>>` captures the anonymous lifetime defined here
-...
+LL |
+LL |     (impl Iterator<Item = char>, &'b str)
+   |      -------------------------- opaque type defined here
+LL | {
 LL |     (v0.chars().chain(v1.chars()), v2)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |

--- a/tests/ui/nll/issue-73159-rpit-static.stderr
+++ b/tests/ui/nll/issue-73159-rpit-static.stderr
@@ -4,6 +4,7 @@ error[E0700]: hidden type for `impl Iterator<Item = u8>` captures lifetime that 
 LL | impl<'a> Foo<'a> {
    |      -- hidden type `Copied<std::slice::Iter<'a, u8>>` captures the lifetime `'a` as defined here
 LL |     fn make_it(&self) -> impl Iterator<Item = u8> {
+   |                          ------------------------ opaque type defined here
 LL |         self.0.iter().copied()
    |         ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/nll/member-constraints/min-choice-reject-ambiguous.stderr
+++ b/tests/ui/nll/member-constraints/min-choice-reject-ambiguous.stderr
@@ -24,7 +24,9 @@ error[E0700]: hidden type for `impl Cap<'b> + Cap<'c>` captures lifetime that do
   --> $DIR/min-choice-reject-ambiguous.rs:39:5
    |
 LL | fn test_ambiguous<'a, 'b, 'c>(s: &'a u8) -> impl Cap<'b> + Cap<'c>
-   |                   -- hidden type `&'a u8` captures the lifetime `'a` as defined here
+   |                   --                        ---------------------- opaque type defined here
+   |                   |
+   |                   hidden type `&'a u8` captures the lifetime `'a` as defined here
 ...
 LL |     s
    |     ^

--- a/tests/ui/nll/member-constraints/nested-impl-trait-fail.stderr
+++ b/tests/ui/nll/member-constraints/nested-impl-trait-fail.stderr
@@ -2,7 +2,9 @@ error[E0700]: hidden type for `impl IntoIterator<Item = impl Cap<'a> + Cap<'b>>`
   --> $DIR/nested-impl-trait-fail.rs:17:5
    |
 LL | fn fail_early_bound<'s, 'a, 'b>(a: &'s u8) -> impl IntoIterator<Item = impl Cap<'a> + Cap<'b>>
-   |                     -- hidden type `[&'s u8; 1]` captures the lifetime `'s` as defined here
+   |                     --                        ------------------------------------------------ opaque type defined here
+   |                     |
+   |                     hidden type `[&'s u8; 1]` captures the lifetime `'s` as defined here
 ...
 LL |     [a]
    |     ^^^
@@ -20,7 +22,9 @@ error[E0700]: hidden type for `impl Cap<'a> + Cap<'b>` captures lifetime that do
   --> $DIR/nested-impl-trait-fail.rs:17:5
    |
 LL | fn fail_early_bound<'s, 'a, 'b>(a: &'s u8) -> impl IntoIterator<Item = impl Cap<'a> + Cap<'b>>
-   |                     -- hidden type `&'s u8` captures the lifetime `'s` as defined here
+   |                     --                                                 ---------------------- opaque type defined here
+   |                     |
+   |                     hidden type `&'s u8` captures the lifetime `'s` as defined here
 ...
 LL |     [a]
    |     ^^^
@@ -40,6 +44,8 @@ error[E0700]: hidden type for `impl IntoIterator<Item = impl Cap<'a> + Cap<'b>>`
 LL | fn fail_late_bound<'s, 'a, 'b>(
    |                    -- hidden type `[&'s u8; 1]` captures the lifetime `'s` as defined here
 ...
+LL | ) -> impl IntoIterator<Item = impl Cap<'a> + Cap<'b>> {
+   |      ------------------------------------------------ opaque type defined here
 LL |     [a]
    |     ^^^
    |
@@ -58,6 +64,8 @@ error[E0700]: hidden type for `impl Cap<'a> + Cap<'b>` captures lifetime that do
 LL | fn fail_late_bound<'s, 'a, 'b>(
    |                    -- hidden type `&'s u8` captures the lifetime `'s` as defined here
 ...
+LL | ) -> impl IntoIterator<Item = impl Cap<'a> + Cap<'b>> {
+   |                               ---------------------- opaque type defined here
 LL |     [a]
    |     ^^^
    |

--- a/tests/ui/nll/ty-outlives/impl-trait-captures.stderr
+++ b/tests/ui/nll/ty-outlives/impl-trait-captures.stderr
@@ -2,7 +2,9 @@ error[E0700]: hidden type for `Opaque(DefId(0:13 ~ impl_trait_captures[1afc]::fo
   --> $DIR/impl-trait-captures.rs:11:5
    |
 LL | fn foo<'a, T>(x: &T) -> impl Foo<'a> {
-   |                  -- hidden type `&ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrNamed(DefId(0:12 ~ impl_trait_captures[1afc]::foo::'_), '_)) T` captures the anonymous lifetime defined here
+   |                  --     ------------ opaque type defined here
+   |                  |
+   |                  hidden type `&ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrNamed(DefId(0:12 ~ impl_trait_captures[1afc]::foo::'_), '_)) T` captures the anonymous lifetime defined here
 LL |     x
    |     ^
    |

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.stderr
@@ -2,8 +2,9 @@ error[E0700]: hidden type for `impl Clone` captures lifetime that does not appea
   --> $DIR/arbitrary_self_types_pin_lifetime_impl_trait-async.rs:8:48
    |
 LL |     async fn f(self: Pin<&Self>) -> impl Clone { self }
-   |                          -----                 ^^^^^^^^
-   |                          |
+   |                          -----      ---------- ^^^^^^^^
+   |                          |          |
+   |                          |          opaque type defined here
    |                          hidden type `Pin<&Foo>` captures the anonymous lifetime defined here
    |
 help: to declare that `impl Clone` captures `'_`, you can add an explicit `'_` lifetime bound

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_impl_trait.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_impl_trait.stderr
@@ -2,8 +2,9 @@ error[E0700]: hidden type for `impl Clone` captures lifetime that does not appea
   --> $DIR/arbitrary_self_types_pin_lifetime_impl_trait.rs:6:44
    |
 LL |     fn f(self: Pin<&Self>) -> impl Clone { self }
-   |                    -----                   ^^^^
-   |                    |
+   |                    -----      ----------   ^^^^
+   |                    |          |
+   |                    |          opaque type defined here
    |                    hidden type `Pin<&Foo>` captures the anonymous lifetime defined here
    |
 help: to declare that `impl Clone` captures `'_`, you can add an explicit `'_` lifetime bound

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
@@ -10,7 +10,9 @@ error[E0700]: hidden type for `impl FnOnce()` captures lifetime that does not ap
   --> $DIR/missing-lifetimes-in-signature.rs:19:5
    |
 LL |   fn foo<G, T>(g: G, dest: &mut T) -> impl FnOnce()
-   |                            ------ hidden type `[closure@$DIR/missing-lifetimes-in-signature.rs:19:5: 19:12]` captures the anonymous lifetime defined here
+   |                            ------     ------------- opaque type defined here
+   |                            |
+   |                            hidden type `[closure@$DIR/missing-lifetimes-in-signature.rs:19:5: 19:12]` captures the anonymous lifetime defined here
 ...
 LL | /     move || {
 LL | |

--- a/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.stderr
+++ b/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.stderr
@@ -2,7 +2,9 @@ error[E0700]: hidden type for `impl PlusOne` captures lifetime that does not app
   --> $DIR/imply_bounds_from_bounds_param.rs:24:5
    |
 LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne {
-   |         -- hidden type `<&'a mut i32 as Callable>::Output` captures the lifetime `'a` as defined here
+   |         --                     ------------ opaque type defined here
+   |         |
+   |         hidden type `<&'a mut i32 as Callable>::Output` captures the lifetime `'a` as defined here
 LL |     <&'a mut i32 as Callable>::call(y)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |

--- a/tests/ui/type-alias-impl-trait/missing_lifetime_bound.stderr
+++ b/tests/ui/type-alias-impl-trait/missing_lifetime_bound.stderr
@@ -1,6 +1,8 @@
 error[E0700]: hidden type for `Opaque<'a, T>` captures lifetime that does not appear in bounds
   --> $DIR/missing_lifetime_bound.rs:4:47
    |
+LL | type Opaque<'a, T> = impl Sized;
+   |                      ---------- opaque type defined here
 LL | fn defining<'a, T>(x: &'a i32) -> Opaque<T> { x }
    |             --                                ^
    |             |


### PR DESCRIPTION
Providing more information may help make this somewhat opaque (lol) error message a bit clearer.