### PR TITLE
Include executed tests in the build metrics (and use a custom test display impl)

### DIFF
--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -12,6 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +47,7 @@ dependencies = [
 name = "bootstrap"
 version = "0.0.0"
 dependencies = [
+ "atty",
  "build_helper",
  "cc",
  "cmake",
@@ -59,6 +71,7 @@ dependencies = [
  "walkdir",
  "winapi",
  "xz2",
+ "yansi-term",
 ]
 
 [[package]]
@@ -800,3 +813,12 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yansi-term"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+dependencies = [
+ "winapi",
+]

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -67,11 +67,11 @@ dependencies = [
  "sha2",
  "sysinfo",
  "tar",
+ "termcolor",
  "toml",
  "walkdir",
  "winapi",
  "xz2",
- "yansi-term",
 ]
 
 [[package]]
@@ -650,6 +650,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,12 +822,3 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
-
-[[package]]
-name = "yansi-term"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
-dependencies = [
- "winapi",
-]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -47,13 +47,13 @@ serde_derive = "1.0.137"
 serde_json = "1.0.2"
 sha2 = "0.10"
 tar = "0.4"
+termcolor = "1.2.0"
 toml = "0.5"
 ignore = "0.4.10"
 opener = "0.5"
 once_cell = "1.7.2"
 xz2 = "0.1"
 walkdir = "2"
-yansi-term = "0.1.2"
 
 # Dependencies needed by the build-metrics feature
 sysinfo = { version = "0.26.0", optional = true }

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -30,6 +30,7 @@ path = "bin/sccache-plus-cl.rs"
 test = false
 
 [dependencies]
+atty = "0.2.14"
 build_helper = { path = "../tools/build_helper" }
 cmake = "0.1.38"
 fd-lock = "3.0.8"
@@ -52,6 +53,7 @@ opener = "0.5"
 once_cell = "1.7.2"
 xz2 = "0.1"
 walkdir = "2"
+yansi-term = "0.1.2"
 
 # Dependencies needed by the build-metrics feature
 sysinfo = { version = "0.26.0", optional = true }

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -87,6 +87,9 @@ pub struct Config {
     pub patch_binaries_for_nix: bool,
     pub stage0_metadata: Stage0Metadata,
 
+    pub stdout_is_tty: bool,
+    pub stderr_is_tty: bool,
+
     pub on_fail: Option<String>,
     pub stage: u32,
     pub keep_stage: Vec<u32>,
@@ -821,6 +824,9 @@ impl Config {
         config.rust_codegen_backends = vec![INTERNER.intern_str("llvm")];
         config.deny_warnings = true;
         config.bindir = "bin".into();
+
+        config.stdout_is_tty = atty::is(atty::Stream::Stdout);
+        config.stderr_is_tty = atty::is(atty::Stream::Stderr);
 
         // set by build.rs
         config.build = TargetSelection::from_user(&env!("BUILD_TRIPLE"));

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -55,6 +55,7 @@ mod format;
 mod install;
 mod metadata;
 mod native;
+mod render_tests;
 mod run;
 mod sanity;
 mod setup;

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -89,6 +89,7 @@ pub use crate::builder::PathSet;
 use crate::cache::{Interned, INTERNER};
 pub use crate::config::Config;
 pub use crate::flags::Subcommand;
+use yansi_term::Color;
 
 const LLVM_TOOLS: &[&str] = &[
     "llvm-cov",      // used to generate coverage report
@@ -1574,6 +1575,23 @@ to download LLVM rather than building it.
         }
 
         self.config.ninja_in_file
+    }
+
+    pub fn color_for_stdout(&self, color: Color, message: &str) -> String {
+        self.color_for_inner(color, message, self.config.stdout_is_tty)
+    }
+
+    pub fn color_for_stderr(&self, color: Color, message: &str) -> String {
+        self.color_for_inner(color, message, self.config.stderr_is_tty)
+    }
+
+    fn color_for_inner(&self, color: Color, message: &str, is_tty: bool) -> String {
+        let use_color = match self.config.color {
+            flags::Color::Always => true,
+            flags::Color::Never => false,
+            flags::Color::Auto => is_tty,
+        };
+        if use_color { color.paint(message).to_string() } else { message.to_string() }
     }
 }
 

--- a/src/bootstrap/render_tests.rs
+++ b/src/bootstrap/render_tests.rs
@@ -99,6 +99,19 @@ impl<'a> Renderer<'a> {
 
     fn render_test_outcome(&mut self, outcome: Outcome<'_>, test: &TestOutcome) {
         self.executed_tests += 1;
+
+        #[cfg(feature = "build-metrics")]
+        self.builder.metrics.record_test(
+            &test.name,
+            match outcome {
+                Outcome::Ok => crate::metrics::TestOutcome::Passed,
+                Outcome::Failed => crate::metrics::TestOutcome::Failed,
+                Outcome::Ignored { reason } => crate::metrics::TestOutcome::Ignored {
+                    ignore_reason: reason.map(|s| s.to_string()),
+                },
+            },
+        );
+
         if self.builder.config.verbose_tests {
             self.render_test_outcome_verbose(outcome, test);
         } else {

--- a/src/bootstrap/render_tests.rs
+++ b/src/bootstrap/render_tests.rs
@@ -105,12 +105,19 @@ impl<'a> Renderer<'a> {
                 break;
             }
 
-            self.render_message(match serde_json::from_str(&line) {
-                Ok(parsed) => parsed,
-                Err(err) => {
-                    panic!("failed to parse libtest json output; error: {err}, line: {line:?}");
-                }
-            });
+            let trimmed = line.trim();
+            if trimmed.starts_with("{") && trimmed.ends_with("}") {
+                self.render_message(match serde_json::from_str(&trimmed) {
+                    Ok(parsed) => parsed,
+                    Err(err) => {
+                        panic!("failed to parse libtest json output; error: {err}, line: {line:?}");
+                    }
+                });
+            } else {
+                // Handle non-JSON output, for example when --nocapture is passed.
+                print!("{line}");
+                let _ = std::io::stdout().flush();
+            }
         }
     }
 

--- a/src/bootstrap/render_tests.rs
+++ b/src/bootstrap/render_tests.rs
@@ -260,6 +260,9 @@ impl<'a> Renderer<'a> {
                 self.render_test_outcome(Outcome::Failed, &outcome);
                 self.failures.push(outcome);
             }
+            Message::Test(TestMessage::Timeout { name }) => {
+                println!("test {name} has been running for a long time");
+            }
             Message::Test(TestMessage::Started) => {} // Not useful
         }
     }
