### PR TITLE
use `ObligationCtxt` not `QueryNormalizer` in rustdoc's `normalization` 

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -294,14 +294,10 @@ impl<'cx, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for QueryNormalizer<'cx, 'tcx> 
                 }?;
                 // We don't expect ambiguity.
                 if result.is_ambiguous() {
-                    // Rustdoc normalizes possibly not well-formed types, so only
-                    // treat this as a bug if we're not in rustdoc.
-                    if !tcx.sess.opts.actually_rustdoc {
-                        tcx.sess.delay_span_bug(
-                            DUMMY_SP,
-                            format!("unexpected ambiguity: {c_data:?} {result:?}"),
-                        );
-                    }
+                    tcx.sess.delay_span_bug(
+                        DUMMY_SP,
+                        format!("unexpected ambiguity: {c_data:?} {result:?}"),
+                    );
                     return Err(NoSolution);
                 }
                 let InferOk { value: result, obligations } = infcx

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1902,22 +1902,45 @@ fn normalize<'tcx>(
     }
 
     use crate::rustc_trait_selection::infer::TyCtxtInferExt;
-    use crate::rustc_trait_selection::traits::query::normalize::QueryNormalizeExt;
+    use crate::rustc_trait_selection::traits::ObligationCtxt;
     use rustc_middle::traits::ObligationCause;
 
-    // Try to normalize `<X as Y>::T` to a type
+    assert!(
+        !ty.has_non_region_infer(),
+        "`ty`: {ty:?} has pre existing infer vars before `InferCtxt` creation",
+    );
+
     let infcx = cx.tcx.infer_ctxt().build();
-    let normalized = infcx
-        .at(&ObligationCause::dummy(), cx.param_env)
-        .query_normalize(ty)
-        .map(|resolved| infcx.resolve_vars_if_possible(resolved.value));
-    match normalized {
-        Ok(normalized_value) => {
-            debug!("normalized {ty:?} to {normalized_value:?}");
-            Some(normalized_value)
+    // use an `ObligationCtxt` as it has a nice API for dealing with returned obligations from normalization
+    // and does not expect us to be inside of typeck. It also does not ICE when the projection could not be
+    // normalized like some other normalization routines (`QueryNormalizer`, `normalize_erasing_regions`, etc)
+    let ocx = ObligationCtxt::new(&infcx);
+
+    // Try to normalize `<X as Y>::T` to a type
+    let normalized = ocx.normalize(&ObligationCause::dummy(), cx.param_env, ty);
+    // We have to ensure that we deal with nested obligations from attempting to normalize as `ty`
+    // normalizing to `normalized` is only the case if the nested obligations hold.
+    let errs = ocx.select_all_or_error();
+    // Evaluating nested obligations might constrain infer vars that were created during normalization
+    // so we should resolve any infer vars in `normalized` to their new values.
+    let normalized = infcx.resolve_vars_if_possible(normalized);
+
+    match errs.as_slice() {
+        [] if normalized == ty => {
+            debug!("normalizing {ty:?} did not make progress");
+            None
         }
-        Err(err) => {
-            debug!("failed to normalize {ty:?}: {err:?}");
+        [] => {
+            debug!("normalized {ty:?} to {normalized:?}");
+
+            assert!(
+                !normalized.has_non_region_infer(),
+                "`normalized` has infer vars which would escape the `InferCtxt` they were created in"
+            );
+            Some(normalized)
+        }
+        errs => {
+            debug!("failed to normalize {ty:?}: {errs:?}");
             None
         }
     }

--- a/tests/rustdoc-ui/normalization_uses_ocx.rs
+++ b/tests/rustdoc-ui/normalization_uses_ocx.rs
@@ -1,0 +1,16 @@
+// check-pass
+// compile-flags: -Znormalize-docs
+// regression test for #112242
+
+trait MyTrait<'a> {
+    type MyItem;
+}
+struct Inner<Q>(Q);
+struct Outer<Q>(Inner<Q>);
+
+unsafe impl<'a, Q> Send for Inner<Q>
+where
+    Q: MyTrait<'a>,
+    <Q as MyTrait<'a>>::MyItem: Copy,
+{
+}


### PR DESCRIPTION
`QueryNormalizer` doesn't handle not-well-formed projections or ambiguity so should not be used by rustdoc as rustdoc happens on code that is not well formed. This PR replaces the usage of `QueryNormalizer` with `ObligationCtxt::normalize` which is designed to work on not-wf code while not being in typeck. This also removes two uses of `actually_rustdoc` from the compiler which seems good to me.

I am somewhat confused as to the "point" of `QueryNormalizer`, it intends to be "the main way of normalizing" in the future and yet ICEs when encountering not wf types or when normalization is ambiguous which seems very incompatible with its stated goal since that makes it only suitable for using after typeck?