### PR TITLE
rustdoc: function signature search with traits in `where` clause

### DIFF
--- a/tests/rustdoc-js-std/option-type-signatures.js
+++ b/tests/rustdoc-js-std/option-type-signatures.js
@@ -1,0 +1,7 @@
+const QUERY = 'option, fnonce -> option';
+
+const EXPECTED = {
+    'others': [
+        { 'path': 'std::option::Option', 'name': 'map' },
+    ],
+};

--- a/tests/rustdoc-js/where-clause.js
+++ b/tests/rustdoc-js/where-clause.js
@@ -1,0 +1,19 @@
+const QUERY = ['trait<nested>', '-> trait<nested>', 't1, t2'];
+
+const EXPECTED = [
+    {
+        'in_args': [
+           { 'path': 'where_clause', 'name': 'abracadabra' },
+        ],
+    },
+    {
+        'others': [
+            { 'path': 'where_clause', 'name': 'alacazam' },
+        ],
+    },
+    {
+        'others': [
+            { 'path': 'where_clause', 'name': 'presto' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/where-clause.rs
+++ b/tests/rustdoc-js/where-clause.rs
@@ -1,0 +1,16 @@
+pub struct Nested;
+
+pub trait Trait<T> {
+    fn thank_you(x: T);
+}
+
+pub fn abracadabra<X>(_: X) where X: Trait<Nested> {}
+
+pub fn alacazam<X>() -> X where X: Trait<Nested> {}
+
+pub trait T1 {}
+pub trait T2<'a, T> {
+    fn please(_: &'a T);
+}
+
+pub fn presto<A, B>(_: A, _: B) where A: T1, B: for <'b> T2<'b, Nested> {}


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/1593513/222873534-a640a72a-c654-4702-9f3b-175129d9591d.png)

## After

![image](https://user-images.githubusercontent.com/1593513/222873544-fdfc431d-2b65-4b56-bede-0302ea9f153a.png)
