### PR TITLE
Fix `x clean` with specific paths

### DIFF
--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -62,6 +62,7 @@ macro_rules! clean_crate_tree {
                 let target = compiler.host;
                 let mut cargo = builder.bare_cargo(compiler, $mode, target, "clean");
                 for krate in &*self.crates {
+                    cargo.arg("-p");
                     cargo.arg(krate);
                 }
 


### PR DESCRIPTION
Fixes #108517

`cargo clean` takes package names to clean with `-p`, rather than as free args