### PR TITLE
rustdoc: include link on all.html location header

### DIFF
--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -600,9 +600,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
         };
         let all = shared.all.replace(AllTypes::new());
         let mut sidebar = Buffer::html();
-        if shared.cache.crate_version.is_some() {
-            write!(sidebar, "<h2 class=\"location\">Crate {}</h2>", crate_name)
-        };
+        write!(sidebar, "<h2 class=\"location\"><a href=\"#\">Crate {}</a></h2>", crate_name);
 
         let mut items = Buffer::html();
         sidebar_module_like(&mut items, all.item_sections());

--- a/tests/rustdoc-gui/sidebar.goml
+++ b/tests/rustdoc-gui/sidebar.goml
@@ -149,3 +149,17 @@ assert-property: (".sidebar", {"clientWidth": "200"})
 click: "#toggle-all-docs"
 assert-text: ("#toggle-all-docs", "[−]")
 assert-property: (".sidebar", {"clientWidth": "200"})
+
+// Checks that all.html and index.html have their sidebar link in the same place.
+goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
+store-property: (index_sidebar_width, ".sidebar .location a", "clientWidth")
+store-property: (index_sidebar_height, ".sidebar .location a", "clientHeight")
+store-property: (index_sidebar_x, ".sidebar .location a", "offsetTop")
+store-property: (index_sidebar_y, ".sidebar .location a", "offsetLeft")
+goto: "file://" + |DOC_PATH| + "/test_docs/all.html"
+assert-property: (".sidebar .location a", {
+    "clientWidth": |index_sidebar_width|,
+    "clientHeight": |index_sidebar_height|,
+    "offsetTop": |index_sidebar_x|,
+    "offsetLeft": |index_sidebar_y|,
+})


### PR DESCRIPTION
This avoids a subtle layout shift when switching from the crate page to all items.

## Before

| index.html | all.html |
|------------|----------|
| ![image](https://user-images.githubusercontent.com/1593513/222607866-4eac3f55-314c-4273-9664-503f2a79ad0a.png) | ![image](https://user-images.githubusercontent.com/1593513/222607895-2d6bac3b-f66a-47d4-b234-360f6f8e1ee3.png) |

## After

| index.html | all.html |
|------------|----------|
| ![image](https://user-images.githubusercontent.com/1593513/222607866-4eac3f55-314c-4273-9664-503f2a79ad0a.png) | ![image](https://user-images.githubusercontent.com/1593513/222607997-e72c48a0-02c7-42a7-80c2-cd6bed48bd15.png) |
