### PR TITLE
Add git config command to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
+# Use `git config blame.ignorerevsfile .git-blame-ignore-revs` to make `git blame` ignore the following commits.
+
 # format the world
 a06baa56b95674fc626b3c3fd680d6a65357fe60
 # format libcore


### PR DESCRIPTION
I always have to look at the git blame for that file to find the git command in the commit message (luckily that commit isn't in the file :D), putting it directly in the file makes it easier to find. Maybe we should mention the config in some other place as well.