@@ -353,6 +356,7 @@ enum TestMessage {
     Ok(TestOutcome),
     Failed(TestOutcome),
     Ignored(TestOutcome),
+    Timeout { name: String },
     Started,
 }
 

--- a/src/bootstrap/render_tests.rs
+++ b/src/bootstrap/render_tests.rs
@@ -14,6 +14,15 @@ use yansi_term::Color;
 
 const TERSE_TESTS_PER_LINE: usize = 88;
 
+pub(crate) fn add_flags_and_try_run_tests(builder: &Builder<'_>, cmd: &mut Command) -> bool {
+    if cmd.get_args().position(|arg| arg == "--").is_none() {
+        cmd.arg("--");
+    }
+    cmd.args(&["-Z", "unstable-options", "--format", "json"]);
+
+    try_run_tests(builder, cmd)
+}
+
 pub(crate) fn try_run_tests(builder: &Builder<'_>, cmd: &mut Command) -> bool {
     if builder.config.dry_run() {
         return true;

--- a/src/bootstrap/render_tests.rs
+++ b/src/bootstrap/render_tests.rs
@@ -7,7 +7,7 @@
 //! to reimplement all the rendering logic in this module because of that.
 
 use crate::builder::Builder;
-use std::io::{BufRead, BufReader, Cursor, Write};
+use std::io::{BufRead, BufReader, Write};
 use std::process::{ChildStdout, Command, Stdio};
 use std::time::Duration;
 use yansi_term::Color;
@@ -43,7 +43,6 @@ pub(crate) fn try_run_tests(builder: &Builder<'_>, cmd: &mut Command) -> bool {
 
 fn run_tests(builder: &Builder<'_>, cmd: &mut Command) -> bool {
     cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::piped());
 
     builder.verbose(&format!("running: {cmd:?}"));
 
@@ -61,10 +60,6 @@ fn run_tests(builder: &Builder<'_>, cmd: &mut Command) -> bool {
             result.status
         );
     }
-
-    // Show the stderr emitted by the test runner at the end. As of 2023-03-02 this is only the
-    // message at the end of a failed compiletest run.
-    std::io::copy(&mut Cursor::new(&result.stderr), &mut std::io::stderr().lock()).unwrap();
 
     result.status.success()
 }

--- a/src/bootstrap/render_tests.rs
+++ b/src/bootstrap/render_tests.rs
@@ -245,7 +245,7 @@ impl<'a> Renderer<'a> {
                     name: outcome.name.clone(),
                     exec_time: None,
                     stdout: None,
-                    reason: None,
+                    message: None,
                 };
                 self.render_test_outcome(Outcome::BenchOk, &fake_test_outcome);
                 self.benches.push(outcome);
@@ -255,7 +255,7 @@ impl<'a> Renderer<'a> {
             }
             Message::Test(TestMessage::Ignored(outcome)) => {
                 self.render_test_outcome(
-                    Outcome::Ignored { reason: outcome.reason.as_deref() },
+                    Outcome::Ignored { reason: outcome.message.as_deref() },
                     &outcome,
                 );
             }
@@ -345,5 +345,5 @@ struct TestOutcome {
     name: String,
     exec_time: Option<f64>,
     stdout: Option<String>,
-    reason: Option<String>,
+    message: Option<String>,
 }

--- a/src/bootstrap/render_tests.rs
+++ b/src/bootstrap/render_tests.rs
@@ -1,0 +1,220 @@
+//! This module renders the JSON output of libtest into a human-readable form, trying to be as
+//! similar to libtest's native output as possible.
+//!
+//! This is needed because we need to use libtest in JSON mode to extract granluar information
+//! about the executed tests. Doing so suppresses the human-readable output, and (compared to Cargo
+//! and rustc) libtest doesn't include the rendered human-readable output as a JSON field. We had
+//! to reimplement all the rendering logic in this module because of that.
+
+use crate::builder::Builder;
+use std::io::{BufRead, BufReader};
+use std::process::{ChildStdout, Command, Stdio};
+use std::time::Duration;
+
+pub(crate) fn try_run_tests(builder: &Builder<'_>, cmd: &mut Command) -> bool {
+    if builder.config.dry_run() {
+        return true;
+    }
+
+    if !run_tests(builder, cmd) {
+        if builder.fail_fast {
+            crate::detail_exit(1);
+        } else {
+            let mut failures = builder.delayed_failures.borrow_mut();
+            failures.push(format!("{cmd:?}"));
+            false
+        }
+    } else {
+        true
+    }
+}
+
+fn run_tests(builder: &Builder<'_>, cmd: &mut Command) -> bool {
+    cmd.stdout(Stdio::piped());
+
+    builder.verbose(&format!("running: {cmd:?}"));
+
+    let mut process = cmd.spawn().unwrap();
+    let stdout = process.stdout.take().unwrap();
+    let handle = std::thread::spawn(move || Renderer::new(stdout).render_all());
+
+    let result = process.wait().unwrap();
+    handle.join().expect("test formatter thread failed");
+
+    if !result.success() && builder.is_verbose() {
+        println!(
+            "\n\ncommand did not execute successfully: {cmd:?}\n\
+             expected success, got: {result}"
+        );
+    }
+
+    result.success()
+}
+
+struct Renderer {
+    stdout: BufReader<ChildStdout>,
+    failures: Vec<TestOutcome>,
+}
+
+impl Renderer {
+    fn new(stdout: ChildStdout) -> Self {
+        Self { stdout: BufReader::new(stdout), failures: Vec::new() }
+    }
+
+    fn render_all(mut self) {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match self.stdout.read_line(&mut line) {
+                Ok(_) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(err) => panic!("failed to read output of test runner: {err}"),
+            }
+            if line.is_empty() {
+                break;
+            }
+
+            self.render_message(match serde_json::from_str(&line) {
+                Ok(parsed) => parsed,
+                Err(err) => {
+                    panic!("failed to parse libtest json output; error: {err}, line: {line:?}");
+                }
+            });
+        }
+    }
+
+    fn render_test_outcome(&self, outcome: Outcome<'_>, test: &TestOutcome) {
+        // TODO: add support for terse output
+        self.render_test_outcome_verbose(outcome, test);
+    }
+
+    fn render_test_outcome_verbose(&self, outcome: Outcome<'_>, test: &TestOutcome) {
+        if let Some(exec_time) = test.exec_time {
+            println!(
+                "test {} ... {outcome} (in {:.2?})",
+                test.name,
+                Duration::from_secs_f64(exec_time)
+            );
+        } else {
+            println!("test {} ... {outcome}", test.name);
+        }
+    }
+
+    fn render_suite_outcome(&self, outcome: Outcome<'_>, suite: &SuiteOutcome) {
+        if !self.failures.is_empty() {
+            println!("\nfailures:\n");
+            for failure in &self.failures {
+                if let Some(stdout) = &failure.stdout {
+                    println!("---- {} stdout ----", failure.name);
+                    println!("{stdout}");
+                }
+            }
+
+            println!("\nfailures:");
+            for failure in &self.failures {
+                println!("    {}", failure.name);
+            }
+        }
+
+        println!(
+            "\ntest result: {outcome}. {} passed; {} failed; {} ignored; {} measured; \
+             {} filtered out; finished in {:.2?}\n",
+            suite.passed,
+            suite.failed,
+            suite.ignored,
+            suite.measured,
+            suite.filtered_out,
+            Duration::from_secs_f64(suite.exec_time)
+        );
+    }
+
+    fn render_message(&mut self, message: Message) {
+        match message {
+            Message::Suite(SuiteMessage::Started { test_count }) => {
+                println!("\nrunning {test_count} tests");
+            }
+            Message::Suite(SuiteMessage::Ok(outcome)) => {
+                self.render_suite_outcome(Outcome::Ok, &outcome);
+            }
+            Message::Suite(SuiteMessage::Failed(outcome)) => {
+                self.render_suite_outcome(Outcome::Failed, &outcome);
+            }
+            Message::Test(TestMessage::Ok(outcome)) => {
+                self.render_test_outcome(Outcome::Ok, &outcome);
+            }
+            Message::Test(TestMessage::Ignored(outcome)) => {
+                self.render_test_outcome(
+                    Outcome::Ignored { reason: outcome.reason.as_deref() },
+                    &outcome,
+                );
+            }
+            Message::Test(TestMessage::Failed(outcome)) => {
+                self.render_test_outcome(Outcome::Failed, &outcome);
+                self.failures.push(outcome);
+            }
+            Message::Test(TestMessage::Started) => {} // Not useful
+            Message::Test(TestMessage::Bench) => todo!("benchmarks are not supported yet"),
+        }
+    }
+}
+
+enum Outcome<'a> {
+    Ok,
+    Failed,
+    Ignored { reason: Option<&'a str> },
+}
+
+impl std::fmt::Display for Outcome<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Outcome::Ok => f.write_str("ok"),
+            Outcome::Failed => f.write_str("FAILED"),
+            Outcome::Ignored { reason: None } => f.write_str("ignored"),
+            Outcome::Ignored { reason: Some(reason) } => write!(f, "ignored, {reason}"),
+        }
+    }
+}
+
+#[derive(serde_derive::Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Message {
+    Suite(SuiteMessage),
+    Test(TestMessage),
+}
+
+#[derive(serde_derive::Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+enum SuiteMessage {
+    Ok(SuiteOutcome),
+    Failed(SuiteOutcome),
+    Started { test_count: usize },
+}
+
+#[derive(serde_derive::Deserialize)]
+struct SuiteOutcome {
+    passed: usize,
+    failed: usize,
+    ignored: usize,
+    measured: usize,
+    filtered_out: usize,
+    exec_time: f64,
+}
+
+#[derive(serde_derive::Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+enum TestMessage {
+    Ok(TestOutcome),
+    Failed(TestOutcome),
+    Ignored(TestOutcome),
+    // Ignored messages:
+    Bench,
+    Started,
+}
+
+#[derive(serde_derive::Deserialize)]
+struct TestOutcome {
+    name: String,
+    exec_time: Option<f64>,
+    stdout: Option<String>,
+    reason: Option<String>,
+}

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1616,9 +1616,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
             cmd.arg("--verbose");
         }
 
