### PR TITLE
Wrap missing provider message correctly

### DIFF
--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -328,8 +328,9 @@ macro_rules! define_callbacks {
 
                 Providers {
                     $($name: |_, key| bug!(
-                        "`tcx.{}({:?})` is not supported for {} crate;\n
-                        hint: Queries can be either made to the local crate, or the external crate. This error means you tried to use it for one that's not supported.\n
+                        "`tcx.{}({:?})` is not supported for {} crate;\n\
+                        hint: Queries can be either made to the local crate, or the external crate. \
+                        This error means you tried to use it for one that's not supported.\n\
                         If that's not the case, {} was likely never assigned to a provider function.\n",
                         stringify!($name),
                         key,


### PR DESCRIPTION
Fixes #108429

```
error: internal compiler error: compiler/rustc_middle/src/ty/query.rs:441:1: `tcx.trigger_delay_span_bug(DefId(0:3 ~ test[78c5]::main))` is not supported for local crate;
                                hint: Queries can be either made to the local crate, or the external crate. This error means you tried to use it for one that's not supported.
                                If that's not the case, trigger_delay_span_bug was likely never assigned to a provider function.

thread 'rustc' panicked at 'Box<dyn Any>', /home/ec2-user/rust3/compiler/rustc_errors/src/lib.rs:1651:9
stack backtrace:
   0:     0x7f51870926d7 - std::backtrace_rs::backtrace::libunwind::trace::hb0876bb39e7adf0d
                               at /home/ec2-user/rust3/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x7f51870926d7 - std::backtrace_rs::backtrace::trace_unsynchronized::h1bcab1313827007b
                               at /home/ec2-user/rust3/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x7f5187077e07 - std::sys_common::backtrace::_print_fmt::h262d2a62279fa102
                               at /home/ec2-user/rust3/library/std/src/sys_common/backtrace.rs:65:5
```