### PR TITLE
Derive `PartialOrd` by calling tuple's version

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2695,6 +2695,8 @@ pub enum VariantData {
     /// Struct variant.
     ///
     /// E.g., `Bar { .. }` as in `enum Foo { Bar { .. } }`.
+    ///
+    /// The `bool` is `true` if recovery was used while parsing it.
     Struct(ThinVec<FieldDef>, bool),
     /// Tuple variant.
     ///

--- a/tests/ui/deriving/deriving-all-codegen.rs
+++ b/tests/ui/deriving/deriving-all-codegen.rs
@@ -163,3 +163,6 @@ pub union Union {
     pub u: u32,
     pub i: i32,
 }
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub struct TooLongForTuple(u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8);

--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -1444,3 +1444,185 @@ impl ::core::clone::Clone for Union {
 }
 #[automatically_derived]
 impl ::core::marker::Copy for Union { }
+
+pub struct TooLongForTuple(u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8,
+    u8, u8);
+#[automatically_derived]
+impl ::core::marker::StructuralPartialEq for TooLongForTuple { }
+#[automatically_derived]
+impl ::core::cmp::PartialEq for TooLongForTuple {
+    #[inline]
+    fn eq(&self, other: &TooLongForTuple) -> bool {
+        self.0 == other.0 && self.1 == other.1 && self.2 == other.2 &&
+                                                        self.3 == other.3 && self.4 == other.4 && self.5 == other.5
+                                            && self.6 == other.6 && self.7 == other.7 &&
+                                    self.8 == other.8 && self.9 == other.9 &&
+                            self.10 == other.10 && self.11 == other.11 &&
+                    self.12 == other.12 && self.13 == other.13 &&
+            self.14 == other.14
+    }
+}
+#[automatically_derived]
+impl ::core::marker::StructuralEq for TooLongForTuple { }
+#[automatically_derived]
+impl ::core::cmp::Eq for TooLongForTuple {
+    #[inline]
+    #[doc(hidden)]
+    #[no_coverage]
+    fn assert_receiver_is_total_eq(&self) -> () {
+        let _: ::core::cmp::AssertParamIsEq<u8>;
+    }
+}
+#[automatically_derived]
+impl ::core::cmp::PartialOrd for TooLongForTuple {
+    #[inline]
+    fn partial_cmp(&self, other: &TooLongForTuple)
+        -> ::core::option::Option<::core::cmp::Ordering> {
+        match ::core::cmp::PartialOrd::partial_cmp(&self.0, &other.0) {
+            ::core::option::Option::Some(::core::cmp::Ordering::Equal) =>
+                match ::core::cmp::PartialOrd::partial_cmp(&self.1, &other.1)
+                    {
+                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                        =>
+                        match ::core::cmp::PartialOrd::partial_cmp(&self.2,
+                                &other.2) {
+                            ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                                =>
+                                match ::core::cmp::PartialOrd::partial_cmp(&self.3,
+                                        &other.3) {
+                                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                                        =>
+                                        match ::core::cmp::PartialOrd::partial_cmp(&self.4,
+                                                &other.4) {
+                                            ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                                                =>
+                                                match ::core::cmp::PartialOrd::partial_cmp(&self.5,
+                                                        &other.5) {
+                                                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                                                        =>
+                                                        match ::core::cmp::PartialOrd::partial_cmp(&self.6,
+                                                                &other.6) {
+                                                            ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                                                                =>
+                                                                match ::core::cmp::PartialOrd::partial_cmp(&self.7,
+                                                                        &other.7) {
+                                                                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                                                                        =>
+                                                                        match ::core::cmp::PartialOrd::partial_cmp(&self.8,
+                                                                                &other.8) {
+                                                                            ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                                                                                =>
+                                                                                match ::core::cmp::PartialOrd::partial_cmp(&self.9,
+                                                                                        &other.9) {
+                                                                                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                                                                                        =>
+                                                                                        match ::core::cmp::PartialOrd::partial_cmp(&self.10,
+                                                                                                &other.10) {
+                                                                                            ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                                                                                                =>
+                                                                                                match ::core::cmp::PartialOrd::partial_cmp(&self.11,
+                                                                                                        &other.11) {
+                                                                                                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                                                                                                        =>
+                                                                                                        match ::core::cmp::PartialOrd::partial_cmp(&self.12,
+                                                                                                                &other.12) {
+                                                                                                            ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                                                                                                                =>
+                                                                                                                match ::core::cmp::PartialOrd::partial_cmp(&self.13,
+                                                                                                                        &other.13) {
+                                                                                                                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                                                                                                                        =>
+                                                                                                                        ::core::cmp::PartialOrd::partial_cmp(&self.14, &other.14),
+                                                                                                                    cmp => cmp,
+                                                                                                                },
+                                                                                                            cmp => cmp,
+                                                                                                        },
+                                                                                                    cmp => cmp,
+                                                                                                },
+                                                                                            cmp => cmp,
+                                                                                        },
+                                                                                    cmp => cmp,
+                                                                                },
+                                                                            cmp => cmp,
+                                                                        },
+                                                                    cmp => cmp,
+                                                                },
+                                                            cmp => cmp,
+                                                        },
+                                                    cmp => cmp,
+                                                },
+                                            cmp => cmp,
+                                        },
+                                    cmp => cmp,
+                                },
+                            cmp => cmp,
+                        },
+                    cmp => cmp,
+                },
+            cmp => cmp,
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::cmp::Ord for TooLongForTuple {
+    #[inline]
+    fn cmp(&self, other: &TooLongForTuple) -> ::core::cmp::Ordering {
+        match ::core::cmp::Ord::cmp(&self.0, &other.0) {
+            ::core::cmp::Ordering::Equal =>
+                match ::core::cmp::Ord::cmp(&self.1, &other.1) {
+                    ::core::cmp::Ordering::Equal =>
+                        match ::core::cmp::Ord::cmp(&self.2, &other.2) {
+                            ::core::cmp::Ordering::Equal =>
+                                match ::core::cmp::Ord::cmp(&self.3, &other.3) {
+                                    ::core::cmp::Ordering::Equal =>
+                                        match ::core::cmp::Ord::cmp(&self.4, &other.4) {
+                                            ::core::cmp::Ordering::Equal =>
+                                                match ::core::cmp::Ord::cmp(&self.5, &other.5) {
+                                                    ::core::cmp::Ordering::Equal =>
+                                                        match ::core::cmp::Ord::cmp(&self.6, &other.6) {
+                                                            ::core::cmp::Ordering::Equal =>
+                                                                match ::core::cmp::Ord::cmp(&self.7, &other.7) {
+                                                                    ::core::cmp::Ordering::Equal =>
+                                                                        match ::core::cmp::Ord::cmp(&self.8, &other.8) {
+                                                                            ::core::cmp::Ordering::Equal =>
+                                                                                match ::core::cmp::Ord::cmp(&self.9, &other.9) {
+                                                                                    ::core::cmp::Ordering::Equal =>
+                                                                                        match ::core::cmp::Ord::cmp(&self.10, &other.10) {
+                                                                                            ::core::cmp::Ordering::Equal =>
+                                                                                                match ::core::cmp::Ord::cmp(&self.11, &other.11) {
+                                                                                                    ::core::cmp::Ordering::Equal =>
+                                                                                                        match ::core::cmp::Ord::cmp(&self.12, &other.12) {
+                                                                                                            ::core::cmp::Ordering::Equal =>
+                                                                                                                match ::core::cmp::Ord::cmp(&self.13, &other.13) {
+                                                                                                                    ::core::cmp::Ordering::Equal =>
+                                                                                                                        ::core::cmp::Ord::cmp(&self.14, &other.14),
+                                                                                                                    cmp => cmp,
+                                                                                                                },
+                                                                                                            cmp => cmp,
+                                                                                                        },
+                                                                                                    cmp => cmp,
+                                                                                                },
+                                                                                            cmp => cmp,
+                                                                                        },
+                                                                                    cmp => cmp,
+                                                                                },
+                                                                            cmp => cmp,
+                                                                        },
+                                                                    cmp => cmp,
+                                                                },
+                                                            cmp => cmp,
+                                                        },
+                                                    cmp => cmp,
+                                                },
+                                            cmp => cmp,
+                                        },
+                                    cmp => cmp,
+                                },
+                            cmp => cmp,
+                        },
+                    cmp => cmp,
+                },
+            cmp => cmp,
+        }
+    }
+}

--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -340,47 +340,10 @@ impl ::core::cmp::PartialOrd for Big {
     #[inline]
     fn partial_cmp(&self, other: &Big)
         -> ::core::option::Option<::core::cmp::Ordering> {
-        match ::core::cmp::PartialOrd::partial_cmp(&self.b1, &other.b1) {
-            ::core::option::Option::Some(::core::cmp::Ordering::Equal) =>
-                match ::core::cmp::PartialOrd::partial_cmp(&self.b2,
-                        &other.b2) {
-                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
-                        =>
-                        match ::core::cmp::PartialOrd::partial_cmp(&self.b3,
-                                &other.b3) {
-                            ::core::option::Option::Some(::core::cmp::Ordering::Equal)
-                                =>
-                                match ::core::cmp::PartialOrd::partial_cmp(&self.b4,
-                                        &other.b4) {
-                                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
-                                        =>
-                                        match ::core::cmp::PartialOrd::partial_cmp(&self.b5,
-                                                &other.b5) {
-                                            ::core::option::Option::Some(::core::cmp::Ordering::Equal)
-                                                =>
-                                                match ::core::cmp::PartialOrd::partial_cmp(&self.b6,
-                                                        &other.b6) {
-                                                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
-                                                        =>
-                                                        match ::core::cmp::PartialOrd::partial_cmp(&self.b7,
-                                                                &other.b7) {
-                                                            ::core::option::Option::Some(::core::cmp::Ordering::Equal)
-                                                                =>
-                                                                ::core::cmp::PartialOrd::partial_cmp(&self.b8, &other.b8),
-                                                            cmp => cmp,
-                                                        },
-                                                    cmp => cmp,
-                                                },
-                                            cmp => cmp,
-                                        },
-                                    cmp => cmp,
-                                },
-                            cmp => cmp,
-                        },
-                    cmp => cmp,
-                },
-            cmp => cmp,
-        }
+        ::core::cmp::PartialOrd::partial_cmp(&(&self.b1, &self.b2, &self.b3,
+                    &self.b4, &self.b5, &self.b6, &self.b7, &self.b8),
+            &(&other.b1, &other.b2, &other.b3, &other.b4, &other.b5,
+                    &other.b6, &other.b7, &other.b8))
     }
 }
 #[automatically_derived]
@@ -622,16 +585,8 @@ impl<T: ::core::cmp::PartialOrd + Trait, U: ::core::cmp::PartialOrd>
     #[inline]
     fn partial_cmp(&self, other: &Generic<T, U>)
         -> ::core::option::Option<::core::cmp::Ordering> {
-        match ::core::cmp::PartialOrd::partial_cmp(&self.t, &other.t) {
-            ::core::option::Option::Some(::core::cmp::Ordering::Equal) =>
-                match ::core::cmp::PartialOrd::partial_cmp(&self.ta,
-                        &other.ta) {
-                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
-                        => ::core::cmp::PartialOrd::partial_cmp(&self.u, &other.u),
-                    cmp => cmp,
-                },
-            cmp => cmp,
-        }
+        ::core::cmp::PartialOrd::partial_cmp(&(&self.t, &self.ta, &self.u),
+            &(&other.t, &other.ta, &other.u))
     }
 }
 #[automatically_derived]
@@ -745,19 +700,8 @@ impl<T: ::core::cmp::PartialOrd + ::core::marker::Copy + Trait,
     #[inline]
     fn partial_cmp(&self, other: &PackedGeneric<T, U>)
         -> ::core::option::Option<::core::cmp::Ordering> {
-        match ::core::cmp::PartialOrd::partial_cmp(&{ self.0 }, &{ other.0 })
-            {
-            ::core::option::Option::Some(::core::cmp::Ordering::Equal) =>
-                match ::core::cmp::PartialOrd::partial_cmp(&{ self.1 },
-                        &{ other.1 }) {
-                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
-                        =>
-                        ::core::cmp::PartialOrd::partial_cmp(&{ self.2 },
-                            &{ other.2 }),
-                    cmp => cmp,
-                },
-            cmp => cmp,
-        }
+        ::core::cmp::PartialOrd::partial_cmp(&(&{ self.0 }, &{ self.1 },
+                    &{ self.2 }), &(&{ other.0 }, &{ other.1 }, &{ other.2 }))
     }
 }
 #[automatically_derived]


### PR DESCRIPTION
Similar idea to #95637 & #98190 -- matching on `::core::option::Option::Some(::core::cmp::Ordering::Equal)` for every field means a ton of output, so maybe we can do better by emitting something shorter that has the same behaviour.

Unlike `Debug`, this doesn't use `dyn` -- it makes a tuple, so preserves the static dispatch of the previous version.

r? @ghost 