### PR TITLE
Replace `CStore::stable_crate_ids` with a fed query.

### DIFF
--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -192,7 +192,7 @@ impl<'tcx> Queries<'tcx> {
 
             let sess = self.session();
 
-            let cstore = RwLock::new(Box::new(CStore::new(sess)) as _);
+            let cstore = RwLock::new(Box::new(CStore::new()) as _);
             let definitions = RwLock::new(Definitions::new(sess.local_stable_crate_id()));
             let source_span = AppendOnlyVec::new();
             let _id = source_span.push(krate.spans.inner_span);

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -945,7 +945,6 @@ pub(crate) enum CrateError {
     ExternLocationNotFile(Symbol, PathBuf),
     MultipleCandidates(Symbol, CrateFlavor, Vec<PathBuf>),
     SymbolConflictsCurrent(Symbol),
-    StableCrateIdCollision(Symbol, Symbol),
     DlOpen(String),
     DlSym(String),
     LocatorCombined(CombinedLocatorError),
@@ -987,9 +986,6 @@ impl CrateError {
             }
             CrateError::SymbolConflictsCurrent(root_name) => {
                 sess.emit_err(errors::SymbolConflictsCurrent { span, crate_name: root_name });
-            }
-            CrateError::StableCrateIdCollision(crate_name0, crate_name1) => {
-                sess.emit_err(errors::StableCrateIdCollision { span, crate_name0, crate_name1 });
             }
             CrateError::DlOpen(s) | CrateError::DlSym(s) => {
                 sess.emit_err(errors::DlError { span, err: s });

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -635,10 +635,6 @@ impl CrateStore for CStore {
         self.get_crate_data(cnum).root.stable_crate_id
     }
 
-    fn stable_crate_id_to_crate_num(&self, stable_crate_id: StableCrateId) -> CrateNum {
-        self.stable_crate_ids[&stable_crate_id]
-    }
-
     /// Returns the `DefKey` for a given `DefId`. This indicates the
     /// parent `DefId` as well as some idea of what kind of data the
     /// `DefId` refers to.

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -9,6 +9,7 @@ use crate::ty::{self, layout::TyAndLayout, Ty, TyCtxt};
 use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
 use rustc_hir::hir_id::{HirId, OwnerId};
 use rustc_query_system::query::{DefaultCacheSelector, SingleCacheSelector, VecCacheSelector};
+use rustc_session::StableCrateId;
 use rustc_span::symbol::{Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
 
@@ -128,6 +129,18 @@ impl Key for CrateNum {
     #[inline(always)]
     fn query_crate_is_local(&self) -> bool {
         *self == LOCAL_CRATE
+    }
+    fn default_span(&self, _: TyCtxt<'_>) -> Span {
+        DUMMY_SP
+    }
+}
+
+impl Key for StableCrateId {
+    type CacheSelector = DefaultCacheSelector<Self>;
+
+    #[inline(always)]
+    fn query_crate_is_local(&self) -> bool {
+        true
     }
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1611,6 +1611,14 @@ rustc_queries! {
         separate_provide_extern
     }
 
+    /// Maps a StableCrateId to the corresponding CrateNum. This method assumes
+    /// that the crate in question has already been loaded by the CrateStore.
+    query stable_crate_id_to_crate_num_raw(_: rustc_span::def_id::StableCrateId) -> CrateNum {
+        feedable
+        no_hash
+        desc { "looking up the CrateNum for a crate's stable hash" }
+    }
+
     /// Gets the hash for the host proc macro. Used to support -Z dual-proc-macro.
     query crate_host_hash(_: CrateNum) -> Option<Svh> {
         eval_always

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -447,6 +447,9 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn feed_local_crate(self) -> TyCtxtFeed<'tcx, CrateNum> {
         TyCtxtFeed { tcx: self, key: LOCAL_CRATE }
     }
+    pub fn feed_stable_crate_id(self, key: rustc_span::def_id::StableCrateId, cnum: CrateNum) {
+        TyCtxtFeed { tcx: self, key }.stable_crate_id_to_crate_num_raw(cnum);
+    }
 }
 
 impl<'tcx, KEY: Copy> TyCtxtFeed<'tcx, KEY> {
@@ -880,7 +883,7 @@ impl<'tcx> TyCtxt<'tcx> {
         if stable_crate_id == self.sess.local_stable_crate_id() {
             LOCAL_CRATE
         } else {
-            self.cstore_untracked().stable_crate_id_to_crate_num(stable_crate_id)
+            self.dep_graph.with_ignore(|| self.stable_crate_id_to_crate_num_raw(stable_crate_id))
         }
     }
 
@@ -900,7 +903,7 @@ impl<'tcx> TyCtxt<'tcx> {
             // If this is a DefPathHash from an upstream crate, let the CrateStore map
             // it to a DefId.
             let cstore = &*self.cstore_untracked();
-            let cnum = cstore.stable_crate_id_to_crate_num(stable_crate_id);
+            let cnum = self.stable_crate_id_to_crate_num(stable_crate_id);
             cstore.def_path_hash_to_def_id(cnum, hash)
         }
     }

--- a/compiler/rustc_session/src/cstore.rs
+++ b/compiler/rustc_session/src/cstore.rs
@@ -230,7 +230,6 @@ pub trait CrateStore: std::fmt::Debug {
     // incr. comp. uses to identify a CrateNum.
     fn crate_name(&self, cnum: CrateNum) -> Symbol;
     fn stable_crate_id(&self, cnum: CrateNum) -> StableCrateId;
-    fn stable_crate_id_to_crate_num(&self, stable_crate_id: StableCrateId) -> CrateNum;
 
     /// Fetch a DefId from a DefPathHash for a foreign crate.
     fn def_path_hash_to_def_id(&self, cnum: CrateNum, hash: DefPathHash) -> DefId;


### PR DESCRIPTION
This avoids more state in the `CStore`, but is a bit odd from the feeding perspective, as there's no "creation" of the query key (the hash). But since it is kinda global information, I believe this is sound. After all, you can't create more crate ids after the resolver.

r? @petrochenkov 