### PR TITLE
support `x fmt` for sub and outside of rust directories

### DIFF
--- a/src/bootstrap/format.rs
+++ b/src/bootstrap/format.rs
@@ -218,7 +218,7 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
                     WalkBuilder::new(first)
                 }
             } else {
-                WalkBuilder::new(first)
+                WalkBuilder::new(src.join(first))
             };
 
             for path in &paths[1..] {
@@ -229,7 +229,7 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
                         walker.add(path);
                     }
                 } else {
-                    walker.add(path);
+                    walker.add(src.join(path));
                 }
             }
 


### PR DESCRIPTION
This PR makes `x fmt` to be succesfully work from sub or outside dir of rust.

The following cases are tested and the results were successful.
```sh
# from rust/library directory
../x fmt compiler --check
../x fmt compiler/rustc

# from outside of rust directory
../../rust/x fmt library/std library/core --check
../../rust/x fmt library/std
```

Resolves #108004


r? @albertlarsan68 
