### PR TITLE
Make the `is_green` assertion in `incremental_verify_ich` a debug_assert!

### DIFF
--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -579,7 +579,7 @@ pub(crate) fn incremental_verify_ich<Tcx, V: Debug>(
 where
     Tcx: DepContext,
 {
-    assert!(
+    debug_assert!(
         tcx.dep_graph().is_green(dep_node),
         "fingerprint for green query instance not loaded from cache: {dep_node:?}",
     );


### PR DESCRIPTION
We only call `incremental_verify_ich` if `try_mark_green` succeeds, so this assertion is unlikely to trigger. 