### PR TITLE
remove unnecessary generic bounds from Vec::append 

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1937,7 +1937,7 @@ impl<T, A: Allocator> Vec<T, A> {
     #[cfg(not(no_global_oom_handling))]
     #[inline]
     #[stable(feature = "append", since = "1.4.0")]
-    pub fn append(&mut self, other: &mut Self) {
+    pub fn append<B: Allocator>(&mut self, other: &mut Vec<T, B>) {
         unsafe {
             self.append_elements(other.as_slice() as _);
             other.set_len(0);


### PR DESCRIPTION
Currently [`Vec::append`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.append) requires that the `other` `Vec` use the same allocator, which is not actually required for the implementation of the method. This PR makes `Vec::append` accept any `Vec<T, B>` where `B: Allocator`.