### PR TITLE
Fix another ICE in `point_at_expr_source_of_inferred_type`

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -315,7 +315,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     probe::ProbeScope::TraitsInScope,
                     None,
                 ) {
-                    Ok(pick) => pick.self_ty,
+                    Ok(pick) => eraser.fold_ty(pick.self_ty),
                     Err(_) => rcvr_ty,
                 };
                 // Remove one layer of references to account for `&mut self` and

--- a/tests/ui/typeck/bad-type-in-vec-contains.rs
+++ b/tests/ui/typeck/bad-type-in-vec-contains.rs
@@ -1,0 +1,7 @@
+// The error message here still is pretty confusing.
+
+fn main() {
+    let primes = Vec::new();
+    primes.contains(3);
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/typeck/bad-type-in-vec-contains.stderr
+++ b/tests/ui/typeck/bad-type-in-vec-contains.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> $DIR/bad-type-in-vec-contains.rs:5:21
+   |
+LL |     primes.contains(3);
+   |            -------- ^
+   |            |        |
+   |            |        expected `&_`, found integer
+   |            |        help: consider borrowing here: `&3`
+   |            arguments to this method are incorrect
+   |            here the type of `primes` is inferred to be `[_]`
+   |
+   = note: expected reference `&_`
+                   found type `{integer}`
+note: method defined here
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Types coming from method probes must only be investigated *structurally*, since they often contain escaping infer variables from generalization and autoderef. We already have a hack in this PR that erases variables from types, so just use that.

Fixes #108664

The note attached to this error is pretty bad:

```
here the type of `primes` is inferred to be `[_]`
```

But that's unrelated to the PR.

---

Side-note: This is a pretty easy to trigger beta regression, so I've nominated it. Alternatively, I'm slightly inclined to remove this code altogether until it can be reformulated to be more accurate and less ICEy.