### PR TITLE
Remove @nagisa from review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -482,7 +482,6 @@ compiler-team = [
     "@davidtwco",
     "@oli-obk",
     "@lcnr",
-    "@nagisa",
     "@wesleywiser",
     "@michaelwoerister",
 ]
@@ -552,7 +551,6 @@ mir = [
     "@oli-obk",
 ]
 mir-opt = [
-    "@nagisa",
     "@oli-obk",
     "@wesleywiser",
 ]


### PR DESCRIPTION
I have been reviewing PRs for a long while during weekends, however recently I’ve been having trouble commiting to that as well. Every weekend I’ve been spending working on a house.

I may return myself to the rotation in a couple of months. I may also just start ninja'ing up some PRs from the PR list whenever I find some time for reviews again, without putting myself back into the rotation, in acknowledgement that me being able to review every weekend or every second weekend is not a great experience for the contributors waiting on reviews from me.