### PR TITLE
Use align attributes on LLVM function arguments

### DIFF
--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -497,7 +497,7 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
         attrs.pointee_size = layout.size;
         // FIXME(eddyb) We should be doing this, but at least on
         // i686-pc-windows-msvc, it results in wrong stack offsets.
-        // attrs.pointee_align = Some(layout.align.abi);
+        attrs.pointee_align = Some(layout.align.abi);
 
         let extra_attrs = layout.is_unsized().then_some(ArgAttributes::new());
 


### PR DESCRIPTION
These attributes are helpful for LLVM in removing local copies of arguments. There's a FIXME for i686-pc-windows-msvc, but I don't know if that's still an issue.

r? @eddyb 