### PR TITLE
WIP: Add lint for `String` in diagnostic implementation

### DIFF
--- a/compiler/rustc_lint/locales/en-US.ftl
+++ b/compiler/rustc_lint/locales/en-US.ftl
@@ -90,6 +90,9 @@ lint_non_existant_doc_keyword = found non-existing keyword `{$keyword}` used in 
 lint_diag_out_of_impl =
     diagnostics should only be created in `IntoDiagnostic`/`AddToDiagnostic` impls
 
+lint_string_in_diag = use of String in diagnostic
+    .note = this could indicate incorrectly eagerly converting to a string
+
 lint_untranslatable_diag = diagnostics should be created using translatable messages
 
 lint_bad_opt_access = {$msg}

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -514,6 +514,7 @@ fn register_internals(store: &mut LintStore) {
     store.register_lints(&TyTyKind::get_lints());
     store.register_late_pass(|_| Box::new(TyTyKind));
     store.register_lints(&Diagnostics::get_lints());
+    store.register_early_pass(|| Box::new(Diagnostics));
     store.register_late_pass(|_| Box::new(Diagnostics));
     store.register_lints(&BadOptAccess::get_lints());
     store.register_late_pass(|_| Box::new(BadOptAccess));

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -801,6 +801,11 @@ pub struct NonExistantDocKeyword {
 pub struct DiagOutOfImpl;
 
 #[derive(LintDiagnostic)]
+#[diag(lint_string_in_diag)]
+#[note]
+pub struct StringInDiagnostic;
+
+#[derive(LintDiagnostic)]
 #[diag(lint_untranslatable_diag)]
 pub struct UntranslatableDiag;
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -608,6 +608,7 @@ symbols! {
         derive_default_enum,
         destruct,
         destructuring_assignment,
+        diag,
         diagnostic,
         direct,
         discriminant_kind,


### PR DESCRIPTION
Implementing the check described in https://github.com/rust-lang/rust/pull/108162#discussion_r1109921987 so we can see what happens. Implemented as a lint so it can be `#[allow]`'d
cc @Nilstrieb 

@rustbot label +A-translation
r? ghost