### PR TITLE
Fix the ffi_unwind_calls lint documentation

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3967,14 +3967,9 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust,ignore (need FFI)
-    /// #![feature(ffi_unwind_calls)]
+    /// ```rust
     /// #![feature(c_unwind)]
-    ///
-    /// # mod impl {
-    /// #     #[no_mangle]
-    /// #     pub fn "C-unwind" fn foo() {}
-    /// # }
+    /// #![warn(ffi_unwind_calls)]
     ///
     /// extern "C-unwind" {
     ///     fn foo();


### PR DESCRIPTION
This fixes the [`ffi_unwind_calls`](https://doc.rust-lang.org/nightly/rustc/lints/listing/allowed-by-default.html#ffi-unwind-calls) documentation to show its output correctly. Currently it is showing the text `{{produces}}` which is not how it should look.

This fixes it by not ignoring the example. I'm not sure why it was ignored, as the way the lint currently works it doesn't seem to require external linkage. This also fixes several mistakes in the example:

* There is no `ffi_unwind_calls` feature.
* Denies the lint (which is otherwise allow be default).
* Removes the `mod impl` which is not valid Rust syntax, and doesn't appear to be needed anyways.

The output now looks like:

```
warning: call to foreign function with FFI-unwind ABI
  --> lint_example.rs:10:14
   |
10 |     unsafe { foo(); }
   |              ^^^^^ call to foreign function with FFI-unwind ABI
   |
note: the lint level is defined here
  --> lint_example.rs:2:9
   |
2  | #![warn(ffi_unwind_calls)]
   |         ^^^^^^^^^^^^^^^^


warning: call to function pointer with FFI-unwind ABI
  --> lint_example.rs:12:14
   |
12 |     unsafe { ptr(); }
   |              ^^^^^ call to function pointer with FFI-unwind ABI

```

This also includes some updates to the lint-docs tool to help with this issue:

* Adds a check if a lint documentation has `{{produces}}` with an ignored example, and generates an error.
* All instances of a lint are now displayed. Previously it only showed the first time the lint fires. Some examples may trigger a lint multiple times, and they are all now displayed.