### PR TITLE
Remove DefiningAnchor from InferCtxt

### DIFF
--- a/compiler/rustc_borrowck/src/consumers.rs
+++ b/compiler/rustc_borrowck/src/consumers.rs
@@ -33,7 +33,7 @@ pub fn get_body_with_borrowck_facts(
     def: ty::WithOptConstParam<LocalDefId>,
 ) -> BodyWithBorrowckFacts<'_> {
     let (input_body, promoted) = tcx.mir_promoted(def);
-    let infcx = tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bind(def.did)).build();
+    let infcx = tcx.infer_ctxt().build();
     let input_body: &Body<'_> = &input_body.borrow();
     let promoted: &IndexVec<_, _> = &promoted.borrow();
     *super::do_mir_borrowck(&infcx, input_body, promoted, true, DefiningAnchor::Bind(def.did))

--- a/compiler/rustc_borrowck/src/consumers.rs
+++ b/compiler/rustc_borrowck/src/consumers.rs
@@ -36,5 +36,7 @@ pub fn get_body_with_borrowck_facts(
     let infcx = tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bind(def.did)).build();
     let input_body: &Body<'_> = &input_body.borrow();
     let promoted: &IndexVec<_, _> = &promoted.borrow();
-    *super::do_mir_borrowck(&infcx, input_body, promoted, true).1.unwrap()
+    *super::do_mir_borrowck(&infcx, input_body, promoted, true, DefiningAnchor::Bind(def.did))
+        .1
+        .unwrap()
 }

--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -6,6 +6,7 @@ use rustc_infer::infer::canonical::Canonical;
 use rustc_infer::infer::error_reporting::nice_region_error::NiceRegionError;
 use rustc_infer::infer::region_constraints::Constraint;
 use rustc_infer::infer::region_constraints::RegionConstraintData;
+use rustc_infer::infer::DefiningAnchor;
 use rustc_infer::infer::RegionVariableOrigin;
 use rustc_infer::infer::{InferCtxt, RegionResolutionError, SubregionOrigin, TyCtxtInferExt as _};
 use rustc_infer::traits::ObligationCause;
@@ -245,7 +246,7 @@ impl<'tcx> TypeOpInfo<'tcx> for PredicateQuery<'tcx> {
     ) -> Option<DiagnosticBuilder<'tcx, ErrorGuaranteed>> {
         let (infcx, key, _) =
             mbcx.infcx.tcx.infer_ctxt().build_with_canonical(cause.span, &self.canonical_query);
-        let ocx = ObligationCtxt::new(&infcx);
+        let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Error);
         type_op_prove_predicate_with_cause(&ocx, key, cause);
         try_extract_error_from_fulfill_cx(&ocx, placeholder_region, error_region)
     }
@@ -286,7 +287,7 @@ where
     ) -> Option<DiagnosticBuilder<'tcx, ErrorGuaranteed>> {
         let (infcx, key, _) =
             mbcx.infcx.tcx.infer_ctxt().build_with_canonical(cause.span, &self.canonical_query);
-        let ocx = ObligationCtxt::new(&infcx);
+        let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Error);
 
         // FIXME(lqd): Unify and de-duplicate the following with the actual
         // `rustc_traits::type_op::type_op_normalize` query to allow the span we need in the
@@ -330,7 +331,7 @@ impl<'tcx> TypeOpInfo<'tcx> for AscribeUserTypeQuery<'tcx> {
     ) -> Option<DiagnosticBuilder<'tcx, ErrorGuaranteed>> {
         let (infcx, key, _) =
             mbcx.infcx.tcx.infer_ctxt().build_with_canonical(cause.span, &self.canonical_query);
