### PR TITLE
Move THIR printing to rustc_mir_build.

### DIFF
--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -29,7 +29,6 @@ use rustc_target::asm::InlineAsmRegOrRegClass;
 use std::fmt;
 use std::ops::Index;
 
-pub mod print;
 pub mod visit;
 
 macro_rules! thir_with_elements {

--- a/compiler/rustc_mir_build/src/lib.rs
+++ b/compiler/rustc_mir_build/src/lib.rs
@@ -38,6 +38,6 @@ pub fn provide(providers: &mut Providers) {
     providers.thir_check_unsafety = check_unsafety::thir_check_unsafety;
     providers.thir_check_unsafety_for_const_arg = check_unsafety::thir_check_unsafety_for_const_arg;
     providers.thir_body = thir::cx::thir_body;
-    providers.thir_tree = thir::cx::thir_tree;
-    providers.thir_flat = thir::cx::thir_flat;
+    providers.thir_tree = thir::print::thir_tree;
+    providers.thir_flat = thir::print::thir_flat;
 }

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -52,23 +52,6 @@ pub(crate) fn thir_body(
     Ok((tcx.alloc_steal_thir(cx.thir), expr))
 }
 
-pub(crate) fn thir_tree(tcx: TyCtxt<'_>, owner_def: ty::WithOptConstParam<LocalDefId>) -> String {
-    match thir_body(tcx, owner_def) {
-        Ok((thir, _)) => {
-            let thir = thir.steal();
-            tcx.thir_tree_representation(&thir)
-        }
-        Err(_) => "error".into(),
-    }
-}
-
-pub(crate) fn thir_flat(tcx: TyCtxt<'_>, owner_def: ty::WithOptConstParam<LocalDefId>) -> String {
-    match thir_body(tcx, owner_def) {
-        Ok((thir, _)) => format!("{:#?}", thir.steal()),
-        Err(_) => "error".into(),
-    }
-}
-
 struct Cx<'tcx> {
     tcx: TyCtxt<'tcx>,
     thir: Thir<'tcx>,

--- a/compiler/rustc_mir_build/src/thir/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/mod.rs
@@ -5,9 +5,7 @@
 //! structures.
 
 pub(crate) mod constant;
-
 pub(crate) mod cx;
-
 pub(crate) mod pattern;
-
+pub(crate) mod print;
 mod util;

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -1,13 +1,24 @@
-use crate::thir::*;
-use crate::ty::{self, TyCtxt};
-
+use rustc_middle::thir::*;
+use rustc_middle::ty::{self, TyCtxt};
+use rustc_span::def_id::LocalDefId;
 use std::fmt::{self, Write};
 
-impl<'tcx> TyCtxt<'tcx> {
-    pub fn thir_tree_representation<'a>(self, thir: &'a Thir<'tcx>) -> String {
-        let mut printer = ThirPrinter::new(thir);
-        printer.print();
-        printer.into_buffer()
+pub(crate) fn thir_tree(tcx: TyCtxt<'_>, owner_def: ty::WithOptConstParam<LocalDefId>) -> String {
+    match super::cx::thir_body(tcx, owner_def) {
+        Ok((thir, _)) => {
+            let thir = thir.steal();
+            let mut printer = ThirPrinter::new(&thir);
+            printer.print();
+            printer.into_buffer()
+        }
+        Err(_) => "error".into(),
+    }
+}
+
+pub(crate) fn thir_flat(tcx: TyCtxt<'_>, owner_def: ty::WithOptConstParam<LocalDefId>) -> String {
+    match super::cx::thir_body(tcx, owner_def) {
+        Ok((thir, _)) => format!("{:#?}", thir.steal()),
+        Err(_) => "error".into(),
     }
 }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/107451 increased the compilation time of `rustc_middle` by 10% = 3s.

As https://github.com/rust-lang/rust/pull/107006 adds quite a lot of code to rustc_middle, I suspect it to be the cause.

This PR moves the THIR printing code to `rustc_mir_build`, where the query provider lives, in order to benefit from higher parallelism when compiling rustc.