### PR TITLE
Tweak query accessors

### DIFF
--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -330,7 +330,7 @@ where
 /// It returns the shard index and a lock guard to the shard,
 /// which will be used if the query is not in the cache and we need
 /// to compute it.
-#[inline]
+#[inline(always)]
 pub fn try_get_cached<Tcx, C>(tcx: Tcx, cache: &C, key: &C::Key) -> Option<C::Value>
 where
     C: QueryCache,


### PR DESCRIPTION
This is a variant of https://github.com/rust-lang/rust/pull/107802 which does not extract the code into a macro. It performs similarly locally.