### PR TITLE
Place binder correctly for arbitrary trait bound suggestion

### DIFF
--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -117,7 +117,7 @@ pub fn suggest_arbitrary_trait_bound<'tcx>(
     }
 
     let param_name = trait_pred.skip_binder().self_ty().to_string();
-    let mut constraint = trait_pred.print_modifiers_and_trait_path().to_string();
+    let mut constraint = trait_pred.to_string();
 
     if let Some((name, term)) = associated_ty {
         // FIXME: this case overlaps with code in TyCtxt::note_and_explain_type_err.
@@ -144,7 +144,7 @@ pub fn suggest_arbitrary_trait_bound<'tcx>(
              this requirement",
             if generics.where_clause_span.is_empty() { "introducing a" } else { "extending the" },
         ),
-        format!("{} {}: {}", generics.add_where_or_trailing_comma(), param_name, constraint),
+        format!("{} {constraint}", generics.add_where_or_trailing_comma()),
         Applicability::MaybeIncorrect,
     );
     true

--- a/tests/ui/suggestions/correct-binder-for-arbitrary-bound-sugg.rs
+++ b/tests/ui/suggestions/correct-binder-for-arbitrary-bound-sugg.rs
@@ -1,0 +1,16 @@
+trait Foo
+where
+    for<'a> &'a Self: Bar,
+{
+}
+
+impl Foo for () {}
+
+trait Bar {}
+
+impl Bar for &() {}
+
+fn foo<T: Foo>() {}
+//~^ ERROR the trait bound `for<'a> &'a T: Bar` is not satisfied
+
+fn main() {}

--- a/tests/ui/suggestions/correct-binder-for-arbitrary-bound-sugg.stderr
+++ b/tests/ui/suggestions/correct-binder-for-arbitrary-bound-sugg.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `for<'a> &'a T: Bar` is not satisfied
+  --> $DIR/correct-binder-for-arbitrary-bound-sugg.rs:13:11
+   |
+LL | fn foo<T: Foo>() {}
+   |           ^^^ the trait `for<'a> Bar` is not implemented for `&'a T`
+   |
+note: required by a bound in `Foo`
+  --> $DIR/correct-binder-for-arbitrary-bound-sugg.rs:3:23
+   |
+LL | trait Foo
+   |       --- required by a bound in this trait
+LL | where
+LL |     for<'a> &'a Self: Bar,
+   |                       ^^^ required by this bound in `Foo`
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | fn foo<T: Foo>() where for<'a> &'a T: Bar {}
+   |                  ++++++++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
suggest `for<'a> &'a T: Trait` instead of `&'a T: for<'a> T`.