### PR TITLE
Fix cross-compiling with dlltool for raw-dylib

### DIFF
--- a/src/ci/docker/host-x86_64/i686-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/i686-gnu/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   zlib1g-dev \
   lib32z1-dev \
   xz-utils \
+  mingw-w64 \
   && rm -rf /var/lib/apt/lists/*
 
 

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-14-stage1/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-14-stage1/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   zlib1g-dev \
   xz-utils \
   nodejs \
+  mingw-w64 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-14/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-14/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   zlib1g-dev \
   xz-utils \
   nodejs \
+  mingw-w64 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install powershell (universal package) so we can test x.ps1 on Linux

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-15/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-15/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   zlib1g-dev \
   xz-utils \
   nodejs \
+  mingw-w64 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install powershell (universal package) so we can test x.ps1 on Linux

--- a/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   pkg-config \
   xz-utils \
+  mingw-w64 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/sccache.sh /scripts/

--- a/tests/run-make/raw-dylib-cross-compilation/Makefile
+++ b/tests/run-make/raw-dylib-cross-compilation/Makefile
@@ -1,0 +1,22 @@
+# Tests that raw-dylib cross compilation works correctly
+
+# only-gnu
+# needs-i686-dlltool
+# needs-x86_64-dlltool
+
+# i686 dlltool.exe can't product x64 binaries.
+# ignore-i686-pc-windows-gnu
+
+include ../../run-make-fulldeps/tools.mk
+
+all:
+	# Build as x86 and make sure that we have x86 objects only.
+	$(RUSTC) --crate-type lib --crate-name i686_raw_dylib_test --target i686-pc-windows-gnu lib.rs
+	"$(LLVM_BIN_DIR)"/llvm-objdump -a $(TMPDIR)/libi686_raw_dylib_test.rlib > $(TMPDIR)/i686.objdump.txt
+	$(CGREP) "file format coff-i386" < $(TMPDIR)/i686.objdump.txt
+	$(CGREP) -v "file format coff-x86-64" < $(TMPDIR)/i686.objdump.txt
+	# Build as x64 and make sure that we have x64 objects only.
+	$(RUSTC) --crate-type lib --crate-name x64_raw_dylib_test --target x86_64-pc-windows-gnu lib.rs
+	"$(LLVM_BIN_DIR)"/llvm-objdump -a $(TMPDIR)/libx64_raw_dylib_test.rlib > $(TMPDIR)/x64.objdump.txt
+	$(CGREP) "file format coff-x86-64" < $(TMPDIR)/x64.objdump.txt
+	$(CGREP) -v "file format coff-i386" < $(TMPDIR)/x64.objdump.txt

--- a/tests/run-make/raw-dylib-cross-compilation/lib.rs
+++ b/tests/run-make/raw-dylib-cross-compilation/lib.rs
@@ -1,0 +1,20 @@
+#![feature(raw_dylib)]
+#![feature(no_core, lang_items)]
+#![no_std]
+#![no_core]
+#![crate_type = "lib"]
+
+// This is needed because of #![no_core]:
+#[lang = "sized"]
+trait Sized {}
+
+#[link(name = "extern_1", kind = "raw-dylib")]
+extern {
+    fn extern_fn();
+}
+
+pub fn extern_fn_caller() {
+    unsafe {
+        extern_fn();
+    }
+}


### PR DESCRIPTION
Fix for #103939

Issue Details:
When attempting to cross-compile using the `raw-dylib` feature and the GNU toolchain, rustc would attempt to find a cross-compiling version of dlltool (e.g., `i686-w64-mingw32-dlltool`). The has two issues 1) on Windows dlltool is always `dlltool` (no cross-compiling named versions exist) and 2) it only supported compiling to i686 and x86_64 resulting in ARM 32 and 64 compiling as x86_64.

Fix Details:
* On Windows always use the normal `dlltool` binary.
* Add the ARM64 cross-compiling dlltool name (support for this is coming: https://sourceware.org/bugzilla/show_bug.cgi?id=29964)
* Provide the `-m` argument to dlltool to indicate the target machine type.

(This is the first of two PRs to fix the remaining issues for the `raw-dylib` feature (#58713) that is blocking stabilization (#104218))