-        if !builder.config.verbose_tests {
-            cmd.arg("--quiet");
-        }
+        cmd.arg("--json");
 
         let mut llvm_components_passed = false;
         let mut copts_passed = false;
@@ -1769,7 +1767,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
             suite, mode, &compiler.host, target
         ));
         let _time = util::timeit(&builder);
-        try_run(builder, &mut cmd);
+        crate::render_tests::try_run_tests(builder, &mut cmd);
 
         if let Some(compare_mode) = compare_mode {
             cmd.arg("--compare-mode").arg(compare_mode);
@@ -1778,7 +1776,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
                 suite, mode, compare_mode, &compiler.host, target
             ));
             let _time = util::timeit(&builder);
-            try_run(builder, &mut cmd);
+            crate::render_tests::try_run_tests(builder, &mut cmd);
         }
     }
 }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -767,7 +767,7 @@ impl Step for Clippy {
 
         cargo.add_rustc_lib_path(builder, compiler);
 
-        if add_flags_and_try_run_tests(builder, &mut cargo.into()) {
+        if builder.try_run(&mut cargo.into()) {
             // The tests succeeded; nothing to do.
             return;
         }

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 
 use crate::util::{add_dylib_path, PathBufExt};
 use lazycell::LazyCell;
-use test::ColorConfig;
+use test::{ColorConfig, OutputFormat};
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Mode {
@@ -337,7 +337,7 @@ pub struct Config {
     pub verbose: bool,
 
     /// Print one character per test instead of one line
-    pub quiet: bool,
+    pub format: OutputFormat,
 
     /// Whether to use colors in test.
     pub color: ColorConfig,

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -114,6 +114,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         )
         .optflag("", "quiet", "print one character per test instead of one line")
         .optopt("", "color", "coloring: auto, always, never", "WHEN")
+        .optflag("", "json", "emit json output instead of plaintext output")
         .optopt("", "logfile", "file to log test execution to", "FILE")
         .optopt("", "target", "the target to build for", "TARGET")
         .optopt("", "host", "the host to build for", "HOST")
@@ -281,7 +282,12 @@ pub fn parse_config(args: Vec<String>) -> Config {
             && !opt_str2(matches.opt_str("adb-test-dir")).is_empty(),
         lldb_python_dir: matches.opt_str("lldb-python-dir"),
         verbose: matches.opt_present("verbose"),
-        quiet: matches.opt_present("quiet"),
+        format: match (matches.opt_present("quiet"), matches.opt_present("json")) {
+            (true, true) => panic!("--quiet and --json are incompatible"),
+            (true, false) => test::OutputFormat::Terse,
+            (false, true) => test::OutputFormat::Json,
+            (false, false) => test::OutputFormat::Pretty,
+        },
         only_modified: matches.opt_present("only-modified"),
         color,
         remote_test_client: matches.opt_str("remote-test-client").map(PathBuf::from),
@@ -339,7 +345,7 @@ pub fn log_config(config: &Config) {
     logv(c, format!("ar: {}", config.ar));
     logv(c, format!("linker: {:?}", config.linker));
     logv(c, format!("verbose: {}", config.verbose));
-    logv(c, format!("quiet: {}", config.quiet));
+    logv(c, format!("format: {:?}", config.format));
     logv(c, "\n".to_string());
 }
 
@@ -501,7 +507,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         filters: config.filters.clone(),
         filter_exact: config.filter_exact,
         run_ignored: if config.run_ignored { test::RunIgnored::Yes } else { test::RunIgnored::No },
-        format: if config.quiet { test::OutputFormat::Terse } else { test::OutputFormat::Pretty },
+        format: config.format,
         logfile: config.logfile.clone(),
         run_tests: true,
         bench_benchmarks: true,

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -422,7 +422,7 @@ pub fn run_tests(config: Config) {
             // easy to miss which tests failed, and as such fail to reproduce
             // the failure locally.
 
-            eprintln!(
+            println!(
                 "Some tests failed in compiletest suite={}{} mode={} host={} target={}",
                 config.suite,
                 config.compare_mode.map(|c| format!(" compare_mode={:?}", c)).unwrap_or_default(),


### PR DESCRIPTION
The main goal of this PR is to include all tests executed in CI inside the build metrics JSON files. I need this for Ferrocene, and @Mark-Simulacrum expressed desire to have this as well to ensure all tests are executed at least once somewhere in CI.

Unfortunately implementing this required rewriting inside of bootstrap all of the code to render the test output to console. libtest supports outputting JSON instead of raw text, which we can indeed use to populate the build metrics. Doing that suppresses the console output though, and compared to rustc and Cargo the console output is not included as a JSON field.

Because of that, this PR had to reimplement both the "pretty" format (one test per line, with `rust.verbose-tests = true`), and the "terse" format (the wall of dots, with `rust.verbose-tests = false`). The current implementation should have the exact same output as libtest, except for the benchmark output. libtest's benchmark output is broken in the "terse" format, so since that's our default I slightly improved how it's rendered.

Also, to bring parity with libtest I had to introduce support for coloring output from bootstrap, using the same dependencies `annotate-snippets` uses. It's now possible to use `builder.color_for_stdout(Color::Red, "text")` and `builder.color_for_stderr(Color::Green, "text")` across all of bootstrap, automatically respecting the `--color` flag and whether the stream is a terminal or not.

I recommend reviewing the PR commit-by-commit.
r? @Mark-Simulacrum 