### PR TITLE
Feed queries on impl side for RPITITs when using lower_impl_trait_in_trait_to_assoc_ty

### DIFF
--- a/tests/ui/impl-trait/in-trait/new-lowering-strategy/simple-trait.rs
+++ b/tests/ui/impl-trait/in-trait/new-lowering-strategy/simple-trait.rs
@@ -1,0 +1,11 @@
+// check-pass
+// compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+
+#![feature(return_position_impl_trait_in_trait)]
+#![allow(incomplete_features)]
+
+trait Foo {
+    fn foo() -> impl Sized;
+}
+
+fn main() {}


### PR DESCRIPTION
I've added a test for traits that were already working and what I think is probably the last bit of infrastructure work needed.
In following PRs I'm going to start adding things TDD style, tests and code that make it work.

r? @compiler-errors 