### PR TITLE
diagnostics: remove inconsistent English article "this" from E0107

### DIFF
--- a/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
@@ -462,7 +462,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
 
         if self.gen_args.span_ext().is_some() {
             format!(
-                "this {} takes {}{} {} argument{} but {} {} supplied",
+                "{} takes {}{} {} argument{} but {} {} supplied",
                 def_kind,
                 quantifier,
                 bound,

--- a/tests/rustdoc-ui/unable-fulfill-trait.stderr
+++ b/tests/rustdoc-ui/unable-fulfill-trait.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/unable-fulfill-trait.rs:4:17
    |
 LL |     field1: dyn Bar<'a, 'b,>,

--- a/tests/ui/argument-suggestions/issue-100154.stderr
+++ b/tests/ui/argument-suggestions/issue-100154.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: function takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-100154.rs:4:5
    |
 LL |     foo::<()>(());

--- a/tests/ui/async-await/issues/issue-65159.rs
+++ b/tests/ui/async-await/issues/issue-65159.rs
@@ -3,7 +3,7 @@
 // edition:2018
 
 async fn copy() -> Result<()>
-//~^ ERROR this enum takes 2 generic arguments
+//~^ ERROR enum takes 2 generic arguments
 {
     Ok(())
 }

--- a/tests/ui/async-await/issues/issue-65159.stderr
+++ b/tests/ui/async-await/issues/issue-65159.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this enum takes 2 generic arguments but 1 generic argument was supplied
+error[E0107]: enum takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-65159.rs:5:20
    |
 LL | async fn copy() -> Result<()>

--- a/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.rs
+++ b/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.rs
@@ -14,8 +14,8 @@ impl MarketMultiplier {
 }
 
 async fn buy_lock(generator: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
-    //~^ ERROR this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
-    //~^^ ERROR this struct takes 1 generic argument but 0 generic arguments were supplied
+    //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument was supplied
+    //~^^ ERROR struct takes 1 generic argument but 0 generic arguments were supplied
     LockedMarket(generator.lock().unwrap().buy())
 }
 

--- a/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
+++ b/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:16:59
    |
 LL | async fn buy_lock(generator: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
@@ -12,7 +12,7 @@ note: struct defined here, with 0 lifetime parameters
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^
 
-error[E0107]: this struct takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:16:59
    |
 LL | async fn buy_lock(generator: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.rs
@@ -7,8 +7,8 @@ trait X {
 
 const _: () = {
     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
-    //~^ ERROR this associated type takes 1 lifetime argument but 0 lifetime arguments
-    //~| ERROR this associated type takes 0 generic arguments but 1 generic argument
+    //~^ ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+    //~| ERROR associated type takes 0 generic arguments but 1 generic argument
 };
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/issue-102768.rs:9:30
    |
 LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
@@ -14,7 +14,7 @@ help: add missing lifetime argument
 LL |     fn f2<'a>(arg: Box<dyn X<Y<'_, 1> = &'a ()>>) {}
    |                                +++
 
-error[E0107]: this associated type takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-102768.rs:9:30
    |
 LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}

--- a/tests/ui/const-generics/generic_const_exprs/issue-76595.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-76595.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this function takes 2 generic arguments but 1 generic argument was supplied
+error[E0107]: function takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-76595.rs:15:5
    |
 LL |     test::<2>();

--- a/tests/ui/const-generics/incorrect-number-of-const-args.stderr
+++ b/tests/ui/const-generics/incorrect-number-of-const-args.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this function takes 2 generic arguments but 1 generic argument was supplied
+error[E0107]: function takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/incorrect-number-of-const-args.rs:6:5
    |
 LL |     foo::<0>();
@@ -16,7 +16,7 @@ help: add missing generic argument
 LL |     foo::<0, Y>();
    |            +++
 
-error[E0107]: this function takes 2 generic arguments but 3 generic arguments were supplied
+error[E0107]: function takes 2 generic arguments but 3 generic arguments were supplied
   --> $DIR/incorrect-number-of-const-args.rs:9:5
    |
 LL |     foo::<0, 0, 0>();

--- a/tests/ui/const-generics/invalid-const-arg-for-type-param.rs
+++ b/tests/ui/const-generics/invalid-const-arg-for-type-param.rs
@@ -4,11 +4,11 @@ struct S;
 
 fn main() {
     let _: u32 = 5i32.try_into::<32>().unwrap();
-    //~^ ERROR this method takes
+    //~^ ERROR method takes
 
     S.f::<0>();
     //~^ ERROR no method named `f`
 
     S::<0>;
-    //~^ ERROR this struct takes 0
+    //~^ ERROR struct takes 0
 }

--- a/tests/ui/const-generics/invalid-const-arg-for-type-param.stderr
+++ b/tests/ui/const-generics/invalid-const-arg-for-type-param.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/invalid-const-arg-for-type-param.rs:6:23
    |
 LL |     let _: u32 = 5i32.try_into::<32>().unwrap();
@@ -23,7 +23,7 @@ LL | struct S;
 LL |     S.f::<0>();
    |       ^ method not found in `S`
 
-error[E0107]: this struct takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/invalid-const-arg-for-type-param.rs:12:5
    |
 LL |     S::<0>;

--- a/tests/ui/const-generics/invalid-constant-in-args.rs
+++ b/tests/ui/const-generics/invalid-constant-in-args.rs
@@ -2,5 +2,5 @@ use std::cell::Cell;
 
 fn main() {
     let _: Cell<&str, "a"> = Cell::new("");
-    //~^ ERROR this struct takes 1 generic argument but 2 generic arguments were supplied
+    //~^ ERROR struct takes 1 generic argument but 2 generic arguments were supplied
 }

--- a/tests/ui/const-generics/invalid-constant-in-args.stderr
+++ b/tests/ui/const-generics/invalid-constant-in-args.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this struct takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/invalid-constant-in-args.rs:4:12
    |
 LL |     let _: Cell<&str, "a"> = Cell::new("");

--- a/tests/ui/const-generics/issues/issue-87493.rs
+++ b/tests/ui/const-generics/issues/issue-87493.rs
@@ -7,7 +7,7 @@ where
     S: MyTrait,
     T: MyTrait<Assoc == S::Assoc>,
     //~^ ERROR: expected one of `,` or `>`, found `==`
-    //~| ERROR: this trait takes 0 generic arguments but 1 generic argument was supplied
+    //~| ERROR: trait takes 0 generic arguments but 1 generic argument was supplied
 {
 }
 

--- a/tests/ui/const-generics/issues/issue-87493.stderr
+++ b/tests/ui/const-generics/issues/issue-87493.stderr
@@ -9,7 +9,7 @@ help: if you meant to use an associated type binding, replace `==` with `=`
 LL |     T: MyTrait<Assoc = S::Assoc>,
    |                      ~
 
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-87493.rs:8:8
    |
 LL |     T: MyTrait<Assoc == S::Assoc>,

--- a/tests/ui/const-generics/parser-error-recovery/issue-89013-no-kw.rs
+++ b/tests/ui/const-generics/parser-error-recovery/issue-89013-no-kw.rs
@@ -7,7 +7,7 @@ struct Bar;
 const T: usize = 42;
 
 impl Foo<N = 3> for Bar {
-//~^ ERROR this trait takes 1 generic argument but 0 generic arguments were supplied
+//~^ ERROR trait takes 1 generic argument but 0 generic arguments were supplied
 //~| ERROR associated type bindings are not allowed here
 //~| ERROR associated const equality is incomplete
     fn do_x(&self) -> [u8; 3] {

--- a/tests/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
+++ b/tests/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
@@ -7,7 +7,7 @@ LL | impl Foo<N = 3> for Bar {
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
 
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/issue-89013-no-kw.rs:9:6
    |
 LL | impl Foo<N = 3> for Bar {

--- a/tests/ui/const-generics/parser-error-recovery/issue-89013.rs
+++ b/tests/ui/const-generics/parser-error-recovery/issue-89013.rs
@@ -8,7 +8,7 @@ const T: usize = 42;
 
 impl Foo<N = const 3> for Bar {
 //~^ ERROR expected lifetime, type, or constant, found keyword `const`
-//~| ERROR this trait takes 1 generic
+//~| ERROR trait takes 1 generic
 //~| ERROR associated type bindings are not allowed here
 //~| ERROR associated const equality is incomplete
     fn do_x(&self) -> [u8; 3] {

--- a/tests/ui/const-generics/parser-error-recovery/issue-89013.stderr
+++ b/tests/ui/const-generics/parser-error-recovery/issue-89013.stderr
@@ -19,7 +19,7 @@ LL | impl Foo<N = const 3> for Bar {
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
 
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/issue-89013.rs:9:6
    |
 LL | impl Foo<N = const 3> for Bar {

--- a/tests/ui/constructor-lifetime-args.rs
+++ b/tests/ui/constructor-lifetime-args.rs
@@ -15,12 +15,12 @@ enum E<'a, 'b> {
 fn main() {
     S(&0, &0); // OK
     S::<'static>(&0, &0);
-    //~^ ERROR this struct takes 2 lifetime arguments
+    //~^ ERROR struct takes 2 lifetime arguments
     S::<'static, 'static, 'static>(&0, &0);
-    //~^ ERROR this struct takes 2 lifetime arguments
+    //~^ ERROR struct takes 2 lifetime arguments
     E::V(&0); // OK
     E::V::<'static>(&0);
-    //~^ ERROR this enum takes 2 lifetime arguments
+    //~^ ERROR enum takes 2 lifetime arguments
     E::V::<'static, 'static, 'static>(&0);
-    //~^ ERROR this enum takes 2 lifetime arguments
+    //~^ ERROR enum takes 2 lifetime arguments
 }

--- a/tests/ui/constructor-lifetime-args.stderr
+++ b/tests/ui/constructor-lifetime-args.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this struct takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: struct takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/constructor-lifetime-args.rs:17:5
    |
 LL |     S::<'static>(&0, &0);
@@ -16,7 +16,7 @@ help: add missing lifetime argument
 LL |     S::<'static, 'static>(&0, &0);
    |                +++++++++
 
-error[E0107]: this struct takes 2 lifetime arguments but 3 lifetime arguments were supplied
+error[E0107]: struct takes 2 lifetime arguments but 3 lifetime arguments were supplied
   --> $DIR/constructor-lifetime-args.rs:19:5
    |
 LL |     S::<'static, 'static, 'static>(&0, &0);
@@ -30,7 +30,7 @@ note: struct defined here, with 2 lifetime parameters: `'a`, `'b`
 LL | struct S<'a, 'b>(&'a u8, &'b u8);
    |        ^ --  --
 
-error[E0107]: this enum takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: enum takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/constructor-lifetime-args.rs:22:8
    |
 LL |     E::V::<'static>(&0);
@@ -48,7 +48,7 @@ help: add missing lifetime argument
 LL |     E::V::<'static, 'static>(&0);
    |                   +++++++++
 
-error[E0107]: this enum takes 2 lifetime arguments but 3 lifetime arguments were supplied
+error[E0107]: enum takes 2 lifetime arguments but 3 lifetime arguments were supplied
   --> $DIR/constructor-lifetime-args.rs:24:8
    |
 LL |     E::V::<'static, 'static, 'static>(&0);

--- a/tests/ui/error-codes/E0107.rs
+++ b/tests/ui/error-codes/E0107.rs
@@ -11,39 +11,39 @@ enum Bar {
 
 struct Baz<'a, 'b, 'c> {
     buzz: Buzz<'a>,
-    //~^ ERROR this struct takes 2 lifetime arguments
+    //~^ ERROR struct takes 2 lifetime arguments
     //~| HELP add missing lifetime argument
 
     bar: Bar<'a>,
-    //~^ ERROR this enum takes 0 lifetime arguments
+    //~^ ERROR enum takes 0 lifetime arguments
     //~| HELP remove these generics
 
     foo2: Foo<'a, 'b, 'c>,
-    //~^ ERROR this struct takes 1 lifetime argument
+    //~^ ERROR struct takes 1 lifetime argument
     //~| HELP remove these lifetime arguments
 
     qux1: Qux<'a, 'b, i32>,
-    //~^ ERROR this struct takes 1 lifetime argument
+    //~^ ERROR struct takes 1 lifetime argument
     //~| HELP remove this lifetime argument
 
     qux2: Qux<'a, i32, 'b>,
-    //~^ ERROR this struct takes 1 lifetime argument
+    //~^ ERROR struct takes 1 lifetime argument
     //~| HELP remove this lifetime argument
 
     qux3: Qux<'a, 'b, 'c, i32>,
-    //~^ ERROR this struct takes 1 lifetime argument
+    //~^ ERROR struct takes 1 lifetime argument
     //~| HELP remove these lifetime arguments
 
     qux4: Qux<'a, i32, 'b, 'c>,
-    //~^ ERROR this struct takes 1 lifetime argument
+    //~^ ERROR struct takes 1 lifetime argument
     //~| HELP remove these lifetime arguments
 
     qux5: Qux<'a, 'b, i32, 'c>,
-    //~^ ERROR this struct takes 1 lifetime argument
+    //~^ ERROR struct takes 1 lifetime argument
     //~| HELP remove this lifetime argument
 
     quux: Quux<'a, i32, 'b>,
-    //~^ ERROR this struct takes 0 lifetime arguments
+    //~^ ERROR struct takes 0 lifetime arguments
     //~| HELP remove this lifetime argument
 }
 
@@ -53,7 +53,7 @@ pub trait T {
 }
 
 fn trait_bound_generic<I: T<u8, u16>>(_i: I) {
-    //~^ ERROR this trait takes 0 generic arguments
+    //~^ ERROR trait takes 0 generic arguments
     //~| HELP replace the generic bounds with the associated types
 }
 

--- a/tests/ui/error-codes/E0107.stderr
+++ b/tests/ui/error-codes/E0107.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this struct takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: struct takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/E0107.rs:13:11
    |
 LL |     buzz: Buzz<'a>,
@@ -16,7 +16,7 @@ help: add missing lifetime argument
 LL |     buzz: Buzz<'a, 'a>,
    |                  ++++
 
-error[E0107]: this enum takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: enum takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/E0107.rs:17:10
    |
 LL |     bar: Bar<'a>,
@@ -30,7 +30,7 @@ note: enum defined here, with 0 lifetime parameters
 LL | enum Bar {
    |      ^^^
 
-error[E0107]: this struct takes 1 lifetime argument but 3 lifetime arguments were supplied
+error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
   --> $DIR/E0107.rs:21:11
    |
 LL |     foo2: Foo<'a, 'b, 'c>,
@@ -44,7 +44,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
 LL | struct Foo<'a>(&'a str);
    |        ^^^ --
 
-error[E0107]: this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/E0107.rs:25:11
    |
 LL |     qux1: Qux<'a, 'b, i32>,
@@ -58,7 +58,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
 
-error[E0107]: this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/E0107.rs:29:11
    |
 LL |     qux2: Qux<'a, i32, 'b>,
@@ -72,7 +72,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
 
-error[E0107]: this struct takes 1 lifetime argument but 3 lifetime arguments were supplied
+error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
   --> $DIR/E0107.rs:33:11
    |
 LL |     qux3: Qux<'a, 'b, 'c, i32>,
@@ -86,7 +86,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
 
-error[E0107]: this struct takes 1 lifetime argument but 3 lifetime arguments were supplied
+error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
   --> $DIR/E0107.rs:37:11
    |
 LL |     qux4: Qux<'a, i32, 'b, 'c>,
@@ -100,7 +100,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
 
-error[E0107]: this struct takes 1 lifetime argument but 3 lifetime arguments were supplied
+error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
   --> $DIR/E0107.rs:41:11
    |
 LL |     qux5: Qux<'a, 'b, i32, 'c>,
@@ -114,7 +114,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
 
-error[E0107]: this struct takes 0 lifetime arguments but 2 lifetime arguments were supplied
+error[E0107]: struct takes 0 lifetime arguments but 2 lifetime arguments were supplied
   --> $DIR/E0107.rs:45:11
    |
 LL |     quux: Quux<'a, i32, 'b>,
@@ -128,7 +128,7 @@ note: struct defined here, with 0 lifetime parameters
 LL | struct Quux<T>(T);
    |        ^^^^
 
-error[E0107]: this trait takes 0 generic arguments but 2 generic arguments were supplied
+error[E0107]: trait takes 0 generic arguments but 2 generic arguments were supplied
   --> $DIR/E0107.rs:55:27
    |
 LL | fn trait_bound_generic<I: T<u8, u16>>(_i: I) {

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.rs
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.rs
@@ -5,12 +5,12 @@ trait X {
 fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
   //~^ ERROR: lifetime in trait object type must be followed by `+`
   //~| ERROR: parenthesized generic arguments cannot be used
-  //~| ERROR this associated type takes 0 generic arguments but 1 generic argument
-  //~| ERROR this associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
 
 
 fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
   //~^ ERROR: parenthesized generic arguments cannot be used
-  //~| ERROR this associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
 
 fn main() {}

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
@@ -23,7 +23,7 @@ LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
    |                            |
    |                            help: remove these parentheses
 
-error[E0107]: this associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
    |
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
@@ -39,7 +39,7 @@ help: add missing lifetime argument
 LL | fn foo<'a>(arg: Box<dyn X<Y('_, 'a) = &'a ()>>) {}
    |                             +++
 
-error[E0107]: this associated type takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
    |
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
@@ -53,7 +53,7 @@ note: associated type defined here, with 0 generic parameters
 LL |   type Y<'a>;
    |        ^
 
-error[E0107]: this associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/gat-trait-path-parenthesised-args.rs:12:27
    |
 LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}

--- a/tests/ui/generic-associated-types/missing_lifetime_args.rs
+++ b/tests/ui/generic-associated-types/missing_lifetime_args.rs
@@ -12,9 +12,9 @@ fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
 //~^ ERROR missing generics for associated type
 
 fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b>) {}
-//~^ ERROR this struct takes 3 lifetime arguments but 2 lifetime
+//~^ ERROR struct takes 3 lifetime arguments but 2 lifetime
 
 fn f<'a>(_arg: Foo<'a>) {}
-//~^ ERROR this struct takes 3 lifetime arguments but 1 lifetime
+//~^ ERROR struct takes 3 lifetime arguments but 1 lifetime
 
 fn main() {}

--- a/tests/ui/generic-associated-types/missing_lifetime_args.stderr
+++ b/tests/ui/generic-associated-types/missing_lifetime_args.stderr
@@ -14,7 +14,7 @@ help: add missing lifetime arguments
 LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
    |                                 ++++++++
 
-error[E0107]: this struct takes 3 lifetime arguments but 2 lifetime arguments were supplied
+error[E0107]: struct takes 3 lifetime arguments but 2 lifetime arguments were supplied
   --> $DIR/missing_lifetime_args.rs:14:26
    |
 LL | fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b>) {}
@@ -32,7 +32,7 @@ help: add missing lifetime argument
 LL | fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b, 'a>) {}
    |                                    ++++
 
-error[E0107]: this struct takes 3 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: struct takes 3 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/missing_lifetime_args.rs:17:16
    |
 LL | fn f<'a>(_arg: Foo<'a>) {}

--- a/tests/ui/generic-associated-types/missing_lifetime_const.rs
+++ b/tests/ui/generic-associated-types/missing_lifetime_const.rs
@@ -4,7 +4,7 @@ trait Foo {
 
 fn foo<T: Foo>() {
     let _: <T as Foo>::Assoc<3>;
-      //~^ ERROR  this associated type
+      //~^ ERROR  associated type
 }
 
 fn main() {}

--- a/tests/ui/generic-associated-types/missing_lifetime_const.stderr
+++ b/tests/ui/generic-associated-types/missing_lifetime_const.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/missing_lifetime_const.rs:6:24
    |
 LL |     let _: <T as Foo>::Assoc<3>;

--- a/tests/ui/generic-associated-types/parameter_number_and_kind.rs
+++ b/tests/ui/generic-associated-types/parameter_number_and_kind.rs
@@ -9,10 +9,10 @@ trait Foo {
     // Test parameters in default values
     type FOk<T> = Self::E<'static, T>;
     type FErr1 = Self::E<'static, 'static>;
-    //~^ ERROR this associated type takes 1 lifetime argument but 2 lifetime arguments were supplied
-    //~| ERROR this associated type takes 1
+    //~^ ERROR associated type takes 1 lifetime argument but 2 lifetime arguments were supplied
+    //~| ERROR associated type takes 1
     type FErr2<T> = Self::E<'static, T, u32>;
-    //~^ ERROR this associated type takes 1
+    //~^ ERROR associated type takes 1
 }
 
 fn main() {}

--- a/tests/ui/generic-associated-types/parameter_number_and_kind.stderr
+++ b/tests/ui/generic-associated-types/parameter_number_and_kind.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated type takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: associated type takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/parameter_number_and_kind.rs:11:24
    |
 LL |     type FErr1 = Self::E<'static, 'static>;
@@ -12,7 +12,7 @@ note: associated type defined here, with 1 lifetime parameter: `'a`
 LL |     type E<'a, T>;
    |          ^ --
 
-error[E0107]: this associated type takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: associated type takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/parameter_number_and_kind.rs:11:24
    |
 LL |     type FErr1 = Self::E<'static, 'static>;
@@ -28,7 +28,7 @@ help: add missing generic argument
 LL |     type FErr1 = Self::E<'static, 'static, T>;
    |                                          +++
 
-error[E0107]: this associated type takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: associated type takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/parameter_number_and_kind.rs:14:27
    |
 LL |     type FErr2<T> = Self::E<'static, T, u32>;

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.rs
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.rs
@@ -4,8 +4,8 @@ trait X {
 
 const _: () = {
   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-      //~^ ERROR this associated type takes 1 lifetime argument but 0 lifetime arguments
-      //~| ERROR this associated type takes 0 generic arguments but 1 generic argument
+      //~^ ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+      //~| ERROR associated type takes 0 generic arguments but 1 generic argument
 };
 
 fn main() {}

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/trait-path-type-error-once-implemented.rs:6:29
    |
 LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
@@ -14,7 +14,7 @@ help: add missing lifetime argument
 LL |   fn f2<'a>(arg : Box<dyn X<Y<'_, 1> = &'a ()>>) {}
    |                               +++
 
-error[E0107]: this associated type takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/trait-path-type-error-once-implemented.rs:6:29
    |
 LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}

--- a/tests/ui/generics/bad-mid-path-type-params.rs
+++ b/tests/ui/generics/bad-mid-path-type-params.rs
@@ -28,17 +28,17 @@ impl Trait<isize> for S2 {
 
 fn foo<'a>() {
     let _ = S::new::<isize,f64>(1, 1.0);
-    //~^ ERROR this associated function takes 1
+    //~^ ERROR associated function takes 1
 
     let _ = S::<'a,isize>::new::<f64>(1, 1.0);
-    //~^ ERROR this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
+    //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument was supplied
 
     let _: S2 = Trait::new::<isize,f64>(1, 1.0);
-    //~^ ERROR this associated function takes 1
+    //~^ ERROR associated function takes 1
 
     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
-    //~^ ERROR this trait takes 0 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR this associated function takes 1
+    //~^ ERROR trait takes 0 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR associated function takes 1
 }
 
 fn main() {}

--- a/tests/ui/generics/bad-mid-path-type-params.stderr
+++ b/tests/ui/generics/bad-mid-path-type-params.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated function takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: associated function takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/bad-mid-path-type-params.rs:30:16
    |
 LL |     let _ = S::new::<isize,f64>(1, 1.0);
@@ -12,7 +12,7 @@ note: associated function defined here, with 1 generic parameter: `U`
 LL |     fn new<U>(x: T, _: U) -> S<T> {
    |        ^^^ -
 
-error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/bad-mid-path-type-params.rs:33:13
    |
 LL |     let _ = S::<'a,isize>::new::<f64>(1, 1.0);
@@ -26,7 +26,7 @@ note: struct defined here, with 0 lifetime parameters
 LL | struct S<T> {
    |        ^
 
-error[E0107]: this associated function takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: associated function takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/bad-mid-path-type-params.rs:36:24
    |
 LL |     let _: S2 = Trait::new::<isize,f64>(1, 1.0);
@@ -40,7 +40,7 @@ note: associated function defined here, with 1 generic parameter: `U`
 LL |     fn new<U>(x: T, y: U) -> Self;
    |        ^^^ -
 
-error[E0107]: this trait takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/bad-mid-path-type-params.rs:39:17
    |
 LL |     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
@@ -54,7 +54,7 @@ note: trait defined here, with 0 lifetime parameters
 LL | trait Trait<T> {
    |       ^^^^^
 
-error[E0107]: this associated function takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: associated function takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/bad-mid-path-type-params.rs:39:36
    |
 LL |     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);

--- a/tests/ui/generics/generic-arg-mismatch-recover.rs
+++ b/tests/ui/generics/generic-arg-mismatch-recover.rs
@@ -4,9 +4,9 @@ struct Bar<'a>(&'a ());
 
 fn main() {
     Foo::<'static, 'static, ()>(&0);
-    //~^ ERROR this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
+    //~^ ERROR struct takes 1 lifetime argument but 2 lifetime arguments were supplied
 
     Bar::<'static, 'static, ()>(&());
-    //~^ ERROR this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
-    //~| ERROR this struct takes 0
+    //~^ ERROR struct takes 1 lifetime argument but 2 lifetime arguments were supplied
+    //~| ERROR struct takes 0
 }

--- a/tests/ui/generics/generic-arg-mismatch-recover.stderr
+++ b/tests/ui/generics/generic-arg-mismatch-recover.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/generic-arg-mismatch-recover.rs:6:5
    |
 LL |     Foo::<'static, 'static, ()>(&0);
@@ -12,7 +12,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
 LL | struct Foo<'a, T: 'a>(&'a T);
    |        ^^^ --
 
-error[E0107]: this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/generic-arg-mismatch-recover.rs:9:5
    |
 LL |     Bar::<'static, 'static, ()>(&());
@@ -26,7 +26,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
 LL | struct Bar<'a>(&'a ());
    |        ^^^ --
 
-error[E0107]: this struct takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/generic-arg-mismatch-recover.rs:9:5
    |
 LL |     Bar::<'static, 'static, ()>(&());

--- a/tests/ui/generics/generic-impl-less-params-with-defaults.rs
+++ b/tests/ui/generics/generic-impl-less-params-with-defaults.rs
@@ -9,5 +9,5 @@ impl<A, B, C> Foo<A, B, C> {
 
 fn main() {
     Foo::<isize>::new();
-    //~^ ERROR this struct takes at least 2 generic arguments but 1 generic argument
+    //~^ ERROR struct takes at least 2 generic arguments but 1 generic argument
 }

--- a/tests/ui/generics/generic-impl-less-params-with-defaults.stderr
+++ b/tests/ui/generics/generic-impl-less-params-with-defaults.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this struct takes at least 2 generic arguments but 1 generic argument was supplied
+error[E0107]: struct takes at least 2 generic arguments but 1 generic argument was supplied
   --> $DIR/generic-impl-less-params-with-defaults.rs:11:5
    |
 LL |     Foo::<isize>::new();

--- a/tests/ui/generics/generic-impl-more-params-with-defaults.rs
+++ b/tests/ui/generics/generic-impl-more-params-with-defaults.rs
@@ -11,5 +11,5 @@ impl<T, A> Vec<T, A> {
 
 fn main() {
     Vec::<isize, Heap, bool>::new();
-    //~^ ERROR this struct takes at most 2 generic arguments but 3 generic arguments were supplied
+    //~^ ERROR struct takes at most 2 generic arguments but 3 generic arguments were supplied
 }

--- a/tests/ui/generics/generic-impl-more-params-with-defaults.stderr
+++ b/tests/ui/generics/generic-impl-more-params-with-defaults.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this struct takes at most 2 generic arguments but 3 generic arguments were supplied
+error[E0107]: struct takes at most 2 generic arguments but 3 generic arguments were supplied
   --> $DIR/generic-impl-more-params-with-defaults.rs:13:5
    |
 LL |     Vec::<isize, Heap, bool>::new();

--- a/tests/ui/generics/generic-type-more-params-with-defaults.rs
+++ b/tests/ui/generics/generic-type-more-params-with-defaults.rs
@@ -7,5 +7,5 @@ struct Vec<T, A = Heap>(
 
 fn main() {
     let _: Vec<isize, Heap, bool>;
-    //~^ ERROR this struct takes at most 2 generic arguments but 3 generic arguments
+    //~^ ERROR struct takes at most 2 generic arguments but 3 generic arguments
 }

--- a/tests/ui/generics/generic-type-more-params-with-defaults.stderr
+++ b/tests/ui/generics/generic-type-more-params-with-defaults.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this struct takes at most 2 generic arguments but 3 generic arguments were supplied
+error[E0107]: struct takes at most 2 generic arguments but 3 generic arguments were supplied
   --> $DIR/generic-type-more-params-with-defaults.rs:9:12
    |
 LL |     let _: Vec<isize, Heap, bool>;

--- a/tests/ui/generics/wrong-number-of-args.rs
+++ b/tests/ui/generics/wrong-number-of-args.rs
@@ -4,18 +4,18 @@ mod no_generics {
     type A = Ty;
 
     type B = Ty<'static>;
-    //~^ ERROR this struct takes 0 lifetime arguments but 1 lifetime argument
+    //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument
     //~| HELP remove these generics
 
     type C = Ty<'static, usize>;
-    //~^ ERROR this struct takes 0 lifetime arguments but 1 lifetime argument
-    //~| ERROR this struct takes 0 generic arguments but 1 generic argument
+    //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument
+    //~| ERROR struct takes 0 generic arguments but 1 generic argument
     //~| HELP remove this lifetime argument
     //~| HELP remove this generic argument
 
     type D = Ty<'static, usize, { 0 }>;
-    //~^ ERROR this struct takes 0 lifetime arguments but 1 lifetime argument
-    //~| ERROR this struct takes 0 generic arguments but 2 generic arguments
+    //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument
+    //~| ERROR struct takes 0 generic arguments but 2 generic arguments
     //~| HELP remove this lifetime argument
     //~| HELP remove these generic arguments
 }
@@ -28,17 +28,17 @@ mod type_and_type {
     //~| HELP add missing
 
     type B = Ty<usize>;
-    //~^ ERROR this struct takes 2 generic arguments but 1 generic argument
+    //~^ ERROR struct takes 2 generic arguments but 1 generic argument
     //~| HELP add missing
 
     type C = Ty<usize, String>;
 
     type D = Ty<usize, String, char>;
-    //~^ ERROR this struct takes 2 generic arguments but 3 generic arguments
+    //~^ ERROR struct takes 2 generic arguments but 3 generic arguments
     //~| HELP remove this
 
     type E = Ty<>;
-    //~^ ERROR this struct takes 2 generic arguments but 0 generic arguments were supplied
+    //~^ ERROR struct takes 2 generic arguments but 0 generic arguments were supplied
     //~| HELP add missing
 }
 
@@ -52,7 +52,7 @@ mod lifetime_and_type {
     //~| HELP consider introducing
 
     type B = Ty<'static>;
-    //~^ ERROR this struct takes 1 generic argument but 0 generic arguments
+    //~^ ERROR struct takes 1 generic argument but 0 generic arguments
     //~| HELP add missing
 
     type C = Ty<usize>;
@@ -62,14 +62,14 @@ mod lifetime_and_type {
     type D = Ty<'static, usize>;
 
     type E = Ty<>;
-    //~^ ERROR this struct takes 1 generic argument but 0 generic arguments
+    //~^ ERROR struct takes 1 generic argument but 0 generic arguments
     //~| ERROR missing lifetime specifier
     //~| HELP consider introducing
     //~| HELP add missing
 
     type F = Ty<'static, usize, 'static, usize>;
-    //~^ ERROR this struct takes 1 lifetime argument but 2 lifetime arguments
-    //~| ERROR this struct takes 1 generic argument but 2 generic arguments
+    //~^ ERROR struct takes 1 lifetime argument but 2 lifetime arguments
+    //~| ERROR struct takes 1 generic argument but 2 generic arguments
     //~| HELP remove this lifetime argument
     //~| HELP remove this generic argument
 }
@@ -82,7 +82,7 @@ mod type_and_type_and_type {
     //~| HELP add missing
 
     type B = Ty<usize>;
-    //~^ ERROR this struct takes at least 2
+    //~^ ERROR struct takes at least 2
     //~| HELP add missing
 
     type C = Ty<usize, String>;
@@ -90,11 +90,11 @@ mod type_and_type_and_type {
     type D = Ty<usize, String, char>;
 
     type E = Ty<usize, String, char, f64>;
-    //~^ ERROR this struct takes at most 3
+    //~^ ERROR struct takes at most 3
     //~| HELP remove
 
     type F = Ty<>;
-    //~^ ERROR this struct takes at least 2 generic arguments but 0 generic arguments
+    //~^ ERROR struct takes at least 2 generic arguments but 0 generic arguments
     //~| HELP add missing
 }
 
@@ -114,7 +114,7 @@ mod r#trait {
     }
 
     type A = Box<dyn NonGeneric<usize>>;
-    //~^ ERROR this trait takes 0 generic arguments but 1 generic argument
+    //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| HELP remove
 
     type B = Box<dyn GenericLifetime>;
@@ -123,7 +123,7 @@ mod r#trait {
     //~| HELP consider making the bound lifetime-generic
 
     type C = Box<dyn GenericLifetime<'static, 'static>>;
-    //~^ ERROR this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
+    //~^ ERROR trait takes 1 lifetime argument but 2 lifetime arguments were supplied
     //~| HELP remove
 
     type D = Box<dyn GenericType>;
@@ -131,7 +131,7 @@ mod r#trait {
     //~| HELP add missing
 
     type E = Box<dyn GenericType<String, usize>>;
-    //~^ ERROR this trait takes 1 generic argument but 2 generic arguments
+    //~^ ERROR trait takes 1 generic argument but 2 generic arguments
     //~| HELP remove
 
     type F = Box<dyn GenericLifetime<>>;
@@ -140,7 +140,7 @@ mod r#trait {
     //~| HELP consider making the bound lifetime-generic
 
     type G = Box<dyn GenericType<>>;
-    //~^ ERROR this trait takes 1 generic argument but 0 generic arguments
+    //~^ ERROR trait takes 1 generic argument but 0 generic arguments
     //~| HELP add missing
 }
 
@@ -151,7 +151,7 @@ mod associated_item {
         }
 
         type A = Box<dyn NonGenericAT<usize, AssocTy=()>>;
-        //~^ ERROR this trait takes 0 generic arguments but 1 generic argument
+        //~^ ERROR trait takes 0 generic arguments but 1 generic argument
         //~| HELP remove
     }
 
@@ -166,14 +166,14 @@ mod associated_item {
         //~| HELP consider making the bound lifetime-generic
 
         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
-        //~^ ERROR this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
+        //~^ ERROR trait takes 1 lifetime argument but 2 lifetime arguments were supplied
         //~| HELP remove
 
         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
         //~^ ERROR missing lifetime specifier
         //~| HELP consider introducing
         //~| HELP consider making the bound lifetime-generic
-        //~| ERROR this trait takes 0 generic arguments but 1 generic argument
+        //~| ERROR trait takes 0 generic arguments but 1 generic argument
         //~| HELP remove
     }
 
@@ -183,17 +183,17 @@ mod associated_item {
         }
 
         type A = Box<dyn GenericTypeAT<AssocTy=()>>;
-        //~^ ERROR this trait takes 1 generic argument but 0 generic arguments
+        //~^ ERROR trait takes 1 generic argument but 0 generic arguments
         //~| HELP add missing
 
         type B = Box<dyn GenericTypeAT<(), (), AssocTy=()>>;
-        //~^ ERROR this trait takes 1 generic argument but 2 generic arguments
+        //~^ ERROR trait takes 1 generic argument but 2 generic arguments
         //~| HELP remove
 
         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
-        //~^ ERROR this trait takes 1 generic argument but 0 generic arguments
+        //~^ ERROR trait takes 1 generic argument but 0 generic arguments
         //~| HELP add missing
-        //~| ERROR this trait takes 0 lifetime arguments but 1 lifetime argument was supplied
+        //~| ERROR trait takes 0 lifetime arguments but 1 lifetime argument was supplied
         //~| HELP remove
     }
 
@@ -203,20 +203,20 @@ mod associated_item {
         }
 
         type A = Box<dyn GenericLifetimeTypeAT<AssocTy=()>>;
-        //~^ ERROR this trait takes 1 generic argument but 0 generic arguments
+        //~^ ERROR trait takes 1 generic argument but 0 generic arguments
         //~| HELP add missing
         //~| ERROR missing lifetime specifier
         //~| HELP consider introducing
         //~| HELP consider making the bound lifetime-generic
 
         type B = Box<dyn GenericLifetimeTypeAT<'static, AssocTy=()>>;
-        //~^ ERROR this trait takes 1 generic argument but 0 generic arguments were supplied
+        //~^ ERROR trait takes 1 generic argument but 0 generic arguments were supplied
         //~| HELP add missing
 
         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
-        //~^ ERROR this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
+        //~^ ERROR trait takes 1 lifetime argument but 2 lifetime arguments were supplied
         //~| HELP remove
-        //~| ERROR this trait takes 1 generic argument but 0 generic arguments
+        //~| ERROR trait takes 1 generic argument but 0 generic arguments
         //~| HELP add missing
 
         type D = Box<dyn GenericLifetimeTypeAT<(), AssocTy=()>>;
@@ -228,21 +228,21 @@ mod associated_item {
         //~^ ERROR missing lifetime specifier
         //~| HELP consider introducing
         //~| HELP consider making the bound lifetime-generic
-        //~| ERROR this trait takes 1 generic argument but 2 generic arguments
+        //~| ERROR trait takes 1 generic argument but 2 generic arguments
         //~| HELP remove
 
         type F = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocTy=()>>;
-        //~^ ERROR this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
+        //~^ ERROR trait takes 1 lifetime argument but 2 lifetime arguments were supplied
         //~| HELP remove
 
         type G = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>>;
-        //~^ ERROR this trait takes 1 generic argument but 2 generic arguments
+        //~^ ERROR trait takes 1 generic argument but 2 generic arguments
         //~| HELP remove
 
         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
-        //~^ ERROR this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
+        //~^ ERROR trait takes 1 lifetime argument but 2 lifetime arguments were supplied
         //~| HELP remove
-        //~| ERROR this trait takes 1 generic argument but 2 generic arguments
+        //~| ERROR trait takes 1 generic argument but 2 generic arguments
         //~| HELP remove
     }
 
@@ -252,15 +252,15 @@ mod associated_item {
         }
 
         type A = Box<dyn GenericTypeTypeAT<AssocTy=()>>;
-        //~^ ERROR this trait takes 2 generic arguments but 0 generic arguments
+        //~^ ERROR trait takes 2 generic arguments but 0 generic arguments
         //~| HELP add missing
 
         type B = Box<dyn GenericTypeTypeAT<(), AssocTy=()>>;
-        //~^ ERROR this trait takes 2 generic arguments but 1 generic argument
+        //~^ ERROR trait takes 2 generic arguments but 1 generic argument
         //~| HELP add missing
 
         type C = Box<dyn GenericTypeTypeAT<(), (), (), AssocTy=()>>;
-        //~^ ERROR this trait takes 2 generic arguments but 3 generic arguments
+        //~^ ERROR trait takes 2 generic arguments but 3 generic arguments
         //~| HELP remove
     }
 
@@ -275,7 +275,7 @@ mod associated_item {
         //~| HELP consider making the bound lifetime-generic
 
         type B = Box<dyn GenericLifetimeLifetimeAT<'static, AssocTy=()>>;
-        //~^ ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+        //~^ ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
         //~| HELP add missing lifetime argument
     }
 
@@ -288,17 +288,17 @@ mod associated_item {
         //~^ ERROR missing lifetime specifier
         //~| HELP consider introducing
         //~| HELP consider making the bound lifetime-generic
-        //~| ERROR this trait takes 1 generic argument but 0 generic arguments
+        //~| ERROR trait takes 1 generic argument but 0 generic arguments
         //~| HELP add missing
 
         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, AssocTy=()>>;
-        //~^ ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+        //~^ ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
         //~| HELP add missing lifetime argument
-        //~| ERROR this trait takes 1 generic argument but 0 generic arguments
+        //~| ERROR trait takes 1 generic argument but 0 generic arguments
         //~| HELP add missing
 
         type C = Box<dyn GenericLifetimeLifetimeTypeAT<'static, (), AssocTy=()>>;
-        //~^ ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+        //~^ ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
         //~| HELP add missing lifetime argument
     }
 }
@@ -312,21 +312,21 @@ mod stdlib {
         //~| HELP add missing
 
         type B = HashMap<String>;
-        //~^ ERROR this struct takes at least
+        //~^ ERROR struct takes at least
         //~| HELP add missing
 
         type C = HashMap<'static>;
-        //~^ ERROR this struct takes 0 lifetime arguments but 1 lifetime argument
+        //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument
         //~| HELP remove these generics
-        //~| ERROR this struct takes at least 2
+        //~| ERROR struct takes at least 2
         //~| HELP add missing
 
         type D = HashMap<usize, String, char, f64>;
-        //~^ ERROR this struct takes at most 3
+        //~^ ERROR struct takes at most 3
         //~| HELP remove this
 
         type E = HashMap<>;
-        //~^ ERROR this struct takes at least 2 generic arguments but 0 generic arguments
+        //~^ ERROR struct takes at least 2 generic arguments but 0 generic arguments
         //~| HELP add missing
     }
 
@@ -336,21 +336,21 @@ mod stdlib {
         //~| HELP add missing
 
         type B = Result<String>;
-        //~^ ERROR this enum takes 2 generic arguments but 1 generic argument
+        //~^ ERROR enum takes 2 generic arguments but 1 generic argument
         //~| HELP add missing
 
         type C = Result<'static>;
-        //~^ ERROR this enum takes 0 lifetime arguments but 1 lifetime argument
+        //~^ ERROR enum takes 0 lifetime arguments but 1 lifetime argument
         //~| HELP remove these generics
-        //~| ERROR this enum takes 2 generic arguments but 0 generic arguments
+        //~| ERROR enum takes 2 generic arguments but 0 generic arguments
         //~| HELP add missing
 
         type D = Result<usize, String, char>;
-        //~^ ERROR this enum takes 2 generic arguments but 3 generic arguments
+        //~^ ERROR enum takes 2 generic arguments but 3 generic arguments
         //~| HELP remove
 
         type E = Result<>;
-        //~^ ERROR this enum takes 2 generic arguments but 0 generic arguments
+        //~^ ERROR enum takes 2 generic arguments but 0 generic arguments
         //~| HELP add missing
     }
 }

--- a/tests/ui/generics/wrong-number-of-args.stderr
+++ b/tests/ui/generics/wrong-number-of-args.stderr
@@ -167,7 +167,7 @@ help: consider introducing a named lifetime parameter
 LL |         type A<'a> = Box<dyn GenericLifetimeLifetimeTypeAT<'a, 'a, AssocTy=()>>;
    |               ++++                                         +++++++
 
-error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:6:14
    |
 LL |     type B = Ty<'static>;
@@ -181,7 +181,7 @@ note: struct defined here, with 0 lifetime parameters
 LL |     struct Ty;
    |            ^^
 
-error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:10:14
    |
 LL |     type C = Ty<'static, usize>;
@@ -195,7 +195,7 @@ note: struct defined here, with 0 lifetime parameters
 LL |     struct Ty;
    |            ^^
 
-error[E0107]: this struct takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:10:14
    |
 LL |     type C = Ty<'static, usize>;
@@ -209,7 +209,7 @@ note: struct defined here, with 0 generic parameters
 LL |     struct Ty;
    |            ^^
 
-error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:16:14
    |
 LL |     type D = Ty<'static, usize, { 0 }>;
@@ -223,7 +223,7 @@ note: struct defined here, with 0 lifetime parameters
 LL |     struct Ty;
    |            ^^
 
-error[E0107]: this struct takes 0 generic arguments but 2 generic arguments were supplied
+error[E0107]: struct takes 0 generic arguments but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:16:14
    |
 LL |     type D = Ty<'static, usize, { 0 }>;
@@ -253,7 +253,7 @@ help: add missing generic arguments
 LL |     type A = Ty<A, B>;
    |                ++++++
 
-error[E0107]: this struct takes 2 generic arguments but 1 generic argument was supplied
+error[E0107]: struct takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:30:14
    |
 LL |     type B = Ty<usize>;
@@ -271,7 +271,7 @@ help: add missing generic argument
 LL |     type B = Ty<usize, B>;
    |                      +++
 
-error[E0107]: this struct takes 2 generic arguments but 3 generic arguments were supplied
+error[E0107]: struct takes 2 generic arguments but 3 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:36:14
    |
 LL |     type D = Ty<usize, String, char>;
@@ -285,7 +285,7 @@ note: struct defined here, with 2 generic parameters: `A`, `B`
 LL |     struct Ty<A, B>;
    |            ^^ -  -
 
-error[E0107]: this struct takes 2 generic arguments but 0 generic arguments were supplied
+error[E0107]: struct takes 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:40:14
    |
 LL |     type E = Ty<>;
@@ -317,7 +317,7 @@ help: add missing generic argument
 LL |     type A = Ty<T>;
    |                +++
 
-error[E0107]: this struct takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:54:14
    |
 LL |     type B = Ty<'static>;
@@ -333,7 +333,7 @@ help: add missing generic argument
 LL |     type B = Ty<'static, T>;
    |                        +++
 
-error[E0107]: this struct takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:64:14
    |
 LL |     type E = Ty<>;
@@ -349,7 +349,7 @@ help: add missing generic argument
 LL |     type E = Ty<T>;
    |                 +
 
-error[E0107]: this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:70:14
    |
 LL |     type F = Ty<'static, usize, 'static, usize>;
@@ -363,7 +363,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
 LL |     struct Ty<'a, T>;
    |            ^^ --
 
-error[E0107]: this struct takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:70:14
    |
 LL |     type F = Ty<'static, usize, 'static, usize>;
@@ -393,7 +393,7 @@ help: add missing generic arguments
 LL |     type A = Ty<A, B>;
    |                ++++++
 
-error[E0107]: this struct takes at least 2 generic arguments but 1 generic argument was supplied
+error[E0107]: struct takes at least 2 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:84:14
    |
 LL |     type B = Ty<usize>;
@@ -411,7 +411,7 @@ help: add missing generic argument
 LL |     type B = Ty<usize, B>;
    |                      +++
 
-error[E0107]: this struct takes at most 3 generic arguments but 4 generic arguments were supplied
+error[E0107]: struct takes at most 3 generic arguments but 4 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:92:14
    |
 LL |     type E = Ty<usize, String, char, f64>;
@@ -425,7 +425,7 @@ note: struct defined here, with at most 3 generic parameters: `A`, `B`, `C`
 LL |     struct Ty<A, B, C = &'static str>;
    |            ^^ -  -  ----------------
 
-error[E0107]: this struct takes at least 2 generic arguments but 0 generic arguments were supplied
+error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:96:14
    |
 LL |     type F = Ty<>;
@@ -441,7 +441,7 @@ help: add missing generic arguments
 LL |     type F = Ty<A, B>;
    |                 ++++
 
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:116:22
    |
 LL |     type A = Box<dyn NonGeneric<usize>>;
@@ -455,7 +455,7 @@ note: trait defined here, with 0 generic parameters
 LL |     trait NonGeneric {
    |           ^^^^^^^^^^
 
-error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:125:22
    |
 LL |     type C = Box<dyn GenericLifetime<'static, 'static>>;
@@ -485,7 +485,7 @@ help: add missing generic argument
 LL |     type D = Box<dyn GenericType<A>>;
    |                                 +++
 
-error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:133:22
    |
 LL |     type E = Box<dyn GenericType<String, usize>>;
@@ -499,7 +499,7 @@ note: trait defined here, with 1 generic parameter: `A`
 LL |     trait GenericType<A> {
    |           ^^^^^^^^^^^ -
 
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:142:22
    |
 LL |     type G = Box<dyn GenericType<>>;
@@ -515,7 +515,7 @@ help: add missing generic argument
 LL |     type G = Box<dyn GenericType<A>>;
    |                                  +
 
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:153:26
    |
 LL |         type A = Box<dyn NonGenericAT<usize, AssocTy=()>>;
@@ -529,7 +529,7 @@ note: trait defined here, with 0 generic parameters
 LL |         trait NonGenericAT {
    |               ^^^^^^^^^^^^
 
-error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:168:26
    |
 LL |         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
@@ -543,7 +543,7 @@ note: trait defined here, with 1 lifetime parameter: `'a`
 LL |         trait GenericLifetimeAT<'a> {
    |               ^^^^^^^^^^^^^^^^^ --
 
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:172:26
    |
 LL |         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
@@ -557,7 +557,7 @@ note: trait defined here, with 0 generic parameters
 LL |         trait GenericLifetimeAT<'a> {
    |               ^^^^^^^^^^^^^^^^^
 
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:185:26
    |
 LL |         type A = Box<dyn GenericTypeAT<AssocTy=()>>;
@@ -573,7 +573,7 @@ help: add missing generic argument
 LL |         type A = Box<dyn GenericTypeAT<A, AssocTy=()>>;
    |                                        ++
 
-error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:189:26
    |
 LL |         type B = Box<dyn GenericTypeAT<(), (), AssocTy=()>>;
@@ -587,7 +587,7 @@ note: trait defined here, with 1 generic parameter: `A`
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^ -
 
-error[E0107]: this trait takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:193:26
    |
 LL |         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
@@ -601,7 +601,7 @@ note: trait defined here, with 0 lifetime parameters
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^
 
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:193:26
    |
 LL |         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
@@ -617,7 +617,7 @@ help: add missing generic argument
 LL |         type C = Box<dyn GenericTypeAT<'static, A, AssocTy=()>>;
    |                                               +++
 
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:205:26
    |
 LL |         type A = Box<dyn GenericLifetimeTypeAT<AssocTy=()>>;
@@ -633,7 +633,7 @@ help: add missing generic argument
 LL |         type A = Box<dyn GenericLifetimeTypeAT<A, AssocTy=()>>;
    |                                                ++
 
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:212:26
    |
 LL |         type B = Box<dyn GenericLifetimeTypeAT<'static, AssocTy=()>>;
@@ -649,7 +649,7 @@ help: add missing generic argument
 LL |         type B = Box<dyn GenericLifetimeTypeAT<'static, A, AssocTy=()>>;
    |                                                       +++
 
-error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:216:26
    |
 LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
@@ -663,7 +663,7 @@ note: trait defined here, with 1 lifetime parameter: `'a`
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
 
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:216:26
    |
 LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
@@ -679,7 +679,7 @@ help: add missing generic argument
 LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, A, AssocTy=()>>;
    |                                                                +++
 
-error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:227:26
    |
 LL |         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
@@ -693,7 +693,7 @@ note: trait defined here, with 1 generic parameter: `A`
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
 
-error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:234:26
    |
 LL |         type F = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocTy=()>>;
@@ -707,7 +707,7 @@ note: trait defined here, with 1 lifetime parameter: `'a`
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
 
-error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:238:26
    |
 LL |         type G = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>>;
@@ -721,7 +721,7 @@ note: trait defined here, with 1 generic parameter: `A`
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
 
-error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:242:26
    |
 LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
@@ -735,7 +735,7 @@ note: trait defined here, with 1 lifetime parameter: `'a`
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
 
-error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:242:26
    |
 LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
@@ -749,7 +749,7 @@ note: trait defined here, with 1 generic parameter: `A`
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
 
-error[E0107]: this trait takes 2 generic arguments but 0 generic arguments were supplied
+error[E0107]: trait takes 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:254:26
    |
 LL |         type A = Box<dyn GenericTypeTypeAT<AssocTy=()>>;
@@ -765,7 +765,7 @@ help: add missing generic arguments
 LL |         type A = Box<dyn GenericTypeTypeAT<A, B, AssocTy=()>>;
    |                                            +++++
 
-error[E0107]: this trait takes 2 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:258:26
    |
 LL |         type B = Box<dyn GenericTypeTypeAT<(), AssocTy=()>>;
@@ -783,7 +783,7 @@ help: add missing generic argument
 LL |         type B = Box<dyn GenericTypeTypeAT<(), B, AssocTy=()>>;
    |                                              +++
 
-error[E0107]: this trait takes 2 generic arguments but 3 generic arguments were supplied
+error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:262:26
    |
 LL |         type C = Box<dyn GenericTypeTypeAT<(), (), (), AssocTy=()>>;
@@ -797,7 +797,7 @@ note: trait defined here, with 2 generic parameters: `A`, `B`
 LL |         trait GenericTypeTypeAT<A, B> {
    |               ^^^^^^^^^^^^^^^^^ -  -
 
-error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:277:26
    |
 LL |         type B = Box<dyn GenericLifetimeLifetimeAT<'static, AssocTy=()>>;
@@ -815,7 +815,7 @@ help: add missing lifetime argument
 LL |         type B = Box<dyn GenericLifetimeLifetimeAT<'static, 'static, AssocTy=()>>;
    |                                                           +++++++++
 
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:287:26
    |
 LL |         type A = Box<dyn GenericLifetimeLifetimeTypeAT<AssocTy=()>>;
@@ -831,7 +831,7 @@ help: add missing generic argument
 LL |         type A = Box<dyn GenericLifetimeLifetimeTypeAT<A, AssocTy=()>>;
    |                                                        ++
 
-error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:294:26
    |
 LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, AssocTy=()>>;
@@ -849,7 +849,7 @@ help: add missing lifetime argument
 LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, 'static, AssocTy=()>>;
    |                                                               +++++++++
 
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:294:26
    |
 LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, AssocTy=()>>;
@@ -865,7 +865,7 @@ help: add missing generic argument
 LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, A, AssocTy=()>>;
    |                                                               +++
 
-error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:300:26
    |
 LL |         type C = Box<dyn GenericLifetimeLifetimeTypeAT<'static, (), AssocTy=()>>;
@@ -894,7 +894,7 @@ help: add missing generic arguments
 LL |         type A = HashMap<K, V>;
    |                         ++++++
 
-error[E0107]: this struct takes at least 2 generic arguments but 1 generic argument was supplied
+error[E0107]: struct takes at least 2 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:314:18
    |
 LL |         type B = HashMap<String>;
@@ -907,7 +907,7 @@ help: add missing generic argument
 LL |         type B = HashMap<String, V>;
    |                                +++
 
-error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:318:18
    |
 LL |         type C = HashMap<'static>;
@@ -915,7 +915,7 @@ LL |         type C = HashMap<'static>;
    |                  |
    |                  expected 0 lifetime arguments
 
-error[E0107]: this struct takes at least 2 generic arguments but 0 generic arguments were supplied
+error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:318:18
    |
 LL |         type C = HashMap<'static>;
@@ -926,7 +926,7 @@ help: add missing generic arguments
 LL |         type C = HashMap<'static, K, V>;
    |                                 ++++++
 
-error[E0107]: this struct takes at most 3 generic arguments but 4 generic arguments were supplied
+error[E0107]: struct takes at most 3 generic arguments but 4 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:324:18
    |
 LL |         type D = HashMap<usize, String, char, f64>;
@@ -934,7 +934,7 @@ LL |         type D = HashMap<usize, String, char, f64>;
    |                  |
    |                  expected at most 3 generic arguments
 
-error[E0107]: this struct takes at least 2 generic arguments but 0 generic arguments were supplied
+error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:328:18
    |
 LL |         type E = HashMap<>;
@@ -956,7 +956,7 @@ help: add missing generic arguments
 LL |         type A = Result<T, E>;
    |                        ++++++
 
-error[E0107]: this enum takes 2 generic arguments but 1 generic argument was supplied
+error[E0107]: enum takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:338:18
    |
 LL |         type B = Result<String>;
@@ -969,7 +969,7 @@ help: add missing generic argument
 LL |         type B = Result<String, E>;
    |                               +++
 
-error[E0107]: this enum takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: enum takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:342:18
    |
 LL |         type C = Result<'static>;
@@ -977,7 +977,7 @@ LL |         type C = Result<'static>;
    |                  |
    |                  expected 0 lifetime arguments
 
-error[E0107]: this enum takes 2 generic arguments but 0 generic arguments were supplied
+error[E0107]: enum takes 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:342:18
    |
 LL |         type C = Result<'static>;
@@ -988,7 +988,7 @@ help: add missing generic arguments
 LL |         type C = Result<'static, T, E>;
    |                                ++++++
 
-error[E0107]: this enum takes 2 generic arguments but 3 generic arguments were supplied
+error[E0107]: enum takes 2 generic arguments but 3 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:348:18
    |
 LL |         type D = Result<usize, String, char>;
@@ -996,7 +996,7 @@ LL |         type D = Result<usize, String, char>;
    |                  |
    |                  expected 2 generic arguments
 
-error[E0107]: this enum takes 2 generic arguments but 0 generic arguments were supplied
+error[E0107]: enum takes 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:352:18
    |
 LL |         type E = Result<>;

--- a/tests/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
+++ b/tests/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this function takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: function takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/explicit-generic-args-for-impl.rs:4:5
    |
 LL |     foo::<str, String>("".to_string());

--- a/tests/ui/impl-trait/explicit-generic-args-with-impl-trait/not-enough-args.stderr
+++ b/tests/ui/impl-trait/explicit-generic-args-with-impl-trait/not-enough-args.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this function takes 2 generic arguments but 1 generic argument was supplied
+error[E0107]: function takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/not-enough-args.rs:4:5
    |
 LL |     f::<[u8]>("a", b"a");

--- a/tests/ui/issues/issue-18423.rs
+++ b/tests/ui/issues/issue-18423.rs
@@ -2,7 +2,7 @@
 
 struct Foo<'a> {
     x: Box<'a, isize>
-    //~^ ERROR this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
+    //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument was supplied
 }
 
 fn main() { }

--- a/tests/ui/issues/issue-18423.stderr
+++ b/tests/ui/issues/issue-18423.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/issue-18423.rs:4:8
    |
 LL |     x: Box<'a, isize>

--- a/tests/ui/issues/issue-3214.rs
+++ b/tests/ui/issues/issue-3214.rs
@@ -4,7 +4,7 @@ fn foo<T>() {
     }
 
     impl<T> Drop for Foo<T> {
-        //~^ ERROR this struct takes 0 generic arguments but 1 generic argument
+        //~^ ERROR struct takes 0 generic arguments but 1 generic argument
         fn drop(&mut self) {}
     }
 }

--- a/tests/ui/issues/issue-3214.stderr
+++ b/tests/ui/issues/issue-3214.stderr
@@ -8,7 +8,7 @@ LL |     struct Foo {
 LL |         x: T,
    |            ^ use of generic parameter from outer function
 
-error[E0107]: this struct takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-3214.rs:6:22
    |
 LL |     impl<T> Drop for Foo<T> {

--- a/tests/ui/issues/issue-53251.rs
+++ b/tests/ui/issues/issue-53251.rs
@@ -9,8 +9,8 @@ macro_rules! impl_add {
         $(
             fn $n() {
                 S::f::<i64>();
-                //~^ ERROR this associated function takes 0 generic
-                //~| ERROR this associated function takes 0 generic
+                //~^ ERROR associated function takes 0 generic
+                //~| ERROR associated function takes 0 generic
             }
         )*
     }

--- a/tests/ui/issues/issue-53251.stderr
+++ b/tests/ui/issues/issue-53251.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: associated function takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-53251.rs:11:20
    |
 LL |                 S::f::<i64>();
@@ -16,7 +16,7 @@ LL |     fn f() {}
    |        ^
    = note: this error originates in the macro `impl_add` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: associated function takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-53251.rs:11:20
    |
 LL |                 S::f::<i64>();

--- a/tests/ui/issues/issue-60622.rs
+++ b/tests/ui/issues/issue-60622.rs
@@ -9,7 +9,7 @@ impl Borked {
 fn run_wild<T>(b: &Borked) {
     b.a::<'_, T>();
     //~^ ERROR cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-    //~| ERROR this method takes 0 generic arguments but 1 generic argument
+    //~| ERROR method takes 0 generic arguments but 1 generic argument
     //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/issues/issue-60622.stderr
+++ b/tests/ui/issues/issue-60622.stderr
@@ -16,7 +16,7 @@ LL | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(late_bound_lifetime_arguments)]` implied by `#[deny(warnings)]`
 
-error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-60622.rs:10:7
    |
 LL |     b.a::<'_, T>();

--- a/tests/ui/late-bound-lifetimes/mismatched_arg_count.rs
+++ b/tests/ui/late-bound-lifetimes/mismatched_arg_count.rs
@@ -7,6 +7,6 @@ trait Trait<'a> {
 type Alias<'a, T> = <T as Trait<'a>>::Assoc;
 
 fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
-//~^ error: this type alias takes 1 lifetime argument but 2 lifetime arguments were supplied
+//~^ error: type alias takes 1 lifetime argument but 2 lifetime arguments were supplied
 
 fn main() {}

--- a/tests/ui/late-bound-lifetimes/mismatched_arg_count.stderr
+++ b/tests/ui/late-bound-lifetimes/mismatched_arg_count.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this type alias takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: type alias takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/mismatched_arg_count.rs:9:29
    |
 LL | fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}

--- a/tests/ui/methods/method-call-lifetime-args-fail.rs
+++ b/tests/ui/methods/method-call-lifetime-args-fail.rs
@@ -14,9 +14,9 @@ impl S {
 fn method_call() {
     S.early(); // OK
     S.early::<'static>();
-    //~^ ERROR this method takes 2 lifetime arguments but 1 lifetime argument
+    //~^ ERROR method takes 2 lifetime arguments but 1 lifetime argument
     S.early::<'static, 'static, 'static>();
-    //~^ ERROR this method takes 2 lifetime arguments but 3 lifetime arguments were supplied
+    //~^ ERROR method takes 2 lifetime arguments but 3 lifetime arguments were supplied
     let _: &u8 = S.life_and_type::<'static>();
     S.life_and_type::<u8>();
     S.life_and_type::<'static, u8>();
@@ -61,9 +61,9 @@ fn ufcs() {
 
     S::early(S); // OK
     S::early::<'static>(S);
-    //~^ ERROR this method takes 2 lifetime arguments but 1 lifetime argument
+    //~^ ERROR method takes 2 lifetime arguments but 1 lifetime argument
     S::early::<'static, 'static, 'static>(S);
-    //~^ ERROR this method takes 2 lifetime arguments but 3 lifetime arguments were supplied
+    //~^ ERROR method takes 2 lifetime arguments but 3 lifetime arguments were supplied
     let _: &u8 = S::life_and_type::<'static>(S);
     S::life_and_type::<u8>(S);
     S::life_and_type::<'static, u8>(S);

--- a/tests/ui/methods/method-call-lifetime-args-fail.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-fail.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this method takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: method takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/method-call-lifetime-args-fail.rs:16:7
    |
 LL |     S.early::<'static>();
@@ -16,7 +16,7 @@ help: add missing lifetime argument
 LL |     S.early::<'static, 'static>();
    |                      +++++++++
 
-error[E0107]: this method takes 2 lifetime arguments but 3 lifetime arguments were supplied
+error[E0107]: method takes 2 lifetime arguments but 3 lifetime arguments were supplied
   --> $DIR/method-call-lifetime-args-fail.rs:18:7
    |
 LL |     S.early::<'static, 'static, 'static>();
@@ -198,7 +198,7 @@ note: the late bound lifetime parameter is introduced here
 LL |     fn late_unused_early<'a, 'b>(self) -> &'b u8 { loop {} }
    |                          ^^
 
-error[E0107]: this method takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: method takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/method-call-lifetime-args-fail.rs:63:8
    |
 LL |     S::early::<'static>(S);
@@ -216,7 +216,7 @@ help: add missing lifetime argument
 LL |     S::early::<'static, 'static>(S);
    |                       +++++++++
 
-error[E0107]: this method takes 2 lifetime arguments but 3 lifetime arguments were supplied
+error[E0107]: method takes 2 lifetime arguments but 3 lifetime arguments were supplied
   --> $DIR/method-call-lifetime-args-fail.rs:65:8
    |
 LL |     S::early::<'static, 'static, 'static>(S);

--- a/tests/ui/seq-args.rs
+++ b/tests/ui/seq-args.rs
@@ -2,12 +2,12 @@ fn main() {
     trait Seq { }
 
     impl<T> Seq<T> for Vec<T> {
-        //~^ ERROR this trait takes 0 generic arguments but 1 generic argument
+        //~^ ERROR trait takes 0 generic arguments but 1 generic argument
         /* ... */
     }
 
     impl Seq<bool> for u32 {
-        //~^ ERROR this trait takes 0 generic arguments but 1 generic argument
+        //~^ ERROR trait takes 0 generic arguments but 1 generic argument
         /* Treat the integer as a sequence of bits */
     }
 }

--- a/tests/ui/seq-args.stderr
+++ b/tests/ui/seq-args.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/seq-args.rs:4:13
    |
 LL |     impl<T> Seq<T> for Vec<T> {
@@ -12,7 +12,7 @@ note: trait defined here, with 0 generic parameters
 LL |     trait Seq { }
    |           ^^^
 
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/seq-args.rs:9:10
    |
 LL |     impl Seq<bool> for u32 {

--- a/tests/ui/structs/struct-path-associated-type.rs
+++ b/tests/ui/structs/struct-path-associated-type.rs
@@ -13,7 +13,7 @@ fn f<T: Tr>() {
     //~^ ERROR expected struct, variant or union type, found associated type
     let z = T::A::<u8> {};
     //~^ ERROR expected struct, variant or union type, found associated type
-    //~| ERROR this associated type takes 0 generic arguments but 1 generic argument was supplied
+    //~| ERROR associated type takes 0 generic arguments but 1 generic argument was supplied
     match S {
         T::A {} => {}
         //~^ ERROR expected struct, variant or union type, found associated type
@@ -22,7 +22,7 @@ fn f<T: Tr>() {
 
 fn g<T: Tr<A = S>>() {
     let s = T::A {}; // OK
-    let z = T::A::<u8> {}; //~ ERROR this associated type takes 0 generic arguments but 1 generic argument was supplied
+    let z = T::A::<u8> {}; //~ ERROR associated type takes 0 generic arguments but 1 generic argument was supplied
     match S {
         T::A {} => {} // OK
     }

--- a/tests/ui/structs/struct-path-associated-type.stderr
+++ b/tests/ui/structs/struct-path-associated-type.stderr
@@ -4,7 +4,7 @@ error[E0071]: expected struct, variant or union type, found associated type
 LL |     let s = T::A {};
    |             ^^^^ not a struct
 
-error[E0107]: this associated type takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/struct-path-associated-type.rs:14:16
    |
 LL |     let z = T::A::<u8> {};
@@ -30,7 +30,7 @@ error[E0071]: expected struct, variant or union type, found associated type
 LL |         T::A {} => {}
    |         ^^^^ not a struct
 
-error[E0107]: this associated type takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/struct-path-associated-type.rs:25:16
    |
 LL |     let z = T::A::<u8> {};

--- a/tests/ui/structs/structure-constructor-type-mismatch.rs
+++ b/tests/ui/structs/structure-constructor-type-mismatch.rs
@@ -45,13 +45,13 @@ fn main() {
         y: 8,
     };
 
-    let pt3 = PointF::<i32> { //~ ERROR this type alias takes 0 generic arguments but 1 generic argument
+    let pt3 = PointF::<i32> { //~ ERROR type alias takes 0 generic arguments but 1 generic argument
         x: 9,  //~ ERROR mismatched types
         y: 10, //~ ERROR mismatched types
     };
 
     match (Point { x: 1, y: 2 }) {
-        PointF::<u32> { .. } => {} //~ ERROR this type alias takes 0 generic arguments but 1 generic argument
+        PointF::<u32> { .. } => {} //~ ERROR type alias takes 0 generic arguments but 1 generic argument
         //~^ ERROR mismatched types
     }
 

--- a/tests/ui/structs/structure-constructor-type-mismatch.stderr
+++ b/tests/ui/structs/structure-constructor-type-mismatch.stderr
@@ -52,7 +52,7 @@ LL |         x: 7,
    |            expected `f32`, found integer
    |            help: use a float literal: `7.0`
 
-error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/structure-constructor-type-mismatch.rs:48:15
    |
 LL |     let pt3 = PointF::<i32> {
@@ -84,7 +84,7 @@ LL |         y: 10,
    |            expected `f32`, found integer
    |            help: use a float literal: `10.0`
 
-error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/structure-constructor-type-mismatch.rs:54:9
    |
 LL |         PointF::<u32> { .. } => {}

--- a/tests/ui/suggestions/issue-101421.rs
+++ b/tests/ui/suggestions/issue-101421.rs
@@ -8,5 +8,5 @@ impl Ice for () {
 
 fn main() {
     ().f::<()>(());
-    //~^ ERROR this method takes 0 generic arguments but 1 generic argument was supplied
+    //~^ ERROR method takes 0 generic arguments but 1 generic argument was supplied
 }

--- a/tests/ui/suggestions/issue-101421.stderr
+++ b/tests/ui/suggestions/issue-101421.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-101421.rs:10:8
    |
 LL |     ().f::<()>(());

--- a/tests/ui/suggestions/issue-104287.rs
+++ b/tests/ui/suggestions/issue-104287.rs
@@ -8,6 +8,6 @@ impl S {
 fn main() {
     let x = S;
     foo::<()>(x);
-    //~^ ERROR this method takes 0 generic arguments but 1 generic argument was supplied
+    //~^ ERROR method takes 0 generic arguments but 1 generic argument was supplied
     //~| ERROR cannot find function `foo` in this scope
 }

--- a/tests/ui/suggestions/issue-104287.stderr
+++ b/tests/ui/suggestions/issue-104287.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-104287.rs:10:5
    |
 LL |     foo::<()>(x);

--- a/tests/ui/suggestions/issue-85347.rs
+++ b/tests/ui/suggestions/issue-85347.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 trait Foo {
     type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;
-    //~^ ERROR this associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+    //~^ ERROR associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
     //~| ERROR associated type bindings are not allowed here
     //~| HELP add missing
 }

--- a/tests/ui/suggestions/issue-85347.stderr
+++ b/tests/ui/suggestions/issue-85347.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/issue-85347.rs:3:42
    |
 LL |     type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;

--- a/tests/ui/suggestions/issue-89064.stderr
+++ b/tests/ui/suggestions/issue-89064.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: associated function takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-89064.rs:17:16
    |
 LL |     let _ = A::foo::<S>();
@@ -20,7 +20,7 @@ LL -     let _ = A::foo::<S>();
 LL +     let _ = A::foo();
    |
 
-error[E0107]: this associated function takes 0 generic arguments but 2 generic arguments were supplied
+error[E0107]: associated function takes 0 generic arguments but 2 generic arguments were supplied
   --> $DIR/issue-89064.rs:22:16
    |
 LL |     let _ = B::bar::<S, S>();
@@ -42,7 +42,7 @@ LL -     let _ = B::bar::<S, S>();
 LL +     let _ = B::bar();
    |
 
-error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: associated function takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-89064.rs:27:21
    |
 LL |     let _ = A::<S>::foo::<S>();
@@ -56,7 +56,7 @@ note: associated function defined here, with 0 generic parameters
 LL |     fn foo() {}
    |        ^^^
 
-error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-89064.rs:31:16
    |
 LL |     let _ = 42.into::<Option<_>>();

--- a/tests/ui/suggestions/missing-lifetime-specifier.rs
+++ b/tests/ui/suggestions/missing-lifetime-specifier.rs
@@ -37,19 +37,19 @@ thread_local! {
 
 thread_local! {
     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
-    //~^ ERROR this union takes 2 lifetime arguments but 1 lifetime argument
-    //~| ERROR this union takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR this union takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR this union takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~^ ERROR union takes 2 lifetime arguments but 1 lifetime argument
+    //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
 }
 thread_local! {
     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-    //~^ ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~^ ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR missing lifetime
     //~| ERROR missing lifetime
 }

--- a/tests/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/tests/ui/suggestions/missing-lifetime-specifier.stderr
@@ -133,7 +133,7 @@ LL | | }
    |
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
-error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/missing-lifetime-specifier.rs:39:44
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -151,7 +151,7 @@ help: add missing lifetime argument
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                       +++++++++
 
-error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/missing-lifetime-specifier.rs:39:44
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -169,7 +169,7 @@ help: add missing lifetime argument
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                       +++++++++
 
-error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/missing-lifetime-specifier.rs:39:44
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -187,7 +187,7 @@ help: add missing lifetime argument
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                       +++++++++
 
-error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/missing-lifetime-specifier.rs:39:44
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -205,7 +205,7 @@ help: add missing lifetime argument
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                       +++++++++
 
-error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/missing-lifetime-specifier.rs:39:44
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -223,7 +223,7 @@ help: add missing lifetime argument
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                       +++++++++
 
-error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/missing-lifetime-specifier.rs:47:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -241,7 +241,7 @@ help: add missing lifetime argument
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                        +++++++++
 
-error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/missing-lifetime-specifier.rs:47:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -259,7 +259,7 @@ help: add missing lifetime argument
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                        +++++++++
 
-error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/missing-lifetime-specifier.rs:47:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -277,7 +277,7 @@ help: add missing lifetime argument
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                        +++++++++
 
-error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/missing-lifetime-specifier.rs:47:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -295,7 +295,7 @@ help: add missing lifetime argument
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                        +++++++++
 
-error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/missing-lifetime-specifier.rs:47:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());

--- a/tests/ui/suggestions/missing-type-param-used-in-param.stderr
+++ b/tests/ui/suggestions/missing-type-param-used-in-param.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this function takes 2 generic arguments but 1 generic argument was supplied
+error[E0107]: function takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/missing-type-param-used-in-param.rs:6:5
    |
 LL |     two_type_params::<String>(100);

--- a/tests/ui/suggestions/move-generic-to-trait-in-method-with-params.rs
+++ b/tests/ui/suggestions/move-generic-to-trait-in-method-with-params.rs
@@ -12,7 +12,7 @@ impl Foo<i32> for i32 {
 
 fn main() {
     1.bar::<i32>(0);
-    //~^ ERROR this method takes 0 generic arguments but 1 generic argument was supplied
+    //~^ ERROR method takes 0 generic arguments but 1 generic argument was supplied
     //~| HELP consider moving this generic argument to the `Foo` trait, which takes up to 1 argument
     //~| HELP remove these generics
 }

--- a/tests/ui/suggestions/move-generic-to-trait-in-method-with-params.stderr
+++ b/tests/ui/suggestions/move-generic-to-trait-in-method-with-params.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/move-generic-to-trait-in-method-with-params.rs:14:7
    |
 LL |     1.bar::<i32>(0);

--- a/tests/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
@@ -18,7 +18,7 @@ LL |     let _: Vec<A:B> = A::B;
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
-error[E0107]: this struct takes at least 1 generic argument but 0 generic arguments were supplied
+error[E0107]: struct takes at least 1 generic argument but 0 generic arguments were supplied
   --> $DIR/type-ascription-instead-of-path-in-type.rs:6:12
    |
 LL |     let _: Vec<A:B> = A::B;

--- a/tests/ui/suggestions/use-type-argument-instead-of-assoc-type.rs
+++ b/tests/ui/suggestions/use-type-argument-instead-of-assoc-type.rs
@@ -6,7 +6,7 @@ pub trait T<X, Y> {
 pub struct Foo {
     i: Box<dyn T<usize, usize, usize, usize, B=usize>>,
     //~^ ERROR must be specified
-    //~| ERROR this trait takes 2 generic arguments but 4 generic arguments were supplied
+    //~| ERROR trait takes 2 generic arguments but 4 generic arguments were supplied
 }
 
 

--- a/tests/ui/suggestions/use-type-argument-instead-of-assoc-type.stderr
+++ b/tests/ui/suggestions/use-type-argument-instead-of-assoc-type.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this trait takes 2 generic arguments but 4 generic arguments were supplied
+error[E0107]: trait takes 2 generic arguments but 4 generic arguments were supplied
   --> $DIR/use-type-argument-instead-of-assoc-type.rs:7:16
    |
 LL |     i: Box<dyn T<usize, usize, usize, usize, B=usize>>,

--- a/tests/ui/traits/object/vs-lifetime.rs
+++ b/tests/ui/traits/object/vs-lifetime.rs
@@ -9,8 +9,8 @@ fn main() {
     let _: S<'static, dyn 'static +>;
     //~^ at least one trait is required for an object type
     let _: S<'static, 'static>;
-    //~^ ERROR this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
-    //~| ERROR this struct takes 1 generic argument but 0 generic arguments were supplied
+    //~^ ERROR struct takes 1 lifetime argument but 2 lifetime arguments were supplied
+    //~| ERROR struct takes 1 generic argument but 0 generic arguments were supplied
     let _: S<dyn 'static +, 'static>;
     //~^ ERROR type provided when a lifetime was expected
     //~| ERROR at least one trait is required for an object type

--- a/tests/ui/traits/object/vs-lifetime.stderr
+++ b/tests/ui/traits/object/vs-lifetime.stderr
@@ -4,7 +4,7 @@ error[E0224]: at least one trait is required for an object type
 LL |     let _: S<'static, dyn 'static +>;
    |                       ^^^^^^^^^^^^^
 
-error[E0107]: this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
+error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/vs-lifetime.rs:11:12
    |
 LL |     let _: S<'static, 'static>;
@@ -18,7 +18,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
 LL | struct S<'a, T>(&'a u8, T);
    |        ^ --
 
-error[E0107]: this struct takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/vs-lifetime.rs:11:12
    |
 LL |     let _: S<'static, 'static>;

--- a/tests/ui/traits/test-2.rs
+++ b/tests/ui/traits/test-2.rs
@@ -7,9 +7,9 @@ impl bar for u32 { fn dup(&self) -> u32 { *self } fn blah<X>(&self) {} }
 
 fn main() {
     10.dup::<i32>();
-    //~^ ERROR this method takes 0 generic arguments but 1
+    //~^ ERROR method takes 0 generic arguments but 1
     10.blah::<i32, i32>();
-    //~^ ERROR this method takes 1 generic argument but 2
+    //~^ ERROR method takes 1 generic argument but 2
     (Box::new(10) as Box<dyn bar>).dup();
     //~^ ERROR E0038
     //~| ERROR E0038

--- a/tests/ui/traits/test-2.stderr
+++ b/tests/ui/traits/test-2.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/test-2.rs:9:8
    |
 LL |     10.dup::<i32>();
@@ -12,7 +12,7 @@ note: method defined here, with 0 generic parameters
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |                ^^^
 
-error[E0107]: this method takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: method takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/test-2.rs:11:8
    |
 LL |     10.blah::<i32, i32>();

--- a/tests/ui/transmutability/issue-101739-2.rs
+++ b/tests/ui/transmutability/issue-101739-2.rs
@@ -15,7 +15,7 @@ mod assert {
         const ASSUME_VISIBILITY: bool,
     >()
     where
-        Dst: BikeshedIntrinsicFrom< //~ ERROR this trait takes at most 3 generic arguments but 6 generic arguments were supplied
+        Dst: BikeshedIntrinsicFrom< //~ ERROR trait takes at most 3 generic arguments but 6 generic arguments were supplied
             Src,
             Context,
             ASSUME_ALIGNMENT,

--- a/tests/ui/transmutability/issue-101739-2.stderr
+++ b/tests/ui/transmutability/issue-101739-2.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this trait takes at most 3 generic arguments but 6 generic arguments were supplied
+error[E0107]: trait takes at most 3 generic arguments but 6 generic arguments were supplied
   --> $DIR/issue-101739-2.rs:18:14
    |
 LL |           Dst: BikeshedIntrinsicFrom<

--- a/tests/ui/type-alias-enum-variants/enum-variant-generic-args.rs
+++ b/tests/ui/type-alias-enum-variants/enum-variant-generic-args.rs
@@ -62,10 +62,10 @@ fn main() {
     AliasFixed::TSVariant::<()>(());
     //~^ ERROR type arguments are not allowed on this type [E0109]
     AliasFixed::<()>::TSVariant(());
-    //~^ ERROR this type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
+    //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
     AliasFixed::<()>::TSVariant::<()>(());
     //~^ ERROR type arguments are not allowed on this type [E0109]
-    //~| ERROR this type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
+    //~| ERROR type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
 
     // Struct variant
 
@@ -80,10 +80,10 @@ fn main() {
     AliasFixed::SVariant::<()> { v: () };
     //~^ ERROR type arguments are not allowed on this type [E0109]
     AliasFixed::<()>::SVariant { v: () };
-    //~^ ERROR this type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
+    //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
     AliasFixed::<()>::SVariant::<()> { v: () };
     //~^ ERROR type arguments are not allowed on this type [E0109]
-    //~| ERROR this type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
+    //~| ERROR type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
 
     // Unit variant
 
@@ -98,8 +98,8 @@ fn main() {
     AliasFixed::UVariant::<()>;
     //~^ ERROR type arguments are not allowed on this type [E0109]
     AliasFixed::<()>::UVariant;
-    //~^ ERROR this type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
+    //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
     AliasFixed::<()>::UVariant::<()>;
     //~^ ERROR type arguments are not allowed on this type [E0109]
-    //~| ERROR this type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
+    //~| ERROR type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
 }

--- a/tests/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/tests/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -304,7 +304,7 @@ LL |     AliasFixed::TSVariant::<()>(());
    |                 |
    |                 not allowed on this type
 
-error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:64:5
    |
 LL |     AliasFixed::<()>::TSVariant(());
@@ -318,7 +318,7 @@ note: type alias defined here, with 0 generic parameters
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
 
-error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:66:5
    |
 LL |     AliasFixed::<()>::TSVariant::<()>(());
@@ -395,7 +395,7 @@ LL -     AliasFixed::SVariant::<()> { v: () };
 LL +     AliasFixed::<()>::SVariant { v: () };
    |
 
-error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:82:5
    |
 LL |     AliasFixed::<()>::SVariant { v: () };
@@ -409,7 +409,7 @@ note: type alias defined here, with 0 generic parameters
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
 
-error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:84:5
    |
 LL |     AliasFixed::<()>::SVariant::<()> { v: () };
@@ -470,7 +470,7 @@ LL |     AliasFixed::UVariant::<()>;
    |                 |
    |                 not allowed on this type
 
-error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:100:5
    |
 LL |     AliasFixed::<()>::UVariant;
@@ -484,7 +484,7 @@ note: type alias defined here, with 0 generic parameters
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
 
-error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:102:5
    |
 LL |     AliasFixed::<()>::UVariant::<()>;

--- a/tests/ui/typeck/issue-75883.rs
+++ b/tests/ui/typeck/issue-75883.rs
@@ -4,7 +4,7 @@ pub struct UI {}
 
 impl UI {
     pub fn run() -> Result<_> {
-        //~^ ERROR: this enum takes 2 generic arguments but 1 generic argument was supplied
+        //~^ ERROR: enum takes 2 generic arguments but 1 generic argument was supplied
         //~| ERROR: the placeholder `_` is not allowed within types on item signatures for return types
         let mut ui = UI {};
         ui.interact();
@@ -13,7 +13,7 @@ impl UI {
     }
 
     pub fn interact(&mut self) -> Result<_> {
-        //~^ ERROR: this enum takes 2 generic arguments but 1 generic argument was supplied
+        //~^ ERROR: enum takes 2 generic arguments but 1 generic argument was supplied
         //~| ERROR: the placeholder `_` is not allowed within types on item signatures for return types
         unimplemented!();
     }

--- a/tests/ui/typeck/issue-75883.stderr
+++ b/tests/ui/typeck/issue-75883.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this enum takes 2 generic arguments but 1 generic argument was supplied
+error[E0107]: enum takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-75883.rs:6:21
    |
 LL |     pub fn run() -> Result<_> {
@@ -11,7 +11,7 @@ help: add missing generic argument
 LL |     pub fn run() -> Result<_, E> {
    |                             +++
 
-error[E0107]: this enum takes 2 generic arguments but 1 generic argument was supplied
+error[E0107]: enum takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-75883.rs:15:35
    |
 LL |     pub fn interact(&mut self) -> Result<_> {

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.rs
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.rs
@@ -1,17 +1,17 @@
 fn foo1<T:Copy<U>, U>(x: T) {}
-//~^ ERROR this trait takes 0 generic arguments but 1 generic argument was supplied
+//~^ ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 
 trait Trait: Copy<dyn Send> {}
-//~^ ERROR this trait takes 0 generic arguments but 1 generic argument was supplied
+//~^ ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 
 struct MyStruct1<T: Copy<T>>;
-//~^ ERROR this trait takes 0 generic arguments but 1 generic argument was supplied
+//~^ ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 
 struct MyStruct2<'a, T: Copy<'a>>;
-//~^ ERROR this trait takes 0 lifetime arguments but 1 lifetime argument was supplied
+//~^ ERROR trait takes 0 lifetime arguments but 1 lifetime argument was supplied
 
 fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
-//~^ ERROR this trait takes 0 lifetime arguments but 1 lifetime argument was supplied
-//~| ERROR this trait takes 0 generic arguments but 1 generic argument was supplied
+//~^ ERROR trait takes 0 lifetime arguments but 1 lifetime argument was supplied
+//~| ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 
 fn main() { }

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:1:11
    |
 LL | fn foo1<T:Copy<U>, U>(x: T) {}
@@ -6,7 +6,7 @@ LL | fn foo1<T:Copy<U>, U>(x: T) {}
    |           |
    |           expected 0 generic arguments
 
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:4:14
    |
 LL | trait Trait: Copy<dyn Send> {}
@@ -14,7 +14,7 @@ LL | trait Trait: Copy<dyn Send> {}
    |              |
    |              expected 0 generic arguments
 
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:7:21
    |
 LL | struct MyStruct1<T: Copy<T>>;
@@ -22,7 +22,7 @@ LL | struct MyStruct1<T: Copy<T>>;
    |                     |
    |                     expected 0 generic arguments
 
-error[E0107]: this trait takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:10:25
    |
 LL | struct MyStruct2<'a, T: Copy<'a>>;
@@ -30,7 +30,7 @@ LL | struct MyStruct2<'a, T: Copy<'a>>;
    |                         |
    |                         expected 0 lifetime arguments
 
-error[E0107]: this trait takes 0 lifetime arguments but 1 lifetime argument was supplied
+error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:13:15
    |
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
@@ -38,7 +38,7 @@ LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               |
    |               expected 0 lifetime arguments
 
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:13:15
    |
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}

--- a/tests/ui/typeck/typeck_type_placeholder_lifetime_1.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_lifetime_1.rs
@@ -7,5 +7,5 @@ struct Foo<'a, T:'a> {
 
 pub fn main() {
     let c: Foo<_, _> = Foo { r: &5 };
-    //~^ ERROR this struct takes 1 generic argument but 2 generic arguments were supplied
+    //~^ ERROR struct takes 1 generic argument but 2 generic arguments were supplied
 }

--- a/tests/ui/typeck/typeck_type_placeholder_lifetime_1.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_lifetime_1.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this struct takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/typeck_type_placeholder_lifetime_1.rs:9:12
    |
 LL |     let c: Foo<_, _> = Foo { r: &5 };

--- a/tests/ui/typeck/typeck_type_placeholder_lifetime_2.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_lifetime_2.rs
@@ -7,5 +7,5 @@ struct Foo<'a, T:'a> {
 
 pub fn main() {
     let c: Foo<_, usize> = Foo { r: &5 };
-    //~^ ERROR this struct takes 1 generic argument but 2 generic arguments were supplied
+    //~^ ERROR struct takes 1 generic argument but 2 generic arguments were supplied
 }

--- a/tests/ui/typeck/typeck_type_placeholder_lifetime_2.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_lifetime_2.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this struct takes 1 generic argument but 2 generic arguments were supplied
+error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/typeck_type_placeholder_lifetime_2.rs:9:12
    |
 LL |     let c: Foo<_, usize> = Foo { r: &5 };

--- a/tests/ui/ufcs/ufcs-qpath-missing-params.rs
+++ b/tests/ui/ufcs/ufcs-qpath-missing-params.rs
@@ -15,6 +15,6 @@ fn main() {
       //~^ ERROR missing generics for
 
     <String as IntoCow>::into_cow::<str>("foo".to_string());
-    //~^ ERROR this method takes 0 generic arguments but 1
+    //~^ ERROR method takes 0 generic arguments but 1
     //~| ERROR missing generics for
 }

--- a/tests/ui/ufcs/ufcs-qpath-missing-params.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-missing-params.stderr
@@ -30,7 +30,7 @@ help: add missing generic argument
 LL |     <String as IntoCow<B>>::into_cow::<str>("foo".to_string());
    |                       +++
 
-error[E0107]: this method takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/ufcs-qpath-missing-params.rs:17:26
    |
 LL |     <String as IntoCow>::into_cow::<str>("foo".to_string());

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
@@ -28,7 +28,7 @@ fn test<'a,'b>() {
 }
 
 fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {
-    //~^ ERROR this trait takes 1 lifetime argument but 0 lifetime arguments were supplied
+    //~^ ERROR trait takes 1 lifetime argument but 0 lifetime arguments were supplied
     // Here, the omitted lifetimes are expanded to distinct things.
     same_type(x, y)
 }

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this trait takes 1 lifetime argument but 0 lifetime arguments were supplied
+error[E0107]: trait takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/unboxed-closure-sugar-region.rs:30:51
    |
 LL | fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.rs
@@ -7,7 +7,7 @@ struct Bar<A> {
 fn bar() {
     let x: Box<Bar()> = panic!();
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
-    //~| ERROR this struct takes 1 generic argument but 0 generic arguments
+    //~| ERROR struct takes 1 generic argument but 0 generic arguments
 }
 
 fn main() { }

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
@@ -4,7 +4,7 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
 LL |     let x: Box<Bar()> = panic!();
    |                ^^^^^ only `Fn` traits may use parentheses
 
-error[E0107]: this struct takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:16
    |
 LL |     let x: Box<Bar()> = panic!();

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.rs
@@ -6,7 +6,7 @@ struct Bar<A> {
 
 fn foo(b: Box<Bar()>) {
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
-    //~| ERROR this struct takes 1 generic argument but 0 generic arguments
+    //~| ERROR struct takes 1 generic argument but 0 generic arguments
 }
 
 fn main() { }

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
@@ -4,7 +4,7 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
 LL | fn foo(b: Box<Bar()>) {
    |               ^^^^^ only `Fn` traits may use parentheses
 
-error[E0107]: this struct takes 1 generic argument but 0 generic arguments were supplied
+error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:15
    |
 LL | fn foo(b: Box<Bar()>) {

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs
@@ -3,7 +3,7 @@
 trait Three<A,B,C> { fn dummy(&self) -> (A,B,C); }
 
 fn foo(_: &dyn Three())
-//~^ ERROR this trait takes 3 generic arguments but 1 generic argument
+//~^ ERROR trait takes 3 generic arguments but 1 generic argument
 //~| ERROR associated type `Output` not found
 {}
 

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters-3.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters-3.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this trait takes 3 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 3 generic arguments but 1 generic argument was supplied
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs:5:16
    |
 LL | fn foo(_: &dyn Three())

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
@@ -3,25 +3,25 @@
 trait Zero { fn dummy(&self); }
 
 fn foo1(_: dyn Zero()) {
-    //~^ ERROR this trait takes 0 generic arguments but 1 generic argument
+    //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type `Output` not found for `Zero`
 }
 
 fn foo2(_: dyn Zero<usize>) {
-    //~^ ERROR this trait takes 0 generic arguments but 1 generic argument
+    //~^ ERROR trait takes 0 generic arguments but 1 generic argument
 }
 
 fn foo3(_: dyn Zero <   usize   >) {
-    //~^ ERROR this trait takes 0 generic arguments but 1 generic argument
+    //~^ ERROR trait takes 0 generic arguments but 1 generic argument
 }
 
 fn foo4(_: dyn Zero(usize)) {
-    //~^ ERROR this trait takes 0 generic arguments but 1 generic argument
+    //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type `Output` not found for `Zero`
 }
 
 fn foo5(_: dyn Zero (   usize   )) {
-    //~^ ERROR this trait takes 0 generic arguments but 1 generic argument
+    //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type `Output` not found for `Zero`
 }
 

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:16
    |
 LL | fn foo1(_: dyn Zero()) {
@@ -18,7 +18,7 @@ error[E0220]: associated type `Output` not found for `Zero`
 LL | fn foo1(_: dyn Zero()) {
    |                ^^^^^^ associated type `Output` not found
 
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:10:16
    |
 LL | fn foo2(_: dyn Zero<usize>) {
@@ -32,7 +32,7 @@ note: trait defined here, with 0 generic parameters
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
 
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:14:16
    |
 LL | fn foo3(_: dyn Zero <   usize   >) {
@@ -46,7 +46,7 @@ note: trait defined here, with 0 generic parameters
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
 
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:16
    |
 LL | fn foo4(_: dyn Zero(usize)) {
@@ -66,7 +66,7 @@ error[E0220]: associated type `Output` not found for `Zero`
 LL | fn foo4(_: dyn Zero(usize)) {
    |                ^^^^^^^^^^^ associated type `Output` not found
 
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:16
    |
 LL | fn foo5(_: dyn Zero (   usize   )) {

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.rs
@@ -3,7 +3,7 @@
 trait Trait {}
 
 fn f<F:Trait(isize) -> isize>(x: F) {}
-//~^ ERROR this trait takes 0 generic arguments but 1 generic argument
+//~^ ERROR trait takes 0 generic arguments but 1 generic argument
 //~| ERROR associated type `Output` not found for `Trait`
 
 fn main() {}

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
@@ -1,4 +1,4 @@
-error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/unboxed-closure-sugar-wrong-trait.rs:5:8
    |
 LL | fn f<F:Trait(isize) -> isize>(x: F) {}


### PR DESCRIPTION
Consider [`tests/ui/const-generics/generic_const_exprs/issue-102768.stderr`][issue-102768.stderr], the error message where it gives additional notes about where the associated type is defined, and how the dead code lint doesn't have an article, like in [`tests/ui/lint/dead-code/issue-85255.stderr`][issue-85255.stderr]. They don't have articles, so it seems unnecessary to have one here.

[issue-102768.stderr]: https://github.com/rust-lang/rust/blob/07c993eba8b76eae497e98433ae075b00f01be10/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
[issue-85255.stderr]: https://github.com/rust-lang/rust/blob/07c993eba8b76eae497e98433ae075b00f01be10/tests/ui/lint/dead-code/issue-85255.stderr