### PR TITLE
Put backtick content from rustdoc search errors into a <code> elements

### DIFF
--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -90,7 +90,6 @@ module.exports = {
         "no-return-assign": "error",
         "no-script-url": "error",
         "no-sequences": "error",
-        "no-throw-literal": "error",
         "no-div-regex": "error",
     }
 };

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1260,6 +1260,11 @@ a.tooltip:hover::after {
 	color: var(--search-tab-title-count-color);
 }
 
+#search .error code {
+	border-radius: 3px;
+	background-color: var(--search-error-code-background-color);
+}
+
 #src-sidebar-toggle {
 	position: sticky;
 	top: 0;

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -43,6 +43,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--search-result-link-focus-background-color: #3c3c3c;
 	--search-result-border-color: #aaa3;
 	--search-color: #fff;
+	--search-error-code-background-color: #4f4c4c;
 	--search-results-alias-color: #c5c5c5;
 	--search-results-grey-color: #999;
 	--search-tab-title-count-color: #888;

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -38,6 +38,7 @@
 	--search-result-link-focus-background-color: #616161;
 	--search-result-border-color: #aaa3;
 	--search-color: #111;
+	--search-error-code-background-color: #484848;
 	--search-results-alias-color: #fff;
 	--search-results-grey-color: #ccc;
 	--search-tab-title-count-color: #888;

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -38,6 +38,7 @@
 	--search-result-link-focus-background-color: #ccc;
 	--search-result-border-color: #aaa3;
 	--search-color: #000;
+	--search-error-code-background-color: #d0cccc;
 	--search-results-alias-color: #000;
 	--search-results-grey-color: #999;
 	--search-tab-title-count-color: #888;

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -138,8 +138,20 @@ function valueCheck(fullPath, expected, result, error_text, queryName) {
                 error_text.push('==> Unknown key "' + key + '"');
                 break;
             }
+            let result_v = result[key];
+            if (result_v !== null && key === "error") {
+                result_v.forEach((value, index) => {
+                    value = value.split("&nbsp;").join(" ");
+                    if (index % 2 === 1) {
+                        result_v[index] = "`" + value + "`";
+                    } else {
+                        result_v[index] = value;
+                    }
+                });
+                result_v = result_v.join("");
+            }
             const obj_path = fullPath + (fullPath.length > 0 ? '.' : '') + key;
-            valueCheck(obj_path, expected[key], result[key], error_text, queryName);
+            valueCheck(obj_path, expected[key], result_v, error_text, queryName);
         }
     } else {
         expectedValue = JSON.stringify(expected);

--- a/tests/rustdoc-gui/search-error.goml
+++ b/tests/rustdoc-gui/search-error.goml
@@ -1,0 +1,39 @@
+// Checks that the crate search filtering is handled correctly and changes the results.
+goto: "file://" + |DOC_PATH| + "/test_docs/index.html?search=sa'%3Bda'%3Bds"
+show-text: true
+
+define-function: (
+    "check-colors",
+    (theme, error_background),
+    block {
+        // Setting the theme.
+        local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
+        // We reload the page so the local storage settings are being used.
+        reload:
+
+        wait-for: "#search .error code"
+        assert-css: ("#search .error code", {"background-color": |error_background|})
+    }
+)
+
+call-function: (
+    "check-colors",
+    {
+        "theme": "ayu",
+        "error_background": "rgb(79, 76, 76)",
+    },
+)
+call-function: (
+    "check-colors",
+    {
+        "theme": "dark",
+        "error_background": "rgb(72, 72, 72)",
+    },
+)
+call-function: (
+    "check-colors",
+    {
+        "theme": "light",
+        "error_background": "rgb(208, 204, 204)",
+    },
+)

--- a/tests/rustdoc-js-std/parser-errors.js
+++ b/tests/rustdoc-js-std/parser-errors.js
@@ -67,7 +67,7 @@ const PARSED = [
         returned: [],
         typeFilter: -1,
         userQuery: "a<\"p\">",
-        error: "`\"` cannot be used in generics",
+        error: "Unexpected `\"` in generics",
     },
     {
         elems: [],
@@ -373,7 +373,7 @@ const PARSED = [
         returned: [],
         typeFilter: -1,
         userQuery: "a!a",
-        error: '`!` can only be at the end of an ident',
+        error: 'Unexpected `!`: it can only be at the end of an ident',
     },
     {
         elems: [],


### PR DESCRIPTION
Some screenshots of the result:

![Screenshot from 2023-02-28 22-37-09](https://user-images.githubusercontent.com/3050060/221990290-fa84f1cf-5a64-4ce5-8433-ee36cedf4c00.png)
![Screenshot from 2023-02-28 22-36-59](https://user-images.githubusercontent.com/3050060/221990298-f8177eeb-894b-4fce-a6fc-06d17c8b7ca2.png)
![Screenshot from 2023-02-28 22-36-51](https://user-images.githubusercontent.com/3050060/221990301-41bffd64-d041-41f1-995a-983925b1fbb1.png)

You can test it [here](https://rustdoc.crud.net/imperio/rustdoc-search-background/foo/index.html?search=%22).

r? @notriddle 