### PR TITLE
Make `ExprKind` the first field in `thir::Expr`

### DIFF
--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -237,6 +237,9 @@ pub struct LocalVarId(pub hir::HirId);
 /// A THIR expression.
 #[derive(Clone, Debug, HashStable)]
 pub struct Expr<'tcx> {
+    /// kind of expression
+    pub kind: ExprKind<'tcx>,
+
     /// The type of this expression
     pub ty: Ty<'tcx>,
 
@@ -246,9 +249,6 @@ pub struct Expr<'tcx> {
 
     /// span of the expression in the source
     pub span: Span,
-
-    /// kind of expression
-    pub kind: ExprKind<'tcx>,
 }
 
 #[derive(Clone, Debug, HashStable)]

--- a/tests/ui/thir-print/thir-flat.stdout
+++ b/tests/ui/thir-print/thir-flat.stdout
@@ -17,21 +17,16 @@ Thir {
     ],
     exprs: [
         Expr {
-            ty: (),
-            temp_lifetime: Some(
-                Node(2),
-            ),
-            span: $DIR/thir-flat.rs:4:15: 4:17 (#0),
             kind: Block {
                 block: b0,
             },
-        },
-        Expr {
             ty: (),
             temp_lifetime: Some(
                 Node(2),
             ),
             span: $DIR/thir-flat.rs:4:15: 4:17 (#0),
+        },
+        Expr {
             kind: Scope {
                 region_scope: Node(2),
                 lint_level: Explicit(
@@ -39,18 +34,23 @@ Thir {
                 ),
                 value: e0,
             },
-        },
-        Expr {
             ty: (),
             temp_lifetime: Some(
                 Node(2),
             ),
             span: $DIR/thir-flat.rs:4:15: 4:17 (#0),
+        },
+        Expr {
             kind: Scope {
                 region_scope: Destruction(2),
                 lint_level: Inherited,
                 value: e1,
             },
+            ty: (),
+            temp_lifetime: Some(
+                Node(2),
+            ),
+            span: $DIR/thir-flat.rs:4:15: 4:17 (#0),
         },
     ],
     stmts: [],


### PR DESCRIPTION
This makes its `Debug` impl print it first which is useful, as it's the most important part when looking at an expr.