### PR TITLE
Don't trigger error for ReError when other region is empty.

### DIFF
--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -438,7 +438,11 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
             }
             (VarValue::Value(a), VarValue::Empty(_)) => {
                 match *a {
-                    ReLateBound(..) | ReErased | ReError(_) => {
+                    // this is always on an error path,
+                    // so it doesn't really matter if it's shorter or longer than an empty region
+                    ReError(_) => false,
+
+                    ReLateBound(..) | ReErased => {
                         bug!("cannot relate region: {:?}", a);
                     }
 
@@ -467,7 +471,11 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
             }
             (VarValue::Empty(a_ui), VarValue::Value(b)) => {
                 match *b {
-                    ReLateBound(..) | ReErased | ReError(_) => {
+                    // this is always on an error path,
+                    // so it doesn't really matter if it's shorter or longer than an empty region
+                    ReError(_) => false,
+
+                    ReLateBound(..) | ReErased => {
                         bug!("cannot relate region: {:?}", b);
                     }
 

--- a/tests/ui/lifetimes/issue-107988.rs
+++ b/tests/ui/lifetimes/issue-107988.rs
@@ -1,0 +1,13 @@
+pub trait TraitEngine<'tcx>: 'tcx {}
+
+pub trait TraitEngineExt<'tcx> {
+    fn register_predicate_obligations(&mut self);
+}
+
+impl<T: ?Sized + TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
+  //~^ ERROR use of undeclared lifetime name `'tcx`
+  //~| ERROR use of undeclared lifetime name `'tcx`
+    fn register_predicate_obligations(&mut self) {}
+}
+
+fn main() {}

--- a/tests/ui/lifetimes/issue-107988.stderr
+++ b/tests/ui/lifetimes/issue-107988.stderr
@@ -1,0 +1,27 @@
+error[E0261]: use of undeclared lifetime name `'tcx`
+  --> $DIR/issue-107988.rs:7:52
+   |
+LL | impl<T: ?Sized + TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
+   |      -                                             ^^^^ undeclared lifetime
+   |      |
+   |      help: consider introducing lifetime `'tcx` here: `'tcx,`
+
+error[E0261]: use of undeclared lifetime name `'tcx`
+  --> $DIR/issue-107988.rs:7:30
+   |
+LL | impl<T: ?Sized + TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
+   |                              ^^^^ undeclared lifetime
+   |
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'tcx` lifetime
+   |
+LL | impl<T: ?Sized + for<'tcx> TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
+   |                  +++++++++
+help: consider introducing lifetime `'tcx` here
+   |
+LL | impl<'tcx, T: ?Sized + TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
+   |      +++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0261`.


### PR DESCRIPTION
Fixes [#107988](https://github.com/rust-lang/rust/issues/107988)