### PR TITLE
Make borrow check results available to Clippy

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1366,7 +1366,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
 
     // Evaluate whether `sup_region: sub_region`.
     #[instrument(skip(self), level = "debug", ret)]
-    fn eval_outlives(&self, sup_region: RegionVid, sub_region: RegionVid) -> bool {
+    pub fn eval_outlives(&self, sup_region: RegionVid, sub_region: RegionVid) -> bool {
         debug!(
             "sup_region's value = {:?} universal={:?}",
             self.region_value_str(sup_region),

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -190,9 +190,9 @@ impl LintStore {
     pub fn register_late_pass(
         &mut self,
         pass: impl for<'tcx> Fn(TyCtxt<'tcx>) -> LateLintPassObject<'tcx>
-        + 'static
-        + sync::DynSend
-        + sync::DynSync,
+            + 'static
+            + sync::DynSend
+            + sync::DynSync,
     ) {
         self.late_passes.push(Box::new(pass));
     }
@@ -200,9 +200,9 @@ impl LintStore {
     pub fn register_late_mod_pass(
         &mut self,
         pass: impl for<'tcx> Fn(TyCtxt<'tcx>) -> LateLintPassObject<'tcx>
-        + 'static
-        + sync::DynSend
-        + sync::DynSync,
+            + 'static
+            + sync::DynSend
+            + sync::DynSync,
     ) {
         self.late_module_passes.push(Box::new(pass));
     }
@@ -533,6 +533,7 @@ impl LintStore {
 }
 
 /// Context for lint checking outside of type inference.
+#[derive(Clone)]
 pub struct LateContext<'tcx> {
     /// Type context we're checking in.
     pub tcx: TyCtxt<'tcx>,
@@ -1145,6 +1146,20 @@ impl LintContext for EarlyContext<'_> {
 }
 
 impl<'tcx> LateContext<'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>, enclosing_body: Option<hir::BodyId>) -> Self {
+        Self {
+            tcx,
+            enclosing_body,
+            cached_typeck_results: Cell::new(None),
+            param_env: ty::ParamEnv::empty(),
+            effective_visibilities: &tcx.effective_visibilities(()),
+            lint_store: crate::unerased_lint_store(tcx),
+            last_node_with_lint_attrs: hir::CRATE_HIR_ID,
+            generics: None,
+            only_module: false,
+        }
+    }
+
     /// Gets the type-checking results for the current body,
     /// or `None` if outside a body.
     pub fn maybe_typeck_results(&self) -> Option<&'tcx ty::TypeckResults<'tcx>> {

--- a/compiler/rustc_lint/src/late.rs
+++ b/compiler/rustc_lint/src/late.rs
@@ -43,8 +43,8 @@ macro_rules! lint_callback { ($cx:expr, $f:ident, $($args:expr),*) => ({
 /// Implements the AST traversal for late lint passes. `T` provides the
 /// `check_*` methods.
 pub struct LateContextAndPass<'tcx, T: LateLintPass<'tcx>> {
-    context: LateContext<'tcx>,
-    pass: T,
+    pub context: LateContext<'tcx>,
+    pub pass: T,
 }
 
 impl<'tcx, T: LateLintPass<'tcx>> LateContextAndPass<'tcx, T> {

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -126,7 +126,7 @@ pub use builtin::SoftLints;
 pub use context::{CheckLintNameResult, FindLintError, LintStore};
 pub use context::{EarlyContext, LateContext, LintContext};
 pub use early::{check_ast_node, EarlyCheckNode};
-pub use late::{check_crate, unerased_lint_store};
+pub use late::{check_crate, unerased_lint_store, LateContextAndPass};
 pub use passes::{EarlyLintPass, LateLintPass};
 pub use rustc_session::lint::Level::{self, *};
 pub use rustc_session::lint::{BufferedEarlyLint, FutureIncompatibleInfo, Lint, LintId};


### PR DESCRIPTION
These changes allow Clippy to reconstruct the MIR on which the borrow checker is run, so that Clippy can reproduce its results.

Most of the changes are about making functions public. A notable exception is the addition of the `NllCtxt` structure. The purpose of this struct is to make it easier to call `nll::compute_regions`. IMHO, the introduction of this struct also untangles the code a bit (i.e., helps to expose what depends on what), as an additional benefit.

For context, Clippy now uses a MIR visitor called `PossibleBorrowers`. Intuitively, this visitor produces an approximation of the compiler's borrower check results. But its imprecision can lead to false negatives in certain circumstances (see https://github.com/rust-lang/rust-clippy/pull/9386#issuecomment-1271479113, for example). My previous attempt to make `PossibleBorrowers` more precise did not end well: it had bad worst case complexity, which was [exposed by some in-the-wild programs](https://github.com/rust-lang/rust-clippy/issues/10134).

The reviewer (@Jarcho) and I have discussed ways of improving `PossibleBorrowers`. But one could argue that the "right" approach is to use "ground truth" rather than an approximation, "ground truth" being the results of the compiler's borrow check analysis.

You can see how these changes will be used in https://github.com/rust-lang/rust-clippy/pull/10173. Relevant discussion starts at https://github.com/rust-lang/rust-clippy/pull/10173#issuecomment-1418319870.