### PR TITLE
move pal cfgs in f32 and f64 to sys

### DIFF
--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -500,10 +500,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log2(self) -> f32 {
-        #[cfg(target_os = "android")]
-        return crate::sys::android::log2f32(self);
-        #[cfg(not(target_os = "android"))]
-        return unsafe { intrinsics::log2f32(self) };
+        crate::sys::log2f32(self)
     }
 
     /// Returns the base 10 logarithm of the number.

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -456,7 +456,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln(self) -> f64 {
-        self.log_wrapper(|n| unsafe { intrinsics::logf64(n) })
+        crate::sys::log_wrapper(self, |n| unsafe { intrinsics::logf64(n) })
     }
 
     /// Returns the logarithm of the number with respect to an arbitrary base.
@@ -500,12 +500,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log2(self) -> f64 {
-        self.log_wrapper(|n| {
-            #[cfg(target_os = "android")]
-            return crate::sys::android::log2f64(n);
-            #[cfg(not(target_os = "android"))]
-            return unsafe { intrinsics::log2f64(n) };
-        })
+        crate::sys::log_wrapper(self, crate::sys::log2f64)
     }
 
     /// Returns the base 10 logarithm of the number.
@@ -525,7 +520,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log10(self) -> f64 {
-        self.log_wrapper(|n| unsafe { intrinsics::log10f64(n) })
+        crate::sys::log_wrapper(self, |n| unsafe { intrinsics::log10f64(n) })
     }
 
     /// The positive difference of two numbers.
@@ -961,29 +956,5 @@ impl f64 {
     #[inline]
     pub fn atanh(self) -> f64 {
         0.5 * ((2.0 * self) / (1.0 - self)).ln_1p()
-    }
-
-    // Solaris/Illumos requires a wrapper around log, log2, and log10 functions
-    // because of their non-standard behavior (e.g., log(-n) returns -Inf instead
-    // of expected NaN).
-    #[rustc_allow_incoherent_impl]
-    fn log_wrapper<F: Fn(f64) -> f64>(self, log_fn: F) -> f64 {
-        if !cfg!(any(target_os = "solaris", target_os = "illumos")) {
-            log_fn(self)
-        } else if self.is_finite() {
-            if self > 0.0 {
-                log_fn(self)
-            } else if self == 0.0 {
-                Self::NEG_INFINITY // log(0) = -Inf
-            } else {
-                Self::NAN // log(-n) = NaN
-            }
-        } else if self.is_nan() {
-            self // log(NaN) = NaN
-        } else if self > 0.0 {
-            self // log(Inf) = Inf
-        } else {
-            Self::NAN // log(-Inf) = NaN
-        }
     }
 }

--- a/library/std/src/sys/mod.rs
+++ b/library/std/src/sys/mod.rs
@@ -60,3 +60,52 @@ cfg_if::cfg_if! {
         pub const FULL_BACKTRACE_DEFAULT: bool = false;
     }
 }
+
+#[cfg(not(test))]
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "android")] {
+        pub use self::android::log2f32;
+        pub use self::android::log2f64;
+    } else {
+        #[inline]
+        pub fn log2f32(n: f32) -> f32 {
+            unsafe { crate::intrinsics::log2f32(n) }
+        }
+
+        #[inline]
+        pub fn log2f64(n: f64) -> f64 {
+            unsafe { crate::intrinsics::log2f64(n) }
+        }
+    }
+}
+
+// Solaris/Illumos requires a wrapper around log, log2, and log10 functions
+// because of their non-standard behavior (e.g., log(-n) returns -Inf instead
+// of expected NaN).
+#[cfg(not(test))]
+#[cfg(any(target_os = "solaris", target_os = "illumos"))]
+#[inline]
+pub fn log_wrapper<F: Fn(f64) -> f64>(n: f64, log_fn: F) -> f64 {
+    if n.is_finite() {
+        if n > 0.0 {
+            log_fn(n)
+        } else if n == 0.0 {
+            f64::NEG_INFINITY // log(0) = -Inf
+        } else {
+            f64::NAN // log(-n) = NaN
+        }
+    } else if n.is_nan() {
+        n // log(NaN) = NaN
+    } else if n > 0.0 {
+        n // log(Inf) = Inf
+    } else {
+        f64::NAN // log(-Inf) = NaN
+    }
+}
+
+#[cfg(not(test))]
+#[cfg(not(any(target_os = "solaris", target_os = "illumos")))]
+#[inline]
+pub fn log_wrapper<F: Fn(f64) -> f64>(n: f64, log_fn: F) -> f64 {
+    log_fn(n)
+}

--- a/src/tools/tidy/src/pal.rs
+++ b/src/tools/tidy/src/pal.rs
@@ -53,8 +53,6 @@ const EXCEPTION_PATHS: &[&str] = &[
     // FIXME: platform-specific code should be moved to `sys`
     "library/std/src/io/copy.rs",
     "library/std/src/io/stdio.rs",
-    "library/std/src/f32.rs",
-    "library/std/src/f64.rs",
     "library/std/src/path.rs",
     "library/std/src/sys_common", // Should only contain abstractions over platforms
     "library/std/src/net/test.rs", // Utility helpers for tests


### PR DESCRIPTION
I'd like to push forward on `sys` being a separate crate. To start with, most of these PAL exception cases are very simple little bits of code like this, so I thought I would try tidying them up.