### PR TITLE
diagnostics: avoid querying `associated_item` in the resolver

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -189,7 +189,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         }
 
         let container = match parent.kind {
-            ModuleKind::Def(kind, _, _) => self.tcx.def_kind_descr(kind, parent.def_id()),
+            // Avoid using TyCtxt::def_kind_descr in the resolver, because it
+            // indirectly *calls* the resolver, and would cause a query cycle.
+            ModuleKind::Def(kind, _, _) => kind.descr(parent.def_id()),
             ModuleKind::Block => "block",
         };
 
@@ -1804,7 +1806,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         found("module")
                     } else {
                         match binding.res() {
-                            Res::Def(kind, id) => found(self.tcx.def_kind_descr(kind, id)),
+                            // Avoid using TyCtxt::def_kind_descr in the resolver, because it
+                            // indirectly *calls* the resolver, and would cause a query cycle.
+                            Res::Def(kind, id) => found(kind.descr(id)),
                             _ => found(ns_to_try.descr()),
                         }
                     }

--- a/tests/ui/resolve/issue-108529.rs
+++ b/tests/ui/resolve/issue-108529.rs
@@ -1,0 +1,8 @@
+#![allow(nonstandard_style)]
+use f::f::f; //~ ERROR
+
+trait f {
+    extern "C" fn f();
+}
+
+fn main() {}

--- a/tests/ui/resolve/issue-108529.stderr
+++ b/tests/ui/resolve/issue-108529.stderr
@@ -1,0 +1,9 @@
+error[E0432]: unresolved import `f::f`
+  --> $DIR/issue-108529.rs:2:8
+   |
+LL | use f::f::f;
+   |        ^ expected type, found associated function `f` in `f`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0432`.


### PR DESCRIPTION
Fixes #108529

CC #108324