### PR TITLE
rustdoc: avoid including `<li>` tags in item table short desc

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -552,10 +552,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> SummaryLine<'a, I> {
 }
 
 fn check_if_allowed_tag(t: &Tag<'_>) -> bool {
-    matches!(
-        t,
-        Tag::Paragraph | Tag::Item | Tag::Emphasis | Tag::Strong | Tag::Link(..) | Tag::BlockQuote
-    )
+    matches!(t, Tag::Paragraph | Tag::Emphasis | Tag::Strong | Tag::Link(..) | Tag::BlockQuote)
 }
 
 fn is_forbidden_tag(t: &Tag<'_>) -> bool {

--- a/tests/rustdoc/item-desc-list-at-start.item-table.html
+++ b/tests/rustdoc/item-desc-list-at-start.item-table.html
@@ -1,0 +1,1 @@
+<ul class="item-table"><li><div class="item-name"><a class="constant" href="constant.MY_CONSTANT.html" title="constant item_desc_list_at_start::MY_CONSTANT">MY_CONSTANT</a></div><div class="desc docblock-short">Groups: <code>SamplePatternSGIS</code>, <code>SamplePatternEXT</code></div></li></ul>

--- a/tests/rustdoc/item-desc-list-at-start.rs
+++ b/tests/rustdoc/item-desc-list-at-start.rs
@@ -1,0 +1,9 @@
+// @has item_desc_list_at_start/index.html
+// @count - '//ul[@class="item-table"]/li/div/li' 0
+// @count - '//ul[@class="item-table"]/li' 1
+// @snapshot item-table - '//ul[@class="item-table"]'
+
+// based on https://docs.rs/gl_constants/0.1.1/src/gl_constants/lib.rs.html#16
+
+/// * Groups: `SamplePatternSGIS`, `SamplePatternEXT`
+pub const MY_CONSTANT: usize = 0;


### PR DESCRIPTION
Fixes a bug seen at https://docs.rs/gl_constants/0.1.1/gl_constants/index.html