### PR TITLE
Use DefKind to give more item kind information during BindingObligation note 

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2784,7 +2784,13 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             _ => true,
                         };
                     if ident.span.is_visible(sm) && !ident.span.overlaps(span) && !same_line {
-                        multispan.push_span_label(ident.span, "required by a bound in this");
+                        multispan.push_span_label(
+                            ident.span,
+                            format!(
+                                "required by a bound in this {}",
+                                tcx.def_kind(item_def_id).descr(item_def_id)
+                            ),
+                        );
                     }
                 }
                 let descr = format!("required by a bound in `{item_name}`");

--- a/tests/ui/associated-types/associated-types-eq-hr.stderr
+++ b/tests/ui/associated-types/associated-types-eq-hr.stderr
@@ -15,7 +15,7 @@ note: required by a bound in `foo`
   --> $DIR/associated-types-eq-hr.rs:45:36
    |
 LL | fn foo<T>()
-   |    --- required by a bound in this
+   |    --- required by a bound in this function
 LL | where
 LL |     T: for<'x> TheTrait<&'x isize, A = &'x isize>,
    |                                    ^^^^^^^^^^^^^ required by this bound in `foo`
@@ -37,7 +37,7 @@ note: required by a bound in `bar`
   --> $DIR/associated-types-eq-hr.rs:52:36
    |
 LL | fn bar<T>()
-   |    --- required by a bound in this
+   |    --- required by a bound in this function
 LL | where
 LL |     T: for<'x> TheTrait<&'x isize, A = &'x usize>,
    |                                    ^^^^^^^^^^^^^ required by this bound in `bar`

