### PR TITLE
Lint dead code in closures and generators

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -395,6 +395,9 @@ impl<'tcx> Visitor<'tcx> for MarkSymbolVisitor<'tcx> {
                     self.mark_as_used_if_union(*adt, fields);
                 }
             }
+            hir::ExprKind::Closure(cls) => {
+                self.insert_def_id(cls.def_id.to_def_id());
+            }
             _ => (),
         }
 

--- a/tests/ui/lint/dead-code/in-closure.rs
+++ b/tests/ui/lint/dead-code/in-closure.rs
@@ -1,0 +1,16 @@
+// edition: 2021
+
+#![deny(dead_code)]
+
+pub fn foo() {
+    let closure = || {
+        fn a() {}   //~ ERROR function `a` is never used
+    };
+    closure()
+}
+
+pub async fn async_foo() {
+    const A: usize = 1; //~ ERROR constant `A` is never used
+}
+
+fn main() {}

--- a/tests/ui/lint/dead-code/in-closure.stderr
+++ b/tests/ui/lint/dead-code/in-closure.stderr
@@ -1,0 +1,20 @@
+error: function `a` is never used
+  --> $DIR/in-closure.rs:7:12
+   |
+LL |         fn a() {}
+   |            ^
+   |
+note: the lint level is defined here
+  --> $DIR/in-closure.rs:3:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: constant `A` is never used
+  --> $DIR/in-closure.rs:13:11
+   |
+LL |     const A: usize = 1;
+   |           ^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #108296

I think this might be a potentially breaking change, but restores the behaviour of pre-1.64.

@rustbot label +A-lint