### PR TITLE
diagnostics: if AssocFn has self argument, describe as method

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2135,7 +2135,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
     ) -> DiagnosticBuilder<'cx, ErrorGuaranteed> {
         let tcx = self.infcx.tcx;
 
-        let (_, escapes_from) = tcx.article_and_description(self.mir_def_id().to_def_id());
+        let escapes_from = tcx.def_descr(self.mir_def_id().to_def_id());
 
         let mut err =
             borrowck_errors::borrowed_data_escapes_closure(tcx, escape_span, escapes_from);

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -660,10 +660,8 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             errci.outlived_fr,
         );
 
-        let (_, escapes_from) = self
-            .infcx
-            .tcx
-            .article_and_description(self.regioncx.universal_regions().defining_ty.def_id());
+        let escapes_from =
+            self.infcx.tcx.def_descr(self.regioncx.universal_regions().defining_ty.def_id());
 
         // Revert to the normal error in these cases.
         // Assignments aren't "escapes" in function items.
@@ -757,8 +755,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             ..
         } = errci;
 
-        let (_, mir_def_name) =
-            self.infcx.tcx.article_and_description(self.mir_def_id().to_def_id());
+        let mir_def_name = self.infcx.tcx.def_descr(self.mir_def_id().to_def_id());
 
         let err = LifetimeOutliveErr { span: *span };
         let mut diag = self.infcx.tcx.sess.create_err(err);

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -124,6 +124,11 @@ pub enum DefKind {
 }
 
 impl DefKind {
+    /// Get an English description for the item's kind.
+    ///
+    /// If you have access to `TyCtxt`, use `TyCtxt::def_descr` or
+    /// `TyCtxt::def_kind_descr` instead, because they give better
+    /// information for generators and associated functions.
     pub fn descr(self, def_id: DefId) -> &'static str {
         match self {
             DefKind::Fn => "function",
@@ -166,6 +171,10 @@ impl DefKind {
     }
 
     /// Gets an English article for the definition.
+    ///
+    /// If you have access to `TyCtxt`, use `TyCtxt::def_descr_article` or
+    /// `TyCtxt::def_kind_descr_article` instead, because they give better
+    /// information for generators and associated functions.
     pub fn article(&self) -> &'static str {
         match *self {
             DefKind::AssocTy

--- a/compiler/rustc_hir_analysis/src/astconv/errors.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/errors.rs
@@ -304,10 +304,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             if let Some(did) = adt_did {
                 err.span_label(
                     tcx.def_span(did),
-                    format!(
-                        "associated item `{name}` not found for this {}",
-                        tcx.def_kind(did).descr(did)
-                    ),
+                    format!("associated item `{name}` not found for this {}", tcx.def_descr(did)),
                 );
             }
         };

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -1217,7 +1217,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     | (hir::def::DefKind::AssocConst, ty::TermKind::Const(_)) => (),
                     (_, _) => {
                         let got = if let Some(_) = term.ty() { "type" } else { "constant" };
-                        let expected = def_kind.descr(assoc_item_def_id);
+                        let expected = tcx.def_descr(assoc_item_def_id);
                         let mut err = tcx.sess.struct_span_err(
                             binding.span,
                             &format!("expected {expected} bound, found {got}"),
@@ -1552,7 +1552,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         i.bottom().1,
                         E0038,
                         "the {} `{}` cannot be made into an object",
-                        tcx.def_kind(def_id).descr(def_id),
+                        tcx.def_descr(def_id),
                         tcx.item_name(def_id),
                     );
                     err.note(
@@ -2174,7 +2174,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             "`{}` could{} refer to the {} defined here",
                             assoc_ident,
                             also,
-                            kind.descr(def_id)
+                            tcx.def_kind_descr(kind, def_id)
                         );
                         lint.span_note(tcx.def_span(def_id), &note_msg);
                     };
@@ -2350,7 +2350,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         let kind = DefKind::AssocTy;
 
         if !tcx.visibility(item).is_accessible_from(def_scope, tcx) {
-            let kind = kind.descr(item);
+            let kind = tcx.def_kind_descr(kind, item);
             let msg = format!("{kind} `{name}` is private");
             let def_span = tcx.def_span(item);
             tcx.sess

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1460,7 +1460,7 @@ fn opaque_type_cycle_error(
                                     span,
                                     format!(
                                         "{} captures itself here",
-                                        tcx.def_kind(closure_def_id).descr(closure_def_id)
+                                        tcx.def_descr(closure_def_id)
                                     ),
                                 );
                             }

--- a/compiler/rustc_hir_analysis/src/check/dropck.rs
+++ b/compiler/rustc_hir_analysis/src/check/dropck.rs
@@ -71,7 +71,7 @@ fn ensure_drop_params_and_item_params_correspond<'tcx>(
 
     let drop_impl_span = tcx.def_span(drop_impl_did);
     let item_span = tcx.def_span(self_type_did);
-    let self_descr = tcx.def_kind(self_type_did).descr(self_type_did);
+    let self_descr = tcx.def_descr(self_type_did);
     let mut err =
         struct_span_err!(tcx.sess, drop_impl_span, E0366, "`Drop` impls cannot be specialized");
     match arg {
@@ -217,7 +217,7 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
 
         if !assumptions_in_impl_context.iter().copied().any(predicate_matches_closure) {
             let item_span = tcx.def_span(self_type_did);
-            let self_descr = tcx.def_kind(self_type_did).descr(self_type_did.to_def_id());
+            let self_descr = tcx.def_descr(self_type_did.to_def_id());
             let reported = struct_span_err!(
                 tcx.sess,
                 predicate_sp,

--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -531,7 +531,7 @@ fn lint_auto_trait_impl<'tcx>(
         }),
         |lint| {
             let item_span = tcx.def_span(self_type_did);
-            let self_descr = tcx.def_kind(self_type_did).descr(self_type_did);
+            let self_descr = tcx.def_descr(self_type_did);
             match arg {
                 ty::util::NotUniqueParam::DuplicateParam(arg) => {
                     lint.note(&format!("`{}` is mentioned multiple times", arg));

--- a/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
@@ -439,7 +439,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
 
     fn create_error_message(&self) -> String {
         let def_path = self.tcx.def_path_str(self.def_id);
-        let def_kind = self.tcx.def_kind(self.def_id).descr(self.def_id);
+        let def_kind = self.tcx.def_descr(self.def_id);
         let (quantifier, bound) = self.get_quantifier_and_bound();
         let kind = self.kind();
         let provided_lt_args = self.num_provided_lifetime_args();
@@ -990,7 +990,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         };
 
         let msg = {
-            let def_kind = self.tcx.def_kind(self.def_id).descr(self.def_id);
+            let def_kind = self.tcx.def_descr(self.def_id);
             let (quantifier, bound) = self.get_quantifier_and_bound();
 
             let params = if bound == 0 {

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -671,7 +671,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 && !self.type_is_sized_modulo_regions(self.param_env, output_ty, callee_expr.span)
             {
                 let descr = match maybe_def {
-                    DefIdOrName::DefId(def_id) => self.tcx.def_kind(def_id).descr(def_id),
+                    DefIdOrName::DefId(def_id) => self.tcx.def_descr(def_id),
                     DefIdOrName::Name(name) => name,
                 };
                 err.span_label(

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2448,7 +2448,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         return_ty: Option<Ty<'tcx>>,
     ) {
         let struct_path = self.tcx().def_path_str(base_did);
-        let kind_name = self.tcx().def_kind(base_did).descr(base_did);
+        let kind_name = self.tcx().def_descr(base_did);
         let mut err = struct_span_err!(
             self.tcx().sess,
             field.span,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1938,8 +1938,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 spans.push_span_label(param.span, "");
             }
 
-            let def_kind = self.tcx.def_kind(def_id);
-            err.span_note(spans, &format!("{} defined here", def_kind.descr(def_id)));
+            err.span_note(spans, &format!("{} defined here", self.tcx.def_descr(def_id)));
         } else if let Some(hir::Node::Expr(e)) = self.tcx.hir().get_if_local(def_id)
             && let hir::ExprKind::Closure(hir::Closure { body, .. }) = &e.kind
         {
@@ -1952,10 +1951,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             };
             err.span_note(span, &format!("{} defined here", kind));
         } else {
-            let def_kind = self.tcx.def_kind(def_id);
             err.span_note(
                 self.tcx.def_span(def_id),
-                &format!("{} defined here", def_kind.descr(def_id)),
+                &format!("{} defined here", self.tcx.def_descr(def_id)),
             );
         }
     }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -120,7 +120,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 DefIdOrName::DefId(def_id) => match self.tcx.def_kind(def_id) {
                     DefKind::Ctor(CtorOf::Struct, _) => "construct this tuple struct".to_string(),
                     DefKind::Ctor(CtorOf::Variant, _) => "construct this tuple variant".to_string(),
-                    kind => format!("call this {}", kind.descr(def_id)),
+                    kind => format!("call this {}", self.tcx.def_kind_descr(kind, def_id)),
                 },
                 DefIdOrName::Name(name) => format!("call this {name}"),
             };
@@ -339,7 +339,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     CtorOf::Variant => "an enum variant",
                 }));
             } else {
-                let descr = kind.descr(def_id);
+                let descr = self.tcx.def_kind_descr(kind, def_id);
                 err.span_label(sp, format!("{descr} `{name}` defined here"));
             }
             return true;

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1366,8 +1366,8 @@ impl<'tcx> Pick<'tcx> {
             span,
             format!(
                 "{} {} with this name may be added to the standard library in the future",
-                def_kind.article(),
-                def_kind.descr(self.item.def_id),
+                tcx.def_kind_descr_article(def_kind, self.item.def_id),
+                tcx.def_kind_descr(def_kind, self.item.def_id),
             ),
             |lint| {
                 match (self.item.kind, self.item.container) {

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -160,7 +160,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
 
             MethodError::PrivateMatch(kind, def_id, out_of_scope_traits) => {
-                let kind = kind.descr(def_id);
+                let kind = self.tcx.def_kind_descr(kind, def_id);
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     item_name.span,
@@ -1062,8 +1062,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         span,
                         &format!(
                             "there is {} {} with a similar name",
-                            def_kind.article(),
-                            def_kind.descr(similar_candidate.def_id),
+                            self.tcx.def_kind_descr_article(def_kind, similar_candidate.def_id),
+                            self.tcx.def_kind_descr(def_kind, similar_candidate.def_id)
                         ),
                         similar_candidate.name,
                         Applicability::MaybeIncorrect,
@@ -1172,7 +1172,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             path,
                             ty,
                             item.kind,
-                            item.def_id,
+                            self.tcx.def_kind_descr(item.kind.as_def_kind(), item.def_id),
                             sugg_span,
                             idx,
                             self.tcx.sess.source_map(),
@@ -1208,7 +1208,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             path,
                             rcvr_ty,
                             item.kind,
-                            item.def_id,
+                            self.tcx.def_kind_descr(item.kind.as_def_kind(), item.def_id),
                             sugg_span,
                             idx,
                             self.tcx.sess.source_map(),
@@ -2853,7 +2853,7 @@ fn print_disambiguation_help<'tcx>(
     trait_name: String,
     rcvr_ty: Ty<'_>,
     kind: ty::AssocKind,
-    def_id: DefId,
+    def_kind_descr: &'static str,
     span: Span,
     candidate: Option<usize>,
     source_map: &source_map::SourceMap,
@@ -2886,7 +2886,7 @@ fn print_disambiguation_help<'tcx>(
         span,
         &format!(
             "disambiguate the {} for {}",
-            kind.as_def_kind().descr(def_id),
+            def_kind_descr,
             if let Some(candidate) = candidate {
                 format!("candidate #{}", candidate)
             } else {

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -122,7 +122,7 @@ impl InferenceDiagnosticsParentData {
             tcx.def_key(parent_def_id).disambiguated_data.data.get_opt_name()?.to_string();
 
         Some(InferenceDiagnosticsParentData {
-            prefix: tcx.def_kind(parent_def_id).descr(parent_def_id),
+            prefix: tcx.def_descr(parent_def_id),
             name: parent_name,
         })
     }

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -255,7 +255,7 @@ fn late_report_deprecation(
     let method_span = method_span.unwrap_or(span);
     tcx.struct_span_lint_hir(lint, hir_id, method_span, message, |diag| {
         if let hir::Node::Expr(_) = tcx.hir().get(hir_id) {
-            let kind = tcx.def_kind(def_id).descr(def_id);
+            let kind = tcx.def_descr(def_id);
             deprecation_suggestion(diag, kind, suggestion, method_span);
         }
         diag
@@ -392,7 +392,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     let lint = deprecation_lint(is_in_effect);
                     if self.lint_level_at_node(lint, id).0 != Level::Allow {
                         let def_path = with_no_trimmed_paths!(self.def_path_str(def_id));
-                        let def_kind = self.def_kind(def_id).descr(def_id);
+                        let def_kind = self.def_descr(def_id);
 
                         late_report_deprecation(
                             self,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1200,13 +1200,8 @@ impl<'tcx> TyCtxt<'tcx> {
 
     /// Returns a displayable description and article for the given `def_id` (e.g. `("a", "struct")`).
     pub fn article_and_description(self, def_id: DefId) -> (&'static str, &'static str) {
-        match self.def_kind(def_id) {
-            DefKind::Generator => match self.generator_kind(def_id).unwrap() {
-                rustc_hir::GeneratorKind::Async(..) => ("an", "async closure"),
-                rustc_hir::GeneratorKind::Gen => ("a", "generator"),
-            },
-            def_kind => (def_kind.article(), def_kind.descr(def_id)),
-        }
+        let kind = self.def_kind(def_id);
+        (self.def_kind_descr_article(kind, def_id), self.def_kind_descr(kind, def_id))
     }
 
     pub fn type_length_limit(self) -> Limit {

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -761,6 +761,40 @@ impl<'tcx> TyCtxt<'tcx> {
         }
         (generator_layout, generator_saved_local_names)
     }
+
+    /// Query and get an English description for the item's kind.
+    pub fn def_descr(self, def_id: DefId) -> &'static str {
+        self.def_kind_descr(self.def_kind(def_id), def_id)
+    }
+
+    /// Get an English description for the item's kind.
+    pub fn def_kind_descr(self, def_kind: DefKind, def_id: DefId) -> &'static str {
+        match def_kind {
+            DefKind::AssocFn if self.associated_item(def_id).fn_has_self_parameter => "method",
+            DefKind::Generator => match self.generator_kind(def_id).unwrap() {
+                rustc_hir::GeneratorKind::Async(..) => "async closure",
+                rustc_hir::GeneratorKind::Gen => "generator",
+            },
+            _ => def_kind.descr(def_id),
+        }
+    }
+
+    /// Gets an English article for the [`TyCtxt::def_descr`].
+    pub fn def_descr_article(self, def_id: DefId) -> &'static str {
+        self.def_kind_descr_article(self.def_kind(def_id), def_id)
+    }
+
+    /// Gets an English article for the [`TyCtxt::def_kind_descr`].
+    pub fn def_kind_descr_article(self, def_kind: DefKind, def_id: DefId) -> &'static str {
+        match def_kind {
+            DefKind::AssocFn if self.associated_item(def_id).fn_has_self_parameter => "a",
+            DefKind::Generator => match self.generator_kind(def_id).unwrap() {
+                rustc_hir::GeneratorKind::Async(..) => "an",
+                rustc_hir::GeneratorKind::Gen => "a",
+            },
+            _ => def_kind.article(),
+        }
+    }
 }
 
 struct OpaqueTypeExpander<'tcx> {

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -691,7 +691,7 @@ impl<'tcx> DeadVisitor<'tcx> {
             })
             .collect();
 
-        let descr = tcx.def_kind(first_id).descr(first_id.to_def_id());
+        let descr = tcx.def_descr(first_id.to_def_id());
         let num = dead_codes.len();
         let multiple = num > 6;
         let name_list = names.into();
@@ -703,7 +703,7 @@ impl<'tcx> DeadVisitor<'tcx> {
         };
 
         let parent_info = if let Some(parent_item) = parent_item {
-            let parent_descr = tcx.def_kind(parent_item).descr(parent_item.to_def_id());
+            let parent_descr = tcx.def_descr(parent_item.to_def_id());
             Some(ParentInfo {
                 num,
                 descr,

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -523,7 +523,7 @@ impl<'tcx> MissingStabilityAnnotations<'tcx> {
             && stab.is_none()
             && self.effective_visibilities.is_reachable(def_id)
         {
-            let descr = self.tcx.def_kind(def_id).descr(def_id.to_def_id());
+            let descr = self.tcx.def_descr(def_id.to_def_id());
             self.tcx.sess.emit_err(errors::MissingStabilityAttr { span, descr });
         }
     }
@@ -551,7 +551,7 @@ impl<'tcx> MissingStabilityAnnotations<'tcx> {
         let is_reachable = self.effective_visibilities.is_reachable(def_id);
 
         if is_const && is_stable && missing_const_stability_attribute && is_reachable {
-            let descr = self.tcx.def_kind(def_id).descr(def_id.to_def_id());
+            let descr = self.tcx.def_descr(def_id.to_def_id());
             self.tcx.sess.emit_err(errors::MissingConstStabAttr { span, descr });
         }
     }

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1329,7 +1329,7 @@ impl<'tcx> Visitor<'tcx> for TypePrivacyVisitor<'tcx> {
                     hir::QPath::Resolved(_, path) => Some(self.tcx.def_path_str(path.res.def_id())),
                     hir::QPath::TypeRelative(_, segment) => Some(segment.ident.to_string()),
                 };
-                let kind = kind.descr(def_id);
+                let kind = self.tcx.def_descr(def_id);
                 let sess = self.tcx.sess;
                 let _ = match name {
                     Some(name) => {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -189,7 +189,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         }
 
         let container = match parent.kind {
-            ModuleKind::Def(kind, _, _) => kind.descr(parent.def_id()),
+            ModuleKind::Def(kind, _, _) => self.tcx.def_kind_descr(kind, parent.def_id()),
             ModuleKind::Block => "block",
         };
 
@@ -1804,7 +1804,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         found("module")
                     } else {
                         match binding.res() {
-                            Res::Def(kind, id) => found(kind.descr(id)),
+                            Res::Def(kind, id) => found(self.tcx.def_kind_descr(kind, id)),
                             _ => found(ns_to_try.descr()),
                         }
                     }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -927,7 +927,10 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 DefKind::Ctor(CtorOf::Variant, _) => {
                     "use parentheses to construct this tuple variant".to_string()
                 }
-                kind => format!("use parentheses to call this {}", kind.descr(def_id)),
+                kind => format!(
+                    "use parentheses to call this {}",
+                    self.tcx.def_kind_descr(kind, def_id)
+                ),
             },
             DefIdOrName::Name(name) => format!("use parentheses to call this {name}"),
         };
@@ -2139,7 +2142,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 err.note(&format!(
                     "{}s cannot be accessed directly on a `trait`, they can only be \
                         accessed through a specific `impl`",
-                    assoc_item.kind.as_def_kind().descr(item_def_id)
+                    self.tcx.def_kind_descr(assoc_item.kind.as_def_kind(), item_def_id)
                 ));
                 err.span_suggestion(
                     span,

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -775,7 +775,7 @@ pub(crate) fn link_tooltip(did: DefId, fragment: &Option<UrlFragment>, cx: &Cont
     let fqp = fqp.iter().map(|sym| sym.as_str()).join("::");
     if let &Some(UrlFragment::Item(id)) = fragment {
         let name = cx.tcx().item_name(id);
-        let descr = cx.tcx().def_kind(id).descr(id);
+        let descr = cx.tcx().def_descr(id);
         format!("{descr} {fqp}::{name}")
     } else {
         format!("{shortty} {fqp}")

--- a/src/tools/clippy/tests/ui/missing_doc_impl.stderr
+++ b/src/tools/clippy/tests/ui/missing_doc_impl.stderr
@@ -51,13 +51,13 @@ LL | |     fn foo_with_impl(&self) {}
 LL | | }
    | |_^
 
-error: missing documentation for an associated function
+error: missing documentation for a method
   --> $DIR/missing_doc_impl.rs:44:5
    |
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
 
-error: missing documentation for an associated function
+error: missing documentation for a method
   --> $DIR/missing_doc_impl.rs:45:5
    |
 LL |     fn foo_with_impl(&self) {}

--- a/tests/rustdoc/intra-doc/basic.rs
+++ b/tests/rustdoc/intra-doc/basic.rs
@@ -2,7 +2,9 @@
 // @has - '//a/@href' 'struct.ThisType.html'
 // @has - '//a/@title' 'struct basic::ThisType'
 // @has - '//a/@href' 'struct.ThisType.html#method.this_method'
-// @has - '//a/@title' 'associated function basic::ThisType::this_method'
+// @has - '//a/@title' 'method basic::ThisType::this_method'
+// @has - '//a/@href' 'struct.ThisType.html#method.this_assoc_fn'
+// @has - '//a/@title' 'associated function basic::ThisType::this_assoc_fn'
 // @has - '//a/@href' 'enum.ThisEnum.html'
 // @has - '//a/@title' 'enum basic::ThisEnum'
 // @has - '//a/@href' 'enum.ThisEnum.html#variant.ThisVariant'
@@ -10,7 +12,9 @@
 // @has - '//a/@href' 'trait.ThisTrait.html'
 // @has - '//a/@title' 'trait basic::ThisTrait'
 // @has - '//a/@href' 'trait.ThisTrait.html#tymethod.this_associated_method'
-// @has - '//a/@title' 'associated function basic::ThisTrait::this_associated_method'
+// @has - '//a/@title' 'method basic::ThisTrait::this_associated_method'
+// @has - '//a/@href' 'trait.ThisTrait.html#tymethod.this_associated_fn'
+// @has - '//a/@title' 'associated function basic::ThisTrait::this_associated_fn'
 // @has - '//a/@href' 'trait.ThisTrait.html#associatedtype.ThisAssociatedType'
 // @has - '//a/@title' 'associated type basic::ThisTrait::ThisAssociatedType'
 // @has - '//a/@href' 'trait.ThisTrait.html#associatedconstant.THIS_ASSOCIATED_CONST'
@@ -37,11 +41,13 @@
 //!
 //! * [`ThisType`](ThisType)
 //! * [`ThisType::this_method`](ThisType::this_method)
+//! * [`ThisType::this_assoc_fn`](ThisType::this_assoc_fn)
 //! * [`ThisEnum`](ThisEnum)
 //! * [`ThisEnum::ThisVariant`](ThisEnum::ThisVariant)
 //! * [`ThisEnum::ThisVariantCtor`](ThisEnum::ThisVariantCtor)
 //! * [`ThisTrait`](ThisTrait)
 //! * [`ThisTrait::this_associated_method`](ThisTrait::this_associated_method)
+//! * [`ThisTrait::this_associated_fn`](ThisTrait::this_associated_fn)
 //! * [`ThisTrait::ThisAssociatedType`](ThisTrait::ThisAssociatedType)
 //! * [`ThisTrait::THIS_ASSOCIATED_CONST`](ThisTrait::THIS_ASSOCIATED_CONST)
 //! * [`ThisAlias`](ThisAlias)
@@ -68,13 +74,15 @@ macro_rules! this_macro {
 pub struct ThisType;
 
 impl ThisType {
-    pub fn this_method() {}
+    pub fn this_assoc_fn() {}
+    pub fn this_method(self) {}
 }
 pub enum ThisEnum { ThisVariant, ThisVariantCtor(u32), }
 pub trait ThisTrait {
     type ThisAssociatedType;
     const THIS_ASSOCIATED_CONST: u8;
-    fn this_associated_method();
+    fn this_associated_fn();
+    fn this_associated_method(&self);
 }
 pub type ThisAlias = Result<(), ()>;
 pub union ThisUnion { this_field: usize, }

--- a/tests/ui/argument-suggestions/too-long.stderr
+++ b/tests/ui/argument-suggestions/too-long.stderr
@@ -6,7 +6,7 @@ LL |     qux.foo(a, b, c, d, e, f, g, h, i, j, k, l);
    |         |
    |         arguments to this method are incorrect
    |
-note: associated function defined here
+note: method defined here
   --> $DIR/too-long.rs:4:8
    |
 LL |     fn foo(

--- a/tests/ui/associated-types/associated-type-projection-from-supertrait.stderr
+++ b/tests/ui/associated-types/associated-type-projection-from-supertrait.stderr
@@ -34,7 +34,7 @@ LL | fn f() { ModelT.chip_paint(Blue); }
    |                 |
    |                 arguments to this method are incorrect
    |
-note: associated function defined here
+note: method defined here
   --> $DIR/associated-type-projection-from-supertrait.rs:12:8
    |
 LL |     fn chip_paint(&self, c: Self::Color) { }
@@ -48,7 +48,7 @@ LL | fn g() { ModelU.chip_paint(Black); }
    |                 |
    |                 arguments to this method are incorrect
    |
-note: associated function defined here
+note: method defined here
   --> $DIR/associated-type-projection-from-supertrait.rs:12:8
    |
 LL |     fn chip_paint(&self, c: Self::Color) { }

--- a/tests/ui/async-await/issues/issue-62097.rs
+++ b/tests/ui/async-await/issues/issue-62097.rs
@@ -12,7 +12,7 @@ impl Struct {
     pub async fn run_dummy_fn(&self) {
         foo(|| self.bar()).await;
         //~^ ERROR closure may outlive the current function
-        //~| ERROR borrowed data escapes outside of associated function
+        //~| ERROR borrowed data escapes outside of method
     }
 
     pub fn bar(&self) {}

--- a/tests/ui/async-await/issues/issue-62097.stderr
+++ b/tests/ui/async-await/issues/issue-62097.stderr
@@ -16,18 +16,18 @@ help: to force the closure to take ownership of `self` (and any other referenced
 LL |         foo(move || self.bar()).await;
    |             ++++
 
-error[E0521]: borrowed data escapes outside of associated function
+error[E0521]: borrowed data escapes outside of method
   --> $DIR/issue-62097.rs:13:9
    |
 LL |     pub async fn run_dummy_fn(&self) {
    |                               -----
    |                               |
-   |                               `self` is a reference that is only valid in the associated function body
+   |                               `self` is a reference that is only valid in the method body
    |                               let's call the lifetime of this reference `'1`
 LL |         foo(|| self.bar()).await;
    |         ^^^^^^^^^^^^^^^^^^
    |         |
-   |         `self` escapes the associated function body here
+   |         `self` escapes the method body here
    |         argument requires that `'1` must outlive `'static`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/async-await/issues/issue-72312.stderr
+++ b/tests/ui/async-await/issues/issue-72312.stderr
@@ -1,10 +1,10 @@
-error[E0521]: borrowed data escapes outside of associated function
+error[E0521]: borrowed data escapes outside of method
   --> $DIR/issue-72312.rs:12:9
    |
 LL |       pub async fn start(&self) {
    |                          -----
    |                          |
-   |                          `self` is a reference that is only valid in the associated function body
+   |                          `self` is a reference that is only valid in the method body
    |                          let's call the lifetime of this reference `'1`
 ...
 LL | /         require_static(async move {
@@ -15,7 +15,7 @@ LL | |             &self;
 LL | |         });
    | |          ^
    | |          |
-   | |__________`self` escapes the associated function body here
+   | |__________`self` escapes the method body here
    |            argument requires that `'1` must outlive `'static`
 
 error: aborting due to previous error

--- a/tests/ui/borrowck/issue-103624.rs
+++ b/tests/ui/borrowck/issue-103624.rs
@@ -12,7 +12,7 @@ impl StructA {
     async fn foo(&self) {
         let bar = self.b.bar().await;
         spawn_blocking(move || {
-            //~^ ERROR borrowed data escapes outside of associated function
+            //~^ ERROR borrowed data escapes outside of method
             self.b;
             //~^ ERROR cannot move out of `self.b`, as `self` is a captured variable in an `Fn` closure
         })

--- a/tests/ui/borrowck/issue-103624.stderr
+++ b/tests/ui/borrowck/issue-103624.stderr
@@ -10,13 +10,13 @@ LL |
 LL |             self.b;
    |             ^^^^^^ move occurs because `self.b` has type `StructB`, which does not implement the `Copy` trait
 
-error[E0521]: borrowed data escapes outside of associated function
+error[E0521]: borrowed data escapes outside of method
   --> $DIR/issue-103624.rs:14:9
    |
 LL |       async fn foo(&self) {
    |                    -----
    |                    |
-   |                    `self` is a reference that is only valid in the associated function body
+   |                    `self` is a reference that is only valid in the method body
    |                    let's call the lifetime of this reference `'1`
 LL |           let bar = self.b.bar().await;
 LL | /         spawn_blocking(move || {
@@ -26,7 +26,7 @@ LL | |
 LL | |         })
    | |          ^
    | |          |
-   | |__________`self` escapes the associated function body here
+   | |__________`self` escapes the method body here
    |            argument requires that `'1` must outlive `'static`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/const-generics/generic_const_exprs/issue-105608.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-105608.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/issue-105608.rs:13:22
    |
 LL |     Combination::<0>.and::<_>().and::<_>();
-   |                      ^^^ cannot infer type of the type parameter `M` declared on the associated function `and`
+   |                      ^^^ cannot infer type of the type parameter `M` declared on the method `and`
    |
 help: consider specifying the generic argument
    |

--- a/tests/ui/const-generics/infer/method-chain.stderr
+++ b/tests/ui/const-generics/infer/method-chain.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/method-chain.rs:15:33
    |
 LL |     Foo.bar().bar().bar().bar().baz();
-   |                                 ^^^ cannot infer the value of the const parameter `N` declared on the associated function `baz`
+   |                                 ^^^ cannot infer the value of the const parameter `N` declared on the method `baz`
    |
 help: consider specifying the generic argument
    |

--- a/tests/ui/const-generics/infer/uninferred-consts.stderr
+++ b/tests/ui/const-generics/infer/uninferred-consts.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/uninferred-consts.rs:9:9
    |
 LL |     Foo.foo();
-   |         ^^^ cannot infer the value of the const parameter `A` declared on the associated function `foo`
+   |         ^^^ cannot infer the value of the const parameter `A` declared on the method `foo`
    |
 help: consider specifying the generic arguments
    |

--- a/tests/ui/const-generics/invalid-const-arg-for-type-param.rs
+++ b/tests/ui/const-generics/invalid-const-arg-for-type-param.rs
@@ -4,7 +4,7 @@ struct S;
 
 fn main() {
     let _: u32 = 5i32.try_into::<32>().unwrap();
-    //~^ ERROR this associated function takes
+    //~^ ERROR this method takes
 
     S.f::<0>();
     //~^ ERROR no method named `f`

--- a/tests/ui/const-generics/invalid-const-arg-for-type-param.stderr
+++ b/tests/ui/const-generics/invalid-const-arg-for-type-param.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/invalid-const-arg-for-type-param.rs:6:23
    |
 LL |     let _: u32 = 5i32.try_into::<32>().unwrap();

--- a/tests/ui/deprecation/deprecation-lint.rs
+++ b/tests/ui/deprecation/deprecation-lint.rs
@@ -14,22 +14,22 @@ mod cross_crate {
         let foo = MethodTester;
 
         deprecated(); //~ ERROR use of deprecated function `deprecation_lint::deprecated`
-        foo.method_deprecated(); //~ ERROR use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated`
-        Foo::method_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated`
-        <Foo>::method_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated`
-        foo.trait_deprecated(); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
-        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
-        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
-        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
+        foo.method_deprecated(); //~ ERROR use of deprecated method `deprecation_lint::MethodTester::method_deprecated`
+        Foo::method_deprecated(&foo); //~ ERROR use of deprecated method `deprecation_lint::MethodTester::method_deprecated`
+        <Foo>::method_deprecated(&foo); //~ ERROR use of deprecated method `deprecation_lint::MethodTester::method_deprecated`
+        foo.trait_deprecated(); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated`
 
         deprecated_text(); //~ ERROR use of deprecated function `deprecation_lint::deprecated_text`: text
-        foo.method_deprecated_text(); //~ ERROR use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated_text`: text
-        Foo::method_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated_text`: text
-        <Foo>::method_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated_text`: text
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
-        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
-        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+        foo.method_deprecated_text(); //~ ERROR use of deprecated method `deprecation_lint::MethodTester::method_deprecated_text`: text
+        Foo::method_deprecated_text(&foo); //~ ERROR use of deprecated method `deprecation_lint::MethodTester::method_deprecated_text`: text
+        <Foo>::method_deprecated_text(&foo); //~ ERROR use of deprecated method `deprecation_lint::MethodTester::method_deprecated_text`: text
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
 
         let _ = DeprecatedStruct { //~ ERROR use of deprecated struct `deprecation_lint::DeprecatedStruct`: text
             i: 0 //~ ERROR use of deprecated field `deprecation_lint::DeprecatedStruct::i`: text
@@ -61,19 +61,19 @@ mod cross_crate {
     }
 
     fn test_method_param<Foo: Trait>(foo: Foo) {
-        foo.trait_deprecated(); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
-        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
-        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
-        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
-        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
-        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+        foo.trait_deprecated(); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
     }
 
     fn test_method_object(foo: &Trait) {
-        foo.trait_deprecated(); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+        foo.trait_deprecated(); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
     }
 
     struct S;
@@ -243,22 +243,22 @@ mod this_crate {
         let foo = MethodTester;
 
         deprecated(); //~ ERROR use of deprecated function `this_crate::deprecated`
-        foo.method_deprecated(); //~ ERROR use of deprecated associated function `this_crate::MethodTester::method_deprecated`
-        Foo::method_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::MethodTester::method_deprecated`
-        <Foo>::method_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::MethodTester::method_deprecated`
-        foo.trait_deprecated(); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        foo.method_deprecated(); //~ ERROR use of deprecated method `this_crate::MethodTester::method_deprecated`
+        Foo::method_deprecated(&foo); //~ ERROR use of deprecated method `this_crate::MethodTester::method_deprecated`
+        <Foo>::method_deprecated(&foo); //~ ERROR use of deprecated method `this_crate::MethodTester::method_deprecated`
+        foo.trait_deprecated(); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated`
 
         deprecated_text(); //~ ERROR use of deprecated function `this_crate::deprecated_text`: text
-        foo.method_deprecated_text(); //~ ERROR use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
-        Foo::method_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
-        <Foo>::method_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
-        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
-        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        foo.method_deprecated_text(); //~ ERROR use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
+        Foo::method_deprecated_text(&foo); //~ ERROR use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
+        <Foo>::method_deprecated_text(&foo); //~ ERROR use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
 
         // Future deprecations are only permitted with `#![feature(staged_api)]`
         deprecated_future(); //~ ERROR use of deprecated function
@@ -289,19 +289,19 @@ mod this_crate {
     }
 
     fn test_method_param<Foo: Trait>(foo: Foo) {
-        foo.trait_deprecated(); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
-        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
-        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        foo.trait_deprecated(); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
     }
 
     fn test_method_object(foo: &Trait) {
-        foo.trait_deprecated(); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        foo.trait_deprecated(); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
     }
 
     #[deprecated(since = "1.0.0", note = "text")]

--- a/tests/ui/deprecation/deprecation-lint.stderr
+++ b/tests/ui/deprecation/deprecation-lint.stderr
@@ -10,13 +10,13 @@ note: the lint level is defined here
 LL | #![deny(deprecated)]
    |         ^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:21:16
    |
 LL |         Trait::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:23:25
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
@@ -28,13 +28,13 @@ error: use of deprecated function `deprecation_lint::deprecated_text`: text
 LL |         deprecated_text();
    |         ^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:30:16
    |
-LL | ...   Trait::trait_deprecated_text(&foo);
-   |              ^^^^^^^^^^^^^^^^^^^^^
+LL |         Trait::trait_deprecated_text(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:32:25
    |
 LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
@@ -100,25 +100,25 @@ error: use of deprecated function `deprecation_lint::deprecated_text`: text
 LL |         macro_test_arg!(macro_test_arg!(deprecated_text()));
    |                                         ^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:65:16
    |
 LL |         Trait::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:67:25
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |                         ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:69:16
    |
-LL | ...   Trait::trait_deprecated_text(&foo);
-   |              ^^^^^^^^^^^^^^^^^^^^^
+LL |         Trait::trait_deprecated_text(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:71:25
    |
 LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
@@ -184,13 +184,13 @@ error: use of deprecated function `this_crate::deprecated`: text
 LL |         deprecated();
    |         ^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:250:16
    |
 LL |         Trait::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:252:25
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
@@ -202,17 +202,17 @@ error: use of deprecated function `this_crate::deprecated_text`: text
 LL |         deprecated_text();
    |         ^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:259:16
    |
 LL |         Trait::trait_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:261:25
    |
-LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
-   |                       ^^^^^^^^^^^^^^^^^^^^^
+LL |         <Foo as Trait>::trait_deprecated_text(&foo);
+   |                         ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated function `this_crate::deprecated_future`: text
   --> $DIR/deprecation-lint.rs:264:9
@@ -274,29 +274,29 @@ error: use of deprecated tuple struct `this_crate::nested::DeprecatedTupleStruct
 LL | ...   let _ = nested::DeprecatedTupleStruct (1);
    |                       ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:293:16
    |
 LL |         Trait::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:295:25
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |                         ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:297:16
    |
 LL |         Trait::trait_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:299:25
    |
-LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
-   |                       ^^^^^^^^^^^^^^^^^^^^^
+LL |         <Foo as Trait>::trait_deprecated_text(&foo);
+   |                         ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated function `this_crate::test_fn_closure_body::{closure#0}::bar`
   --> $DIR/deprecation-lint.rs:317:13
@@ -352,65 +352,65 @@ error: use of deprecated tuple struct `this_crate2::Deprecated2`: text
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated`: text
+error: use of deprecated method `deprecation_lint::MethodTester::method_deprecated`: text
   --> $DIR/deprecation-lint.rs:17:13
    |
 LL |         foo.method_deprecated();
    |             ^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated`: text
+error: use of deprecated method `deprecation_lint::MethodTester::method_deprecated`: text
   --> $DIR/deprecation-lint.rs:18:14
    |
 LL |         Foo::method_deprecated(&foo);
    |              ^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated`: text
+error: use of deprecated method `deprecation_lint::MethodTester::method_deprecated`: text
   --> $DIR/deprecation-lint.rs:19:16
    |
 LL |         <Foo>::method_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:20:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:22:16
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated_text`: text
+error: use of deprecated method `deprecation_lint::MethodTester::method_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:26:13
    |
-LL | ...   foo.method_deprecated_text();
-   |           ^^^^^^^^^^^^^^^^^^^^^^
+LL |         foo.method_deprecated_text();
+   |             ^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated_text`: text
+error: use of deprecated method `deprecation_lint::MethodTester::method_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:27:14
    |
-LL | ...   Foo::method_deprecated_text(&foo);
-   |            ^^^^^^^^^^^^^^^^^^^^^^
+LL |         Foo::method_deprecated_text(&foo);
+   |              ^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated_text`: text
+error: use of deprecated method `deprecation_lint::MethodTester::method_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:28:16
    |
 LL | ...   <Foo>::method_deprecated_text(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:29:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:31:16
    |
-LL | ...   <Foo>::trait_deprecated_text(&foo);
-   |              ^^^^^^^^^^^^^^^^^^^^^
+LL |         <Foo>::trait_deprecated_text(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated field `deprecation_lint::DeprecatedStruct::i`: text
   --> $DIR/deprecation-lint.rs:35:13
@@ -424,37 +424,37 @@ error: use of deprecated field `deprecation_lint::nested::DeprecatedStruct::i`: 
 LL |             i: 0
    |             ^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:64:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:66:16
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:68:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:70:16
    |
-LL | ...   <Foo>::trait_deprecated_text(&foo);
-   |              ^^^^^^^^^^^^^^^^^^^^^
+LL |         <Foo>::trait_deprecated_text(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:75:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+error: use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:76:13
    |
 LL |         foo.trait_deprecated_text();
@@ -544,61 +544,61 @@ error: use of deprecated field `deprecation_lint::Deprecated2::2`: text
 LL |              _)
    |              ^
 
-error: use of deprecated associated function `this_crate::MethodTester::method_deprecated`: text
+error: use of deprecated method `this_crate::MethodTester::method_deprecated`: text
   --> $DIR/deprecation-lint.rs:246:13
    |
 LL |         foo.method_deprecated();
    |             ^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::MethodTester::method_deprecated`: text
+error: use of deprecated method `this_crate::MethodTester::method_deprecated`: text
   --> $DIR/deprecation-lint.rs:247:14
    |
 LL |         Foo::method_deprecated(&foo);
    |              ^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::MethodTester::method_deprecated`: text
+error: use of deprecated method `this_crate::MethodTester::method_deprecated`: text
   --> $DIR/deprecation-lint.rs:248:16
    |
 LL |         <Foo>::method_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:249:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:251:16
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
+error: use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:255:13
    |
-LL | ...   foo.method_deprecated_text();
-   |           ^^^^^^^^^^^^^^^^^^^^^^
+LL |         foo.method_deprecated_text();
+   |             ^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
+error: use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:256:14
    |
-LL | ...   Foo::method_deprecated_text(&foo);
-   |            ^^^^^^^^^^^^^^^^^^^^^^
-
-error: use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
-  --> $DIR/deprecation-lint.rs:257:16
-   |
-LL | ...   <Foo>::method_deprecated_text(&foo);
+LL |         Foo::method_deprecated_text(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+error: use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
+  --> $DIR/deprecation-lint.rs:257:16
+   |
+LL |         <Foo>::method_deprecated_text(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^^
+
+error: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:258:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:260:16
    |
 LL |         <Foo>::trait_deprecated_text(&foo);
@@ -616,37 +616,37 @@ error: use of deprecated field `this_crate::nested::DeprecatedStruct::i`: text
 LL |             i: 0
    |             ^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:292:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:294:16
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:296:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:298:16
    |
 LL |         <Foo>::trait_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:303:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+error: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:304:13
    |
 LL |         foo.trait_deprecated_text();

--- a/tests/ui/deprecation/issue-84637-deprecated-associated-function.fixed
+++ b/tests/ui/deprecation/issue-84637-deprecated-associated-function.fixed
@@ -3,7 +3,7 @@
 #![deny(deprecated)]
 
 fn main() {
-    let _foo = str::trim_start("   aoeu"); //~ ERROR use of deprecated associated function `core::str::<impl str>::trim_left`: superseded by `trim_start` [deprecated]
+    let _foo = str::trim_start("   aoeu"); //~ ERROR use of deprecated method `core::str::<impl str>::trim_left`: superseded by `trim_start` [deprecated]
 
-    let _bar = "   aoeu".trim_start(); //~ ERROR use of deprecated associated function `core::str::<impl str>::trim_left`: superseded by `trim_start` [deprecated]
+    let _bar = "   aoeu".trim_start(); //~ ERROR use of deprecated method `core::str::<impl str>::trim_left`: superseded by `trim_start` [deprecated]
 }

--- a/tests/ui/deprecation/issue-84637-deprecated-associated-function.rs
+++ b/tests/ui/deprecation/issue-84637-deprecated-associated-function.rs
@@ -3,7 +3,7 @@
 #![deny(deprecated)]
 
 fn main() {
-    let _foo = str::trim_left("   aoeu"); //~ ERROR use of deprecated associated function `core::str::<impl str>::trim_left`: superseded by `trim_start` [deprecated]
+    let _foo = str::trim_left("   aoeu"); //~ ERROR use of deprecated method `core::str::<impl str>::trim_left`: superseded by `trim_start` [deprecated]
 
-    let _bar = "   aoeu".trim_left(); //~ ERROR use of deprecated associated function `core::str::<impl str>::trim_left`: superseded by `trim_start` [deprecated]
+    let _bar = "   aoeu".trim_left(); //~ ERROR use of deprecated method `core::str::<impl str>::trim_left`: superseded by `trim_start` [deprecated]
 }

--- a/tests/ui/deprecation/issue-84637-deprecated-associated-function.stderr
+++ b/tests/ui/deprecation/issue-84637-deprecated-associated-function.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated associated function `core::str::<impl str>::trim_left`: superseded by `trim_start`
+error: use of deprecated method `core::str::<impl str>::trim_left`: superseded by `trim_start`
   --> $DIR/issue-84637-deprecated-associated-function.rs:6:21
    |
 LL |     let _foo = str::trim_left("   aoeu");
@@ -9,18 +9,18 @@ note: the lint level is defined here
    |
 LL | #![deny(deprecated)]
    |         ^^^^^^^^^^
-help: replace the use of the deprecated associated function
+help: replace the use of the deprecated method
    |
 LL |     let _foo = str::trim_start("   aoeu");
    |                     ~~~~~~~~~~
 
-error: use of deprecated associated function `core::str::<impl str>::trim_left`: superseded by `trim_start`
+error: use of deprecated method `core::str::<impl str>::trim_left`: superseded by `trim_start`
   --> $DIR/issue-84637-deprecated-associated-function.rs:8:26
    |
 LL |     let _bar = "   aoeu".trim_left();
    |                          ^^^^^^^^^
    |
-help: replace the use of the deprecated associated function
+help: replace the use of the deprecated method
    |
 LL |     let _bar = "   aoeu".trim_start();
    |                          ~~~~~~~~~~

--- a/tests/ui/deprecation/suggestion.stderr
+++ b/tests/ui/deprecation/suggestion.stderr
@@ -14,13 +14,13 @@ help: replace the use of the deprecated function
 LL |     bar::replacement();
    |          ~~~~~~~~~~~
 
-error: use of deprecated associated function `Foo::deprecated`: replaced by `replacement`
+error: use of deprecated method `Foo::deprecated`: replaced by `replacement`
   --> $DIR/suggestion.rs:40:9
    |
 LL |     foo.deprecated();
    |         ^^^^^^^^^^
    |
-help: replace the use of the deprecated associated function
+help: replace the use of the deprecated method
    |
 LL |     foo.replacement();
    |         ~~~~~~~~~~~

--- a/tests/ui/error-codes/E0624.rs
+++ b/tests/ui/error-codes/E0624.rs
@@ -8,5 +8,5 @@ mod inner {
 
 fn main() {
     let foo = inner::Foo;
-    foo.method(); //~ ERROR associated function `method` is private [E0624]
+    foo.method(); //~ ERROR method `method` is private [E0624]
 }

--- a/tests/ui/error-codes/E0624.stderr
+++ b/tests/ui/error-codes/E0624.stderr
@@ -1,11 +1,11 @@
-error[E0624]: associated function `method` is private
+error[E0624]: method `method` is private
   --> $DIR/E0624.rs:11:9
    |
 LL |         fn method(&self) {}
-   |         ---------------- private associated function defined here
+   |         ---------------- private method defined here
 ...
 LL |     foo.method();
-   |         ^^^^^^ private associated function
+   |         ^^^^^^ private method
 
 error: aborting due to previous error
 

--- a/tests/ui/explore-issue-38412.stderr
+++ b/tests/ui/explore-issue-38412.stderr
@@ -79,38 +79,38 @@ LL |     r.unstable_undeclared();
    = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
-error[E0624]: associated function `pub_crate` is private
+error[E0624]: method `pub_crate` is private
   --> $DIR/explore-issue-38412.rs:48:7
    |
 LL |     r.pub_crate();
-   |       ^^^^^^^^^ private associated function
+   |       ^^^^^^^^^ private method
    |
   ::: $DIR/auxiliary/pub-and-stability.rs:114:9
    |
 LL |         pub(crate) fn pub_crate(&self) -> i32 { self.d_priv }
-   |         ------------------------------------- private associated function defined here
+   |         ------------------------------------- private method defined here
 
-error[E0624]: associated function `pub_mod` is private
+error[E0624]: method `pub_mod` is private
   --> $DIR/explore-issue-38412.rs:49:7
    |
 LL |     r.pub_mod();
-   |       ^^^^^^^ private associated function
+   |       ^^^^^^^ private method
    |
   ::: $DIR/auxiliary/pub-and-stability.rs:116:9
    |
 LL |         pub(in m) fn pub_mod(&self) -> i32 { self.d_priv }
-   |         ---------------------------------- private associated function defined here
+   |         ---------------------------------- private method defined here
 
-error[E0624]: associated function `private` is private
+error[E0624]: method `private` is private
   --> $DIR/explore-issue-38412.rs:50:7
    |
 LL |     r.private();
-   |       ^^^^^^^ private associated function
+   |       ^^^^^^^ private method
    |
   ::: $DIR/auxiliary/pub-and-stability.rs:118:9
    |
 LL |         fn private(&self) -> i32 { self.d_priv }
-   |         ------------------------ private associated function defined here
+   |         ------------------------ private method defined here
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
   --> $DIR/explore-issue-38412.rs:55:7
@@ -130,38 +130,38 @@ LL |     t.unstable_undeclared();
    = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
-error[E0624]: associated function `pub_crate` is private
+error[E0624]: method `pub_crate` is private
   --> $DIR/explore-issue-38412.rs:61:7
    |
 LL |     t.pub_crate();
-   |       ^^^^^^^^^ private associated function
+   |       ^^^^^^^^^ private method
    |
   ::: $DIR/auxiliary/pub-and-stability.rs:129:9
    |
 LL |         pub(crate) fn pub_crate(&self) -> i32 { self.0 }
-   |         ------------------------------------- private associated function defined here
+   |         ------------------------------------- private method defined here
 
-error[E0624]: associated function `pub_mod` is private
+error[E0624]: method `pub_mod` is private
   --> $DIR/explore-issue-38412.rs:62:7
    |
 LL |     t.pub_mod();
-   |       ^^^^^^^ private associated function
+   |       ^^^^^^^ private method
    |
   ::: $DIR/auxiliary/pub-and-stability.rs:130:9
    |
 LL |         pub(in m) fn pub_mod(&self) -> i32 { self.0 }
-   |         ---------------------------------- private associated function defined here
+   |         ---------------------------------- private method defined here
 
-error[E0624]: associated function `private` is private
+error[E0624]: method `private` is private
   --> $DIR/explore-issue-38412.rs:63:7
    |
 LL |     t.private();
-   |       ^^^^^^^ private associated function
+   |       ^^^^^^^ private method
    |
   ::: $DIR/auxiliary/pub-and-stability.rs:131:9
    |
 LL |         fn private(&self) -> i32 { self.0 }
-   |         ------------------------ private associated function defined here
+   |         ------------------------ private method defined here
 
 error: aborting due to 19 previous errors
 

--- a/tests/ui/fn/issue-3044.stderr
+++ b/tests/ui/fn/issue-3044.stderr
@@ -7,7 +7,7 @@ LL | |
 LL | |     });
    | |______- an argument is missing
    |
-note: associated function defined here
+note: method defined here
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 help: provide the argument
    |

--- a/tests/ui/generator/issue-102645.stderr
+++ b/tests/ui/generator/issue-102645.stderr
@@ -4,7 +4,7 @@ error[E0061]: this method takes 1 argument but 0 arguments were supplied
 LL |     Pin::new(&mut b).resume();
    |                      ^^^^^^-- an argument of type `()` is missing
    |
-note: associated function defined here
+note: method defined here
   --> $SRC_DIR/core/src/ops/generator.rs:LL:COL
 help: provide the argument
    |

--- a/tests/ui/inference/inference_unstable.rs
+++ b/tests/ui/inference/inference_unstable.rs
@@ -14,16 +14,16 @@ use inference_unstable_itertools::IpuItertools;
 
 fn main() {
     assert_eq!('x'.ipu_flatten(), 1);
-//~^ WARN an associated function with this name may be added to the standard library in the future
+//~^ WARN a method with this name may be added to the standard library in the future
 //~| WARN once this associated item is added to the standard library, the ambiguity may cause an
     assert_eq!('x'.ipu_by_value_vs_by_ref(), 1);
-//~^ WARN an associated function with this name may be added to the standard library in the future
+//~^ WARN a method with this name may be added to the standard library in the future
 //~| WARN once this associated item is added to the standard library, the ambiguity may cause an
     assert_eq!('x'.ipu_by_ref_vs_by_ref_mut(), 1);
-//~^ WARN an associated function with this name may be added to the standard library in the future
+//~^ WARN a method with this name may be added to the standard library in the future
 //~| WARN once this associated item is added to the standard library, the ambiguity may cause an
     assert_eq!((&mut 'x' as *mut char).ipu_by_mut_ptr_vs_by_const_ptr(), 1);
-//~^ WARN an associated function with this name may be added to the standard library in the future
+//~^ WARN a method with this name may be added to the standard library in the future
 //~| WARN once this associated item is added to the standard library, the ambiguity may cause an
     assert_eq!(char::C, 1);
 //~^ WARN an associated constant with this name may be added to the standard library in the future

--- a/tests/ui/inference/inference_unstable.stderr
+++ b/tests/ui/inference/inference_unstable.stderr
@@ -1,4 +1,4 @@
-warning: an associated function with this name may be added to the standard library in the future
+warning: a method with this name may be added to the standard library in the future
   --> $DIR/inference_unstable.rs:16:20
    |
 LL |     assert_eq!('x'.ipu_flatten(), 1);
@@ -10,7 +10,7 @@ LL |     assert_eq!('x'.ipu_flatten(), 1);
    = help: add `#![feature(ipu_flatten)]` to the crate attributes to enable `inference_unstable_iterator::IpuIterator::ipu_flatten`
    = note: `#[warn(unstable_name_collisions)]` on by default
 
-warning: an associated function with this name may be added to the standard library in the future
+warning: a method with this name may be added to the standard library in the future
   --> $DIR/inference_unstable.rs:19:20
    |
 LL |     assert_eq!('x'.ipu_by_value_vs_by_ref(), 1);
@@ -21,7 +21,7 @@ LL |     assert_eq!('x'.ipu_by_value_vs_by_ref(), 1);
    = help: call with fully qualified syntax `inference_unstable_itertools::IpuItertools::ipu_by_value_vs_by_ref(...)` to keep using the current method
    = help: add `#![feature(ipu_flatten)]` to the crate attributes to enable `inference_unstable_iterator::IpuIterator::ipu_by_value_vs_by_ref`
 
-warning: an associated function with this name may be added to the standard library in the future
+warning: a method with this name may be added to the standard library in the future
   --> $DIR/inference_unstable.rs:22:20
    |
 LL |     assert_eq!('x'.ipu_by_ref_vs_by_ref_mut(), 1);
@@ -32,7 +32,7 @@ LL |     assert_eq!('x'.ipu_by_ref_vs_by_ref_mut(), 1);
    = help: call with fully qualified syntax `inference_unstable_itertools::IpuItertools::ipu_by_ref_vs_by_ref_mut(...)` to keep using the current method
    = help: add `#![feature(ipu_flatten)]` to the crate attributes to enable `inference_unstable_iterator::IpuIterator::ipu_by_ref_vs_by_ref_mut`
 
-warning: an associated function with this name may be added to the standard library in the future
+warning: a method with this name may be added to the standard library in the future
   --> $DIR/inference_unstable.rs:25:40
    |
 LL |     assert_eq!((&mut 'x' as *mut char).ipu_by_mut_ptr_vs_by_const_ptr(), 1);

--- a/tests/ui/inference/inference_unstable_featured.stderr
+++ b/tests/ui/inference/inference_unstable_featured.stderr
@@ -6,11 +6,11 @@ LL |     assert_eq!('x'.ipu_flatten(), 0);
    |
    = note: candidate #1 is defined in an impl of the trait `IpuIterator` for the type `char`
    = note: candidate #2 is defined in an impl of the trait `IpuItertools` for the type `char`
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL |     assert_eq!(IpuIterator::ipu_flatten(&'x'), 0);
    |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |     assert_eq!(IpuItertools::ipu_flatten(&'x'), 0);
    |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/ui/inference/issue-71732.stderr
+++ b/tests/ui/inference/issue-71732.stderr
@@ -4,7 +4,7 @@ error[E0283]: type annotations needed
 LL |         .get(&"key".into())
    |          ^^^ ------------- type must be known at this point
    |          |
-   |          cannot infer type of the type parameter `Q` declared on the associated function `get`
+   |          cannot infer type of the type parameter `Q` declared on the method `get`
    |
    = note: multiple `impl`s satisfying `String: Borrow<_>` found in the following crates: `alloc`, `core`:
            - impl Borrow<str> for String;

--- a/tests/ui/inference/question-mark-type-infer.stderr
+++ b/tests/ui/inference/question-mark-type-infer.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/question-mark-type-infer.rs:10:21
    |
 LL |     l.iter().map(f).collect()?
-   |                     ^^^^^^^ cannot infer type of the type parameter `B` declared on the associated function `collect`
+   |                     ^^^^^^^ cannot infer type of the type parameter `B` declared on the method `collect`
    |
 help: consider specifying the generic argument
    |

--- a/tests/ui/issues/issue-11374.stderr
+++ b/tests/ui/issues/issue-11374.stderr
@@ -10,7 +10,7 @@ LL |     c.read_to(v);
    |
    = note: expected mutable reference `&mut [u8]`
                          found struct `Vec<_>`
-note: associated function defined here
+note: method defined here
   --> $DIR/issue-11374.rs:13:12
    |
 LL |     pub fn read_to(&mut self, vec: &mut [u8]) {

--- a/tests/ui/issues/issue-17337.stderr
+++ b/tests/ui/issues/issue-17337.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated associated function `Foo::foo`: text
+error: use of deprecated method `Foo::foo`: text
   --> $DIR/issue-17337.rs:16:6
    |
 LL |     .foo();

--- a/tests/ui/issues/issue-18446.stderr
+++ b/tests/ui/issues/issue-18446.stderr
@@ -14,7 +14,7 @@ note: candidate #2 is defined in the trait `T`
    |
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |     T::foo(&x);
    |     ~~~~~~~~~~

--- a/tests/ui/issues/issue-21202.rs
+++ b/tests/ui/issues/issue-21202.rs
@@ -8,7 +8,7 @@ mod B {
     use crate1::A::Foo;
     fn bar(f: Foo) {
         Foo::foo(&f);
-        //~^ ERROR: associated function `foo` is private
+        //~^ ERROR: method `foo` is private
     }
 }
 

--- a/tests/ui/issues/issue-21202.stderr
+++ b/tests/ui/issues/issue-21202.stderr
@@ -1,13 +1,13 @@
-error[E0624]: associated function `foo` is private
+error[E0624]: method `foo` is private
   --> $DIR/issue-21202.rs:10:14
    |
 LL |         Foo::foo(&f);
-   |              ^^^ private associated function
+   |              ^^^ private method
    |
   ::: $DIR/auxiliary/issue-21202.rs:4:9
    |
 LL |         fn foo(&self) { }
-   |         ------------- private associated function defined here
+   |         ------------- private method defined here
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-23041.stderr
+++ b/tests/ui/issues/issue-23041.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/issue-23041.rs:6:7
    |
 LL |     b.downcast_ref::<fn(_)->_>();
-   |       ^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the associated function `downcast_ref`
+   |       ^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the method `downcast_ref`
    |
 help: consider specifying the generic argument
    |

--- a/tests/ui/issues/issue-3702-2.stderr
+++ b/tests/ui/issues/issue-3702-2.stderr
@@ -14,11 +14,11 @@ note: candidate #2 is defined in an impl of the trait `Add` for the type `isize`
    |
 LL |     fn to_int(&self) -> isize { *self }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL |         ToPrimitive::to_int(&self) + other.to_int()
    |         ~~~~~~~~~~~~~~~~~~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |         Add::to_int(&self) + other.to_int()
    |         ~~~~~~~~~~~~~~~~~~

--- a/tests/ui/issues/issue-3763.rs
+++ b/tests/ui/issues/issue-3763.rs
@@ -20,9 +20,9 @@ fn main() {
     let _woohoo = (Box::new(my_struct)).priv_field;
     //~^ ERROR field `priv_field` of struct `MyStruct` is private
 
-    (&my_struct).happyfun();               //~ ERROR associated function `happyfun` is private
+    (&my_struct).happyfun();               //~ ERROR method `happyfun` is private
 
-    (Box::new(my_struct)).happyfun();          //~ ERROR associated function `happyfun` is private
+    (Box::new(my_struct)).happyfun();          //~ ERROR method `happyfun` is private
     let nope = my_struct.priv_field;
     //~^ ERROR field `priv_field` of struct `MyStruct` is private
 }

--- a/tests/ui/issues/issue-3763.stderr
+++ b/tests/ui/issues/issue-3763.stderr
@@ -10,23 +10,23 @@ error[E0616]: field `priv_field` of struct `MyStruct` is private
 LL |     let _woohoo = (Box::new(my_struct)).priv_field;
    |                                         ^^^^^^^^^^ private field
 
-error[E0624]: associated function `happyfun` is private
+error[E0624]: method `happyfun` is private
   --> $DIR/issue-3763.rs:23:18
    |
 LL |         fn happyfun(&self) {}
-   |         ------------------ private associated function defined here
+   |         ------------------ private method defined here
 ...
 LL |     (&my_struct).happyfun();
-   |                  ^^^^^^^^ private associated function
+   |                  ^^^^^^^^ private method
 
-error[E0624]: associated function `happyfun` is private
+error[E0624]: method `happyfun` is private
   --> $DIR/issue-3763.rs:25:27
    |
 LL |         fn happyfun(&self) {}
-   |         ------------------ private associated function defined here
+   |         ------------------ private method defined here
 ...
 LL |     (Box::new(my_struct)).happyfun();
-   |                           ^^^^^^^^ private associated function
+   |                           ^^^^^^^^ private method
 
 error[E0616]: field `priv_field` of struct `MyStruct` is private
   --> $DIR/issue-3763.rs:26:26

--- a/tests/ui/issues/issue-48364.stderr
+++ b/tests/ui/issues/issue-48364.stderr
@@ -8,7 +8,7 @@ LL |     b"".starts_with(stringify!(foo))
    |
    = note: expected reference `&[u8]`
               found reference `&'static str`
-note: associated function defined here
+note: method defined here
   --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
    = note: this error originates in the macro `stringify` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/issues/issue-60622.rs
+++ b/tests/ui/issues/issue-60622.rs
@@ -9,7 +9,7 @@ impl Borked {
 fn run_wild<T>(b: &Borked) {
     b.a::<'_, T>();
     //~^ ERROR cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-    //~| ERROR this associated function takes 0 generic arguments but 1 generic argument
+    //~| ERROR this method takes 0 generic arguments but 1 generic argument
     //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/issues/issue-60622.stderr
+++ b/tests/ui/issues/issue-60622.stderr
@@ -16,7 +16,7 @@ LL | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(late_bound_lifetime_arguments)]` implied by `#[deny(warnings)]`
 
-error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-60622.rs:10:7
    |
 LL |     b.a::<'_, T>();
@@ -24,7 +24,7 @@ LL |     b.a::<'_, T>();
    |       |
    |       expected 0 generic arguments
    |
-note: associated function defined here, with 0 generic parameters
+note: method defined here, with 0 generic parameters
   --> $DIR/issue-60622.rs:6:8
    |
 LL |     fn a(&self) {}

--- a/tests/ui/issues/issue-65634-raw-ident-suggestion.edition2015.stderr
+++ b/tests/ui/issues/issue-65634-raw-ident-suggestion.edition2015.stderr
@@ -14,11 +14,11 @@ note: candidate #2 is defined in an impl of the trait `await` for the type `r#fn
    |
 LL |     fn r#struct(&self) {
    |     ^^^^^^^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL |     async::r#struct(&r#fn {});
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |     await::r#struct(&r#fn {});
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/ui/issues/issue-65634-raw-ident-suggestion.edition2018.stderr
+++ b/tests/ui/issues/issue-65634-raw-ident-suggestion.edition2018.stderr
@@ -14,11 +14,11 @@ note: candidate #2 is defined in an impl of the trait `r#await` for the type `r#
    |
 LL |     fn r#struct(&self) {
    |     ^^^^^^^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL |     r#async::r#struct(&r#fn {});
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |     r#await::r#struct(&r#fn {});
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/ui/issues/issue-69455.stderr
+++ b/tests/ui/issues/issue-69455.stderr
@@ -2,7 +2,7 @@ error[E0284]: type annotations needed
   --> $DIR/issue-69455.rs:29:41
    |
 LL |     println!("{}", 23u64.test(xs.iter().sum()));
-   |                          ----           ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
+   |                          ----           ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
    |                          |
    |                          type must be known at this point
    |
@@ -16,7 +16,7 @@ error[E0283]: type annotations needed
   --> $DIR/issue-69455.rs:29:41
    |
 LL |     println!("{}", 23u64.test(xs.iter().sum()));
-   |                          ----           ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
+   |                          ----           ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
    |                          |
    |                          required by a bound introduced by this call
    |

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
@@ -7,7 +7,7 @@ LL |   fn foo<'a>(&self, x: &'a i32) -> &i32 {
    |          lifetime `'a` defined here
 LL |
 LL |     x
-   |     ^ associated function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
+   |     ^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
 
 error: aborting due to previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.stderr
@@ -7,7 +7,7 @@ LL |     fn foo<'a>(&self, x: &'a Foo) -> &'a Foo {
    |            lifetime `'a` defined here
 LL |
 LL |         if true { x } else { self }
-   |                              ^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
+   |                              ^^^^ method was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: aborting due to previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
@@ -6,7 +6,7 @@ LL |   fn foo<'a>(&self, x: &i32) -> &i32 {
    |              |
    |              let's call the lifetime of this reference `'2`
 LL |     x
-   |     ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |     ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.stderr
@@ -6,7 +6,7 @@ LL |     fn foo<'a>(&self, x: &Foo) -> &Foo {
    |                |
    |                let's call the lifetime of this reference `'2`
 LL |         if true { x } else { self }
-   |                   ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |                   ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |

--- a/tests/ui/lint/dead-code/issue-85255.rs
+++ b/tests/ui/lint/dead-code/issue-85255.rs
@@ -11,8 +11,8 @@ struct Foo {
 struct Bar;
 
 impl Bar {
-    fn a(&self) -> i32 { 5 } //~ WARNING: associated function `a` is never used
-    pub fn b(&self) -> i32 { 6 } //~ WARNING: associated function `b` is never used
+    fn a(&self) -> i32 { 5 } //~ WARNING: method `a` is never used
+    pub fn b(&self) -> i32 { 6 } //~ WARNING: method `b` is never used
 }
 
 pub(crate) struct Foo1 {
@@ -23,8 +23,8 @@ pub(crate) struct Foo1 {
 pub(crate) struct Bar1;
 
 impl Bar1 {
-    fn a(&self) -> i32 { 5 } //~ WARNING: associated function `a` is never used
-    pub fn b(&self) -> i32 { 6 } //~ WARNING: associated function `b` is never used
+    fn a(&self) -> i32 { 5 } //~ WARNING: method `a` is never used
+    pub fn b(&self) -> i32 { 6 } //~ WARNING: method `b` is never used
 }
 
 pub(crate) struct Foo2 {
@@ -35,8 +35,8 @@ pub(crate) struct Foo2 {
 pub(crate) struct Bar2;
 
 impl Bar2 {
-    fn a(&self) -> i32 { 5 } //~ WARNING: associated function `a` is never used
-    pub fn b(&self) -> i32 { 6 } //~ WARNING: associated function `b` is never used
+    fn a(&self) -> i32 { 5 } //~ WARNING: method `a` is never used
+    pub fn b(&self) -> i32 { 6 } //~ WARNING: method `b` is never used
 }
 
 

--- a/tests/ui/lint/dead-code/issue-85255.stderr
+++ b/tests/ui/lint/dead-code/issue-85255.stderr
@@ -34,37 +34,37 @@ LL |     a: i32,
 LL |     pub b: i32,
    |         ^
 
-warning: associated function `a` is never used
+warning: method `a` is never used
   --> $DIR/issue-85255.rs:14:8
    |
 LL |     fn a(&self) -> i32 { 5 }
    |        ^
 
-warning: associated function `b` is never used
+warning: method `b` is never used
   --> $DIR/issue-85255.rs:15:12
    |
 LL |     pub fn b(&self) -> i32 { 6 }
    |            ^
 
-warning: associated function `a` is never used
+warning: method `a` is never used
   --> $DIR/issue-85255.rs:26:8
    |
 LL |     fn a(&self) -> i32 { 5 }
    |        ^
 
-warning: associated function `b` is never used
+warning: method `b` is never used
   --> $DIR/issue-85255.rs:27:12
    |
 LL |     pub fn b(&self) -> i32 { 6 }
    |            ^
 
-warning: associated function `a` is never used
+warning: method `a` is never used
   --> $DIR/issue-85255.rs:38:8
    |
 LL |     fn a(&self) -> i32 { 5 }
    |        ^
 
-warning: associated function `b` is never used
+warning: method `b` is never used
   --> $DIR/issue-85255.rs:39:12
    |
 LL |     pub fn b(&self) -> i32 { 6 }

--- a/tests/ui/lint/dead-code/lint-dead-code-3.rs
+++ b/tests/ui/lint/dead-code/lint-dead-code-3.rs
@@ -13,7 +13,7 @@ extern "C" {
 
 struct Foo; //~ ERROR: struct `Foo` is never constructed
 impl Foo {
-    fn foo(&self) { //~ ERROR: associated function `foo` is never used
+    fn foo(&self) { //~ ERROR: method `foo` is never used
         bar()
     }
 }

--- a/tests/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/tests/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -34,7 +34,7 @@ error: function `blah` is never used
 LL |         fn blah() {}
    |            ^^^^
 
-error: associated function `foo` is never used
+error: method `foo` is never used
   --> $DIR/lint-dead-code-3.rs:16:8
    |
 LL |     fn foo(&self) {

--- a/tests/ui/lint/lint-missing-doc.rs
+++ b/tests/ui/lint/lint-missing-doc.rs
@@ -50,8 +50,10 @@ trait B {
 }
 
 pub trait C { //~ ERROR: missing documentation for a trait
-    fn foo(&self); //~ ERROR: missing documentation for an associated function
-    fn foo_with_impl(&self) {} //~ ERROR: missing documentation for an associated function
+    fn foo(&self); //~ ERROR: missing documentation for a method
+    fn foo_with_impl(&self) {} //~ ERROR: missing documentation for a method
+    fn foo_no_self(); //~ ERROR: missing documentation for an associated function
+    fn foo_no_self_with_impl() {} //~ ERROR: missing documentation for an associated function
 }
 
 #[allow(missing_docs)]

--- a/tests/ui/lint/lint-missing-doc.stderr
+++ b/tests/ui/lint/lint-missing-doc.stderr
@@ -40,101 +40,113 @@ error: missing documentation for a trait
 LL | pub trait C {
    | ^^^^^^^^^^^
 
-error: missing documentation for an associated function
+error: missing documentation for a method
   --> $DIR/lint-missing-doc.rs:53:5
    |
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
 
-error: missing documentation for an associated function
+error: missing documentation for a method
   --> $DIR/lint-missing-doc.rs:54:5
    |
 LL |     fn foo_with_impl(&self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
+error: missing documentation for an associated function
+  --> $DIR/lint-missing-doc.rs:55:5
+   |
+LL |     fn foo_no_self();
+   |     ^^^^^^^^^^^^^^^^^
+
+error: missing documentation for an associated function
+  --> $DIR/lint-missing-doc.rs:56:5
+   |
+LL |     fn foo_no_self_with_impl() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: missing documentation for an associated type
-  --> $DIR/lint-missing-doc.rs:64:5
+  --> $DIR/lint-missing-doc.rs:66:5
    |
 LL |     type AssociatedType;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated type
-  --> $DIR/lint-missing-doc.rs:65:5
+  --> $DIR/lint-missing-doc.rs:67:5
    |
 LL |     type AssociatedTypeDef = Self;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated function
-  --> $DIR/lint-missing-doc.rs:81:5
+  --> $DIR/lint-missing-doc.rs:83:5
    |
 LL |     pub fn foo() {}
    |     ^^^^^^^^^^^^
 
 error: missing documentation for an enum
-  --> $DIR/lint-missing-doc.rs:118:1
+  --> $DIR/lint-missing-doc.rs:120:1
    |
 LL | pub enum PubBaz {
    | ^^^^^^^^^^^^^^^
 
 error: missing documentation for a variant
-  --> $DIR/lint-missing-doc.rs:119:5
+  --> $DIR/lint-missing-doc.rs:121:5
    |
 LL |     PubBazA {
    |     ^^^^^^^
 
 error: missing documentation for a struct field
-  --> $DIR/lint-missing-doc.rs:120:9
+  --> $DIR/lint-missing-doc.rs:122:9
    |
 LL |         a: isize,
    |         ^^^^^^^^
 
 error: missing documentation for a constant
-  --> $DIR/lint-missing-doc.rs:151:1
+  --> $DIR/lint-missing-doc.rs:153:1
    |
 LL | pub const FOO4: u32 = 0;
    | ^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a static
-  --> $DIR/lint-missing-doc.rs:161:1
+  --> $DIR/lint-missing-doc.rs:163:1
    |
 LL | pub static BAR4: u32 = 0;
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:167:5
+  --> $DIR/lint-missing-doc.rs:169:5
    |
 LL |     pub fn undocumented1() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:168:5
+  --> $DIR/lint-missing-doc.rs:170:5
    |
 LL |     pub fn undocumented2() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:174:9
+  --> $DIR/lint-missing-doc.rs:176:9
    |
 LL |         pub fn also_undocumented1() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:189:5
+  --> $DIR/lint-missing-doc.rs:191:5
    |
 LL |     pub fn extern_fn_undocumented(f: f32) -> f32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a static
-  --> $DIR/lint-missing-doc.rs:194:5
+  --> $DIR/lint-missing-doc.rs:196:5
    |
 LL |     pub static EXTERN_STATIC_UNDOCUMENTED: u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a foreign type
-  --> $DIR/lint-missing-doc.rs:199:5
+  --> $DIR/lint-missing-doc.rs:201:5
    |
 LL |     pub type ExternTyUndocumented;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 22 previous errors
+error: aborting due to 24 previous errors
 

--- a/tests/ui/lint/lint-stability-deprecated.rs
+++ b/tests/ui/lint/lint-stability-deprecated.rs
@@ -22,40 +22,40 @@ mod cross_crate {
         let foo = MethodTester;
 
         deprecated(); //~ WARN use of deprecated function `lint_stability::deprecated`
-        foo.method_deprecated(); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated`
-        Foo::method_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated`
-        <Foo>::method_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated`
-        foo.trait_deprecated(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
-        Trait::trait_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
-        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
-        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
+        foo.method_deprecated(); //~ WARN use of deprecated method `lint_stability::MethodTester::method_deprecated`
+        Foo::method_deprecated(&foo); //~ WARN use of deprecated method `lint_stability::MethodTester::method_deprecated`
+        <Foo>::method_deprecated(&foo); //~ WARN use of deprecated method `lint_stability::MethodTester::method_deprecated`
+        foo.trait_deprecated(); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated`
 
         deprecated_text(); //~ WARN use of deprecated function `lint_stability::deprecated_text`: text
-        foo.method_deprecated_text(); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_text`: text
-        Foo::method_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_text`: text
-        <Foo>::method_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_text`: text
-        foo.trait_deprecated_text(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
-        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
-        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+        foo.method_deprecated_text(); //~ WARN use of deprecated method `lint_stability::MethodTester::method_deprecated_text`: text
+        Foo::method_deprecated_text(&foo); //~ WARN use of deprecated method `lint_stability::MethodTester::method_deprecated_text`: text
+        <Foo>::method_deprecated_text(&foo); //~ WARN use of deprecated method `lint_stability::MethodTester::method_deprecated_text`: text
+        foo.trait_deprecated_text(); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
 
         deprecated_unstable(); //~ WARN use of deprecated function `lint_stability::deprecated_unstable`
-        foo.method_deprecated_unstable(); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable`
-        Foo::method_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable`
-        <Foo>::method_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable`
-        foo.trait_deprecated_unstable(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
-        Trait::trait_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
-        <Foo>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
-        <Foo as Trait>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
+        foo.method_deprecated_unstable(); //~ WARN use of deprecated method `lint_stability::MethodTester::method_deprecated_unstable`
+        Foo::method_deprecated_unstable(&foo); //~ WARN use of deprecated method `lint_stability::MethodTester::method_deprecated_unstable`
+        <Foo>::method_deprecated_unstable(&foo); //~ WARN use of deprecated method `lint_stability::MethodTester::method_deprecated_unstable`
+        foo.trait_deprecated_unstable(); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`
+        Trait::trait_deprecated_unstable(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`
+        <Foo>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`
+        <Foo as Trait>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`
 
         deprecated_unstable_text(); //~ WARN use of deprecated function `lint_stability::deprecated_unstable_text`: text
-        foo.method_deprecated_unstable_text(); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable_text`: text
-        Foo::method_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable_text`: text
-        <Foo>::method_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable_text`: text
-        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
-        Trait::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
-        <Foo>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
-        <Foo as Trait>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        foo.method_deprecated_unstable_text(); //~ WARN use of deprecated method `lint_stability::MethodTester::method_deprecated_unstable_text`: text
+        Foo::method_deprecated_unstable_text(&foo); //~ WARN use of deprecated method `lint_stability::MethodTester::method_deprecated_unstable_text`: text
+        <Foo>::method_deprecated_unstable_text(&foo); //~ WARN use of deprecated method `lint_stability::MethodTester::method_deprecated_unstable_text`: text
+        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        Trait::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        <Foo>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        <Foo as Trait>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
 
         unstable();
         foo.method_unstable();
@@ -141,22 +141,22 @@ mod cross_crate {
     }
 
     fn test_method_param<Foo: Trait>(foo: Foo) {
-        foo.trait_deprecated(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
-        Trait::trait_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
-        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
-        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
-        foo.trait_deprecated_text(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
-        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
-        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
-        foo.trait_deprecated_unstable(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
-        Trait::trait_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
-        <Foo>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
-        <Foo as Trait>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
-        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
-        Trait::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
-        <Foo>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
-        <Foo as Trait>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        foo.trait_deprecated(); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
+        foo.trait_deprecated_unstable(); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`
+        Trait::trait_deprecated_unstable(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`
+        <Foo>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`
+        <Foo as Trait>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`
+        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        Trait::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        <Foo>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        <Foo as Trait>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
         foo.trait_unstable();
         Trait::trait_unstable(&foo);
         <Foo>::trait_unstable(&foo);
@@ -172,10 +172,10 @@ mod cross_crate {
     }
 
     fn test_method_object(foo: &dyn Trait) {
-        foo.trait_deprecated(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
-        foo.trait_deprecated_text(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
-        foo.trait_deprecated_unstable(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
-        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        foo.trait_deprecated(); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
+        foo.trait_deprecated_unstable(); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`
+        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
         foo.trait_unstable();
         foo.trait_unstable_text();
         foo.trait_stable();
@@ -328,22 +328,22 @@ mod this_crate {
         let foo = MethodTester;
 
         deprecated(); //~ WARN use of deprecated function `this_crate::deprecated`
-        foo.method_deprecated(); //~ WARN use of deprecated associated function `this_crate::MethodTester::method_deprecated`
-        Foo::method_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::MethodTester::method_deprecated`
-        <Foo>::method_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::MethodTester::method_deprecated`
-        foo.trait_deprecated(); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        Trait::trait_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        foo.method_deprecated(); //~ WARN use of deprecated method `this_crate::MethodTester::method_deprecated`
+        Foo::method_deprecated(&foo); //~ WARN use of deprecated method `this_crate::MethodTester::method_deprecated`
+        <Foo>::method_deprecated(&foo); //~ WARN use of deprecated method `this_crate::MethodTester::method_deprecated`
+        foo.trait_deprecated(); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated`
 
         deprecated_text(); //~ WARN use of deprecated function `this_crate::deprecated_text`: text
-        foo.method_deprecated_text(); //~ WARN use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
-        Foo::method_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
-        <Foo>::method_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
-        foo.trait_deprecated_text(); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
-        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
-        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        foo.method_deprecated_text(); //~ WARN use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
+        Foo::method_deprecated_text(&foo); //~ WARN use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
+        <Foo>::method_deprecated_text(&foo); //~ WARN use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
+        foo.trait_deprecated_text(); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
 
         unstable();
         foo.method_unstable();
@@ -402,14 +402,14 @@ mod this_crate {
     }
 
     fn test_method_param<Foo: Trait>(foo: Foo) {
-        foo.trait_deprecated(); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        Trait::trait_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        foo.trait_deprecated_text(); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
-        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
-        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        foo.trait_deprecated(); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
         foo.trait_unstable();
         Trait::trait_unstable(&foo);
         <Foo>::trait_unstable(&foo);
@@ -425,8 +425,8 @@ mod this_crate {
     }
 
     fn test_method_object(foo: &dyn Trait) {
-        foo.trait_deprecated(); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
-        foo.trait_deprecated_text(); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        foo.trait_deprecated(); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ WARN use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
         foo.trait_unstable();
         foo.trait_unstable_text();
         foo.trait_stable();

--- a/tests/ui/lint/lint-stability-deprecated.stderr
+++ b/tests/ui/lint/lint-stability-deprecated.stderr
@@ -10,13 +10,13 @@ note: the lint level is defined here
 LL | #![warn(deprecated)]
    |         ^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:29:16
    |
 LL |         Trait::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:31:25
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
@@ -28,17 +28,17 @@ warning: use of deprecated function `lint_stability::deprecated_text`: text
 LL |         deprecated_text();
    |         ^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:38:16
    |
-LL | ...   Trait::trait_deprecated_text(&foo);
-   |              ^^^^^^^^^^^^^^^^^^^^^
+LL |         Trait::trait_deprecated_text(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:40:25
    |
-LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
-   |                       ^^^^^^^^^^^^^^^^^^^^^
+LL |         <Foo as Trait>::trait_deprecated_text(&foo);
+   |                         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated function `lint_stability::deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:42:9
@@ -46,13 +46,13 @@ warning: use of deprecated function `lint_stability::deprecated_unstable`: text
 LL |         deprecated_unstable();
    |         ^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:47:16
    |
-LL | ...   Trait::trait_deprecated_unstable(&foo);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         Trait::trait_deprecated_unstable(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:49:25
    |
 LL | ...   <Foo as Trait>::trait_deprecated_unstable(&foo);
@@ -64,13 +64,13 @@ warning: use of deprecated function `lint_stability::deprecated_unstable_text`: 
 LL |         deprecated_unstable_text();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:56:16
    |
 LL | ...   Trait::trait_deprecated_unstable_text(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:58:25
    |
 LL | ...   <Foo as Trait>::trait_deprecated_unstable_text(&foo);
@@ -142,49 +142,49 @@ warning: use of deprecated function `lint_stability::deprecated_text`: text
 LL |         macro_test_arg!(macro_test_arg!(deprecated_text()));
    |                                         ^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:145:16
    |
 LL |         Trait::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:147:25
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |                         ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:149:16
    |
-LL | ...   Trait::trait_deprecated_text(&foo);
-   |              ^^^^^^^^^^^^^^^^^^^^^
+LL |         Trait::trait_deprecated_text(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:151:25
    |
-LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
-   |                       ^^^^^^^^^^^^^^^^^^^^^
+LL |         <Foo as Trait>::trait_deprecated_text(&foo);
+   |                         ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:153:16
    |
-LL | ...   Trait::trait_deprecated_unstable(&foo);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         Trait::trait_deprecated_unstable(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:155:25
    |
 LL | ...   <Foo as Trait>::trait_deprecated_unstable(&foo);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:157:16
    |
 LL | ...   Trait::trait_deprecated_unstable_text(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:159:25
    |
 LL | ...   <Foo as Trait>::trait_deprecated_unstable_text(&foo);
@@ -214,13 +214,13 @@ warning: use of deprecated function `this_crate::deprecated`: text
 LL |         deprecated();
    |         ^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:335:16
    |
 LL |         Trait::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:337:25
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
@@ -232,17 +232,17 @@ warning: use of deprecated function `this_crate::deprecated_text`: text
 LL |         deprecated_text();
    |         ^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:344:16
    |
 LL |         Trait::trait_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:346:25
    |
-LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
-   |                       ^^^^^^^^^^^^^^^^^^^^^
+LL |         <Foo as Trait>::trait_deprecated_text(&foo);
+   |                         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated struct `this_crate::DeprecatedStruct`: text
   --> $DIR/lint-stability-deprecated.rs:384:17
@@ -268,29 +268,29 @@ warning: use of deprecated tuple struct `this_crate::DeprecatedTupleStruct`: tex
 LL |         let _ = DeprecatedTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:406:16
    |
 LL |         Trait::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:408:25
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |                         ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:410:16
    |
 LL |         Trait::trait_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:412:25
    |
-LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
-   |                       ^^^^^^^^^^^^^^^^^^^^^
+LL |         <Foo as Trait>::trait_deprecated_text(&foo);
+   |                         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated function `this_crate::test_fn_body::fn_in_body`: text
   --> $DIR/lint-stability-deprecated.rs:439:9
@@ -328,121 +328,121 @@ warning: use of deprecated associated type `lint_stability::TraitWithAssociatedT
 LL |             TypeDeprecated = u16,
    |             ^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated`: text
+warning: use of deprecated method `lint_stability::MethodTester::method_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:25:13
    |
 LL |         foo.method_deprecated();
    |             ^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated`: text
+warning: use of deprecated method `lint_stability::MethodTester::method_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:26:14
    |
 LL |         Foo::method_deprecated(&foo);
    |              ^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated`: text
+warning: use of deprecated method `lint_stability::MethodTester::method_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:27:16
    |
 LL |         <Foo>::method_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:28:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:30:16
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_text`: text
+warning: use of deprecated method `lint_stability::MethodTester::method_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:34:13
    |
-LL | ...   foo.method_deprecated_text();
-   |           ^^^^^^^^^^^^^^^^^^^^^^
+LL |         foo.method_deprecated_text();
+   |             ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_text`: text
+warning: use of deprecated method `lint_stability::MethodTester::method_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:35:14
    |
-LL | ...   Foo::method_deprecated_text(&foo);
-   |            ^^^^^^^^^^^^^^^^^^^^^^
-
-warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:36:16
-   |
-LL | ...   <Foo>::method_deprecated_text(&foo);
+LL |         Foo::method_deprecated_text(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `lint_stability::MethodTester::method_deprecated_text`: text
+  --> $DIR/lint-stability-deprecated.rs:36:16
+   |
+LL |         <Foo>::method_deprecated_text(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:37:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:39:16
    |
-LL | ...   <Foo>::trait_deprecated_text(&foo);
-   |              ^^^^^^^^^^^^^^^^^^^^^
+LL |         <Foo>::trait_deprecated_text(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable`: text
+warning: use of deprecated method `lint_stability::MethodTester::method_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:43:13
    |
-LL | ...   foo.method_deprecated_unstable();
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         foo.method_deprecated_unstable();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable`: text
+warning: use of deprecated method `lint_stability::MethodTester::method_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:44:14
    |
-LL | ...   Foo::method_deprecated_unstable(&foo);
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         Foo::method_deprecated_unstable(&foo);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable`: text
+warning: use of deprecated method `lint_stability::MethodTester::method_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:45:16
    |
 LL | ...   <Foo>::method_deprecated_unstable(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:46:13
    |
 LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:48:16
    |
-LL | ...   <Foo>::trait_deprecated_unstable(&foo);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         <Foo>::trait_deprecated_unstable(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable_text`: text
+warning: use of deprecated method `lint_stability::MethodTester::method_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:52:13
    |
 LL | ...   foo.method_deprecated_unstable_text();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable_text`: text
+warning: use of deprecated method `lint_stability::MethodTester::method_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:53:14
    |
 LL | ...   Foo::method_deprecated_unstable_text(&foo);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable_text`: text
+warning: use of deprecated method `lint_stability::MethodTester::method_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:54:16
    |
 LL | ...   <Foo>::method_deprecated_unstable_text(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:55:13
    |
 LL | ...   foo.trait_deprecated_unstable_text();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:57:16
    |
 LL | ...   <Foo>::trait_deprecated_unstable_text(&foo);
@@ -460,133 +460,133 @@ warning: use of deprecated field `lint_stability::DeprecatedUnstableStruct::i`: 
 LL |             i: 0
    |             ^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:144:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:146:16
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:148:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:150:16
    |
-LL | ...   <Foo>::trait_deprecated_text(&foo);
-   |              ^^^^^^^^^^^^^^^^^^^^^
+LL |         <Foo>::trait_deprecated_text(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:152:13
    |
 LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:154:16
    |
-LL | ...   <Foo>::trait_deprecated_unstable(&foo);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         <Foo>::trait_deprecated_unstable(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:156:13
    |
 LL | ...   foo.trait_deprecated_unstable_text();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:158:16
    |
 LL | ...   <Foo>::trait_deprecated_unstable_text(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:175:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:176:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:177:13
    |
 LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:178:13
    |
 LL | ...   foo.trait_deprecated_unstable_text();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::MethodTester::method_deprecated`: text
+warning: use of deprecated method `this_crate::MethodTester::method_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:331:13
    |
 LL |         foo.method_deprecated();
    |             ^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::MethodTester::method_deprecated`: text
+warning: use of deprecated method `this_crate::MethodTester::method_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:332:14
    |
 LL |         Foo::method_deprecated(&foo);
    |              ^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::MethodTester::method_deprecated`: text
+warning: use of deprecated method `this_crate::MethodTester::method_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:333:16
    |
 LL |         <Foo>::method_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:334:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:336:16
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
+warning: use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:340:13
    |
-LL | ...   foo.method_deprecated_text();
-   |           ^^^^^^^^^^^^^^^^^^^^^^
+LL |         foo.method_deprecated_text();
+   |             ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
+warning: use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:341:14
    |
-LL | ...   Foo::method_deprecated_text(&foo);
-   |            ^^^^^^^^^^^^^^^^^^^^^^
-
-warning: use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:342:16
-   |
-LL | ...   <Foo>::method_deprecated_text(&foo);
+LL |         Foo::method_deprecated_text(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
+  --> $DIR/lint-stability-deprecated.rs:342:16
+   |
+LL |         <Foo>::method_deprecated_text(&foo);
+   |                ^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:343:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:345:16
    |
 LL |         <Foo>::trait_deprecated_text(&foo);
@@ -598,37 +598,37 @@ warning: use of deprecated field `this_crate::DeprecatedStruct::i`: text
 LL |             i: 0
    |             ^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:405:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:407:16
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:409:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:411:16
    |
 LL |         <Foo>::trait_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:428:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:429:13
    |
 LL |         foo.trait_deprecated_text();

--- a/tests/ui/match/match-ref-mut-invariance.stderr
+++ b/tests/ui/match/match-ref-mut-invariance.stderr
@@ -6,7 +6,7 @@ LL | impl<'b> S<'b> {
 LL |     fn bar<'a>(&'a mut self) -> &'a mut &'a i32 {
    |            -- lifetime `'a` defined here
 LL |         match self.0 { ref mut x => x }
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ associated function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable reference to `&i32`

--- a/tests/ui/match/match-ref-mut-let-invariance.stderr
+++ b/tests/ui/match/match-ref-mut-let-invariance.stderr
@@ -7,7 +7,7 @@ LL |     fn bar<'a>(&'a mut self) -> &'a mut &'a i32 {
    |            -- lifetime `'a` defined here
 LL |         let ref mut x = self.0;
 LL |         x
-   |         ^ associated function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+   |         ^ method was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable reference to `&i32`

--- a/tests/ui/methods/issues/issue-61525.stderr
+++ b/tests/ui/methods/issues/issue-61525.stderr
@@ -27,7 +27,7 @@ LL |         1.query::<dyn ToString>("")
    |
    = note: expected trait object `dyn ToString`
                  found reference `&'static str`
-note: associated function defined here
+note: method defined here
   --> $DIR/issue-61525.rs:2:8
    |
 LL |     fn query<Q>(self, q: Q);

--- a/tests/ui/methods/method-ambig-two-traits-cross-crate.stderr
+++ b/tests/ui/methods/method-ambig-two-traits-cross-crate.stderr
@@ -10,11 +10,11 @@ note: candidate #2 is defined in an impl of the trait `Me2` for the type `usize`
    |
 LL | impl Me2 for usize { fn me(&self) -> usize { *self } }
    |                      ^^^^^^^^^^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL | fn main() { Me::me(&1_usize); }
    |             ~~~~~~~~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL | fn main() { Me2::me(&1_usize); }
    |             ~~~~~~~~~~~~~~~~~

--- a/tests/ui/methods/method-ambig-two-traits-from-bounds.stderr
+++ b/tests/ui/methods/method-ambig-two-traits-from-bounds.stderr
@@ -14,11 +14,11 @@ note: candidate #2 is defined in the trait `B`
    |
 LL | trait B { fn foo(&self); }
    |           ^^^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL |     A::foo(t);
    |     ~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |     B::foo(t);
    |     ~~~~~~~~~

--- a/tests/ui/methods/method-ambig-two-traits-from-impls.stderr
+++ b/tests/ui/methods/method-ambig-two-traits-from-impls.stderr
@@ -14,11 +14,11 @@ note: candidate #2 is defined in an impl of the trait `B` for the type `AB`
    |
 LL |     fn foo(self) {}
    |     ^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL |     A::foo(AB {});
    |     ~~~~~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |     B::foo(AB {});
    |     ~~~~~~~~~~~~~

--- a/tests/ui/methods/method-ambig-two-traits-with-default-method.stderr
+++ b/tests/ui/methods/method-ambig-two-traits-with-default-method.stderr
@@ -14,11 +14,11 @@ note: candidate #2 is defined in an impl of the trait `Bar` for the type `usize`
    |
 LL | trait Bar { fn method(&self) {} }
    |             ^^^^^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL |     Foo::method(&1_usize);
    |     ~~~~~~~~~~~~~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |     Bar::method(&1_usize);
    |     ~~~~~~~~~~~~~~~~~~~~~

--- a/tests/ui/methods/method-call-err-msg.stderr
+++ b/tests/ui/methods/method-call-err-msg.stderr
@@ -7,7 +7,7 @@ LL |     x.zero(0)
    |            unexpected argument of type `{integer}`
    |            help: remove the extra argument
    |
-note: associated function defined here
+note: method defined here
   --> $DIR/method-call-err-msg.rs:5:8
    |
 LL |     fn zero(self) -> Foo { self }
@@ -19,7 +19,7 @@ error[E0061]: this method takes 1 argument but 0 arguments were supplied
 LL |      .one()
    |       ^^^-- an argument of type `isize` is missing
    |
-note: associated function defined here
+note: method defined here
   --> $DIR/method-call-err-msg.rs:6:8
    |
 LL |     fn one(self, _: isize) -> Foo { self }
@@ -35,7 +35,7 @@ error[E0061]: this method takes 2 arguments but 1 argument was supplied
 LL |      .two(0);
    |       ^^^--- an argument of type `isize` is missing
    |
-note: associated function defined here
+note: method defined here
   --> $DIR/method-call-err-msg.rs:7:8
    |
 LL |     fn two(self, _: isize, _: isize) -> Foo { self }
@@ -72,7 +72,7 @@ error[E0061]: this method takes 3 arguments but 0 arguments were supplied
 LL |     y.three::<usize>();
    |       ^^^^^^^^^^^^^^-- three arguments of type `usize`, `usize`, and `usize` are missing
    |
-note: associated function defined here
+note: method defined here
   --> $DIR/method-call-err-msg.rs:8:8
    |
 LL |     fn three<T>(self, _: T, _: T, _: T) -> Foo { self }

--- a/tests/ui/methods/method-call-lifetime-args-fail.rs
+++ b/tests/ui/methods/method-call-lifetime-args-fail.rs
@@ -14,9 +14,9 @@ impl S {
 fn method_call() {
     S.early(); // OK
     S.early::<'static>();
-    //~^ ERROR this associated function takes 2 lifetime arguments but 1 lifetime argument
+    //~^ ERROR this method takes 2 lifetime arguments but 1 lifetime argument
     S.early::<'static, 'static, 'static>();
-    //~^ ERROR this associated function takes 2 lifetime arguments but 3 lifetime arguments were supplied
+    //~^ ERROR this method takes 2 lifetime arguments but 3 lifetime arguments were supplied
     let _: &u8 = S.life_and_type::<'static>();
     S.life_and_type::<u8>();
     S.life_and_type::<'static, u8>();
@@ -61,9 +61,9 @@ fn ufcs() {
 
     S::early(S); // OK
     S::early::<'static>(S);
-    //~^ ERROR this associated function takes 2 lifetime arguments but 1 lifetime argument
+    //~^ ERROR this method takes 2 lifetime arguments but 1 lifetime argument
     S::early::<'static, 'static, 'static>(S);
-    //~^ ERROR this associated function takes 2 lifetime arguments but 3 lifetime arguments were supplied
+    //~^ ERROR this method takes 2 lifetime arguments but 3 lifetime arguments were supplied
     let _: &u8 = S::life_and_type::<'static>(S);
     S::life_and_type::<u8>(S);
     S::life_and_type::<'static, u8>(S);

--- a/tests/ui/methods/method-call-lifetime-args-fail.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-fail.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated function takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: this method takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/method-call-lifetime-args-fail.rs:16:7
    |
 LL |     S.early::<'static>();
@@ -6,7 +6,7 @@ LL |     S.early::<'static>();
    |       |
    |       expected 2 lifetime arguments
    |
-note: associated function defined here, with 2 lifetime parameters: `'a`, `'b`
+note: method defined here, with 2 lifetime parameters: `'a`, `'b`
   --> $DIR/method-call-lifetime-args-fail.rs:6:8
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
@@ -16,7 +16,7 @@ help: add missing lifetime argument
 LL |     S.early::<'static, 'static>();
    |                      +++++++++
 
-error[E0107]: this associated function takes 2 lifetime arguments but 3 lifetime arguments were supplied
+error[E0107]: this method takes 2 lifetime arguments but 3 lifetime arguments were supplied
   --> $DIR/method-call-lifetime-args-fail.rs:18:7
    |
 LL |     S.early::<'static, 'static, 'static>();
@@ -24,7 +24,7 @@ LL |     S.early::<'static, 'static, 'static>();
    |       |
    |       expected 2 lifetime arguments
    |
-note: associated function defined here, with 2 lifetime parameters: `'a`, `'b`
+note: method defined here, with 2 lifetime parameters: `'a`, `'b`
   --> $DIR/method-call-lifetime-args-fail.rs:6:8
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
@@ -198,7 +198,7 @@ note: the late bound lifetime parameter is introduced here
 LL |     fn late_unused_early<'a, 'b>(self) -> &'b u8 { loop {} }
    |                          ^^
 
-error[E0107]: this associated function takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: this method takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/method-call-lifetime-args-fail.rs:63:8
    |
 LL |     S::early::<'static>(S);
@@ -206,7 +206,7 @@ LL |     S::early::<'static>(S);
    |        |
    |        expected 2 lifetime arguments
    |
-note: associated function defined here, with 2 lifetime parameters: `'a`, `'b`
+note: method defined here, with 2 lifetime parameters: `'a`, `'b`
   --> $DIR/method-call-lifetime-args-fail.rs:6:8
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
@@ -216,7 +216,7 @@ help: add missing lifetime argument
 LL |     S::early::<'static, 'static>(S);
    |                       +++++++++
 
-error[E0107]: this associated function takes 2 lifetime arguments but 3 lifetime arguments were supplied
+error[E0107]: this method takes 2 lifetime arguments but 3 lifetime arguments were supplied
   --> $DIR/method-call-lifetime-args-fail.rs:65:8
    |
 LL |     S::early::<'static, 'static, 'static>(S);
@@ -224,7 +224,7 @@ LL |     S::early::<'static, 'static, 'static>(S);
    |        |
    |        expected 2 lifetime arguments
    |
-note: associated function defined here, with 2 lifetime parameters: `'a`, `'b`
+note: method defined here, with 2 lifetime parameters: `'a`, `'b`
   --> $DIR/method-call-lifetime-args-fail.rs:6:8
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }

--- a/tests/ui/methods/method-deref-to-same-trait-object-with-separate-params.stderr
+++ b/tests/ui/methods/method-deref-to-same-trait-object-with-separate-params.stderr
@@ -44,15 +44,15 @@ note: candidate #3 is defined in the trait `FinalFoo`
    |
 LL |     fn foo(&self) -> u8;
    |     ^^^^^^^^^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL |     let z = X::foo(x);
    |             ~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |     let z = NuisanceFoo::foo(x);
    |             ~~~~~~~~~~~~~~~~~~~
-help: disambiguate the associated function for candidate #3
+help: disambiguate the method for candidate #3
    |
 LL |     let z = FinalFoo::foo(x);
    |             ~~~~~~~~~~~~~~~~

--- a/tests/ui/methods/method-self-arg-1.stderr
+++ b/tests/ui/methods/method-self-arg-1.stderr
@@ -8,7 +8,7 @@ LL |     Foo::bar(x);
    |     |        help: consider borrowing here: `&x`
    |     arguments to this function are incorrect
    |
-note: associated function defined here
+note: method defined here
   --> $DIR/method-self-arg-1.rs:6:8
    |
 LL |     fn bar(&self) {}
@@ -24,7 +24,7 @@ LL |     Foo::bar(&42);
    |
    = note: expected reference `&Foo`
               found reference `&{integer}`
-note: associated function defined here
+note: method defined here
   --> $DIR/method-self-arg-1.rs:6:8
    |
 LL |     fn bar(&self) {}

--- a/tests/ui/nll/outlives-suggestion-simple.stderr
+++ b/tests/ui/nll/outlives-suggestion-simple.stderr
@@ -73,7 +73,7 @@ LL | impl<'a> Bar<'a> {
 LL |     pub fn get<'b>(&self) -> &'b usize {
    |                -- lifetime `'b` defined here
 LL |         self.x
-   |         ^^^^^^ associated function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+   |         ^^^^^^ method was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 
@@ -85,7 +85,7 @@ LL | impl<'a> Baz<'a> {
 LL |     fn get<'b>(&'b self) -> &'a i32 {
    |            -- lifetime `'b` defined here
 LL |         self.x
-   |         ^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |         ^^^^^^ method was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
 

--- a/tests/ui/privacy/privacy1.rs
+++ b/tests/ui/privacy/privacy1.rs
@@ -106,7 +106,7 @@ mod foo {
                                 //~^ ERROR: associated function `bar` is private
         ::bar::baz::A.foo2();   //~ ERROR: module `baz` is private
         ::bar::baz::A.bar2();   //~ ERROR: module `baz` is private
-                                //~^ ERROR: associated function `bar2` is private
+                                //~^ ERROR: method `bar2` is private
 
         let _: isize =
         ::bar::B::foo();        //~ ERROR: trait `B` is private

--- a/tests/ui/privacy/privacy1.stderr
+++ b/tests/ui/privacy/privacy1.stderr
@@ -190,14 +190,14 @@ LL |             fn bar() {}
 LL |         ::bar::baz::A::bar();
    |                        ^^^ private associated function
 
-error[E0624]: associated function `bar2` is private
+error[E0624]: method `bar2` is private
   --> $DIR/privacy1.rs:108:23
    |
 LL |             fn bar2(&self) {}
-   |             -------------- private associated function defined here
+   |             -------------- private method defined here
 ...
 LL |         ::bar::baz::A.bar2();
-   |                       ^^^^ private associated function
+   |                       ^^^^ private method
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/privacy/private-impl-method.rs
+++ b/tests/ui/privacy/private-impl-method.rs
@@ -17,5 +17,5 @@ fn f() {
 fn main() {
     let s = a::Foo { x: 1 };
     s.bar();
-    s.foo();    //~ ERROR associated function `foo` is private
+    s.foo();    //~ ERROR method `foo` is private
 }

--- a/tests/ui/privacy/private-impl-method.stderr
+++ b/tests/ui/privacy/private-impl-method.stderr
@@ -1,11 +1,11 @@
-error[E0624]: associated function `foo` is private
+error[E0624]: method `foo` is private
   --> $DIR/private-impl-method.rs:20:7
    |
 LL |         fn foo(&self) {}
-   |         ------------- private associated function defined here
+   |         ------------- private method defined here
 ...
 LL |     s.foo();
-   |       ^^^ private associated function
+   |       ^^^ private method
 
 error: aborting due to previous error
 

--- a/tests/ui/privacy/private-method-cross-crate.rs
+++ b/tests/ui/privacy/private-method-cross-crate.rs
@@ -4,5 +4,5 @@ use cci_class_5::kitties::cat;
 
 fn main() {
   let nyan : cat = cat(52, 99);
-  nyan.nap();   //~ ERROR associated function `nap` is private
+  nyan.nap();   //~ ERROR method `nap` is private
 }

--- a/tests/ui/privacy/private-method-cross-crate.stderr
+++ b/tests/ui/privacy/private-method-cross-crate.stderr
@@ -1,13 +1,13 @@
-error[E0624]: associated function `nap` is private
+error[E0624]: method `nap` is private
   --> $DIR/private-method-cross-crate.rs:7:8
    |
 LL |   nyan.nap();
-   |        ^^^ private associated function
+   |        ^^^ private method
    |
   ::: $DIR/auxiliary/cci_class_5.rs:8:9
    |
 LL |         fn nap(&self) {}
-   |         ------------- private associated function defined here
+   |         ------------- private method defined here
 
 error: aborting due to previous error
 

--- a/tests/ui/privacy/private-method-inherited.rs
+++ b/tests/ui/privacy/private-method-inherited.rs
@@ -10,5 +10,5 @@ mod a {
 
 fn main() {
     let x = a::Foo;
-    x.f();  //~ ERROR associated function `f` is private
+    x.f();  //~ ERROR method `f` is private
 }

--- a/tests/ui/privacy/private-method-inherited.stderr
+++ b/tests/ui/privacy/private-method-inherited.stderr
@@ -1,11 +1,11 @@
-error[E0624]: associated function `f` is private
+error[E0624]: method `f` is private
   --> $DIR/private-method-inherited.rs:13:7
    |
 LL |         fn f(self) {}
-   |         ---------- private associated function defined here
+   |         ---------- private method defined here
 ...
 LL |     x.f();
-   |       ^ private associated function
+   |       ^ private method
 
 error: aborting due to previous error
 

--- a/tests/ui/privacy/private-method.rs
+++ b/tests/ui/privacy/private-method.rs
@@ -19,5 +19,5 @@ mod kitties {
 
 fn main() {
   let nyan : kitties::Cat = kitties::cat(52, 99);
-  nyan.nap(); //~ ERROR associated function `nap` is private
+  nyan.nap(); //~ ERROR method `nap` is private
 }

--- a/tests/ui/privacy/private-method.stderr
+++ b/tests/ui/privacy/private-method.stderr
@@ -1,11 +1,11 @@
-error[E0624]: associated function `nap` is private
+error[E0624]: method `nap` is private
   --> $DIR/private-method.rs:22:8
    |
 LL |         fn nap(&self) {}
-   |         ------------- private associated function defined here
+   |         ------------- private method defined here
 ...
 LL |   nyan.nap();
-   |        ^^^ private associated function
+   |        ^^^ private method
 
 error: aborting due to previous error
 

--- a/tests/ui/privacy/restricted/test.stderr
+++ b/tests/ui/privacy/restricted/test.stderr
@@ -54,14 +54,14 @@ error[E0616]: field `x` of struct `S` is private
 LL |     S::default().x;
    |                  ^ private field
 
-error[E0624]: associated function `f` is private
+error[E0624]: method `f` is private
   --> $DIR/test.rs:32:18
    |
 LL |             pub(super) fn f(&self) {}
-   |             ---------------------- private associated function defined here
+   |             ---------------------- private method defined here
 ...
 LL |     S::default().f();
-   |                  ^ private associated function
+   |                  ^ private method
 
 error[E0624]: associated function `g` is private
   --> $DIR/test.rs:33:8
@@ -84,27 +84,27 @@ error[E0616]: field `z` of struct `Universe` is private
 LL |     let _ = u.z;
    |               ^ private field
 
-error[E0624]: associated function `g` is private
+error[E0624]: method `g` is private
   --> $DIR/test.rs:45:7
    |
 LL |     u.g();
-   |       ^ private associated function
+   |       ^ private method
    |
   ::: $DIR/auxiliary/pub_restricted.rs:12:5
    |
 LL |     pub(crate) fn g(&self) {}
-   |     ---------------------- private associated function defined here
+   |     ---------------------- private method defined here
 
-error[E0624]: associated function `h` is private
+error[E0624]: method `h` is private
   --> $DIR/test.rs:46:7
    |
 LL |     u.h();
-   |       ^ private associated function
+   |       ^ private method
    |
   ::: $DIR/auxiliary/pub_restricted.rs:13:5
    |
 LL |     pub(crate) fn h(&self) {}
-   |     ---------------------- private associated function defined here
+   |     ---------------------- private method defined here
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/regions/regions-early-bound-error-method.stderr
+++ b/tests/ui/regions/regions-early-bound-error-method.stderr
@@ -6,7 +6,7 @@ LL | impl<'a> Box<'a> {
 LL |     fn or<'b,G:GetRef<'b>>(&self, g2: G) -> &'a isize {
    |           -- lifetime `'b` defined here
 LL |         g2.get()
-   |         ^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |         ^^^^^^^^ method was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
 

--- a/tests/ui/regions/regions-free-region-ordering-incorrect.stderr
+++ b/tests/ui/regions/regions-free-region-ordering-incorrect.stderr
@@ -9,7 +9,7 @@ LL | /         match self.next {
 LL | |             Some(ref next) => next.get(),
 LL | |             None => &self.val
 LL | |         }
-   | |_________^ associated function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+   | |_________^ method was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
@@ -2,7 +2,7 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:8:52
    |
 LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
-   |                          -         -               ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |                          -         -               ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |                          |         |
    |                          |         let's call the lifetime of this reference `'1`
    |                          let's call the lifetime of this reference `'2`
@@ -16,7 +16,7 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:11:75
    |
 LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-   |                          -          -                                     ^^^^^^^^^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |                          -          -                                     ^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |                          |          |
    |                          |          let's call the lifetime of this reference `'1`
    |                          let's call the lifetime of this reference `'2`
@@ -30,7 +30,7 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:17:64
    |
 LL |     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
-   |                  --              -                             ^^^ associated function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
+   |                  --              -                             ^^^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
    |                  |               |
    |                  |               let's call the lifetime of this reference `'1`
    |                  lifetime `'a` defined here

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
@@ -2,7 +2,7 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:6:46
    |
 LL |     fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
-   |                    -         -               ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |                    -         -               ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |                    |         |
    |                    |         let's call the lifetime of this reference `'1`
    |                    let's call the lifetime of this reference `'2`
@@ -16,7 +16,7 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:9:69
    |
 LL |     fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-   |                    -          -                                     ^^^^^^^^^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |                    -          -                                     ^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |                    |          |
    |                    |          let's call the lifetime of this reference `'1`
    |                    let's call the lifetime of this reference `'2`
@@ -30,7 +30,7 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:15:58
    |
 LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
-   |            --  ---- has type `Pin<&'1 Foo>`              ^^^ associated function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
+   |            --  ---- has type `Pin<&'1 Foo>`              ^^^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
    |            |
    |            lifetime `'a` defined here
 

--- a/tests/ui/self/elision/lt-ref-self-async.stderr
+++ b/tests/ui/self/elision/lt-ref-self-async.stderr
@@ -6,7 +6,7 @@ LL |     async fn ref_self(&self, f: &u32) -> &u32 {
    |                       |
    |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -21,7 +21,7 @@ LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                             |
    |                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -36,7 +36,7 @@ LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                     |
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -51,7 +51,7 @@ LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                     |
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -66,7 +66,7 @@ LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                             |
    |                                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -81,7 +81,7 @@ LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                         |
    |                                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |

--- a/tests/ui/self/elision/lt-ref-self.stderr
+++ b/tests/ui/self/elision/lt-ref-self.stderr
@@ -6,7 +6,7 @@ LL |     fn ref_self(&self, f: &u32) -> &u32 {
    |                 |
    |                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -21,7 +21,7 @@ LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                       |
    |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -36,7 +36,7 @@ LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -51,7 +51,7 @@ LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -66,7 +66,7 @@ LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -81,7 +81,7 @@ LL |     fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                   |
    |                                   let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |

--- a/tests/ui/self/elision/ref-mut-self-async.stderr
+++ b/tests/ui/self/elision/ref-mut-self-async.stderr
@@ -6,7 +6,7 @@ LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
    |                       |
    |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -21,7 +21,7 @@ LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
    |                             |
    |                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -36,7 +36,7 @@ LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
    |                                     |
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -51,7 +51,7 @@ LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
    |                                     |
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -66,7 +66,7 @@ LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
    |                                             |
    |                                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -81,7 +81,7 @@ LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
    |                                             |
    |                                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |

--- a/tests/ui/self/elision/ref-mut-self.stderr
+++ b/tests/ui/self/elision/ref-mut-self.stderr
@@ -6,7 +6,7 @@ LL |     fn ref_self(&mut self, f: &u32) -> &u32 {
    |                 |
    |                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -21,7 +21,7 @@ LL |     fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
    |                       |
    |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -36,7 +36,7 @@ LL |     fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -51,7 +51,7 @@ LL |     fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -66,7 +66,7 @@ LL |     fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -81,7 +81,7 @@ LL |     fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |

--- a/tests/ui/self/elision/ref-mut-struct-async.stderr
+++ b/tests/ui/self/elision/ref-mut-struct-async.stderr
@@ -6,7 +6,7 @@ LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -21,7 +21,7 @@ LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -36,7 +36,7 @@ LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -51,7 +51,7 @@ LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u
    |                                               |
    |                                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -66,7 +66,7 @@ LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u
    |                                               |
    |                                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |

--- a/tests/ui/self/elision/ref-mut-struct.stderr
+++ b/tests/ui/self/elision/ref-mut-struct.stderr
@@ -6,7 +6,7 @@ LL |     fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
    |                         |
    |                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -21,7 +21,7 @@ LL |     fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
    |                                 |
    |                                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -36,7 +36,7 @@ LL |     fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
    |                                 |
    |                                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -51,7 +51,7 @@ LL |     fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
    |                                         |
    |                                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -66,7 +66,7 @@ LL |     fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
    |                                         |
    |                                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |

--- a/tests/ui/self/elision/ref-self-async.stderr
+++ b/tests/ui/self/elision/ref-self-async.stderr
@@ -6,7 +6,7 @@ LL |     async fn ref_self(&self, f: &u32) -> &u32 {
    |                       |
    |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -21,7 +21,7 @@ LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                             |
    |                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -36,7 +36,7 @@ LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                     |
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -51,7 +51,7 @@ LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                     |
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -66,7 +66,7 @@ LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                             |
    |                                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -81,7 +81,7 @@ LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                             |
    |                                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -96,7 +96,7 @@ LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
    |                                            |
    |                                            let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |

--- a/tests/ui/self/elision/ref-self.stderr
+++ b/tests/ui/self/elision/ref-self.stderr
@@ -6,7 +6,7 @@ LL |     fn ref_self(&self, f: &u32) -> &u32 {
    |                 |
    |                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -21,7 +21,7 @@ LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                       |
    |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -36,7 +36,7 @@ LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -51,7 +51,7 @@ LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -66,7 +66,7 @@ LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -81,7 +81,7 @@ LL |     fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -96,7 +96,7 @@ LL |     fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
    |                                      |
    |                                      let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |

--- a/tests/ui/self/elision/ref-struct-async.stderr
+++ b/tests/ui/self/elision/ref-struct-async.stderr
@@ -6,7 +6,7 @@ LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -21,7 +21,7 @@ LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -36,7 +36,7 @@ LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -51,7 +51,7 @@ LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
    |                                               |
    |                                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -66,7 +66,7 @@ LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
    |                                           |
    |                                           let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |

--- a/tests/ui/self/elision/ref-struct.stderr
+++ b/tests/ui/self/elision/ref-struct.stderr
@@ -6,7 +6,7 @@ LL |     fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                         |
    |                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -21,7 +21,7 @@ LL |     fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
    |                                 |
    |                                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -36,7 +36,7 @@ LL |     fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
    |                                 |
    |                                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -51,7 +51,7 @@ LL |     fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
    |                                         |
    |                                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
@@ -66,7 +66,7 @@ LL |     fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
    |                                     |
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |

--- a/tests/ui/span/issue-37767.stderr
+++ b/tests/ui/span/issue-37767.stderr
@@ -14,11 +14,11 @@ note: candidate #2 is defined in the trait `B`
    |
 LL |     fn foo(&mut self) {}
    |     ^^^^^^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL |     A::foo(&a)
    |     ~~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |     B::foo(&a)
    |     ~~~~~~~~~~
@@ -39,11 +39,11 @@ note: candidate #2 is defined in the trait `D`
    |
 LL |     fn foo(&self) {}
    |     ^^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL |     C::foo(&a)
    |     ~~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |     D::foo(&a)
    |     ~~~~~~~~~~
@@ -64,11 +64,11 @@ note: candidate #2 is defined in the trait `F`
    |
 LL |     fn foo(self) {}
    |     ^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL |     E::foo(a)
    |     ~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |     F::foo(a)
    |     ~~~~~~~~~

--- a/tests/ui/span/issue-42234-unknown-receiver-type.full.stderr
+++ b/tests/ui/span/issue-42234-unknown-receiver-type.full.stderr
@@ -15,7 +15,7 @@ error[E0282]: type annotations needed
   --> $DIR/issue-42234-unknown-receiver-type.rs:15:10
    |
 LL |         .sum::<_>()
-   |          ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
+   |          ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
    |
 help: consider specifying the generic argument
    |

--- a/tests/ui/span/issue-42234-unknown-receiver-type.generic_arg.stderr
+++ b/tests/ui/span/issue-42234-unknown-receiver-type.generic_arg.stderr
@@ -15,7 +15,7 @@ error[E0282]: type annotations needed
   --> $DIR/issue-42234-unknown-receiver-type.rs:15:10
    |
 LL |         .sum::<_>()
-   |          ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
+   |          ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
    |
 help: consider specifying the generic argument
    |

--- a/tests/ui/span/missing-unit-argument.stderr
+++ b/tests/ui/span/missing-unit-argument.stderr
@@ -65,7 +65,7 @@ error[E0061]: this method takes 1 argument but 0 arguments were supplied
 LL |     S.baz();
    |       ^^^-- an argument of type `()` is missing
    |
-note: associated function defined here
+note: method defined here
   --> $DIR/missing-unit-argument.rs:6:8
    |
 LL |     fn baz(self, (): ()) { }
@@ -81,7 +81,7 @@ error[E0061]: this method takes 1 argument but 0 arguments were supplied
 LL |     S.generic::<()>();
    |       ^^^^^^^^^^^^^-- an argument of type `()` is missing
    |
-note: associated function defined here
+note: method defined here
   --> $DIR/missing-unit-argument.rs:7:8
    |
 LL |     fn generic<T>(self, _: T) { }

--- a/tests/ui/span/type-annotations-needed-expr.stderr
+++ b/tests/ui/span/type-annotations-needed-expr.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/type-annotations-needed-expr.rs:2:39
    |
 LL |     let _ = (vec![1,2,3]).into_iter().sum() as f64;
-   |                                       ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
+   |                                       ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
    |
 help: consider specifying the generic argument
    |

--- a/tests/ui/suggestions/assoc-ct-for-assoc-method.stderr
+++ b/tests/ui/suggestions/assoc-ct-for-assoc-method.stderr
@@ -36,7 +36,7 @@ LL |     let y: i32 = i32::max - 42;
    |                  |
    |                  fn(i32, i32) -> i32 {<i32 as Ord>::max}
    |
-help: use parentheses to call this associated function
+help: use parentheses to call this method
    |
 LL |     let y: i32 = i32::max(/* i32 */, /* i32 */) - 42;
    |                          ++++++++++++++++++++++

--- a/tests/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/tests/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -206,7 +206,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:41:20
    |
 LL |     fn ban(&self) -> usize { 42 }
-   |     ---------------------- associated function `ban` defined here
+   |     ---------------------- method `ban` defined here
 ...
 LL |     let _: usize = X::ban;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -215,7 +215,7 @@ LL |     let _: usize = X::ban;
    |
    = note: expected type `usize`
            found fn item `for<'a> fn(&'a X) -> usize {<X as T>::ban}`
-help: use parentheses to call this associated function
+help: use parentheses to call this method
    |
 LL |     let _: usize = X::ban(/* &X */);
    |                          ++++++++++
@@ -224,7 +224,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:42:20
    |
 LL |     fn bal(&self) -> usize;
-   |     ----------------------- associated function `bal` defined here
+   |     ----------------------- method `bal` defined here
 ...
 LL |     let _: usize = X::bal;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -233,7 +233,7 @@ LL |     let _: usize = X::bal;
    |
    = note: expected type `usize`
            found fn item `for<'a> fn(&'a X) -> usize {<X as T>::bal}`
-help: use parentheses to call this associated function
+help: use parentheses to call this method
    |
 LL |     let _: usize = X::bal(/* &X */);
    |                          ++++++++++

--- a/tests/ui/suggestions/issue-101421.rs
+++ b/tests/ui/suggestions/issue-101421.rs
@@ -8,5 +8,5 @@ impl Ice for () {
 
 fn main() {
     ().f::<()>(());
-    //~^ ERROR this associated function takes 0 generic arguments but 1 generic argument was supplied
+    //~^ ERROR this method takes 0 generic arguments but 1 generic argument was supplied
 }

--- a/tests/ui/suggestions/issue-101421.stderr
+++ b/tests/ui/suggestions/issue-101421.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-101421.rs:10:8
    |
 LL |     ().f::<()>(());
@@ -6,7 +6,7 @@ LL |     ().f::<()>(());
    |        |
    |        expected 0 generic arguments
    |
-note: associated function defined here, with 0 generic parameters
+note: method defined here, with 0 generic parameters
   --> $DIR/issue-101421.rs:2:8
    |
 LL |     fn f(&self, _: ());

--- a/tests/ui/suggestions/issue-104287.rs
+++ b/tests/ui/suggestions/issue-104287.rs
@@ -8,6 +8,6 @@ impl S {
 fn main() {
     let x = S;
     foo::<()>(x);
-    //~^ ERROR this associated function takes 0 generic arguments but 1 generic argument was supplied
+    //~^ ERROR this method takes 0 generic arguments but 1 generic argument was supplied
     //~| ERROR cannot find function `foo` in this scope
 }

--- a/tests/ui/suggestions/issue-104287.stderr
+++ b/tests/ui/suggestions/issue-104287.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-104287.rs:10:5
    |
 LL |     foo::<()>(x);
@@ -6,7 +6,7 @@ LL |     foo::<()>(x);
    |     |
    |     expected 0 generic arguments
    |
-note: associated function defined here, with 0 generic parameters
+note: method defined here, with 0 generic parameters
   --> $DIR/issue-104287.rs:6:8
    |
 LL |     fn foo(&self) {}

--- a/tests/ui/suggestions/issue-89064.stderr
+++ b/tests/ui/suggestions/issue-89064.stderr
@@ -56,7 +56,7 @@ note: associated function defined here, with 0 generic parameters
 LL |     fn foo() {}
    |        ^^^
 
-error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-89064.rs:31:16
    |
 LL |     let _ = 42.into::<Option<_>>();

--- a/tests/ui/suggestions/move-generic-to-trait-in-method-with-params.rs
+++ b/tests/ui/suggestions/move-generic-to-trait-in-method-with-params.rs
@@ -12,7 +12,7 @@ impl Foo<i32> for i32 {
 
 fn main() {
     1.bar::<i32>(0);
-    //~^ ERROR this associated function takes 0 generic arguments but 1 generic argument was supplied
+    //~^ ERROR this method takes 0 generic arguments but 1 generic argument was supplied
     //~| HELP consider moving this generic argument to the `Foo` trait, which takes up to 1 argument
     //~| HELP remove these generics
 }

--- a/tests/ui/suggestions/move-generic-to-trait-in-method-with-params.stderr
+++ b/tests/ui/suggestions/move-generic-to-trait-in-method-with-params.stderr
@@ -1,10 +1,10 @@
-error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/move-generic-to-trait-in-method-with-params.rs:14:7
    |
 LL |     1.bar::<i32>(0);
    |       ^^^ expected 0 generic arguments
    |
-note: associated function defined here, with 0 generic parameters
+note: method defined here, with 0 generic parameters
   --> $DIR/move-generic-to-trait-in-method-with-params.rs:4:8
    |
 LL |     fn bar(&self, _: T);

--- a/tests/ui/suggestions/sugg-else-for-closure.stderr
+++ b/tests/ui/suggestions/sugg-else-for-closure.stderr
@@ -15,7 +15,7 @@ LL |     let _s = y.unwrap_or(|| x.split('.').nth(1).unwrap());
    |              ^^^^^^^^^^^^-------------------------------^
    |                          |
    |                          this argument influences the return type of `unwrap_or`
-note: associated function defined here
+note: method defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
 help: try calling `unwrap_or_else` instead
    |

--- a/tests/ui/suggestions/trait-with-missing-associated-type-restriction.stderr
+++ b/tests/ui/suggestions/trait-with-missing-associated-type-restriction.stderr
@@ -90,7 +90,7 @@ LL |     fn func(&self) -> Self::A;
 LL |     fn funk(&self, _: Self::A);
 LL |     fn funq(&self) -> Self::A {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ consider calling `Trait::funq`
-note: associated function defined here
+note: method defined here
   --> $DIR/trait-with-missing-associated-type-restriction.rs:9:8
    |
 LL |     fn funk(&self, _: Self::A);

--- a/tests/ui/traits/alias/ambiguous.stderr
+++ b/tests/ui/traits/alias/ambiguous.stderr
@@ -14,11 +14,11 @@ note: candidate #2 is defined in an impl of the trait `B` for the type `u8`
    |
 LL |         fn foo(&self) {}
    |         ^^^^^^^^^^^^^
-help: disambiguate the associated function for candidate #1
+help: disambiguate the method for candidate #1
    |
 LL |     A::foo(&t);
    |     ~~~~~~~~~~
-help: disambiguate the associated function for candidate #2
+help: disambiguate the method for candidate #2
    |
 LL |     B::foo(&t);
    |     ~~~~~~~~~~

--- a/tests/ui/traits/issue-52893.stderr
+++ b/tests/ui/traits/issue-52893.stderr
@@ -18,7 +18,7 @@ LL |         builder.push(output);
    |         ^^^^^^^^^^^^^------^
    |                      |
    |                      this argument influences the return type of `push`
-note: associated function defined here
+note: method defined here
   --> $DIR/issue-52893.rs:11:8
    |
 LL |     fn push(self, other: T) -> Self::PushRes;

--- a/tests/ui/traits/issue-77982.stderr
+++ b/tests/ui/traits/issue-77982.stderr
@@ -4,7 +4,7 @@ error[E0283]: type annotations needed
 LL |     opts.get(opt.as_ref());
    |          ^^^ ------------ type must be known at this point
    |          |
-   |          cannot infer type of the type parameter `Q` declared on the associated function `get`
+   |          cannot infer type of the type parameter `Q` declared on the method `get`
    |
    = note: multiple `impl`s satisfying `String: Borrow<_>` found in the following crates: `alloc`, `core`:
            - impl Borrow<str> for String;
@@ -23,7 +23,7 @@ error[E0283]: type annotations needed
 LL |     opts.get(opt.as_ref());
    |          ^^^     ------ type must be known at this point
    |          |
-   |          cannot infer type of the type parameter `Q` declared on the associated function `get`
+   |          cannot infer type of the type parameter `Q` declared on the method `get`
    |
    = note: multiple `impl`s satisfying `String: AsRef<_>` found in the following crates: `alloc`, `std`:
            - impl AsRef<OsStr> for String;

--- a/tests/ui/traits/item-privacy.rs
+++ b/tests/ui/traits/item-privacy.rs
@@ -69,7 +69,7 @@ fn check_method() {
     S.c(); // OK
     // a, b, c are resolved as inherent items, their traits don't need to be in scope
     let c = &S as &dyn C;
-    c.a(); //~ ERROR associated function `a` is private
+    c.a(); //~ ERROR method `a` is private
     c.b(); // OK
     c.c(); // OK
 
@@ -81,7 +81,7 @@ fn check_method() {
     //~^ ERROR no function or associated item named `b` found
     S::c(&S); // OK
     // a, b, c are resolved as inherent items, their traits don't need to be in scope
-    <dyn C>::a(&S); //~ ERROR associated function `a` is private
+    <dyn C>::a(&S); //~ ERROR method `a` is private
     <dyn C>::b(&S); // OK
     C::c(&S); // OK
 }

--- a/tests/ui/traits/item-privacy.stderr
+++ b/tests/ui/traits/item-privacy.stderr
@@ -32,14 +32,14 @@ help: the following trait is implemented but not in scope; perhaps add a `use` f
 LL | use method::B;
    |
 
-error[E0624]: associated function `a` is private
+error[E0624]: method `a` is private
   --> $DIR/item-privacy.rs:72:7
    |
 LL |         fn a(&self) { }
-   |         ----------- private associated function defined here
+   |         ----------- private method defined here
 ...
 LL |     c.a();
-   |       ^ private associated function
+   |       ^ private method
 
 error[E0599]: no function or associated item named `a` found for struct `S` in the current scope
   --> $DIR/item-privacy.rs:78:8
@@ -72,14 +72,14 @@ help: the following trait is implemented but not in scope; perhaps add a `use` f
 LL | use method::B;
    |
 
-error[E0624]: associated function `a` is private
+error[E0624]: method `a` is private
   --> $DIR/item-privacy.rs:84:14
    |
 LL |         fn a(&self) { }
-   |         ----------- private associated function defined here
+   |         ----------- private method defined here
 ...
 LL |     <dyn C>::a(&S);
-   |              ^ private associated function
+   |              ^ private method
 
 error[E0599]: no associated item named `A` found for struct `S` in the current scope
   --> $DIR/item-privacy.rs:97:8

--- a/tests/ui/traits/method-private.stderr
+++ b/tests/ui/traits/method-private.stderr
@@ -1,11 +1,11 @@
-error[E0624]: associated function `method` is private
+error[E0624]: method `method` is private
   --> $DIR/method-private.rs:19:9
    |
 LL |         fn method(&self) {}
-   |         ---------------- private associated function defined here
+   |         ---------------- private method defined here
 ...
 LL |     foo.method();
-   |         ^^^^^^ private associated function
+   |         ^^^^^^ private method
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:

--- a/tests/ui/traits/test-2.rs
+++ b/tests/ui/traits/test-2.rs
@@ -7,9 +7,9 @@ impl bar for u32 { fn dup(&self) -> u32 { *self } fn blah<X>(&self) {} }
 
 fn main() {
     10.dup::<i32>();
-    //~^ ERROR this associated function takes 0 generic arguments but 1
+    //~^ ERROR this method takes 0 generic arguments but 1
     10.blah::<i32, i32>();
-    //~^ ERROR this associated function takes 1 generic argument but 2
+    //~^ ERROR this method takes 1 generic argument but 2
     (Box::new(10) as Box<dyn bar>).dup();
     //~^ ERROR E0038
     //~| ERROR E0038

--- a/tests/ui/traits/test-2.stderr
+++ b/tests/ui/traits/test-2.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/test-2.rs:9:8
    |
 LL |     10.dup::<i32>();
@@ -6,13 +6,13 @@ LL |     10.dup::<i32>();
    |        |
    |        expected 0 generic arguments
    |
-note: associated function defined here, with 0 generic parameters
+note: method defined here, with 0 generic parameters
   --> $DIR/test-2.rs:4:16
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |                ^^^
 
-error[E0107]: this associated function takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: this method takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/test-2.rs:11:8
    |
 LL |     10.blah::<i32, i32>();
@@ -20,7 +20,7 @@ LL |     10.blah::<i32, i32>();
    |        |
    |        expected 1 generic argument
    |
-note: associated function defined here, with 1 generic parameter: `X`
+note: method defined here, with 1 generic parameter: `X`
   --> $DIR/test-2.rs:4:39
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }

--- a/tests/ui/tuple/wrong_argument_ice-3.stderr
+++ b/tests/ui/tuple/wrong_argument_ice-3.stderr
@@ -11,7 +11,7 @@ LL |         groups.push(new_group, vec![process]);
    |                     ^^^^^^^^^
    = note: expected tuple `(Vec<String>, Vec<Process>)`
              found struct `Vec<String>`
-note: associated function defined here
+note: method defined here
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 help: remove the extra argument
    |

--- a/tests/ui/tuple/wrong_argument_ice.stderr
+++ b/tests/ui/tuple/wrong_argument_ice.stderr
@@ -4,7 +4,7 @@ error[E0061]: method takes 1 argument but 2 arguments were supplied
 LL |         self.acc.push_back(self.current_provides, self.current_requires);
    |                  ^^^^^^^^^
    |
-note: associated function defined here
+note: method defined here
   --> $SRC_DIR/alloc/src/collections/vec_deque/mod.rs:LL:COL
 help: wrap these arguments in parentheses to construct a tuple
    |

--- a/tests/ui/type-inference/sort_by_key.stderr
+++ b/tests/ui/type-inference/sort_by_key.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/sort_by_key.rs:3:40
    |
 LL |     lst.sort_by_key(|&(v, _)| v.iter().sum());
-   |                                        ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
+   |                                        ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
    |
 help: consider specifying the generic argument
    |

--- a/tests/ui/type/type-check/point-at-inference-3.fixed
+++ b/tests/ui/type/type-check/point-at-inference-3.fixed
@@ -7,6 +7,6 @@ fn main() {
     v.push(1i32); //~ ERROR mismatched types
     //~^ NOTE expected `i32`, found `u32`
     //~| NOTE arguments to this method are incorrect
-    //~| NOTE associated function defined here
+    //~| NOTE method defined here
     //~| HELP change the type of the numeric literal from `u32` to `i32`
 }

--- a/tests/ui/type/type-check/point-at-inference-3.rs
+++ b/tests/ui/type/type-check/point-at-inference-3.rs
@@ -7,6 +7,6 @@ fn main() {
     v.push(1u32); //~ ERROR mismatched types
     //~^ NOTE expected `i32`, found `u32`
     //~| NOTE arguments to this method are incorrect
-    //~| NOTE associated function defined here
+    //~| NOTE method defined here
     //~| HELP change the type of the numeric literal from `u32` to `i32`
 }

--- a/tests/ui/type/type-check/point-at-inference-3.stderr
+++ b/tests/ui/type/type-check/point-at-inference-3.stderr
@@ -9,7 +9,7 @@ LL |     v.push(1u32);
    |       |
    |       arguments to this method are incorrect
    |
-note: associated function defined here
+note: method defined here
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 help: change the type of the numeric literal from `u32` to `i32`
    |

--- a/tests/ui/type/type-check/point-at-inference-4.rs
+++ b/tests/ui/type/type-check/point-at-inference-4.rs
@@ -2,7 +2,7 @@ struct S<A, B>(Option<(A, B)>);
 
 impl<A, B> S<A, B> {
     fn infer(&self, a: A, b: B) {}
-    //~^ NOTE associated function defined here
+    //~^ NOTE method defined here
     //~| NOTE
     //~| NOTE
 }

--- a/tests/ui/type/type-check/point-at-inference-4.stderr
+++ b/tests/ui/type/type-check/point-at-inference-4.stderr
@@ -4,7 +4,7 @@ error[E0061]: this method takes 2 arguments but 1 argument was supplied
 LL |     s.infer(0i32);
    |       ^^^^^------ an argument is missing
    |
-note: associated function defined here
+note: method defined here
   --> $DIR/point-at-inference-4.rs:4:8
    |
 LL |     fn infer(&self, a: A, b: B) {}

--- a/tests/ui/type/wrong-call-return-type-due-to-generic-arg.stderr
+++ b/tests/ui/type/wrong-call-return-type-due-to-generic-arg.stderr
@@ -95,7 +95,7 @@ LL |     let x: u16 = (S {}).method(0u32);
    |                  ^^^^^^^^^^^^^^----^
    |                                |
    |                                this argument influences the return type of `method`
-note: associated function defined here
+note: method defined here
   --> $DIR/wrong-call-return-type-due-to-generic-arg.rs:7:8
    |
 LL |     fn method<T>(&self, x: T) -> T {

--- a/tests/ui/typeck/bad-type-in-vec-push.stderr
+++ b/tests/ui/typeck/bad-type-in-vec-push.stderr
@@ -10,7 +10,7 @@ LL |     result.push(vector);
    |
    = note: expected type `{integer}`
             found struct `Vec<_>`
-note: associated function defined here
+note: method defined here
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error[E0308]: mismatched types
@@ -21,7 +21,7 @@ LL |     x.push("");
    |       |
    |       arguments to this method are incorrect
    |
-note: associated function defined here
+note: method defined here
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error: aborting due to 2 previous errors

--- a/tests/ui/typeck/issue-84768.stderr
+++ b/tests/ui/typeck/issue-84768.stderr
@@ -21,7 +21,7 @@ LL |     <F as FnOnce(&mut u8)>::call_once(f, 1)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^
    |                                          |
    |                                          this argument influences the return type of `FnOnce`
-note: associated function defined here
+note: method defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: aborting due to 2 previous errors

--- a/tests/ui/ufcs/ufcs-qpath-missing-params.rs
+++ b/tests/ui/ufcs/ufcs-qpath-missing-params.rs
@@ -15,6 +15,6 @@ fn main() {
       //~^ ERROR missing generics for
 
     <String as IntoCow>::into_cow::<str>("foo".to_string());
-    //~^ ERROR this associated function takes 0 generic arguments but 1
+    //~^ ERROR this method takes 0 generic arguments but 1
     //~| ERROR missing generics for
 }

--- a/tests/ui/ufcs/ufcs-qpath-missing-params.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-missing-params.stderr
@@ -30,7 +30,7 @@ help: add missing generic argument
 LL |     <String as IntoCow<B>>::into_cow::<str>("foo".to_string());
    |                       +++
 
-error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/ufcs-qpath-missing-params.rs:17:26
    |
 LL |     <String as IntoCow>::into_cow::<str>("foo".to_string());
@@ -38,7 +38,7 @@ LL |     <String as IntoCow>::into_cow::<str>("foo".to_string());
    |                          |
    |                          expected 0 generic arguments
    |
-note: associated function defined here, with 0 generic parameters
+note: method defined here, with 0 generic parameters
   --> $DIR/ufcs-qpath-missing-params.rs:4:8
    |
 LL |     fn into_cow(self) -> Cow<'a, B>;

--- a/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -28,7 +28,7 @@ LL |     <i32 as Add<i32>>::add(1u32, 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^----^^^^
    |                            |
    |                            this argument influences the return type of `Add`
-note: associated function defined here
+note: method defined here
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 help: change the type of the numeric literal from `u32` to `i32`
    |
@@ -50,7 +50,7 @@ LL |     <i32 as Add<i32>>::add(1, 2u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^----^
    |                               |
    |                               this argument influences the return type of `Add`
-note: associated function defined here
+note: method defined here
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 help: change the type of the numeric literal from `u32` to `i32`
    |

--- a/tests/ui/xc-private-method2.rs
+++ b/tests/ui/xc-private-method2.rs
@@ -4,8 +4,8 @@ extern crate xc_private_method_lib;
 
 fn main() {
     let _ = xc_private_method_lib::Struct{ x: 10 }.meth_struct();
-    //~^ ERROR associated function `meth_struct` is private
+    //~^ ERROR method `meth_struct` is private
 
     let _ = xc_private_method_lib::Enum::Variant1(20).meth_enum();
-    //~^ ERROR associated function `meth_enum` is private
+    //~^ ERROR method `meth_enum` is private
 }

--- a/tests/ui/xc-private-method2.stderr
+++ b/tests/ui/xc-private-method2.stderr
@@ -1,24 +1,24 @@
-error[E0624]: associated function `meth_struct` is private
+error[E0624]: method `meth_struct` is private
   --> $DIR/xc-private-method2.rs:6:52
    |
 LL |     let _ = xc_private_method_lib::Struct{ x: 10 }.meth_struct();
-   |                                                    ^^^^^^^^^^^ private associated function
+   |                                                    ^^^^^^^^^^^ private method
    |
   ::: $DIR/auxiliary/xc-private-method-lib.rs:12:5
    |
 LL |     fn meth_struct(&self) -> isize {
-   |     ------------------------------ private associated function defined here
+   |     ------------------------------ private method defined here
 
-error[E0624]: associated function `meth_enum` is private
+error[E0624]: method `meth_enum` is private
   --> $DIR/xc-private-method2.rs:9:55
    |
 LL |     let _ = xc_private_method_lib::Enum::Variant1(20).meth_enum();
-   |                                                       ^^^^^^^^^ private associated function
+   |                                                       ^^^^^^^^^ private method
    |
   ::: $DIR/auxiliary/xc-private-method-lib.rs:27:5
    |
 LL |     fn meth_enum(&self) -> isize {
-   |     ---------------------------- private associated function defined here
+   |     ---------------------------- private method defined here
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Discussed in https://rust-lang.zulipchat.com/#narrow/stream/147480-t-compiler.2Fwg-diagnostics/topic/.22associated.20function.22.20vs.20.22method.22/near/329265515

This commit also changes the tooltips on rustdoc intra-doc links targeting methods.

For anyone not sure why this is being done, see the Reference definitions of these terms in <https://doc.rust-lang.org/1.67.1/reference/items/associated-items.html#methods>

> Associated functions whose first parameter is named `self` are called methods and may be invoked using the [method call operator](https://doc.rust-lang.org/1.67.1/reference/expressions/method-call-expr.html), for example, `x.foo()`, as well as the usual function call notation.

In particular, while this means it's technically correct for rustc to refer to a method as an associated function (and there are a few cases where it'll still do so), rustc *must never* use the term "method" to refer to an associated function that does not have a `self` parameter.