### PR TITLE
rustdoc: Show that repeated expression arrays can be made with constant values

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -589,7 +589,7 @@ mod prim_pointer {}
 /// * A list with each element, i.e., `[x, y, z]`.
 /// * A repeat expression `[expr; N]` where `N` is how many times to repeat `expr` in the array. `expr` must either be:
 ///
-///   * A value of type `Copy`
+///   * A value of a type implementing the [`Copy`] trait
 ///   * A `const` value
 ///
 /// Note that `[expr; 0]` is allowed, and produces an empty array.

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -587,8 +587,10 @@ mod prim_pointer {}
 /// There are two syntactic forms for creating an array:
 ///
 /// * A list with each element, i.e., `[x, y, z]`.
-/// * A repeat expression `[x; N]`, which produces an array with `N` copies of `x`.
-///   The type of `x` must be [`Copy`].
+/// * A repeat expression `[expr; N]` where `N` is how many times to repeat `expr` in the array. `expr` must either be:
+///
+///   * A value of type `Copy`
+///   * A `const` value
 ///
 /// Note that `[expr; 0]` is allowed, and produces an empty array.
 /// This will still evaluate `expr`, however, and immediately drop the resulting value, so

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -589,7 +589,7 @@ mod prim_pointer {}
 /// * A list with each element, i.e., `[x, y, z]`.
 /// * A repeat expression `[expr; N]` where `N` is how many times to repeat `expr` in the array. `expr` must either be:
 ///
-///   * A value of type `Copy`
+///   * A value of a type implementing the [`Copy`] trait
 ///   * A `const` value
 ///
 /// Note that `[expr; 0]` is allowed, and produces an empty array.

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -587,8 +587,10 @@ mod prim_pointer {}
 /// There are two syntactic forms for creating an array:
 ///
 /// * A list with each element, i.e., `[x, y, z]`.
-/// * A repeat expression `[x; N]`, which produces an array with `N` copies of `x`.
-///   The type of `x` must be [`Copy`].
+/// * A repeat expression `[expr; N]` where `N` is how many times to repeat `expr` in the array. `expr` must either be:
+///
+///   * A value of type `Copy`
+///   * A `const` value
 ///
 /// Note that `[expr; 0]` is allowed, and produces an empty array.
 /// This will still evaluate `expr`, however, and immediately drop the resulting value, so


### PR DESCRIPTION
The [rust reference](https://doc.rust-lang.org/reference/expressions/array-expr.html) currently says that repeated values for arrays can be constant or `Copy`
> repeat operand is [Copy](https://doc.rust-lang.org/reference/special-types-and-traits.html#copy) or that it must be a [path](https://doc.rust-lang.org/reference/expressions/path-expr.html) to a constant item

This updates the rust documentation on primitive arrays to reflect what the rust reference says (and also compiler suggestions if you do not use a `const` item)