### PR TITLE
Restrict `#[rustc_box]` to `Box::new` calls

### DIFF
--- a/compiler/rustc_ast_lowering/locales/en-US.ftl
+++ b/compiler/rustc_ast_lowering/locales/en-US.ftl
@@ -22,9 +22,6 @@ ast_lowering_misplaced_impl_trait =
 ast_lowering_misplaced_assoc_ty_binding =
     associated type bounds are only allowed in where clauses and function signatures, not in {$position}
 
-ast_lowering_rustc_box_attribute_error =
-    #[rustc_box] requires precisely one argument and no other attributes are allowed
-
 ast_lowering_underscore_expr_lhs_assign =
     in expressions, `_` can only be used on the left-hand side of an assignment
     .label = `_` not allowed here

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -88,13 +88,6 @@ pub struct MisplacedAssocTyBinding<'a> {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering_rustc_box_attribute_error)]
-pub struct RustcBoxAttributeError {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_underscore_expr_lhs_assign)]
 pub struct UnderscoreExprLhsAssign {
     #[primary_span]

--- a/compiler/rustc_mir_build/locales/en-US.ftl
+++ b/compiler/rustc_mir_build/locales/en-US.ftl
@@ -374,3 +374,9 @@ mir_build_suggest_let_else = you might want to use `let else` to handle the {$co
     } matched
 
 mir_build_suggest_attempted_int_lit = alternatively, you could prepend the pattern with an underscore to define a new named variable; identifiers cannot begin with digits
+
+
+mir_build_rustc_box_attribute_error = `#[rustc_box]` attribute used incorrectly
+    .attributes = no other attributes may be applied
+    .not_box = `#[rustc_box]` may only be applied to a `Box::new()` call
+    .missing_box = `#[rustc_box]` requires the `owned_box` lang item

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -888,3 +888,22 @@ pub enum MiscPatternSuggestion {
         start_span: Span,
     },
 }
+
+#[derive(Diagnostic)]
+#[diag(mir_build_rustc_box_attribute_error)]
+pub struct RustcBoxAttributeError {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub reason: RustcBoxAttrReason,
+}
+
+#[derive(Subdiagnostic)]
+pub enum RustcBoxAttrReason {
+    #[note(mir_build_attributes)]
+    Attributes,
+    #[note(mir_build_not_box)]
+    NotBoxNew,
+    #[note(mir_build_missing_box)]
+    MissingBox,
+}

--- a/src/tools/clippy/clippy_utils/src/higher.rs
+++ b/src/tools/clippy/clippy_utils/src/higher.rs
@@ -287,15 +287,12 @@ impl<'a> VecArgs<'a> {
                     Some(VecArgs::Repeat(&args[0], &args[1]))
                 } else if match_def_path(cx, fun_def_id, &paths::SLICE_INTO_VEC) && args.len() == 1 {
                     // `vec![a, b, c]` case
-                    if_chain! {
-                        if let hir::ExprKind::Box(boxed) = args[0].kind;
-                        if let hir::ExprKind::Array(args) = boxed.kind;
-                        then {
-                            return Some(VecArgs::Vec(args));
-                        }
+                    if let hir::ExprKind::Call(_, [arg]) = &args[0].kind
+                        && let hir::ExprKind::Array(args) = arg.kind {
+                        Some(VecArgs::Vec(args))
+                    } else {
+                        None
                     }
-
-                    None
                 } else if match_def_path(cx, fun_def_id, &paths::VEC_NEW) && args.is_empty() {
                     Some(VecArgs::Vec(&[]))
                 } else {

--- a/tests/ui/attributes/rustc-box.rs
+++ b/tests/ui/attributes/rustc-box.rs
@@ -1,0 +1,18 @@
+#![feature(rustc_attrs, stmt_expr_attributes)]
+
+fn foo(_: u32, _: u32) {}
+fn bar(_: u32) {}
+
+fn main() {
+    #[rustc_box]
+    Box::new(1); // OK
+    #[rustc_box]
+    Box::pin(1); //~ ERROR `#[rustc_box]` attribute used incorrectly
+    #[rustc_box]
+    foo(1, 1); //~ ERROR `#[rustc_box]` attribute used incorrectly
+    #[rustc_box]
+    bar(1); //~ ERROR `#[rustc_box]` attribute used incorrectly
+    #[rustc_box] //~ ERROR `#[rustc_box]` attribute used incorrectly
+    #[rustfmt::skip]
+    Box::new(1);
+}

--- a/tests/ui/attributes/rustc-box.stderr
+++ b/tests/ui/attributes/rustc-box.stderr
@@ -1,0 +1,34 @@
+error: `#[rustc_box]` attribute used incorrectly
+  --> $DIR/rustc-box.rs:10:5
+   |
+LL |     Box::pin(1);
+   |     ^^^^^^^^^^^
+   |
+   = note: `#[rustc_box]` may only be applied to a `Box::new()` call
+
+error: `#[rustc_box]` attribute used incorrectly
+  --> $DIR/rustc-box.rs:12:5
+   |
+LL |     foo(1, 1);
+   |     ^^^^^^^^^
+   |
+   = note: `#[rustc_box]` may only be applied to a `Box::new()` call
+
+error: `#[rustc_box]` attribute used incorrectly
+  --> $DIR/rustc-box.rs:14:5
+   |
+LL |     bar(1);
+   |     ^^^^^^
+   |
+   = note: `#[rustc_box]` may only be applied to a `Box::new()` call
+
+error: `#[rustc_box]` attribute used incorrectly
+  --> $DIR/rustc-box.rs:15:5
+   |
+LL |     #[rustc_box]
+   |     ^^^^^^^^^^^^
+   |
+   = note: no other attributes may be applied
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Currently, `#[rustc_box]` can be applied to any call expression with a single argument. This PR only allows it to be applied to calls to `Box::new`