### PR TITLE
Remove duplicate guard in diagnostic method suggest

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -910,8 +910,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                         // for instance
                                         self.tcx.at(span).type_of(*def_id).subst_identity()
                                             != rcvr_ty
-                                            && self.tcx.at(span).type_of(*def_id).subst_identity()
-                                                != rcvr_ty
                                     }
                                     (Mode::Path, false, _) => true,
                                     _ => false,


### PR DESCRIPTION
This was leftover after refactoring in c183110cc26a
