### PR TITLE
Force parentheses around `match` expression in binary expression

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -244,6 +244,10 @@ impl<'a> State<'a> {
             (&ast::ExprKind::Let { .. }, _) if !parser::needs_par_as_let_scrutinee(prec) => {
                 parser::PREC_FORCE_PAREN
             }
+            // For a binary expression like `(match () { _ => a }) OP b`, the parens are required
+            // otherwise the parser would interpret `match () { _ => a }` as a statement,
+            // with the remaining `OP b` not making sense. So we force parens.
+            (&ast::ExprKind::Match(..), _) => parser::PREC_FORCE_PAREN,
             _ => left_prec,
         };
 

--- a/tests/ui/macros/issue-98790.rs
+++ b/tests/ui/macros/issue-98790.rs
@@ -1,0 +1,24 @@
+// run-pass
+
+macro_rules! stringify_item {
+    ($item:item) => {
+        stringify!($item)
+    };
+}
+
+macro_rules! repro {
+    ($expr:expr) => {
+        stringify_item! {
+            pub fn repro() -> bool {
+                $expr
+            }
+        }
+    };
+}
+
+fn main() {
+    assert_eq!(
+        repro!(match () { () => true } | true),
+        "pub fn repro() -> bool { (match () { () => true, }) | true }"
+    );
+}

--- a/tests/ui/macros/rfc-2011-nicer-assert-messages/all-expr-kinds.rs
+++ b/tests/ui/macros/rfc-2011-nicer-assert-messages/all-expr-kinds.rs
@@ -164,7 +164,7 @@ fn main() {
     // mac call
 
     // match
-    [ match elem { _ => elem } == 3 ] => "Assertion failed: match elem { _ => elem, } == 3"
+    [ match elem { _ => elem } == 3 ] => "Assertion failed: (match elem { _ => elem, }) == 3"
 
     // ret
     [ (|| { return elem; })() == 3 ] => "Assertion failed: (|| { return elem; })() == 3"


### PR DESCRIPTION
This attempts to solve https://github.com/rust-lang/rust/issues/98790.