### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/locales/en-US.ftl
+++ b/compiler/rustc_ast_lowering/locales/en-US.ftl
@@ -22,9 +22,6 @@ ast_lowering_misplaced_impl_trait =
 ast_lowering_misplaced_assoc_ty_binding =
     associated type bounds are only allowed in where clauses and function signatures, not in {$position}
 
-ast_lowering_rustc_box_attribute_error =
-    #[rustc_box] requires precisely one argument and no other attributes are allowed
-
 ast_lowering_underscore_expr_lhs_assign =
     in expressions, `_` can only be used on the left-hand side of an assignment
     .label = `_` not allowed here

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -88,13 +88,6 @@ pub struct MisplacedAssocTyBinding<'a> {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering_rustc_box_attribute_error)]
-pub struct RustcBoxAttributeError {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_underscore_expr_lhs_assign)]
 pub struct UnderscoreExprLhsAssign {
     #[primary_span]

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -2403,8 +2403,10 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                 infcx
                                     .can_eq(
                                         ty::ParamEnv::empty(),
-                                        tcx.erase_regions(impl_.self_ty()),
-                                        tcx.erase_regions(qself_ty),
+                                        impl_.self_ty(),
+                                        // Must fold past escaping bound vars too,
+                                        // since we have those at this point in astconv.
+                                        tcx.fold_regions(qself_ty, |_, _| tcx.lifetimes.re_erased),
                                     )
                             })
                             && tcx.impl_polarity(impl_def_id) != ty::ImplPolarity::Negative

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -333,6 +333,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             rcvr_ty.prefix_string(self.tcx),
             ty_str_reported,
         );
+        if tcx.sess.source_map().is_multiline(sugg_span) {
+            err.span_label(sugg_span.with_hi(span.lo()), "");
+        }
         let ty_str = if short_ty_str.len() < ty_str.len() && ty_str.len() > 10 {
             short_ty_str
         } else {

--- a/compiler/rustc_mir_build/locales/en-US.ftl
+++ b/compiler/rustc_mir_build/locales/en-US.ftl
@@ -374,3 +374,9 @@ mir_build_suggest_let_else = you might want to use `let else` to handle the {$co
     } matched
 
 mir_build_suggest_attempted_int_lit = alternatively, you could prepend the pattern with an underscore to define a new named variable; identifiers cannot begin with digits
+
+
+mir_build_rustc_box_attribute_error = `#[rustc_box]` attribute used incorrectly
+    .attributes = no other attributes may be applied
+    .not_box = `#[rustc_box]` may only be applied to a `Box::new()` call
+    .missing_box = `#[rustc_box]` requires the `owned_box` lang item

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -888,3 +888,22 @@ pub enum MiscPatternSuggestion {
         start_span: Span,
     },
 }
+
+#[derive(Diagnostic)]
+#[diag(mir_build_rustc_box_attribute_error)]
+pub struct RustcBoxAttributeError {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub reason: RustcBoxAttrReason,
+}
+
+#[derive(Subdiagnostic)]
+pub enum RustcBoxAttrReason {
+    #[note(mir_build_attributes)]
+    Attributes,
+    #[note(mir_build_not_box)]
+    NotBoxNew,
+    #[note(mir_build_missing_box)]
+    MissingBox,
+}

--- a/src/doc/rustc/src/platform-support/fuchsia.md
+++ b/src/doc/rustc/src/platform-support/fuchsia.md
@@ -717,7 +717,7 @@ run the full `tests/ui` test suite:
     --stage=2                                                                 \
     test tests/ui                                                             \
     --target x86_64-unknown-fuchsia                                           \
-    --run=always --jobs 1                                                     \
+    --run=always                                                              \
     --test-args --target-rustcflags                                           \
     --test-args -Lnative=${SDK_PATH}/arch/{x64|arm64}/sysroot/lib             \
     --test-args --target-rustcflags                                           \
