### PR TITLE
feat: impl better help for `.poll()` not found on `impl Future`

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -348,6 +348,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             err.downgrade_to_delayed_bug();
         }
 
+        if tcx.ty_is_opaque_future(rcvr_ty) && item_name.name == sym::poll {
+            err.help(&format!(
+                "method `poll` found on `Pin<&mut {ty_str}>`, \
+                see documentation for `std::pin::Pin`"
+            ));
+            err.help("self type must be pinned to call `Future::poll`, \
+                see https://rust-lang.github.io/async-book/04_pinning/01_chapter.html#pinning-in-practice"
+            );
+        }
+
         if let Mode::MethodCall = mode && let SelfSource::MethodCall(cal) = source {
             self.suggest_await_before_method(
                 &mut err, item_name, rcvr_ty, cal, span, expected.only_has_type(self),

--- a/tests/ui/async-await/issue-108572.rs
+++ b/tests/ui/async-await/issue-108572.rs
@@ -1,0 +1,12 @@
+// edition: 2021
+
+use std::future::Future;
+fn foo() -> impl Future<Output=()> {
+    async { }
+}
+
+fn main() {
+    let fut = foo();
+    fut.poll();
+    //~^ ERROR no method named `poll` found for opaque type `impl Future<Output = ()>` in the current scope [E0599]
+}

--- a/tests/ui/async-await/issue-108572.stderr
+++ b/tests/ui/async-await/issue-108572.stderr
@@ -1,0 +1,12 @@
+error[E0599]: no method named `poll` found for opaque type `impl Future<Output = ()>` in the current scope
+  --> $DIR/issue-108572.rs:10:9
+   |
+LL |     fut.poll();
+   |         ^^^^ method not found in `impl Future<Output = ()>`
+   |
+   = help: method `poll` found on `Pin<&mut impl Future<Output = ()>>`, see documentation for `std::pin::Pin`
+   = help: self type must be pinned to call `Future::poll`, see https://rust-lang.github.io/async-book/04_pinning/01_chapter.html#pinning-in-practice
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Partially address #108572

I'd like to also address suggestions for generalized `Self` parameters as well. That'll be a separate PR.