### PR TITLE
Stabilize `atomic_as_ptr`

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -916,6 +916,7 @@ impl AtomicBool {
     /// ```ignore (extern-declaration)
     /// # fn main() {
     /// use std::sync::atomic::AtomicBool;
+    ///
     /// extern "C" {
     ///     fn my_atomic_op(arg: *mut bool);
     /// }
@@ -927,7 +928,8 @@ impl AtomicBool {
     /// # }
     /// ```
     #[inline]
-    #[unstable(feature = "atomic_mut_ptr", reason = "recently added", issue = "66893")]
+    #[stable(feature = "atomic_as_ptr", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "atomic_as_ptr", since = "CURRENT_RUSTC_VERSION")]
     pub const fn as_ptr(&self) -> *mut bool {
         self.v.get().cast()
     }
@@ -1802,7 +1804,6 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```ignore (extern-declaration)
-    /// #![feature(atomic_mut_ptr)]
     /// use std::sync::atomic::AtomicPtr;
     ///
     /// extern "C" {
@@ -1818,7 +1819,8 @@ impl<T> AtomicPtr<T> {
     /// }
     /// ```
     #[inline]
-    #[unstable(feature = "atomic_mut_ptr", reason = "recently added", issue = "66893")]
+    #[stable(feature = "atomic_as_ptr", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "atomic_as_ptr", since = "CURRENT_RUSTC_VERSION")]
     pub const fn as_ptr(&self) -> *mut *mut T {
         self.p.get()
     }
@@ -2724,9 +2726,8 @@ macro_rules! atomic_int {
             /// # }
             /// ```
             #[inline]
-            #[unstable(feature = "atomic_mut_ptr",
-                   reason = "recently added",
-                   issue = "66893")]
+            #[stable(feature = "atomic_as_ptr", since = "CURRENT_RUSTC_VERSION")]
+            #[rustc_const_stable(feature = "atomic_as_ptr", since = "CURRENT_RUSTC_VERSION")]
             pub const fn as_ptr(&self) -> *mut $int_type {
                 self.v.get()
             }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -273,7 +273,6 @@
 #![feature(utf8_chunks)]
 //
 // Library features (core):
-#![feature(atomic_mut_ptr)]
 #![feature(char_internals)]
 #![feature(core_intrinsics)]
 #![feature(duration_constants)]


### PR DESCRIPTION
Fixes #66893

This stabilizes the `as_ptr` methods for atomics. The stabilization feature gate used here is `atomic_as_ptr` which supersedes `atomic_mut_ptr` to match the change in https://github.com/rust-lang/rust/pull/107736.

This needs FCP.

New stable API:

```rust
impl AtomicBool {
    pub const fn as_ptr(&self) -> *mut bool;
}

impl AtomicI32 {
    pub const fn as_ptr(&self) -> *mut i32;
}

// Includes all other atomic types

impl<T> AtomicPtr<T> {
    pub const fn as_ptr(&self) -> *mut *mut T;
}
```

r? libs-api
@rustbot label +needs-fcp