### PR TITLE
std: time: Avoid to use "was created" in elapsed() description

### DIFF
--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -352,7 +352,7 @@ impl Instant {
         self.checked_duration_since(earlier).unwrap_or_default()
     }
 
-    /// Returns the amount of time elapsed since this instant was created.
+    /// Returns the amount of time elapsed since this instant.
     ///
     /// # Panics
     ///
@@ -525,8 +525,8 @@ impl SystemTime {
         self.0.sub_time(&earlier.0).map_err(SystemTimeError)
     }
 
-    /// Returns the difference between the clock time when this
-    /// system time was created, and the current clock time.
+    /// Returns the difference from this system time to the
+    /// current clock time.
     ///
     /// This function may fail as the underlying system clock is susceptible to
     /// drift and updates (e.g., the system clock could go backwards), so this


### PR DESCRIPTION
".. since this instant was created" is inaccurate and misleading, consider the following case:
```rust
	let i1 = Instant::now(); // i1 is created at T1
	let i2 = i1 + Duration::from_nanos(0); // i2 is "created" at T2
	i2.elapsed(); // at T3
```
Per the current description, `elapsed()` at T3 should return T3 - T2?

To avoid the inaccuracy, removes the "was created" in the description of {Instant,SystemTime}::elapsed().
And since these types represent times, it's OK to use prepostions with them, e.g. "since this instant".