### PR TITLE
Point error span at Some constructor argument when trait resolution fails

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
@@ -731,6 +731,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         // For example, `Some(5)` triggers this case.
                         self.tcx.parent(expr_ctor_def_id)
                     } else {
+                        // FIXME: Deal with type aliases?
                         return Err(expr);
                     }
                 }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
@@ -714,12 +714,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.tcx.parent(expr_ctor_def_id)
                 }
                 hir::def::DefKind::Ctor(hir::def::CtorOf::Variant, hir::def::CtorKind::Fn) => {
-                    if in_ty_adt.did() == self.tcx.parent(expr_ctor_def_id) {
-                        // The constructor definition refers to the variant:
-                        // For example, for a local type `MyEnum::MyVariant` triggers this case.
-                        expr_ctor_def_id
-                    } else if in_ty_adt.did() == self.tcx.parent(self.tcx.parent(expr_ctor_def_id))
-                    {
+                    // For a typical enum like
+                    // `enum Blah<T> { Variant(T) }`
+                    // we get the following resolutions:
+                    // - expr_ctor_def_id :::                                   DefId(0:29 ~ source_file[b442]::Blah::Variant::{constructor#0})
+                    // - self.tcx.parent(expr_ctor_def_id) :::                  DefId(0:28 ~ source_file[b442]::Blah::Variant)
+                    // - self.tcx.parent(self.tcx.parent(expr_ctor_def_id)) ::: DefId(0:26 ~ source_file[b442]::Blah)
+
+                    // Therefore, we need to go up once to obtain the variant and up twice to obtain the type.
+                    // Note that this pattern still holds even when we `use` a variant or `use` an enum type to rename it, or chain `use` expressions
+                    // together; this resolution is handled automatically by `qpath_res`.
+
+                    // FIXME: Deal with type aliases?
+                    if in_ty_adt.did() == self.tcx.parent(self.tcx.parent(expr_ctor_def_id)) {
                         // The constructor definition refers to the "constructor" of the variant:
                         // For example, `Some(5)` triggers this case.
                         self.tcx.parent(expr_ctor_def_id)

--- a/tests/ui/errors/trait-bound-error-spans/blame-trait-error.rs
+++ b/tests/ui/errors/trait-bound-error-spans/blame-trait-error.rs
@@ -18,11 +18,24 @@ struct Burrito<F> {
     filling: F,
 }
 
+impl<It: Iterator> T1 for Option<It> {}
+
+impl<'a, A: T1> T1 for &'a A {}
+
 fn want<V: T1>(_x: V) {}
 
 fn example<Q>(q: Q) {
     want(Wrapper { value: Burrito { filling: q } });
     //~^ ERROR the trait bound `Q: T3` is not satisfied [E0277]
+
+    want(Some(()));
+    //~^ ERROR `()` is not an iterator [E0277]
+
+    want(Some(q));
+    //~^ ERROR `Q` is not an iterator [E0277]
+
+    want(&Some(q));
+    //~^ ERROR `Q` is not an iterator [E0277]
 }
 
 fn main() {}

--- a/tests/ui/errors/trait-bound-error-spans/blame-trait-error.rs
+++ b/tests/ui/errors/trait-bound-error-spans/blame-trait-error.rs
@@ -24,6 +24,31 @@ impl<'a, A: T1> T1 for &'a A {}
 
 fn want<V: T1>(_x: V) {}
 
+enum ExampleTuple<T> {
+    ExampleTupleVariant(T),
+}
+use ExampleDifferentTupleVariantName as ExampleYetAnotherTupleVariantName;
+use ExampleTuple as ExampleOtherTuple;
+use ExampleTuple::ExampleTupleVariant as ExampleDifferentTupleVariantName;
+use ExampleTuple::*;
+
+impl<A> T1 for ExampleTuple<A> where A: T3 {}
+
+enum ExampleStruct<T> {
+    ExampleStructVariant { field: T },
+}
+use ExampleDifferentStructVariantName as ExampleYetAnotherStructVariantName;
+use ExampleStruct as ExampleOtherStruct;
+use ExampleStruct::ExampleStructVariant as ExampleDifferentStructVariantName;
+use ExampleStruct::*;
+
+impl<A> T1 for ExampleStruct<A> where A: T3 {}
+
+struct ExampleActuallyTupleStruct<T>(T, i32);
+use ExampleActuallyTupleStruct as ExampleActuallyTupleStructOther;
+
+impl<A> T1 for ExampleActuallyTupleStruct<A> where A: T3 {}
+
 fn example<Q>(q: Q) {
     want(Wrapper { value: Burrito { filling: q } });
     //~^ ERROR the trait bound `Q: T3` is not satisfied [E0277]
@@ -36,6 +61,42 @@ fn example<Q>(q: Q) {
 
     want(&Some(q));
     //~^ ERROR `Q` is not an iterator [E0277]
+
+    want(&ExampleTuple::ExampleTupleVariant(q));
+    //~^ ERROR `Q: T3` is not satisfied [E0277]
+
+    want(&ExampleTupleVariant(q));
+    //~^ ERROR `Q: T3` is not satisfied [E0277]
+
+    want(&ExampleOtherTuple::ExampleTupleVariant(q));
+    //~^ ERROR `Q: T3` is not satisfied [E0277]
+
+    want(&ExampleDifferentTupleVariantName(q));
+    //~^ ERROR `Q: T3` is not satisfied [E0277]
+
+    want(&ExampleYetAnotherTupleVariantName(q));
+    //~^ ERROR `Q: T3` is not satisfied [E0277]
+
+    want(&ExampleStruct::ExampleStructVariant { field: q });
+    //~^ ERROR `Q: T3` is not satisfied [E0277]
+
+    want(&ExampleStructVariant { field: q });
+    //~^ ERROR `Q: T3` is not satisfied [E0277]
+
+    want(&ExampleOtherStruct::ExampleStructVariant { field: q });
+    //~^ ERROR `Q: T3` is not satisfied [E0277]
+
+    want(&ExampleDifferentStructVariantName { field: q });
+    //~^ ERROR `Q: T3` is not satisfied [E0277]
+
+    want(&ExampleYetAnotherStructVariantName { field: q });
+    //~^ ERROR `Q: T3` is not satisfied [E0277]
+
+    want(&ExampleActuallyTupleStruct(q, 0));
+    //~^ ERROR `Q: T3` is not satisfied [E0277]
+
+    want(&ExampleActuallyTupleStructOther(q, 0));
+    //~^ ERROR `Q: T3` is not satisfied [E0277]
 }
 
 fn main() {}

--- a/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
+++ b/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Q: T3` is not satisfied
-  --> $DIR/blame-trait-error.rs:28:46
+  --> $DIR/blame-trait-error.rs:53:46
    |
 LL |     want(Wrapper { value: Burrito { filling: q } });
    |     ----                                     ^ the trait `T3` is not implemented for `Q`
@@ -31,7 +31,7 @@ LL | fn example<Q: T3>(q: Q) {
    |             ++++
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/blame-trait-error.rs:31:15
+  --> $DIR/blame-trait-error.rs:56:15
    |
 LL |     want(Some(()));
    |     ----      ^^ `()` is not an iterator
@@ -54,7 +54,7 @@ LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
 
 error[E0277]: `Q` is not an iterator
-  --> $DIR/blame-trait-error.rs:34:15
+  --> $DIR/blame-trait-error.rs:59:15
    |
 LL |     want(Some(q));
    |     ----      ^ `Q` is not an iterator
@@ -79,7 +79,7 @@ LL | fn example<Q: std::iter::Iterator>(q: Q) {
    |             +++++++++++++++++++++
 
 error[E0277]: `Q` is not an iterator
-  --> $DIR/blame-trait-error.rs:37:16
+  --> $DIR/blame-trait-error.rs:62:16
    |
 LL |     want(&Some(q));
    |     ----       ^ `Q` is not an iterator
@@ -105,6 +105,298 @@ help: consider restricting type parameter `Q`
 LL | fn example<Q: std::iter::Iterator>(q: Q) {
    |             +++++++++++++++++++++
 
-error: aborting due to 4 previous errors
+error[E0277]: the trait bound `Q: T3` is not satisfied
+  --> $DIR/blame-trait-error.rs:65:45
+   |
+LL |     want(&ExampleTuple::ExampleTupleVariant(q));
+   |     ----                                    ^ the trait `T3` is not implemented for `Q`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required for `ExampleTuple<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:35:9
+   |
+LL | impl<A> T1 for ExampleTuple<A> where A: T3 {}
+   |         ^^     ^^^^^^^^^^^^^^^          -- unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&ExampleTuple<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: T3>(q: Q) {
+   |             ++++
+
+error[E0277]: the trait bound `Q: T3` is not satisfied
+  --> $DIR/blame-trait-error.rs:68:31
+   |
+LL |     want(&ExampleTupleVariant(q));
+   |     ----                      ^ the trait `T3` is not implemented for `Q`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required for `ExampleTuple<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:35:9
+   |
+LL | impl<A> T1 for ExampleTuple<A> where A: T3 {}
+   |         ^^     ^^^^^^^^^^^^^^^          -- unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&ExampleTuple<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: T3>(q: Q) {
+   |             ++++
+
+error[E0277]: the trait bound `Q: T3` is not satisfied
+  --> $DIR/blame-trait-error.rs:71:50
+   |
+LL |     want(&ExampleOtherTuple::ExampleTupleVariant(q));
+   |     ----                                         ^ the trait `T3` is not implemented for `Q`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required for `ExampleTuple<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:35:9
+   |
+LL | impl<A> T1 for ExampleTuple<A> where A: T3 {}
+   |         ^^     ^^^^^^^^^^^^^^^          -- unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&ExampleTuple<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: T3>(q: Q) {
+   |             ++++
+
+error[E0277]: the trait bound `Q: T3` is not satisfied
+  --> $DIR/blame-trait-error.rs:74:44
+   |
+LL |     want(&ExampleDifferentTupleVariantName(q));
+   |     ----                                   ^ the trait `T3` is not implemented for `Q`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required for `ExampleTuple<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:35:9
+   |
+LL | impl<A> T1 for ExampleTuple<A> where A: T3 {}
+   |         ^^     ^^^^^^^^^^^^^^^          -- unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&ExampleTuple<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: T3>(q: Q) {
+   |             ++++
+
+error[E0277]: the trait bound `Q: T3` is not satisfied
+  --> $DIR/blame-trait-error.rs:77:45
+   |
+LL |     want(&ExampleYetAnotherTupleVariantName(q));
+   |     ----                                    ^ the trait `T3` is not implemented for `Q`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required for `ExampleTuple<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:35:9
+   |
+LL | impl<A> T1 for ExampleTuple<A> where A: T3 {}
+   |         ^^     ^^^^^^^^^^^^^^^          -- unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&ExampleTuple<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: T3>(q: Q) {
+   |             ++++
+
+error[E0277]: the trait bound `Q: T3` is not satisfied
+  --> $DIR/blame-trait-error.rs:80:56
+   |
+LL |     want(&ExampleStruct::ExampleStructVariant { field: q });
+   |     ---- required by a bound introduced by this call   ^ the trait `T3` is not implemented for `Q`
+   |
+note: required for `ExampleStruct<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:45:9
+   |
+LL | impl<A> T1 for ExampleStruct<A> where A: T3 {}
+   |         ^^     ^^^^^^^^^^^^^^^^          -- unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&ExampleStruct<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: T3>(q: Q) {
+   |             ++++
+
+error[E0277]: the trait bound `Q: T3` is not satisfied
+  --> $DIR/blame-trait-error.rs:83:41
+   |
+LL |     want(&ExampleStructVariant { field: q });
+   |     ----                                ^ the trait `T3` is not implemented for `Q`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required for `ExampleStruct<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:45:9
+   |
+LL | impl<A> T1 for ExampleStruct<A> where A: T3 {}
+   |         ^^     ^^^^^^^^^^^^^^^^          -- unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&ExampleStruct<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: T3>(q: Q) {
+   |             ++++
+
+error[E0277]: the trait bound `Q: T3` is not satisfied
+  --> $DIR/blame-trait-error.rs:86:61
+   |
+LL |     want(&ExampleOtherStruct::ExampleStructVariant { field: q });
+   |     ---- required by a bound introduced by this call        ^ the trait `T3` is not implemented for `Q`
+   |
+note: required for `ExampleStruct<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:45:9
+   |
+LL | impl<A> T1 for ExampleStruct<A> where A: T3 {}
+   |         ^^     ^^^^^^^^^^^^^^^^          -- unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&ExampleStruct<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: T3>(q: Q) {
+   |             ++++
+
+error[E0277]: the trait bound `Q: T3` is not satisfied
+  --> $DIR/blame-trait-error.rs:89:54
+   |
+LL |     want(&ExampleDifferentStructVariantName { field: q });
+   |     ---- required by a bound introduced by this call ^ the trait `T3` is not implemented for `Q`
+   |
+note: required for `ExampleStruct<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:45:9
+   |
+LL | impl<A> T1 for ExampleStruct<A> where A: T3 {}
+   |         ^^     ^^^^^^^^^^^^^^^^          -- unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&ExampleStruct<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: T3>(q: Q) {
+   |             ++++
+
+error[E0277]: the trait bound `Q: T3` is not satisfied
+  --> $DIR/blame-trait-error.rs:92:55
+   |
+LL |     want(&ExampleYetAnotherStructVariantName { field: q });
+   |     ---- required by a bound introduced by this call  ^ the trait `T3` is not implemented for `Q`
+   |
+note: required for `ExampleStruct<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:45:9
+   |
+LL | impl<A> T1 for ExampleStruct<A> where A: T3 {}
+   |         ^^     ^^^^^^^^^^^^^^^^          -- unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&ExampleStruct<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: T3>(q: Q) {
+   |             ++++
+
+error[E0277]: the trait bound `Q: T3` is not satisfied
+  --> $DIR/blame-trait-error.rs:95:38
+   |
+LL |     want(&ExampleActuallyTupleStruct(q, 0));
+   |     ----                             ^ the trait `T3` is not implemented for `Q`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required for `ExampleActuallyTupleStruct<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:50:9
+   |
+LL | impl<A> T1 for ExampleActuallyTupleStruct<A> where A: T3 {}
+   |         ^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          -- unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&ExampleActuallyTupleStruct<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: T3>(q: Q) {
+   |             ++++
+
+error[E0277]: the trait bound `Q: T3` is not satisfied
+  --> $DIR/blame-trait-error.rs:98:43
+   |
+LL |     want(&ExampleActuallyTupleStructOther(q, 0));
+   |     ----                                  ^ the trait `T3` is not implemented for `Q`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required for `ExampleActuallyTupleStruct<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:50:9
+   |
+LL | impl<A> T1 for ExampleActuallyTupleStruct<A> where A: T3 {}
+   |         ^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          -- unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&ExampleActuallyTupleStruct<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: T3>(q: Q) {
+   |             ++++
+
+error: aborting due to 16 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
+++ b/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Q: T3` is not satisfied
-  --> $DIR/blame-trait-error.rs:24:46
+  --> $DIR/blame-trait-error.rs:28:46
    |
 LL |     want(Wrapper { value: Burrito { filling: q } });
    |     ----                                     ^ the trait `T3` is not implemented for `Q`
@@ -21,7 +21,7 @@ LL | impl<B: T2> T1 for Wrapper<B> {}
    |         |
    |         unsatisfied trait bound introduced here
 note: required by a bound in `want`
-  --> $DIR/blame-trait-error.rs:21:12
+  --> $DIR/blame-trait-error.rs:25:12
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
@@ -30,6 +30,81 @@ help: consider restricting type parameter `Q`
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
 
-error: aborting due to previous error
+error[E0277]: `()` is not an iterator
+  --> $DIR/blame-trait-error.rs:31:15
+   |
+LL |     want(Some(()));
+   |     ----      ^^ `()` is not an iterator
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Iterator` is not implemented for `()`
+   = help: the trait `T1` is implemented for `Option<It>`
+note: required for `Option<()>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:21:20
+   |
+LL | impl<It: Iterator> T1 for Option<It> {}
+   |          --------  ^^     ^^^^^^^^^^
+   |          |
+   |          unsatisfied trait bound introduced here
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+
+error[E0277]: `Q` is not an iterator
+  --> $DIR/blame-trait-error.rs:34:15
+   |
+LL |     want(Some(q));
+   |     ----      ^ `Q` is not an iterator
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required for `Option<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:21:20
+   |
+LL | impl<It: Iterator> T1 for Option<It> {}
+   |          --------  ^^     ^^^^^^^^^^
+   |          |
+   |          unsatisfied trait bound introduced here
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: std::iter::Iterator>(q: Q) {
+   |             +++++++++++++++++++++
+
+error[E0277]: `Q` is not an iterator
+  --> $DIR/blame-trait-error.rs:37:16
+   |
+LL |     want(&Some(q));
+   |     ----       ^ `Q` is not an iterator
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required for `Option<Q>` to implement `T1`
+  --> $DIR/blame-trait-error.rs:21:20
+   |
+LL | impl<It: Iterator> T1 for Option<It> {}
+   |          --------  ^^     ^^^^^^^^^^
+   |          |
+   |          unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `&Option<Q>` to implement `T1`
+note: required by a bound in `want`
+  --> $DIR/blame-trait-error.rs:25:12
+   |
+LL | fn want<V: T1>(_x: V) {}
+   |            ^^ required by this bound in `want`
+help: consider restricting type parameter `Q`
+   |
+LL | fn example<Q: std::iter::Iterator>(q: Q) {
+   |             +++++++++++++++++++++
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/traits/blame-trait-error-spans-on-exprs.stderr
+++ b/tests/ui/errors/traits/blame-trait-error-spans-on-exprs.stderr
@@ -91,10 +91,10 @@ LL | fn example<Q: T3>(q: Q) {
    |             ++++
 
 error[E0277]: the trait bound `Q: T3` is not satisfied
-  --> $DIR/blame-trait-error-spans-on-exprs.rs:93:27
+  --> $DIR/blame-trait-error-spans-on-exprs.rs:93:53
    |
 LL |     want(Wrapper { value: TacoKinds::OneTaco(false, q) });
-   |     ----                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `T3` is not implemented for `Q`
+   |     ----                                            ^ the trait `T3` is not implemented for `Q`
    |     |
    |     required by a bound introduced by this call
    |


### PR DESCRIPTION
This is a follow up to #108254 and #106477 which extends error span refinement to handle a case which I mistakenly believed was handled in #106477. The goal is to refine the error span depicted below:

```rs
trait Fancy {}
impl <T> Fancy for Option<T> where T: Iterator {}

fn want_fancy<F>(f: F) where F: Fancy {}

fn example() {
    want_fancy(Some(5));
//  (BEFORE)   ^^^^^^^ `{integer}` is not an iterator 
//  (AFTER)         ^  `{integer}` is not an iterator
}
```

I had used a (slightly more complex) example as an illustrative example in #108254 , but hadn't actually turned it into a test, because I had (incorrectly) believed at the time it was covered by existing behavior. It turns out that `Some` is slightly "special" in that it resolves differently from the other `enum` constructors I had tried, and therefore this test was actually broken.

I've now updated the tests to include this example, and fixed the code to correctly resolve the `Some` constructor so that the span of the error is reduced.