### PR TITLE
[107049][Easy] Modify readme to suggest using configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ See [the rustc-dev-guide for more info][sysllvm].
    list of options in `config.toml.example`.
 
    ```sh
-   ./configure --set changelog-seen=2 --set profile=user
+   ./configure --set profile=user
    ```
    If you plan to use `x.py install` to create an installation, it is
    recommended that you set the `prefix` value in the `[install]` section to a

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ See [the rustc-dev-guide for more info][sysllvm].
    ```sh
    ./configure --set changelog-seen=2 --set profile=user
    ```
-cpmfog/tp
    If you plan to use `x.py install` to create an installation, it is
    recommended that you set the `prefix` value in the `[install]` section to a
    directory.

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ See [the rustc-dev-guide for more info][sysllvm].
    list of options in `config.toml.example`.
 
    ```sh
-   printf 'profile = "user" \nchangelog-seen = 2 \n' > config.toml
+   ./configure --set changelog-seen=2 --set profile=user
    ```
-
+cpmfog/tp
    If you plan to use `x.py install` to create an installation, it is
    recommended that you set the `prefix` value in the `[install]` section to a
    directory.


### PR DESCRIPTION
This is related to https://github.com/rust-lang/rust/issues/107050. Modifying instructions in readme to use configure instead of printf

Manual Test: 

Command 
```
lionellloh@lionellloh-mbp rust % ./configure --set changelog-seen=1 --set profile=user                   
```
```
configure: processing command line
configure: 
configure: changelog-seen       := 1
configure: profile              := user
configure: build.configure-args := ['--set', 'changelog-seen=1', '--set', 'profil ...
configure: 
configure: writing `config.toml` in current directory
configure: 
configure: run `python /Users/lionellloh/rust/x.py --help`
```

**Result** 
```
16c16
< changelog-seen = 1
---
> changelog-seen = 2
26c26
< profile = user
---
> #profile = <none>
331c331
< configure-args = ['--set', 'changelog-seen=1', '--set', 'profile=user']
---
> #configure-args = []
678c678
< [target.x86_64-apple-darwin]
---
> [target.x86_64-unknown-linux-gnu]
812d811
< 
```