### PR TITLE
Reformulate `point_at_expr_source_of_inferred_type` to be more accurate

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -814,7 +814,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.note_source_of_type_mismatch_constraint(
                     &mut err,
                     rcvr,
-                    crate::demand::TypeMismatchSource::Arg(call_expr, provided_idx.as_usize()),
+                    crate::demand::TypeMismatchSource::Arg {
+                        call_expr,
+                        incompatible_arg: provided_idx.as_usize(),
+                    },
                 );
             }
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -807,24 +807,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 full_call_span,
                 format!("arguments to this {} are incorrect", call_name),
             );
-            if let (Some(callee_ty), hir::ExprKind::MethodCall(_, rcvr, _, _)) =
-                (callee_ty, &call_expr.kind)
-            {
-                // Type that would have accepted this argument if it hadn't been inferred earlier.
-                // FIXME: We leave an inference variable for now, but it'd be nice to get a more
-                // specific type to increase the accuracy of the diagnostic.
-                let expected = self.infcx.next_ty_var(TypeVariableOrigin {
-                    kind: TypeVariableOriginKind::MiscVariable,
-                    span: full_call_span,
-                });
-                self.point_at_expr_source_of_inferred_type(
-                    &mut err,
-                    rcvr,
-                    expected,
-                    callee_ty,
-                    provided_arg_span,
-                );
-            }
+
+            // TODO: We would like to point out when the rcvr was constrained
+            // such that the arg mismatch occurs.
+
             // Call out where the function is defined
             self.label_fn_like(
                 &mut err,

--- a/tests/ui/type/type-check/assignment-in-if.stderr
+++ b/tests/ui/type/type-check/assignment-in-if.stderr
@@ -67,9 +67,6 @@ LL |             x == 5
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:44:18
    |
-LL |     if y = (Foo { foo: x }) {
-   |                        - here the type of `x` is inferred to be `usize`
-...
 LL |     if x == x && x = x && x == x {
    |        ------    ^ expected `bool`, found `usize`
    |        |
@@ -78,9 +75,6 @@ LL |     if x == x && x = x && x == x {
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:44:22
    |
-LL |     if y = (Foo { foo: x }) {
-   |                        - here the type of `x` is inferred to be `usize`
-...
 LL |     if x == x && x = x && x == x {
    |                      ^ expected `bool`, found `usize`
 
@@ -98,9 +92,6 @@ LL |     if x == x && x == x && x == x {
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:51:28
    |
-LL |     if y = (Foo { foo: x }) {
-   |                        - here the type of `x` is inferred to be `usize`
-...
 LL |     if x == x && x == x && x = x {
    |        ----------------    ^ expected `bool`, found `usize`
    |        |

--- a/tests/ui/type/type-check/point-at-inference-3.fixed
+++ b/tests/ui/type/type-check/point-at-inference-3.fixed
@@ -2,6 +2,8 @@
 fn main() {
     let mut v = Vec::new();
     v.push(0i32);
+    //~^ NOTE this argument has type `i32`...
+    //~| NOTE ... which causes `v` to have type `Vec<i32>`
     v.push(0);
     v.push(1i32); //~ ERROR mismatched types
     //~^ NOTE expected `i32`, found `u32`

--- a/tests/ui/type/type-check/point-at-inference-3.fixed
+++ b/tests/ui/type/type-check/point-at-inference-3.fixed
@@ -2,7 +2,6 @@
 fn main() {
     let mut v = Vec::new();
     v.push(0i32);
-    //~^ NOTE this is of type `i32`, which causes `v` to be inferred as `Vec<i32>`
     v.push(0);
     v.push(1i32); //~ ERROR mismatched types
     //~^ NOTE expected `i32`, found `u32`

--- a/tests/ui/type/type-check/point-at-inference-3.rs
+++ b/tests/ui/type/type-check/point-at-inference-3.rs
@@ -2,7 +2,6 @@
 fn main() {
     let mut v = Vec::new();
     v.push(0i32);
-    //~^ NOTE this is of type `i32`, which causes `v` to be inferred as `Vec<i32>`
     v.push(0);
     v.push(1u32); //~ ERROR mismatched types
     //~^ NOTE expected `i32`, found `u32`

--- a/tests/ui/type/type-check/point-at-inference-3.rs
+++ b/tests/ui/type/type-check/point-at-inference-3.rs
@@ -2,6 +2,8 @@
 fn main() {
     let mut v = Vec::new();
     v.push(0i32);
+    //~^ NOTE this argument has type `i32`...
+    //~| NOTE ... which causes `v` to have type `Vec<i32>`
     v.push(0);
     v.push(1u32); //~ ERROR mismatched types
     //~^ NOTE expected `i32`, found `u32`

--- a/tests/ui/type/type-check/point-at-inference-3.stderr
+++ b/tests/ui/type/type-check/point-at-inference-3.stderr
@@ -1,6 +1,11 @@
 error[E0308]: mismatched types
-  --> $DIR/point-at-inference-3.rs:6:12
+  --> $DIR/point-at-inference-3.rs:8:12
    |
+LL |     v.push(0i32);
+   |     -      ---- this argument has type `i32`...
+   |     |
+   |     ... which causes `v` to have type `Vec<i32>`
+...
 LL |     v.push(1u32);
    |       ---- ^^^^ expected `i32`, found `u32`
    |       |

--- a/tests/ui/type/type-check/point-at-inference-3.stderr
+++ b/tests/ui/type/type-check/point-at-inference-3.stderr
@@ -1,9 +1,6 @@
 error[E0308]: mismatched types
-  --> $DIR/point-at-inference-3.rs:7:12
+  --> $DIR/point-at-inference-3.rs:6:12
    |
-LL |     v.push(0i32);
-   |            ---- this is of type `i32`, which causes `v` to be inferred as `Vec<i32>`
-...
 LL |     v.push(1u32);
    |       ---- ^^^^ expected `i32`, found `u32`
    |       |

--- a/tests/ui/type/type-check/point-at-inference-4.rs
+++ b/tests/ui/type/type-check/point-at-inference-4.rs
@@ -11,6 +11,7 @@ fn main() {
     let s = S(None);
     s.infer(0i32);
     //~^ ERROR this method takes 2 arguments but 1 argument was supplied
+    //~| NOTE here the type of `s` is inferred to be `S<i32, _>`
     //~| NOTE an argument is missing
     //~| HELP provide the argument
     let t: S<u32, _> = s;

--- a/tests/ui/type/type-check/point-at-inference-4.rs
+++ b/tests/ui/type/type-check/point-at-inference-4.rs
@@ -11,9 +11,11 @@ fn main() {
     let s = S(None);
     s.infer(0i32);
     //~^ ERROR this method takes 2 arguments but 1 argument was supplied
-    //~| NOTE here the type of `s` is inferred to be `S<i32, _>`
+    //~| NOTE this argument has type `i32`...
+    //~| NOTE ... which causes `s` to have type `S<i32, _>`
     //~| NOTE an argument is missing
     //~| HELP provide the argument
+    //~| HELP change the type of the numeric literal from `i32` to `u32`
     let t: S<u32, _> = s;
     //~^ ERROR mismatched types
     //~| NOTE expected `S<u32, _>`, found `S<i32, _>`

--- a/tests/ui/type/type-check/point-at-inference-4.stderr
+++ b/tests/ui/type/type-check/point-at-inference-4.stderr
@@ -15,8 +15,11 @@ LL |     s.infer(0i32, /* b */);
    |            ~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
-  --> $DIR/point-at-inference-4.rs:16:24
+  --> $DIR/point-at-inference-4.rs:17:24
    |
+LL |     s.infer(0i32);
+   |     - here the type of `s` is inferred to be `S<i32, _>`
+...
 LL |     let t: S<u32, _> = s;
    |            ---------   ^ expected `S<u32, _>`, found `S<i32, _>`
    |            |

--- a/tests/ui/type/type-check/point-at-inference-4.stderr
+++ b/tests/ui/type/type-check/point-at-inference-4.stderr
@@ -15,10 +15,12 @@ LL |     s.infer(0i32, /* b */);
    |            ~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
-  --> $DIR/point-at-inference-4.rs:17:24
+  --> $DIR/point-at-inference-4.rs:19:24
    |
 LL |     s.infer(0i32);
-   |     - here the type of `s` is inferred to be `S<i32, _>`
+   |     -       ---- this argument has type `i32`...
+   |     |
+   |     ... which causes `s` to have type `S<i32, _>`
 ...
 LL |     let t: S<u32, _> = s;
    |            ---------   ^ expected `S<u32, _>`, found `S<i32, _>`
@@ -27,6 +29,10 @@ LL |     let t: S<u32, _> = s;
    |
    = note: expected struct `S<u32, _>`
               found struct `S<i32, _>`
+help: change the type of the numeric literal from `i32` to `u32`
+   |
+LL |     s.infer(0u32);
+   |              ~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type/type-check/point-at-inference.fixed
+++ b/tests/ui/type/type-check/point-at-inference.fixed
@@ -6,7 +6,7 @@ fn main() {
     let mut foo = vec![];
     baz(&foo);
     for i in &v {
-        foo.push(*i);
+        foo.push(i);
     }
     baz(&foo);
     bar(foo); //~ ERROR E0308

--- a/tests/ui/type/type-check/point-at-inference.fixed
+++ b/tests/ui/type/type-check/point-at-inference.fixed
@@ -6,7 +6,7 @@ fn main() {
     let mut foo = vec![];
     baz(&foo);
     for i in &v {
-        foo.push(i);
+        foo.push(*i);
     }
     baz(&foo);
     bar(foo); //~ ERROR E0308

--- a/tests/ui/type/type-check/point-at-inference.stderr
+++ b/tests/ui/type/type-check/point-at-inference.stderr
@@ -2,7 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/point-at-inference.rs:12:9
    |
 LL |         foo.push(i);
-   |         --- here the type of `foo` is inferred to be `Vec<&{integer}>`
+   |         ---      - this argument has type `&{integer}`...
+   |         |
+   |         ... which causes `foo` to have type `Vec<&{integer}>`
 ...
 LL |     bar(foo);
    |     --- ^^^ expected `Vec<i32>`, found `Vec<&{integer}>`

--- a/tests/ui/type/type-check/point-at-inference.stderr
+++ b/tests/ui/type/type-check/point-at-inference.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/point-at-inference.rs:12:9
    |
 LL |         foo.push(i);
-   |                  - this is of type `&{integer}`, which causes `foo` to be inferred as `Vec<&{integer}>`
+   |         --- here the type of `foo` is inferred to be `Vec<&{integer}>`
 ...
 LL |     bar(foo);
    |     --- ^^^ expected `Vec<i32>`, found `Vec<&{integer}>`
@@ -16,10 +16,6 @@ note: function defined here
    |
 LL | fn bar(_: Vec<i32>) {}
    |    ^^^ -----------
-help: consider dereferencing the borrow
-   |
-LL |         foo.push(*i);
-   |                  +
 
 error: aborting due to previous error
 

--- a/tests/ui/type/type-check/point-at-inference.stderr
+++ b/tests/ui/type/type-check/point-at-inference.stderr
@@ -18,6 +18,10 @@ note: function defined here
    |
 LL | fn bar(_: Vec<i32>) {}
    |    ^^^ -----------
+help: consider dereferencing the borrow
+   |
+LL |         foo.push(*i);
+   |                  +
 
 error: aborting due to previous error
 

--- a/tests/ui/typeck/bad-type-in-vec-contains.stderr
+++ b/tests/ui/typeck/bad-type-in-vec-contains.stderr
@@ -7,7 +7,6 @@ LL |     primes.contains(3);
    |            |        expected `&_`, found integer
    |            |        help: consider borrowing here: `&3`
    |            arguments to this method are incorrect
-   |            here the type of `primes` is inferred to be `[_]`
    |
    = note: expected reference `&_`
                    found type `{integer}`

--- a/tests/ui/typeck/bad-type-in-vec-push.stderr
+++ b/tests/ui/typeck/bad-type-in-vec-push.stderr
@@ -1,8 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/bad-type-in-vec-push.rs:11:17
    |
-LL |     vector.sort();
-   |     ------ here the type of `vector` is inferred to be `Vec<_>`
 LL |     result.push(vector);
    |            ---- ^^^^^^ expected integer, found `Vec<_>`
    |            |

--- a/tests/ui/typeck/issue-107775.stderr
+++ b/tests/ui/typeck/issue-107775.stderr
@@ -2,9 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-107775.rs:35:16
    |
 LL |         map.insert(1, Struct::do_something);
-   |                    -  -------------------- this is of type `fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}`, which causes `map` to be inferred as `HashMap<{integer}, fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`
-   |                    |
-   |                    this is of type `{integer}`, which causes `map` to be inferred as `HashMap<{integer}, fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`
+   |         --- here the type of `map` is inferred to be `HashMap<{integer}, fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`
 LL |         Self { map }
    |                ^^^ expected `HashMap<u16, fn(u8) -> Pin<...>>`, found `HashMap<{integer}, ...>`
    |

--- a/tests/ui/typeck/issue-107775.stderr
+++ b/tests/ui/typeck/issue-107775.stderr
@@ -2,7 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/issue-107775.rs:35:16
    |
 LL |         map.insert(1, Struct::do_something);
-   |         --- here the type of `map` is inferred to be `HashMap<{integer}, fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`
+   |         ---           -------------------- this argument has type `fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}`...
+   |         |
+   |         ... which causes `map` to have type `HashMap<{integer}, fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`
 LL |         Self { map }
    |                ^^^ expected `HashMap<u16, fn(u8) -> Pin<...>>`, found `HashMap<{integer}, ...>`
    |


### PR DESCRIPTION
Be more accurate when deducing where along the several usages of a binding it is constrained to be some type that is incompatible with an expectation.

This also renames the method to `note_source_of_type_mismatch_constraint` because I prefer that name, though I guess I can revert that. (Also drive-by rename `note_result_coercion` -> `suggest_coercing_result_via_try_operator`, because it's suggesting, not noting!)

This PR is (probably?) best reviewed per commit, but it does regress a bit only to fix it later on, so it could also be reviewed as a whole if that makes the final results more clear.

r? @estebank