### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
+# Use `git config blame.ignorerevsfile .git-blame-ignore-revs` to make `git blame` ignore the following commits.
+
 # format the world
 a06baa56b95674fc626b3c3fd680d6a65357fe60
 # format libcore

--- a/compiler/rustc_ast_lowering/locales/en-US.ftl
+++ b/compiler/rustc_ast_lowering/locales/en-US.ftl
@@ -19,6 +19,9 @@ ast_lowering_remove_parentheses = remove these parentheses
 ast_lowering_misplaced_impl_trait =
     `impl Trait` only allowed in function and inherent method return types, not in {$position}
 
+ast_lowering_misplaced_assoc_ty_binding =
+    associated type bounds are only allowed in where clauses and function signatures, not in {$position}
+
 ast_lowering_rustc_box_attribute_error =
     #[rustc_box] requires precisely one argument and no other attributes are allowed
 

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -79,6 +79,14 @@ pub struct MisplacedImplTrait<'a> {
     pub position: DiagnosticArgFromDisplay<'a>,
 }
 
+#[derive(Diagnostic)]
+#[diag(ast_lowering_misplaced_assoc_ty_binding)]
+pub struct MisplacedAssocTyBinding<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub position: DiagnosticArgFromDisplay<'a>,
+}
+
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_rustc_box_attribute_error)]
 pub struct RustcBoxAttributeError {

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1011,8 +1011,14 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 hir::TypeBindingKind::Equality { term }
             }
             AssocConstraintKind::Bound { bounds } => {
+                enum DesugarKind<'a> {
+                    ImplTrait,
+                    Error(&'a ImplTraitPosition),
+                    Bound,
+                }
+
                 // Piggy-back on the `impl Trait` context to figure out the correct behavior.
-                let (desugar_to_impl_trait, itctx) = match itctx {
+                let desugar_kind = match itctx {
                     // We are in the return position:
                     //
                     //     fn foo() -> impl Iterator<Item: Debug>
@@ -1021,7 +1027,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     //
                     //     fn foo() -> impl Iterator<Item = impl Debug>
                     ImplTraitContext::ReturnPositionOpaqueTy { .. }
-                    | ImplTraitContext::TypeAliasesOpaqueTy { .. } => (true, itctx),
+                    | ImplTraitContext::TypeAliasesOpaqueTy { .. } => DesugarKind::ImplTrait,
 
                     // We are in the argument position, but within a dyn type:
                     //
@@ -1030,7 +1036,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     // so desugar to
                     //
                     //     fn foo(x: dyn Iterator<Item = impl Debug>)
-                    ImplTraitContext::Universal if self.is_in_dyn_type => (true, itctx),
+                    ImplTraitContext::Universal if self.is_in_dyn_type => DesugarKind::ImplTrait,
 
                     // In `type Foo = dyn Iterator<Item: Debug>` we desugar to
                     // `type Foo = dyn Iterator<Item = impl Debug>` but we have to override the
@@ -1039,11 +1045,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     //
                     // FIXME: this is only needed until `impl Trait` is allowed in type aliases.
                     ImplTraitContext::Disallowed(position) if self.is_in_dyn_type => {
-                        self.tcx.sess.emit_err(errors::MisplacedAssocTyBinding {
-                            span: constraint.span,
-                            position: DiagnosticArgFromDisplay(position),
-                        });
-                        (false, itctx)
+                        DesugarKind::Error(position)
                     }
 
                     // We are in the parameter position, but not within a dyn type:
@@ -1053,35 +1055,46 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     // so we leave it as is and this gets expanded in astconv to a bound like
                     // `<T as Iterator>::Item: Debug` where `T` is the type parameter for the
                     // `impl Iterator`.
-                    _ => (false, itctx),
+                    _ => DesugarKind::Bound,
                 };
 
-                if desugar_to_impl_trait {
-                    // Desugar `AssocTy: Bounds` into `AssocTy = impl Bounds`. We do this by
-                    // constructing the HIR for `impl bounds...` and then lowering that.
+                match desugar_kind {
+                    DesugarKind::ImplTrait => {
+                        // Desugar `AssocTy: Bounds` into `AssocTy = impl Bounds`. We do this by
+                        // constructing the HIR for `impl bounds...` and then lowering that.
 
-                    let impl_trait_node_id = self.next_node_id();
+                        let impl_trait_node_id = self.next_node_id();
 
-                    self.with_dyn_type_scope(false, |this| {
-                        let node_id = this.next_node_id();
-                        let ty = this.lower_ty(
-                            &Ty {
-                                id: node_id,
-                                kind: TyKind::ImplTrait(impl_trait_node_id, bounds.clone()),
-                                span: this.lower_span(constraint.span),
-                                tokens: None,
-                            },
-                            itctx,
-                        );
+                        self.with_dyn_type_scope(false, |this| {
+                            let node_id = this.next_node_id();
+                            let ty = this.lower_ty(
+                                &Ty {
+                                    id: node_id,
+                                    kind: TyKind::ImplTrait(impl_trait_node_id, bounds.clone()),
+                                    span: this.lower_span(constraint.span),
+                                    tokens: None,
+                                },
+                                itctx,
+                            );
 
-                        hir::TypeBindingKind::Equality { term: ty.into() }
-                    })
-                } else {
-                    // Desugar `AssocTy: Bounds` into a type binding where the
-                    // later desugars into a trait predicate.
-                    let bounds = self.lower_param_bounds(bounds, itctx);
+                            hir::TypeBindingKind::Equality { term: ty.into() }
+                        })
+                    }
+                    DesugarKind::Bound => {
+                        // Desugar `AssocTy: Bounds` into a type binding where the
+                        // later desugars into a trait predicate.
+                        let bounds = self.lower_param_bounds(bounds, itctx);
 
-                    hir::TypeBindingKind::Constraint { bounds }
+                        hir::TypeBindingKind::Constraint { bounds }
+                    }
+                    DesugarKind::Error(position) => {
+                        self.tcx.sess.emit_err(errors::MisplacedAssocTyBinding {
+                            span: constraint.span,
+                            position: DiagnosticArgFromDisplay(position),
+                        });
+                        let err_ty = &*self.arena.alloc(self.ty(constraint.span, hir::TyKind::Err));
+                        hir::TypeBindingKind::Equality { term: err_ty.into() }
+                    }
                 }
             }
         };

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -288,31 +288,31 @@ enum ImplTraitPosition {
 impl std::fmt::Display for ImplTraitPosition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match self {
-            ImplTraitPosition::Path => "path",
-            ImplTraitPosition::Variable => "variable binding",
-            ImplTraitPosition::Trait => "trait",
-            ImplTraitPosition::AsyncBlock => "async block",
-            ImplTraitPosition::Bound => "bound",
-            ImplTraitPosition::Generic => "generic",
-            ImplTraitPosition::ExternFnParam => "`extern fn` param",
-            ImplTraitPosition::ClosureParam => "closure param",
-            ImplTraitPosition::PointerParam => "`fn` pointer param",
-            ImplTraitPosition::FnTraitParam => "`Fn` trait param",
-            ImplTraitPosition::TraitParam => "trait method param",
-            ImplTraitPosition::ImplParam => "`impl` method param",
-            ImplTraitPosition::ExternFnReturn => "`extern fn` return",
-            ImplTraitPosition::ClosureReturn => "closure return",
-            ImplTraitPosition::PointerReturn => "`fn` pointer return",
-            ImplTraitPosition::FnTraitReturn => "`Fn` trait return",
-            ImplTraitPosition::TraitReturn => "trait method return",
-            ImplTraitPosition::ImplReturn => "`impl` method return",
-            ImplTraitPosition::GenericDefault => "generic parameter default",
-            ImplTraitPosition::ConstTy => "const type",
-            ImplTraitPosition::StaticTy => "static type",
-            ImplTraitPosition::AssocTy => "associated type",
-            ImplTraitPosition::FieldTy => "field type",
-            ImplTraitPosition::Cast => "cast type",
-            ImplTraitPosition::ImplSelf => "impl header",
+            ImplTraitPosition::Path => "paths",
+            ImplTraitPosition::Variable => "variable bindings",
+            ImplTraitPosition::Trait => "traits",
+            ImplTraitPosition::AsyncBlock => "async blocks",
+            ImplTraitPosition::Bound => "bounds",
+            ImplTraitPosition::Generic => "generics",
+            ImplTraitPosition::ExternFnParam => "`extern fn` params",
+            ImplTraitPosition::ClosureParam => "closure params",
+            ImplTraitPosition::PointerParam => "`fn` pointer params",
+            ImplTraitPosition::FnTraitParam => "`Fn` trait params",
+            ImplTraitPosition::TraitParam => "trait method params",
+            ImplTraitPosition::ImplParam => "`impl` method params",
+            ImplTraitPosition::ExternFnReturn => "`extern fn` return types",
+            ImplTraitPosition::ClosureReturn => "closure return types",
+            ImplTraitPosition::PointerReturn => "`fn` pointer return types",
+            ImplTraitPosition::FnTraitReturn => "`Fn` trait return types",
+            ImplTraitPosition::TraitReturn => "trait method return types",
+            ImplTraitPosition::ImplReturn => "`impl` method return types",
+            ImplTraitPosition::GenericDefault => "generic parameter defaults",
+            ImplTraitPosition::ConstTy => "const types",
+            ImplTraitPosition::StaticTy => "static types",
+            ImplTraitPosition::AssocTy => "associated types",
+            ImplTraitPosition::FieldTy => "field types",
+            ImplTraitPosition::Cast => "cast types",
+            ImplTraitPosition::ImplSelf => "impl headers",
         };
 
         write!(f, "{name}")
@@ -1038,12 +1038,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     //     fn foo(x: dyn Iterator<Item = impl Debug>)
                     ImplTraitContext::Universal if self.is_in_dyn_type => DesugarKind::ImplTrait,
 
-                    // In `type Foo = dyn Iterator<Item: Debug>` we desugar to
-                    // `type Foo = dyn Iterator<Item = impl Debug>` but we have to override the
-                    // "impl trait context" to permit `impl Debug` in this position (it desugars
-                    // then to an opaque type).
-                    //
-                    // FIXME: this is only needed until `impl Trait` is allowed in type aliases.
                     ImplTraitContext::Disallowed(position) if self.is_in_dyn_type => {
                         DesugarKind::Error(position)
                     }

--- a/compiler/rustc_ast_passes/locales/en-US.ftl
+++ b/compiler/rustc_ast_passes/locales/en-US.ftl
@@ -11,9 +11,6 @@ ast_passes_forbidden_let_stable =
 ast_passes_deprecated_where_clause_location =
     where clause not allowed here
 
-ast_passes_forbidden_assoc_constraint =
-    associated type bounds are not allowed within structs, enums, or unions
-
 ast_passes_keyword_lifetime =
     lifetimes cannot use keyword names
 

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -24,13 +24,6 @@ pub struct ForbiddenLetStable {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes_forbidden_assoc_constraint)]
-pub struct ForbiddenAssocConstraint {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(ast_passes_keyword_lifetime)]
 pub struct KeywordLifetime {
     #[primary_span]

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1,6 +1,7 @@
 //! This query borrow-checks the MIR to (further) ensure it is not broken.
 
 #![allow(rustc::potential_query_instability)]
+#![feature(associated_type_bounds)]
 #![feature(box_patterns)]
 #![feature(let_chains)]
 #![feature(min_specialization)]

--- a/compiler/rustc_borrowck/src/type_check/canonical.rs
+++ b/compiler/rustc_borrowck/src/type_check/canonical.rs
@@ -117,7 +117,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
     pub(super) fn prove_predicates(
         &mut self,
-        predicates: impl IntoIterator<Item = impl ToPredicate<'tcx> + std::fmt::Debug>,
+        predicates: impl IntoIterator<Item: ToPredicate<'tcx> + std::fmt::Debug>,
         locations: Locations,
         category: ConstraintCategory<'tcx>,
     ) {

--- a/compiler/rustc_hir_analysis/locales/en-US.ftl
+++ b/compiler/rustc_hir_analysis/locales/en-US.ftl
@@ -127,5 +127,8 @@ hir_analysis_auto_deref_reached_recursion_limit = reached the recursion limit wh
     .label = deref recursion limit reached
     .help = consider increasing the recursion limit by adding a `#![recursion_limit = "{$suggested_limit}"]` attribute to your crate (`{$crate_name}`)
 
+hir_analysis_where_clause_on_main = `main` function is not allowed to have a `where` clause
+    .label = `main` cannot have a `where` clause
+
 hir_analysis_track_caller_on_main = `main` function is not allowed to be `#[track_caller]`
     .label = `main` function is not allowed to be `#[track_caller]`

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -317,6 +317,15 @@ pub struct AutoDerefReachedRecursionLimit<'a> {
 }
 
 #[derive(Diagnostic)]
+#[diag(hir_analysis_where_clause_on_main, code = "E0646")]
+pub(crate) struct WhereClauseOnMain {
+    #[primary_span]
+    pub span: Span,
+    #[label]
+    pub generics_span: Option<Span>,
+}
+
+#[derive(Diagnostic)]
 #[diag(hir_analysis_track_caller_on_main)]
 pub(crate) struct TrackCallerOnMain {
     #[primary_span]

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -271,16 +271,10 @@ fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: DefId) {
     } else if !main_fn_predicates.predicates.is_empty() {
         // generics may bring in implicit predicates, so we skip this check if generics is present.
         let generics_where_clauses_span = main_fn_where_clauses_span(tcx, main_def_id);
-        let mut diag = struct_span_err!(
-            tcx.sess,
-            generics_where_clauses_span.unwrap_or(main_span),
-            E0646,
-            "`main` function is not allowed to have a `where` clause"
-        );
-        if let Some(generics_where_clauses_span) = generics_where_clauses_span {
-            diag.span_label(generics_where_clauses_span, "`main` cannot have a `where` clause");
-        }
-        diag.emit();
+        tcx.sess.emit_err(errors::WhereClauseOnMain {
+            span: generics_where_clauses_span.unwrap_or(main_span),
+            generics_span: generics_where_clauses_span,
+        });
         error = true;
     }
 

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -478,10 +478,7 @@ impl<'infcx, 'tcx> CombineFields<'infcx, 'tcx> {
         self.obligations.extend(obligations.into_iter());
     }
 
-    pub fn register_predicates(
-        &mut self,
-        obligations: impl IntoIterator<Item = impl ToPredicate<'tcx>>,
-    ) {
+    pub fn register_predicates(&mut self, obligations: impl IntoIterator<Item: ToPredicate<'tcx>>) {
         self.obligations.extend(obligations.into_iter().map(|to_pred| {
             Obligation::new(self.infcx.tcx, self.trace.cause.clone(), self.param_env, to_pred)
         }))
@@ -814,10 +811,7 @@ pub trait ObligationEmittingRelation<'tcx>: TypeRelation<'tcx> {
     /// Register predicates that must hold in order for this relation to hold. Uses
     /// a default obligation cause, [`ObligationEmittingRelation::register_obligations`] should
     /// be used if control over the obligaton causes is required.
-    fn register_predicates(
-        &mut self,
-        obligations: impl IntoIterator<Item = impl ToPredicate<'tcx>>,
-    );
+    fn register_predicates(&mut self, obligations: impl IntoIterator<Item: ToPredicate<'tcx>>);
 
     /// Register an obligation that both constants must be equal to each other.
     ///

--- a/compiler/rustc_infer/src/infer/equate.rs
+++ b/compiler/rustc_infer/src/infer/equate.rs
@@ -201,10 +201,7 @@ impl<'tcx> TypeRelation<'tcx> for Equate<'_, '_, 'tcx> {
 }
 
 impl<'tcx> ObligationEmittingRelation<'tcx> for Equate<'_, '_, 'tcx> {
-    fn register_predicates(
-        &mut self,
-        obligations: impl IntoIterator<Item = impl ty::ToPredicate<'tcx>>,
-    ) {
+    fn register_predicates(&mut self, obligations: impl IntoIterator<Item: ty::ToPredicate<'tcx>>) {
         self.fields.register_predicates(obligations);
     }
 

--- a/compiler/rustc_infer/src/infer/glb.rs
+++ b/compiler/rustc_infer/src/infer/glb.rs
@@ -148,10 +148,7 @@ impl<'combine, 'infcx, 'tcx> LatticeDir<'infcx, 'tcx> for Glb<'combine, 'infcx, 
 }
 
 impl<'tcx> ObligationEmittingRelation<'tcx> for Glb<'_, '_, 'tcx> {
-    fn register_predicates(
-        &mut self,
-        obligations: impl IntoIterator<Item = impl ty::ToPredicate<'tcx>>,
-    ) {
+    fn register_predicates(&mut self, obligations: impl IntoIterator<Item: ty::ToPredicate<'tcx>>) {
         self.fields.register_predicates(obligations);
     }
 

--- a/compiler/rustc_infer/src/infer/lub.rs
+++ b/compiler/rustc_infer/src/infer/lub.rs
@@ -148,10 +148,7 @@ impl<'combine, 'infcx, 'tcx> LatticeDir<'infcx, 'tcx> for Lub<'combine, 'infcx, 
 }
 
 impl<'tcx> ObligationEmittingRelation<'tcx> for Lub<'_, '_, 'tcx> {
-    fn register_predicates(
-        &mut self,
-        obligations: impl IntoIterator<Item = impl ty::ToPredicate<'tcx>>,
-    ) {
+    fn register_predicates(&mut self, obligations: impl IntoIterator<Item: ty::ToPredicate<'tcx>>) {
         self.fields.register_predicates(obligations);
     }
 

--- a/compiler/rustc_infer/src/infer/nll_relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/nll_relate/mod.rs
@@ -759,10 +759,7 @@ impl<'tcx, D> ObligationEmittingRelation<'tcx> for TypeRelating<'_, 'tcx, D>
 where
     D: TypeRelatingDelegate<'tcx>,
 {
-    fn register_predicates(
-        &mut self,
-        obligations: impl IntoIterator<Item = impl ty::ToPredicate<'tcx>>,
-    ) {
+    fn register_predicates(&mut self, obligations: impl IntoIterator<Item: ty::ToPredicate<'tcx>>) {
         self.delegate.register_obligations(
             obligations
                 .into_iter()

--- a/compiler/rustc_infer/src/infer/sub.rs
+++ b/compiler/rustc_infer/src/infer/sub.rs
@@ -228,10 +228,7 @@ impl<'tcx> TypeRelation<'tcx> for Sub<'_, '_, 'tcx> {
 }
 
 impl<'tcx> ObligationEmittingRelation<'tcx> for Sub<'_, '_, 'tcx> {
-    fn register_predicates(
-        &mut self,
-        obligations: impl IntoIterator<Item = impl ty::ToPredicate<'tcx>>,
-    ) {
+    fn register_predicates(&mut self, obligations: impl IntoIterator<Item: ty::ToPredicate<'tcx>>) {
         self.fields.register_predicates(obligations);
     }
 

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -13,6 +13,7 @@
 //! This API is completely unstable and subject to change.
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
+#![feature(associated_type_bounds)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(extend_one)]

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1857,7 +1857,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn mk_fn_def(
         self,
         def_id: DefId,
-        substs: impl IntoIterator<Item = impl Into<GenericArg<'tcx>>>,
+        substs: impl IntoIterator<Item: Into<GenericArg<'tcx>>>,
     ) -> Ty<'tcx> {
         let substs = self.check_substs(def_id, substs);
         self.mk_ty(FnDef(def_id, substs))
@@ -1867,7 +1867,7 @@ impl<'tcx> TyCtxt<'tcx> {
     fn check_substs(
         self,
         _def_id: DefId,
-        substs: impl IntoIterator<Item = impl Into<GenericArg<'tcx>>>,
+        substs: impl IntoIterator<Item: Into<GenericArg<'tcx>>>,
     ) -> SubstsRef<'tcx> {
         let substs = substs.into_iter().map(Into::into);
         #[cfg(debug_assertions)]
@@ -1902,7 +1902,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn mk_projection(
         self,
         item_def_id: DefId,
-        substs: impl IntoIterator<Item = impl Into<GenericArg<'tcx>>>,
+        substs: impl IntoIterator<Item: Into<GenericArg<'tcx>>>,
     ) -> Ty<'tcx> {
         self.mk_alias(ty::Projection, self.mk_alias_ty(item_def_id, substs))
     }
@@ -2294,7 +2294,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn mk_trait_ref(
         self,
         trait_def_id: DefId,
-        substs: impl IntoIterator<Item = impl Into<GenericArg<'tcx>>>,
+        substs: impl IntoIterator<Item: Into<GenericArg<'tcx>>>,
     ) -> ty::TraitRef<'tcx> {
         let substs = self.check_substs(trait_def_id, substs);
         ty::TraitRef { def_id: trait_def_id, substs, _use_mk_trait_ref_instead: () }
@@ -2303,7 +2303,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn mk_alias_ty(
         self,
         def_id: DefId,
-        substs: impl IntoIterator<Item = impl Into<GenericArg<'tcx>>>,
+        substs: impl IntoIterator<Item: Into<GenericArg<'tcx>>>,
     ) -> ty::AliasTy<'tcx> {
         let substs = self.check_substs(def_id, substs);
         ty::AliasTy { def_id, substs, _use_mk_alias_ty_instead: () }
@@ -2469,7 +2469,7 @@ impl<'tcx> TyCtxtAt<'tcx> {
     pub fn mk_trait_ref(
         self,
         trait_lang_item: LangItem,
-        substs: impl IntoIterator<Item = impl Into<ty::GenericArg<'tcx>>>,
+        substs: impl IntoIterator<Item: Into<ty::GenericArg<'tcx>>>,
     ) -> ty::TraitRef<'tcx> {
         let trait_def_id = self.require_lang_item(trait_lang_item, Some(self.span));
         self.tcx.mk_trait_ref(trait_def_id, substs)

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -570,7 +570,7 @@ impl<'tcx> GeneratorSubsts<'tcx> {
         self,
         def_id: DefId,
         tcx: TyCtxt<'tcx>,
-    ) -> impl Iterator<Item = impl Iterator<Item = Ty<'tcx>> + Captures<'tcx>> {
+    ) -> impl Iterator<Item: Iterator<Item = Ty<'tcx>> + Captures<'tcx>> {
         let layout = tcx.generator_layout(def_id).unwrap();
         layout.variant_fields.iter().map(move |variant| {
             variant.iter().map(move |field| {

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -832,7 +832,7 @@ fn trait_method<'tcx>(
     tcx: TyCtxt<'tcx>,
     trait_def_id: DefId,
     method_name: Symbol,
-    substs: impl IntoIterator<Item = impl Into<GenericArg<'tcx>>>,
+    substs: impl IntoIterator<Item: Into<GenericArg<'tcx>>>,
 ) -> ConstantKind<'tcx> {
     // The unhygienic comparison here is acceptable because this is only
     // used on known traits.

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -122,7 +122,10 @@ impl<'tcx> ValueAnalysis<'tcx> for ConstAnalysis<'_, 'tcx> {
     ) {
         match rvalue {
             Rvalue::Aggregate(kind, operands) => {
-                state.flood_with(target.as_ref(), self.map(), FlatSet::Bottom);
+                // If we assign `target = Enum::Variant#0(operand)`,
+                // we must make sure that all `target as Variant#i` are `Top`.
+                state.flood(target.as_ref(), self.map());
+
                 if let Some(target_idx) = self.map().find(target.as_ref()) {
                     let (variant_target, variant_index) = match **kind {
                         AggregateKind::Tuple | AggregateKind::Closure(..) => {

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -134,18 +134,21 @@ impl<'tcx> ValueAnalysis<'tcx> for ConstAnalysis<'_, 'tcx> {
                         AggregateKind::Adt(def_id, variant_index, ..) => {
                             match self.tcx.def_kind(def_id) {
                                 DefKind::Struct => (Some(target_idx), None),
-                                DefKind::Enum => (Some(target_idx), Some(variant_index)),
+                                DefKind::Enum => (
+                                    self.map.apply(target_idx, TrackElem::Variant(variant_index)),
+                                    Some(variant_index),
+                                ),
                                 _ => (None, None),
                             }
                         }
                         _ => (None, None),
                     };
-                    if let Some(target) = variant_target {
+                    if let Some(variant_target_idx) = variant_target {
                         for (field_index, operand) in operands.iter().enumerate() {
-                            if let Some(field) = self
-                                .map()
-                                .apply(target, TrackElem::Field(Field::from_usize(field_index)))
-                            {
+                            if let Some(field) = self.map().apply(
+                                variant_target_idx,
+                                TrackElem::Field(Field::from_usize(field_index)),
+                            ) {
                                 let result = self.handle_operand(operand, state);
                                 state.insert_idx(field, result, self.map());
                             }
@@ -154,6 +157,11 @@ impl<'tcx> ValueAnalysis<'tcx> for ConstAnalysis<'_, 'tcx> {
                     if let Some(variant_index) = variant_index
                         && let Some(discr_idx) = self.map().apply(target_idx, TrackElem::Discriminant)
                     {
+                        // We are assigning the discriminant as part of an aggregate.
+                        // This discriminant can only alias a variant field's value if the operand
+                        // had an invalid value for that type.
+                        // Using invalid values is UB, so we are allowed to perform the assignment
+                        // without extra flooding.
                         let enum_ty = target.ty(self.local_decls, self.tcx).ty;
                         if let Some(discr_val) = self.eval_discriminant(enum_ty, variant_index) {
                             state.insert_value_idx(discr_idx, FlatSet::Elem(discr_val), &self.map);

--- a/compiler/rustc_trait_selection/src/infer.rs
+++ b/compiler/rustc_trait_selection/src/infer.rs
@@ -42,7 +42,7 @@ pub trait InferCtxtExt<'tcx> {
     fn type_implements_trait(
         &self,
         trait_def_id: DefId,
-        params: impl IntoIterator<Item = impl Into<GenericArg<'tcx>>>,
+        params: impl IntoIterator<Item: Into<GenericArg<'tcx>>>,
         param_env: ty::ParamEnv<'tcx>,
     ) -> traits::EvaluationResult;
 }
@@ -82,7 +82,7 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
     fn type_implements_trait(
         &self,
         trait_def_id: DefId,
-        params: impl IntoIterator<Item = impl Into<GenericArg<'tcx>>>,
+        params: impl IntoIterator<Item: Into<GenericArg<'tcx>>>,
         param_env: ty::ParamEnv<'tcx>,
     ) -> traits::EvaluationResult {
         let trait_ref = self.tcx.mk_trait_ref(trait_def_id, params);

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/method_chain.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/method_chain.rs
@@ -98,7 +98,7 @@ impl<'tcx> ObligationEmittingRelation<'tcx> for CollectAllMismatches<'_, 'tcx> {
 
     fn register_predicates(
         &mut self,
-        _obligations: impl IntoIterator<Item = impl ty::ToPredicate<'tcx>>,
+        _obligations: impl IntoIterator<Item: ty::ToPredicate<'tcx>>,
     ) {
         // FIXME(deferred_projection_equality)
     }

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -239,7 +239,7 @@ pub fn predicate_for_trait_def<'tcx>(
     cause: ObligationCause<'tcx>,
     trait_def_id: DefId,
     recursion_depth: usize,
-    params: impl IntoIterator<Item = impl Into<GenericArg<'tcx>>>,
+    params: impl IntoIterator<Item: Into<GenericArg<'tcx>>>,
 ) -> PredicateObligation<'tcx> {
     let trait_ref = tcx.mk_trait_ref(trait_def_id, params);
     predicate_for_trait_ref(tcx, cause, param_env, trait_ref, recursion_depth)

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -77,7 +77,7 @@ pub(crate) fn clean_doc_module<'tcx>(doc: &DocModule<'tcx>, cx: &mut DocContext<
     // This covers the case where somebody does an import which should pull in an item,
     // but there's already an item with the same namespace and same name. Rust gives
     // priority to the not-imported one, so we should, too.
-    items.extend(doc.items.iter().flat_map(|(item, renamed, import_id)| {
+    items.extend(doc.items.values().flat_map(|(item, renamed, import_id)| {
         // First, lower everything other than imports.
         if matches!(item.kind, hir::ItemKind::Use(_, hir::UseKind::Glob)) {
             return Vec::new();
@@ -90,7 +90,7 @@ pub(crate) fn clean_doc_module<'tcx>(doc: &DocModule<'tcx>, cx: &mut DocContext<
         }
         v
     }));
-    items.extend(doc.items.iter().flat_map(|(item, renamed, _)| {
+    items.extend(doc.items.values().flat_map(|(item, renamed, _)| {
         // Now we actually lower the imports, skipping everything else.
         if let hir::ItemKind::Use(path, hir::UseKind::Glob) = item.kind {
             let name = renamed.unwrap_or_else(|| cx.tcx.hir().name(item.hir_id()));

--- a/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.diff
@@ -1,0 +1,83 @@
+- // MIR for `multiple` before DataflowConstProp
++ // MIR for `multiple` after DataflowConstProp
+  
+  fn multiple(_1: bool, _2: u8) -> () {
+      debug x => _1;                       // in scope 0 at $DIR/enum.rs:+0:13: +0:14
+      debug i => _2;                       // in scope 0 at $DIR/enum.rs:+0:22: +0:23
+      let mut _0: ();                      // return place in scope 0 at $DIR/enum.rs:+0:29: +0:29
+      let _3: std::option::Option<u8>;     // in scope 0 at $DIR/enum.rs:+1:9: +1:10
+      let mut _4: bool;                    // in scope 0 at $DIR/enum.rs:+1:16: +1:17
+      let mut _5: u8;                      // in scope 0 at $DIR/enum.rs:+2:14: +2:15
+      let mut _7: isize;                   // in scope 0 at $DIR/enum.rs:+9:23: +9:30
+      scope 1 {
+          debug e => _3;                   // in scope 1 at $DIR/enum.rs:+1:9: +1:10
+          let _6: u8;                      // in scope 1 at $DIR/enum.rs:+9:9: +9:10
+          let _8: u8;                      // in scope 1 at $DIR/enum.rs:+9:28: +9:29
+          scope 2 {
+              debug x => _6;               // in scope 2 at $DIR/enum.rs:+9:9: +9:10
+              let _9: u8;                  // in scope 2 at $DIR/enum.rs:+11:9: +11:10
+              scope 4 {
+                  debug y => _9;           // in scope 4 at $DIR/enum.rs:+11:9: +11:10
+              }
+          }
+          scope 3 {
+              debug i => _8;               // in scope 3 at $DIR/enum.rs:+9:28: +9:29
+          }
+      }
+  
+      bb0: {
+          StorageLive(_3);                 // scope 0 at $DIR/enum.rs:+1:9: +1:10
+          StorageLive(_4);                 // scope 0 at $DIR/enum.rs:+1:16: +1:17
+          _4 = _1;                         // scope 0 at $DIR/enum.rs:+1:16: +1:17
+          switchInt(move _4) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/enum.rs:+1:16: +1:17
+      }
+  
+      bb1: {
+          StorageLive(_5);                 // scope 0 at $DIR/enum.rs:+2:14: +2:15
+          _5 = _2;                         // scope 0 at $DIR/enum.rs:+2:14: +2:15
+          _3 = Option::<u8>::Some(move _5); // scope 0 at $DIR/enum.rs:+2:9: +2:16
+          StorageDead(_5);                 // scope 0 at $DIR/enum.rs:+2:15: +2:16
+          goto -> bb3;                     // scope 0 at $DIR/enum.rs:+1:13: +5:6
+      }
+  
+      bb2: {
+          _3 = Option::<u8>::None;         // scope 0 at $DIR/enum.rs:+4:9: +4:13
+          goto -> bb3;                     // scope 0 at $DIR/enum.rs:+1:13: +5:6
+      }
+  
+      bb3: {
+          StorageDead(_4);                 // scope 0 at $DIR/enum.rs:+5:5: +5:6
+          StorageLive(_6);                 // scope 1 at $DIR/enum.rs:+9:9: +9:10
+          _7 = discriminant(_3);           // scope 1 at $DIR/enum.rs:+9:19: +9:20
+          switchInt(move _7) -> [0: bb4, 1: bb6, otherwise: bb5]; // scope 1 at $DIR/enum.rs:+9:13: +9:20
+      }
+  
+      bb4: {
+          _6 = const 0_u8;                 // scope 1 at $DIR/enum.rs:+9:45: +9:46
+          goto -> bb7;                     // scope 1 at $DIR/enum.rs:+9:45: +9:46
+      }
+  
+      bb5: {
+          unreachable;                     // scope 1 at $DIR/enum.rs:+9:19: +9:20
+      }
+  
+      bb6: {
+          StorageLive(_8);                 // scope 1 at $DIR/enum.rs:+9:28: +9:29
+          _8 = ((_3 as Some).0: u8);       // scope 1 at $DIR/enum.rs:+9:28: +9:29
+          _6 = _8;                         // scope 3 at $DIR/enum.rs:+9:34: +9:35
+          StorageDead(_8);                 // scope 1 at $DIR/enum.rs:+9:34: +9:35
+          goto -> bb7;                     // scope 1 at $DIR/enum.rs:+9:34: +9:35
+      }
+  
+      bb7: {
+          StorageLive(_9);                 // scope 2 at $DIR/enum.rs:+11:9: +11:10
+-         _9 = _6;                         // scope 2 at $DIR/enum.rs:+11:13: +11:14
++         _9 = const 0_u8;                 // scope 2 at $DIR/enum.rs:+11:13: +11:14
+          _0 = const ();                   // scope 0 at $DIR/enum.rs:+0:29: +12:2
+          StorageDead(_9);                 // scope 2 at $DIR/enum.rs:+12:1: +12:2
+          StorageDead(_6);                 // scope 1 at $DIR/enum.rs:+12:1: +12:2
+          StorageDead(_3);                 // scope 0 at $DIR/enum.rs:+12:1: +12:2
+          return;                          // scope 0 at $DIR/enum.rs:+12:2: +12:2
+      }
+  }
+  

--- a/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.diff
@@ -71,8 +71,7 @@
   
       bb7: {
           StorageLive(_9);                 // scope 2 at $DIR/enum.rs:+11:9: +11:10
--         _9 = _6;                         // scope 2 at $DIR/enum.rs:+11:13: +11:14
-+         _9 = const 0_u8;                 // scope 2 at $DIR/enum.rs:+11:13: +11:14
+          _9 = _6;                         // scope 2 at $DIR/enum.rs:+11:13: +11:14
           _0 = const ();                   // scope 0 at $DIR/enum.rs:+0:29: +12:2
           StorageDead(_9);                 // scope 2 at $DIR/enum.rs:+12:1: +12:2
           StorageDead(_6);                 // scope 1 at $DIR/enum.rs:+12:1: +12:2

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -46,7 +46,23 @@ fn mutate_discriminant() -> u8 {
     )
 }
 
+// EMIT_MIR enum.multiple.DataflowConstProp.diff
+fn multiple(x: bool, i: u8) {
+    let e = if x {
+        Some(i)
+    } else {
+        None
+    };
+    // The dataflow state must have:
+    //   discriminant(e) => Top
+    //   (e as Some).0 => Top
+    let x = match e { Some(i) => i, None => 0 };
+    // Therefore, `x` should be `Top` here, and no replacement shall happen.
+    let y = x;
+}
+
 fn main() {
     simple();
     mutate_discriminant();
+    multiple(false, 5);
 }

--- a/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.diff
@@ -45,8 +45,10 @@
   
       bb3: {
           StorageLive(_4);                 // scope 1 at $DIR/enum.rs:+2:29: +2:30
-          _4 = ((_1 as V1).0: i32);        // scope 1 at $DIR/enum.rs:+2:29: +2:30
-          _2 = _4;                         // scope 3 at $DIR/enum.rs:+2:35: +2:36
+-         _4 = ((_1 as V1).0: i32);        // scope 1 at $DIR/enum.rs:+2:29: +2:30
+-         _2 = _4;                         // scope 3 at $DIR/enum.rs:+2:35: +2:36
++         _4 = const 0_i32;                // scope 1 at $DIR/enum.rs:+2:29: +2:30
++         _2 = const 0_i32;                // scope 3 at $DIR/enum.rs:+2:35: +2:36
           StorageDead(_4);                 // scope 1 at $DIR/enum.rs:+2:35: +2:36
           goto -> bb4;                     // scope 1 at $DIR/enum.rs:+2:35: +2:36
       }

--- a/tests/rustdoc/reexports-of-same-name.rs
+++ b/tests/rustdoc/reexports-of-same-name.rs
@@ -1,0 +1,26 @@
+// This test ensures that there are 4 imports as expected:
+// * 2 for `Foo`
+// * 2 for `Bar`
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html'
+
+pub mod nested {
+    /// Foo the struct
+    pub struct Foo {}
+
+    #[allow(non_snake_case)]
+    /// Foo the function
+    pub fn Foo() {}
+}
+
+// @count - '//*[@id="main-content"]//code' 'pub use nested::Foo;' 2
+// @has - '//*[@id="reexport.Foo"]//a[@href="nested/struct.Foo.html"]' 'Foo'
+// @has - '//*[@id="reexport.Foo-1"]//a[@href="nested/fn.Foo.html"]' 'Foo'
+pub use nested::Foo;
+
+// @count - '//*[@id="main-content"]//code' 'pub use Foo as Bar;' 2
+// @has - '//*[@id="reexport.Bar"]//a[@href="nested/struct.Foo.html"]' 'Foo'
+// @has - '//*[@id="reexport.Bar-1"]//a[@href="nested/fn.Foo.html"]' 'Foo'
+pub use Foo as Bar;

--- a/tests/ui/associated-consts/issue-105330.stderr
+++ b/tests/ui/associated-consts/issue-105330.stderr
@@ -33,7 +33,7 @@ LL | fn main<A: TraitWAssocConst<A=32>>() {
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl header
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl headers
   --> $DIR/issue-105330.rs:6:27
    |
 LL | impl TraitWAssocConst for impl Demo {

--- a/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.rs
+++ b/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.rs
@@ -1,0 +1,15 @@
+#![feature(associated_type_bounds)]
+
+trait B {
+    type AssocType;
+}
+
+fn f()
+where
+    dyn for<'j> B<AssocType: 'j>:,
+    //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+    //~| ERROR the value of the associated type `AssocType` (from trait `B`) must be specified
+{
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.rs
+++ b/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.rs
@@ -8,7 +8,6 @@ fn f()
 where
     dyn for<'j> B<AssocType: 'j>:,
     //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-    //~| ERROR the value of the associated type `AssocType` (from trait `B`) must be specified
 {
 }
 

--- a/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.stderr
+++ b/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.stderr
@@ -4,15 +4,5 @@ error: associated type bounds are only allowed in where clauses and function sig
 LL |     dyn for<'j> B<AssocType: 'j>:,
    |                   ^^^^^^^^^^^^^
 
-error[E0191]: the value of the associated type `AssocType` (from trait `B`) must be specified
-  --> $DIR/bad-universal-in-dyn-in-where-clause.rs:9:9
-   |
-LL |     type AssocType;
-   |     -------------- `AssocType` defined here
-...
-LL |     dyn for<'j> B<AssocType: 'j>:,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `for<'j> B<AssocType: 'j, AssocType = Type>`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.stderr
+++ b/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.stderr
@@ -1,0 +1,18 @@
+error: associated type bounds are only allowed in where clauses and function signatures, not in bound
+  --> $DIR/bad-universal-in-dyn-in-where-clause.rs:9:19
+   |
+LL |     dyn for<'j> B<AssocType: 'j>:,
+   |                   ^^^^^^^^^^^^^
+
+error[E0191]: the value of the associated type `AssocType` (from trait `B`) must be specified
+  --> $DIR/bad-universal-in-dyn-in-where-clause.rs:9:9
+   |
+LL |     type AssocType;
+   |     -------------- `AssocType` defined here
+...
+LL |     dyn for<'j> B<AssocType: 'j>:,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `for<'j> B<AssocType: 'j, AssocType = Type>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.stderr
+++ b/tests/ui/associated-type-bounds/bad-universal-in-dyn-in-where-clause.stderr
@@ -1,4 +1,4 @@
-error: associated type bounds are only allowed in where clauses and function signatures, not in bound
+error: associated type bounds are only allowed in where clauses and function signatures, not in bounds
   --> $DIR/bad-universal-in-dyn-in-where-clause.rs:9:19
    |
 LL |     dyn for<'j> B<AssocType: 'j>:,

--- a/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.rs
+++ b/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.rs
@@ -1,0 +1,14 @@
+#![feature(associated_type_bounds)]
+
+trait Trait {
+    type Item;
+}
+
+trait Trait2 {}
+
+// It's not possible to insert a universal `impl Trait` here!
+impl dyn Trait<Item: Trait2> {}
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Trait`) must be specified
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.rs
+++ b/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.rs
@@ -9,6 +9,5 @@ trait Trait2 {}
 // It's not possible to insert a universal `impl Trait` here!
 impl dyn Trait<Item: Trait2> {}
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Trait`) must be specified
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.stderr
+++ b/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.stderr
@@ -1,0 +1,8 @@
+error: associated type bounds are only allowed in where clauses and function signatures, not in impl header
+  --> $DIR/bad-universal-in-impl-sig.rs:10:16
+   |
+LL | impl dyn Trait<Item: Trait2> {}
+   |                ^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.stderr
+++ b/tests/ui/associated-type-bounds/bad-universal-in-impl-sig.stderr
@@ -1,4 +1,4 @@
-error: associated type bounds are only allowed in where clauses and function signatures, not in impl header
+error: associated type bounds are only allowed in where clauses and function signatures, not in impl headers
   --> $DIR/bad-universal-in-impl-sig.rs:10:16
    |
 LL | impl dyn Trait<Item: Trait2> {}

--- a/tests/ui/associated-type-bounds/inside-adt.rs
+++ b/tests/ui/associated-type-bounds/inside-adt.rs
@@ -4,32 +4,23 @@ use std::mem::ManuallyDrop;
 
 struct S1 { f: dyn Iterator<Item: Copy> }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 struct S2 { f: Box<dyn Iterator<Item: Copy>> }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 struct S3 { f: dyn Iterator<Item: 'static> }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 
 enum E1 { V(dyn Iterator<Item: Copy>) }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 enum E3 { V(dyn Iterator<Item: 'static>) }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 
 union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }
 //~^ ERROR associated type bounds are only allowed in where clauses and function signatures
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/inside-adt.rs
+++ b/tests/ui/associated-type-bounds/inside-adt.rs
@@ -3,28 +3,33 @@
 use std::mem::ManuallyDrop;
 
 struct S1 { f: dyn Iterator<Item: Copy> }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 struct S2 { f: Box<dyn Iterator<Item: Copy>> }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 struct S3 { f: dyn Iterator<Item: 'static> }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 
 enum E1 { V(dyn Iterator<Item: Copy>) }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
-//~| ERROR the size for values of type `(dyn Iterator<Item = impl Copy> + 'static)`
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 enum E3 { V(dyn Iterator<Item: 'static>) }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
-//~| ERROR the size for values of type `(dyn Iterator<Item = impl Sized + 'static> + 'static)`
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 
 union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
-//~| ERROR the size for values of type `(dyn Iterator<Item = impl Copy> + 'static)`
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }
-//~^ ERROR associated type bounds are not allowed within structs, enums, or unions
-//~| ERROR the size for values of type `(dyn Iterator<Item = impl Sized + 'static> + 'static)`
+//~^ ERROR associated type bounds are only allowed in where clauses and function signatures
+//~| ERROR the value of the associated type `Item` (from trait `Iterator`) must be specified
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/inside-adt.stderr
+++ b/tests/ui/associated-type-bounds/inside-adt.stderr
@@ -1,131 +1,129 @@
-error: associated type bounds are not allowed within structs, enums, or unions
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
   --> $DIR/inside-adt.rs:5:29
    |
 LL | struct S1 { f: dyn Iterator<Item: Copy> }
    |                             ^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:7:33
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:8:33
    |
 LL | struct S2 { f: Box<dyn Iterator<Item: Copy>> }
    |                                 ^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:9:29
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:11:29
    |
 LL | struct S3 { f: dyn Iterator<Item: 'static> }
    |                             ^^^^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:12:26
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:15:26
    |
 LL | enum E1 { V(dyn Iterator<Item: Copy>) }
    |                          ^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:15:30
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:18:30
    |
 LL | enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
    |                              ^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:17:26
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:21:26
    |
 LL | enum E3 { V(dyn Iterator<Item: 'static>) }
    |                          ^^^^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:21:41
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:25:41
    |
 LL | union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
    |                                         ^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:24:45
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:28:45
    |
 LL | union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
    |                                             ^^^^^^^^^^
 
-error: associated type bounds are not allowed within structs, enums, or unions
-  --> $DIR/inside-adt.rs:26:41
+error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+  --> $DIR/inside-adt.rs:31:41
    |
 LL | union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }
    |                                         ^^^^^^^^^^^^^
 
-error[E0277]: the size for values of type `(dyn Iterator<Item = impl Copy> + 'static)` cannot be known at compilation time
-  --> $DIR/inside-adt.rs:12:13
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:5:20
+   |
+LL | struct S1 { f: dyn Iterator<Item: Copy> }
+   |                    ^^^^^^^^^^^^^^^^^^^^
+   |                    |
+   |                    associated type `Item` must be specified
+   |                    help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
+
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:8:24
+   |
+LL | struct S2 { f: Box<dyn Iterator<Item: Copy>> }
+   |                        ^^^^^^^^^^^^^^^^^^^^
+   |                        |
+   |                        associated type `Item` must be specified
+   |                        help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
+
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:11:20
+   |
+LL | struct S3 { f: dyn Iterator<Item: 'static> }
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Iterator<Item: 'static, Item = Type>`
+
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:15:17
    |
 LL | enum E1 { V(dyn Iterator<Item: Copy>) }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `(dyn Iterator<Item = impl Copy> + 'static)`
-   = note: no field of an enum variant may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
-   |
-LL | enum E1 { V(&dyn Iterator<Item: Copy>) }
-   |             +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL | enum E1 { V(Box<dyn Iterator<Item: Copy>>) }
-   |             ++++                        +
+   |                 ^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 associated type `Item` must be specified
+   |                 help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
 
-error[E0277]: the size for values of type `(dyn Iterator<Item = impl Sized + 'static> + 'static)` cannot be known at compilation time
-  --> $DIR/inside-adt.rs:17:13
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:18:21
+   |
+LL | enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
+   |                     ^^^^^^^^^^^^^^^^^^^^
+   |                     |
+   |                     associated type `Item` must be specified
+   |                     help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
+
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:21:17
    |
 LL | enum E3 { V(dyn Iterator<Item: 'static>) }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `(dyn Iterator<Item = impl Sized + 'static> + 'static)`
-   = note: no field of an enum variant may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
-   |
-LL | enum E3 { V(&dyn Iterator<Item: 'static>) }
-   |             +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL | enum E3 { V(Box<dyn Iterator<Item: 'static>>) }
-   |             ++++                           +
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Iterator<Item: 'static, Item = Type>`
 
-error[E0277]: the size for values of type `(dyn Iterator<Item = impl Copy> + 'static)` cannot be known at compilation time
-  --> $DIR/inside-adt.rs:21:15
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:25:32
    |
 LL | union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: within `ManuallyDrop<(dyn Iterator<Item = impl Copy> + 'static)>`, the trait `Sized` is not implemented for `(dyn Iterator<Item = impl Copy> + 'static)`
-   = note: required because it appears within the type `ManuallyDrop<dyn Iterator<Item = impl Copy>>`
-   = note: no field of a union may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
-   |
-LL | union U1 { f: &ManuallyDrop<dyn Iterator<Item: Copy>> }
-   |               +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL | union U1 { f: Box<ManuallyDrop<dyn Iterator<Item: Copy>>> }
-   |               ++++                                      +
+   |                                ^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                associated type `Item` must be specified
+   |                                help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
 
-error[E0277]: the size for values of type `(dyn Iterator<Item = impl Sized + 'static> + 'static)` cannot be known at compilation time
-  --> $DIR/inside-adt.rs:26:15
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:28:36
+   |
+LL | union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
+   |                                    ^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    associated type `Item` must be specified
+   |                                    help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
+
+error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+  --> $DIR/inside-adt.rs:31:32
    |
 LL | union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: within `ManuallyDrop<(dyn Iterator<Item = impl Sized + 'static> + 'static)>`, the trait `Sized` is not implemented for `(dyn Iterator<Item = impl Sized + 'static> + 'static)`
-   = note: required because it appears within the type `ManuallyDrop<dyn Iterator<Item = impl Sized>>`
-   = note: no field of a union may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
-   |
-LL | union U3 { f: &ManuallyDrop<dyn Iterator<Item: 'static>> }
-   |               +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL | union U3 { f: Box<ManuallyDrop<dyn Iterator<Item: 'static>>> }
-   |               ++++                                         +
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Iterator<Item: 'static, Item = Type>`
 
-error: aborting due to 13 previous errors
+error: aborting due to 18 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/associated-type-bounds/inside-adt.stderr
+++ b/tests/ui/associated-type-bounds/inside-adt.stderr
@@ -5,125 +5,52 @@ LL | struct S1 { f: dyn Iterator<Item: Copy> }
    |                             ^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:8:33
+  --> $DIR/inside-adt.rs:7:33
    |
 LL | struct S2 { f: Box<dyn Iterator<Item: Copy>> }
    |                                 ^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:11:29
+  --> $DIR/inside-adt.rs:9:29
    |
 LL | struct S3 { f: dyn Iterator<Item: 'static> }
    |                             ^^^^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:15:26
+  --> $DIR/inside-adt.rs:12:26
    |
 LL | enum E1 { V(dyn Iterator<Item: Copy>) }
    |                          ^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:18:30
+  --> $DIR/inside-adt.rs:14:30
    |
 LL | enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
    |                              ^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:21:26
+  --> $DIR/inside-adt.rs:16:26
    |
 LL | enum E3 { V(dyn Iterator<Item: 'static>) }
    |                          ^^^^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:25:41
+  --> $DIR/inside-adt.rs:19:41
    |
 LL | union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
    |                                         ^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:28:45
+  --> $DIR/inside-adt.rs:21:45
    |
 LL | union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
    |                                             ^^^^^^^^^^
 
 error: associated type bounds are only allowed in where clauses and function signatures, not in field type
-  --> $DIR/inside-adt.rs:31:41
+  --> $DIR/inside-adt.rs:23:41
    |
 LL | union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }
    |                                         ^^^^^^^^^^^^^
 
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:5:20
-   |
-LL | struct S1 { f: dyn Iterator<Item: Copy> }
-   |                    ^^^^^^^^^^^^^^^^^^^^
-   |                    |
-   |                    associated type `Item` must be specified
-   |                    help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
+error: aborting due to 9 previous errors
 
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:8:24
-   |
-LL | struct S2 { f: Box<dyn Iterator<Item: Copy>> }
-   |                        ^^^^^^^^^^^^^^^^^^^^
-   |                        |
-   |                        associated type `Item` must be specified
-   |                        help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:11:20
-   |
-LL | struct S3 { f: dyn Iterator<Item: 'static> }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Iterator<Item: 'static, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:15:17
-   |
-LL | enum E1 { V(dyn Iterator<Item: Copy>) }
-   |                 ^^^^^^^^^^^^^^^^^^^^
-   |                 |
-   |                 associated type `Item` must be specified
-   |                 help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:18:21
-   |
-LL | enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
-   |                     ^^^^^^^^^^^^^^^^^^^^
-   |                     |
-   |                     associated type `Item` must be specified
-   |                     help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:21:17
-   |
-LL | enum E3 { V(dyn Iterator<Item: 'static>) }
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Iterator<Item: 'static, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:25:32
-   |
-LL | union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
-   |                                ^^^^^^^^^^^^^^^^^^^^
-   |                                |
-   |                                associated type `Item` must be specified
-   |                                help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:28:36
-   |
-LL | union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
-   |                                    ^^^^^^^^^^^^^^^^^^^^
-   |                                    |
-   |                                    associated type `Item` must be specified
-   |                                    help: specify the associated types: `Iterator<Item: Copy, Item = Type>`
-
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
-  --> $DIR/inside-adt.rs:31:32
-   |
-LL | union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Iterator<Item: 'static, Item = Type>`
-
-error: aborting due to 18 previous errors
-
-For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/associated-type-bounds/inside-adt.stderr
+++ b/tests/ui/associated-type-bounds/inside-adt.stderr
@@ -1,52 +1,52 @@
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:5:29
    |
 LL | struct S1 { f: dyn Iterator<Item: Copy> }
    |                             ^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:7:33
    |
 LL | struct S2 { f: Box<dyn Iterator<Item: Copy>> }
    |                                 ^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:9:29
    |
 LL | struct S3 { f: dyn Iterator<Item: 'static> }
    |                             ^^^^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:12:26
    |
 LL | enum E1 { V(dyn Iterator<Item: Copy>) }
    |                          ^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:14:30
    |
 LL | enum E2 { V(Box<dyn Iterator<Item: Copy>>) }
    |                              ^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:16:26
    |
 LL | enum E3 { V(dyn Iterator<Item: 'static>) }
    |                          ^^^^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:19:41
    |
 LL | union U1 { f: ManuallyDrop<dyn Iterator<Item: Copy>> }
    |                                         ^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:21:45
    |
 LL | union U2 { f: ManuallyDrop<Box<dyn Iterator<Item: Copy>>> }
    |                                             ^^^^^^^^^^
 
-error: associated type bounds are only allowed in where clauses and function signatures, not in field type
+error: associated type bounds are only allowed in where clauses and function signatures, not in field types
   --> $DIR/inside-adt.rs:23:41
    |
 LL | union U3 { f: ManuallyDrop<dyn Iterator<Item: 'static>> }

--- a/tests/ui/async-await/in-trait/fn-not-async-err2.rs
+++ b/tests/ui/async-await/in-trait/fn-not-async-err2.rs
@@ -11,7 +11,7 @@ trait MyTrait {
 
 impl MyTrait for i32 {
     fn foo(&self) -> impl Future<Output = i32> {
-        //~^ ERROR `impl Trait` only allowed in function and inherent method return types, not in `impl` method return [E0562]
+        //~^ ERROR `impl Trait` only allowed in function and inherent method return types, not in `impl` method return types
         async { *self }
     }
 }

--- a/tests/ui/async-await/in-trait/fn-not-async-err2.stderr
+++ b/tests/ui/async-await/in-trait/fn-not-async-err2.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `impl` method return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `impl` method return types
   --> $DIR/fn-not-async-err2.rs:13:22
    |
 LL |     fn foo(&self) -> impl Future<Output = i32> {

--- a/tests/ui/feature-gates/feature-gate-associated_type_bounds.stderr
+++ b/tests/ui/feature-gates/feature-gate-associated_type_bounds.stderr
@@ -115,19 +115,19 @@ LL |     let _: impl Tr1<As1: Copy> = S1;
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const types
   --> $DIR/feature-gate-associated_type_bounds.rs:55:14
    |
 LL | const _cdef: impl Tr1<As1: Copy> = S1;
    |              ^^^^^^^^^^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const types
   --> $DIR/feature-gate-associated_type_bounds.rs:61:15
    |
 LL | static _sdef: impl Tr1<As1: Copy> = S1;
    |               ^^^^^^^^^^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/feature-gate-associated_type_bounds.rs:68:12
    |
 LL |     let _: impl Tr1<As1: Copy> = S1;

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_fn_trait_return.stderr
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_fn_trait_return.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
   --> $DIR/feature-gate-impl_trait_in_fn_trait_return.rs:1:24
    |
 LL | fn f() -> impl Fn() -> impl Sized { || () }
@@ -7,7 +7,7 @@ LL | fn f() -> impl Fn() -> impl Sized { || () }
    = note: see issue #99697 <https://github.com/rust-lang/rust/issues/99697> for more information
    = help: add `#![feature(impl_trait_in_fn_trait_return)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
   --> $DIR/feature-gate-impl_trait_in_fn_trait_return.rs:3:32
    |
 LL | fn g() -> &'static dyn Fn() -> impl Sized { &|| () }

--- a/tests/ui/feature-gates/feature-gate-return_position_impl_trait_in_trait.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_position_impl_trait_in_trait.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
   --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:8:17
    |
 LL |     fn bar() -> impl Sized;
@@ -7,7 +7,7 @@ LL |     fn bar() -> impl Sized;
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
   --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:9:21
    |
 LL |     fn baz() -> Box<impl std::fmt::Display>;
@@ -16,7 +16,7 @@ LL |     fn baz() -> Box<impl std::fmt::Display>;
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
   --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:15:23
    |
 LL |     async fn bar() -> impl Sized;

--- a/tests/ui/impl-trait/issues/issue-54600.stderr
+++ b/tests/ui/impl-trait/issues/issue-54600.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-54600.rs:4:19
    |
 LL |     let x: Option<impl Debug> = Some(44_u32);

--- a/tests/ui/impl-trait/issues/issue-54840.stderr
+++ b/tests/ui/impl-trait/issues/issue-54840.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-54840.rs:5:13
    |
 LL |     let j: &impl Add = &i;

--- a/tests/ui/impl-trait/issues/issue-58504.stderr
+++ b/tests/ui/impl-trait/issues/issue-58504.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-58504.rs:10:16
    |
 LL |     let gens: [impl Generator<Return=!, Yield=()>;2] = [ mk_gen(), mk_gen() ];

--- a/tests/ui/impl-trait/issues/issue-58956.stderr
+++ b/tests/ui/impl-trait/issues/issue-58956.stderr
@@ -1,10 +1,10 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const types
   --> $DIR/issue-58956.rs:7:11
    |
 LL | const _A: impl Lam = {
    |           ^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-58956.rs:9:17
    |
 LL |     let x: Wrap<impl Lam> = Wrap(B);

--- a/tests/ui/impl-trait/issues/issue-70971.stderr
+++ b/tests/ui/impl-trait/issues/issue-70971.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-70971.rs:2:14
    |
 LL |     let x : (impl Copy,) = (true,);

--- a/tests/ui/impl-trait/issues/issue-79099.stderr
+++ b/tests/ui/impl-trait/issues/issue-79099.stderr
@@ -9,7 +9,7 @@ LL |         let f: impl core::future::Future<Output = u8> = async { 1 };
    = help: pass `--edition 2021` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-79099.rs:3:16
    |
 LL |         let f: impl core::future::Future<Output = u8> = async { 1 };

--- a/tests/ui/impl-trait/issues/issue-83929-impl-trait-in-generic-default.stderr
+++ b/tests/ui/impl-trait/issues/issue-83929-impl-trait-in-generic-default.stderr
@@ -1,10 +1,10 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/issue-83929-impl-trait-in-generic-default.rs:1:16
    |
 LL | struct Foo<T = impl Copy>(T);
    |                ^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/issue-83929-impl-trait-in-generic-default.rs:4:20
    |
 LL | type Result<T, E = impl std::error::Error> = std::result::Result<T, E>;

--- a/tests/ui/impl-trait/issues/issue-84919.stderr
+++ b/tests/ui/impl-trait/issues/issue-84919.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-84919.rs:5:13
    |
 LL |     let _x: impl Trait = ();

--- a/tests/ui/impl-trait/issues/issue-86642.stderr
+++ b/tests/ui/impl-trait/issues/issue-86642.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in const types
   --> $DIR/issue-86642.rs:1:11
    |
 LL | static x: impl Fn(&str) -> Result<&str, ()> = move |source| {

--- a/tests/ui/impl-trait/issues/issue-87295.stderr
+++ b/tests/ui/impl-trait/issues/issue-87295.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-87295.rs:16:31
    |
 LL |     let _do_not_waste: Struct<impl Trait<Output = i32>> = Struct::new(());

--- a/tests/ui/impl-trait/nested_impl_trait.stderr
+++ b/tests/ui/impl-trait/nested_impl_trait.stderr
@@ -34,7 +34,7 @@ LL |     fn bad(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                  |         nested `impl Trait` here
    |                                  outer `impl Trait`
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
   --> $DIR/nested_impl_trait.rs:10:32
    |
 LL | fn bad_in_fn_syntax(x: fn() -> impl Into<impl Debug>) {}

--- a/tests/ui/impl-trait/where-allowed.stderr
+++ b/tests/ui/impl-trait/where-allowed.stderr
@@ -43,109 +43,109 @@ LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer params
   --> $DIR/where-allowed.rs:16:40
    |
 LL | fn in_fn_parameter_in_parameters(_: fn(impl Debug)) { panic!() }
    |                                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
   --> $DIR/where-allowed.rs:20:42
    |
 LL | fn in_fn_return_in_parameters(_: fn() -> impl Debug) { panic!() }
    |                                          ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer params
   --> $DIR/where-allowed.rs:24:38
    |
 LL | fn in_fn_parameter_in_return() -> fn(impl Debug) { panic!() }
    |                                      ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
   --> $DIR/where-allowed.rs:28:40
    |
 LL | fn in_fn_return_in_return() -> fn() -> impl Debug { panic!() }
    |                                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
   --> $DIR/where-allowed.rs:32:49
    |
 LL | fn in_dyn_Fn_parameter_in_parameters(_: &dyn Fn(impl Debug)) { panic!() }
    |                                                 ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
   --> $DIR/where-allowed.rs:36:51
    |
 LL | fn in_dyn_Fn_return_in_parameters(_: &dyn Fn() -> impl Debug) { panic!() }
    |                                                   ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
   --> $DIR/where-allowed.rs:40:55
    |
 LL | fn in_dyn_Fn_parameter_in_return() -> &'static dyn Fn(impl Debug) { panic!() }
    |                                                       ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
   --> $DIR/where-allowed.rs:47:51
    |
 LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                                   ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
   --> $DIR/where-allowed.rs:52:53
    |
 LL | fn in_impl_Fn_return_in_parameters(_: &impl Fn() -> impl Debug) { panic!() }
    |                                                     ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
   --> $DIR/where-allowed.rs:56:57
    |
 LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
    |                                                         ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
   --> $DIR/where-allowed.rs:64:38
    |
 LL | fn in_Fn_parameter_in_generics<F: Fn(impl Debug)> (_: F) { panic!() }
    |                                      ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
   --> $DIR/where-allowed.rs:68:40
    |
 LL | fn in_Fn_return_in_generics<F: Fn() -> impl Debug> (_: F) { panic!() }
    |                                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
   --> $DIR/where-allowed.rs:81:32
    |
 LL | struct InBraceStructField { x: impl Debug }
    |                                ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
   --> $DIR/where-allowed.rs:85:41
    |
 LL | struct InAdtInBraceStructField { x: Vec<impl Debug> }
    |                                         ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
   --> $DIR/where-allowed.rs:89:27
    |
 LL | struct InTupleStructField(impl Debug);
    |                           ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
   --> $DIR/where-allowed.rs:94:25
    |
 LL |     InBraceVariant { x: impl Debug },
    |                         ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field type
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
   --> $DIR/where-allowed.rs:96:20
    |
 LL |     InTupleVariant(impl Debug),
    |                    ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
   --> $DIR/where-allowed.rs:107:23
    |
 LL |     fn in_return() -> impl Debug;
@@ -154,7 +154,7 @@ LL |     fn in_return() -> impl Debug;
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `impl` method return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `impl` method return types
   --> $DIR/where-allowed.rs:124:34
    |
 LL |     fn in_trait_impl_return() -> impl Debug { () }
@@ -163,121 +163,121 @@ LL |     fn in_trait_impl_return() -> impl Debug { () }
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` params
   --> $DIR/where-allowed.rs:137:33
    |
 LL |     fn in_foreign_parameters(_: impl Debug);
    |                                 ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` return types
   --> $DIR/where-allowed.rs:140:31
    |
 LL |     fn in_foreign_return() -> impl Debug;
    |                               ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
   --> $DIR/where-allowed.rs:156:39
    |
 LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |                                       ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in traits
   --> $DIR/where-allowed.rs:161:16
    |
 LL | impl PartialEq<impl Debug> for () {
    |                ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl header
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl headers
   --> $DIR/where-allowed.rs:166:24
    |
 LL | impl PartialEq<()> for impl Debug {
    |                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl header
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl headers
   --> $DIR/where-allowed.rs:171:6
    |
 LL | impl impl Debug {
    |      ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl header
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl headers
   --> $DIR/where-allowed.rs:177:24
    |
 LL | impl InInherentImplAdt<impl Debug> {
    |                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bound
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bounds
   --> $DIR/where-allowed.rs:183:11
    |
 LL |     where impl Debug: Debug
    |           ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bound
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bounds
   --> $DIR/where-allowed.rs:190:15
    |
 LL |     where Vec<impl Debug>: Debug
    |               ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bound
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bounds
   --> $DIR/where-allowed.rs:197:24
    |
 LL |     where T: PartialEq<impl Debug>
    |                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
   --> $DIR/where-allowed.rs:204:17
    |
 LL |     where T: Fn(impl Debug)
    |                 ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
   --> $DIR/where-allowed.rs:211:22
    |
 LL |     where T: Fn() -> impl Debug
    |                      ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/where-allowed.rs:217:40
    |
 LL | struct InStructGenericParamDefault<T = impl Debug>(T);
    |                                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/where-allowed.rs:221:36
    |
 LL | enum InEnumGenericParamDefault<T = impl Debug> { Variant(T) }
    |                                    ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/where-allowed.rs:225:38
    |
 LL | trait InTraitGenericParamDefault<T = impl Debug> {}
    |                                      ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/where-allowed.rs:229:41
    |
 LL | type InTypeAliasGenericParamDefault<T = impl Debug> = T;
    |                                         ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/where-allowed.rs:233:11
    |
 LL | impl <T = impl Debug> T {}
    |           ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter default
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
   --> $DIR/where-allowed.rs:240:40
    |
 LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    |                                        ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/where-allowed.rs:246:29
    |
 LL |     let _in_local_variable: impl Fn() = || {};
    |                             ^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in closure return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in closure return types
   --> $DIR/where-allowed.rs:248:46
    |
 LL |     let _in_return_in_local_variable = || -> impl Fn() { || {} };

--- a/tests/ui/issues/issue-47715.stderr
+++ b/tests/ui/issues/issue-47715.stderr
@@ -1,22 +1,22 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generics
   --> $DIR/issue-47715.rs:9:37
    |
 LL | struct Container<T: Iterable<Item = impl Foo>> {
    |                                     ^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generics
   --> $DIR/issue-47715.rs:14:30
    |
 LL | enum Enum<T: Iterable<Item = impl Foo>> {
    |                              ^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generics
   --> $DIR/issue-47715.rs:19:32
    |
 LL | union Union<T: Iterable<Item = impl Foo> + Copy> {
    |                                ^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generics
   --> $DIR/issue-47715.rs:24:30
    |
 LL | type Type<T: Iterable<Item = impl Foo>> = T;

--- a/tests/ui/type-alias-impl-trait/type-alias-impl-trait-fn-type.stderr
+++ b/tests/ui/type-alias-impl-trait/type-alias-impl-trait-fn-type.stderr
@@ -1,4 +1,4 @@
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
   --> $DIR/type-alias-impl-trait-fn-type.rs:6:20
    |
 LL | type Foo = fn() -> impl Send;

--- a/tests/ui/typeck/issue-104513-ice.stderr
+++ b/tests/ui/typeck/issue-104513-ice.stderr
@@ -4,7 +4,7 @@ error[E0405]: cannot find trait `Oops` in this scope
 LL |     let _: S<impl Oops> = S;
    |                   ^^^^ not found in this scope
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
   --> $DIR/issue-104513-ice.rs:3:14
    |
 LL |     let _: S<impl Oops> = S;


### PR DESCRIPTION
Successful merges:

 - #108063 (Ban associated type bounds in bad positions)
 - #108208 (Correctly handle aggregates in DataflowConstProp)
 - #108218 (Windows: Quote more batch file arguments)
 - #108349 (rustdoc: Prevent duplicated imports)
 - #108350 (Use associated type bounds in some places in the compiler)
 - #108358 (Add git config command to `.git-blame-ignore-revs`)
 - #108373 (hir-analysis: make where-clause-on-main diagnostic translatable)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=108063,108208,108218,108349,108350,108358,108373)
<!-- homu-ignore:end -->