### PR TITLE
Make stream_len more atomic

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -795,6 +795,11 @@ impl Seek for File {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         self.inner.seek(pos)
     }
+
+    fn stream_len(&mut self) -> io::Result<u64> {
+        let file_attr = self.inner.file_attr()?;
+        Ok(file_attr.size())
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Read for &File {
@@ -850,6 +855,10 @@ impl Write for &File {
 impl Seek for &File {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         self.inner.seek(pos)
+    }
+    fn stream_len(&mut self) -> io::Result<u64> {
+        let file_attr = self.inner.file_attr()?;
+        Ok(file_attr.size())
     }
 }
 

--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -489,6 +489,10 @@ impl<R: Seek> Seek for BufReader<R> {
             )
         })
     }
+
+    fn stream_len(&mut self) -> io::Result<u64> {
+        self.inner.stream_len()
+    }
 }
 
 impl<T> SizeHint for BufReader<T> {

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -661,6 +661,10 @@ impl<W: Write + Seek> Seek for BufWriter<W> {
         self.flush_buf()?;
         self.get_mut().seek(pos)
     }
+
+    fn stream_len(&mut self) -> io::Result<u64> {
+        self.inner.stream_len()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -93,6 +93,11 @@ impl<S: Seek + ?Sized> Seek for &mut S {
     fn stream_position(&mut self) -> io::Result<u64> {
         (**self).stream_position()
     }
+
+    #[inline]
+    fn stream_len(&mut self) -> io::Result<u64> {
+        (**self).stream_len()
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<B: BufRead + ?Sized> BufRead for &mut B {
@@ -196,6 +201,11 @@ impl<S: Seek + ?Sized> Seek for Box<S> {
     #[inline]
     fn stream_position(&mut self) -> io::Result<u64> {
         (**self).stream_position()
+    }
+
+    #[inline]
+    fn stream_len(&mut self) -> io::Result<u64> {
+        (**self).stream_len()
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
This makes stream_len atomic for File in an attempt to resolve the [concerns](https://github.com/rust-lang/rust/pull/70904#issuecomment-635280410) brought up during the last stabilization attempt from which `stream_len` was ultimately removed.

This gives us atomic `stream_len` for all of the `Seek` implementations in std (or makes us use atomic `stream_len` if the underlying construct has such an atomic `stream_len`):

* `Empty` → already returns `Ok(0)` since f1cd17961ccaac4bfaeeab81969cf36c56eec4a5
* `Cursor<impl Read>` → already uses atomic operation since c518f2dd7040eca7591d3cacffe3646d8f54ac7c
* `File`/`&File` → now uses atomic operation with this PR
* `Box<impl Seek>` → now uses inner `stream_len`
* `&mut impl Seek` → now uses inner `stream_len`
* `BufReader<impl Seek>` → now uses inner `stream_len`
* `BufWriter<impl Seek>` → now uses inner `stream_len`

The only non-atomic implementation remaining is the one on the trait itself, which is unfortunate, but I'm not sure if the alternatives to that are better or not.

cc @sfackler @LukasKalbertodt 