-        let ocx = ObligationCtxt::new(&infcx);
+        let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Error);
         type_op_ascribe_user_type_with_span(&ocx, key, Some(cause.span)).ok()?;
         try_extract_error_from_fulfill_cx(&ocx, placeholder_region, error_region)
     }

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -152,8 +152,7 @@ fn mir_borrowck(tcx: TyCtxt<'_>, def: ty::WithOptConstParam<LocalDefId>) -> &Bor
 
     let hir_owner = tcx.hir().local_def_id_to_hir_id(def.did).owner;
 
-    let infcx =
-        tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bind(hir_owner.def_id)).build();
+    let infcx = tcx.infer_ctxt().build();
     let input_body: &Body<'_> = &input_body.borrow();
     let promoted: &IndexVec<_, _> = &promoted.borrow();
     let opt_closure_req = do_mir_borrowck(

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -5,6 +5,7 @@
 use rustc_data_structures::vec_map::VecMap;
 use rustc_hir::def_id::LocalDefId;
 use rustc_index::vec::IndexVec;
+use rustc_infer::infer::DefiningAnchor;
 use rustc_middle::mir::{create_dump_file, dump_enabled, dump_mir, PassWhere};
 use rustc_middle::mir::{
     BasicBlock, Body, ClosureOutlivesSubject, ClosureRegionRequirements, LocalKind, Location,
@@ -167,6 +168,7 @@ pub(crate) fn compute_regions<'cx, 'tcx>(
     borrow_set: &BorrowSet<'tcx>,
     upvars: &[Upvar<'tcx>],
     use_polonius: bool,
+    defining_use_anchor: DefiningAnchor,
 ) -> NllOutput<'tcx> {
     let mut all_facts =
         (use_polonius || AllFacts::enabled(infcx.tcx)).then_some(AllFacts::default());
@@ -191,6 +193,7 @@ pub(crate) fn compute_regions<'cx, 'tcx>(
             elements,
             upvars,
             use_polonius,
+            defining_use_anchor,
         );
 
     if let Some(all_facts) = &mut all_facts {

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -3,8 +3,8 @@ use rustc_data_structures::vec_map::VecMap;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::OpaqueTyOrigin;
+use rustc_infer::infer::InferCtxt;
 use rustc_infer::infer::TyCtxtInferExt as _;
-use rustc_infer::infer::{DefiningAnchor, InferCtxt};
 use rustc_infer::traits::{Obligation, ObligationCause};
 use rustc_middle::ty::subst::{GenericArgKind, InternalSubsts};
 use rustc_middle::ty::visit::TypeVisitableExt;
@@ -273,11 +273,10 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
         // This logic duplicates most of `check_opaque_meets_bounds`.
         // FIXME(oli-obk): Also do region checks here and then consider removing `check_opaque_meets_bounds` entirely.
         let param_env = self.tcx.param_env(def_id);
+        let infcx = self.tcx.infer_ctxt().build();
         // HACK This bubble is required for this tests to pass:
         // nested-return-type2-tait2.rs
         // nested-return-type2-tait3.rs
-        let infcx =
-            self.tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bubble).build();
         let ocx = ObligationCtxt::new_with_opaque_type_bubbling(&infcx);
         // Require the hidden type to be well-formed with only the generics of the opaque type.
         // Defining use functions may have more bounds than the opaque type, which is ok, as long as the

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -3,8 +3,8 @@ use rustc_data_structures::vec_map::VecMap;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::OpaqueTyOrigin;
-use rustc_infer::infer::InferCtxt;
 use rustc_infer::infer::TyCtxtInferExt as _;
+use rustc_infer::infer::{DefiningAnchor, InferCtxt};
 use rustc_infer::traits::{Obligation, ObligationCause};
 use rustc_middle::ty::subst::{GenericArgKind, InternalSubsts};
 use rustc_middle::ty::visit::TypeVisitableExt;
@@ -277,7 +277,7 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
         // HACK This bubble is required for this tests to pass:
         // nested-return-type2-tait2.rs
         // nested-return-type2-tait3.rs
-        let ocx = ObligationCtxt::new_with_opaque_type_bubbling(&infcx);
+        let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Bubble);
         // Require the hidden type to be well-formed with only the generics of the opaque type.
         // Defining use functions may have more bounds than the opaque type, which is ok, as long as the
         // hidden type is well formed even without those bounds.

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -278,7 +278,7 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
         // nested-return-type2-tait3.rs
         let infcx =
             self.tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bubble).build();
-        let ocx = ObligationCtxt::new(&infcx);
+        let ocx = ObligationCtxt::new_with_opaque_type_bubbling(&infcx);
         // Require the hidden type to be well-formed with only the generics of the opaque type.
         // Defining use functions may have more bounds than the opaque type, which is ok, as long as the
         // hidden type is well formed even without those bounds.

--- a/compiler/rustc_borrowck/src/type_check/canonical.rs
+++ b/compiler/rustc_borrowck/src/type_check/canonical.rs
@@ -37,7 +37,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
     {
         let old_universe = self.infcx.universe();
 
-        let TypeOpOutput { output, constraints, error_info } = op.fully_perform(self.infcx)?;
+        let TypeOpOutput { output, constraints, error_info } =
+            op.fully_perform(self.infcx, self.defining_use_anchor)?;
 
         debug!(?output, ?constraints);
 

--- a/compiler/rustc_borrowck/src/type_check/canonical.rs
+++ b/compiler/rustc_borrowck/src/type_check/canonical.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use rustc_infer::infer::DefiningAnchor;
 use rustc_infer::infer::{canonical::Canonical, InferOk};
 use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::ty::{self, ToPredicate, Ty, TyCtxt, TypeFoldable};
@@ -221,7 +222,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         let cause = ObligationCause::dummy_with_span(span);
         let param_env = self.param_env;
         let op = |infcx: &'_ _| {
-            let ocx = ObligationCtxt::new_in_snapshot(infcx);
+            let ocx = ObligationCtxt::new_in_snapshot(infcx, DefiningAnchor::Error);
             let user_ty = ocx.normalize(&cause, param_env, user_ty);
             ocx.eq(&cause, param_env, user_ty, mir_ty)?;
             if !ocx.select_all_or_error().is_empty() {

--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -268,7 +268,7 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
             let TypeOpOutput { output: norm_ty, constraints: constraints_normalize, .. } = self
                 .param_env
                 .and(type_op::normalize::Normalize::new(ty))
-                .fully_perform(self.infcx)
+                .fully_perform(self.infcx, rustc_infer::infer::DefiningAnchor::Error)
                 .unwrap_or_else(|_| {
                     let guar = self
                         .infcx
@@ -349,7 +349,7 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
         let TypeOpOutput { output: bounds, constraints, .. } = self
             .param_env
             .and(type_op::implied_outlives_bounds::ImpliedOutlivesBounds { ty })
-            .fully_perform(self.infcx)
+            .fully_perform(self.infcx, rustc_infer::infer::DefiningAnchor::Error)
             .unwrap_or_else(|_| bug!("failed to compute implied bounds {:?}", ty));
         debug!(?bounds, ?constraints);
         self.add_outlives_bounds(bounds);

--- a/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
@@ -570,8 +570,10 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
         debug!("compute_drop_data(dropped_ty={:?})", dropped_ty,);
 
         let param_env = typeck.param_env;
-        let TypeOpOutput { output, constraints, .. } =
-            param_env.and(DropckOutlives::new(dropped_ty)).fully_perform(typeck.infcx).unwrap();
+        let TypeOpOutput { output, constraints, .. } = param_env
+            .and(DropckOutlives::new(dropped_ty))
+            .fully_perform(typeck.infcx, typeck.defining_use_anchor)
+            .unwrap();
 
         DropData { dropck_result: output, region_constraint_data: constraints }
     }

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -2720,10 +2720,15 @@ impl<'tcx> TypeOp<'tcx> for InstantiateOpaqueType<'tcx> {
     /// constraints in our `InferCtxt`
     type ErrorInfo = InstantiateOpaqueType<'tcx>;
 
-    fn fully_perform(mut self, infcx: &InferCtxt<'tcx>) -> Fallible<TypeOpOutput<'tcx, Self>> {
-        let (mut output, region_constraints) = scrape_region_constraints(infcx, || {
-            Ok(InferOk { value: (), obligations: self.obligations.clone() })
-        })?;
+    fn fully_perform(
+        mut self,
+        infcx: &InferCtxt<'tcx>,
+        defining_use_anchor: DefiningAnchor,
+    ) -> Fallible<TypeOpOutput<'tcx, Self>> {
+        let (mut output, region_constraints) =
+            scrape_region_constraints(infcx, defining_use_anchor, || {
+                Ok(InferOk { value: (), obligations: self.obligations.clone() })
+            })?;
         self.region_constraints = Some(region_constraints);
         output.error_info = Some(self);
         Ok(output)

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -21,7 +21,8 @@ use rustc_infer::infer::outlives::env::RegionBoundPairs;
 use rustc_infer::infer::region_constraints::RegionConstraintData;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::infer::{
-    InferCtxt, InferOk, LateBoundRegion, LateBoundRegionConversionTime, NllRegionVariableOrigin,
+    DefiningAnchor, InferCtxt, InferOk, LateBoundRegion, LateBoundRegionConversionTime,
+    NllRegionVariableOrigin,
 };
 use rustc_middle::mir::tcx::PlaceTy;
 use rustc_middle::mir::visit::{NonMutatingUseContext, PlaceContext, Visitor};
@@ -136,6 +137,7 @@ pub(crate) fn type_check<'mir, 'tcx>(
     elements: &Rc<RegionValueElements>,
     upvars: &[Upvar<'tcx>],
     use_polonius: bool,
+    defining_use_anchor: DefiningAnchor,
 ) -> MirTypeckResults<'tcx> {
     let implicit_region_bound = infcx.tcx.mk_re_var(universal_regions.fr_fn_body);
     let mut constraints = MirTypeckRegionConstraints {
@@ -182,6 +184,7 @@ pub(crate) fn type_check<'mir, 'tcx>(
         &region_bound_pairs,
         implicit_region_bound,
         &mut borrowck_context,
+        defining_use_anchor,
     );
 
     let errors_reported = {
@@ -877,6 +880,7 @@ struct TypeChecker<'a, 'tcx> {
     implicit_region_bound: ty::Region<'tcx>,
     reported_errors: FxHashSet<(Ty<'tcx>, Span)>,
     borrowck_context: &'a mut BorrowCheckContext<'a, 'tcx>,
+    defining_use_anchor: DefiningAnchor,
 }
 
 struct BorrowCheckContext<'a, 'tcx> {
@@ -1025,6 +1029,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         region_bound_pairs: &'a RegionBoundPairs<'tcx>,
         implicit_region_bound: ty::Region<'tcx>,
         borrowck_context: &'a mut BorrowCheckContext<'a, 'tcx>,
+        defining_use_anchor: DefiningAnchor,
     ) -> Self {
         let mut checker = Self {
             infcx,
@@ -1036,6 +1041,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             implicit_region_bound,
             borrowck_context,
             reported_errors: Default::default(),
+            defining_use_anchor,
         };
         checker.check_user_type_annotations();
         checker

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -88,7 +88,7 @@ impl<'tcx> TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> 
     }
 
     fn defining_use_anchor(&self) -> rustc_infer::infer::DefiningAnchor {
-        self.type_checker.infcx.defining_use_anchor
+        self.type_checker.defining_use_anchor
     }
 
     fn param_env(&self) -> ty::ParamEnv<'tcx> {

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -87,6 +87,10 @@ impl<'tcx> TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> 
         self.locations.span(self.type_checker.body)
     }
 
+    fn defining_use_anchor(&self) -> rustc_infer::infer::DefiningAnchor {
+        self.type_checker.infcx.defining_use_anchor
+    }
+
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.type_checker.param_env
     }

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -744,7 +744,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
 
                     let implsrc = {
                         let infcx = tcx.infer_ctxt().build();
-                        let mut selcx = SelectionContext::new(&infcx);
+                        let mut selcx = SelectionContext::new(&infcx, DefiningAnchor::Error);
                         selcx.select(&obligation)
                     };
 

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -4,7 +4,7 @@ use rustc_errors::{Diagnostic, ErrorGuaranteed};
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_index::bit_set::BitSet;
-use rustc_infer::infer::TyCtxtInferExt;
+use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_infer::traits::{ImplSource, Obligation, ObligationCause};
 use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::*;
@@ -752,7 +752,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                     // "non-const" check. This is required for correctness here.
                     {
                         let infcx = tcx.infer_ctxt().build();
-                        let ocx = ObligationCtxt::new(&infcx);
+                        let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Error);
 
                         let predicates = tcx.predicates_of(callee).instantiate(tcx, substs);
                         let cause = ObligationCause::new(

--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -7,7 +7,7 @@ use rustc_errors::{
 };
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
-use rustc_infer::infer::TyCtxtInferExt;
+use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_infer::traits::{ImplSource, Obligation, ObligationCause};
 use rustc_middle::mir;
 use rustc_middle::ty::print::with_no_trimmed_paths;
@@ -149,7 +149,7 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
                     );
 
                     let infcx = tcx.infer_ctxt().build();
-                    let mut selcx = SelectionContext::new(&infcx);
+                    let mut selcx = SelectionContext::new(&infcx, DefiningAnchor::Error);
                     let implsrc = selcx.select(&obligation);
 
                     if let Ok(Some(ImplSource::UserDefined(data))) = implsrc {

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -184,7 +184,12 @@ impl Qualif for NeedsNonConstDrop {
         }
 
         // If we had any errors, then it's bad
-        !traits::fully_solve_obligations(&infcx, impl_src.nested_obligations()).is_empty()
+        !traits::fully_solve_obligations(
+            &infcx,
+            impl_src.nested_obligations(),
+            rustc_infer::infer::DefiningAnchor::Error,
+        )
+        .is_empty()
     }
 
     fn in_adt_inherently<'tcx>(

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -4,7 +4,7 @@
 
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::LangItem;
-use rustc_infer::infer::TyCtxtInferExt;
+use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_middle::mir;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, subst::SubstsRef, AdtDef, Ty};
@@ -162,7 +162,7 @@ impl Qualif for NeedsNonConstDrop {
         );
 
         let infcx = cx.tcx.infer_ctxt().build();
-        let mut selcx = SelectionContext::new(&infcx);
+        let mut selcx = SelectionContext::new(&infcx, DefiningAnchor::Error);
         let Some(impl_src) = selcx.select(&obligation).ok().flatten() else {
             // If we couldn't select a const destruct candidate, then it's bad
             return true;

--- a/compiler/rustc_const_eval/src/util/compare_types.rs
+++ b/compiler/rustc_const_eval/src/util/compare_types.rs
@@ -3,7 +3,7 @@
 //! FIXME: Move this to a more general place. The utility of this extends to
 //! other areas of the compiler as well.
 
-use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
+use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::ObligationCause;
 use rustc_middle::ty::{ParamEnv, Ty, TyCtxt};
 use rustc_trait_selection::traits::ObligationCtxt;
@@ -41,8 +41,7 @@ pub fn is_subtype<'tcx>(
         return true;
     }
 
-    let mut builder =
-        tcx.infer_ctxt().ignoring_regions().with_opaque_type_inference(DefiningAnchor::Bubble);
+    let mut builder = tcx.infer_ctxt().ignoring_regions();
     let infcx = builder.build();
     let ocx = ObligationCtxt::new_with_opaque_type_bubbling(&infcx);
     let cause = ObligationCause::dummy();

--- a/compiler/rustc_const_eval/src/util/compare_types.rs
+++ b/compiler/rustc_const_eval/src/util/compare_types.rs
@@ -44,7 +44,7 @@ pub fn is_subtype<'tcx>(
     let mut builder =
         tcx.infer_ctxt().ignoring_regions().with_opaque_type_inference(DefiningAnchor::Bubble);
     let infcx = builder.build();
-    let ocx = ObligationCtxt::new(&infcx);
+    let ocx = ObligationCtxt::new_with_opaque_type_bubbling(&infcx);
     let cause = ObligationCause::dummy();
     let src = ocx.normalize(&cause, param_env, src);
     let dest = ocx.normalize(&cause, param_env, dest);

--- a/compiler/rustc_const_eval/src/util/compare_types.rs
+++ b/compiler/rustc_const_eval/src/util/compare_types.rs
@@ -3,7 +3,7 @@
 //! FIXME: Move this to a more general place. The utility of this extends to
 //! other areas of the compiler as well.
 
-use rustc_infer::infer::TyCtxtInferExt;
+use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_infer::traits::ObligationCause;
 use rustc_middle::ty::{ParamEnv, Ty, TyCtxt};
 use rustc_trait_selection::traits::ObligationCtxt;
@@ -43,7 +43,7 @@ pub fn is_subtype<'tcx>(
 
     let mut builder = tcx.infer_ctxt().ignoring_regions();
     let infcx = builder.build();
-    let ocx = ObligationCtxt::new_with_opaque_type_bubbling(&infcx);
+    let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Bubble);
     let cause = ObligationCause::dummy();
     let src = ocx.normalize(&cause, param_env, src);
     let dest = ocx.normalize(&cause, param_env, dest);

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -28,7 +28,7 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit::{walk_generics, Visitor as _};
 use rustc_hir::{GenericArg, GenericArgs, OpaqueTyOrigin};
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
-use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
+use rustc_infer::infer::{DefiningAnchor, InferCtxt, TyCtxtInferExt};
 use rustc_infer::traits::ObligationCause;
 use rustc_middle::infer::unify_key::{ConstVariableOrigin, ConstVariableOriginKind};
 use rustc_middle::middle::stability::AllowUnstable;
@@ -2231,7 +2231,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             .iter()
             .filter_map(|&(impl_, (assoc_item, def_scope))| {
                 infcx.probe(|_| {
-                    let ocx = ObligationCtxt::new_in_snapshot(&infcx);
+                    let ocx = ObligationCtxt::new_in_snapshot(&infcx, DefiningAnchor::Error);
 
                     let impl_ty = tcx.type_of(impl_);
                     let impl_substs = infcx.fresh_item_substs(impl_);

--- a/compiler/rustc_hir_analysis/src/autoderef.rs
+++ b/compiler/rustc_hir_analysis/src/autoderef.rs
@@ -143,7 +143,7 @@ impl<'a, 'tcx> Autoderef<'a, 'tcx> {
 
         let normalized_ty = self
             .infcx
-            .at(&cause, self.param_env)
+            .at(&cause, self.param_env, DefiningAnchor::Error)
             .normalize(tcx.mk_projection(tcx.lang_items().deref_target()?, trait_ref.substs));
         let mut fulfillcx = <dyn TraitEngine<'tcx>>::new_in_snapshot(tcx, self.defining_use_anchor);
         let normalized_ty =

--- a/compiler/rustc_hir_analysis/src/autoderef.rs
+++ b/compiler/rustc_hir_analysis/src/autoderef.rs
@@ -145,10 +145,10 @@ impl<'a, 'tcx> Autoderef<'a, 'tcx> {
             .infcx
             .at(&cause, self.param_env)
             .normalize(tcx.mk_projection(tcx.lang_items().deref_target()?, trait_ref.substs));
-        let mut fulfillcx = <dyn TraitEngine<'tcx>>::new_in_snapshot(tcx);
+        let mut fulfillcx = <dyn TraitEngine<'tcx>>::new_in_snapshot(tcx, self.defining_use_anchor);
         let normalized_ty =
             normalized_ty.into_value_registering_obligations(self.infcx, &mut *fulfillcx);
-        let errors = fulfillcx.select_where_possible(&self.infcx, self.defining_use_anchor);
+        let errors = fulfillcx.select_where_possible(&self.infcx);
         if !errors.is_empty() {
             // This shouldn't happen, except for evaluate/fulfill mismatches,
             // but that's not a reason for an ICE (`predicate_may_hold` is conservative

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1545,7 +1545,7 @@ pub(super) fn check_generator_obligations(tcx: TyCtxt<'_>, def_id: LocalDefId) {
         let obligation = Obligation::new(tcx, cause.clone(), param_env, *predicate);
         fulfillment_cx.register_predicate_obligation(&infcx, obligation);
     }
-    let errors = fulfillment_cx.select_all_or_error(&infcx);
+    let errors = fulfillment_cx.select_all_or_error(&infcx, DefiningAnchor::Bind(def_id));
     debug!(?errors);
     if !errors.is_empty() {
         infcx.err_ctxt().report_fulfillment_errors(&errors, None);

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1535,13 +1535,13 @@ pub(super) fn check_generator_obligations(tcx: TyCtxt<'_>, def_id: LocalDefId) {
         .ignoring_regions()
         .build();
 
-    let mut fulfillment_cx = <dyn TraitEngine<'_>>::new(infcx.tcx);
+    let mut fulfillment_cx = <dyn TraitEngine<'_>>::new(infcx.tcx, DefiningAnchor::Bind(def_id));
     for (predicate, cause) in generator_interior_predicates {
         let obligation = Obligation::new(tcx, cause.clone(), param_env, *predicate);
         fulfillment_cx.register_predicate_obligation(&infcx, obligation);
     }
     // Bind opaque types to `def_id` as they should have been checked by borrowck.
-    let errors = fulfillment_cx.select_all_or_error(&infcx, DefiningAnchor::Bind(def_id));
+    let errors = fulfillment_cx.select_all_or_error(&infcx);
     debug!(?errors);
     if !errors.is_empty() {
         infcx.err_ctxt().report_fulfillment_errors(&errors, None);

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -417,7 +417,7 @@ fn check_opaque_meets_bounds<'tcx>(
         .infer_ctxt()
         .with_opaque_type_inference(DefiningAnchor::Bind(defining_use_anchor))
         .build();
-    let ocx = ObligationCtxt::new(&infcx);
+    let ocx = ObligationCtxt::new_with_opaque_type_anchor(&infcx, defining_use_anchor);
     let opaque_ty = tcx.mk_opaque(def_id.to_def_id(), substs);
 
     // `ReErased` regions appear in the "parent_substs" of closures/generators.

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -414,7 +414,7 @@ fn check_opaque_meets_bounds<'tcx>(
     let param_env = tcx.param_env(defining_use_anchor);
 
     let infcx = tcx.infer_ctxt().build();
-    let ocx = ObligationCtxt::new_with_opaque_type_anchor(&infcx, defining_use_anchor);
+    let ocx = ObligationCtxt::new(&infcx, defining_use_anchor);
     let opaque_ty = tcx.mk_opaque(def_id.to_def_id(), substs);
 
     // `ReErased` regions appear in the "parent_substs" of closures/generators.

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -11,7 +11,7 @@ use rustc_hir::intravisit;
 use rustc_hir::{GenericParamKind, ImplItemKind};
 use rustc_infer::infer::outlives::env::OutlivesEnvironment;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
-use rustc_infer::infer::{self, InferCtxt, TyCtxtInferExt};
+use rustc_infer::infer::{self, DefiningAnchor, InferCtxt, TyCtxtInferExt};
 use rustc_infer::traits::util;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::util::ExplicitSelf;
@@ -203,7 +203,7 @@ fn compare_method_predicate_entailment<'tcx>(
     let param_env = traits::normalize_param_env_or_error(tcx, param_env, normalize_cause);
 
     let infcx = &tcx.infer_ctxt().build();
-    let ocx = ObligationCtxt::new(infcx);
+    let ocx = ObligationCtxt::new(infcx, DefiningAnchor::Error);
 
     debug!("compare_impl_method: caller_bounds={:?}", param_env.caller_bounds());
 
@@ -619,7 +619,7 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
         impl_to_placeholder_substs.rebase_onto(tcx, impl_m.container_id(tcx), trait_to_impl_substs);
 
     let infcx = &tcx.infer_ctxt().build();
-    let ocx = ObligationCtxt::new(infcx);
+    let ocx = ObligationCtxt::new(infcx, DefiningAnchor::Error);
 
     // Normalize the impl signature with fresh variables for lifetime inference.
     let norm_cause = ObligationCause::misc(return_span, impl_m_def_id);
@@ -1652,7 +1652,7 @@ pub(super) fn compare_impl_const_raw(
 
     let infcx = tcx.infer_ctxt().build();
     let param_env = tcx.param_env(impl_const_item_def.to_def_id());
-    let ocx = ObligationCtxt::new(&infcx);
+    let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Error);
 
     // The below is for the most part highly similar to the procedure
     // for methods above. It is simpler in many respects, especially
@@ -1806,7 +1806,7 @@ fn compare_type_predicate_entailment<'tcx>(
     );
     let param_env = traits::normalize_param_env_or_error(tcx, param_env, normalize_cause);
     let infcx = tcx.infer_ctxt().build();
-    let ocx = ObligationCtxt::new(&infcx);
+    let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Error);
 
     debug!("compare_type_predicate_entailment: caller_bounds={:?}", param_env.caller_bounds());
 
@@ -1992,7 +1992,7 @@ pub(super) fn check_type_bounds<'tcx>(
     let rebased_substs = impl_ty_substs.rebase_onto(tcx, container_id, impl_trait_ref.substs);
 
     let infcx = tcx.infer_ctxt().build();
-    let ocx = ObligationCtxt::new(&infcx);
+    let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Error);
 
     let impl_ty_span = match tcx.hir().get_by_def_id(impl_ty_def_id) {
         hir::Node::TraitItem(hir::TraitItem {

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -238,8 +238,6 @@ fn compare_method_predicate_entailment<'tcx>(
     // type.
 
     // Compute placeholder form of impl and trait method tys.
-    let tcx = infcx.tcx;
-
     let mut wf_tys = FxIndexSet::default();
 
     let unnormalized_impl_sig = infcx.instantiate_binder_with_fresh_vars(

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1674,7 +1674,14 @@ fn receiver_is_valid<'tcx>(
         return true;
     }
 
-    let mut autoderef = Autoderef::new(infcx, wfcx.param_env, wfcx.body_def_id, span, receiver_ty);
+    let mut autoderef = Autoderef::new(
+        infcx,
+        wfcx.param_env,
+        wfcx.body_def_id,
+        span,
+        receiver_ty,
+        wfcx.ocx.defining_use_anchor(),
+    );
 
     // The `arbitrary_self_types` feature allows raw pointer receivers like `self: *const Self`.
     if arbitrary_self_types_enabled {

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -11,7 +11,7 @@ use rustc_hir::lang_items::LangItem;
 use rustc_hir::ItemKind;
 use rustc_infer::infer::outlives::env::{OutlivesEnvironment, RegionBoundPairs};
 use rustc_infer::infer::outlives::obligations::TypeOutlives;
-use rustc_infer::infer::{self, InferCtxt, TyCtxtInferExt};
+use rustc_infer::infer::{self, DefiningAnchor, InferCtxt, TyCtxtInferExt};
 use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::trait_def::TraitSpecializationKind;
@@ -97,7 +97,7 @@ pub(super) fn enter_wf_checking_ctxt<'tcx, F>(
 {
     let param_env = tcx.param_env(body_def_id);
     let infcx = &tcx.infer_ctxt().build();
-    let ocx = ObligationCtxt::new(infcx);
+    let ocx = ObligationCtxt::new(infcx, DefiningAnchor::Error);
 
     let mut wfcx = WfCheckingCtxt { ocx, span, body_def_id, param_env };
 

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -335,6 +335,7 @@ fn visit_implementation_of_dispatch_from_dyn(tcx: TyCtxt<'_>, impl_did: LocalDef
                             [field.ty(tcx, substs_a), field.ty(tcx, substs_b)],
                         )
                     }),
+                    infer::DefiningAnchor::Error,
                 );
                 if !errors.is_empty() {
                     infcx.err_ctxt().report_fulfillment_errors(&errors, None);

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -8,8 +8,8 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::ItemKind;
 use rustc_infer::infer::outlives::env::OutlivesEnvironment;
-use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::infer::{self, RegionResolutionError};
+use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_middle::ty::adjustment::CoerceUnsizedInfo;
 use rustc_middle::ty::{self, suggest_constraining_type_params, Ty, TyCtxt, TypeVisitableExt};
 use rustc_trait_selection::traits::error_reporting::TypeErrCtxtExt;
@@ -227,7 +227,8 @@ fn visit_implementation_of_dispatch_from_dyn(tcx: TyCtxt<'_>, impl_did: LocalDef
     use rustc_type_ir::sty::TyKind::*;
     match (source.kind(), target.kind()) {
         (&Ref(r_a, _, mutbl_a), Ref(r_b, _, mutbl_b))
-            if infcx.at(&cause, param_env).eq(r_a, *r_b).is_ok() && mutbl_a == *mutbl_b => {}
+            if infcx.at(&cause, param_env, DefiningAnchor::Error).eq(r_a, *r_b).is_ok()
+                && mutbl_a == *mutbl_b => {}
         (&RawPtr(tm_a), &RawPtr(tm_b)) if tm_a.mutbl == tm_b.mutbl => (),
         (&Adt(def_a, substs_a), &Adt(def_b, substs_b))
             if def_a.is_struct() && def_b.is_struct() =>
@@ -270,7 +271,9 @@ fn visit_implementation_of_dispatch_from_dyn(tcx: TyCtxt<'_>, impl_did: LocalDef
                         }
                     }
 
-                    if let Ok(ok) = infcx.at(&cause, param_env).eq(ty_a, ty_b) {
+                    if let Ok(ok) =
+                        infcx.at(&cause, param_env, DefiningAnchor::Error).eq(ty_a, ty_b)
+                    {
                         if ok.obligations.is_empty() {
                             create_err(
                                 "the trait `DispatchFromDyn` may only be implemented \
@@ -497,7 +500,7 @@ pub fn coerce_unsized_info<'tcx>(tcx: TyCtxt<'tcx>, impl_did: DefId) -> CoerceUn
                     // we may have to evaluate constraint
                     // expressions in the course of execution.)
                     // See e.g., #41936.
-                    if let Ok(ok) = infcx.at(&cause, param_env).eq(a, b) {
+                    if let Ok(ok) = infcx.at(&cause, param_env, DefiningAnchor::Error).eq(a, b) {
                         if ok.obligations.is_empty() {
                             return None;
                         }

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -576,7 +576,7 @@ pub fn coerce_unsized_info<'tcx>(tcx: TyCtxt<'tcx>, impl_did: DefId) -> CoerceUn
     let cause = traits::ObligationCause::misc(span, impl_did);
     let predicate =
         predicate_for_trait_def(tcx, param_env, cause, trait_def_id, 0, [source, target]);
-    let errors = traits::fully_solve_obligation(&infcx, predicate);
+    let errors = traits::fully_solve_obligation(&infcx, predicate, infer::DefiningAnchor::Error);
     if !errors.is_empty() {
         infcx.err_ctxt().report_fulfillment_errors(&errors, None);
     }

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -25,7 +25,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{GenericParamKind, Node};
-use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
+use rustc_infer::infer::{DefiningAnchor, InferCtxt, TyCtxtInferExt};
 use rustc_infer::traits::ObligationCause;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::query::Providers;
@@ -1320,7 +1320,7 @@ fn suggest_impl_trait<'tcx>(
         {
             continue;
         }
-        let ocx = ObligationCtxt::new_in_snapshot(&infcx);
+        let ocx = ObligationCtxt::new_in_snapshot(&infcx, DefiningAnchor::Error);
         let item_ty = ocx.normalize(
             &ObligationCause::misc(span, def_id),
             param_env,

--- a/compiler/rustc_hir_analysis/src/hir_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/hir_wf_check.rs
@@ -80,6 +80,7 @@ fn diagnostic_hir_wf_check<'tcx>(
                     self.param_env,
                     ty::Binder::dummy(ty::PredicateKind::WellFormed(tcx_ty.into())),
                 ),
+                rustc_infer::infer::DefiningAnchor::Error,
             );
             if !errors.is_empty() {
                 debug!("Wf-check got errors for {:?}: {:?}", ty, errors);

--- a/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
@@ -72,7 +72,7 @@ use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_infer::infer::outlives::env::OutlivesEnvironment;
-use rustc_infer::infer::TyCtxtInferExt;
+use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_infer::traits::specialization_graph::Node;
 use rustc_middle::ty::subst::{GenericArg, InternalSubsts, SubstsRef};
 use rustc_middle::ty::trait_def::TraitSpecializationKind;
@@ -162,7 +162,7 @@ fn get_impl_substs(
     impl2_node: Node,
 ) -> Option<(SubstsRef<'_>, SubstsRef<'_>)> {
     let infcx = &tcx.infer_ctxt().build();
-    let ocx = ObligationCtxt::new(infcx);
+    let ocx = ObligationCtxt::new(infcx, DefiningAnchor::Error);
     let param_env = tcx.param_env(impl1_def_id);
 
     let assumed_wf_types =

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -165,7 +165,7 @@ fn require_same_types<'tcx>(
 ) -> bool {
     let infcx = &tcx.infer_ctxt().build();
     let param_env = ty::ParamEnv::empty();
-    let errors = match infcx.at(cause, param_env).eq(expected, actual) {
+    let errors = match infcx.at(cause, param_env, DefiningAnchor::Error).eq(expected, actual) {
         Ok(InferOk { obligations, .. }) => traits::fully_solve_obligations(
             infcx,
             obligations,

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -166,7 +166,11 @@ fn require_same_types<'tcx>(
     let infcx = &tcx.infer_ctxt().build();
     let param_env = ty::ParamEnv::empty();
     let errors = match infcx.at(cause, param_env).eq(expected, actual) {
-        Ok(InferOk { obligations, .. }) => traits::fully_solve_obligations(infcx, obligations),
+        Ok(InferOk { obligations, .. }) => traits::fully_solve_obligations(
+            infcx,
+            obligations,
+            rustc_infer::infer::DefiningAnchor::Error,
+        ),
         Err(err) => {
             infcx.err_ctxt().report_mismatched_types(cause, expected, actual, err).emit();
             return false;

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -102,7 +102,7 @@ use rustc_errors::ErrorGuaranteed;
 use rustc_errors::{DiagnosticMessage, SubdiagnosticMessage};
 use rustc_hir as hir;
 use rustc_hir::Node;
-use rustc_infer::infer::{InferOk, TyCtxtInferExt};
+use rustc_infer::infer::{DefiningAnchor, InferOk, TyCtxtInferExt};
 use rustc_macros::fluent_messages;
 use rustc_middle::middle;
 use rustc_middle::ty::query::Providers;
@@ -308,7 +308,7 @@ fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: DefId) {
             main_diagnostics_def_id,
             ObligationCauseCode::MainFunctionType,
         );
-        let ocx = traits::ObligationCtxt::new(&infcx);
+        let ocx = traits::ObligationCtxt::new(&infcx, DefiningAnchor::Error);
         let norm_return_ty = ocx.normalize(&cause, param_env, return_ty);
         ocx.register_bound(cause, param_env, norm_return_ty, term_did);
         let errors = ocx.select_all_or_error();

--- a/compiler/rustc_hir_typeck/src/autoderef.rs
+++ b/compiler/rustc_hir_typeck/src/autoderef.rs
@@ -12,7 +12,14 @@ use std::iter;
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn autoderef(&'a self, span: Span, base_ty: Ty<'tcx>) -> Autoderef<'a, 'tcx> {
-        Autoderef::new(self, self.param_env, self.body_id, span, base_ty, self.defining_use_anchor)
+        Autoderef::new(
+            self,
+            self.param_env,
+            self.body_id,
+            span,
+            base_ty,
+            self.defining_use_anchor(),
+        )
     }
 
     pub fn try_overloaded_deref(

--- a/compiler/rustc_hir_typeck/src/autoderef.rs
+++ b/compiler/rustc_hir_typeck/src/autoderef.rs
@@ -12,7 +12,7 @@ use std::iter;
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn autoderef(&'a self, span: Span, base_ty: Ty<'tcx>) -> Autoderef<'a, 'tcx> {
-        Autoderef::new(self, self.param_env, self.body_id, span, base_ty)
+        Autoderef::new(self, self.param_env, self.body_id, span, base_ty, self.defining_use_anchor)
     }
 
     pub fn try_overloaded_deref(

--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -46,7 +46,7 @@ pub(super) fn check_fn<'a, 'tcx>(
             fn_def_id,
             decl.output.span(),
             fcx.param_env,
-            fcx.defining_use_anchor,
+            fcx.defining_use_anchor(),
         ));
 
     fcx.ret_coercion = Some(RefCell::new(CoerceMany::new(ret_ty)));

--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -46,6 +46,7 @@ pub(super) fn check_fn<'a, 'tcx>(
             fn_def_id,
             decl.output.span(),
             fcx.param_env,
+            fcx.defining_use_anchor,
         ));
 
     fcx.ret_coercion = Some(RefCell::new(CoerceMany::new(ret_ty)));

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -565,7 +565,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let cause = self.misc(hir_ty.span);
                 let InferOk { value: (), obligations } = self
                     .at(&cause, self.param_env)
-                    .define_opaque_types(true)
+                    .define_opaque_types(self.defining_use_anchor)
                     .eq(*expected_ty, supplied_ty)?;
                 all_obligations.extend(obligations);
             }
@@ -578,7 +578,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let cause = &self.misc(decl.output.span());
             let InferOk { value: (), obligations } = self
                 .at(cause, self.param_env)
-                .define_opaque_types(true)
+                .define_opaque_types(self.defining_use_anchor)
                 .eq(expected_sigs.liberated_sig.output(), supplied_output_ty)?;
             all_obligations.extend(obligations);
 
@@ -735,6 +735,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 body_def_id,
                 self.tcx.def_span(expr_def_id),
                 self.param_env,
+                self.defining_use_anchor,
             );
         self.register_predicates(obligations);
 

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -564,7 +564,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // Check that E' = S'.
                 let cause = self.misc(hir_ty.span);
                 let InferOk { value: (), obligations } = self
-                    .at(&cause, self.param_env)
+                    .at(&cause)
                     .define_opaque_types(self.defining_use_anchor())
                     .eq(*expected_ty, supplied_ty)?;
                 all_obligations.extend(obligations);
@@ -577,7 +577,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             );
             let cause = &self.misc(decl.output.span());
             let InferOk { value: (), obligations } = self
-                .at(cause, self.param_env)
+                .at(cause)
                 .define_opaque_types(self.defining_use_anchor())
                 .eq(expected_sigs.liberated_sig.output(), supplied_output_ty)?;
             all_obligations.extend(obligations);

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -565,7 +565,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let cause = self.misc(hir_ty.span);
                 let InferOk { value: (), obligations } = self
                     .at(&cause, self.param_env)
-                    .define_opaque_types(self.defining_use_anchor)
+                    .define_opaque_types(self.defining_use_anchor())
                     .eq(*expected_ty, supplied_ty)?;
                 all_obligations.extend(obligations);
             }
@@ -578,7 +578,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let cause = &self.misc(decl.output.span());
             let InferOk { value: (), obligations } = self
                 .at(cause, self.param_env)
-                .define_opaque_types(self.defining_use_anchor)
+                .define_opaque_types(self.defining_use_anchor())
                 .eq(expected_sigs.liberated_sig.output(), supplied_output_ty)?;
             all_obligations.extend(obligations);
 
@@ -735,7 +735,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 body_def_id,
                 self.tcx.def_span(expr_def_id),
                 self.param_env,
-                self.defining_use_anchor,
+                self.defining_use_anchor(),
             );
         self.register_predicates(obligations);
 

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -45,7 +45,7 @@ use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::Expr;
 use rustc_hir_analysis::astconv::AstConv;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
-use rustc_infer::infer::{Coercion, InferOk, InferResult};
+use rustc_infer::infer::{Coercion, DefiningAnchor, InferOk, InferResult};
 use rustc_infer::traits::Obligation;
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::adjustment::{
@@ -1020,7 +1020,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let Ok(ok) = coerce.coerce(source, target) else {
                 return false;
             };
-            let ocx = ObligationCtxt::new_in_snapshot(self);
+            let ocx = ObligationCtxt::new_in_snapshot(self, DefiningAnchor::Error);
             ocx.register_obligations(ok.obligations);
             ocx.select_where_possible().is_empty()
         })

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -145,7 +145,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         self.commit_if_ok(|_| {
             let at = self
                 .at(&self.cause, self.fcx.param_env)
-                .define_opaque_types(self.defining_use_anchor);
+                .define_opaque_types(self.defining_use_anchor());
             if self.use_lub {
                 at.lub(b, a)
             } else {
@@ -178,7 +178,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             // due to `[type error]` and `_` not coercing together.
             let _ = self.commit_if_ok(|_| {
                 self.at(&self.cause, self.param_env)
-                    .define_opaque_types(self.defining_use_anchor)
+                    .define_opaque_types(self.defining_use_anchor())
                     .eq(a, b)
             });
             return success(vec![], self.fcx.tcx.ty_error(guar), vec![]);
@@ -585,8 +585,8 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             }
         })?;
 
-        let mut selcx =
-            traits::SelectionContext::new(self).with_defining_use_anchor(self.defining_use_anchor);
+        let mut selcx = traits::SelectionContext::new(self)
+            .with_defining_use_anchor(self.defining_use_anchor());
 
         // Create an obligation for `Source: CoerceUnsized<Target>`.
         let cause = ObligationCause::new(
@@ -1492,7 +1492,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
             assert!(expression_ty.is_unit(), "if let hack without unit type");
             fcx.at(cause, fcx.param_env)
                 // needed for tests/ui/type-alias-impl-trait/issue-65679-inst-opaque-ty-from-val-twice.rs
-                .define_opaque_types(fcx.defining_use_anchor)
+                .define_opaque_types(fcx.defining_use_anchor())
                 .eq_exp(label_expression_as_expected, expression_ty, self.merged_ty())
                 .map(|infer_ok| {
                     fcx.register_infer_ok_obligations(infer_ok);

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -142,7 +142,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
     }
 
     pub fn at(&self) -> At<'_, 'tcx> {
-        self.infcx.at(&self.cause, self.param_env)
+        self.fcx.at(&self.cause)
     }
 
     fn unify(&self, a: Ty<'tcx>, b: Ty<'tcx>) -> InferResult<'tcx, Ty<'tcx>> {

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -585,7 +585,8 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             }
         })?;
 
-        let mut selcx = traits::SelectionContext::new(self);
+        let mut selcx =
+            traits::SelectionContext::new(self).with_defining_use_anchor(self.defining_use_anchor);
 
         // Create an obligation for `Source: CoerceUnsized<Target>`.
         let cause = ObligationCause::new(

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -585,8 +585,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             }
         })?;
 
-        let mut selcx = traits::SelectionContext::new(self)
-            .with_defining_use_anchor(self.defining_use_anchor());
+        let mut selcx = traits::SelectionContext::new(self, self.defining_use_anchor());
 
         // Create an obligation for `Source: CoerceUnsized<Target>`.
         let cause = ObligationCause::new(

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -113,7 +113,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         actual: Ty<'tcx>,
     ) -> Option<DiagnosticBuilder<'tcx, ErrorGuaranteed>> {
-        match self.at(cause, self.param_env).define_opaque_types(true).sup(expected, actual) {
+        match self.at(cause, self.param_env).define_opaque_types(self.defining_use_anchor).sup(expected, actual) {
             Ok(InferOk { obligations, value: () }) => {
                 self.register_predicates(obligations);
                 None
@@ -143,7 +143,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         actual: Ty<'tcx>,
     ) -> Option<DiagnosticBuilder<'tcx, ErrorGuaranteed>> {
-        match self.at(cause, self.param_env).define_opaque_types(true).eq(expected, actual) {
+        match self
+            .at(cause, self.param_env)
+            .define_opaque_types(self.defining_use_anchor)
+            .eq(expected, actual)
+        {
             Ok(InferOk { obligations, value: () }) => {
                 self.register_predicates(obligations);
                 None

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -113,7 +113,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         actual: Ty<'tcx>,
     ) -> Option<DiagnosticBuilder<'tcx, ErrorGuaranteed>> {
-        match self.at(cause, self.param_env).define_opaque_types(self.defining_use_anchor).sup(expected, actual) {
+        match self
+            .at(cause, self.param_env)
+            .define_opaque_types(self.defining_use_anchor)
+            .sup(expected, actual)
+        {
             Ok(InferOk { obligations, value: () }) => {
                 self.register_predicates(obligations);
                 None

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -115,7 +115,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Option<DiagnosticBuilder<'tcx, ErrorGuaranteed>> {
         match self
             .at(cause, self.param_env)
-            .define_opaque_types(self.defining_use_anchor)
+            .define_opaque_types(self.defining_use_anchor())
             .sup(expected, actual)
         {
             Ok(InferOk { obligations, value: () }) => {
@@ -149,7 +149,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Option<DiagnosticBuilder<'tcx, ErrorGuaranteed>> {
         match self
             .at(cause, self.param_env)
-            .define_opaque_types(self.defining_use_anchor)
+            .define_opaque_types(self.defining_use_anchor())
             .eq(expected, actual)
         {
             Ok(InferOk { obligations, value: () }) => {

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -113,11 +113,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         actual: Ty<'tcx>,
     ) -> Option<DiagnosticBuilder<'tcx, ErrorGuaranteed>> {
-        match self
-            .at(cause, self.param_env)
-            .define_opaque_types(self.defining_use_anchor())
-            .sup(expected, actual)
-        {
+        match self.at(cause).define_opaque_types(self.defining_use_anchor()).sup(expected, actual) {
             Ok(InferOk { obligations, value: () }) => {
                 self.register_predicates(obligations);
                 None
@@ -147,11 +143,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         actual: Ty<'tcx>,
     ) -> Option<DiagnosticBuilder<'tcx, ErrorGuaranteed>> {
-        match self
-            .at(cause, self.param_env)
-            .define_opaque_types(self.defining_use_anchor())
-            .eq(expected, actual)
-        {
+        match self.at(cause).define_opaque_types(self.defining_use_anchor()).eq(expected, actual) {
             Ok(InferOk { obligations, value: () }) => {
                 self.register_predicates(obligations);
                 None

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1683,7 +1683,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             if let Some(_) = remaining_fields.remove(&ident) {
                                 let target_ty = self.field_ty(base_expr.span, f, substs);
                                 let cause = self.misc(base_expr.span);
-                                match self.at(&cause, self.param_env).sup(target_ty, fru_ty) {
+                                match self.at(&cause).sup(target_ty, fru_ty) {
                                     Ok(InferOk { obligations, value: () }) => {
                                         self.register_predicates(obligations)
                                     }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -594,7 +594,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         mutate_fulfillment_errors: impl Fn(&mut Vec<traits::FulfillmentError<'tcx>>),
     ) {
-        let mut result = self.fulfillment_cx.borrow_mut().select_where_possible(self);
+        let mut result =
+            self.fulfillment_cx.borrow_mut().select_where_possible(self, self.defining_use_anchor);
         if !result.is_empty() {
             mutate_fulfillment_errors(&mut result);
             self.adjust_fulfillment_errors_for_expr_obligation(&mut result);
@@ -746,7 +747,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let expect_args = self
             .fudge_inference_if_ok(|| {
-                let ocx = ObligationCtxt::new_in_snapshot(self);
+                let ocx = ObligationCtxt::new_in_snapshot(self)
+                    .with_defining_use_anchor(self.defining_use_anchor);
 
                 // Attempt to apply a subtyping relationship between the formal
                 // return type (likely containing type variables if the function

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1462,6 +1462,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.param_env,
             original_values,
             query_result,
+            self.defining_use_anchor,
         )
     }
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -317,9 +317,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
     {
-        self.register_infer_ok_obligations(
-            self.at(&self.misc(span), self.param_env).normalize(value),
-        )
+        self.register_infer_ok_obligations(self.at(&self.misc(span)).normalize(value))
     }
 
     pub fn require_type_meets(
@@ -561,7 +559,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Unify `interior` with `witness` and collect all the resulting obligations.
             let span = self.tcx.hir().body(body_id).value.span;
             let ok = self
-                .at(&self.misc(span), self.param_env)
+                .at(&self.misc(span))
                 .eq(interior, witness)
                 .expect("Failed to unify generator interior type");
             let mut obligations = ok.obligations;
@@ -1319,7 +1317,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // This also occurs for an enum variant on a type alias.
             let impl_ty = self.normalize(span, tcx.type_of(impl_def_id).subst(tcx, substs));
             let self_ty = self.normalize(span, self_ty);
-            match self.at(&self.misc(span), self.param_env).eq(impl_ty, self_ty) {
+            match self.at(&self.misc(span)).eq(impl_ty, self_ty) {
                 Ok(ok) => self.register_infer_ok_obligations(ok),
                 Err(_) => {
                     self.tcx.sess.delay_span_bug(

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -594,8 +594,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         mutate_fulfillment_errors: impl Fn(&mut Vec<traits::FulfillmentError<'tcx>>),
     ) {
-        let mut result =
-            self.fulfillment_cx.borrow_mut().select_where_possible(self, self.defining_use_anchor);
+        let mut result = self.fulfillment_cx.borrow_mut().select_where_possible(self);
         if !result.is_empty() {
             mutate_fulfillment_errors(&mut result);
             self.adjust_fulfillment_errors_for_expr_obligation(&mut result);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -747,8 +747,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let expect_args = self
             .fudge_inference_if_ok(|| {
-                let ocx = ObligationCtxt::new_in_snapshot(self)
-                    .with_defining_use_anchor(self.defining_use_anchor);
+                let ocx = ObligationCtxt::new_in_snapshot(self, self.defining_use_anchor);
 
                 // Attempt to apply a subtyping relationship between the formal
                 // return type (likely containing type variables if the function

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -738,7 +738,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if let ty::subst::GenericArgKind::Type(ty) = ty.unpack()
                     && let ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }) = *ty.kind()
                     && let Some(def_id) = def_id.as_local()
-                    && self.opaque_type_origin(def_id, self.defining_use_anchor).is_some() {
+                    && self.opaque_type_origin(def_id, self.defining_use_anchor()).is_some() {
                     return None;
                 }
             }
@@ -746,7 +746,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let expect_args = self
             .fudge_inference_if_ok(|| {
-                let ocx = ObligationCtxt::new_in_snapshot(self, self.defining_use_anchor);
+                let ocx = ObligationCtxt::new_in_snapshot(self, self.defining_use_anchor());
 
                 // Attempt to apply a subtyping relationship between the formal
                 // return type (likely containing type variables if the function
@@ -1460,7 +1460,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.param_env,
             original_values,
             query_result,
-            self.defining_use_anchor,
+            self.defining_use_anchor(),
         )
     }
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -738,7 +738,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if let ty::subst::GenericArgKind::Type(ty) = ty.unpack()
                     && let ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }) = *ty.kind()
                     && let Some(def_id) = def_id.as_local()
-                    && self.opaque_type_origin(def_id).is_some() {
+                    && self.opaque_type_origin(def_id, self.defining_use_anchor).is_some() {
                     return None;
                 }
             }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -302,9 +302,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             // 3. Check if the formal type is a supertype of the checked one
             //    and register any such obligations for future type checks
-            let supertype_error = self
-                .at(&self.misc(provided_arg.span), self.param_env)
-                .sup(formal_input_ty, coerced_ty);
+            let supertype_error =
+                self.at(&self.misc(provided_arg.span)).sup(formal_input_ty, coerced_ty);
             let subtyping_error = match supertype_error {
                 Ok(InferOk { obligations, value: () }) => {
                     self.register_predicates(obligations);
@@ -585,9 +584,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
 
             // Using probe here, since we don't want this subtyping to affect inference.
-            let subtyping_error = self.probe(|_| {
-                self.at(&self.misc(arg_span), self.param_env).sup(formal_input_ty, coerced_ty).err()
-            });
+            let subtyping_error = self
+                .probe(|_| self.at(&self.misc(arg_span)).sup(formal_input_ty, coerced_ty).err());
 
             // Same as above: if either the coerce type or the checked type is an error type,
             // consider them *not* compatible.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1903,7 +1903,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.param_env,
                             ty::Binder::dummy(trait_ref),
                         );
-                        match SelectionContext::new(&self).with_defining_use_anchor(self.defining_use_anchor).select(&obligation) {
+                        match SelectionContext::new(&self).with_defining_use_anchor(self.defining_use_anchor()).select(&obligation) {
                             Ok(Some(traits::ImplSource::UserDefined(impl_source))) => {
                                 Some(impl_source.impl_def_id)
                             }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1903,7 +1903,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.param_env,
                             ty::Binder::dummy(trait_ref),
                         );
-                        match SelectionContext::new(&self).with_defining_use_anchor(self.defining_use_anchor()).select(&obligation) {
+                        match SelectionContext::new(&self,self.defining_use_anchor()).select(&obligation) {
                             Ok(Some(traits::ImplSource::UserDefined(impl_source))) => {
                                 Some(impl_source.impl_def_id)
                             }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1903,7 +1903,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.param_env,
                             ty::Binder::dummy(trait_ref),
                         );
-                        match SelectionContext::new(&self).select(&obligation) {
+                        match SelectionContext::new(&self).with_defining_use_anchor(self.defining_use_anchor).select(&obligation) {
                             Ok(Some(traits::ImplSource::UserDefined(impl_source))) => {
                                 Some(impl_source.impl_def_id)
                             }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -13,9 +13,9 @@ use crate::{Diverges, EnclosingBreakables, Inherited};
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir_analysis::astconv::AstConv;
-use rustc_infer::infer;
 use rustc_infer::infer::error_reporting::TypeErrCtxt;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
+use rustc_infer::infer::{self, DefiningAnchor};
 use rustc_middle::infer::unify_key::{ConstVariableOrigin, ConstVariableOriginKind};
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::{self, Const, Ty, TyCtxt, TypeVisitableExt};
@@ -164,7 +164,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     return fn_sig;
                 }
                 self.probe(|_| {
-                    let ocx = ObligationCtxt::new_in_snapshot(self);
+                    let ocx = ObligationCtxt::new_in_snapshot(self, DefiningAnchor::Error);
                     let normalized_fn_sig =
                         ocx.normalize(&ObligationCause::dummy(), self.param_env, fn_sig);
                     if ocx.select_all_or_error().is_empty() {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -6,6 +6,7 @@ mod suggestions;
 
 pub use _impl::*;
 use rustc_errors::ErrorGuaranteed;
+use rustc_infer::infer::at::At;
 pub use suggestions::*;
 
 use crate::coercion::DynamicCoerceMany;
@@ -143,6 +144,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     pub fn misc(&self, span: Span) -> ObligationCause<'tcx> {
         self.cause(span, ObligationCauseCode::MiscObligation)
+    }
+
+    pub fn at(&'a self, cause: &'a ObligationCause<'tcx>) -> At<'a, 'tcx> {
+        self.infcx.at(cause, self.param_env)
     }
 
     pub fn sess(&self) -> &Session {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -147,7 +147,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     pub fn at(&'a self, cause: &'a ObligationCause<'tcx>) -> At<'a, 'tcx> {
-        self.infcx.at(cause, self.param_env)
+        self.infcx.at(cause, self.param_env, self.defining_use_anchor())
     }
 
     pub fn sess(&self) -> &Session {

--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -327,7 +327,7 @@ pub fn resolve_interior<'a, 'tcx>(
     );
 
     // Unify the type variable inside the generator with the new witness
-    match fcx.at(&fcx.misc(body.value.span), fcx.param_env).eq(interior, witness) {
+    match fcx.at(&fcx.misc(body.value.span)).eq(interior, witness) {
         Ok(ok) => fcx.register_infer_ok_obligations(ok),
         _ => bug!("failed to relate {interior} and {witness}"),
     }

--- a/compiler/rustc_hir_typeck/src/inherited.rs
+++ b/compiler/rustc_hir_typeck/src/inherited.rs
@@ -28,13 +28,6 @@ use std::ops::Deref;
 pub struct Inherited<'tcx> {
     pub(super) infcx: InferCtxt<'tcx>,
 
-    /// The `DefId` of the item in whose context we are performing inference or typeck.
-    /// It is used to check whether an opaque type use is a defining use.
-    ///
-    /// Its default value is `DefiningAnchor::Error`, this way it is easier to catch errors that
-    /// might come up during inference or typeck.
-    pub(super) defining_use_anchor: DefiningAnchor,
-
     pub(super) typeck_results: RefCell<ty::TypeckResults<'tcx>>,
 
     pub(super) locals: RefCell<HirIdMap<super::LocalTy<'tcx>>>,
@@ -124,7 +117,6 @@ impl<'tcx> Inherited<'tcx> {
 
         let defining_use_anchor = DefiningAnchor::Bind(typeck_results.borrow().hir_owner.def_id);
         Inherited {
-            defining_use_anchor,
             typeck_results,
             infcx,
             fulfillment_cx: RefCell::new(<dyn TraitEngine<'_>>::new(tcx, defining_use_anchor)),
@@ -139,6 +131,10 @@ impl<'tcx> Inherited<'tcx> {
             body_id,
             infer_var_info: RefCell::new(Default::default()),
         }
+    }
+
+    pub fn defining_use_anchor(&self) -> DefiningAnchor {
+        self.fulfillment_cx.borrow().defining_use_anchor()
     }
 
     #[instrument(level = "debug", skip(self))]

--- a/compiler/rustc_hir_typeck/src/inherited.rs
+++ b/compiler/rustc_hir_typeck/src/inherited.rs
@@ -96,10 +96,7 @@ impl<'tcx> Inherited<'tcx> {
         let hir_owner = tcx.hir().local_def_id_to_hir_id(def_id).owner;
 
         InheritedBuilder {
-            infcx: tcx
-                .infer_ctxt()
-                .ignoring_regions()
-                .with_opaque_type_inference(DefiningAnchor::Bind(hir_owner.def_id)),
+            infcx: tcx.infer_ctxt().ignoring_regions(),
             def_id,
             typeck_results: RefCell::new(ty::TypeckResults::new(hir_owner)),
         }

--- a/compiler/rustc_hir_typeck/src/inherited.rs
+++ b/compiler/rustc_hir_typeck/src/inherited.rs
@@ -127,7 +127,7 @@ impl<'tcx> Inherited<'tcx> {
             defining_use_anchor,
             typeck_results,
             infcx,
-            fulfillment_cx: RefCell::new(<dyn TraitEngine<'_>>::new(tcx)),
+            fulfillment_cx: RefCell::new(<dyn TraitEngine<'_>>::new(tcx, defining_use_anchor)),
             locals: RefCell::new(Default::default()),
             deferred_sized_obligations: RefCell::new(Vec::new()),
             deferred_call_resolutions: RefCell::new(Default::default()),

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -478,7 +478,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                 substs,
             })),
         );
-        match self.at(&cause, self.param_env).sup(method_self_ty, self_ty) {
+        match self.at(&cause).sup(method_self_ty, self_ty) {
             Ok(InferOk { obligations, value: () }) => {
                 self.register_predicates(obligations);
             }

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -409,8 +409,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let fn_sig =
             self.instantiate_binder_with_fresh_vars(obligation.cause.span, infer::FnCall, fn_sig);
 
-        let InferOk { value, obligations: o } =
-            self.at(&obligation.cause, self.param_env).normalize(fn_sig);
+        let InferOk { value, obligations: o } = self.at(&obligation.cause).normalize(fn_sig);
         let fn_sig = {
             obligations.extend(o);
             value
@@ -426,8 +425,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // any late-bound regions appearing in its bounds.
         let bounds = self.tcx.predicates_of(def_id).instantiate(self.tcx, substs);
 
-        let InferOk { value, obligations: o } =
-            self.at(&obligation.cause, self.param_env).normalize(bounds);
+        let InferOk { value, obligations: o } = self.at(&obligation.cause).normalize(bounds);
         let bounds = {
             obligations.extend(o);
             value

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1429,7 +1429,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         let predicate = ty::Binder::dummy(trait_ref);
         let obligation = traits::Obligation::new(self.tcx, cause, self.param_env, predicate);
         traits::SelectionContext::new(self)
-            .with_defining_use_anchor(self.defining_use_anchor)
+            .with_defining_use_anchor(self.defining_use_anchor())
             .select(&obligation)
     }
 

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1428,9 +1428,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         let cause = traits::ObligationCause::misc(self.span, self.body_id);
         let predicate = ty::Binder::dummy(trait_ref);
         let obligation = traits::Obligation::new(self.tcx, cause, self.param_env, predicate);
-        traits::SelectionContext::new(self)
-            .with_defining_use_anchor(self.defining_use_anchor())
-            .select(&obligation)
+        traits::SelectionContext::new(self, self.defining_use_anchor()).select(&obligation)
     }
 
     fn candidate_source(&self, candidate: &Candidate<'tcx>, self_ty: Ty<'tcx>) -> CandidateSource {

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1422,7 +1422,9 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         let cause = traits::ObligationCause::misc(self.span, self.body_id);
         let predicate = ty::Binder::dummy(trait_ref);
         let obligation = traits::Obligation::new(self.tcx, cause, self.param_env, predicate);
-        traits::SelectionContext::new(self).select(&obligation)
+        traits::SelectionContext::new(self)
+            .with_defining_use_anchor(self.defining_use_anchor)
+            .select(&obligation)
     }
 
     fn candidate_source(&self, candidate: &Candidate<'tcx>, self_ty: Ty<'tcx>) -> CandidateSource {

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -507,10 +507,16 @@ fn method_autoderef_steps<'tcx>(
     let (ref infcx, goal, inference_vars) = tcx.infer_ctxt().build_with_canonical(DUMMY_SP, &goal);
     let ParamEnvAnd { param_env, value: self_ty } = goal;
 
-    let mut autoderef =
-        Autoderef::new(infcx, param_env, hir::def_id::CRATE_DEF_ID, DUMMY_SP, self_ty)
-            .include_raw_pointers()
-            .silence_errors();
+    let mut autoderef = Autoderef::new(
+        infcx,
+        param_env,
+        hir::def_id::CRATE_DEF_ID,
+        DUMMY_SP,
+        self_ty,
+        infer::DefiningAnchor::Error,
+    )
+    .include_raw_pointers()
+    .silence_errors();
     let mut reached_raw_pointer = false;
     let mut steps: Vec<_> = autoderef
         .by_ref()

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -775,7 +775,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             (None, Some(trait_did)) => {
                 let (obligation, _) =
                     self.obligation_for_method(cause, trait_did, lhs_ty, Some(input_types));
-                Err(rustc_trait_selection::traits::fully_solve_obligation(self, obligation))
+                Err(rustc_trait_selection::traits::fully_solve_obligation(
+                    self,
+                    obligation,
+                    self.defining_use_anchor,
+                ))
             }
         }
     }

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -778,7 +778,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 Err(rustc_trait_selection::traits::fully_solve_obligation(
                     self,
                     obligation,
-                    self.defining_use_anchor,
+                    self.defining_use_anchor(),
                 ))
             }
         }

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -61,7 +61,6 @@ impl<'tcx> InferCtxt<'tcx> {
     pub fn fork(&self) -> Self {
         Self {
             tcx: self.tcx,
-            old_defining_use_anchor: self.old_defining_use_anchor,
             considering_regions: self.considering_regions,
             inner: self.inner.clone(),
             skip_leak_check: self.skip_leak_check.clone(),

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -61,7 +61,7 @@ impl<'tcx> InferCtxt<'tcx> {
     pub fn fork(&self) -> Self {
         Self {
             tcx: self.tcx,
-            defining_use_anchor: self.defining_use_anchor,
+            old_defining_use_anchor: self.old_defining_use_anchor,
             considering_regions: self.considering_regions,
             inner: self.inner.clone(),
             skip_leak_check: self.skip_leak_check.clone(),

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -51,8 +51,9 @@ impl<'tcx> InferCtxt<'tcx> {
         &'a self,
         cause: &'a ObligationCause<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
+        define_opaque_types: impl Into<DefiningAnchor>,
     ) -> At<'a, 'tcx> {
-        At { infcx: self, cause, param_env, define_opaque_types: DefiningAnchor::Error }
+        At { infcx: self, cause, param_env, define_opaque_types: define_opaque_types.into() }
     }
 
     /// Forks the inference context, creating a new inference context with the same inference

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -36,10 +36,7 @@ pub struct At<'a, 'tcx> {
     pub param_env: ty::ParamEnv<'tcx>,
     /// Whether we should define opaque types
     /// or just treat them opaquely.
-    /// Currently only used to prevent predicate
-    /// matching from matching anything against opaque
-    /// types.
-    pub define_opaque_types: bool,
+    pub define_opaque_types: DefiningAnchor,
 }
 
 pub struct Trace<'a, 'tcx> {
@@ -55,7 +52,7 @@ impl<'tcx> InferCtxt<'tcx> {
         cause: &'a ObligationCause<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
     ) -> At<'a, 'tcx> {
-        At { infcx: self, cause, param_env, define_opaque_types: false }
+        At { infcx: self, cause, param_env, define_opaque_types: DefiningAnchor::Error }
     }
 
     /// Forks the inference context, creating a new inference context with the same inference
@@ -93,7 +90,7 @@ pub trait ToTrace<'tcx>: Relate<'tcx> + Copy {
 }
 
 impl<'a, 'tcx> At<'a, 'tcx> {
-    pub fn define_opaque_types(self, define_opaque_types: bool) -> Self {
+    pub fn define_opaque_types(self, define_opaque_types: DefiningAnchor) -> Self {
         Self { define_opaque_types, ..self }
     }
 

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -181,12 +181,18 @@ impl<'tcx> InferCtxt<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         original_values: &OriginalQueryValues<'tcx>,
         query_response: &Canonical<'tcx, QueryResponse<'tcx, R>>,
+        defining_use_anchor: DefiningAnchor,
     ) -> InferResult<'tcx, R>
     where
         R: Debug + TypeFoldable<TyCtxt<'tcx>>,
     {
-        let InferOk { value: result_subst, mut obligations } =
-            self.query_response_substitution(cause, param_env, original_values, query_response)?;
+        let InferOk { value: result_subst, mut obligations } = self.query_response_substitution(
+            cause,
+            param_env,
+            original_values,
+            query_response,
+            defining_use_anchor,
+        )?;
 
         obligations.extend(self.query_outlives_constraints_into_obligations(
             cause,
@@ -243,12 +249,19 @@ impl<'tcx> InferCtxt<'tcx> {
         original_values: &OriginalQueryValues<'tcx>,
         query_response: &Canonical<'tcx, QueryResponse<'tcx, R>>,
         output_query_region_constraints: &mut QueryRegionConstraints<'tcx>,
+        defining_use_anchor: DefiningAnchor,
     ) -> InferResult<'tcx, R>
     where
         R: Debug + TypeFoldable<TyCtxt<'tcx>>,
     {
         let InferOk { value: result_subst, mut obligations } = self
-            .query_response_substitution_guess(cause, param_env, original_values, query_response)?;
+            .query_response_substitution_guess(
+                cause,
+                param_env,
+                original_values,
+                query_response,
+                defining_use_anchor,
+            )?;
 
         // Compute `QueryOutlivesConstraint` values that unify each of
         // the original values `v_o` that was canonicalized into a
@@ -357,6 +370,7 @@ impl<'tcx> InferCtxt<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         original_values: &OriginalQueryValues<'tcx>,
         query_response: &Canonical<'tcx, QueryResponse<'tcx, R>>,
+        defining_use_anchor: DefiningAnchor,
     ) -> InferResult<'tcx, CanonicalVarValues<'tcx>>
     where
         R: Debug + TypeFoldable<TyCtxt<'tcx>>,
@@ -371,6 +385,7 @@ impl<'tcx> InferCtxt<'tcx> {
             param_env,
             original_values,
             query_response,
+            defining_use_anchor,
         )?;
 
         value.obligations.extend(
@@ -403,6 +418,7 @@ impl<'tcx> InferCtxt<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         original_values: &OriginalQueryValues<'tcx>,
         query_response: &Canonical<'tcx, QueryResponse<'tcx, R>>,
+        defining_use_anchor: DefiningAnchor,
     ) -> InferResult<'tcx, CanonicalVarValues<'tcx>>
     where
         R: Debug + TypeFoldable<TyCtxt<'tcx>>,
@@ -504,7 +520,7 @@ impl<'tcx> InferCtxt<'tcx> {
             debug!(?a, ?b, "constrain opaque type");
             obligations.extend(
                 self.at(cause, param_env)
-                    .define_opaque_types(self.old_defining_use_anchor)
+                    .define_opaque_types(defining_use_anchor)
                     .eq(a, b)?
                     .obligations,
             );

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -111,7 +111,7 @@ impl<'tcx> InferCtxt<'tcx> {
         let tcx = self.tcx;
 
         // Select everything, returning errors.
-        let true_errors = fulfill_cx.select_where_possible(self);
+        let true_errors = fulfill_cx.select_where_possible(self, self.old_defining_use_anchor);
         debug!("true_errors = {:#?}", true_errors);
 
         if !true_errors.is_empty() {
@@ -121,7 +121,7 @@ impl<'tcx> InferCtxt<'tcx> {
         }
 
         // Anything left unselected *now* must be an ambiguity.
-        let ambig_errors = fulfill_cx.select_all_or_error(self);
+        let ambig_errors = fulfill_cx.select_all_or_error(self, self.old_defining_use_anchor);
         debug!("ambig_errors = {:#?}", ambig_errors);
 
         let region_obligations = self.take_registered_region_obligations();

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -57,14 +57,12 @@ impl<'tcx> InferCtxt<'tcx> {
         inference_vars: CanonicalVarValues<'tcx>,
         answer: T,
         fulfill_cx: &mut dyn TraitEngine<'tcx>,
-        defining_use_anchor: DefiningAnchor,
     ) -> Fallible<CanonicalQueryResponse<'tcx, T>>
     where
         T: Debug + TypeFoldable<TyCtxt<'tcx>>,
         Canonical<'tcx, QueryResponse<'tcx, T>>: ArenaAllocatable<'tcx>,
     {
-        let query_response =
-            self.make_query_response(inference_vars, answer, fulfill_cx, defining_use_anchor)?;
+        let query_response = self.make_query_response(inference_vars, answer, fulfill_cx)?;
         debug!("query_response = {:#?}", query_response);
         let canonical_result = self.canonicalize_response(query_response);
         debug!("canonical_result = {:#?}", canonical_result);
@@ -106,7 +104,6 @@ impl<'tcx> InferCtxt<'tcx> {
         inference_vars: CanonicalVarValues<'tcx>,
         answer: T,
         fulfill_cx: &mut dyn TraitEngine<'tcx>,
-        defining_use_anchor: DefiningAnchor,
     ) -> Result<QueryResponse<'tcx, T>, NoSolution>
     where
         T: Debug + TypeFoldable<TyCtxt<'tcx>>,
@@ -114,7 +111,7 @@ impl<'tcx> InferCtxt<'tcx> {
         let tcx = self.tcx;
 
         // Select everything, returning errors.
-        let true_errors = fulfill_cx.select_where_possible(self, defining_use_anchor);
+        let true_errors = fulfill_cx.select_where_possible(self);
         debug!("true_errors = {:#?}", true_errors);
 
         if !true_errors.is_empty() {
@@ -124,7 +121,7 @@ impl<'tcx> InferCtxt<'tcx> {
         }
 
         // Anything left unselected *now* must be an ambiguity.
-        let ambig_errors = fulfill_cx.select_all_or_error(self, defining_use_anchor);
+        let ambig_errors = fulfill_cx.select_all_or_error(self);
         debug!("ambig_errors = {:#?}", ambig_errors);
 
         let region_obligations = self.take_registered_region_obligations();

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -501,7 +501,7 @@ impl<'tcx> InferCtxt<'tcx> {
             debug!(?a, ?b, "constrain opaque type");
             obligations.extend(
                 self.at(cause, param_env)
-                    .define_opaque_types(self.defining_use_anchor)
+                    .define_opaque_types(self.old_defining_use_anchor)
                     .eq(a, b)?
                     .obligations,
             );

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -27,7 +27,7 @@ use super::glb::Glb;
 use super::lub::Lub;
 use super::sub::Sub;
 use super::type_variable::TypeVariableValue;
-use super::{InferCtxt, MiscVariable, TypeTrace};
+use super::{DefiningAnchor, InferCtxt, MiscVariable, TypeTrace};
 use crate::traits::{Obligation, PredicateObligations};
 use rustc_data_structures::sso::SsoHashMap;
 use rustc_hir::def_id::DefId;
@@ -55,10 +55,7 @@ pub struct CombineFields<'infcx, 'tcx> {
     pub obligations: PredicateObligations<'tcx>,
     /// Whether we should define opaque types
     /// or just treat them opaquely.
-    /// Currently only used to prevent predicate
-    /// matching from matching anything against opaque
-    /// types.
-    pub define_opaque_types: bool,
+    pub define_opaque_types: DefiningAnchor,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/compiler/rustc_infer/src/infer/equate.rs
+++ b/compiler/rustc_infer/src/infer/equate.rs
@@ -110,7 +110,7 @@ impl<'tcx> TypeRelation<'tcx> for Equate<'_, '_, 'tcx> {
             }
             (&ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }), _)
             | (_, &ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }))
-                if self.fields.define_opaque_types && def_id.is_local() =>
+                if def_id.is_local() =>
             {
                 self.fields.obligations.extend(
                     infcx
@@ -120,6 +120,7 @@ impl<'tcx> TypeRelation<'tcx> for Equate<'_, '_, 'tcx> {
                             self.a_is_expected(),
                             &self.fields.trace.cause,
                             self.param_env(),
+                            self.fields.define_opaque_types,
                         )?
                         .obligations,
                 );

--- a/compiler/rustc_infer/src/infer/glb.rs
+++ b/compiler/rustc_infer/src/infer/glb.rs
@@ -2,8 +2,8 @@
 
 use super::combine::{CombineFields, ObligationEmittingRelation};
 use super::lattice::{self, LatticeDir};
-use super::InferCtxt;
 use super::Subtype;
+use super::{DefiningAnchor, InferCtxt};
 
 use crate::traits::{ObligationCause, PredicateObligations};
 use rustc_middle::ty::relate::{Relate, RelateResult, TypeRelation};
@@ -142,7 +142,7 @@ impl<'combine, 'infcx, 'tcx> LatticeDir<'infcx, 'tcx> for Glb<'combine, 'infcx, 
         Ok(())
     }
 
-    fn define_opaque_types(&self) -> bool {
+    fn define_opaque_types(&self) -> DefiningAnchor {
         self.fields.define_opaque_types
     }
 }

--- a/compiler/rustc_infer/src/infer/lattice.rs
+++ b/compiler/rustc_infer/src/infer/lattice.rs
@@ -19,7 +19,7 @@
 
 use super::combine::ObligationEmittingRelation;
 use super::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
-use super::InferCtxt;
+use super::{DefiningAnchor, InferCtxt};
 
 use crate::traits::ObligationCause;
 use rustc_middle::ty::relate::RelateResult;
@@ -36,7 +36,7 @@ pub trait LatticeDir<'f, 'tcx>: ObligationEmittingRelation<'tcx> {
 
     fn cause(&self) -> &ObligationCause<'tcx>;
 
-    fn define_opaque_types(&self) -> bool;
+    fn define_opaque_types(&self) -> DefiningAnchor;
 
     // Relates the type `v` to `a` and `b` such that `v` represents
     // the LUB/GLB of `a` and `b` as appropriate.
@@ -110,11 +110,18 @@ where
         ) if a_def_id == b_def_id => infcx.super_combine_tys(this, a, b),
         (&ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }), _)
         | (_, &ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }))
-            if this.define_opaque_types() && def_id.is_local() =>
+            if def_id.is_local() =>
         {
             this.register_obligations(
                 infcx
-                    .handle_opaque_type(a, b, this.a_is_expected(), this.cause(), this.param_env())?
+                    .handle_opaque_type(
+                        a,
+                        b,
+                        this.a_is_expected(),
+                        this.cause(),
+                        this.param_env(),
+                        this.define_opaque_types(),
+                    )?
                     .obligations,
             );
             Ok(a)

--- a/compiler/rustc_infer/src/infer/lub.rs
+++ b/compiler/rustc_infer/src/infer/lub.rs
@@ -2,8 +2,8 @@
 
 use super::combine::{CombineFields, ObligationEmittingRelation};
 use super::lattice::{self, LatticeDir};
-use super::InferCtxt;
 use super::Subtype;
+use super::{DefiningAnchor, InferCtxt};
 
 use crate::traits::{ObligationCause, PredicateObligations};
 use rustc_middle::ty::relate::{Relate, RelateResult, TypeRelation};
@@ -142,7 +142,7 @@ impl<'combine, 'infcx, 'tcx> LatticeDir<'infcx, 'tcx> for Lub<'combine, 'infcx, 
         Ok(())
     }
 
-    fn define_opaque_types(&self) -> bool {
+    fn define_opaque_types(&self) -> DefiningAnchor {
         self.fields.define_opaque_types
     }
 }

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -232,18 +232,6 @@ pub enum DefiningAnchor {
 pub struct InferCtxt<'tcx> {
     pub tcx: TyCtxt<'tcx>,
 
-    /// The `DefId` of the item in whose context we are performing inference or typeck.
-    /// It is used to check whether an opaque type use is a defining use.
-    ///
-    /// If it is `DefiningAnchor::Bubble`, we can't resolve opaque types here and need to bubble up
-    /// the obligation. This frequently happens for
-    /// short lived InferCtxt within queries. The opaque type obligations are forwarded
-    /// to the outside until the end up in an `InferCtxt` for typeck or borrowck.
-    ///
-    /// Its default value is `DefiningAnchor::Error`, this way it is easier to catch errors that
-    /// might come up during inference or typeck.
-    pub old_defining_use_anchor: DefiningAnchor,
-
     /// Whether this inference context should care about region obligations in
     /// the root universe. Most notably, this is used during hir typeck as region
     /// solving is left to borrowck instead.
@@ -537,7 +525,6 @@ impl<'tcx> fmt::Display for FixupError<'tcx> {
 /// Used to configure inference contexts before their creation
 pub struct InferCtxtBuilder<'tcx> {
     tcx: TyCtxt<'tcx>,
-    defining_use_anchor: DefiningAnchor,
     considering_regions: bool,
     /// Whether we are in coherence mode.
     intercrate: bool,
@@ -549,27 +536,11 @@ pub trait TyCtxtInferExt<'tcx> {
 
 impl<'tcx> TyCtxtInferExt<'tcx> for TyCtxt<'tcx> {
     fn infer_ctxt(self) -> InferCtxtBuilder<'tcx> {
-        InferCtxtBuilder {
-            tcx: self,
-            defining_use_anchor: DefiningAnchor::Error,
-            considering_regions: true,
-            intercrate: false,
-        }
+        InferCtxtBuilder { tcx: self, considering_regions: true, intercrate: false }
     }
 }
 
 impl<'tcx> InferCtxtBuilder<'tcx> {
-    /// Whenever the `InferCtxt` should be able to handle defining uses of opaque types,
-    /// you need to call this function. Otherwise the opaque type will be treated opaquely.
-    ///
-    /// It is only meant to be called in two places, for typeck
-    /// (via `Inherited::build`) and for the inference context used
-    /// in mir borrowck.
-    pub fn with_opaque_type_inference(mut self, defining_use_anchor: DefiningAnchor) -> Self {
-        self.defining_use_anchor = defining_use_anchor;
-        self
-    }
-
     pub fn intercrate(mut self) -> Self {
         self.intercrate = true;
         self
@@ -601,10 +572,9 @@ impl<'tcx> InferCtxtBuilder<'tcx> {
     }
 
     pub fn build(&mut self) -> InferCtxt<'tcx> {
-        let InferCtxtBuilder { tcx, defining_use_anchor, considering_regions, intercrate } = *self;
+        let InferCtxtBuilder { tcx, considering_regions, intercrate } = *self;
         InferCtxt {
             tcx,
-            old_defining_use_anchor: defining_use_anchor,
             considering_regions,
             inner: RefCell::new(InferCtxtInner::new()),
             lexical_region_resolutions: RefCell::new(None),

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -242,7 +242,7 @@ pub struct InferCtxt<'tcx> {
     ///
     /// Its default value is `DefiningAnchor::Error`, this way it is easier to catch errors that
     /// might come up during inference or typeck.
-    pub defining_use_anchor: DefiningAnchor,
+    pub old_defining_use_anchor: DefiningAnchor,
 
     /// Whether this inference context should care about region obligations in
     /// the root universe. Most notably, this is used during hir typeck as region
@@ -604,7 +604,7 @@ impl<'tcx> InferCtxtBuilder<'tcx> {
         let InferCtxtBuilder { tcx, defining_use_anchor, considering_regions, intercrate } = *self;
         InferCtxt {
             tcx,
-            defining_use_anchor,
+            old_defining_use_anchor: defining_use_anchor,
             considering_regions,
             inner: RefCell::new(InferCtxtInner::new()),
             lexical_region_resolutions: RefCell::new(None),
@@ -1318,7 +1318,7 @@ impl<'tcx> InferCtxt<'tcx> {
 
     #[instrument(level = "debug", skip(self), ret)]
     pub fn take_opaque_types(&self) -> opaque_types::OpaqueTypeMap<'tcx> {
-        debug_assert_ne!(self.defining_use_anchor, DefiningAnchor::Error);
+        debug_assert_ne!(self.old_defining_use_anchor, DefiningAnchor::Error);
         std::mem::take(&mut self.inner.borrow_mut().opaque_type_storage.opaque_types)
     }
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -837,7 +837,7 @@ impl<'tcx> InferCtxt<'tcx> {
         T: at::ToTrace<'tcx>,
     {
         let origin = &ObligationCause::dummy();
-        self.probe(|_| self.at(origin, param_env).sub(a, b).is_ok())
+        self.probe(|_| self.at(origin, param_env, DefiningAnchor::Error).sub(a, b).is_ok())
     }
 
     pub fn can_eq<T>(&self, param_env: ty::ParamEnv<'tcx>, a: T, b: T) -> bool
@@ -845,7 +845,7 @@ impl<'tcx> InferCtxt<'tcx> {
         T: at::ToTrace<'tcx>,
     {
         let origin = &ObligationCause::dummy();
-        self.probe(|_| self.at(origin, param_env).eq(a, b).is_ok())
+        self.probe(|_| self.at(origin, param_env, DefiningAnchor::Error).eq(a, b).is_ok())
     }
 
     #[instrument(skip(self), level = "debug")]
@@ -940,7 +940,8 @@ impl<'tcx> InferCtxt<'tcx> {
             let ty::SubtypePredicate { a_is_expected, a, b } =
                 self.instantiate_binder_with_placeholders(predicate);
 
-            let ok = self.at(cause, param_env).sub_exp(a_is_expected, a, b)?;
+            let ok =
+                self.at(cause, param_env, DefiningAnchor::Error).sub_exp(a_is_expected, a, b)?;
 
             Ok(ok.unit())
         }))

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -229,6 +229,12 @@ pub enum DefiningAnchor {
     Error,
 }
 
+impl From<LocalDefId> for DefiningAnchor {
+    fn from(v: LocalDefId) -> Self {
+        Self::Bind(v)
+    }
+}
+
 pub struct InferCtxt<'tcx> {
     pub tcx: TyCtxt<'tcx>,
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -726,7 +726,7 @@ impl<'tcx> InferCtxt<'tcx> {
         &'a self,
         trace: TypeTrace<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
-        define_opaque_types: bool,
+        define_opaque_types: DefiningAnchor,
     ) -> CombineFields<'a, 'tcx> {
         CombineFields {
             infcx: self,

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1318,7 +1318,6 @@ impl<'tcx> InferCtxt<'tcx> {
 
     #[instrument(level = "debug", skip(self), ret)]
     pub fn take_opaque_types(&self) -> opaque_types::OpaqueTypeMap<'tcx> {
-        debug_assert_ne!(self.old_defining_use_anchor, DefiningAnchor::Error);
         std::mem::take(&mut self.inner.borrow_mut().opaque_type_storage.opaque_types)
     }
 

--- a/compiler/rustc_infer/src/infer/nll_relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/nll_relate/mod.rs
@@ -36,6 +36,7 @@ use std::fmt::Debug;
 use std::ops::ControlFlow;
 
 use super::combine::ObligationEmittingRelation;
+use super::DefiningAnchor;
 
 pub struct TypeRelating<'me, 'tcx, D>
 where
@@ -74,6 +75,7 @@ where
 
 pub trait TypeRelatingDelegate<'tcx> {
     fn param_env(&self) -> ty::ParamEnv<'tcx>;
+    fn defining_use_anchor(&self) -> DefiningAnchor;
     fn span(&self) -> Span;
 
     /// Push a constraint `sup: sub` -- this constraint must be
@@ -373,7 +375,14 @@ where
         let cause = ObligationCause::dummy_with_span(self.delegate.span());
         let obligations = self
             .infcx
-            .handle_opaque_type(a, b, true, &cause, self.delegate.param_env())?
+            .handle_opaque_type(
+                a,
+                b,
+                true,
+                &cause,
+                self.delegate.param_env(),
+                self.delegate.defining_use_anchor(),
+            )?
             .obligations;
         self.delegate.register_obligations(obligations);
         trace!(a = ?a.kind(), b = ?b.kind(), "opaque type instantiated");

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -564,8 +564,7 @@ impl<'tcx> InferCtxt<'tcx> {
         );
         if let Some(prev) = prev {
             obligations = self
-                .at(&cause, param_env)
-                .define_opaque_types(defining_use_anchor)
+                .at(&cause, param_env, defining_use_anchor)
                 .eq_exp(a_is_expected, prev, hidden_ty)?
                 .obligations;
         }

--- a/compiler/rustc_infer/src/infer/sub.rs
+++ b/compiler/rustc_infer/src/infer/sub.rs
@@ -138,7 +138,7 @@ impl<'tcx> TypeRelation<'tcx> for Sub<'_, '_, 'tcx> {
             }
             (&ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }), _)
             | (_, &ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }))
-                if self.fields.define_opaque_types && def_id.is_local() =>
+                if def_id.is_local() =>
             {
                 self.fields.obligations.extend(
                     infcx
@@ -148,6 +148,7 @@ impl<'tcx> TypeRelation<'tcx> for Sub<'_, '_, 'tcx> {
                             self.a_is_expected,
                             &self.fields.trace.cause,
                             self.param_env(),
+                            self.fields.define_opaque_types,
                         )?
                         .obligations,
                 );

--- a/compiler/rustc_infer/src/traits/engine.rs
+++ b/compiler/rustc_infer/src/traits/engine.rs
@@ -36,11 +36,7 @@ pub trait TraitEngine<'tcx>: 'tcx {
         obligation: PredicateObligation<'tcx>,
     );
 
-    fn select_where_possible(
-        &mut self,
-        infcx: &InferCtxt<'tcx>,
-        defining_use_anchor: DefiningAnchor,
-    ) -> Vec<FulfillmentError<'tcx>>;
+    fn select_where_possible(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>>;
 
     fn collect_remaining_errors(&mut self) -> Vec<FulfillmentError<'tcx>>;
 
@@ -53,6 +49,8 @@ pub trait TraitEngine<'tcx>: 'tcx {
         &mut self,
         infcx: &InferCtxt<'tcx>,
     ) -> Vec<PredicateObligation<'tcx>>;
+
+    fn defining_use_anchor(&self) -> DefiningAnchor;
 }
 
 pub trait TraitEngineExt<'tcx> {
@@ -62,11 +60,7 @@ pub trait TraitEngineExt<'tcx> {
         obligations: impl IntoIterator<Item = PredicateObligation<'tcx>>,
     );
 
-    fn select_all_or_error(
-        &mut self,
-        infcx: &InferCtxt<'tcx>,
-        defining_use_anchor: DefiningAnchor,
-    ) -> Vec<FulfillmentError<'tcx>>;
+    fn select_all_or_error(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>>;
 }
 
 impl<'tcx, T: ?Sized + TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
@@ -80,12 +74,8 @@ impl<'tcx, T: ?Sized + TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
         }
     }
 
-    fn select_all_or_error(
-        &mut self,
-        infcx: &InferCtxt<'tcx>,
-        defining_use_anchor: DefiningAnchor,
-    ) -> Vec<FulfillmentError<'tcx>> {
-        let errors = self.select_where_possible(infcx, defining_use_anchor);
+    fn select_all_or_error(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>> {
+        let errors = self.select_where_possible(infcx);
         if !errors.is_empty() {
             return errors;
         }

--- a/compiler/rustc_infer/src/traits/engine.rs
+++ b/compiler/rustc_infer/src/traits/engine.rs
@@ -1,4 +1,4 @@
-use crate::infer::InferCtxt;
+use crate::infer::{DefiningAnchor, InferCtxt};
 use crate::traits::Obligation;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::{self, ToPredicate, Ty};
@@ -36,7 +36,11 @@ pub trait TraitEngine<'tcx>: 'tcx {
         obligation: PredicateObligation<'tcx>,
     );
 
-    fn select_where_possible(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>>;
+    fn select_where_possible(
+        &mut self,
+        infcx: &InferCtxt<'tcx>,
+        defining_use_anchor: DefiningAnchor,
+    ) -> Vec<FulfillmentError<'tcx>>;
 
     fn collect_remaining_errors(&mut self) -> Vec<FulfillmentError<'tcx>>;
 
@@ -58,7 +62,11 @@ pub trait TraitEngineExt<'tcx> {
         obligations: impl IntoIterator<Item = PredicateObligation<'tcx>>,
     );
 
-    fn select_all_or_error(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>>;
+    fn select_all_or_error(
+        &mut self,
+        infcx: &InferCtxt<'tcx>,
+        defining_use_anchor: DefiningAnchor,
+    ) -> Vec<FulfillmentError<'tcx>>;
 }
 
 impl<'tcx, T: ?Sized + TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
@@ -72,8 +80,12 @@ impl<'tcx, T: ?Sized + TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
         }
     }
 
-    fn select_all_or_error(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>> {
-        let errors = self.select_where_possible(infcx);
+    fn select_all_or_error(
+        &mut self,
+        infcx: &InferCtxt<'tcx>,
+        defining_use_anchor: DefiningAnchor,
+    ) -> Vec<FulfillmentError<'tcx>> {
+        let errors = self.select_where_possible(infcx, defining_use_anchor);
         if !errors.is_empty() {
             return errors;
         }

--- a/compiler/rustc_trait_selection/src/infer.rs
+++ b/compiler/rustc_trait_selection/src/infer.rs
@@ -138,7 +138,7 @@ impl<'tcx> InferCtxtBuilderExt<'tcx> for InferCtxtBuilder<'tcx> {
     {
         let (infcx, key, canonical_inference_vars) =
             self.build_with_canonical(DUMMY_SP, canonical_key);
-        let ocx = ObligationCtxt::new(&infcx);
+        let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Error);
         let value = operation(&ocx, key)?;
         ocx.make_canonicalized_query_response(canonical_inference_vars, value)
     }

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -130,7 +130,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         rhs: T,
     ) -> Result<Vec<Goal<'tcx, ty::Predicate<'tcx>>>, NoSolution> {
         self.infcx
-            .at(&ObligationCause::dummy(), param_env)
+            .at(&ObligationCause::dummy(), param_env, DefiningAnchor::Error)
             .eq(lhs, rhs)
             .map(|InferOk { value: (), obligations }| {
                 obligations.into_iter().map(|o| o.into()).collect()

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -2,7 +2,7 @@ use rustc_hir::def_id::DefId;
 use rustc_infer::infer::at::ToTrace;
 use rustc_infer::infer::canonical::CanonicalVarValues;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
-use rustc_infer::infer::{InferCtxt, InferOk, LateBoundRegionConversionTime};
+use rustc_infer::infer::{DefiningAnchor, InferCtxt, InferOk, LateBoundRegionConversionTime};
 use rustc_infer::traits::query::NoSolution;
 use rustc_infer::traits::ObligationCause;
 use rustc_middle::infer::unify_key::{ConstVariableOrigin, ConstVariableOriginKind};
@@ -27,6 +27,7 @@ pub struct EvalCtxt<'a, 'tcx> {
     /// This field is used by a debug assertion in [`EvalCtxt::evaluate_goal`],
     /// see the comment in that method for more details.
     pub in_projection_eq_hack: bool,
+    pub(super) defining_use_anchor: DefiningAnchor,
 }
 
 impl<'tcx> EvalCtxt<'_, 'tcx> {

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -54,7 +54,7 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
     fn select_where_possible(
         &mut self,
         infcx: &InferCtxt<'tcx>,
-        _defining_use_anchor: DefiningAnchor,
+        defining_use_anchor: DefiningAnchor,
     ) -> Vec<FulfillmentError<'tcx>> {
         let mut errors = Vec::new();
         for i in 0.. {
@@ -65,7 +65,8 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
             let mut has_changed = false;
             for obligation in mem::take(&mut self.obligations) {
                 let goal = obligation.clone().into();
-                let (changed, certainty) = match infcx.evaluate_root_goal(goal) {
+                let (changed, certainty) = match infcx.evaluate_root_goal(goal, defining_use_anchor)
+                {
                     Ok(result) => result,
                     Err(NoSolution) => {
                         errors.push(FulfillmentError {

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -23,11 +23,12 @@ use super::{Certainty, InferCtxtEvalExt};
 /// here as this will have to deal with far more root goals than `evaluate_all`.
 pub struct FulfillmentCtxt<'tcx> {
     obligations: Vec<PredicateObligation<'tcx>>,
+    defining_use_anchor: DefiningAnchor,
 }
 
 impl<'tcx> FulfillmentCtxt<'tcx> {
-    pub fn new() -> FulfillmentCtxt<'tcx> {
-        FulfillmentCtxt { obligations: Vec::new() }
+    pub fn new(defining_use_anchor: impl Into<DefiningAnchor>) -> FulfillmentCtxt<'tcx> {
+        FulfillmentCtxt { obligations: Vec::new(), defining_use_anchor: defining_use_anchor.into() }
     }
 }
 
@@ -51,11 +52,7 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
             .collect()
     }
 
-    fn select_where_possible(
-        &mut self,
-        infcx: &InferCtxt<'tcx>,
-        defining_use_anchor: DefiningAnchor,
-    ) -> Vec<FulfillmentError<'tcx>> {
+    fn select_where_possible(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>> {
         let mut errors = Vec::new();
         for i in 0.. {
             if !infcx.tcx.recursion_limit().value_within_limit(i) {
@@ -65,71 +62,71 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
             let mut has_changed = false;
             for obligation in mem::take(&mut self.obligations) {
                 let goal = obligation.clone().into();
-                let (changed, certainty) = match infcx.evaluate_root_goal(goal, defining_use_anchor)
-                {
-                    Ok(result) => result,
-                    Err(NoSolution) => {
-                        errors.push(FulfillmentError {
-                            obligation: obligation.clone(),
-                            code: match goal.predicate.kind().skip_binder() {
-                                ty::PredicateKind::Clause(ty::Clause::Projection(_)) => {
-                                    FulfillmentErrorCode::CodeProjectionError(
-                                        // FIXME: This could be a `Sorts` if the term is a type
-                                        MismatchedProjectionTypes { err: TypeError::Mismatch },
-                                    )
-                                }
-                                ty::PredicateKind::AliasEq(_, _) => {
-                                    FulfillmentErrorCode::CodeProjectionError(
-                                        MismatchedProjectionTypes { err: TypeError::Mismatch },
-                                    )
-                                }
-                                ty::PredicateKind::Subtype(pred) => {
-                                    let (a, b) = infcx.instantiate_binder_with_placeholders(
-                                        goal.predicate.kind().rebind((pred.a, pred.b)),
-                                    );
-                                    let expected_found = ExpectedFound::new(true, a, b);
-                                    FulfillmentErrorCode::CodeSubtypeError(
-                                        expected_found,
-                                        TypeError::Sorts(expected_found),
-                                    )
-                                }
-                                ty::PredicateKind::Coerce(pred) => {
-                                    let (a, b) = infcx.instantiate_binder_with_placeholders(
-                                        goal.predicate.kind().rebind((pred.a, pred.b)),
-                                    );
-                                    let expected_found = ExpectedFound::new(false, a, b);
-                                    FulfillmentErrorCode::CodeSubtypeError(
-                                        expected_found,
-                                        TypeError::Sorts(expected_found),
-                                    )
-                                }
-                                ty::PredicateKind::ConstEquate(a, b) => {
-                                    let (a, b) = infcx.instantiate_binder_with_placeholders(
-                                        goal.predicate.kind().rebind((a, b)),
-                                    );
-                                    let expected_found = ExpectedFound::new(true, a, b);
-                                    FulfillmentErrorCode::CodeConstEquateError(
-                                        expected_found,
-                                        TypeError::ConstMismatch(expected_found),
-                                    )
-                                }
-                                ty::PredicateKind::Clause(_)
-                                | ty::PredicateKind::WellFormed(_)
-                                | ty::PredicateKind::ObjectSafe(_)
-                                | ty::PredicateKind::ClosureKind(_, _, _)
-                                | ty::PredicateKind::ConstEvaluatable(_)
-                                | ty::PredicateKind::TypeWellFormedFromEnv(_)
-                                | ty::PredicateKind::Ambiguous => {
-                                    FulfillmentErrorCode::CodeSelectionError(
-                                        SelectionError::Unimplemented,
-                                    )
-                                }
-                            },
-                            root_obligation: obligation,
-                        });
-                        continue;
-                    }
-                };
+                let (changed, certainty) =
+                    match infcx.evaluate_root_goal(goal, self.defining_use_anchor) {
+                        Ok(result) => result,
+                        Err(NoSolution) => {
+                            errors.push(FulfillmentError {
+                                obligation: obligation.clone(),
+                                code: match goal.predicate.kind().skip_binder() {
+                                    ty::PredicateKind::Clause(ty::Clause::Projection(_)) => {
+                                        FulfillmentErrorCode::CodeProjectionError(
+                                            // FIXME: This could be a `Sorts` if the term is a type
+                                            MismatchedProjectionTypes { err: TypeError::Mismatch },
+                                        )
+                                    }
+                                    ty::PredicateKind::AliasEq(_, _) => {
+                                        FulfillmentErrorCode::CodeProjectionError(
+                                            MismatchedProjectionTypes { err: TypeError::Mismatch },
+                                        )
+                                    }
+                                    ty::PredicateKind::Subtype(pred) => {
+                                        let (a, b) = infcx.instantiate_binder_with_placeholders(
+                                            goal.predicate.kind().rebind((pred.a, pred.b)),
+                                        );
+                                        let expected_found = ExpectedFound::new(true, a, b);
+                                        FulfillmentErrorCode::CodeSubtypeError(
+                                            expected_found,
+                                            TypeError::Sorts(expected_found),
+                                        )
+                                    }
+                                    ty::PredicateKind::Coerce(pred) => {
+                                        let (a, b) = infcx.instantiate_binder_with_placeholders(
+                                            goal.predicate.kind().rebind((pred.a, pred.b)),
+                                        );
+                                        let expected_found = ExpectedFound::new(false, a, b);
+                                        FulfillmentErrorCode::CodeSubtypeError(
+                                            expected_found,
+                                            TypeError::Sorts(expected_found),
+                                        )
+                                    }
+                                    ty::PredicateKind::ConstEquate(a, b) => {
+                                        let (a, b) = infcx.instantiate_binder_with_placeholders(
+                                            goal.predicate.kind().rebind((a, b)),
+                                        );
+                                        let expected_found = ExpectedFound::new(true, a, b);
+                                        FulfillmentErrorCode::CodeConstEquateError(
+                                            expected_found,
+                                            TypeError::ConstMismatch(expected_found),
+                                        )
+                                    }
+                                    ty::PredicateKind::Clause(_)
+                                    | ty::PredicateKind::WellFormed(_)
+                                    | ty::PredicateKind::ObjectSafe(_)
+                                    | ty::PredicateKind::ClosureKind(_, _, _)
+                                    | ty::PredicateKind::ConstEvaluatable(_)
+                                    | ty::PredicateKind::TypeWellFormedFromEnv(_)
+                                    | ty::PredicateKind::Ambiguous => {
+                                        FulfillmentErrorCode::CodeSelectionError(
+                                            SelectionError::Unimplemented,
+                                        )
+                                    }
+                                },
+                                root_obligation: obligation,
+                            });
+                            continue;
+                        }
+                    };
 
                 has_changed |= changed;
                 match certainty {
@@ -155,5 +152,9 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
         _: &InferCtxt<'tcx>,
     ) -> Vec<PredicateObligation<'tcx>> {
         unimplemented!()
+    }
+
+    fn defining_use_anchor(&self) -> DefiningAnchor {
+        self.defining_use_anchor
     }
 }

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use rustc_infer::infer::InferCtxt;
+use rustc_infer::infer::{DefiningAnchor, InferCtxt};
 use rustc_infer::traits::{
     query::NoSolution, FulfillmentError, FulfillmentErrorCode, MismatchedProjectionTypes,
     PredicateObligation, SelectionError, TraitEngine,
@@ -51,7 +51,11 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
             .collect()
     }
 
-    fn select_where_possible(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>> {
+    fn select_where_possible(
+        &mut self,
+        infcx: &InferCtxt<'tcx>,
+        _defining_use_anchor: DefiningAnchor,
+    ) -> Vec<FulfillmentError<'tcx>> {
         let mut errors = Vec::new();
         for i in 0.. {
             if !infcx.tcx.recursion_limit().value_within_limit(i) {

--- a/compiler/rustc_trait_selection/src/solve/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/mod.rs
@@ -374,7 +374,7 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
         } else {
             let InferOk { value: (), obligations } = self
                 .infcx
-                .at(&ObligationCause::dummy(), goal.param_env)
+                .at(&ObligationCause::dummy(), goal.param_env, DefiningAnchor::Error)
                 .sub(goal.predicate.a, goal.predicate.b)?;
             self.evaluate_all_and_make_canonical_response(
                 obligations.into_iter().map(|pred| pred.into()).collect(),

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -89,7 +89,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
         let trait_ref = tcx.mk_trait_ref(trait_did, [ty]);
 
         let infcx = tcx.infer_ctxt().build();
-        let mut selcx = SelectionContext::new(&infcx);
+        let mut selcx = SelectionContext::new(&infcx, DefiningAnchor::Error);
         for polarity in [true, false] {
             let result = selcx.select(&Obligation::new(
                 tcx,
@@ -256,7 +256,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             fresh_preds.insert(self.clean_pred(infcx, predicate));
         }
 
-        let mut select = SelectionContext::new(&infcx);
+        let mut select = SelectionContext::new(&infcx, DefiningAnchor::Error);
 
         let mut already_visited = FxHashSet::default();
         let mut predicates = VecDeque::new();

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -814,7 +814,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
 
                     match (evaluate(c1), evaluate(c2)) {
                         (Ok(c1), Ok(c2)) => {
-                            match selcx.infcx.at(&obligation.cause, obligation.param_env).eq(c1, c2)
+                            match selcx.infcx.at(&obligation.cause, obligation.param_env, DefiningAnchor::Error).eq(c1, c2)
                             {
                                 Ok(_) => (),
                                 Err(_) => return false,

--- a/compiler/rustc_trait_selection/src/traits/chalk_fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/chalk_fulfill.rs
@@ -58,7 +58,7 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentContext<'tcx> {
     fn select_where_possible(
         &mut self,
         infcx: &InferCtxt<'tcx>,
-        _defining_use_anchor: DefiningAnchor,
+        defining_use_anchor: DefiningAnchor,
     ) -> Vec<FulfillmentError<'tcx>> {
         if !self.usable_in_snapshot {
             assert!(!infcx.is_in_snapshot());
@@ -95,6 +95,7 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentContext<'tcx> {
                                 obligation.param_env,
                                 &orig_values,
                                 &response,
+                                defining_use_anchor,
                             ) {
                                 Ok(infer_ok) => next_round.extend(
                                     infer_ok.obligations.into_iter().map(|obligation| {

--- a/compiler/rustc_trait_selection/src/traits/chalk_fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/chalk_fulfill.rs
@@ -8,6 +8,7 @@ use crate::traits::{
     SelectionError, TraitEngine,
 };
 use rustc_data_structures::fx::FxIndexSet;
+use rustc_infer::infer::DefiningAnchor;
 use rustc_middle::ty::TypeVisitableExt;
 
 pub struct FulfillmentContext<'tcx> {
@@ -54,7 +55,11 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentContext<'tcx> {
             .collect()
     }
 
-    fn select_where_possible(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>> {
+    fn select_where_possible(
+        &mut self,
+        infcx: &InferCtxt<'tcx>,
+        _defining_use_anchor: DefiningAnchor,
+    ) -> Vec<FulfillmentError<'tcx>> {
         if !self.usable_in_snapshot {
             assert!(!infcx.is_in_snapshot());
         }

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -95,8 +95,7 @@ pub fn overlapping_impls(
         return None;
     }
 
-    let infcx =
-        tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bubble).intercrate().build();
+    let infcx = tcx.infer_ctxt().intercrate().build();
     let selcx = &mut SelectionContext::new(&infcx);
     let overlaps =
         overlap(selcx, skip_leak_check, impl1_def_id, impl2_def_id, overlap_mode).is_some();
@@ -107,8 +106,7 @@ pub fn overlapping_impls(
     // In the case where we detect an error, run the check again, but
     // this time tracking intercrate ambiguity causes for better
     // diagnostics. (These take time and can lead to false errors.)
-    let infcx =
-        tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bubble).intercrate().build();
+    let infcx = tcx.infer_ctxt().intercrate().build();
     let selcx = &mut SelectionContext::new(&infcx);
     selcx.enable_tracking_intercrate_ambiguity_causes();
     Some(overlap(selcx, skip_leak_check, impl1_def_id, impl2_def_id, overlap_mode).unwrap())
@@ -217,7 +215,7 @@ fn equate_impl_headers<'cx, 'tcx>(
     selcx
         .infcx
         .at(&ObligationCause::dummy(), ty::ParamEnv::empty())
-        .define_opaque_types(true)
+        .define_opaque_types(DefiningAnchor::Bubble)
         .eq_impl_headers(impl1_header, impl2_header)
         .map(|infer_ok| infer_ok.obligations)
         .ok()

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -376,7 +376,7 @@ fn resolve_negative_obligation<'tcx>(
     };
 
     let param_env = o.param_env;
-    if !super::fully_solve_obligation(&infcx, o, infcx.old_defining_use_anchor).is_empty() {
+    if !super::fully_solve_obligation(&infcx, o, DefiningAnchor::Error).is_empty() {
         return false;
     }
 

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -382,7 +382,7 @@ fn resolve_negative_obligation<'tcx>(
 
     let body_def_id = body_def_id.as_local().unwrap_or(CRATE_DEF_ID);
 
-    let ocx = ObligationCtxt::new(&infcx);
+    let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Error);
     let wf_tys = ocx.assumed_wf_types(param_env, DUMMY_SP, body_def_id);
     let outlives_env = OutlivesEnvironment::with_bounds(
         param_env,

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -376,7 +376,7 @@ fn resolve_negative_obligation<'tcx>(
     };
 
     let param_env = o.param_env;
-    if !super::fully_solve_obligation(&infcx, o).is_empty() {
+    if !super::fully_solve_obligation(&infcx, o, infcx.old_defining_use_anchor).is_empty() {
         return false;
     }
 

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -96,7 +96,7 @@ pub fn overlapping_impls(
     }
 
     let infcx = tcx.infer_ctxt().intercrate().build();
-    let selcx = &mut SelectionContext::new(&infcx);
+    let selcx = &mut SelectionContext::new(&infcx, DefiningAnchor::Error);
     let overlaps =
         overlap(selcx, skip_leak_check, impl1_def_id, impl2_def_id, overlap_mode).is_some();
     if !overlaps {
@@ -107,7 +107,7 @@ pub fn overlapping_impls(
     // this time tracking intercrate ambiguity causes for better
     // diagnostics. (These take time and can lead to false errors.)
     let infcx = tcx.infer_ctxt().intercrate().build();
-    let selcx = &mut SelectionContext::new(&infcx);
+    let selcx = &mut SelectionContext::new(&infcx, DefiningAnchor::Error);
     selcx.enable_tracking_intercrate_ambiguity_causes();
     Some(overlap(selcx, skip_leak_check, impl1_def_id, impl2_def_id, overlap_mode).unwrap())
 }
@@ -305,7 +305,7 @@ fn negative_impl(tcx: TyCtxt<'_>, impl1_def_id: DefId, impl2_def_id: DefId) -> b
     };
 
     // Attempt to prove that impl2 applies, given all of the above.
-    let selcx = &mut SelectionContext::new(&infcx);
+    let selcx = &mut SelectionContext::new(&infcx, DefiningAnchor::Error);
     let impl2_substs = infcx.fresh_substs_for_item(DUMMY_SP, impl2_def_id);
     let (subject2, obligations) =
         impl_subject_and_oblig(selcx, impl_env, impl2_def_id, impl2_substs);

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -127,8 +127,10 @@ fn with_fresh_ty_vars<'cx, 'tcx>(
         predicates: tcx.predicates_of(impl_def_id).instantiate(tcx, impl_substs).predicates,
     };
 
-    let InferOk { value: mut header, obligations } =
-        selcx.infcx.at(&ObligationCause::dummy(), param_env).normalize(header);
+    let InferOk { value: mut header, obligations } = selcx
+        .infcx
+        .at(&ObligationCause::dummy(), param_env, DefiningAnchor::Error)
+        .normalize(header);
 
     header.predicates.extend(obligations.into_iter().map(|o| o.predicate));
     header
@@ -214,7 +216,7 @@ fn equate_impl_headers<'cx, 'tcx>(
     debug!("equate_impl_headers(impl1_header={:?}, impl2_header={:?}", impl1_header, impl2_header);
     selcx
         .infcx
-        .at(&ObligationCause::dummy(), ty::ParamEnv::empty())
+        .at(&ObligationCause::dummy(), ty::ParamEnv::empty(), DefiningAnchor::Error)
         .define_opaque_types(DefiningAnchor::Bubble)
         .eq_impl_headers(impl1_header, impl2_header)
         .map(|infer_ok| infer_ok.obligations)
@@ -323,7 +325,7 @@ fn equate<'tcx>(
 ) -> bool {
     // do the impls unify? If not, not disjoint.
     let Ok(InferOk { obligations: more_obligations, .. }) =
-        infcx.at(&ObligationCause::dummy(), impl_env).eq(subject1, subject2)
+        infcx.at(&ObligationCause::dummy(), impl_env, DefiningAnchor::Error).eq(subject1, subject2)
     else {
         debug!("explicit_disjoint: {:?} does not unify with {:?}", subject1, subject2);
         return true;

--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -9,7 +9,7 @@
 //! `thir_abstract_const` which can then be checked for structural equality with other
 //! generic constants mentioned in the `caller_bounds` of the current environment.
 use rustc_hir::def::DefKind;
-use rustc_infer::infer::InferCtxt;
+use rustc_infer::infer::{DefiningAnchor, InferCtxt};
 use rustc_middle::mir::interpret::ErrorHandled;
 
 use rustc_middle::traits::ObligationCause;
@@ -176,7 +176,7 @@ fn satisfied_from_param_env<'tcx>(
         fn visit_const(&mut self, c: ty::Const<'tcx>) -> ControlFlow<Self::BreakTy> {
             debug!("is_const_evaluatable: candidate={:?}", c);
             if self.infcx.probe(|_| {
-                let ocx = ObligationCtxt::new_in_snapshot(self.infcx);
+                let ocx = ObligationCtxt::new_in_snapshot(self.infcx, DefiningAnchor::Error);
                 ocx.eq(&ObligationCause::dummy(), self.param_env, c.ty(), self.ct.ty()).is_ok()
                     && ocx.eq(&ObligationCause::dummy(), self.param_env, c, self.ct).is_ok()
                     && ocx.select_all_or_error().is_empty()
@@ -219,7 +219,7 @@ fn satisfied_from_param_env<'tcx>(
     }
 
     if let Some(Ok(c)) = single_match {
-        let ocx = ObligationCtxt::new_in_snapshot(infcx);
+        let ocx = ObligationCtxt::new_in_snapshot(infcx, DefiningAnchor::Error);
         assert!(ocx.eq(&ObligationCause::dummy(), param_env, c.ty(), ct.ty()).is_ok());
         assert!(ocx.eq(&ObligationCause::dummy(), param_env, c, ct).is_ok());
         assert!(ocx.select_all_or_error().is_empty());

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -128,7 +128,7 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
     {
         self.infcx
             .at(cause, param_env)
-            .define_opaque_types(true)
+            .define_opaque_types(self.infcx.defining_use_anchor)
             .eq_exp(a_is_expected, a, b)
             .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
     }
@@ -142,7 +142,7 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
     ) -> Result<(), TypeError<'tcx>> {
         self.infcx
             .at(cause, param_env)
-            .define_opaque_types(true)
+            .define_opaque_types(self.infcx.defining_use_anchor)
             .eq(expected, actual)
             .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
     }
@@ -157,7 +157,7 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
     ) -> Result<(), TypeError<'tcx>> {
         self.infcx
             .at(cause, param_env)
-            .define_opaque_types(true)
+            .define_opaque_types(self.infcx.defining_use_anchor)
             .sup(expected, actual)
             .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
     }
@@ -172,7 +172,7 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
     ) -> Result<(), TypeError<'tcx>> {
         self.infcx
             .at(cause, param_env)
-            .define_opaque_types(true)
+            .define_opaque_types(self.infcx.defining_use_anchor)
             .sup(expected, actual)
             .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
     }

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -248,6 +248,7 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
             inference_vars,
             answer,
             &mut **self.engine.borrow_mut(),
+            self.defining_use_anchor,
         )
     }
 

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -60,7 +60,23 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
         Self {
             infcx,
             engine: RefCell::new(<dyn TraitEngine<'_>>::new(infcx.tcx)),
-            defining_use_anchor: infcx.old_defining_use_anchor,
+            defining_use_anchor: DefiningAnchor::Error,
+        }
+    }
+
+    pub fn new_with_opaque_type_bubbling(infcx: &'a InferCtxt<'tcx>) -> Self {
+        Self {
+            infcx,
+            engine: RefCell::new(<dyn TraitEngine<'_>>::new(infcx.tcx)),
+            defining_use_anchor: DefiningAnchor::Bubble,
+        }
+    }
+
+    pub fn new_with_opaque_type_anchor(infcx: &'a InferCtxt<'tcx>, anchor: LocalDefId) -> Self {
+        Self {
+            infcx,
+            engine: RefCell::new(<dyn TraitEngine<'_>>::new(infcx.tcx)),
+            defining_use_anchor: DefiningAnchor::Bind(anchor),
         }
     }
 

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -56,32 +56,23 @@ pub struct ObligationCtxt<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
-    pub fn new(infcx: &'a InferCtxt<'tcx>) -> Self {
+    pub fn new(infcx: &'a InferCtxt<'tcx>, defining_use_anchor: impl Into<DefiningAnchor>) -> Self {
         Self {
             infcx,
             engine: RefCell::new(<dyn TraitEngine<'_>>::new(infcx.tcx)),
-            defining_use_anchor: DefiningAnchor::Error,
+            defining_use_anchor: defining_use_anchor.into(),
         }
     }
 
-    pub fn new_with_opaque_type_bubbling(infcx: &'a InferCtxt<'tcx>) -> Self {
-        Self::new(infcx).with_defining_use_anchor(DefiningAnchor::Bubble)
-    }
-
-    pub fn new_with_opaque_type_anchor(infcx: &'a InferCtxt<'tcx>, anchor: LocalDefId) -> Self {
-        Self::new(infcx).with_defining_use_anchor(DefiningAnchor::Bind(anchor))
-    }
-
-    pub fn new_in_snapshot(infcx: &'a InferCtxt<'tcx>) -> Self {
+    pub fn new_in_snapshot(
+        infcx: &'a InferCtxt<'tcx>,
+        defining_use_anchor: impl Into<DefiningAnchor>,
+    ) -> Self {
         Self {
             infcx,
             engine: RefCell::new(<dyn TraitEngine<'_>>::new_in_snapshot(infcx.tcx)),
-            defining_use_anchor: DefiningAnchor::Error,
+            defining_use_anchor: defining_use_anchor.into(),
         }
-    }
-
-    pub fn with_defining_use_anchor(self, defining_use_anchor: DefiningAnchor) -> Self {
-        Self { defining_use_anchor, ..self }
     }
 
     pub fn register_obligation(&self, obligation: PredicateObligation<'tcx>) {

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -68,7 +68,7 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
         Self {
             infcx,
             engine: RefCell::new(<dyn TraitEngine<'_>>::new_in_snapshot(infcx.tcx)),
-            defining_use_anchor: infcx.old_defining_use_anchor,
+            defining_use_anchor: DefiningAnchor::Error,
         }
     }
 

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -132,7 +132,7 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         value: T,
     ) -> T {
-        let infer_ok = self.infcx.at(&cause, param_env).normalize(value);
+        let infer_ok = self.infcx.at(&cause, param_env, DefiningAnchor::Error).normalize(value);
         self.register_infer_ok_obligations(infer_ok)
     }
 
@@ -149,7 +149,7 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
         T: ToTrace<'tcx>,
     {
         self.infcx
-            .at(cause, param_env)
+            .at(cause, param_env, DefiningAnchor::Error)
             .define_opaque_types(self.defining_use_anchor())
             .eq_exp(a_is_expected, a, b)
             .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
@@ -163,7 +163,7 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
         actual: T,
     ) -> Result<(), TypeError<'tcx>> {
         self.infcx
-            .at(cause, param_env)
+            .at(cause, param_env, DefiningAnchor::Error)
             .define_opaque_types(self.defining_use_anchor())
             .eq(expected, actual)
             .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
@@ -178,7 +178,7 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
         actual: T,
     ) -> Result<(), TypeError<'tcx>> {
         self.infcx
-            .at(cause, param_env)
+            .at(cause, param_env, DefiningAnchor::Error)
             .define_opaque_types(self.defining_use_anchor())
             .sup(expected, actual)
             .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
@@ -193,7 +193,7 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
         actual: T,
     ) -> Result<(), TypeError<'tcx>> {
         self.infcx
-            .at(cause, param_env)
+            .at(cause, param_env, DefiningAnchor::Error)
             .define_opaque_types(self.defining_use_anchor())
             .sup(expected, actual)
             .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/ambiguity.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/ambiguity.rs
@@ -1,5 +1,5 @@
 use rustc_hir::def_id::DefId;
-use rustc_infer::infer::{InferCtxt, LateBoundRegionConversionTime};
+use rustc_infer::infer::{DefiningAnchor, InferCtxt, LateBoundRegionConversionTime};
 use rustc_infer::traits::util::elaborate_predicates_with_span;
 use rustc_infer::traits::{Obligation, ObligationCause, TraitObligation};
 use rustc_middle::ty;
@@ -20,7 +20,7 @@ pub fn recompute_applicable_impls<'tcx>(
     let param_env = obligation.param_env;
 
     let impl_may_apply = |impl_def_id| {
-        let ocx = ObligationCtxt::new_in_snapshot(infcx);
+        let ocx = ObligationCtxt::new_in_snapshot(infcx, DefiningAnchor::Error);
         let placeholder_obligation =
             infcx.instantiate_binder_with_placeholders(obligation.predicate);
         let obligation_trait_ref =
@@ -45,7 +45,7 @@ pub fn recompute_applicable_impls<'tcx>(
     };
 
     let param_env_candidate_may_apply = |poly_trait_predicate: ty::PolyTraitPredicate<'tcx>| {
-        let ocx = ObligationCtxt::new_in_snapshot(infcx);
+        let ocx = ObligationCtxt::new_in_snapshot(infcx, DefiningAnchor::Error);
         let placeholder_obligation =
             infcx.instantiate_binder_with_placeholders(obligation.predicate);
         let obligation_trait_ref =

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2316,8 +2316,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 };
 
                 let obligation = obligation.with(self.tcx, trait_ref);
-                let mut selcx =
-                    SelectionContext::new(&self).with_defining_use_anchor(DefiningAnchor::Bubble);
+                let mut selcx = SelectionContext::new(&self, DefiningAnchor::Bubble);
                 match selcx.select_from_obligation(&obligation) {
                     Ok(None) => {
                         let ambiguities =

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2142,7 +2142,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             .map(|ImplCandidate { trait_ref, similarity }| {
                 // FIXME(compiler-errors): This should be using `NormalizeExt::normalize`
                 let normalized = self
-                    .at(&ObligationCause::dummy(), ty::ParamEnv::empty())
+                    .at(&ObligationCause::dummy(), ty::ParamEnv::empty(), DefiningAnchor::Error)
                     .query_normalize(trait_ref)
                     .map_or(trait_ref, |normalized| normalized.value);
                 (similarity, normalized)
@@ -2706,8 +2706,10 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             let cleaned_pred =
                 pred.fold_with(&mut ParamToVarFolder { infcx: self, var_map: Default::default() });
 
-            let InferOk { value: cleaned_pred, .. } =
-                self.infcx.at(&ObligationCause::dummy(), param_env).normalize(cleaned_pred);
+            let InferOk { value: cleaned_pred, .. } = self
+                .infcx
+                .at(&ObligationCause::dummy(), param_env, DefiningAnchor::Error)
+                .normalize(cleaned_pred);
 
             let obligation =
                 Obligation::new(self.tcx, ObligationCause::dummy(), param_env, cleaned_pred);

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -30,7 +30,7 @@ use rustc_hir::GenericParam;
 use rustc_hir::Item;
 use rustc_hir::Node;
 use rustc_infer::infer::error_reporting::TypeErrCtxt;
-use rustc_infer::infer::{InferOk, TypeTrace};
+use rustc_infer::infer::{DefiningAnchor, InferOk, TypeTrace};
 use rustc_middle::traits::select::OverflowError;
 use rustc_middle::ty::abstract_const::NotConstEvaluatable;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
@@ -2316,7 +2316,8 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 };
 
                 let obligation = obligation.with(self.tcx, trait_ref);
-                let mut selcx = SelectionContext::new(&self);
+                let mut selcx =
+                    SelectionContext::new(&self).with_defining_use_anchor(DefiningAnchor::Bubble);
                 match selcx.select_from_obligation(&obligation) {
                     Ok(None) => {
                         let ambiguities =

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -370,7 +370,7 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
                     param_env,
                     ty.rebind(ty::TraitPredicate { trait_ref, constness, polarity }),
                 );
-                let ocx = ObligationCtxt::new_in_snapshot(self);
+                let ocx = ObligationCtxt::new_in_snapshot(self, DefiningAnchor::Error);
                 ocx.register_obligation(obligation);
                 if ocx.select_all_or_error().is_empty() {
                     return Ok((
@@ -1718,7 +1718,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         }
 
         self.probe(|_| {
-            let ocx = ObligationCtxt::new_in_snapshot(self);
+            let ocx = ObligationCtxt::new_in_snapshot(self, DefiningAnchor::Error);
 
             // try to find the mismatched types to report the error with.
             //

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1211,7 +1211,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         // implied by wf, but also because that would possibly result in
         // erroneous errors later on.
         let InferOk { value: output, obligations: _ } =
-            self.at(&ObligationCause::dummy(), param_env).normalize(output);
+            self.at(&ObligationCause::dummy(), param_env, DefiningAnchor::Error).normalize(output);
 
         if output.is_ty_var() { None } else { Some((def_id_or_name, output, inputs)) }
     }
@@ -3388,8 +3388,9 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         [trait_pred.self_ty()],
                     )
                 });
-                let InferOk { value: projection_ty, .. } =
-                    self.at(&obligation.cause, obligation.param_env).normalize(projection_ty);
+                let InferOk { value: projection_ty, .. } = self
+                    .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
+                    .normalize(projection_ty);
 
                 debug!(
                     normalized_projection_type = ?self.resolve_vars_if_possible(projection_ty)

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -25,7 +25,7 @@ use rustc_hir::{AsyncGeneratorKind, GeneratorKind, Node};
 use rustc_hir::{Expr, HirId};
 use rustc_infer::infer::error_reporting::TypeErrCtxt;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
-use rustc_infer::infer::{InferOk, LateBoundRegionConversionTime};
+use rustc_infer::infer::{DefiningAnchor, InferOk, LateBoundRegionConversionTime};
 use rustc_middle::hir::map;
 use rustc_middle::ty::error::TypeError::{self, Sorts};
 use rustc_middle::ty::relate::TypeRelation;
@@ -3770,7 +3770,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         body_id: hir::HirId,
         param_env: ty::ParamEnv<'tcx>,
     ) -> Vec<Option<(Span, (DefId, Ty<'tcx>))>> {
-        let ocx = ObligationCtxt::new_in_snapshot(self.infcx);
+        let ocx = ObligationCtxt::new_in_snapshot(self.infcx, DefiningAnchor::Error);
         let mut assocs_in_this_method = Vec::with_capacity(type_diffs.len());
         for diff in type_diffs {
             let Sorts(expected_found) = diff else { continue; };

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -137,7 +137,8 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentContext<'tcx> {
     }
 
     fn select_where_possible(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>> {
-        let selcx = SelectionContext::new(infcx);
+        let selcx =
+            SelectionContext::new(infcx).with_defining_use_anchor(infcx.old_defining_use_anchor);
         self.select(selcx)
     }
 

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -2,6 +2,7 @@ use crate::infer::{InferCtxt, TyOrConstInferVar};
 use rustc_data_structures::obligation_forest::ProcessResult;
 use rustc_data_structures::obligation_forest::{Error, ForestObligation, Outcome};
 use rustc_data_structures::obligation_forest::{ObligationForest, ObligationProcessor};
+use rustc_infer::infer::DefiningAnchor;
 use rustc_infer::traits::ProjectionCacheKey;
 use rustc_infer::traits::{SelectionError, TraitEngine, TraitObligation};
 use rustc_middle::mir::interpret::ErrorHandled;
@@ -136,9 +137,12 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentContext<'tcx> {
         self.predicates.to_errors(CodeAmbiguity).into_iter().map(to_fulfillment_error).collect()
     }
 
-    fn select_where_possible(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>> {
-        let selcx =
-            SelectionContext::new(infcx).with_defining_use_anchor(infcx.old_defining_use_anchor);
+    fn select_where_possible(
+        &mut self,
+        infcx: &InferCtxt<'tcx>,
+        defining_use_anchor: DefiningAnchor,
+    ) -> Vec<FulfillmentError<'tcx>> {
+        let selcx = SelectionContext::new(infcx).with_defining_use_anchor(defining_use_anchor);
         self.select(selcx)
     }
 

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -521,7 +521,11 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                                     && tcx.def_kind(a.def.did) == DefKind::AssocConst =>
                             {
                                 if let Ok(new_obligations) = infcx
-                                    .at(&obligation.cause, obligation.param_env)
+                                    .at(
+                                        &obligation.cause,
+                                        obligation.param_env,
+                                        DefiningAnchor::Error,
+                                    )
                                     .trace(c1, c2)
                                     .eq(a.substs, b.substs)
                                 {
@@ -532,8 +536,13 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                             }
                             (_, Unevaluated(_)) | (Unevaluated(_), _) => (),
                             (_, _) => {
-                                if let Ok(new_obligations) =
-                                    infcx.at(&obligation.cause, obligation.param_env).eq(c1, c2)
+                                if let Ok(new_obligations) = infcx
+                                    .at(
+                                        &obligation.cause,
+                                        obligation.param_env,
+                                        DefiningAnchor::Error,
+                                    )
+                                    .eq(c1, c2)
                                 {
                                     return ProcessResult::Changed(mk_pending(
                                         new_obligations.into_obligations(),
@@ -576,7 +585,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                             match self
                                 .selcx
                                 .infcx
-                                .at(&obligation.cause, obligation.param_env)
+                                .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
                                 .eq(c1, c2)
                             {
                                 Ok(inf_ok) => {
@@ -621,7 +630,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                     match self
                         .selcx
                         .infcx
-                        .at(&obligation.cause, obligation.param_env)
+                        .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
                         .eq(ct.ty(), ty)
                     {
                         Ok(inf_ok) => ProcessResult::Changed(mk_pending(inf_ok.into_obligations())),

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -149,7 +149,7 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentContext<'tcx> {
     }
 
     fn select_where_possible(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<FulfillmentError<'tcx>> {
-        let selcx = SelectionContext::new(infcx).with_defining_use_anchor(self.defining_use_anchor);
+        let selcx = SelectionContext::new(infcx, self.defining_use_anchor);
         self.select(selcx)
     }
 

--- a/compiler/rustc_trait_selection/src/traits/misc.rs
+++ b/compiler/rustc_trait_selection/src/traits/misc.rs
@@ -5,7 +5,7 @@ use crate::traits::{self, ObligationCause, ObligationCtxt};
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_hir as hir;
 use rustc_infer::infer::canonical::Canonical;
-use rustc_infer::infer::{RegionResolutionError, TyCtxtInferExt};
+use rustc_infer::infer::{DefiningAnchor, RegionResolutionError, TyCtxtInferExt};
 use rustc_infer::traits::query::NoSolution;
 use rustc_infer::{infer::outlives::env::OutlivesEnvironment, traits::FulfillmentError};
 use rustc_middle::ty::{self, ParamEnv, Ty, TyCtxt, TypeVisitableExt};
@@ -59,7 +59,7 @@ pub fn type_allowed_to_implement_copy<'tcx>(
         for field in &variant.fields {
             // Do this per-field to get better error messages.
             let infcx = tcx.infer_ctxt().build();
-            let ocx = traits::ObligationCtxt::new(&infcx);
+            let ocx = traits::ObligationCtxt::new(&infcx, DefiningAnchor::Error);
 
             let unnormalized_ty = field.ty(tcx, substs);
             if unnormalized_ty.references_error() {
@@ -141,7 +141,7 @@ pub fn check_tys_might_be_eq<'tcx>(
 ) -> Result<(), NoSolution> {
     let (infcx, (param_env, ty_a, ty_b), _) =
         tcx.infer_ctxt().build_with_canonical(DUMMY_SP, &canonical);
-    let ocx = ObligationCtxt::new(&infcx);
+    let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Error);
 
     let result = ocx.eq(&ObligationCause::dummy(), param_env, ty_a, ty_b);
     // use `select_where_possible` instead of `select_all_or_error` so that

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -373,7 +373,7 @@ pub fn fully_normalize<'tcx, T>(
 where
     T: TypeFoldable<TyCtxt<'tcx>>,
 {
-    let ocx = ObligationCtxt::new(infcx);
+    let ocx = ObligationCtxt::new(infcx, DefiningAnchor::Error);
     debug!(?value);
     let normalized_value = ocx.normalize(&cause, param_env, value);
     debug!(?normalized_value);
@@ -405,7 +405,7 @@ pub fn fully_solve_obligations<'tcx>(
     obligations: impl IntoIterator<Item = PredicateObligation<'tcx>>,
     defining_use_anchor: DefiningAnchor,
 ) -> Vec<FulfillmentError<'tcx>> {
-    let ocx = ObligationCtxt::new(infcx).with_defining_use_anchor(defining_use_anchor);
+    let ocx = ObligationCtxt::new(infcx, defining_use_anchor);
     ocx.register_obligations(obligations);
     ocx.select_all_or_error()
 }
@@ -438,7 +438,7 @@ pub fn impossible_predicates<'tcx>(
 
     let infcx = tcx.infer_ctxt().build();
     let param_env = ty::ParamEnv::reveal_all();
-    let ocx = ObligationCtxt::new(&infcx);
+    let ocx = ObligationCtxt::new(&infcx, DefiningAnchor::Error);
     let predicates = ocx.normalize(&ObligationCause::dummy(), param_env, predicates);
     for predicate in predicates {
         let obligation = Obligation::new(tcx, ObligationCause::dummy(), param_env, predicate);

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -26,6 +26,7 @@ use crate::infer::{InferCtxt, TyCtxtInferExt};
 use crate::traits::error_reporting::TypeErrCtxtExt as _;
 use crate::traits::query::evaluate_obligation::InferCtxtExt as _;
 use rustc_errors::ErrorGuaranteed;
+use rustc_infer::infer::DefiningAnchor;
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::visit::{TypeVisitable, TypeVisitableExt};
 use rustc_middle::ty::{self, DefIdTree, ToPredicate, Ty, TyCtxt, TypeSuperVisitable};
@@ -393,7 +394,7 @@ pub fn fully_solve_obligation<'tcx>(
     infcx: &InferCtxt<'tcx>,
     obligation: PredicateObligation<'tcx>,
 ) -> Vec<FulfillmentError<'tcx>> {
-    fully_solve_obligations(infcx, [obligation])
+    fully_solve_obligations(infcx, [obligation], infcx.old_defining_use_anchor)
 }
 
 /// Process a set of obligations (and any nested obligations that come from them)
@@ -401,8 +402,9 @@ pub fn fully_solve_obligation<'tcx>(
 pub fn fully_solve_obligations<'tcx>(
     infcx: &InferCtxt<'tcx>,
     obligations: impl IntoIterator<Item = PredicateObligation<'tcx>>,
+    defining_use_anchor: DefiningAnchor,
 ) -> Vec<FulfillmentError<'tcx>> {
-    let ocx = ObligationCtxt::new(infcx).with_defining_use_anchor(infcx.old_defining_use_anchor);
+    let ocx = ObligationCtxt::new(infcx).with_defining_use_anchor(defining_use_anchor);
     ocx.register_obligations(obligations);
     ocx.select_all_or_error()
 }

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -402,7 +402,7 @@ pub fn fully_solve_obligations<'tcx>(
     infcx: &InferCtxt<'tcx>,
     obligations: impl IntoIterator<Item = PredicateObligation<'tcx>>,
 ) -> Vec<FulfillmentError<'tcx>> {
-    let ocx = ObligationCtxt::new(infcx);
+    let ocx = ObligationCtxt::new(infcx).with_defining_use_anchor(infcx.old_defining_use_anchor);
     ocx.register_obligations(obligations);
     ocx.select_all_or_error()
 }

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -170,7 +170,7 @@ fn pred_known_to_hold_modulo_regions<'tcx>(
         // The handling of regions in this area of the code is terrible,
         // see issue #29149. We should be able to improve on this with
         // NLL.
-        let errors = fully_solve_obligation(infcx, obligation, infcx.old_defining_use_anchor);
+        let errors = fully_solve_obligation(infcx, obligation, DefiningAnchor::Error);
 
         match &errors[..] {
             [] => true,

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -424,7 +424,7 @@ pub fn fully_solve_bound<'tcx>(
     let trait_ref = tcx.mk_trait_ref(bound, [ty]);
     let obligation = Obligation::new(tcx, cause, param_env, ty::Binder::dummy(trait_ref));
 
-    fully_solve_obligation(infcx, obligation, infcx.old_defining_use_anchor)
+    fully_solve_obligation(infcx, obligation, DefiningAnchor::Error)
 }
 
 /// Normalizes the predicates and checks whether they hold in an empty environment. If this

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -170,7 +170,7 @@ fn pred_known_to_hold_modulo_regions<'tcx>(
         // The handling of regions in this area of the code is terrible,
         // see issue #29149. We should be able to improve on this with
         // NLL.
-        let errors = fully_solve_obligation(infcx, obligation);
+        let errors = fully_solve_obligation(infcx, obligation, infcx.old_defining_use_anchor);
 
         match &errors[..] {
             [] => true,
@@ -393,8 +393,9 @@ where
 pub fn fully_solve_obligation<'tcx>(
     infcx: &InferCtxt<'tcx>,
     obligation: PredicateObligation<'tcx>,
+    defining_use_anchor: DefiningAnchor,
 ) -> Vec<FulfillmentError<'tcx>> {
-    fully_solve_obligations(infcx, [obligation], infcx.old_defining_use_anchor)
+    fully_solve_obligations(infcx, [obligation], defining_use_anchor)
 }
 
 /// Process a set of obligations (and any nested obligations that come from them)
@@ -423,7 +424,7 @@ pub fn fully_solve_bound<'tcx>(
     let trait_ref = tcx.mk_trait_ref(bound, [ty]);
     let obligation = Obligation::new(tcx, cause, param_env, ty::Binder::dummy(trait_ref));
 
-    fully_solve_obligation(infcx, obligation)
+    fully_solve_obligation(infcx, obligation, infcx.old_defining_use_anchor)
 }
 
 /// Normalizes the predicates and checks whether they hold in an empty environment. If this

--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -83,7 +83,7 @@ impl<'a, 'tcx: 'a> InferCtxtExt<'a, 'tcx> for InferCtxt<'tcx> {
                         param_env,
                     )
                 }),
-                self.old_defining_use_anchor,
+                rustc_infer::infer::DefiningAnchor::Error,
             );
             if !constraints.member_constraints.is_empty() {
                 span_bug!(span, "{:#?}", constraints.member_constraints);

--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -55,7 +55,7 @@ impl<'a, 'tcx: 'a> InferCtxtExt<'a, 'tcx> for InferCtxt<'tcx> {
         let span = self.tcx.def_span(body_id);
         let result = param_env
             .and(type_op::implied_outlives_bounds::ImpliedOutlivesBounds { ty })
-            .fully_perform(self);
+            .fully_perform(self, rustc_infer::infer::DefiningAnchor::Error);
         let result = match result {
             Ok(r) => r,
             Err(NoSolution) => {

--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -83,6 +83,7 @@ impl<'a, 'tcx: 'a> InferCtxtExt<'a, 'tcx> for InferCtxt<'tcx> {
                         param_env,
                     )
                 }),
+                self.old_defining_use_anchor,
             );
             if !constraints.member_constraints.is_empty() {
                 span_bug!(span, "{:#?}", constraints.member_constraints);

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -28,6 +28,7 @@ use rustc_hir::def::DefKind;
 use rustc_hir::lang_items::LangItem;
 use rustc_infer::infer::at::At;
 use rustc_infer::infer::resolve::OpportunisticRegionResolver;
+use rustc_infer::infer::DefiningAnchor;
 use rustc_infer::traits::ImplSourceBuiltinData;
 use rustc_middle::traits::select::OverflowError;
 use rustc_middle::ty::fold::{TypeFoldable, TypeFolder, TypeSuperFoldable};
@@ -58,7 +59,7 @@ pub trait NormalizeExt<'tcx> {
 
 impl<'tcx> NormalizeExt<'tcx> for At<'_, 'tcx> {
     fn normalize<T: TypeFoldable<TyCtxt<'tcx>>>(&self, value: T) -> InferOk<'tcx, T> {
-        let mut selcx = SelectionContext::new(self.infcx);
+        let mut selcx = SelectionContext::new(self.infcx, DefiningAnchor::Error);
         let Normalized { value, obligations } =
             normalize_with_depth(&mut selcx, self.param_env, self.cause.clone(), 0, value);
         InferOk { value, obligations }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -283,14 +283,14 @@ fn project_and_unify_type<'cx, 'tcx>(
             obligation.cause.body_id,
             obligation.cause.span,
             obligation.param_env,
-            infcx.defining_use_anchor,
+            selcx.defining_use_anchor(),
         );
     obligations.extend(new);
 
     match infcx
         .at(&obligation.cause, obligation.param_env)
         // This is needed to support nested opaque types like `impl Fn() -> impl Trait`
-        .define_opaque_types(infcx.defining_use_anchor)
+        .define_opaque_types(selcx.defining_use_anchor())
         .eq(normalized, actual)
     {
         Ok(InferOk { obligations: inferred_obligations, value: () }) => {

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -283,13 +283,14 @@ fn project_and_unify_type<'cx, 'tcx>(
             obligation.cause.body_id,
             obligation.cause.span,
             obligation.param_env,
+            infcx.defining_use_anchor,
         );
     obligations.extend(new);
 
     match infcx
         .at(&obligation.cause, obligation.param_env)
         // This is needed to support nested opaque types like `impl Fn() -> impl Trait`
-        .define_opaque_types(true)
+        .define_opaque_types(infcx.defining_use_anchor)
         .eq(normalized, actual)
     {
         Ok(InferOk { obligations: inferred_obligations, value: () }) => {

--- a/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
@@ -1,3 +1,4 @@
+use rustc_infer::infer::DefiningAnchor;
 use rustc_middle::ty;
 use rustc_session::config::TraitSolver;
 
@@ -127,7 +128,7 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
         match self.evaluate_obligation(obligation) {
             Ok(result) => result,
             Err(OverflowError::Canonical) => {
-                let mut selcx = SelectionContext::new(&self);
+                let mut selcx = SelectionContext::new(&self, DefiningAnchor::Error);
                 selcx.evaluate_root_obligation(obligation).unwrap_or_else(|r| match r {
                     OverflowError::Canonical => {
                         span_bug!(

--- a/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
@@ -87,9 +87,10 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
             self.tcx.at(obligation.cause.span()).evaluate_obligation(c_pred)
         } else {
             self.probe(|snapshot| {
-                if let Ok((_, certainty)) =
-                    self.evaluate_root_goal(Goal::new(self.tcx, param_env, obligation.predicate))
-                {
+                if let Ok((_, certainty)) = self.evaluate_root_goal(
+                    Goal::new(self.tcx, param_env, obligation.predicate),
+                    rustc_infer::infer::DefiningAnchor::Error,
+                ) {
                     match certainty {
                         Certainty::Yes => {
                             if self.opaque_types_added_in_snapshot(snapshot) {

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/custom.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/custom.rs
@@ -73,7 +73,7 @@ pub fn scrape_region_constraints<'tcx, Op: super::TypeOp<'tcx, Output = R>, R>(
     );
 
     let InferOk { value, obligations } = infcx.commit_if_ok(|_| op())?;
-    let errors = traits::fully_solve_obligations(infcx, obligations);
+    let errors = traits::fully_solve_obligations(infcx, obligations, infcx.old_defining_use_anchor);
     if !errors.is_empty() {
         infcx.tcx.sess.diagnostic().delay_span_bug(
             DUMMY_SP,

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
@@ -5,6 +5,7 @@ use crate::infer::{InferCtxt, InferOk};
 use crate::traits::query::Fallible;
 use crate::traits::ObligationCause;
 use rustc_infer::infer::canonical::Certainty;
+use rustc_infer::infer::DefiningAnchor;
 use rustc_infer::traits::query::NoSolution;
 use rustc_infer::traits::PredicateObligations;
 use rustc_middle::ty::fold::TypeFoldable;
@@ -32,7 +33,11 @@ pub trait TypeOp<'tcx>: Sized + fmt::Debug {
     /// Processes the operation and all resulting obligations,
     /// returning the final result along with any region constraints
     /// (they will be given over to the NLL region solver).
-    fn fully_perform(self, infcx: &InferCtxt<'tcx>) -> Fallible<TypeOpOutput<'tcx, Self>>;
+    fn fully_perform(
+        self,
+        infcx: &InferCtxt<'tcx>,
+        defining_use_anchor: DefiningAnchor,
+    ) -> Fallible<TypeOpOutput<'tcx, Self>>;
 }
 
 /// The output from performing a type op
@@ -120,7 +125,11 @@ where
     type Output = Q::QueryResponse;
     type ErrorInfo = Canonical<'tcx, ParamEnvAnd<'tcx, Q>>;
 
-    fn fully_perform(self, infcx: &InferCtxt<'tcx>) -> Fallible<TypeOpOutput<'tcx, Self>> {
+    fn fully_perform(
+        self,
+        infcx: &InferCtxt<'tcx>,
+        _defining_use_anchor: DefiningAnchor,
+    ) -> Fallible<TypeOpOutput<'tcx, Self>> {
         let mut region_constraints = QueryRegionConstraints::default();
         let (output, error_info, mut obligations, _) =
             Q::fully_perform_into(self, infcx, &mut region_constraints)?;

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -822,7 +822,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         self.infcx
             .at(&obligation.cause, obligation.param_env)
             // needed for tests/ui/type-alias-impl-trait/assoc-projection-ice.rs
-            .define_opaque_types(true)
+            .define_opaque_types(self.infcx.defining_use_anchor)
             .sup(obligation_trait_ref, expected_trait_ref)
             .map(|InferOk { mut obligations, .. }| {
                 obligations.extend(nested);

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -822,7 +822,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         self.infcx
             .at(&obligation.cause, obligation.param_env)
             // needed for tests/ui/type-alias-impl-trait/assoc-projection-ice.rs
-            .define_opaque_types(self.infcx.defining_use_anchor)
+            .define_opaque_types(self.defining_use_anchor())
             .sup(obligation_trait_ref, expected_trait_ref)
             .map(|InferOk { mut obligations, .. }| {
                 obligations.extend(nested);

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -8,8 +8,8 @@
 //! https://rustc-dev-guide.rust-lang.org/traits/resolution.html#confirmation
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_hir::lang_items::LangItem;
-use rustc_infer::infer::InferOk;
 use rustc_infer::infer::LateBoundRegionConversionTime::HigherRankedType;
+use rustc_infer::infer::{DefiningAnchor, InferOk};
 use rustc_middle::ty::{
     self, Binder, GenericParamDefKind, InternalSubsts, SubstsRef, ToPolyTraitRef, ToPredicate,
     TraitRef, Ty, TyCtxt, TypeVisitableExt,
@@ -176,7 +176,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         obligations.extend(self.infcx.commit_if_ok(|_| {
             self.infcx
-                .at(&obligation.cause, obligation.param_env)
+                .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
                 .sup(placeholder_trait_predicate, candidate)
                 .map(|InferOk { obligations, .. }| obligations)
                 .map_err(|_| Unimplemented)
@@ -461,7 +461,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         nested.extend(self.infcx.commit_if_ok(|_| {
             self.infcx
-                .at(&obligation.cause, obligation.param_env)
+                .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
                 .sup(obligation_trait_ref, upcast_trait_ref)
                 .map(|InferOk { obligations, .. }| obligations)
                 .map_err(|_| Unimplemented)
@@ -820,7 +820,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             });
 
         self.infcx
-            .at(&obligation.cause, obligation.param_env)
+            .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
             // needed for tests/ui/type-alias-impl-trait/assoc-projection-ice.rs
             .define_opaque_types(self.defining_use_anchor())
             .sup(obligation_trait_ref, expected_trait_ref)
@@ -887,7 +887,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 // only the **lifetime bound** is changed.
                 let InferOk { obligations, .. } = self
                     .infcx
-                    .at(&obligation.cause, obligation.param_env)
+                    .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
                     .sup(target, source_trait)
                     .map_err(|_| Unimplemented)?;
                 nested.extend(obligations);
@@ -986,7 +986,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 // only the **lifetime bound** is changed.
                 let InferOk { obligations, .. } = self
                     .infcx
-                    .at(&obligation.cause, obligation.param_env)
+                    .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
                     .sup(target, source_trait)
                     .map_err(|_| Unimplemented)?;
                 nested.extend(obligations);
@@ -1057,7 +1057,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             (&ty::Array(a, _), &ty::Slice(b)) => {
                 let InferOk { obligations, .. } = self
                     .infcx
-                    .at(&obligation.cause, obligation.param_env)
+                    .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
                     .eq(b, a)
                     .map_err(|_| Unimplemented)?;
                 nested.extend(obligations);
@@ -1105,7 +1105,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 let new_struct = tcx.mk_adt(def, substs);
                 let InferOk { obligations, .. } = self
                     .infcx
-                    .at(&obligation.cause, obligation.param_env)
+                    .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
                     .eq(target, new_struct)
                     .map_err(|_| Unimplemented)?;
                 nested.extend(obligations);
@@ -1135,7 +1135,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     tcx.mk_tup_from_iter(a_mid.iter().copied().chain(iter::once(b_last)));
                 let InferOk { obligations, .. } = self
                     .infcx
-                    .at(&obligation.cause, obligation.param_env)
+                    .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
                     .eq(target, new_tuple)
                     .map_err(|_| Unimplemented)?;
                 nested.extend(obligations);

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -919,7 +919,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                             {
                                 if let Ok(new_obligations) = self
                                     .infcx
-                                    .at(&obligation.cause, obligation.param_env)
+                                    .at(
+                                        &obligation.cause,
+                                        obligation.param_env,
+                                        DefiningAnchor::Error,
+                                    )
                                     .trace(c1, c2)
                                     .eq(a.substs, b.substs)
                                 {
@@ -938,7 +942,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                             (_, _) => {
                                 if let Ok(new_obligations) = self
                                     .infcx
-                                    .at(&obligation.cause, obligation.param_env)
+                                    .at(
+                                        &obligation.cause,
+                                        obligation.param_env,
+                                        DefiningAnchor::Error,
+                                    )
                                     .eq(c1, c2)
                                 {
                                     let mut obligations = new_obligations.obligations;
@@ -973,7 +981,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                     match (evaluate(c1), evaluate(c2)) {
                         (Ok(c1), Ok(c2)) => {
-                            match self.infcx.at(&obligation.cause, obligation.param_env).eq(c1, c2)
+                            match self
+                                .infcx
+                                .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
+                                .eq(c1, c2)
                             {
                                 Ok(inf_ok) => self.evaluate_predicates_recursively(
                                     previous_stack,
@@ -1002,7 +1013,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 }
                 ty::PredicateKind::Ambiguous => Ok(EvaluatedToAmbig),
                 ty::PredicateKind::Clause(ty::Clause::ConstArgHasType(ct, ty)) => {
-                    match self.infcx.at(&obligation.cause, obligation.param_env).eq(ct.ty(), ty) {
+                    match self
+                        .infcx
+                        .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
+                        .eq(ct.ty(), ty)
+                    {
                         Ok(inf_ok) => self.evaluate_predicates_recursively(
                             previous_stack,
                             inf_ok.into_obligations(),
@@ -1759,7 +1774,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             )
         });
         self.infcx
-            .at(&obligation.cause, obligation.param_env)
+            .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
             .sup(ty::Binder::dummy(placeholder_trait_ref), trait_bound)
             .map(|InferOk { obligations: _, value: () }| {
                 // This method is called within a probe, so we can't have
@@ -1821,7 +1836,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         let is_match = self
             .infcx
-            .at(&obligation.cause, obligation.param_env)
+            .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
             .sup(obligation.predicate, infer_projection)
             .map_or(false, |InferOk { obligations, value: () }| {
                 self.evaluate_predicates_recursively(
@@ -2514,7 +2529,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         let InferOk { obligations, .. } = self
             .infcx
-            .at(&cause, obligation.param_env)
+            .at(&cause, obligation.param_env, DefiningAnchor::Error)
             .eq(placeholder_obligation_trait_ref, impl_trait_ref)
             .map_err(|e| {
                 debug!("match_impl: failed eq_trait_refs due to `{}`", e.to_string(self.tcx()))
@@ -2564,7 +2579,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         poly_trait_ref: ty::PolyTraitRef<'tcx>,
     ) -> Result<Vec<PredicateObligation<'tcx>>, ()> {
         self.infcx
-            .at(&obligation.cause, obligation.param_env)
+            .at(&obligation.cause, obligation.param_env, DefiningAnchor::Error)
             .sup(obligation.predicate.to_poly_trait_ref(), poly_trait_ref)
             .map(|InferOk { obligations, .. }| obligations)
             .map_err(|_| ())

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -217,16 +217,20 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             freshener: infcx.freshener_keep_static(),
             intercrate_ambiguity_causes: None,
             query_mode: TraitQueryMode::Standard,
-            defining_use_anchor: infcx.old_defining_use_anchor,
+            defining_use_anchor: DefiningAnchor::Error,
         }
     }
 
-    pub fn with_query_mode(
-        infcx: &'cx InferCtxt<'tcx>,
-        query_mode: TraitQueryMode,
-    ) -> SelectionContext<'cx, 'tcx> {
-        debug!(?query_mode, "with_query_mode");
-        SelectionContext { query_mode, ..SelectionContext::new(infcx) }
+    pub fn with_defining_use_anchor(self, defining_use_anchor: DefiningAnchor) -> Self {
+        Self { defining_use_anchor, ..self }
+    }
+
+    pub fn new_in_canonical_query(infcx: &'cx InferCtxt<'tcx>) -> SelectionContext<'cx, 'tcx> {
+        SelectionContext {
+            query_mode: TraitQueryMode::Canonical,
+            defining_use_anchor: DefiningAnchor::Bubble,
+            ..SelectionContext::new(infcx)
+        }
     }
 
     /// Enables tracking of intercrate ambiguity causes. See

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -38,6 +38,7 @@ use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::Diagnostic;
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
+use rustc_infer::infer::DefiningAnchor;
 use rustc_infer::infer::LateBoundRegionConversionTime;
 use rustc_infer::traits::TraitEngine;
 use rustc_infer::traits::TraitEngineExt;
@@ -127,6 +128,8 @@ pub struct SelectionContext<'cx, 'tcx> {
     /// policy. In essence, canonicalized queries need their errors propagated
     /// rather than immediately reported because we do not have accurate spans.
     query_mode: TraitQueryMode,
+
+    defining_use_anchor: DefiningAnchor,
 }
 
 // A stack that walks back up the stack frame.
@@ -214,6 +217,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             freshener: infcx.freshener_keep_static(),
             intercrate_ambiguity_causes: None,
             query_mode: TraitQueryMode::Standard,
+            defining_use_anchor: infcx.old_defining_use_anchor,
         }
     }
 
@@ -2678,6 +2682,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
 
         obligations
+    }
+
+    pub fn defining_use_anchor(&self) -> DefiningAnchor {
+        self.defining_use_anchor
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -228,6 +228,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     pub fn new_in_canonical_query(infcx: &'cx InferCtxt<'tcx>) -> SelectionContext<'cx, 'tcx> {
         SelectionContext {
             query_mode: TraitQueryMode::Canonical,
+            // This bubble is required for this tests to pass:
+            // impl-trait/issue99642.rs
             defining_use_anchor: DefiningAnchor::Bubble,
             ..SelectionContext::new(infcx)
         }

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -625,10 +625,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let mut fulfill_cx = crate::solve::FulfillmentCtxt::new();
         fulfill_cx.register_predicate_obligations(self.infcx, predicates);
         // True errors
-        if !fulfill_cx.select_where_possible(self.infcx).is_empty() {
+        if !fulfill_cx.select_where_possible(self.infcx, DefiningAnchor::Bubble).is_empty() {
             return Ok(EvaluatedToErr);
         }
-        if !fulfill_cx.select_all_or_error(self.infcx).is_empty() {
+        if !fulfill_cx.select_all_or_error(self.infcx, DefiningAnchor::Bubble).is_empty() {
             return Ok(EvaluatedToAmbig);
         }
         // Regions and opaques are handled in the `evaluation_probe` by looking at the snapshot

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -211,18 +211,17 @@ enum BuiltinImplConditions<'tcx> {
 }
 
 impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
-    pub fn new(infcx: &'cx InferCtxt<'tcx>) -> SelectionContext<'cx, 'tcx> {
+    pub fn new(
+        infcx: &'cx InferCtxt<'tcx>,
+        defining_use_anchor: impl Into<DefiningAnchor>,
+    ) -> SelectionContext<'cx, 'tcx> {
         SelectionContext {
             infcx,
             freshener: infcx.freshener_keep_static(),
             intercrate_ambiguity_causes: None,
             query_mode: TraitQueryMode::Standard,
-            defining_use_anchor: DefiningAnchor::Error,
+            defining_use_anchor: defining_use_anchor.into(),
         }
-    }
-
-    pub fn with_defining_use_anchor(self, defining_use_anchor: DefiningAnchor) -> Self {
-        Self { defining_use_anchor, ..self }
     }
 
     pub fn new_in_canonical_query(infcx: &'cx InferCtxt<'tcx>) -> SelectionContext<'cx, 'tcx> {
@@ -230,8 +229,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             query_mode: TraitQueryMode::Canonical,
             // This bubble is required for this tests to pass:
             // impl-trait/issue99642.rs
-            defining_use_anchor: DefiningAnchor::Bubble,
-            ..SelectionContext::new(infcx)
+            ..SelectionContext::new(infcx, DefiningAnchor::Bubble)
         }
     }
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -624,13 +624,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         &mut self,
         predicates: impl IntoIterator<Item = PredicateObligation<'tcx>>,
     ) -> Result<EvaluationResult, OverflowError> {
-        let mut fulfill_cx = crate::solve::FulfillmentCtxt::new();
+        let mut fulfill_cx = crate::solve::FulfillmentCtxt::new(DefiningAnchor::Bubble);
         fulfill_cx.register_predicate_obligations(self.infcx, predicates);
         // True errors
-        if !fulfill_cx.select_where_possible(self.infcx, DefiningAnchor::Bubble).is_empty() {
+        if !fulfill_cx.select_where_possible(self.infcx).is_empty() {
             return Ok(EvaluatedToErr);
         }
-        if !fulfill_cx.select_all_or_error(self.infcx, DefiningAnchor::Bubble).is_empty() {
+        if !fulfill_cx.select_all_or_error(self.infcx).is_empty() {
             return Ok(EvaluatedToAmbig);
         }
         // Regions and opaques are handled in the `evaluation_probe` by looking at the snapshot

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -187,7 +187,7 @@ fn fulfill_implication<'tcx>(
 
     let source_trait = ImplSubject::Trait(source_trait_ref);
 
-    let selcx = &mut SelectionContext::new(&infcx);
+    let selcx = &mut SelectionContext::new(&infcx, DefiningAnchor::Error);
     let target_substs = infcx.fresh_substs_for_item(DUMMY_SP, target_impl);
     let (target_trait, obligations) =
         util::impl_subject_and_oblig(selcx, param_env, target_impl, target_substs);

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -10,6 +10,7 @@
 //! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/specialization.html
 
 pub mod specialization_graph;
+use rustc_infer::infer::DefiningAnchor;
 use specialization_graph::GraphExt;
 
 use crate::errors::NegativePositiveConflict;
@@ -204,7 +205,7 @@ fn fulfill_implication<'tcx>(
 
     // Needs to be `in_snapshot` because this function is used to rebase
     // substitutions, which may happen inside of a select within a probe.
-    let ocx = ObligationCtxt::new_in_snapshot(infcx);
+    let ocx = ObligationCtxt::new_in_snapshot(infcx, DefiningAnchor::Error);
     // attempt to prove all of the predicates for impl2 given those for impl1
     // (which are packed up in penv)
     ocx.register_obligations(obligations.chain(more_obligations));

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -194,7 +194,7 @@ fn fulfill_implication<'tcx>(
 
     // do the impls unify? If not, no specialization.
     let Ok(InferOk { obligations: more_obligations, .. }) =
-        infcx.at(&ObligationCause::dummy(), param_env).eq(source_trait, target_trait)
+        infcx.at(&ObligationCause::dummy(), param_env, DefiningAnchor::Error).eq(source_trait, target_trait)
     else {
         debug!(
             "fulfill_implication: {:?} does not unify with {:?}",

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -9,7 +9,7 @@ use rustc_middle::ty::{GenericArg, SubstsRef};
 
 use super::NormalizeExt;
 use super::{Obligation, ObligationCause, PredicateObligation, SelectionContext};
-use rustc_infer::infer::InferOk;
+use rustc_infer::infer::{DefiningAnchor, InferOk};
 pub use rustc_infer::traits::{self, util::*};
 
 ///////////////////////////////////////////////////////////////////////////
@@ -201,13 +201,17 @@ pub fn impl_subject_and_oblig<'a, 'tcx>(
 ) -> (ImplSubject<'tcx>, impl Iterator<Item = PredicateObligation<'tcx>>) {
     let subject = selcx.tcx().bound_impl_subject(impl_def_id);
     let subject = subject.subst(selcx.tcx(), impl_substs);
-    let InferOk { value: subject, obligations: normalization_obligations1 } =
-        selcx.infcx.at(&ObligationCause::dummy(), param_env).normalize(subject);
+    let InferOk { value: subject, obligations: normalization_obligations1 } = selcx
+        .infcx
+        .at(&ObligationCause::dummy(), param_env, DefiningAnchor::Error)
+        .normalize(subject);
 
     let predicates = selcx.tcx().predicates_of(impl_def_id);
     let predicates = predicates.instantiate(selcx.tcx(), impl_substs);
-    let InferOk { value: predicates, obligations: normalization_obligations2 } =
-        selcx.infcx.at(&ObligationCause::dummy(), param_env).normalize(predicates);
+    let InferOk { value: predicates, obligations: normalization_obligations2 } = selcx
+        .infcx
+        .at(&ObligationCause::dummy(), param_env, DefiningAnchor::Error)
+        .normalize(predicates);
     let impl_obligations =
         super::predicates_for_generics(|_, _| ObligationCause::dummy(), param_env, predicates);
 

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -2,6 +2,7 @@ use crate::infer::InferCtxt;
 use crate::traits;
 use rustc_hir as hir;
 use rustc_hir::lang_items::LangItem;
+use rustc_infer::infer::DefiningAnchor;
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind, SubstsRef};
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt};
 use rustc_span::def_id::{DefId, LocalDefId, CRATE_DEF_ID};
@@ -314,7 +315,7 @@ impl<'tcx> WfPredicates<'tcx> {
         let mut obligations = Vec::with_capacity(self.out.len());
         for mut obligation in self.out {
             assert!(!obligation.has_escaping_bound_vars());
-            let mut selcx = traits::SelectionContext::new(infcx);
+            let mut selcx = traits::SelectionContext::new(infcx, DefiningAnchor::Error);
             // Don't normalize the whole obligation, the param env is either
             // already normalized, or we're currently normalizing the
             // param_env. Either way we should only normalize the predicate.

--- a/compiler/rustc_traits/src/codegen.rs
+++ b/compiler/rustc_traits/src/codegen.rs
@@ -32,7 +32,7 @@ pub fn codegen_select_candidate<'tcx>(
     let infcx = tcx.infer_ctxt().ignoring_regions().build();
     // HACK `Bubble` is required for
     // this test to pass: type-alias-impl-trait/assoc-projection-ice.rs
-    let mut selcx = SelectionContext::new(&infcx).with_defining_use_anchor(DefiningAnchor::Bubble);
+    let mut selcx = SelectionContext::new(&infcx, DefiningAnchor::Bubble);
 
     let obligation_cause = ObligationCause::dummy();
     let obligation = Obligation::new(tcx, obligation_cause, param_env, trait_ref);

--- a/compiler/rustc_traits/src/codegen.rs
+++ b/compiler/rustc_traits/src/codegen.rs
@@ -36,7 +36,7 @@ pub fn codegen_select_candidate<'tcx>(
         .build();
     //~^ HACK `Bubble` is required for
     // this test to pass: type-alias-impl-trait/assoc-projection-ice.rs
-    let mut selcx = SelectionContext::new(&infcx);
+    let mut selcx = SelectionContext::new(&infcx).with_defining_use_anchor(DefiningAnchor::Bubble);
 
     let obligation_cause = ObligationCause::dummy();
     let obligation = Obligation::new(tcx, obligation_cause, param_env, trait_ref);

--- a/compiler/rustc_traits/src/codegen.rs
+++ b/compiler/rustc_traits/src/codegen.rs
@@ -29,12 +29,8 @@ pub fn codegen_select_candidate<'tcx>(
 
     // Do the initial selection for the obligation. This yields the
     // shallow result we are looking for -- that is, what specific impl.
-    let infcx = tcx
-        .infer_ctxt()
-        .ignoring_regions()
-        .with_opaque_type_inference(DefiningAnchor::Bubble)
-        .build();
-    //~^ HACK `Bubble` is required for
+    let infcx = tcx.infer_ctxt().ignoring_regions().build();
+    // HACK `Bubble` is required for
     // this test to pass: type-alias-impl-trait/assoc-projection-ice.rs
     let mut selcx = SelectionContext::new(&infcx).with_defining_use_anchor(DefiningAnchor::Bubble);
 

--- a/compiler/rustc_traits/src/codegen.rs
+++ b/compiler/rustc_traits/src/codegen.rs
@@ -63,7 +63,7 @@ pub fn codegen_select_candidate<'tcx>(
     // In principle, we only need to do this so long as `impl_source`
     // contains unbound type parameters. It could be a slight
     // optimization to stop iterating early.
-    let errors = fulfill_cx.select_all_or_error(&infcx);
+    let errors = fulfill_cx.select_all_or_error(&infcx, DefiningAnchor::Bubble);
     if !errors.is_empty() {
         // `rustc_monomorphize::collector` assumes there are no type errors.
         // Cycle errors are the only post-monomorphization errors possible; emit them now so

--- a/compiler/rustc_traits/src/codegen.rs
+++ b/compiler/rustc_traits/src/codegen.rs
@@ -51,7 +51,7 @@ pub fn codegen_select_candidate<'tcx>(
     // Currently, we use a fulfillment context to completely resolve
     // all nested obligations. This is because they can inform the
     // inference of the impl's type parameters.
-    let mut fulfill_cx = <dyn TraitEngine<'tcx>>::new(tcx);
+    let mut fulfill_cx = <dyn TraitEngine<'tcx>>::new(tcx, DefiningAnchor::Bubble);
     let impl_source = selection.map(|predicate| {
         fulfill_cx.register_predicate_obligation(&infcx, predicate);
     });
@@ -59,7 +59,7 @@ pub fn codegen_select_candidate<'tcx>(
     // In principle, we only need to do this so long as `impl_source`
     // contains unbound type parameters. It could be a slight
     // optimization to stop iterating early.
-    let errors = fulfill_cx.select_all_or_error(&infcx, DefiningAnchor::Bubble);
+    let errors = fulfill_cx.select_all_or_error(&infcx);
     if !errors.is_empty() {
         // `rustc_monomorphize::collector` assumes there are no type errors.
         // Cycle errors are the only post-monomorphization errors possible; emit them now so

--- a/compiler/rustc_traits/src/dropck_outlives.rs
+++ b/compiler/rustc_traits/src/dropck_outlives.rs
@@ -1,7 +1,7 @@
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::canonical::{Canonical, QueryResponse};
-use rustc_infer::infer::TyCtxtInferExt;
+use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::InternalSubsts;
 use rustc_middle::ty::{self, EarlyBinder, ParamEnvAnd, Ty, TyCtxt};
@@ -100,7 +100,7 @@ fn dropck_outlives<'tcx>(
             // to push them onto the stack to be expanded.
             for ty in constraints.dtorck_types.drain(..) {
                 let Normalized { value: ty, obligations } =
-                    ocx.infcx.at(&cause, param_env).query_normalize(ty)?;
+                    ocx.infcx.at(&cause, param_env, DefiningAnchor::Error).query_normalize(ty)?;
                 ocx.register_obligations(obligations);
 
                 debug!("dropck_outlives: ty from dtorck_types = {:?}", ty);

--- a/compiler/rustc_traits/src/evaluate_obligation.rs
+++ b/compiler/rustc_traits/src/evaluate_obligation.rs
@@ -4,7 +4,7 @@ use rustc_middle::ty::{ParamEnvAnd, TyCtxt};
 use rustc_span::source_map::DUMMY_SP;
 use rustc_trait_selection::traits::query::CanonicalPredicateGoal;
 use rustc_trait_selection::traits::{
-    EvaluationResult, Obligation, ObligationCause, OverflowError, SelectionContext, TraitQueryMode,
+    EvaluationResult, Obligation, ObligationCause, OverflowError, SelectionContext,
 };
 
 pub(crate) fn provide(p: &mut Providers) {
@@ -25,7 +25,7 @@ fn evaluate_obligation<'tcx>(
     debug!("evaluate_obligation: goal={:#?}", goal);
     let ParamEnvAnd { param_env, value: predicate } = goal;
 
-    let mut selcx = SelectionContext::with_query_mode(&infcx, TraitQueryMode::Canonical);
+    let mut selcx = SelectionContext::new_in_canonical_query(&infcx);
     let obligation = Obligation::new(tcx, ObligationCause::dummy(), param_env, predicate);
 
     selcx.evaluate_root_obligation(&obligation)

--- a/compiler/rustc_traits/src/evaluate_obligation.rs
+++ b/compiler/rustc_traits/src/evaluate_obligation.rs
@@ -1,4 +1,4 @@
-use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
+use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{ParamEnvAnd, TyCtxt};
 use rustc_span::source_map::DUMMY_SP;
@@ -16,12 +16,8 @@ fn evaluate_obligation<'tcx>(
     canonical_goal: CanonicalPredicateGoal<'tcx>,
 ) -> Result<EvaluationResult, OverflowError> {
     debug!("evaluate_obligation(canonical_goal={:#?})", canonical_goal);
-    // HACK This bubble is required for this tests to pass:
-    // impl-trait/issue99642.rs
-    let (ref infcx, goal, _canonical_inference_vars) = tcx
-        .infer_ctxt()
-        .with_opaque_type_inference(DefiningAnchor::Bubble)
-        .build_with_canonical(DUMMY_SP, &canonical_goal);
+    let (ref infcx, goal, _canonical_inference_vars) =
+        tcx.infer_ctxt().build_with_canonical(DUMMY_SP, &canonical_goal);
     debug!("evaluate_obligation: goal={:#?}", goal);
     let ParamEnvAnd { param_env, value: predicate } = goal;
 

--- a/compiler/rustc_traits/src/normalize_erasing_regions.rs
+++ b/compiler/rustc_traits/src/normalize_erasing_regions.rs
@@ -1,4 +1,4 @@
-use rustc_infer::infer::TyCtxtInferExt;
+use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, ParamEnvAnd, TyCtxt, TypeFoldable, TypeVisitableExt};
@@ -29,7 +29,7 @@ fn try_normalize_after_erasing_regions<'tcx, T: TypeFoldable<TyCtxt<'tcx>> + Par
     let ParamEnvAnd { param_env, value } = goal;
     let infcx = tcx.infer_ctxt().build();
     let cause = ObligationCause::dummy();
-    match infcx.at(&cause, param_env).query_normalize(value) {
+    match infcx.at(&cause, param_env, DefiningAnchor::Error).query_normalize(value) {
         Ok(Normalized { value: normalized_value, obligations: normalized_obligations }) => {
             // We don't care about the `obligations`; they are
             // always only region relations, and we are about to

--- a/compiler/rustc_traits/src/normalize_projection_ty.rs
+++ b/compiler/rustc_traits/src/normalize_projection_ty.rs
@@ -1,5 +1,5 @@
 use rustc_infer::infer::canonical::{Canonical, QueryResponse};
-use rustc_infer::infer::TyCtxtInferExt;
+use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{ParamEnvAnd, TyCtxt};
 use rustc_trait_selection::infer::InferCtxtBuilderExt;
@@ -23,7 +23,7 @@ fn normalize_projection_ty<'tcx>(
     tcx.infer_ctxt().enter_canonical_trait_query(
         &goal,
         |ocx, ParamEnvAnd { param_env, value: goal }| {
-            let selcx = &mut SelectionContext::new(ocx.infcx);
+            let selcx = &mut SelectionContext::new(ocx.infcx, DefiningAnchor::Error);
             let cause = ObligationCause::dummy();
             let mut obligations = vec![];
             let answer = traits::normalize_projection_type(

--- a/compiler/rustc_traits/src/type_op.rs
+++ b/compiler/rustc_traits/src/type_op.rs
@@ -1,6 +1,6 @@
 use rustc_hir as hir;
 use rustc_infer::infer::canonical::{Canonical, QueryResponse};
-use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
+use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::ObligationCauseCode;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, FnSig, Lift, PolyFnSig, Ty, TyCtxt, TypeFoldable};
@@ -212,15 +212,10 @@ fn type_op_prove_predicate<'tcx>(
     tcx: TyCtxt<'tcx>,
     canonicalized: Canonical<'tcx, ParamEnvAnd<'tcx, ProvePredicate<'tcx>>>,
 ) -> Result<&'tcx Canonical<'tcx, QueryResponse<'tcx, ()>>, NoSolution> {
-    // HACK This bubble is required for this test to pass:
-    // impl-trait/issue-99642.rs
-    tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bubble).enter_canonical_trait_query(
-        &canonicalized,
-        |ocx, key| {
-            type_op_prove_predicate_with_cause(ocx, key, ObligationCause::dummy());
-            Ok(())
-        },
-    )
+    tcx.infer_ctxt().enter_canonical_trait_query(&canonicalized, |ocx, key| {
+        type_op_prove_predicate_with_cause(ocx, key, ObligationCause::dummy());
+        Ok(())
+    })
 }
 
 /// The core of the `type_op_prove_predicate` query: for diagnostics purposes in NLL HRTB errors,

--- a/compiler/rustc_traits/src/type_op.rs
+++ b/compiler/rustc_traits/src/type_op.rs
@@ -1,6 +1,6 @@
 use rustc_hir as hir;
 use rustc_infer::infer::canonical::{Canonical, QueryResponse};
-use rustc_infer::infer::TyCtxtInferExt;
+use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_infer::traits::ObligationCauseCode;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, FnSig, Lift, PolyFnSig, Ty, TyCtxt, TypeFoldable};
@@ -164,8 +164,10 @@ where
     T: fmt::Debug + TypeFoldable<TyCtxt<'tcx>> + Lift<'tcx>,
 {
     let (param_env, Normalize { value }) = key.into_parts();
-    let Normalized { value, obligations } =
-        ocx.infcx.at(&ObligationCause::dummy(), param_env).query_normalize(value)?;
+    let Normalized { value, obligations } = ocx
+        .infcx
+        .at(&ObligationCause::dummy(), param_env, DefiningAnchor::Error)
+        .query_normalize(value)?;
     ocx.register_obligations(obligations);
     Ok(value)
 }

--- a/compiler/rustc_ty_utils/src/structural_match.rs
+++ b/compiler/rustc_ty_utils/src/structural_match.rs
@@ -2,7 +2,7 @@ use rustc_hir::lang_items::LangItem;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 
-use rustc_infer::infer::TyCtxtInferExt;
+use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_trait_selection::traits::{ObligationCause, ObligationCtxt};
 
 /// This method returns true if and only if `adt_ty` itself has been marked as
@@ -16,7 +16,7 @@ fn has_structural_eq_impls<'tcx>(tcx: TyCtxt<'tcx>, adt_ty: Ty<'tcx>) -> bool {
     let ref infcx = tcx.infer_ctxt().build();
     let cause = ObligationCause::dummy();
 
-    let ocx = ObligationCtxt::new(infcx);
+    let ocx = ObligationCtxt::new(infcx, DefiningAnchor::Error);
     // require `#[derive(PartialEq)]`
     let structural_peq_def_id =
         infcx.tcx.require_lang_item(LangItem::StructuralPeq, Some(cause.span));

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -48,9 +48,9 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                 // Require the type the impl is implemented on to match
                 // our type, and ignore the impl if there was a mismatch.
                 let cause = traits::ObligationCause::dummy();
-                let Ok(eq_result) = infcx.at(&cause, param_env).eq(impl_trait_ref.self_ty(), impl_ty) else {
-                        continue
-                    };
+                let Ok(eq_result) = infcx.at(&cause, param_env, DefiningAnchor::Error).eq(impl_trait_ref.self_ty(), impl_ty) else {
+                    continue
+                };
                 let InferOk { value: (), obligations } = eq_result;
                 // FIXME(eddyb) ignoring `obligations` might cause false positives.
                 drop(obligations);

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -21,6 +21,7 @@ use rustc_hir::def_id::{DefId, DefIdMap, DefIdSet, LocalDefId, LOCAL_CRATE};
 use rustc_hir::PredicateOrigin;
 use rustc_hir_analysis::hir_ty_to_ty;
 use rustc_infer::infer::region_constraints::{Constraint, RegionConstraintData};
+use rustc_infer::infer::DefiningAnchor;
 use rustc_middle::middle::resolve_bound_vars as rbv;
 use rustc_middle::ty::fold::TypeFolder;
 use rustc_middle::ty::InternalSubsts;
@@ -1682,7 +1683,7 @@ fn normalize<'tcx>(
     // Try to normalize `<X as Y>::T` to a type
     let infcx = cx.tcx.infer_ctxt().build();
     let normalized = infcx
-        .at(&ObligationCause::dummy(), cx.param_env)
+        .at(&ObligationCause::dummy(), cx.param_env, DefiningAnchor::Error)
         .query_normalize(ty)
         .map(|resolved| infcx.resolve_vars_if_possible(resolved.value));
     match normalized {

--- a/src/tools/clippy/clippy_utils/src/ty.rs
+++ b/src/tools/clippy/clippy_utils/src/ty.rs
@@ -11,7 +11,7 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, FnDecl, LangItem, TyKind, Unsafety};
 use rustc_infer::infer::{
     type_variable::{TypeVariableOrigin, TypeVariableOriginKind},
-    TyCtxtInferExt,
+    TyCtxtInferExt, DefiningAnchor,
 };
 use rustc_lint::LateContext;
 use rustc_middle::mir::interpret::{ConstValue, Scalar};
@@ -312,7 +312,7 @@ fn is_normalizable_helper<'tcx>(
     cache.insert(ty, false);
     let infcx = cx.tcx.infer_ctxt().build();
     let cause = rustc_middle::traits::ObligationCause::dummy();
-    let result = if infcx.at(&cause, param_env).query_normalize(ty).is_ok() {
+    let result = if infcx.at(&cause, param_env, DefiningAnchor::Error).query_normalize(ty).is_ok() {
         match ty.kind() {
             ty::Adt(def, substs) => def.variants().iter().all(|variant| {
                 variant

--- a/tests/ui/type-alias-impl-trait/issue-53398-cyclic-types.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-53398-cyclic-types.stderr
@@ -1,11 +1,8 @@
-error[E0275]: overflow evaluating the requirement `Foo: Sized`
+error[E0275]: overflow evaluating the requirement `<fn() -> Foo {foo} as FnOnce<()>>::Output == fn() -> Foo {foo}`
   --> $DIR/issue-53398-cyclic-types.rs:5:13
    |
 LL | fn foo() -> Foo {
    |             ^^^
-   |
-   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_53398_cyclic_types`)
-   = note: required because it appears within the type `fn() -> Foo {foo}`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This PR removes the `InferCtxt::defining_use_anchor` field and instead bubbles it through the appropriate types and functions that already need to know about their body owner (e.g. hir typeck or mir borrowck/typeck).

follow-up to https://github.com/rust-lang/rust/pull/108311

r? @lcnr