@@ -728,9 +728,6 @@ run the full `tests/ui` test suite:
     --test-args src/ci/docker/scripts/fuchsia-test-runner.py                  \
 )
 ```
-
-*Note: The test suite cannot be run in parallel at the moment, so `x.py`
-must be run with `--jobs 1` to ensure only one test runs at a time.*
 
 By default, `x.py` compiles test binaries with `panic=unwind`. If you built your
 Rust toolchain with `-Cpanic=abort`, you need to tell `x.py` to compile test
@@ -908,7 +905,7 @@ through our `x.py` invocation. The full invocation is:
     --stage=2                                                                 \
     test tests/${TEST}                                                        \
     --target x86_64-unknown-fuchsia                                           \
-    --run=always --jobs 1                                                     \
+    --run=always                                                              \
     --test-args --target-rustcflags                                           \
     --test-args -Lnative=${SDK_PATH}/arch/{x64|arm64}/sysroot/lib             \
     --test-args --target-rustcflags                                           \

--- a/src/tools/clippy/clippy_utils/src/higher.rs
+++ b/src/tools/clippy/clippy_utils/src/higher.rs
@@ -287,15 +287,12 @@ impl<'a> VecArgs<'a> {
                     Some(VecArgs::Repeat(&args[0], &args[1]))
                 } else if match_def_path(cx, fun_def_id, &paths::SLICE_INTO_VEC) && args.len() == 1 {
                     // `vec![a, b, c]` case
-                    if_chain! {
-                        if let hir::ExprKind::Box(boxed) = args[0].kind;
-                        if let hir::ExprKind::Array(args) = boxed.kind;
-                        then {
-                            return Some(VecArgs::Vec(args));
-                        }
+                    if let hir::ExprKind::Call(_, [arg]) = &args[0].kind
+                        && let hir::ExprKind::Array(args) = arg.kind {
+                        Some(VecArgs::Vec(args))
+                    } else {
+                        None
                     }
-
-                    None
                 } else if match_def_path(cx, fun_def_id, &paths::VEC_NEW) && args.is_empty() {
                     Some(VecArgs::Vec(&[]))
                 } else {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1432,12 +1432,13 @@ impl<'test> TestCx<'test> {
         expect_help: bool,
         expect_note: bool,
     ) -> bool {
-        match actual_error.kind {
-            Some(ErrorKind::Help) => expect_help,
-            Some(ErrorKind::Note) => expect_note,
-            Some(ErrorKind::Error) | Some(ErrorKind::Warning) => true,
-            Some(ErrorKind::Suggestion) | None => false,
-        }
+        !actual_error.msg.is_empty()
+            && match actual_error.kind {
+                Some(ErrorKind::Help) => expect_help,
+                Some(ErrorKind::Note) => expect_note,
+                Some(ErrorKind::Error) | Some(ErrorKind::Warning) => true,
+                Some(ErrorKind::Suggestion) | None => false,
+            }
     }
 
     fn should_emit_metadata(&self, pm: Option<PassMode>) -> Emit {

--- a/tests/ui/attributes/rustc-box.rs
+++ b/tests/ui/attributes/rustc-box.rs
@@ -1,0 +1,18 @@
+#![feature(rustc_attrs, stmt_expr_attributes)]
+
+fn foo(_: u32, _: u32) {}
+fn bar(_: u32) {}
+
+fn main() {
+    #[rustc_box]
+    Box::new(1); // OK
+    #[rustc_box]
+    Box::pin(1); //~ ERROR `#[rustc_box]` attribute used incorrectly
+    #[rustc_box]
+    foo(1, 1); //~ ERROR `#[rustc_box]` attribute used incorrectly
+    #[rustc_box]
+    bar(1); //~ ERROR `#[rustc_box]` attribute used incorrectly
+    #[rustc_box] //~ ERROR `#[rustc_box]` attribute used incorrectly
+    #[rustfmt::skip]
+    Box::new(1);
+}

--- a/tests/ui/attributes/rustc-box.stderr
+++ b/tests/ui/attributes/rustc-box.stderr
@@ -1,0 +1,34 @@
+error: `#[rustc_box]` attribute used incorrectly
+  --> $DIR/rustc-box.rs:10:5
+   |
+LL |     Box::pin(1);
+   |     ^^^^^^^^^^^
+   |
+   = note: `#[rustc_box]` may only be applied to a `Box::new()` call
+
+error: `#[rustc_box]` attribute used incorrectly
+  --> $DIR/rustc-box.rs:12:5
+   |
+LL |     foo(1, 1);
+   |     ^^^^^^^^^
+   |
+   = note: `#[rustc_box]` may only be applied to a `Box::new()` call
+
+error: `#[rustc_box]` attribute used incorrectly
+  --> $DIR/rustc-box.rs:14:5
+   |
+LL |     bar(1);
+   |     ^^^^^^
+   |
+   = note: `#[rustc_box]` may only be applied to a `Box::new()` call
+
+error: `#[rustc_box]` attribute used incorrectly
+  --> $DIR/rustc-box.rs:15:5
+   |
+LL |     #[rustc_box]
+   |     ^^^^^^^^^^^^
+   |
+   = note: no other attributes may be applied
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/methods/method-call-err-msg.stderr
+++ b/tests/ui/methods/method-call-err-msg.stderr
@@ -48,14 +48,17 @@ LL |      .two(0, /* isize */);
 error[E0599]: `Foo` is not an iterator
   --> $DIR/method-call-err-msg.rs:19:7
    |
-LL | pub struct Foo;
-   | --------------
-   | |
-   | method `take` not found for this struct
-   | doesn't satisfy `Foo: Iterator`
+LL |   pub struct Foo;
+   |   --------------
+   |   |
+   |   method `take` not found for this struct
+   |   doesn't satisfy `Foo: Iterator`
 ...
-LL |      .take()
-   |       ^^^^ `Foo` is not an iterator
+LL | /     y.zero()
+LL | |      .take()
+   | |      -^^^^ `Foo` is not an iterator
+   | |______|
+   | 
    |
    = note: the following trait bounds were not satisfied:
            `Foo: Iterator`

