### PR TITLE
Allow checking whether a type allows being uninitialized

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -444,6 +444,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                             "aborted execution: attempted to leave type `{}` uninitialized, which is invalid",
                             ty
                         ),
+                        ValidityRequirement::Uninit => bug!("assert_uninit_valid doesn't exist"),
                     };
 
                     M::abort(self, msg)?;

--- a/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
+++ b/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
@@ -30,7 +30,7 @@ pub fn check_validity_requirement<'tcx>(
         return Ok(!layout.abi.is_uninhabited());
     }
 
-    if tcx.sess.opts.unstable_opts.strict_init_checks {
+    if kind == ValidityRequirement::Uninit || tcx.sess.opts.unstable_opts.strict_init_checks {
         might_permit_raw_init_strict(layout, tcx, kind)
     } else {
         let layout_cx = LayoutCx { tcx, param_env: param_env_and_ty.param_env };
@@ -98,6 +98,9 @@ fn might_permit_raw_init_lax<'tcx>(
                     val = (val << 8) | 0x01;
                 }
                 s.valid_range(cx).contains(val)
+            }
+            ValidityRequirement::Uninit => {
+                bug!("ValidityRequirement::Uninit should have been handled above")
             }
         }
     };

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -170,13 +170,17 @@ pub const FAT_PTR_EXTRA: usize = 1;
 /// * Cranelift stores the base-2 log of the lane count in a 4 bit integer.
 pub const MAX_SIMD_LANES: u64 = 1 << 0xF;
 
-/// Used in `might_permit_raw_init` to indicate the kind of initialisation
+/// Used in `check_validity_requirement` to indicate the kind of initialization
 /// that is checked to be valid
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, HashStable)]
 pub enum ValidityRequirement {
     Inhabited,
     Zero,
+    /// The return value of mem::uninitialized, 0x01
+    /// (unless -Zstrict-init-checks is on, in which case it's the same as Uninit).
     UninitMitigated0x01Fill,
+    /// True uninitialized memory.
+    Uninit,
 }
 
 impl ValidityRequirement {
@@ -196,6 +200,7 @@ impl fmt::Display for ValidityRequirement {
             Self::Inhabited => f.write_str("is inhabited"),
             Self::Zero => f.write_str("allows being left zeroed"),
             Self::UninitMitigated0x01Fill => f.write_str("allows being filled with 0x01"),
+            Self::Uninit => f.write_str("allows being left uninitialized"),
         }
     }
 }


### PR DESCRIPTION
This is useful for clippy ([rust-lang/clippy#10407](https://github.com/rust-lang/rust-clippy/issues/10407)) and for the future `MaybeUninit::assume_init` panics (#100423).