### PR TITLE
Commit some new solver tests

### DIFF
--- a/tests/ui/traits/new-solver/try-example.rs
+++ b/tests/ui/traits/new-solver/try-example.rs
@@ -1,0 +1,28 @@
+// check-pass
+// compile-flags: -Ztrait-solver=next
+
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let x: i32 = parse()?;
+    Ok(())
+}
+
+trait Parse {}
+
+impl Parse for i32 {}
+
+#[derive(Debug)]
+struct ParseError;
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ParseError")
+    }
+}
+
+impl Error for ParseError {}
+
+fn parse<T: Parse>() -> Result<T, ParseError> {
+    todo!()
+}

--- a/tests/ui/typeck/lazy-norm/equating-projection-cyclically.rs
+++ b/tests/ui/typeck/lazy-norm/equating-projection-cyclically.rs
@@ -1,0 +1,24 @@
+// compile-flags: -Ztrait-solver=next
+// known-bug: unknown
+
+trait Test {
+    type Assoc;
+}
+
+fn transform<T: Test>(x: T) -> T::Assoc {
+    todo!()
+}
+
+impl Test for i32 {
+    type Assoc = i32;
+}
+
+impl Test for String {
+    type Assoc = String;
+}
+
+fn main() {
+    let mut x = Default::default();
+    x = transform(x);
+    x = 1i32;
+}

--- a/tests/ui/typeck/lazy-norm/equating-projection-cyclically.stderr
+++ b/tests/ui/typeck/lazy-norm/equating-projection-cyclically.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/equating-projection-cyclically.rs:22:19
+   |
+LL |     x = transform(x);
+   |                   ^ expected inferred type, found associated type
+   |
+   = note:         expected type `_`
+           found associated type `<_ as Test>::Assoc`
+   = help: consider constraining the associated type `<_ as Test>::Assoc` to `_`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Lazy norm is hard.

`<?0 as Trait>::Assoc = ?0` ... probably should emit an alias-eq goal, but currently we don't do that. Right now it fails with a cyclical ty error.

Also committed a check-pass test that broken when I attempted to fix this (unsuccessfully).

r? types