--- a/tests/ui/parser/issues/issue-104367.rs
+++ b/tests/ui/parser/issues/issue-104367.rs
@@ -1,0 +1,6 @@
+#[derive(A)]
+struct S {
+    d: [u32; {
+        #![cfg] {
+            #![w,) //~ ERROR mismatched closing delimiter
+                   //~ ERROR this file contains an unclosed delimiter

--- a/tests/ui/parser/issues/issue-104367.stderr
+++ b/tests/ui/parser/issues/issue-104367.stderr
@@ -1,0 +1,26 @@
+error: mismatched closing delimiter: `)`
+  --> $DIR/issue-104367.rs:5:15
+   |
+LL |             #![w,)
+   |               ^  ^ mismatched closing delimiter
+   |               |
+   |               unclosed delimiter
+
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-104367.rs:6:71
+   |
+LL | struct S {
+   |          - unclosed delimiter
+LL |     d: [u32; {
+   |        -     - unclosed delimiter
+   |        |
+   |        unclosed delimiter
+LL |         #![cfg] {
+   |                 - unclosed delimiter
+LL |             #![w,)
+   |                  - missing open `(` for this delimiter
+LL |
+   |                                                                       ^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/parser/issues/issue-105209.rs
+++ b/tests/ui/parser/issues/issue-105209.rs
@@ -1,0 +1,3 @@
+// compile-flags: -Zunpretty=ast-tree
+#![c={#![c[)x   //~ ERROR mismatched closing delimiter
+                //~ ERROR this file contains an unclosed delimiter

--- a/tests/ui/parser/issues/issue-105209.stderr
+++ b/tests/ui/parser/issues/issue-105209.stderr
@@ -1,0 +1,22 @@
+error: mismatched closing delimiter: `)`
+  --> $DIR/issue-105209.rs:2:11
+   |
+LL | #![c={#![c[)x
+   |           ^^ mismatched closing delimiter
+   |           |
+   |           unclosed delimiter
+
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-105209.rs:3:68
+   |
+LL | #![c={#![c[)x
+   |   -  -  -  - missing open `(` for this delimiter
+   |   |  |  |
+   |   |  |  unclosed delimiter
+   |   |  unclosed delimiter
+   |   unclosed delimiter
+LL |
+   |                                                                    ^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/suggestions/suggest-trait-in-ufcs-in-hrtb.rs
+++ b/tests/ui/suggestions/suggest-trait-in-ufcs-in-hrtb.rs
@@ -1,0 +1,8 @@
+pub struct Bar<S>(S);
+
+pub trait Foo {}
+
+impl<S> Foo for Bar<S> where for<'a> <&'a S>::Item: Foo {}
+//~^ ERROR ambiguous associated type
+
+fn main() {}

--- a/tests/ui/suggestions/suggest-trait-in-ufcs-in-hrtb.stderr
+++ b/tests/ui/suggestions/suggest-trait-in-ufcs-in-hrtb.stderr
@@ -1,0 +1,9 @@
+error[E0223]: ambiguous associated type
+  --> $DIR/suggest-trait-in-ufcs-in-hrtb.rs:5:38
+   |
+LL | impl<S> Foo for Bar<S> where for<'a> <&'a S>::Item: Foo {}
+   |                                      ^^^^^^^^^^^^^ help: use the fully-qualified path: `<&'a S as IntoIterator>::Item`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0223`.

--- a/tests/ui/typeck/issue-31173.stderr
+++ b/tests/ui/typeck/issue-31173.stderr
@@ -24,8 +24,17 @@ note: required by a bound in `cloned`
 error[E0599]: the method `collect` exists for struct `Cloned<TakeWhile<&mut IntoIter<u8>, [closure@issue-31173.rs:7:21]>>`, but its trait bounds were not satisfied
   --> $DIR/issue-31173.rs:12:10
    |
-LL |         .collect();
-   |          ^^^^^^^ method cannot be called due to unsatisfied trait bounds
+LL |       let temp: Vec<u8> = it
+   |  _________________________-
+LL | |         .take_while(|&x| {
+LL | |             found_e = true;
+LL | |             false
+LL | |         })
+LL | |         .cloned()
+LL | |         .collect();
+   | |         -^^^^^^^ method cannot be called due to unsatisfied trait bounds
+   | |_________|
+   | 
   --> $SRC_DIR/core/src/iter/adapters/take_while.rs:LL:COL
    |
    = note: doesn't satisfy `<_ as Iterator>::Item = &_`


### PR DESCRIPTION
Successful merges:

 - #108516 (Restrict `#[rustc_box]` to `Box::new` calls)
 - #108575 (Erase **all** regions when probing for associated types on ambiguity in astconv)
 - #108585 (Run compiler test suite in parallel on Fuchsia)
 - #108606 (Add test case for mismatched open/close delims)
 - #108609 (Highlight whole expression for E0599)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=108516,108575,108585,108606,108609)
<!-- homu-ignore:end -->