### PR TITLE
Add a new config flag, dist.include-mingw-linker.

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -669,6 +669,10 @@ changelog-seen = 2
 # Build compiler with the optimization enabled and -Zvalidate-mir, currently only for `std`
 #validate-mir-opts = 3
 
+# Copy the linker, DLLs, and various libraries from MinGW into the rustc toolchain.
+# Only applies when the host or target is pc-windows-gnu.
+#include-mingw-linker = true
+
 # =============================================================================
 # Options for specific targets
 #

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -192,6 +192,7 @@ pub struct Config {
     pub dist_sign_folder: Option<PathBuf>,
     pub dist_upload_addr: Option<String>,
     pub dist_compression_formats: Option<Vec<String>>,
+    pub dist_include_mingw_linker: bool,
 
     // libstd features
     pub backtrace: bool, // support for RUST_BACKTRACE
@@ -704,6 +705,7 @@ define_config! {
         src_tarball: Option<bool> = "src-tarball",
         missing_tools: Option<bool> = "missing-tools",
         compression_formats: Option<Vec<String>> = "compression-formats",
+        include_mingw_linker: Option<bool> = "include-mingw-linker",
     }
 }
 
@@ -821,6 +823,7 @@ impl Config {
         config.rust_codegen_backends = vec![INTERNER.intern_str("llvm")];
         config.deny_warnings = true;
         config.bindir = "bin".into();
+        config.dist_include_mingw_linker = true;
 
         // set by build.rs
         config.build = TargetSelection::from_user(&env!("BUILD_TRIPLE"));
@@ -1311,6 +1314,7 @@ impl Config {
             config.dist_compression_formats = t.compression_formats;
             set(&mut config.rust_dist_src, t.src_tarball);
             set(&mut config.missing_tools, t.missing_tools);
+            set(&mut config.dist_include_mingw_linker, t.include_mingw_linker)
         }
 
         if let Some(r) = build.rustfmt {

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -322,7 +322,7 @@ impl Step for Mingw {
     /// without any extra installed software (e.g., we bundle gcc, libraries, etc).
     fn run(self, builder: &Builder<'_>) -> Option<GeneratedTarball> {
         let host = self.host;
-        if !host.ends_with("pc-windows-gnu") {
+        if !host.ends_with("pc-windows-gnu") || !builder.config.dist_include_mingw_linker {
             return None;
         }
 
@@ -378,7 +378,7 @@ impl Step for Rustc {
         // anything requiring us to distribute a license, but it's likely the
         // install will *also* include the rust-mingw package, which also needs
         // licenses, so to be safe we just include it here in all MinGW packages.
-        if host.ends_with("pc-windows-gnu") {
+        if host.ends_with("pc-windows-gnu") && builder.config.dist_include_mingw_linker {
             make_win_dist(tarball.image_dir(), &tmpdir(builder), host, builder);
             tarball.add_dir(builder.src.join("src/etc/third-party"), "share/doc");
         }


### PR DESCRIPTION
The flag controls whether to copy the linker, DLLs, and various libraries from MinGW into the rustc toolchain.

It applies only when the host or target is pc-windows-gnu.

The flag is true by default to preserve existing behavior.