### PR TITLE
When encountering `&SmallImplCopy < &SmallImplCopy`, suggest copying

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -894,7 +894,7 @@ impl PartialEq for Nonterminal {
     fn eq(&self, rhs: &Self) -> bool {
         match (self, rhs) {
             (NtIdent(ident_lhs, is_raw_lhs), NtIdent(ident_rhs, is_raw_rhs)) => {
-                ident_lhs == ident_rhs && is_raw_lhs == is_raw_rhs
+                ident_lhs == ident_rhs && *is_raw_lhs == *is_raw_rhs
             }
             (NtLifetime(ident_lhs), NtLifetime(ident_rhs)) => ident_lhs == ident_rhs,
             // FIXME: Assume that all "complex" nonterminal are not equal, we can't compare them

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -65,7 +65,7 @@ impl TokenTree {
         match (self, other) {
             (TokenTree::Token(token, _), TokenTree::Token(token2, _)) => token.kind == token2.kind,
             (TokenTree::Delimited(_, delim, tts), TokenTree::Delimited(_, delim2, tts2)) => {
-                delim == delim2 && tts.eq_unspanned(tts2)
+                *delim == *delim2 && tts.eq_unspanned(tts2)
             }
             _ => false,
         }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -617,7 +617,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         self.impl_trait_defs = current_impl_trait_defs;
         self.impl_trait_bounds = current_impl_trait_bounds;
 
-        debug_assert!(!self.children.iter().any(|(id, _)| id == &def_id));
+        debug_assert!(!self.children.iter().any(|(id, _)| *id == def_id));
         self.children.push((def_id, hir::MaybeOwner::Owner(info)));
     }
 

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -688,8 +688,9 @@ fn check_incompatible_features(sess: &Session) {
         .iter()
         .filter(|&&(f1, f2)| features.enabled(f1) && features.enabled(f2))
     {
-        if let Some((f1_name, f1_span)) = declared_features.clone().find(|(name, _)| name == f1) {
-            if let Some((f2_name, f2_span)) = declared_features.clone().find(|(name, _)| name == f2)
+        if let Some((f1_name, f1_span)) = declared_features.clone().find(|(name, _)| *name == *f1) {
+            if let Some((f2_name, f2_span)) =
+                declared_features.clone().find(|(name, _)| *name == *f2)
             {
                 let spans = vec![f1_span, f2_span];
                 sess.struct_span_err(

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2825,7 +2825,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 let mut arguments = Vec::new();
                 for (index, argument) in sig.inputs().skip_binder().iter().enumerate() {
                     if let ty::Ref(argument_region, _, _) = argument.kind() {
-                        if argument_region == return_region {
+                        if *argument_region == *return_region {
                             // Need to use the `rustc_middle::ty` types to compare against the
                             // `return_region`. Then use the `rustc_hir` type to get only
                             // the lifetime span.

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -694,7 +694,7 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
             let cgus: Vec<_> = cgu_reuse
                 .iter()
                 .enumerate()
-                .filter(|&(_, reuse)| reuse == &CguReuse::No)
+                .filter(|&(_, reuse)| *reuse == CguReuse::No)
                 .take(tcx.sess.threads())
                 .collect();
 

--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -258,15 +258,15 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             (PassMode::Pair(a1, b1), PassMode::Pair(a2, b2)) => {
                 arg_attr_compat(a1, a2) && arg_attr_compat(b1, b2)
             }
-            (PassMode::Cast(c1, pad1), PassMode::Cast(c2, pad2)) => c1 == c2 && pad1 == pad2,
+            (PassMode::Cast(c1, pad1), PassMode::Cast(c2, pad2)) => c1 == c2 && *pad1 == *pad2,
             (
                 PassMode::Indirect { attrs: a1, extra_attrs: None, on_stack: s1 },
                 PassMode::Indirect { attrs: a2, extra_attrs: None, on_stack: s2 },
-            ) => arg_attr_compat(a1, a2) && s1 == s2,
+            ) => arg_attr_compat(a1, a2) && *s1 == *s2,
             (
                 PassMode::Indirect { attrs: a1, extra_attrs: Some(e1), on_stack: s1 },
                 PassMode::Indirect { attrs: a2, extra_attrs: Some(e2), on_stack: s2 },
-            ) => arg_attr_compat(a1, a2) && arg_attr_compat(e1, e2) && s1 == s2,
+            ) => arg_attr_compat(a1, a2) && arg_attr_compat(e1, e2) && *s1 == *s2,
             _ => false,
         };
 

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -351,7 +351,7 @@ pub trait Emitter: Translate {
             if let Some((macro_kind, name)) = has_macro_spans.first() {
                 // Mark the actual macro this originates from
                 let and_then = if let Some((macro_kind, last_name)) = has_macro_spans.last()
-                    && last_name != name
+                    && *last_name != *name
                 {
                     let descr = macro_kind.descr();
                     format!(
@@ -2753,7 +2753,7 @@ pub fn is_case_difference(sm: &SourceMap, suggested: &str, sp: Span) -> bool {
     let ascii_confusables = &['c', 'f', 'i', 'k', 'o', 's', 'u', 'v', 'w', 'x', 'y', 'z'];
     // All the chars that differ in capitalization are confusable (above):
     let confusable = iter::zip(found.chars(), suggested.chars())
-        .filter(|(f, s)| f != s)
+        .filter(|(f, s)| *f != *s)
         .all(|(f, s)| (ascii_confusables.contains(&f) || ascii_confusables.contains(&s)));
     confusable && found.to_lowercase() == suggested.to_lowercase()
             // FIXME: We sometimes suggest the same thing we already have, which is a

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -123,7 +123,7 @@ pub(super) fn transcribe<'a>(
             if let Frame::Sequence { idx, sep, .. } = stack.last_mut().unwrap() {
                 let (repeat_idx, repeat_len) = repeats.last_mut().unwrap();
                 *repeat_idx += 1;
-                if repeat_idx < repeat_len {
+                if *repeat_idx < *repeat_len {
                     *idx = 0;
                     if let Some(sep) = sep {
                         result.push(TokenTree::Token(sep.clone(), Spacing::Alone));

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -579,7 +579,7 @@ fn gather_gat_bounds<'tcx, T: TypeFoldable<TyCtxt<'tcx>>>(
         for (region_b, region_b_idx) in &regions {
             // Again, skip `'static` because it outlives everything. Also, we trivially
             // know that a region outlives itself.
-            if ty::ReStatic == **region_b || region_a == region_b {
+            if ty::ReStatic == **region_b || *region_a == *region_b {
                 continue;
             }
             if region_known_to_outlive(

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -2092,7 +2092,7 @@ impl<'a> State<'a> {
 
             match bound {
                 GenericBound::Trait(tref, modifier) => {
-                    if modifier == &TraitBoundModifier::Maybe {
+                    if *modifier == TraitBoundModifier::Maybe {
                         self.word("?");
                     }
                     self.print_poly_trait_ref(tref);

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -321,7 +321,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // Remove one layer of references to account for `&mut self` and
                 // `&self`, so that we can compare it against the binding.
                 let (ty, def_self_ty) = match (ty.kind(), def_self_ty.kind()) {
-                    (ty::Ref(_, ty, a), ty::Ref(_, self_ty, b)) if a == b => (*ty, *self_ty),
+                    (ty::Ref(_, ty, a), ty::Ref(_, self_ty, b)) if *a == *b => (*ty, *self_ty),
                     _ => (ty, def_self_ty),
                 };
                 let mut param_args = FxHashMap::default();

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1739,7 +1739,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.check_expr_has_type_or_error(base_expr, adt_ty, |_| {
                     let base_ty = self.typeck_results.borrow().expr_ty(*base_expr);
                     let same_adt = match (adt_ty.kind(), base_ty.kind()) {
-                        (ty::Adt(adt, _), ty::Adt(base_adt, _)) if adt == base_adt => true,
+                        (ty::Adt(adt, _), ty::Adt(base_adt, _)) if *adt == *base_adt => true,
                         _ => false,
                     };
                     if self.tcx.sess.is_nightly_build() && same_adt {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -815,7 +815,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 _ => None,
             })
             .map(|(ty, bounds)| match ty.kind() {
-                ty::Param(param_ty) if param_ty == expected_ty_as_param => Ok(Some(bounds)),
+                ty::Param(param_ty) if *param_ty == *expected_ty_as_param => Ok(Some(bounds)),
                 // check whether there is any predicate that contains our `T`, like `Option<T>: Send`
                 _ => match ty.contains(expected) {
                     true => Err(()),
@@ -848,7 +848,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let ty_param_used_in_fn_params = fn_parameters.iter().any(|param| {
                 let ty = self.astconv().ast_ty_to_ty( param);
-                matches!(ty.kind(), ty::Param(fn_param_ty_param) if expected_ty_as_param == fn_param_ty_param)
+                matches!(ty.kind(), ty::Param(fn_param_ty_param) if *expected_ty_as_param == *fn_param_ty_param)
             });
 
         if ty_param_used_in_fn_params {
@@ -1008,7 +1008,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> bool {
         let ty::Adt(adt_def, substs) = expr_ty.kind() else { return false; };
         let ty::Adt(expected_adt_def, expected_substs) = expected_ty.kind() else { return false; };
-        if adt_def != expected_adt_def {
+        if *adt_def != *expected_adt_def {
             return false;
         }
 

--- a/compiler/rustc_index/src/interval.rs
+++ b/compiler/rustc_index/src/interval.rs
@@ -223,7 +223,7 @@ impl<I: Idx> IntervalSet<I> {
     fn check_invariants(&self) -> bool {
         let mut current: Option<u32> = None;
         for (start, end) in &self.map {
-            if start > end || current.map_or(false, |x| x + 1 >= *start) {
+            if *start > *end || current.map_or(false, |x| x + 1 >= *start) {
                 return false;
             }
             current = Some(*end);

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1144,7 +1144,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     let remainder2: Vec<_> = sub2.types().skip(common_len).collect();
                     let common_default_params =
                         iter::zip(remainder1.iter().rev(), remainder2.iter().rev())
-                            .filter(|(a, b)| a == b)
+                            .filter(|(a, b)| **a == **b)
                             .count();
                     let len = sub1.len() - common_default_params;
                     let consts_offset = len - sub1.consts().count();
@@ -2028,7 +2028,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                                                 }),
                                                 ..
                                             } = s
-                                            && init_span == &self.span {
+                                            && *init_span == self.span {
                                                 self.result = Some(*array_ty);
                                             }
                                         }

--- a/compiler/rustc_infer/src/infer/error_reporting/suggest.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/suggest.rs
@@ -449,7 +449,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             (expected.kind(), found.kind())
         {
             if let ty::Adt(found_def, found_substs) = *found_ty.kind() {
-                if exp_def == &found_def {
+                if *exp_def == found_def {
                     let have_as_ref = &[
                         (
                             sym::Option,
@@ -581,7 +581,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             (
                 ty::Alias(ty::Opaque, ty::AliasTy { def_id: last_def_id, .. }),
                 ty::Alias(ty::Opaque, ty::AliasTy { def_id: exp_def_id, .. }),
-            ) if last_def_id == exp_def_id => StatementAsExpression::CorrectType,
+            ) if *last_def_id == *exp_def_id => StatementAsExpression::CorrectType,
             (
                 ty::Alias(ty::Opaque, ty::AliasTy { def_id: last_def_id, substs: last_bounds, .. }),
                 ty::Alias(ty::Opaque, ty::AliasTy { def_id: exp_def_id, substs: exp_bounds, .. }),
@@ -607,14 +607,14 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                                 hir::GenericBound::Trait(tl, ml),
                                 hir::GenericBound::Trait(tr, mr),
                             ) if tl.trait_ref.trait_def_id() == tr.trait_ref.trait_def_id()
-                                && ml == mr =>
+                                && *ml == *mr =>
                             {
                                 true
                             }
                             (
                                 hir::GenericBound::LangItemTrait(langl, _, _, argsl),
                                 hir::GenericBound::LangItemTrait(langr, _, _, argsr),
-                            ) if langl == langr => {
+                            ) if *langl == *langr => {
                                 // FIXME: consider the bounds!
                                 debug!("{:?} {:?}", argsl, argsr);
                                 true

--- a/compiler/rustc_lint/locales/en-US.ftl
+++ b/compiler/rustc_lint/locales/en-US.ftl
@@ -5,6 +5,11 @@ lint_array_into_iter =
     .use_explicit_into_iter_suggestion =
         or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value
 
+lint_ref_binop_on_copy_type =
+    binary operation on reference to `Copy` type `{$ty}`
+    .note = `{$ty}` takes `{$bytes}` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
+    .suggestion = dereferencing the expressions will allow the compiler to more consistently optimize these binary operations
+
 lint_enum_intrinsics_mem_discriminant =
     the return value of `mem::discriminant` is unspecified when called with a non-enum type
     .note = the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `{$ty_param}`, which is not an enum.

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -3335,7 +3335,7 @@ declare_lint! {
     /// smaller than a 64 bit pointer, we suggest dereferencing the value so the compiler will have
     /// a better chance of producing optimal instructions.
     REF_BINOP_ON_COPY_TYPE,
-    Warn,
+    Deny,
     "detects binary operations on references to `Copy` types like `&42 < &50`",
 }
 

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -3316,6 +3316,7 @@ declare_lint! {
     ///
     /// ```rust
     /// # #![allow(unused)]
+    /// #![warn(ref_binop_on_copy_type)]
     /// pub fn slice_of_ints(input: &[(usize, usize, usize, usize)]) -> usize {
     ///     input
     ///         .iter()
@@ -3335,7 +3336,7 @@ declare_lint! {
     /// smaller than a 64 bit pointer, we suggest dereferencing the value so the compiler will have
     /// a better chance of producing optimal instructions.
     REF_BINOP_ON_COPY_TYPE,
-    Deny,
+    Allow,
     "detects binary operations on references to `Copy` types like `&42 < &50`",
 }
 

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -204,6 +204,7 @@ late_lint_methods!(
             ImproperCTypesDefinitions: ImproperCTypesDefinitions,
             VariantSizeDifferences: VariantSizeDifferences,
             BoxPointers: BoxPointers,
+            RefBinopOnCopyType: RefBinopOnCopyType,
             PathStatements: PathStatements,
             LetUnderscore: LetUnderscore,
             // Depends on referenced function signatures in expressions

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -49,6 +49,36 @@ pub enum ArrayIntoIterDiagSub {
     },
 }
 
+#[derive(LintDiagnostic)]
+#[diag(lint_ref_binop_on_copy_type)]
+pub struct RefBinopOnCopyTypeDiag<'a> {
+    pub ty: String,
+    pub bytes: u64,
+    #[subdiagnostic]
+    pub suggestion: RefBinopOnCopyTypeSuggestion<'a>,
+    #[note]
+    pub note: Option<()>,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(lint_suggestion, applicability = "machine-applicable")]
+pub struct RefBinopOnCopyTypeSuggestion<'a> {
+    pub left_brace_start: &'a str,
+    pub left_brace_end: &'a str,
+    pub left_sugg: &'a str,
+    #[suggestion_part(code = "{left_sugg}{left_brace_start}")]
+    pub left_start: Span,
+    #[suggestion_part(code = "{left_brace_end}")]
+    pub left_end: Option<Span>,
+    pub right_brace_start: &'a str,
+    pub right_brace_end: &'a str,
+    pub right_sugg: &'a str,
+    #[suggestion_part(code = "{right_sugg}{right_brace_start}")]
+    pub right_start: Span,
+    #[suggestion_part(code = "{right_brace_end}")]
+    pub right_end: Option<Span>,
+}
+
 // builtin.rs
 #[derive(LintDiagnostic)]
 #[diag(lint_builtin_while_true)]

--- a/compiler/rustc_middle/src/middle/privacy.rs
+++ b/compiler/rustc_middle/src/middle/privacy.rs
@@ -121,7 +121,7 @@ impl EffectiveVisibilities {
                 for l in Level::all_levels() {
                     let vis_at_level = eff_vis.at_level(l);
                     let old_vis_at_level = old_eff_vis.at_level_mut(l);
-                    if vis_at_level != old_vis_at_level
+                    if *vis_at_level != *old_vis_at_level
                         && vis_at_level.is_at_least(*old_vis_at_level, tree)
                     {
                         *old_vis_at_level = *vis_at_level

--- a/compiler/rustc_middle/src/ty/closure.rs
+++ b/compiler/rustc_middle/src/ty/closure.rs
@@ -267,7 +267,7 @@ pub fn is_ancestor_or_same_capture(
         return false;
     }
 
-    proj_possible_ancestor.iter().zip(proj_capture).all(|(a, b)| a == b)
+    proj_possible_ancestor.iter().zip(proj_capture).all(|(a, b)| *a == *b)
 }
 
 /// Part of `MinCaptureInformationMap`; describes the capture kind (&, &mut, move)

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1941,7 +1941,7 @@ impl PartialEq for VariantDef {
 
         let Self { def_id: lhs_def_id, ctor: _, name: _, discr: _, fields: _, flags: _ } = &self;
         let Self { def_id: rhs_def_id, ctor: _, name: _, discr: _, fields: _, flags: _ } = other;
-        lhs_def_id == rhs_def_id
+        *lhs_def_id == *rhs_def_id
     }
 }
 
@@ -1996,7 +1996,7 @@ impl PartialEq for FieldDef {
 
         let Self { did: rhs_did, name: _, vis: _ } = other;
 
-        lhs_did == rhs_did
+        *lhs_did == *rhs_did
     }
 }
 

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -315,7 +315,7 @@ impl<'tcx> TyCtxt<'tcx> {
         loop {
             match (&a.kind(), &b.kind()) {
                 (&ty::Adt(a_def, a_substs), &ty::Adt(b_def, b_substs))
-                    if a_def == b_def && a_def.is_struct() =>
+                    if *a_def == *b_def && a_def.is_struct() =>
                 {
                     if let Some(f) = a_def.non_enum_variant().fields.last() {
                         a = f.ty(self, a_substs);

--- a/compiler/rustc_mir_build/src/build/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_place.rs
@@ -143,7 +143,7 @@ fn is_ancestor_or_same_capture(
         return false;
     }
 
-    iter::zip(proj_possible_ancestor, proj_capture).all(|(a, b)| a == b)
+    iter::zip(proj_possible_ancestor, proj_capture).all(|(a, b)| *a == *b)
 }
 
 /// Given a closure, returns the index of a capture within the desugared closure struct and the

--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -803,7 +803,7 @@ impl<'tcx> Constructor<'tcx> {
             (Missing { .. } | Wildcard, _) => false,
 
             (Single, Single) => true,
-            (Variant(self_id), Variant(other_id)) => self_id == other_id,
+            (Variant(self_id), Variant(other_id)) => *self_id == *other_id,
 
             (IntRange(self_range), IntRange(other_range)) => self_range.is_covered_by(other_range),
             (
@@ -817,7 +817,7 @@ impl<'tcx> Constructor<'tcx> {
                     (Some(to), Some(from)) => {
                         (from == Ordering::Greater || from == Ordering::Equal)
                             && (to == Ordering::Less
-                                || (other_end == self_end && to == Ordering::Equal))
+                                || (*other_end == *self_end && to == Ordering::Equal))
                     }
                     _ => false,
                 }
@@ -859,7 +859,7 @@ impl<'tcx> Constructor<'tcx> {
         match self {
             // If `self` is `Single`, `used_ctors` cannot contain anything else than `Single`s.
             Single => !used_ctors.is_empty(),
-            Variant(vid) => used_ctors.iter().any(|c| matches!(c, Variant(i) if i == vid)),
+            Variant(vid) => used_ctors.iter().any(|c| matches!(c, Variant(i) if *i == *vid)),
             IntRange(range) => used_ctors
                 .iter()
                 .filter_map(|c| c.as_int_range())

--- a/compiler/rustc_mir_transform/src/lower_slice_len.rs
+++ b/compiler/rustc_mir_transform/src/lower_slice_len.rs
@@ -65,7 +65,7 @@ fn lower_slice_len_call<'tcx>(
             let Some(arg) = args[0].place() else { return };
             let func_ty = func.ty(local_decls, tcx);
             match func_ty.kind() {
-                ty::FnDef(fn_def_id, _) if fn_def_id == &slice_len_fn_item_def_id => {
+                ty::FnDef(fn_def_id, _) if *fn_def_id == slice_len_fn_item_def_id => {
                     // perform modifications
                     // from something like `_5 = core::slice::<impl [u8]>::len(move _6) -> bb1`
                     // into `_5 = Len(*_6)

--- a/compiler/rustc_parse/src/lexer/tokentrees.rs
+++ b/compiler/rustc_parse/src/lexer/tokentrees.rs
@@ -153,7 +153,7 @@ impl<'a> TokenTreesReader<'a> {
                     };
                     for (brace, brace_span) in &self.diag_info.open_braces {
                         if same_identation_level(&sm, self.token.span, *brace_span)
-                            && brace == &close_delim
+                            && *brace == close_delim
                         {
                             // high likelihood of these two corresponding
                             candidate = Some(*brace_span);

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -414,7 +414,7 @@ impl<'a> Parser<'a> {
                 fn is_ident_eq_keyword(found: &TokenKind, expected: &TokenType) -> bool {
                     if let TokenKind::Ident(current_sym, _) = found {
                         if let TokenType::Keyword(suggested_sym) = expected {
-                            return current_sym == suggested_sym;
+                            return *current_sym == *suggested_sym;
                         }
                     }
                     false

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -207,7 +207,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             (ident.name, self.tcx.sess.source_map().guess_head_span(new_binding.span));
 
         if let Some(s) = self.name_already_seen.get(&name) {
-            if s == &span {
+            if *s == span {
                 return;
             }
         }

--- a/compiler/rustc_span/src/edit_distance.rs
+++ b/compiler/rustc_span/src/edit_distance.rs
@@ -37,14 +37,14 @@ pub fn edit_distance(a: &str, b: &str, limit: usize) -> Option<usize> {
 
     // Strip common prefix.
     while let Some(((b_char, b_rest), (a_char, a_rest))) = b.split_first().zip(a.split_first())
-        && a_char == b_char
+        && *a_char == *b_char
     {
         a = a_rest;
         b = b_rest;
     }
     // Strip common suffix.
     while let Some(((b_char, b_rest), (a_char, a_rest))) = b.split_last().zip(a.split_last())
-        && a_char == b_char
+        && *a_char == *b_char
     {
         a = a_rest;
         b = b_rest;

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1655,7 +1655,7 @@ impl SourceFile {
     /// number. If the source_file is empty or the position is located before the
     /// first line, `None` is returned.
     pub fn lookup_line(&self, pos: BytePos) -> Option<usize> {
-        self.lines(|lines| lines.partition_point(|x| x <= &pos).checked_sub(1))
+        self.lines(|lines| lines.partition_point(|x| *x <= pos).checked_sub(1))
     }
 
     pub fn line_bounds(&self, line_index: usize) -> Range<BytePos> {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1965,8 +1965,8 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             Some(CandidateSimilarity::Exact { ignoring_lifetimes })
         } else if cat_a == cat_b {
             match (a.kind(), b.kind()) {
-                (ty::Adt(def_a, _), ty::Adt(def_b, _)) => def_a == def_b,
-                (ty::Foreign(def_a), ty::Foreign(def_b)) => def_a == def_b,
+                (ty::Adt(def_a, _), ty::Adt(def_b, _)) => *def_a == *def_b,
+                (ty::Foreign(def_a), ty::Foreign(def_b)) => *def_a == *def_b,
                 // Matching on references results in a lot of unhelpful
                 // suggestions, so let's just not do that for now.
                 //
@@ -2849,14 +2849,14 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         if let ObligationCauseCode::BuiltinDerivedObligation(ref data) = cause_code {
             let parent_trait_ref = self.resolve_vars_if_possible(data.parent_trait_pred);
             let self_ty = parent_trait_ref.skip_binder().self_ty();
-            if obligated_types.iter().any(|ot| ot == &self_ty) {
+            if obligated_types.iter().any(|ot| *ot == self_ty) {
                 return true;
             }
             if let ty::Adt(def, substs) = self_ty.kind()
                 && let [arg] = &substs[..]
                 && let ty::subst::GenericArgKind::Type(ty) = arg.unpack()
                 && let ty::Adt(inner_def, _) = ty.kind()
-                && inner_def == def
+                && *inner_def == *def
             {
                 return true;
             }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2100,7 +2100,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 .find(|(other_idx, (pred, _))| match pred.kind().skip_binder() {
                     ty::PredicateKind::Clause(ty::Clause::Trait(trait_pred))
                         if self.tcx.is_fn_trait(trait_pred.def_id())
-                            && other_idx != idx
+                            && *other_idx != *idx
                             // Make sure that the self type matches
                             // (i.e. constraining this closure)
                             && expected_self

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1967,7 +1967,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             | (ObjectCandidate(i), ObjectCandidate(j)) => {
                 // Arbitrarily pick the lower numbered candidate for backwards
                 // compatibility reasons. Don't let this affect inference.
-                i < j && !needs_infer
+                *i < *j && !needs_infer
             }
             (ObjectCandidate(_), ProjectionCandidate(..))
             | (ProjectionCandidate(..), ObjectCandidate(_)) => {

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -951,7 +951,7 @@ pub(crate) fn required_region_bounds<'tcx>(
                     // it's kind of a moot point since you could never
                     // construct such an object, but this seems
                     // correct even if that code changes).
-                    if t == &erased_self_ty && !r.has_escaping_bound_vars() {
+                    if *t == erased_self_ty && !r.has_escaping_bound_vars() {
                         Some(*r)
                     } else {
                         None

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -1086,7 +1086,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ParamsSubstitutor<'tcx> {
 
     fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
         match *t.kind() {
-            ty::Param(param) => match self.list.iter().position(|r| r == &param) {
+            ty::Param(param) => match self.list.iter().position(|r| *r == param) {
                 Some(idx) => self.tcx.mk_placeholder(ty::PlaceholderType {
                     universe: ty::UniverseIndex::from_usize(0),
                     name: ty::BoundTyKind::Anon(idx as u32),

--- a/compiler/rustc_type_ir/src/sty.rs
+++ b/compiler/rustc_type_ir/src/sty.rs
@@ -315,9 +315,9 @@ impl<I: Interner> PartialEq for TyKind<I> {
         // but the data patterns in practice are such that a comparison
         // succeeds 99%+ of the time, and it's faster to omit it.
         match (self, other) {
-            (Int(a_i), Int(b_i)) => a_i == b_i,
-            (Uint(a_u), Uint(b_u)) => a_u == b_u,
-            (Float(a_f), Float(b_f)) => a_f == b_f,
+            (Int(a_i), Int(b_i)) => *a_i == *b_i,
+            (Uint(a_u), Uint(b_u)) => *a_u == *b_u,
+            (Float(a_f), Float(b_f)) => *a_f == *b_f,
             (Adt(a_d, a_s), Adt(b_d, b_s)) => a_d == b_d && a_s == b_s,
             (Foreign(a_d), Foreign(b_d)) => a_d == b_d,
             (Array(a_t, a_c), Array(b_t, b_c)) => a_t == b_t && a_c == b_c,
@@ -327,7 +327,7 @@ impl<I: Interner> PartialEq for TyKind<I> {
             (FnDef(a_d, a_s), FnDef(b_d, b_s)) => a_d == b_d && a_s == b_s,
             (FnPtr(a_s), FnPtr(b_s)) => a_s == b_s,
             (Dynamic(a_p, a_r, a_repr), Dynamic(b_p, b_r, b_repr)) => {
-                a_p == b_p && a_r == b_r && a_repr == b_repr
+                a_p == b_p && a_r == b_r && *a_repr == *b_repr
             }
             (Closure(a_d, a_s), Closure(b_d, b_s)) => a_d == b_d && a_s == b_s,
             (Generator(a_d, a_s, a_m), Generator(b_d, b_s, b_m)) => {
@@ -338,9 +338,9 @@ impl<I: Interner> PartialEq for TyKind<I> {
                 a_d == b_d && a_s == b_s
             }
             (Tuple(a_t), Tuple(b_t)) => a_t == b_t,
-            (Alias(a_i, a_p), Alias(b_i, b_p)) => a_i == b_i && a_p == b_p,
+            (Alias(a_i, a_p), Alias(b_i, b_p)) => *a_i == *b_i && *a_p == *b_p,
             (Param(a_p), Param(b_p)) => a_p == b_p,
-            (Bound(a_d, a_b), Bound(b_d, b_b)) => a_d == b_d && a_b == b_b,
+            (Bound(a_d, a_b), Bound(b_d, b_b)) => *a_d == *b_d && *a_b == *b_b,
             (Placeholder(a_p), Placeholder(b_p)) => a_p == b_p,
             (Infer(a_t), Infer(b_t)) => a_t == b_t,
             (Error(a_e), Error(b_e)) => a_e == b_e,
@@ -1014,7 +1014,7 @@ impl<I: Interner> PartialEq for RegionKind<I> {
         regionkind_discriminant(self) == regionkind_discriminant(other)
             && match (self, other) {
                 (ReEarlyBound(a_r), ReEarlyBound(b_r)) => a_r == b_r,
-                (ReLateBound(a_d, a_r), ReLateBound(b_d, b_r)) => a_d == b_d && a_r == b_r,
+                (ReLateBound(a_d, a_r), ReLateBound(b_d, b_r)) => *a_d == *b_d && *a_r == *b_r,
                 (ReFree(a_r), ReFree(b_r)) => a_r == b_r,
                 (ReStatic, ReStatic) => true,
                 (ReVar(a_r), ReVar(b_r)) => a_r == b_r,

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -535,7 +535,7 @@ impl CStr {
     pub const fn is_empty(&self) -> bool {
         // SAFETY: We know there is at least one byte; for empty strings it
         // is the NUL terminator.
-        (unsafe { self.inner.get_unchecked(0) }) == &0
+        *(unsafe { self.inner.get_unchecked(0) }) == 0
     }
 
     /// Converts this C string to a byte slice.

--- a/library/std/src/net/ip_addr.rs
+++ b/library/std/src/net/ip_addr.rs
@@ -1018,7 +1018,7 @@ impl PartialEq<Ipv4Addr> for IpAddr {
     #[inline]
     fn eq(&self, other: &Ipv4Addr) -> bool {
         match self {
-            IpAddr::V4(v4) => v4 == other,
+            IpAddr::V4(v4) => *v4 == *other,
             IpAddr::V6(_) => false,
         }
     }
@@ -1029,7 +1029,7 @@ impl PartialEq<IpAddr> for Ipv4Addr {
     #[inline]
     fn eq(&self, other: &IpAddr) -> bool {
         match other {
-            IpAddr::V4(v4) => self == v4,
+            IpAddr::V4(v4) => *self == *v4,
             IpAddr::V6(_) => false,
         }
     }
@@ -1875,7 +1875,7 @@ impl PartialEq<IpAddr> for Ipv6Addr {
     fn eq(&self, other: &IpAddr) -> bool {
         match other {
             IpAddr::V4(_) => false,
-            IpAddr::V6(v6) => self == v6,
+            IpAddr::V6(v6) => *self == *v6,
         }
     }
 }
@@ -1886,7 +1886,7 @@ impl PartialEq<Ipv6Addr> for IpAddr {
     fn eq(&self, other: &Ipv6Addr) -> bool {
         match self {
             IpAddr::V4(_) => false,
-            IpAddr::V6(v6) => v6 == other,
+            IpAddr::V6(v6) => *v6 == *other,
         }
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1388,14 +1388,14 @@ pub(crate) fn clean_middle_assoc_item<'tcx>(
                     && let Some(GenericParamDef {
                         kind: GenericParamDefKind::Type { bounds: param_bounds, .. },
                         ..
-                    }) = generics.params.iter_mut().find(|param| &param.name == arg)
+                    }) = generics.params.iter_mut().find(|param| param.name == *arg)
                     {
                         param_bounds.append(bounds);
                     } else if let WherePredicate::RegionPredicate { lifetime: Lifetime(arg), bounds } = &mut pred
                     && let Some(GenericParamDef {
                         kind: GenericParamDefKind::Lifetime { outlives: param_bounds },
                         ..
-                    }) = generics.params.iter_mut().find(|param| &param.name == arg) {
+                    }) = generics.params.iter_mut().find(|param| param.name == *arg) {
                         param_bounds.extend(bounds.drain(..).map(|bound| match bound {
                             GenericBound::Outlives(lifetime) => lifetime,
                             _ => unreachable!(),

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1483,12 +1483,12 @@ impl Type {
             (Type::Slice(a), Type::Slice(b)) => a.is_same(b, cache),
             (Type::Array(a, al), Type::Array(b, bl)) => al == bl && a.is_same(b, cache),
             (Type::RawPointer(mutability, type_), Type::RawPointer(b_mutability, b_type_)) => {
-                mutability == b_mutability && type_.is_same(b_type_, cache)
+                *mutability == *b_mutability && type_.is_same(b_type_, cache)
             }
             (
                 Type::BorrowedRef { mutability, type_, .. },
                 Type::BorrowedRef { mutability: b_mutability, type_: b_type_, .. },
-            ) => mutability == b_mutability && type_.is_same(b_type_, cache),
+            ) => *mutability == *b_mutability && type_.is_same(b_type_, cache),
             // Placeholders and generics are equal to all other types.
             (Type::Infer, _) | (_, Type::Infer) => true,
             (Type::Generic(_), _) | (_, Type::Generic(_)) => true,

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -744,7 +744,7 @@ pub(crate) fn href_relative_parts<'fqp>(
 ) -> Box<dyn Iterator<Item = Symbol> + 'fqp> {
     for (i, (f, r)) in fqp.iter().zip(relative_to_fqp.iter()).enumerate() {
         // e.g. linking to std::iter from std::vec (`dissimilar_part_count` will be 1)
-        if f != r {
+        if *f != *r {
             let dissimilar_part_count = relative_to_fqp.len() - i;
             let fqp_module = &fqp[i..fqp.len()];
             return Box::new(

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -228,7 +228,7 @@ impl<'tcx> Context<'tcx> {
         } else {
             if let Some(&(ref names, ty)) = self.cache().paths.get(&it.item_id.expect_def_id()) {
                 if self.current.len() + 1 != names.len()
-                    || self.current.iter().zip(names.iter()).any(|(a, b)| a != b)
+                    || self.current.iter().zip(names.iter()).any(|(a, b)| *a != *b)
                 {
                     // We checked that the redirection isn't pointing to the current file,
                     // preventing an infinite redirection loop in the generated

--- a/tests/mir-opt/slice_filter.rs
+++ b/tests/mir-opt/slice_filter.rs
@@ -1,3 +1,4 @@
+#![allow(ref_binop_on_copy_type)]
 fn main() {
     let input = vec![];
     let _variant_a_result = variant_a(&input);

--- a/tests/mir-opt/slice_filter.variant_a-{closure#0}.CopyProp.diff
+++ b/tests/mir-opt/slice_filter.variant_a-{closure#0}.CopyProp.diff
@@ -1,7 +1,7 @@
 - // MIR for `variant_a::{closure#0}` before CopyProp
 + // MIR for `variant_a::{closure#0}` after CopyProp
   
-  fn variant_a::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:8:25: 8:39], _2: &&(usize, usize, usize, usize)) -> bool {
+  fn variant_a::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:9:25: 9:39], _2: &&(usize, usize, usize, usize)) -> bool {
       let mut _0: bool;                    // return place in scope 0 at $DIR/slice_filter.rs:+0:40: +0:40
       let _3: &usize;                      // in scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
       let _4: &usize;                      // in scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
@@ -42,7 +42,7 @@
           debug b => _4;                   // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
           debug c => _5;                   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
           debug d => _6;                   // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
-          scope 2 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:40: 8:46
+          scope 2 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:9:40: 9:46
               debug self => _9;            // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
               debug other => _10;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _29: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -56,7 +56,7 @@
                   let mut _34: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
-          scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:60: 8:66
+          scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:9:60: 9:66
               debug self => _18;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
               debug other => _19;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _35: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -70,7 +70,7 @@
                   let mut _40: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
-          scope 6 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:50: 8:56
+          scope 6 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:9:50: 9:56
               debug self => _13;           // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
               debug other => _14;          // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _41: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -84,7 +84,7 @@
                   let mut _46: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
-          scope 8 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:70: 8:76
+          scope 8 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:9:70: 9:76
               debug self => _22;           // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
               debug other => _23;          // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _47: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL

--- a/tests/mir-opt/slice_filter.variant_a-{closure#0}.DestinationPropagation.diff
+++ b/tests/mir-opt/slice_filter.variant_a-{closure#0}.DestinationPropagation.diff
@@ -1,7 +1,7 @@
 - // MIR for `variant_a::{closure#0}` before DestinationPropagation
 + // MIR for `variant_a::{closure#0}` after DestinationPropagation
   
-  fn variant_a::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:8:25: 8:39], _2: &&(usize, usize, usize, usize)) -> bool {
+  fn variant_a::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:9:25: 9:39], _2: &&(usize, usize, usize, usize)) -> bool {
       let mut _0: bool;                    // return place in scope 0 at $DIR/slice_filter.rs:+0:40: +0:40
       let _3: &usize;                      // in scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
       let _4: &usize;                      // in scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
@@ -34,7 +34,7 @@
           debug b => _4;                   // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
           debug c => _5;                   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
           debug d => _6;                   // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
-          scope 2 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:40: 8:46
+          scope 2 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:9:40: 9:46
               debug self => _9;            // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
               debug other => _10;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _29: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -46,7 +46,7 @@
                   let mut _32: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
-          scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:60: 8:66
+          scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:9:60: 9:66
               debug self => _18;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
               debug other => _19;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _33: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -58,7 +58,7 @@
                   let mut _36: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
-          scope 6 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:50: 8:56
+          scope 6 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:9:50: 9:56
               debug self => _13;           // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
               debug other => _14;          // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _37: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -70,7 +70,7 @@
                   let mut _40: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
-          scope 8 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:70: 8:76
+          scope 8 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:9:70: 9:76
               debug self => _22;           // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
               debug other => _23;          // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _41: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL

--- a/tests/mir-opt/slice_filter.variant_b-{closure#0}.CopyProp.diff
+++ b/tests/mir-opt/slice_filter.variant_b-{closure#0}.CopyProp.diff
@@ -1,7 +1,7 @@
 - // MIR for `variant_b::{closure#0}` before CopyProp
 + // MIR for `variant_b::{closure#0}` after CopyProp
   
-  fn variant_b::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:12:25: 12:41], _2: &&(usize, usize, usize, usize)) -> bool {
+  fn variant_b::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:13:25: 13:41], _2: &&(usize, usize, usize, usize)) -> bool {
       let mut _0: bool;                    // return place in scope 0 at $DIR/slice_filter.rs:+0:42: +0:42
       let _3: usize;                       // in scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
       let _4: usize;                       // in scope 0 at $DIR/slice_filter.rs:+0:32: +0:33

--- a/tests/mir-opt/slice_filter.variant_b-{closure#0}.DestinationPropagation.diff
+++ b/tests/mir-opt/slice_filter.variant_b-{closure#0}.DestinationPropagation.diff
@@ -1,7 +1,7 @@
 - // MIR for `variant_b::{closure#0}` before DestinationPropagation
 + // MIR for `variant_b::{closure#0}` after DestinationPropagation
   
-  fn variant_b::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:12:25: 12:41], _2: &&(usize, usize, usize, usize)) -> bool {
+  fn variant_b::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:13:25: 13:41], _2: &&(usize, usize, usize, usize)) -> bool {
       let mut _0: bool;                    // return place in scope 0 at $DIR/slice_filter.rs:+0:42: +0:42
       let _3: usize;                       // in scope 0 at $DIR/slice_filter.rs:+0:29: +0:30
       let _4: usize;                       // in scope 0 at $DIR/slice_filter.rs:+0:32: +0:33

--- a/tests/ui/const-generics/generic_const_exprs/issue-100360.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-100360.rs
@@ -2,7 +2,7 @@
 // (this requires debug assertions)
 
 #![feature(adt_const_params)]
-#![allow(incomplete_features)]
+#![allow(incomplete_features, ref_binop_on_copy_type)]
 
 fn foo<const B: &'static bool>(arg: &'static bool) -> bool {
     B == arg

--- a/tests/ui/issues/issue-27949.rs
+++ b/tests/ui/issues/issue-27949.rs
@@ -5,6 +5,7 @@
 // LHS and RHS to be exactly identical--i.e. to have the same lifetimes.
 //
 // This was fixed in 1a7fb7dc78439a704f024609ce3dc0beb1386552.
+#![allow(ref_binop_on_copy_type)]
 
 #[derive(Copy, Clone)]
 struct Input<'a> {

--- a/tests/ui/issues/issue-54696.rs
+++ b/tests/ui/issues/issue-54696.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![allow(ref_binop_on_copy_type)]
 
 fn main() {
     // We shouldn't promote this

--- a/tests/ui/lint/ref_binop_on_copy_type.fixed
+++ b/tests/ui/lint/ref_binop_on_copy_type.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+// normalize-stderr-test "takes `\d` bytes" -> "takes `N` bytes"
 #![deny(ref_binop_on_copy_type)]
 // #105259
 

--- a/tests/ui/lint/ref_binop_on_copy_type.fixed
+++ b/tests/ui/lint/ref_binop_on_copy_type.fixed
@@ -1,0 +1,41 @@
+// run-rustfix
+#![deny(ref_binop_on_copy_type)]
+// #105259
+
+fn main() {
+    let input = vec![
+        (2, 4, 6, 8),
+        (2, 3, 4, 5),
+        (5, 7, 7, 9),
+        (2, 8, 3, 7),
+        (6, 6, 4, 6),
+        (2, 6, 4, 8), // .. 500000000 lines of random data, read from disk with real code (~12GB)
+    ];
+
+    // 1761ms on my machine
+    let _variant_a_result = variant_a(&input);
+
+    //  656ms on my machine
+    let _variant_b_result = variant_b(&input);
+
+    let _ = 42 <= 0;
+    //~^ ERROR binary operation on reference
+}
+
+pub fn variant_a(input: &[(usize, usize, usize, usize)]) -> usize {
+    input
+        .iter()
+        .filter(|(a, b, c, d)| *a <= *c && *(d as &usize) <= *b || *c <= *a && *b <= *d)
+        //~^ ERROR binary operation on reference
+        //~| ERROR binary operation on reference
+        //~| ERROR binary operation on reference
+        //~| ERROR binary operation on reference
+        .count()
+}
+
+pub fn variant_b(input: &[(usize, usize, usize, usize)]) -> usize {
+    input
+        .iter()
+        .filter(|&&(a, b, c, d)| a <= c && d + &2usize <= b || c <= a && b <= d)
+        .count()
+}

--- a/tests/ui/lint/ref_binop_on_copy_type.rs
+++ b/tests/ui/lint/ref_binop_on_copy_type.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+// normalize-stderr-test "takes `\d` bytes" -> "takes `N` bytes"
 #![deny(ref_binop_on_copy_type)]
 // #105259
 

--- a/tests/ui/lint/ref_binop_on_copy_type.rs
+++ b/tests/ui/lint/ref_binop_on_copy_type.rs
@@ -1,0 +1,41 @@
+// run-rustfix
+#![deny(ref_binop_on_copy_type)]
+// #105259
+
+fn main() {
+    let input = vec![
+        (2, 4, 6, 8),
+        (2, 3, 4, 5),
+        (5, 7, 7, 9),
+        (2, 8, 3, 7),
+        (6, 6, 4, 6),
+        (2, 6, 4, 8), // .. 500000000 lines of random data, read from disk with real code (~12GB)
+    ];
+
+    // 1761ms on my machine
+    let _variant_a_result = variant_a(&input);
+
+    //  656ms on my machine
+    let _variant_b_result = variant_b(&input);
+
+    let _ = &42 <= &0;
+    //~^ ERROR binary operation on reference
+}
+
+pub fn variant_a(input: &[(usize, usize, usize, usize)]) -> usize {
+    input
+        .iter()
+        .filter(|(a, b, c, d)| a <= c && d as &usize <= b || c <= a && &b <= &d)
+        //~^ ERROR binary operation on reference
+        //~| ERROR binary operation on reference
+        //~| ERROR binary operation on reference
+        //~| ERROR binary operation on reference
+        .count()
+}
+
+pub fn variant_b(input: &[(usize, usize, usize, usize)]) -> usize {
+    input
+        .iter()
+        .filter(|&&(a, b, c, d)| a <= c && d + &2usize <= b || c <= a && b <= d)
+        .count()
+}

--- a/tests/ui/lint/ref_binop_on_copy_type.stderr
+++ b/tests/ui/lint/ref_binop_on_copy_type.stderr
@@ -1,0 +1,68 @@
+error: binary operation on reference to `Copy` type `i32`
+  --> $DIR/ref_binop_on_copy_type.rs:21:17
+   |
+LL |     let _ = &42 <= &0;
+   |                 ^^
+   |
+   = note: `i32` takes `4` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
+note: the lint level is defined here
+  --> $DIR/ref_binop_on_copy_type.rs:2:9
+   |
+LL | #![deny(ref_binop_on_copy_type)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+help: dereferencing the expressions will allow the compiler to more consistently optimize these binary operations
+   |
+LL -     let _ = &42 <= &0;
+LL +     let _ = 42 <= 0;
+   |
+
+error: binary operation on reference to `Copy` type `usize`
+  --> $DIR/ref_binop_on_copy_type.rs:28:34
+   |
+LL |         .filter(|(a, b, c, d)| a <= c && d as &usize <= b || c <= a && &b <= &d)
+   |                                  ^^
+   |
+   = note: `usize` takes `8` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
+help: dereferencing the expressions will allow the compiler to more consistently optimize these binary operations
+   |
+LL |         .filter(|(a, b, c, d)| *a <= *c && d as &usize <= b || c <= a && &b <= &d)
+   |                                +     +
+
+error: binary operation on reference to `Copy` type `usize`
+  --> $DIR/ref_binop_on_copy_type.rs:28:54
+   |
+LL |         .filter(|(a, b, c, d)| a <= c && d as &usize <= b || c <= a && &b <= &d)
+   |                                                      ^^
+   |
+   = note: `usize` takes `8` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
+help: dereferencing the expressions will allow the compiler to more consistently optimize these binary operations
+   |
+LL |         .filter(|(a, b, c, d)| a <= c && *(d as &usize) <= *b || c <= a && &b <= &d)
+   |                                          ++           +    +
+
+error: binary operation on reference to `Copy` type `usize`
+  --> $DIR/ref_binop_on_copy_type.rs:28:64
+   |
+LL |         .filter(|(a, b, c, d)| a <= c && d as &usize <= b || c <= a && &b <= &d)
+   |                                                                ^^
+   |
+   = note: `usize` takes `8` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
+help: dereferencing the expressions will allow the compiler to more consistently optimize these binary operations
+   |
+LL |         .filter(|(a, b, c, d)| a <= c && d as &usize <= b || *c <= *a && &b <= &d)
+   |                                                              +     +
+
+error: binary operation on reference to `Copy` type `usize`
+  --> $DIR/ref_binop_on_copy_type.rs:28:75
+   |
+LL |         .filter(|(a, b, c, d)| a <= c && d as &usize <= b || c <= a && &b <= &d)
+   |                                                                           ^^
+   |
+   = note: `usize` takes `8` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
+help: dereferencing the expressions will allow the compiler to more consistently optimize these binary operations
+   |
+LL |         .filter(|(a, b, c, d)| a <= c && d as &usize <= b || c <= a && *b <= *d)
+   |                                                                        ~     ~
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/lint/ref_binop_on_copy_type.stderr
+++ b/tests/ui/lint/ref_binop_on_copy_type.stderr
@@ -1,12 +1,12 @@
 error: binary operation on reference to `Copy` type `i32`
-  --> $DIR/ref_binop_on_copy_type.rs:21:17
+  --> $DIR/ref_binop_on_copy_type.rs:22:17
    |
 LL |     let _ = &42 <= &0;
    |                 ^^
    |
-   = note: `i32` takes `4` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
+   = note: `i32` takes `N` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
 note: the lint level is defined here
-  --> $DIR/ref_binop_on_copy_type.rs:2:9
+  --> $DIR/ref_binop_on_copy_type.rs:3:9
    |
 LL | #![deny(ref_binop_on_copy_type)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -17,48 +17,48 @@ LL +     let _ = 42 <= 0;
    |
 
 error: binary operation on reference to `Copy` type `usize`
-  --> $DIR/ref_binop_on_copy_type.rs:28:34
+  --> $DIR/ref_binop_on_copy_type.rs:29:34
    |
 LL |         .filter(|(a, b, c, d)| a <= c && d as &usize <= b || c <= a && &b <= &d)
    |                                  ^^
    |
-   = note: `usize` takes `8` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
+   = note: `usize` takes `N` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
 help: dereferencing the expressions will allow the compiler to more consistently optimize these binary operations
    |
 LL |         .filter(|(a, b, c, d)| *a <= *c && d as &usize <= b || c <= a && &b <= &d)
    |                                +     +
 
 error: binary operation on reference to `Copy` type `usize`
-  --> $DIR/ref_binop_on_copy_type.rs:28:54
+  --> $DIR/ref_binop_on_copy_type.rs:29:54
    |
 LL |         .filter(|(a, b, c, d)| a <= c && d as &usize <= b || c <= a && &b <= &d)
    |                                                      ^^
    |
-   = note: `usize` takes `8` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
+   = note: `usize` takes `N` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
 help: dereferencing the expressions will allow the compiler to more consistently optimize these binary operations
    |
 LL |         .filter(|(a, b, c, d)| a <= c && *(d as &usize) <= *b || c <= a && &b <= &d)
    |                                          ++           +    +
 
 error: binary operation on reference to `Copy` type `usize`
-  --> $DIR/ref_binop_on_copy_type.rs:28:64
+  --> $DIR/ref_binop_on_copy_type.rs:29:64
    |
 LL |         .filter(|(a, b, c, d)| a <= c && d as &usize <= b || c <= a && &b <= &d)
    |                                                                ^^
    |
-   = note: `usize` takes `8` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
+   = note: `usize` takes `N` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
 help: dereferencing the expressions will allow the compiler to more consistently optimize these binary operations
    |
 LL |         .filter(|(a, b, c, d)| a <= c && d as &usize <= b || *c <= *a && &b <= &d)
    |                                                              +     +
 
 error: binary operation on reference to `Copy` type `usize`
-  --> $DIR/ref_binop_on_copy_type.rs:28:75
+  --> $DIR/ref_binop_on_copy_type.rs:29:75
    |
 LL |         .filter(|(a, b, c, d)| a <= c && d as &usize <= b || c <= a && &b <= &d)
    |                                                                           ^^
    |
-   = note: `usize` takes `8` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
+   = note: `usize` takes `N` bytes of memory; copying the value instead of referencing it might avoid unnecessary pointer indirections
 help: dereferencing the expressions will allow the compiler to more consistently optimize these binary operations
    |
 LL |         .filter(|(a, b, c, d)| a <= c && d as &usize <= b || c <= a && *b <= *d)

--- a/tests/ui/macros/rfc-2011-nicer-assert-messages/all-expr-kinds.rs
+++ b/tests/ui/macros/rfc-2011-nicer-assert-messages/all-expr-kinds.rs
@@ -4,7 +4,7 @@
 // run-pass
 // needs-unwind Asserting on contents of error message
 
-#![allow(path_statements, unused_allocation)]
+#![allow(path_statements, unused_allocation, ref_binop_on_copy_type)]
 #![feature(box_syntax, core_intrinsics, generic_assert, generic_assert_internals)]
 
 macro_rules! test {

--- a/tests/ui/nll/issue-24535-allow-mutable-borrow-in-match-guard.rs
+++ b/tests/ui/nll/issue-24535-allow-mutable-borrow-in-match-guard.rs
@@ -6,6 +6,7 @@
 // rust-lang/rfcs#1006, and rust-lang/rfcs#107
 
 #![feature(if_let_guard)]
+#![allow(ref_binop_on_copy_type)]
 
 fn main() {
     rust_issue_24535();

--- a/tests/ui/pattern/bindings-after-at/or-patterns-slice-patterns.rs
+++ b/tests/ui/pattern/bindings-after-at/or-patterns-slice-patterns.rs
@@ -1,7 +1,7 @@
 // Test bindings-after-at with or-patterns and slice-patterns
 
 // run-pass
-
+#![allow(ref_binop_on_copy_type)]
 
 #[derive(Debug, PartialEq)]
 enum MatchArm {

--- a/tests/ui/pattern/bindings-after-at/slice-patterns.rs
+++ b/tests/ui/pattern/bindings-after-at/slice-patterns.rs
@@ -1,7 +1,7 @@
 // Test bindings-after-at with slice-patterns
 
 // run-pass
-
+#![allow(ref_binop_on_copy_type)]
 
 #[derive(Debug, PartialEq)]
 enum MatchArm {


### PR DESCRIPTION
When encountering a binary operation for two `T: Copy` where `T` is as small as a 64bit pointer, suggest dereferencing the expressions so the binary operation is inlined.

Mitigate the effects of #105259, particularly when match ergonomics is involved.