### PR TITLE
Erase **all** regions when probing for associated types on ambiguity in astconv

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -2403,8 +2403,10 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                 infcx
                                     .can_eq(
                                         ty::ParamEnv::empty(),
-                                        tcx.erase_regions(impl_.self_ty()),
-                                        tcx.erase_regions(qself_ty),
+                                        impl_.self_ty(),
+                                        // Must fold past escaping bound vars too,
+                                        // since we have those at this point in astconv.
+                                        tcx.fold_regions(qself_ty, |_, _| tcx.lifetimes.re_erased),
                                     )
                             })
                             && tcx.impl_polarity(impl_def_id) != ty::ImplPolarity::Negative

--- a/tests/ui/suggestions/suggest-trait-in-ufcs-in-hrtb.rs
+++ b/tests/ui/suggestions/suggest-trait-in-ufcs-in-hrtb.rs
@@ -1,0 +1,8 @@
+pub struct Bar<S>(S);
+
+pub trait Foo {}
+
+impl<S> Foo for Bar<S> where for<'a> <&'a S>::Item: Foo {}
+//~^ ERROR ambiguous associated type
+
+fn main() {}

--- a/tests/ui/suggestions/suggest-trait-in-ufcs-in-hrtb.stderr
+++ b/tests/ui/suggestions/suggest-trait-in-ufcs-in-hrtb.stderr
@@ -1,0 +1,9 @@
+error[E0223]: ambiguous associated type
+  --> $DIR/suggest-trait-in-ufcs-in-hrtb.rs:5:38
+   |
+LL | impl<S> Foo for Bar<S> where for<'a> <&'a S>::Item: Foo {}
+   |                                      ^^^^^^^^^^^^^ help: use the fully-qualified path: `<&'a S as IntoIterator>::Item`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0223`.


### PR DESCRIPTION
Fixes #108562