### PR TITLE
Reexport MetadataBlob so it can be used in rustc plugins

### DIFF
--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -45,6 +45,6 @@ pub mod locator;
 
 pub use fs::{emit_wrapper_file, METADATA_FILENAME};
 pub use native_libs::find_native_static_library;
-pub use rmeta::{encode_metadata, EncodedMetadata, METADATA_HEADER};
+pub use rmeta::{encode_metadata, EncodedMetadata, MetadataBlob, METADATA_HEADER};
 
 fluent_messages! { "../locales/en-US.ftl" }

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -50,7 +50,7 @@ mod cstore_impl;
 /// A `MetadataBlob` internally is just a reference counted pointer to
 /// the actual data, so cloning it is cheap.
 #[derive(Clone)]
-pub(crate) struct MetadataBlob(Lrc<MetadataRef>);
+pub struct MetadataBlob(Lrc<MetadataRef>);
 
 // This is needed so we can create an OwningRef into the blob.
 // The data behind a `MetadataBlob` has a stable address because it is

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -38,7 +38,8 @@ use std::num::NonZeroUsize;
 
 pub use decoder::provide_extern;
 use decoder::DecodeContext;
-pub(crate) use decoder::{CrateMetadata, CrateNumMap, MetadataBlob};
+pub use decoder::MetadataBlob;
+pub(crate) use decoder::{CrateMetadata, CrateNumMap};
 use encoder::EncodeContext;
 pub use encoder::{encode_metadata, EncodedMetadata};
 use rustc_span::hygiene::SyntaxContextData;


### PR DESCRIPTION
I was investigating on https://github.com/rust-lang/rust/issues/81893. Currently, if a `pub use` of a foreign item has documentation, it's apparently not saved in the `rmeta`. However, I'm not completely sure of that so I wanted to look into the `rmeta` file to check if I missed anything, but I couldn't find a `rmeta` reader, so I started writing my own (the work in progress of this fix can be seen [here](https://github.com/rust-lang/rust/compare/master...GuillaumeGomez:rust:fix-missing-foreign-reexport-doc?expand=1)).

You can see the very beginning of this rmeta reader [here](https://github.com/GuillaumeGomez/rmeta-reader). Not working at the moment and I can't find out how to make `rust-toolchain` and its `path` argument work for rustc crates at the moment (if you have an idea?).

Anyway, hopefully this will be helpful for other rustc contributors. At least it'll be for me. :)

cc @lqd