--- a/tests/ui/associated-types/defaults-suitability.stderr
+++ b/tests/ui/associated-types/defaults-suitability.stderr
@@ -27,7 +27,7 @@ LL |     Self::Ty: Clone,
    |               ^^^^^ required by this bound in `Tr2::Ty`
 LL | {
 LL |     type Ty = NotClone;
-   |          -- required by a bound in this
+   |          -- required by a bound in this associated type
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL | #[derive(Clone)]
@@ -75,7 +75,7 @@ LL |     Self::Assoc: IsU8<Self::Assoc>,
    |                  ^^^^^^^^^^^^^^^^^ required by this bound in `D::Assoc`
 ...
 LL |     type Assoc = NotClone;
-   |          ----- required by a bound in this
+   |          ----- required by a bound in this associated type
 
 error[E0277]: the trait bound `<Self as Foo2<T>>::Baz: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:65:23
@@ -124,7 +124,7 @@ LL |     Self::Baz: Clone,
    |                ^^^^^ required by this bound in `Foo3::Baz`
 ...
 LL |     type Baz = T;
-   |          --- required by a bound in this
+   |          --- required by a bound in this associated type
 help: consider further restricting type parameter `T`
    |
 LL |     Self::Baz: Clone, T: std::clone::Clone

--- a/tests/ui/associated-types/hr-associated-type-bound-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-1.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-1.rs:3:33
    |
 LL | trait X<'a>
-   |       - required by a bound in this
+   |       - required by a bound in this trait
 LL | where
 LL |     for<'b> <Self as X<'b>>::U: Clone,
    |                                 ^^^^^ required by this bound in `X`

--- a/tests/ui/associated-types/hr-associated-type-bound-object.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-object.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-object.rs:3:33
    |
 LL | trait X<'a>
-   |       - required by a bound in this
+   |       - required by a bound in this trait
 LL | where
 LL |     for<'b> <Self as X<'b>>::U: Clone,
    |                                 ^^^^^ required by this bound in `X`

--- a/tests/ui/associated-types/hr-associated-type-bound-param-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-1.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Y`
   --> $DIR/hr-associated-type-bound-param-1.rs:4:36
    |
 LL | trait Y<'a, T: ?Sized>
-   |       - required by a bound in this
+   |       - required by a bound in this trait
 ...
 LL |     for<'b> <Self as Y<'b, T>>::V: Clone,
    |                                    ^^^^^ required by this bound in `Y`

--- a/tests/ui/associated-types/hr-associated-type-bound-param-2.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-2.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Z`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |
 LL | trait Z<'a, T: ?Sized>
-   |       - required by a bound in this
+   |       - required by a bound in this trait
 ...
 LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
    |                                   ^^^^^ required by this bound in `Z`
@@ -25,7 +25,7 @@ note: required by a bound in `Z`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |
 LL | trait Z<'a, T: ?Sized>
-   |       - required by a bound in this
+   |       - required by a bound in this trait
 ...
 LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
    |                                   ^^^^^ required by this bound in `Z`
@@ -41,7 +41,7 @@ note: required by a bound in `Z`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |
 LL | trait Z<'a, T: ?Sized>
-   |       - required by a bound in this
+   |       - required by a bound in this trait
 ...
 LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
    |                                   ^^^^^ required by this bound in `Z`

--- a/tests/ui/associated-types/hr-associated-type-bound-param-3.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-3.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-param-3.rs:4:33
    |
 LL | trait X<'a, T>
-   |       - required by a bound in this
+   |       - required by a bound in this trait
 ...
 LL |     for<'b> <T as X<'b, T>>::U: Clone,
    |                                 ^^^^^ required by this bound in `X`

--- a/tests/ui/associated-types/hr-associated-type-bound-param-4.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-4.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-param-4.rs:4:36
    |
 LL | trait X<'a, T>
-   |       - required by a bound in this
+   |       - required by a bound in this trait
 ...
 LL |     for<'b> <(T,) as X<'b, T>>::U: Clone,
    |                                    ^^^^^ required by this bound in `X`

--- a/tests/ui/associated-types/hr-associated-type-bound-param-5.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-5.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-param-5.rs:17:45
    |
 LL | trait X<'a, T: Cycle + for<'b> X<'b, T>>
-   |       - required by a bound in this
+   |       - required by a bound in this trait
 ...
 LL |     for<'b> <T::Next as X<'b, T::Next>>::U: Clone,
    |                                             ^^^^^ required by this bound in `X`
@@ -25,7 +25,7 @@ note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-param-5.rs:17:45
    |
 LL | trait X<'a, T: Cycle + for<'b> X<'b, T>>
-   |       - required by a bound in this
+   |       - required by a bound in this trait
 ...
 LL |     for<'b> <T::Next as X<'b, T::Next>>::U: Clone,
    |                                             ^^^^^ required by this bound in `X`

--- a/tests/ui/associated-types/hr-associated-type-projection-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-projection-1.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `UnsafeCopy`
   --> $DIR/hr-associated-type-projection-1.rs:3:64
    |
 LL | trait UnsafeCopy<'a, T: Copy>
-   |       ---------- required by a bound in this
+   |       ---------- required by a bound in this trait
 LL | where
 LL |     for<'b> <Self as UnsafeCopy<'b, T>>::Item: std::ops::Deref<Target = T>,
    |                                                                ^^^^^^^^^^ required by this bound in `UnsafeCopy`

--- a/tests/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
+++ b/tests/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
@@ -23,7 +23,7 @@ LL |     Self::Assoc: Bar,
    |                  ^^^ required by this bound in `Baz::Assoc`
 LL | {
 LL |     type Assoc;
-   |          ----- required by a bound in this
+   |          ----- required by a bound in this associated type
 
 error[E0277]: the trait bound `bool: Bar` is not satisfied
   --> $DIR/point-at-type-on-obligation-failure-2.rs:30:18
@@ -38,7 +38,7 @@ LL |     <Self as Bat>::Assoc: Bar,
    |                           ^^^ required by this bound in `Bat::Assoc`
 LL | {
 LL |     type Assoc;
-   |          ----- required by a bound in this
+   |          ----- required by a bound in this associated type
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
+++ b/tests/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
@@ -12,7 +12,7 @@ note: required by a bound in `with_closure`
   --> $DIR/expect-infer-var-appearing-twice.rs:2:14
    |
 LL | fn with_closure<F, A>(_: F)
-   |    ------------ required by a bound in this
+   |    ------------ required by a bound in this function
 LL |     where F: FnOnce(A, A)
    |              ^^^^^^^^^^^^ required by this bound in `with_closure`
 

--- a/tests/ui/const-generics/defaults/wfness.stderr
+++ b/tests/ui/const-generics/defaults/wfness.stderr
@@ -23,7 +23,7 @@ note: required by a bound in `WhereClause`
   --> $DIR/wfness.rs:8:9
    |
 LL | struct WhereClause<const N: u8 = 2>
-   |        ----------- required by a bound in this
+   |        ----------- required by a bound in this struct
 LL | where
 LL |     (): Trait<N>;
    |         ^^^^^^^^ required by this bound in `WhereClause`

--- a/tests/ui/const-generics/ensure_is_evaluatable.stderr
+++ b/tests/ui/const-generics/ensure_is_evaluatable.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `bar`
   --> $DIR/ensure_is_evaluatable.rs:15:10
    |
 LL | fn bar<const N: usize>() -> [(); N]
-   |    --- required by a bound in this
+   |    --- required by a bound in this function
 LL | where
 LL |     [(); N + 1]:,
    |          ^^^^^ required by this bound in `bar`

--- a/tests/ui/const-generics/fn_with_two_const_inputs.stderr
+++ b/tests/ui/const-generics/fn_with_two_const_inputs.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `bar`
   --> $DIR/fn_with_two_const_inputs.rs:18:10
    |
 LL | fn bar<const N: usize>() -> [(); N]
-   |    --- required by a bound in this
+   |    --- required by a bound in this function
 LL | where
 LL |     [(); N + 1]:,
    |          ^^^^^ required by this bound in `bar`

--- a/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.full.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.full.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Arr`
   --> $DIR/issue-72819-generic-in-const-eval.rs:8:39
    |
 LL | struct Arr<const N: usize>
-   |        --- required by a bound in this
+   |        --- required by a bound in this struct
 LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                                       ^^^^^^ required by this bound in `Arr`
 
@@ -26,7 +26,7 @@ note: required by a bound in `Arr`
   --> $DIR/issue-72819-generic-in-const-eval.rs:8:39
    |
 LL | struct Arr<const N: usize>
-   |        --- required by a bound in this
+   |        --- required by a bound in this struct
 LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                                       ^^^^^^ required by this bound in `Arr`
 

--- a/tests/ui/const-generics/generic_const_exprs/obligation-cause.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/obligation-cause.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `g`
   --> $DIR/obligation-cause.rs:13:44
    |
 LL | fn g<T>()
-   |    - required by a bound in this
+   |    - required by a bound in this function
 ...
 LL |     Is<{ std::mem::size_of::<T>() == 0 }>: True,
    |                                            ^^^^ required by this bound in `g`

--- a/tests/ui/const-generics/issues/issue-67185-2.stderr
+++ b/tests/ui/const-generics/issues/issue-67185-2.stderr
@@ -35,7 +35,7 @@ note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:15:25
    |
 LL | trait Foo
-   |       --- required by a bound in this
+   |       --- required by a bound in this trait
 ...
 LL |     <u8 as Baz>::Quaks: Bar,
    |                         ^^^ required by this bound in `Foo`
@@ -53,7 +53,7 @@ note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:14:30
    |
 LL | trait Foo
-   |       --- required by a bound in this
+   |       --- required by a bound in this trait
 LL | where
 LL |     [<u8 as Baz>::Quaks; 2]: Bar,
    |                              ^^^ required by this bound in `Foo`
@@ -71,7 +71,7 @@ note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:14:30
    |
 LL | trait Foo
-   |       --- required by a bound in this
+   |       --- required by a bound in this trait
 LL | where
 LL |     [<u8 as Baz>::Quaks; 2]: Bar,
    |                              ^^^ required by this bound in `Foo`
@@ -89,7 +89,7 @@ note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:15:25
    |
 LL | trait Foo
-   |       --- required by a bound in this
+   |       --- required by a bound in this trait
 ...
 LL |     <u8 as Baz>::Quaks: Bar,
    |                         ^^^ required by this bound in `Foo`

--- a/tests/ui/const-generics/issues/issue-73260.stderr
+++ b/tests/ui/const-generics/issues/issue-73260.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Arr`
   --> $DIR/issue-73260.rs:5:37
    |
 LL | struct Arr<const N: usize>
-   |        --- required by a bound in this
+   |        --- required by a bound in this struct
 LL | where
 LL |     Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                                     ^^^^^^ required by this bound in `Arr`
@@ -27,7 +27,7 @@ note: required by a bound in `Arr`
   --> $DIR/issue-73260.rs:5:37
    |
 LL | struct Arr<const N: usize>
-   |        --- required by a bound in this
+   |        --- required by a bound in this struct
 LL | where
 LL |     Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                                     ^^^^^^ required by this bound in `Arr`

--- a/tests/ui/const-generics/issues/issue-79674.stderr
+++ b/tests/ui/const-generics/issues/issue-79674.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `requires_distinct`
   --> $DIR/issue-79674.rs:23:37
    |
 LL | fn requires_distinct<A, B>(_a: A, _b: B) where
-   |    ----------------- required by a bound in this
+   |    ----------------- required by a bound in this function
 LL |     A: MiniTypeId, B: MiniTypeId,
 LL |     Lift<{is_same_type::<A, B>()}>: IsFalse {}
    |                                     ^^^^^^^ required by this bound in `requires_distinct`

--- a/tests/ui/const-generics/issues/issue-86530.stderr
+++ b/tests/ui/const-generics/issues/issue-86530.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `z`
   --> $DIR/issue-86530.rs:10:8
    |
 LL | fn z<T>(t: T)
-   |    - required by a bound in this
+   |    - required by a bound in this function
 LL | where
 LL |     T: X,
    |        ^ required by this bound in `z`

--- a/tests/ui/const-generics/occurs-check/unused-substs-1.stderr
+++ b/tests/ui/const-generics/occurs-check/unused-substs-1.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `A`
   --> $DIR/unused-substs-1.rs:9:11
    |
 LL | struct A<const N: usize>
-   |        - required by a bound in this
+   |        - required by a bound in this unit struct
 LL | where
 LL |     A<N>: Bar<N>;
    |           ^^^^^^ required by this bound in `A`

--- a/tests/ui/const-generics/unify_with_nested_expr.stderr
+++ b/tests/ui/const-generics/unify_with_nested_expr.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `bar`
   --> $DIR/unify_with_nested_expr.rs:14:10
    |
 LL | fn bar<const N: usize>()
-   |    --- required by a bound in this
+   |    --- required by a bound in this function
 LL | where
 LL |     [(); N + 1]:,
    |          ^^^^^ required by this bound in `bar`

--- a/tests/ui/consts/ct-var-in-collect_all_mismatches.stderr
+++ b/tests/ui/consts/ct-var-in-collect_all_mismatches.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `Foo::<T, N>::unsatisfied`
   --> $DIR/ct-var-in-collect_all_mismatches.rs:15:12
    |
 LL |     fn unsatisfied(self)
-   |        ----------- required by a bound in this
+   |        ----------- required by a bound in this associated function
 LL |     where
 LL |         T: Bar<N>,
    |            ^^^^^^ required by this bound in `Foo::<T, N>::unsatisfied`

--- a/tests/ui/generator/generator-yielding-or-returning-itself.stderr
+++ b/tests/ui/generator/generator-yielding-or-returning-itself.stderr
@@ -19,7 +19,7 @@ note: required by a bound in `want_cyclic_generator_return`
   --> $DIR/generator-yielding-or-returning-itself.rs:10:36
    |
 LL | pub fn want_cyclic_generator_return<T>(_: T)
-   |        ---------------------------- required by a bound in this
+   |        ---------------------------- required by a bound in this function
 LL |     where T: Generator<Yield = (), Return = T>
    |                                    ^^^^^^^^^^ required by this bound in `want_cyclic_generator_return`
 
@@ -44,7 +44,7 @@ note: required by a bound in `want_cyclic_generator_yield`
   --> $DIR/generator-yielding-or-returning-itself.rs:23:24
    |
 LL | pub fn want_cyclic_generator_yield<T>(_: T)
-   |        --------------------------- required by a bound in this
+   |        --------------------------- required by a bound in this function
 LL |     where T: Generator<Yield = T, Return = ()>
    |                        ^^^^^^^^^ required by this bound in `want_cyclic_generator_yield`
 

--- a/tests/ui/generic-associated-types/bugs/issue-88460.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-88460.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `test`
   --> $DIR/issue-88460.rs:15:27
    |
 LL | fn test<T>(value: T)
-   |    ---- required by a bound in this
+   |    ---- required by a bound in this function
 ...
 LL |     for<'a> T::Assoc<'a>: Marker,
    |                           ^^^^^^ required by this bound in `test`

--- a/tests/ui/generic-associated-types/issue-101020.stderr
+++ b/tests/ui/generic-associated-types/issue-101020.stderr
@@ -13,7 +13,7 @@ note: required by a bound in `LendingIterator::consume`
   --> $DIR/issue-101020.rs:9:33
    |
 LL |     fn consume<F>(self, _f: F)
-   |        ------- required by a bound in this
+   |        ------- required by a bound in this associated function
 ...
 LL |         for<'a> Self::Item<'a>: FuncInput<'a, Self::Item<'a>>,
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `LendingIterator::consume`

--- a/tests/ui/higher-rank-trait-bounds/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/tests/ui/higher-rank-trait-bounds/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `want_bar_for_any_ccx`
   --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:32:15
    |
 LL | fn want_bar_for_any_ccx<B>(b: &B)
-   |    -------------------- required by a bound in this
+   |    -------------------- required by a bound in this function
 LL |     where B : for<'ccx> Bar<'ccx>
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_bar_for_any_ccx`
 help: consider further restricting this bound

--- a/tests/ui/higher-rank-trait-bounds/hrtb-higher-ranker-supertraits.stderr
+++ b/tests/ui/higher-rank-trait-bounds/hrtb-higher-ranker-supertraits.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `want_foo_for_any_tcx`
   --> $DIR/hrtb-higher-ranker-supertraits.rs:22:15
    |
 LL | fn want_foo_for_any_tcx<F>(f: &F)
-   |    -------------------- required by a bound in this
+   |    -------------------- required by a bound in this function
 LL |     where F : for<'tcx> Foo<'tcx>
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_foo_for_any_tcx`
 help: consider further restricting this bound
@@ -30,7 +30,7 @@ note: required by a bound in `want_bar_for_any_ccx`
   --> $DIR/hrtb-higher-ranker-supertraits.rs:39:15
    |
 LL | fn want_bar_for_any_ccx<B>(b: &B)
-   |    -------------------- required by a bound in this
+   |    -------------------- required by a bound in this function
 LL |     where B : for<'ccx> Bar<'ccx>
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_bar_for_any_ccx`
 help: consider further restricting this bound

--- a/tests/ui/higher-rank-trait-bounds/issue-62203-hrtb-ice.stderr
+++ b/tests/ui/higher-rank-trait-bounds/issue-62203-hrtb-ice.stderr
@@ -25,7 +25,7 @@ note: required by a bound in `T1::m`
   --> $DIR/issue-62203-hrtb-ice.rs:27:51
    |
 LL |     fn m<'a, B: Ty<'a>, F>(&self, f: F) -> Unit1
-   |        - required by a bound in this
+   |        - required by a bound in this associated function
 LL |     where
 LL |         F: for<'r> T0<'r, (<Self as Ty<'r>>::V,), O = <B as Ty<'r>>::V>,
    |                                                   ^^^^^^^^^^^^^^^^^^^^ required by this bound in `T1::m`
@@ -56,7 +56,7 @@ note: required by a bound in `T1::m`
   --> $DIR/issue-62203-hrtb-ice.rs:27:12
    |
 LL |     fn m<'a, B: Ty<'a>, F>(&self, f: F) -> Unit1
-   |        - required by a bound in this
+   |        - required by a bound in this associated function
 LL |     where
 LL |         F: for<'r> T0<'r, (<Self as Ty<'r>>::V,), O = <B as Ty<'r>>::V>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `T1::m`

--- a/tests/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.stderr
+++ b/tests/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.stderr
@@ -15,7 +15,7 @@ note: required by a bound in `StackContext`
   --> $DIR/issue-89118.rs:9:14
    |
 LL | trait StackContext
-   |       ------------ required by a bound in this
+   |       ------------ required by a bound in this trait
 LL | where
 LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StackContext`
@@ -37,7 +37,7 @@ note: required by a bound in `EthernetWorker`
   --> $DIR/issue-89118.rs:28:14
    |
 LL | struct EthernetWorker<C>(C)
-   |        -------------- required by a bound in this
+   |        -------------- required by a bound in this struct
 LL | where
 LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EthernetWorker`
@@ -59,7 +59,7 @@ note: required by a bound in `StackContext`
   --> $DIR/issue-89118.rs:9:14
    |
 LL | trait StackContext
-   |       ------------ required by a bound in this
+   |       ------------ required by a bound in this trait
 LL | where
 LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StackContext`

--- a/tests/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90950.stderr
+++ b/tests/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90950.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `upcast`
   --> $DIR/issue-90950.rs:27:42
    |
 LL | fn upcast<Y>(x: Yoke<Y>) -> Yoke<Box<dyn IsCovariant<'static> + 'static>> where
-   |    ------ required by a bound in this
+   |    ------ required by a bound in this function
 LL |     Y: for<'a> Yokeable<'a>,
 LL |     for<'a> <Y as Yokeable<'a>>::Output: IsCovariant<'a>
    |                                          ^^^^^^^^^^^^^^^ required by this bound in `upcast`

--- a/tests/ui/higher-rank-trait-bounds/normalize-under-binder/norm-before-method-resolution.stderr
+++ b/tests/ui/higher-rank-trait-bounds/normalize-under-binder/norm-before-method-resolution.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `weird_bound`
   --> $DIR/norm-before-method-resolution.rs:18:40
    |
 LL | fn weird_bound<X>() -> X
-   |    ----------- required by a bound in this
+   |    ----------- required by a bound in this function
 ...
 LL |         for<'a> <X as Trait<'a>>::Out: Copy
    |                                        ^^^^ required by this bound in `weird_bound`

--- a/tests/ui/implied-bounds/issue-100690.stderr
+++ b/tests/ui/implied-bounds/issue-100690.stderr
@@ -12,7 +12,7 @@ note: required by a bound in `real_dispatch`
   --> $DIR/issue-100690.rs:9:8
    |
 LL | fn real_dispatch<T, F>(f: F) -> Result<(), io::Error>
-   |    ------------- required by a bound in this
+   |    ------------- required by a bound in this function
 ...
 LL |     F: FnOnce(&mut UIView<T>) -> Result<(), io::Error> + Send + 'static,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `real_dispatch`

--- a/tests/ui/issues/issue-60218.stderr
+++ b/tests/ui/issues/issue-60218.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `trigger_error`
   --> $DIR/issue-60218.rs:13:72
    |
 LL | pub fn trigger_error<I, F>(iterable: I, functor: F)
-   |        ------------- required by a bound in this
+   |        ------------- required by a bound in this function
 ...
 LL | for<'t> <Map<<&'t I as IntoIterator>::IntoIter, F> as Iterator>::Item: Foo,
    |                                                                        ^^^ required by this bound in `trigger_error`

--- a/tests/ui/issues/issue-69683.stderr
+++ b/tests/ui/issues/issue-69683.stderr
@@ -31,7 +31,7 @@ LL |     u8: Element<I>,
    |         ^^^^^^^^^^ required by this bound in `Foo::foo`
 LL | {
 LL |     fn foo(self, x: <u8 as Element<I>>::Array);
-   |        --- required by a bound in this
+   |        --- required by a bound in this associated function
 help: try using a fully qualified path to specify the expected types
    |
 LL |     <u16 as Foo<I>>::foo(0u16, b);

--- a/tests/ui/mismatched_types/issue-47706.stderr
+++ b/tests/ui/mismatched_types/issue-47706.stderr
@@ -27,7 +27,7 @@ note: required by a bound in `foo`
   --> $DIR/issue-47706.rs:22:8
    |
 LL | fn foo<F>(f: F)
-   |    --- required by a bound in this
+   |    --- required by a bound in this function
 LL | where
 LL |     F: Fn(),
    |        ^^^^ required by this bound in `foo`

--- a/tests/ui/suggestions/imm-ref-trait-object-literal-bound-regions.stderr
+++ b/tests/ui/suggestions/imm-ref-trait-object-literal-bound-regions.stderr
@@ -12,7 +12,7 @@ note: required by a bound in `foo`
   --> $DIR/imm-ref-trait-object-literal-bound-regions.rs:11:20
    |
 LL | fn foo<X>(_: X)
-   |    --- required by a bound in this
+   |    --- required by a bound in this function
 LL | where
 LL |     for<'b> &'b X: Trait,
    |                    ^^^^^ required by this bound in `foo`

--- a/tests/ui/suggestions/issue-84973.stderr
+++ b/tests/ui/suggestions/issue-84973.stderr
@@ -13,7 +13,7 @@ LL |     G: SomeTrait,
    |        ^^^^^^^^^ required by this bound in `Other::<'a, G>::new`
 LL | {
 LL |     pub fn new(g: G) -> Self {
-   |            --- required by a bound in this
+   |            --- required by a bound in this associated function
 help: consider borrowing here
    |
 LL |     let o = Other::new(&f);

--- a/tests/ui/traits/multidispatch-convert-ambig-dest.stderr
+++ b/tests/ui/traits/multidispatch-convert-ambig-dest.stderr
@@ -29,7 +29,7 @@ note: required by a bound in `test`
   --> $DIR/multidispatch-convert-ambig-dest.rs:21:11
    |
 LL | fn test<T,U>(_: T, _: U)
-   |    ---- required by a bound in this
+   |    ---- required by a bound in this function
 LL | where T : Convert<U>
    |           ^^^^^^^^^^ required by this bound in `test`
 help: consider specifying the generic arguments

--- a/tests/ui/traits/non_lifetime_binders/bad-sized-cond.stderr
+++ b/tests/ui/traits/non_lifetime_binders/bad-sized-cond.stderr
@@ -18,7 +18,7 @@ note: required by a bound in `foo`
   --> $DIR/bad-sized-cond.rs:6:15
    |
 LL | pub fn foo()
-   |        --- required by a bound in this
+   |        --- required by a bound in this function
 LL | where
 LL |     for<V> V: Sized,
    |               ^^^^^ required by this bound in `foo`
@@ -35,7 +35,7 @@ note: required by a bound in `bar`
   --> $DIR/bad-sized-cond.rs:12:15
    |
 LL | pub fn bar()
-   |        --- required by a bound in this
+   |        --- required by a bound in this function
 LL | where
 LL |     for<V> V: IntoIterator,
    |               ^^^^^^^^^^^^ required by this bound in `bar`
@@ -52,7 +52,7 @@ note: required by a bound in `bar`
   --> $DIR/bad-sized-cond.rs:12:15
    |
 LL | pub fn bar()
-   |        --- required by a bound in this
+   |        --- required by a bound in this function
 LL | where
 LL |     for<V> V: IntoIterator,
    |               ^^^^^^^^^^^^ required by this bound in `bar`

--- a/tests/ui/traits/non_lifetime_binders/fail.stderr
+++ b/tests/ui/traits/non_lifetime_binders/fail.stderr
@@ -17,7 +17,7 @@ note: required by a bound in `fail`
   --> $DIR/fail.rs:10:15
    |
 LL | fn fail()
-   |    ---- required by a bound in this
+   |    ---- required by a bound in this function
 LL | where
 LL |     for<T> T: Trait,
    |               ^^^^^ required by this bound in `fail`
@@ -33,7 +33,7 @@ note: required by a bound in `auto_trait`
   --> $DIR/fail.rs:15:15
    |
 LL | fn auto_trait()
-   |    ---------- required by a bound in this
+   |    ---------- required by a bound in this function
 LL | where
 LL |     for<T> T: Send,
    |               ^^^^ required by this bound in `auto_trait`

--- a/tests/ui/traits/object/enforce-supertrait-projection.stderr
+++ b/tests/ui/traits/object/enforce-supertrait-projection.stderr
@@ -16,7 +16,7 @@ note: required by a bound in `foo`
   --> $DIR/enforce-supertrait-projection.rs:15:8
    |
 LL | fn foo<A, B, T: ?Sized>(x: T::A) -> B
-   |    --- required by a bound in this
+   |    --- required by a bound in this function
 LL | where
 LL |     T: Trait<B = B>,
    |        ^^^^^^^^^^^^ required by this bound in `foo`

--- a/tests/ui/transmutability/arrays/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/arrays/should_require_well_defined_layout.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -31,7 +31,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -53,7 +53,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -75,7 +75,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -97,7 +97,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -119,7 +119,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^

--- a/tests/ui/transmutability/enums/repr/primitive_reprs_should_have_correct_length.stderr
+++ b/tests/ui/transmutability/enums/repr/primitive_reprs_should_have_correct_length.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -32,7 +32,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -55,7 +55,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -78,7 +78,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -101,7 +101,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -124,7 +124,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -147,7 +147,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -170,7 +170,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -193,7 +193,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -216,7 +216,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -239,7 +239,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -262,7 +262,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -285,7 +285,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -308,7 +308,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -331,7 +331,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -354,7 +354,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -377,7 +377,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -400,7 +400,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -423,7 +423,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -446,7 +446,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^

--- a/tests/ui/transmutability/enums/repr/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/enums/repr/should_require_well_defined_layout.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -32,7 +32,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -55,7 +55,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -78,7 +78,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -101,7 +101,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -124,7 +124,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^

--- a/tests/ui/transmutability/enums/should_pad_variants.stderr
+++ b/tests/ui/transmutability/enums/should_pad_variants.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/should_pad_variants.rs:13:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^

--- a/tests/ui/transmutability/enums/should_respect_endianness.stderr
+++ b/tests/ui/transmutability/enums/should_respect_endianness.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/should_respect_endianness.rs:14:14
    |
 LL |       pub fn is_transmutable<Src, Dst>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^

--- a/tests/ui/transmutability/primitives/bool.stderr
+++ b/tests/ui/transmutability/primitives/bool.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/bool.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`

--- a/tests/ui/transmutability/primitives/numbers.stderr
+++ b/tests/ui/transmutability/primitives/numbers.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -25,7 +25,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -41,7 +41,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -57,7 +57,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -73,7 +73,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -89,7 +89,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -105,7 +105,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -121,7 +121,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -137,7 +137,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -153,7 +153,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -169,7 +169,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -185,7 +185,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -201,7 +201,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -217,7 +217,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -233,7 +233,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -249,7 +249,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -265,7 +265,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -281,7 +281,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -297,7 +297,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -313,7 +313,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -329,7 +329,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -345,7 +345,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -361,7 +361,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -377,7 +377,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -393,7 +393,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -409,7 +409,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -425,7 +425,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -441,7 +441,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -457,7 +457,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -473,7 +473,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -489,7 +489,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -505,7 +505,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -521,7 +521,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -537,7 +537,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -553,7 +553,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -569,7 +569,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -585,7 +585,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -601,7 +601,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -617,7 +617,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -633,7 +633,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -649,7 +649,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -665,7 +665,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -681,7 +681,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -697,7 +697,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -713,7 +713,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -729,7 +729,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -745,7 +745,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -761,7 +761,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -777,7 +777,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -793,7 +793,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -809,7 +809,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -825,7 +825,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -841,7 +841,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -857,7 +857,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -873,7 +873,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -889,7 +889,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -905,7 +905,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:12:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`

--- a/tests/ui/transmutability/primitives/unit.stderr
+++ b/tests/ui/transmutability/primitives/unit.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/unit.rs:12:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^

--- a/tests/ui/transmutability/references.stderr
+++ b/tests/ui/transmutability/references.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/references.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^

--- a/tests/ui/transmutability/structs/repr/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/structs/repr/should_require_well_defined_layout.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -32,7 +32,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -55,7 +55,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -78,7 +78,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -101,7 +101,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -124,7 +124,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -147,7 +147,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -170,7 +170,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -193,7 +193,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -216,7 +216,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -239,7 +239,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -262,7 +262,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^

--- a/tests/ui/transmutability/unions/repr/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/unions/repr/should_require_well_defined_layout.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^
@@ -32,7 +32,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^

--- a/tests/ui/transmutability/unions/should_pad_variants.stderr
+++ b/tests/ui/transmutability/unions/should_pad_variants.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/should_pad_variants.rs:13:14
    |
 LL |       pub fn is_transmutable<Src, Dst, Context>()
-   |              --------------- required by a bound in this
+   |              --------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<Src, Context, {
    |  ______________^

--- a/tests/ui/transmutability/unions/should_reject_contraction.stderr
+++ b/tests/ui/transmutability/unions/should_reject_contraction.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_contraction.rs:13:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`

--- a/tests/ui/transmutability/unions/should_reject_disjoint.stderr
+++ b/tests/ui/transmutability/unions/should_reject_disjoint.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_reject_disjoint.rs:13:14
    |
 LL |     pub fn is_maybe_transmutable<Src, Dst>()
-   |            --------------------- required by a bound in this
+   |            --------------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY.and(Assume::VALIDITY) }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
@@ -25,7 +25,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_reject_disjoint.rs:13:14
    |
 LL |     pub fn is_maybe_transmutable<Src, Dst>()
-   |            --------------------- required by a bound in this
+   |            --------------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY.and(Assume::VALIDITY) }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`

--- a/tests/ui/transmutability/unions/should_reject_intersecting.stderr
+++ b/tests/ui/transmutability/unions/should_reject_intersecting.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_intersecting.rs:14:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
@@ -25,7 +25,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_intersecting.rs:14:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`

--- a/tests/ui/transmutability/visibility/should_reject_if_dst_has_private_field.stderr
+++ b/tests/ui/transmutability/visibility/should_reject_if_dst_has_private_field.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_if_dst_has_private_field.rs:13:14
    |
 LL |     pub fn is_transmutable<Src, Dst, Context>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context> // safety is NOT assumed
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`

--- a/tests/ui/transmutability/visibility/should_reject_if_dst_has_private_variant.stderr
+++ b/tests/ui/transmutability/visibility/should_reject_if_dst_has_private_variant.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_if_dst_has_private_variant.rs:13:14
    |
 LL |     pub fn is_transmutable<Src, Dst, Context>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context> // safety is NOT assumed
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`

--- a/tests/ui/transmutability/visibility/should_reject_if_dst_has_unreachable_field.stderr
+++ b/tests/ui/transmutability/visibility/should_reject_if_dst_has_unreachable_field.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_if_dst_has_unreachable_field.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst, Context>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context> // safety is NOT assumed
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`

--- a/tests/ui/transmutability/visibility/should_reject_if_dst_has_unreachable_ty.stderr
+++ b/tests/ui/transmutability/visibility/should_reject_if_dst_has_unreachable_ty.stderr
@@ -21,7 +21,7 @@ note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_if_dst_has_unreachable_ty.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst, Context>()
-   |            --------------- required by a bound in this
+   |            --------------- required by a bound in this function
 LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context> // safety is NOT assumed
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`

--- a/tests/ui/transmute/transmute-padding-ice.stderr
+++ b/tests/ui/transmute/transmute-padding-ice.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_maybe_transmutable`
   --> $DIR/transmute-padding-ice.rs:11:14
    |
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
-   |              --------------------- required by a bound in this
+   |              --------------------- required by a bound in this function
 LL |       where
 LL |           Dst: BikeshedIntrinsicFrom<
    |  ______________^

--- a/tests/ui/unboxed-closures/unboxed-closures-infer-fn-once-move-from-projection.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-infer-fn-once-move-from-projection.stderr
@@ -14,7 +14,7 @@ note: required by a bound in `foo`
   --> $DIR/unboxed-closures-infer-fn-once-move-from-projection.rs:4:14
    |
 LL | fn foo<F>(f: F)
-   |    --- required by a bound in this
+   |    --- required by a bound in this function
 LL |     where F: Fn()
    |              ^^^^ required by this bound in `foo`
 

--- a/tests/ui/unsized/issue-71659.stderr
+++ b/tests/ui/unsized/issue-71659.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `Cast::cast`
   --> $DIR/issue-71659.rs:19:15
    |
 LL |     fn cast<T: ?Sized>(&self) -> &T
-   |        ---- required by a bound in this
+   |        ---- required by a bound in this associated function
 LL |     where
 LL |         Self: CastTo<T>,
    |               ^^^^^^^^^ required by this bound in `Cast::cast`

--- a/tests/ui/where-clauses/higher-ranked-fn-type.quiet.stderr
+++ b/tests/ui/where-clauses/higher-ranked-fn-type.quiet.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `called`
   --> $DIR/higher-ranked-fn-type.rs:12:25
    |
 LL | fn called()
-   |    ------ required by a bound in this
+   |    ------ required by a bound in this function
 LL | where
 LL |     for<'b> fn(&'b ()): Foo,
    |                         ^^^ required by this bound in `called`

--- a/tests/ui/where-clauses/higher-ranked-fn-type.verbose.stderr
+++ b/tests/ui/where-clauses/higher-ranked-fn-type.verbose.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `called`
   --> $DIR/higher-ranked-fn-type.rs:12:25
    |
 LL | fn called()
-   |    ------ required by a bound in this
+   |    ------ required by a bound in this function
 LL | where
 LL |     for<'b> fn(&'b ()): Foo,
    |                         ^^^ required by this bound in `called`


### PR DESCRIPTION
The current label says "required by a bound in this". When I see that label, my immediate impression is "this... **what**?". It feels like it was cut short.

Alternative to this would be saying "in this item", but adding the item kind is strictly more informational and adds very little overhead to the existing error presentation.