### PR TITLE
Descriptive error when users try to combine RPITIT/AFIT with specialization

### DIFF
--- a/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.stderr
+++ b/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.stderr
@@ -7,20 +7,13 @@ LL | #![feature(async_fn_in_trait)]
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0053]: method `foo` has an incompatible type for trait
-  --> $DIR/dont-project-to-specializable-projection.rs:14:35
+error: async associated function in trait cannot be specialized
+  --> $DIR/dont-project-to-specializable-projection.rs:14:5
    |
 LL |     default async fn foo(_: T) -> &'static str {
-   |                                   ^^^^^^^^^^^^ expected associated type, found future
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: type in trait
-  --> $DIR/dont-project-to-specializable-projection.rs:10:27
-   |
-LL |     async fn foo(_: T) -> &'static str;
-   |                           ^^^^^^^^^^^^
-   = note: expected signature `fn(_) -> impl Future<Output = &'static str>`
-              found signature `fn(_) -> impl Future<Output = &'static str>`
+   = note: specialization behaves in inconsistent and surprising ways with `#![feature(async_fn_in_trait)]`, and for now is disallowed
 
 error: aborting due to previous error; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0053`.

--- a/tests/ui/impl-trait/in-trait/specialization-broken.rs
+++ b/tests/ui/impl-trait/in-trait/specialization-broken.rs
@@ -15,6 +15,7 @@ where
 {
     fn bar(&self) -> U {
         //~^ ERROR method `bar` has an incompatible type for trait
+        //~| ERROR method with return-position `impl Trait` in trait cannot be specialized
         *self
     }
 }

--- a/tests/ui/impl-trait/in-trait/specialization-broken.stderr
+++ b/tests/ui/impl-trait/in-trait/specialization-broken.stderr
@@ -18,6 +18,14 @@ LL |     fn bar(&self) -> impl Sized;
    = note: expected signature `fn(&U) -> impl Sized`
               found signature `fn(&U) -> U`
 
-error: aborting due to previous error
+error: method with return-position `impl Trait` in trait cannot be specialized
+  --> $DIR/specialization-broken.rs:16:5
+   |
+LL |     fn bar(&self) -> U {
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: specialization behaves in inconsistent and surprising ways with `#![feature(return_position_impl_trait_in_trait)]`, and for now is disallowed
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0053`.


### PR DESCRIPTION
Previously we failed with some esoteric error like:

```
error[E0053]: method `foo` has an incompatible type for trait
  --> $DIR/dont-project-to-specializable-projection.rs:14:35
   |
LL |     default async fn foo(_: T) -> &'static str {
   |                                   ^^^^^^^^^^^^ expected associated type, found future
   |
note: type in trait
  --> $DIR/dont-project-to-specializable-projection.rs:10:27
   |
LL |     async fn foo(_: T) -> &'static str;
   |                           ^^^^^^^^^^^^
   = note: expected signature `fn(_) -> impl Future<Output = &'static str>`
              found signature `fn(_) -> impl Future<Output = &'static str>`
```

Now we error like:

```
error: async associated function in trait cannot be specialized
  --> $DIR/dont-project-to-specializable-projection.rs:14:5
   |
LL |     default async fn foo(_: T) -> &'static str {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: specialization behaves in inconsistent and surprising ways with `#![feature(async_fn_in_trait)]`, and for now is disallowed
```