### PR TITLE
Remove issue number for `link_cfg`

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -160,6 +160,8 @@ declare_features! (
     (active, intrinsics, "1.0.0", None, None),
     /// Allows using `#[lang = ".."]` attribute for linking items to special compiler logic.
     (active, lang_items, "1.0.0", None, None),
+    /// Allows `#[link(..., cfg(..))]`; perma-unstable per #37406
+    (active, link_cfg, "1.14.0", None, None),
     /// Allows the `multiple_supertrait_upcastable` lint.
     (active, multiple_supertrait_upcastable, "CURRENT_RUSTC_VERSION", None, None),
     /// Allows using `#[omit_gdb_pretty_printer_section]`.
@@ -438,8 +440,6 @@ declare_features! (
     (active, large_assignments, "1.52.0", Some(83518), None),
     /// Allows `if/while p && let q = r && ...` chains.
     (active, let_chains, "1.37.0", Some(53667), None),
-    /// Allows `#[link(..., cfg(..))]`.
-    (active, link_cfg, "1.14.0", Some(37406), None),
     /// Allows using `reason` in lint attributes and the `#[expect(lint)]` lint check.
     (active, lint_reasons, "1.31.0", Some(54503), None),
     /// Give access to additional metadata about declarative macro meta-variables.

--- a/tests/ui/feature-gates/feature-gate-link_cfg.stderr
+++ b/tests/ui/feature-gates/feature-gate-link_cfg.stderr
@@ -4,7 +4,6 @@ error[E0658]: link cfg is unstable
 LL | #[link(name = "foo", cfg(foo))]
    |                      ^^^^^^^^
    |
-   = note: see issue #37406 <https://github.com/rust-lang/rust/issues/37406> for more information
    = help: add `#![feature(link_cfg)]` to the crate attributes to enable
 
 error: aborting due to previous error


### PR DESCRIPTION
Fixes #72059

Per #37406 and its [unstable book entry](https://doc.rust-lang.org/beta/unstable-book/language-features/link-cfg.html), this is an internal feature, and therefore perma-unstable and not being tracked