### PR TITLE
Create a query cache for DefId

### DIFF
--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -9,7 +9,9 @@ use crate::ty::subst::{GenericArg, SubstsRef};
 use crate::ty::{self, Ty, TyCtxt};
 use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
 use rustc_hir::hir_id::{HirId, OwnerId};
-use rustc_query_system::query::{DefaultCacheSelector, SingleCacheSelector, VecCacheSelector};
+use rustc_query_system::query::{
+    DefIdCacheSelector, DefaultCacheSelector, SingleCacheSelector, VecCacheSelector,
+};
 use rustc_span::symbol::{Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
 use rustc_target::abi::FieldIdx;
@@ -153,7 +155,7 @@ impl Key for LocalDefId {
 }
 
 impl Key for DefId {
-    type CacheSelector = DefaultCacheSelector<Self>;
+    type CacheSelector = DefIdCacheSelector;
 
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(*self)

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -8,7 +8,8 @@ pub use self::job::{print_query_stack, QueryInfo, QueryJob, QueryJobId, QueryJob
 
 mod caches;
 pub use self::caches::{
-    CacheSelector, DefaultCacheSelector, QueryCache, SingleCacheSelector, VecCacheSelector,
+    CacheSelector, DefIdCacheSelector, DefaultCacheSelector, QueryCache, SingleCacheSelector,
+    VecCacheSelector,
 };
 
 mod config;


### PR DESCRIPTION
This adds a specialized cache for `DefId` which stores a `IndexVec` of hashmaps reducing the size of the stored hashmap key.

<table><tr><td rowspan="2">Benchmark</td><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th></tr><tr><td align="right">Time</td><td align="right">Time</td><td align="right">%</th></tr><tr><td>🟣 <b>clap</b>:check</td><td align="right">1.6924s</td><td align="right">1.6879s</td><td align="right"> -0.26%</td></tr><tr><td>🟣 <b>hyper</b>:check</td><td align="right">0.2522s</td><td align="right">0.2527s</td><td align="right"> 0.21%</td></tr><tr><td>🟣 <b>regex</b>:check</td><td align="right">0.9573s</td><td align="right">0.9542s</td><td align="right"> -0.32%</td></tr><tr><td>🟣 <b>syn</b>:check</td><td align="right">1.5345s</td><td align="right">1.5265s</td><td align="right"> -0.52%</td></tr><tr><td>🟣 <b>syntex_syntax</b>:check</td><td align="right">5.8742s</td><td align="right">5.8500s</td><td align="right"> -0.41%</td></tr><tr><td>Total</td><td align="right">10.3105s</td><td align="right">10.2714s</td><td align="right"> -0.38%</td></tr><tr><td>Summary</td><td align="right">1.0000s</td><td align="right">0.9974s</td><td align="right"> -0.26%</td></tr></table>