### PR TITLE
rustc_expand: make proc-macro derive error translatable

### DIFF
--- a/compiler/rustc_expand/locales/en-US.ftl
+++ b/compiler/rustc_expand/locales/en-US.ftl
@@ -133,3 +133,6 @@ expand_trace_macro = trace_macro
 expand_proc_macro_panicked =
     proc macro panicked
     .help = message: {$message}
+
+expand_proc_macro_derive_tokens =
+    proc-macro derive produced unparseable tokens

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -390,3 +390,10 @@ pub(crate) struct ProcMacroPanicked {
 pub(crate) struct ProcMacroPanickedHelp {
     pub message: String,
 }
+
+#[derive(Diagnostic)]
+#[diag(expand_proc_macro_derive_tokens)]
+pub struct ProcMacroDeriveTokens {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -176,7 +176,7 @@ impl MultiItemModifier for DeriveProcMacro {
 
         // fail if there have been errors emitted
         if ecx.sess.parse_sess.span_diagnostic.err_count() > error_count_before {
-            ecx.struct_span_err(span, "proc-macro derive produced unparseable tokens").emit();
+            ecx.sess.emit_err(errors::ProcMacroDeriveTokens { span });
         }
 
         ExpandResult::Ready(items)


### PR DESCRIPTION
kept this tiny so as to point to it as an example in rustc-dev-guide

@rustbot label +A-translation