### PR TITLE
Rustdoc search: Emit an error for unclosed generic

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -469,6 +469,15 @@ function initSearch(rawSearchIndex) {
             }
             const posBefore = parserState.pos;
             getNextElem(query, parserState, elems, endChar === ">");
+            if (endChar !== "") {
+                if (parserState.pos >= parserState.length) {
+                    throw ["Unclosed ", "<"];
+                }
+                const c2 = parserState.userQuery[parserState.pos];
+                if (!isSeparatorCharacter(c2) && c2 !== endChar) {
+                    throw ["Expected ", endChar, ", found ", c2];
+                }
+            }
             // This case can be encountered if `getNextElem` encountered a "stop character" right
             // from the start. For example if you have `,,` or `<>`. In this case, we simply move up
             // the current position to continue the parsing.
@@ -477,7 +486,10 @@ function initSearch(rawSearchIndex) {
             }
             foundStopChar = false;
         }
-        // We are either at the end of the string or on the `endChar`` character, let's move forward
+        if (parserState.pos >= parserState.length && endChar !== "") {
+            throw ["Unclosed ", "<"];
+        }
+        // We are either at the end of the string or on the `endChar` character, let's move forward
         // in any case.
         parserState.pos += 1;
     }

--- a/tests/rustdoc-js-std/parser-errors.js
+++ b/tests/rustdoc-js-std/parser-errors.js
@@ -39,6 +39,7 @@ const QUERY = [
     "a!!",
     "mod:a!",
     "a!::a",
+    "a<",
 ];
 
 const PARSED = [
@@ -401,5 +402,14 @@ const PARSED = [
         typeFilter: -1,
         userQuery: "a!::a",
         error: 'Cannot have associated items in macros',
+    },
+    {
+        elems: [],
+        foundElems: 0,
+        original: "a<",
+        returned: [],
+        typeFilter: -1,
+        userQuery: "a<",
+        error: "Unclosed `<`",
     },
 ];


### PR DESCRIPTION
Now, search like `a<` will error as it should (and as written in the eBNF).

r? @notriddle 