### PR TITLE
Fix ICE in 'duplicate diagnostic item' diagnostic

### DIFF
--- a/compiler/rustc_passes/locales/en-US.ftl
+++ b/compiler/rustc_passes/locales/en-US.ftl
@@ -407,10 +407,10 @@ passes_duplicate_diagnostic_item =
 
 passes_duplicate_diagnostic_item_in_crate =
     duplicate diagnostic item in crate `{$crate_name}`: `{$name}`.
+    .note = the diagnostic item is first defined in crate `{$orig_crate_name}`.
 
 passes_diagnostic_item_first_defined =
     the diagnostic item is first defined here
-    .note = the diagnostic item is first defined in crate `{$orig_crate_name}`.
 
 passes_abi =
     abi: {$abi}

--- a/tests/ui/tool-attributes/auxiliary/p1.rs
+++ b/tests/ui/tool-attributes/auxiliary/p1.rs
@@ -1,0 +1,3 @@
+#![feature(rustc_attrs)]
+#[rustc_diagnostic_item = "Foo"]
+pub struct Foo {}

--- a/tests/ui/tool-attributes/auxiliary/p2.rs
+++ b/tests/ui/tool-attributes/auxiliary/p2.rs
@@ -1,0 +1,3 @@
+#![feature(rustc_attrs)]
+#[rustc_diagnostic_item = "Foo"]
+pub struct Foo {}

--- a/tests/ui/tool-attributes/duplicate-diagnostic.rs
+++ b/tests/ui/tool-attributes/duplicate-diagnostic.rs
@@ -1,0 +1,13 @@
+// aux-build: p1.rs
+// aux-build: p2.rs
+
+// error-pattern: duplicate diagnostic item in crate `p2`
+// error-pattern: note: the diagnostic item is first defined in crate `p1`
+
+#![feature(rustc_attrs)]
+extern crate p1;
+extern crate p2;
+
+#[rustc_diagnostic_item = "Foo"]
+pub struct Foo {} //~ ERROR duplicate diagnostic item found
+fn main() {}

--- a/tests/ui/tool-attributes/duplicate-diagnostic.stderr
+++ b/tests/ui/tool-attributes/duplicate-diagnostic.stderr
@@ -1,0 +1,12 @@
+error: duplicate diagnostic item in crate `p2`: `Foo`.
+   |
+   = note: the diagnostic item is first defined in crate `p1`.
+
+error: duplicate diagnostic item found: `Foo`.
+  --> $DIR/duplicate-diagnostic.rs:12:1
+   |
+LL | pub struct Foo {}
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Not sure how to add this in a test; I found it by mistakenly running `cargo fix --lib -p std` rather than `x fix` at the root.