### PR TITLE
Highlight whole expression for E0599

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -333,6 +333,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             rcvr_ty.prefix_string(self.tcx),
             ty_str_reported,
         );
+        if tcx.sess.source_map().is_multiline(sugg_span) {
+            err.span_label(sugg_span.with_hi(span.lo()), "");
+        }
         let ty_str = if short_ty_str.len() < ty_str.len() && ty_str.len() > 10 {
             short_ty_str
         } else {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1432,12 +1432,13 @@ impl<'test> TestCx<'test> {
         expect_help: bool,
         expect_note: bool,
     ) -> bool {
-        match actual_error.kind {
-            Some(ErrorKind::Help) => expect_help,
-            Some(ErrorKind::Note) => expect_note,
-            Some(ErrorKind::Error) | Some(ErrorKind::Warning) => true,
-            Some(ErrorKind::Suggestion) | None => false,
-        }
+        !actual_error.msg.is_empty()
+            && match actual_error.kind {
+                Some(ErrorKind::Help) => expect_help,
+                Some(ErrorKind::Note) => expect_note,
+                Some(ErrorKind::Error) | Some(ErrorKind::Warning) => true,
+                Some(ErrorKind::Suggestion) | None => false,
+            }
     }
 
     fn should_emit_metadata(&self, pm: Option<PassMode>) -> Emit {

--- a/tests/ui/methods/method-call-err-msg.stderr
+++ b/tests/ui/methods/method-call-err-msg.stderr
@@ -48,14 +48,17 @@ LL |      .two(0, /* isize */);
 error[E0599]: `Foo` is not an iterator
   --> $DIR/method-call-err-msg.rs:19:7
    |
-LL | pub struct Foo;
-   | --------------
-   | |
-   | method `take` not found for this struct
-   | doesn't satisfy `Foo: Iterator`
+LL |   pub struct Foo;
+   |   --------------
+   |   |
+   |   method `take` not found for this struct
+   |   doesn't satisfy `Foo: Iterator`
 ...
-LL |      .take()
-   |       ^^^^ `Foo` is not an iterator
+LL | /     y.zero()
+LL | |      .take()
+   | |      -^^^^ `Foo` is not an iterator
+   | |______|
+   | 
    |
    = note: the following trait bounds were not satisfied:
            `Foo: Iterator`

--- a/tests/ui/typeck/issue-31173.stderr
+++ b/tests/ui/typeck/issue-31173.stderr
@@ -24,8 +24,17 @@ note: required by a bound in `cloned`
 error[E0599]: the method `collect` exists for struct `Cloned<TakeWhile<&mut IntoIter<u8>, [closure@issue-31173.rs:7:21]>>`, but its trait bounds were not satisfied
   --> $DIR/issue-31173.rs:12:10
    |
-LL |         .collect();
-   |          ^^^^^^^ method cannot be called due to unsatisfied trait bounds
+LL |       let temp: Vec<u8> = it
+   |  _________________________-
+LL | |         .take_while(|&x| {
+LL | |             found_e = true;
+LL | |             false
+LL | |         })
+LL | |         .cloned()
+LL | |         .collect();
+   | |         -^^^^^^^ method cannot be called due to unsatisfied trait bounds
+   | |_________|
+   | 
   --> $SRC_DIR/core/src/iter/adapters/take_while.rs:LL:COL
    |
    = note: doesn't satisfy `<_ as Iterator>::Item = &_`


### PR DESCRIPTION
Fixes #108603

This adds a secondary label to highlight the whole expression leading to the error. It also prevents empty labels being recognised as 'unexpected' by compiletest - otherwise, tests with NOTE annotations would pick up empty labels.

@rustbot label +A-diagnostics