### PR TITLE
Dedup elaborated predicates with const generic parameter in AutoTrait

### DIFF
--- a/tests/rustdoc-ui/issue_107715.rs
+++ b/tests/rustdoc-ui/issue_107715.rs
@@ -1,0 +1,18 @@
+// check-pass
+#![crate_type = "lib"]
+
+const N: usize = 1;
+
+trait Supertrait<V> {
+    type AssociatedType;
+}
+
+trait Subtrait: Supertrait<[u8; N]> {}
+
+struct MapType<K: Supertrait<V>, V> {
+    map: K::AssociatedType,
+}
+
+struct Container<S: Subtrait> {
+    _x: MapType<S, [u8; N]>,
+}


### PR DESCRIPTION
## Fixes https://github.com/rust-lang/rust/issues/107715

## Explanation

The `param_env` passed in to `evaluate_predicates` in the added test case has the constant `N` substituted for the value of the referencing constant `1`. But the call to `elaborate_predicates` produces non normalized obligations (without the constant being substituted).

This means we will call `SelectionContext.select` with a `param_env` with multiple Predicates that will `relate` and cause a ambiguity. And eventually run in to a panic!.

Other normalization workarounds already happens in the `AutoTraitFinder`
in the `add_user_pred` method to work around lifetime differences.
But that method is called before `elaborate_predicates` which is what ends up adding the non normalized predicate.

This PR adds extra de-duplication with normalization that ends up removing the redundant predicate that causes the error here.

The first place I tried to put this de-duplication was in the Elaborator ([this](https://github.com/rust-lang/rust/blob/master/compiler/rustc_infer/src/traits/util.rs#L69)).
But the normalize utility I'm calling is not available from `rustc_infer` and the comments in `AutoTraitFinder` seems to suggest that the need to normalize the predicates like this is unique to it's use.

## Existing Regression

running `cargo-rustc-bisect` finds that the test example was working before `d49e7e7` (PR: #103279).
The removal of the code [here](https://github.com/rust-lang/rust/commit/d49e7e7fa13479c11a3733824c78e280e391288b#diff-cc7918c05504318c0c6d5b387e1045614559c4fa1346b85ff207ac921273bf4cR606-R607) makes the test pass. Not because the predicates then gets normalized the same. The `param_env` will still have extra predicates in it. But without the  extra eval in the `relate_consts` code `SelectionContext.select` will only pick on off the 2 bounds and there will not be a ambiguity.
Making sure there are not multiple duplicates in the `param_env` seems more in line with the rest of `AutoTraitFinder`.

## generic_const_exprs

With `generic_const_exprs` turned on the example works before and after this PR. The predicates get normalized to leaving the const un-evaluated in all cases.
So I left a comment that this de-duping can probably be removed when that feature is stable. [this](https://github.com/rust-lang/rust/commit/d49e7e7fa13479c11a3733824c78e280e391288b#diff-cc7918c05504318c0c6d5b387e1045614559c4fa1346b85ff207ac921273bf4cR606-R607) code has a similar comment.

## Questions:

- [ ] I could add a extra test case that generates docs for the same test case but with `generic_const_exprs` enabled. That functionality was not broken before this so maybe its not needed? 🤷🏻 But the functionality of this is different in that case