### PR TITLE
Add RUSTC_EMIT option to pass on --emit to crates during bootstrap

### DIFF
--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   from the default rust toolchain. [#78513](https://github.com/rust-lang/rust/pull/78513)
 - Add options for enabling overflow checks, one for std (`overflow-checks-std`) and one for everything else (`overflow-checks`). Both default to false.
 - Add llvm option `enable-warnings` to have control on llvm compilation warnings. Default to false.
+- Add a `RUSTC_EMIT` environment variable which passes on `--emit` to `rustc`. [#108365](https://github.com/rust-lang/rust/pull/108365)
 
 
 ## [Version 2] - 2020-09-25

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1183,6 +1183,11 @@ impl<'a> Builder<'a> {
         let mut cargo = self.bare_cargo(compiler, mode, target, cmd);
         let out_dir = self.stage_out(compiler, mode);
 
+        cargo.env(
+            "RUSTC_EMIT_DIR",
+            self.out.join(target.triple).join("emit").join(out_dir.file_name().unwrap()),
+        );
+
         // Codegen backends are not yet tracked by -Zbinary-dep-depinfo,
         // so we need to explicitly clear out if they've been updated.
         for backend in self.codegen_backends(compiler) {


### PR DESCRIPTION
This makes it a bit more convenient to inspect the generated code of `rustc` crates. I also have an upstream patch to add demangling  support to `llvm-reduce` which pairs well with this to make the LLVM IR output more readable.