### PR TITLE
[PERF EXPERIMENT] Enable the parallel compiler.

### DIFF
--- a/compiler/rustc_data_structures/src/sharded.rs
+++ b/compiler/rustc_data_structures/src/sharded.rs
@@ -13,7 +13,7 @@ struct CacheAligned<T>(T);
 // 32 shards is sufficient to reduce contention on an 8-core Ryzen 7 1700,
 // but this should be tested on higher core count CPUs. How the `Sharded` type gets used
 // may also affect the ideal number of shards.
-const SHARD_BITS: usize = 5;
+const SHARD_BITS: usize = 0;
 
 #[cfg(not(parallel_compiler))]
 const SHARD_BITS: usize = 0;

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1122,7 +1122,7 @@ impl Config {
             set(&mut config.use_lld, rust.use_lld);
             set(&mut config.lld_enabled, rust.lld);
             set(&mut config.llvm_tools_enabled, rust.llvm_tools);
-            config.rustc_parallel = rust.parallel_compiler.unwrap_or(false);
+            config.rustc_parallel = rust.parallel_compiler.unwrap_or(true);
             config.rustc_default_linker = rust.default_linker;
             config.musl_root = rust.musl_root.map(PathBuf::from);
             config.save_toolstates = rust.save_toolstates.map(PathBuf::from);


### PR DESCRIPTION
In the recent [wg-parallel-rustc](https://rust-lang.zulipchat.com/#narrow/stream/187679-t-compiler.2Fwg-parallel-rustc/topic/meeting.202023-02-27) meeting we discussed how the parallel compiler with `-Zthreads=1` isn't that much of a performance regression if you look at instruction counts, but is much worse if you look at wall times.

Instruction counts is our usual primary metric for CI perf runs, and it works well when comparing two very similar versions of the compiler. But the parallel compiler is sufficiently different to the serial compiler that wall times should be the comparison point in this case. This PR is for a perf run to quantify the situation in a way that everyone can see.

r? @ghost