### PR TITLE
Account for binders correctly when adding default RPITIT method assumption

### DIFF
--- a/tests/ui/impl-trait/in-trait/default-method-binder-shifting.rs
+++ b/tests/ui/impl-trait/in-trait/default-method-binder-shifting.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+#![feature(return_position_impl_trait_in_trait)]
+//~^ WARN the feature `return_position_impl_trait_in_trait` is incomplete
+
+trait Trait {
+    type Type;
+
+    // Check that we're adjusting bound vars correctly when installing the default
+    // method projection assumptions.
+    fn method(&self) -> impl Trait<Type = impl Sized + '_>;
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/default-method-binder-shifting.stderr
+++ b/tests/ui/impl-trait/in-trait/default-method-binder-shifting.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_position_impl_trait_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/default-method-binder-shifting.rs:3:12
+   |
+LL | #![feature(return_position_impl_trait_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
As of #108203, we install extra projection predicates into the param-env of a default trait method when it has return-position `impl Trait` (or is async).

The implementation didn't account for the fact that it's walking into and out of binders, so we just need to shift all the debruijn indices accordingly when constructing the projection predicates.

Fixes #108579

r? types