### PR TITLE
feat: dedup "the size for values ... cannot be known" error

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -571,18 +571,20 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     );
                 }
             }
-            // Here we want to prevent struct constructors from returning unsized types.
-            // There were two cases this happened: fn pointer coercion in stable
-            // and usual function call in presence of unsized_locals.
-            // Also, as we just want to check sizedness, instead of introducing
-            // placeholder lifetimes with probing, we just replace higher lifetimes
-            // with fresh vars.
-            let output = self.instantiate_binder_with_fresh_vars(
-                expr.span,
-                infer::LateBoundRegionConversionTime::FnCall,
-                fn_sig.output(),
-            );
-            self.require_type_is_sized_deferred(output, expr.span, traits::SizedReturnType);
+            if tcx.features().unsized_fn_params {
+                // Here we want to prevent struct constructors from returning unsized types.
+                // There were two cases this happened: fn pointer coercion in stable
+                // and usual function call in presence of unsized_locals.
+                // Also, as we just want to check sizedness, instead of introducing
+                // placeholder lifetimes with probing, we just replace higher lifetimes
+                // with fresh vars.
+                let output = self.instantiate_binder_with_fresh_vars(
+                    expr.span,
+                    infer::LateBoundRegionConversionTime::FnCall,
+                    fn_sig.output(),
+                );
+                self.require_type_is_sized_deferred(output, expr.span, traits::SizedReturnType);
+            }
         }
 
         // We always require that the type provided as the value for

--- a/tests/incremental/const-generics/hash-tyvid-regression-1.rs
+++ b/tests/incremental/const-generics/hash-tyvid-regression-1.rs
@@ -9,7 +9,6 @@ where
     use std::convert::TryFrom;
     <[T; N.get()]>::try_from(())
     //~^ error: the trait bound
-    //~| error: the trait bound
     //~| error: mismatched types
 }
 

--- a/tests/ui/impl-trait/in-trait/issue-102140.current.stderr
+++ b/tests/ui/impl-trait/in-trait/issue-102140.current.stderr
@@ -20,14 +20,6 @@ LL |         MyTrait::foo(&self)
    |
    = help: the trait `MyTrait` is implemented for `Outer`
 
-error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
-  --> $DIR/issue-102140.rs:26:9
-   |
-LL |         MyTrait::foo(&self)
-   |         ^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
-   |
-   = help: the trait `MyTrait` is implemented for `Outer`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/in-trait/issue-102140.next.stderr
+++ b/tests/ui/impl-trait/in-trait/issue-102140.next.stderr
@@ -20,14 +20,6 @@ LL |         MyTrait::foo(&self)
    |
    = help: the trait `MyTrait` is implemented for `Outer`
 
-error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
-  --> $DIR/issue-102140.rs:26:9
-   |
-LL |         MyTrait::foo(&self)
-   |         ^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
-   |
-   = help: the trait `MyTrait` is implemented for `Outer`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/in-trait/issue-102140.rs
+++ b/tests/ui/impl-trait/in-trait/issue-102140.rs
@@ -26,7 +26,6 @@ impl dyn MyTrait {
         MyTrait::foo(&self)
         //~^ ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied
         //~| ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied
-        //~| ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied
     }
 }
 

--- a/tests/ui/iterators/issue-28098.rs
+++ b/tests/ui/iterators/issue-28098.rs
@@ -2,7 +2,6 @@ fn main() {
     let _ = Iterator::next(&mut ());
     //~^ ERROR `()` is not an iterator
     //~| ERROR `()` is not an iterator
-    //~| ERROR `()` is not an iterator
 
     for _ in false {}
     //~^ ERROR `bool` is not an iterator
@@ -19,7 +18,6 @@ pub fn other() {
 
     let _ = Iterator::next(&mut ());
     //~^ ERROR `()` is not an iterator
-    //~| ERROR `()` is not an iterator
     //~| ERROR `()` is not an iterator
 
     let _ = Iterator::next(&mut ());

--- a/tests/ui/iterators/issue-28098.stderr
+++ b/tests/ui/iterators/issue-28098.stderr
@@ -17,7 +17,7 @@ LL |     let _ = Iterator::next(&mut ());
    = help: the trait `Iterator` is not implemented for `()`
 
 error[E0277]: `bool` is not an iterator
-  --> $DIR/issue-28098.rs:7:14
+  --> $DIR/issue-28098.rs:6:14
    |
 LL |     for _ in false {}
    |              ^^^^^ `bool` is not an iterator
@@ -26,7 +26,7 @@ LL |     for _ in false {}
    = note: required for `bool` to implement `IntoIterator`
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:10:28
+  --> $DIR/issue-28098.rs:9:28
    |
 LL |     let _ = Iterator::next(&mut ());
    |             -------------- ^^^^^^^ `()` is not an iterator
@@ -36,7 +36,7 @@ LL |     let _ = Iterator::next(&mut ());
    = help: the trait `Iterator` is not implemented for `()`
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:10:13
+  --> $DIR/issue-28098.rs:9:13
    |
 LL |     let _ = Iterator::next(&mut ());
    |             ^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
@@ -44,15 +44,7 @@ LL |     let _ = Iterator::next(&mut ());
    = help: the trait `Iterator` is not implemented for `()`
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:2:13
-   |
-LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^ `()` is not an iterator
-   |
-   = help: the trait `Iterator` is not implemented for `()`
-
-error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:20:28
+  --> $DIR/issue-28098.rs:19:28
    |
 LL |     let _ = Iterator::next(&mut ());
    |             -------------- ^^^^^^^ `()` is not an iterator
@@ -62,7 +54,7 @@ LL |     let _ = Iterator::next(&mut ());
    = help: the trait `Iterator` is not implemented for `()`
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:20:13
+  --> $DIR/issue-28098.rs:19:13
    |
 LL |     let _ = Iterator::next(&mut ());
    |             ^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
@@ -70,7 +62,7 @@ LL |     let _ = Iterator::next(&mut ());
    = help: the trait `Iterator` is not implemented for `()`
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:25:28
+  --> $DIR/issue-28098.rs:23:28
    |
 LL |     let _ = Iterator::next(&mut ());
    |             -------------- ^^^^^^^ `()` is not an iterator
@@ -80,7 +72,7 @@ LL |     let _ = Iterator::next(&mut ());
    = help: the trait `Iterator` is not implemented for `()`
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:25:13
+  --> $DIR/issue-28098.rs:23:13
    |
 LL |     let _ = Iterator::next(&mut ());
    |             ^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
@@ -88,7 +80,7 @@ LL |     let _ = Iterator::next(&mut ());
    = help: the trait `Iterator` is not implemented for `()`
 
 error[E0277]: `bool` is not an iterator
-  --> $DIR/issue-28098.rs:29:14
+  --> $DIR/issue-28098.rs:27:14
    |
 LL |     for _ in false {}
    |              ^^^^^ `bool` is not an iterator
@@ -96,14 +88,6 @@ LL |     for _ in false {}
    = help: the trait `Iterator` is not implemented for `bool`
    = note: required for `bool` to implement `IntoIterator`
 
-error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:20:13
-   |
-LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^ `()` is not an iterator
-   |
-   = help: the trait `Iterator` is not implemented for `()`
-
-error: aborting due to 12 previous errors
+error: aborting due to 10 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/on-unimplemented/multiple-impls.rs
+++ b/tests/ui/on-unimplemented/multiple-impls.rs
@@ -33,13 +33,10 @@ fn main() {
     Index::index(&[] as &[i32], 2u32);
     //~^ ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
     Index::index(&[] as &[i32], Foo(2u32));
     //~^ ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
     Index::index(&[] as &[i32], Bar(2u32));
     //~^ ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0277
 }

--- a/tests/ui/on-unimplemented/multiple-impls.stderr
+++ b/tests/ui/on-unimplemented/multiple-impls.stderr
@@ -23,7 +23,7 @@ LL |     Index::index(&[] as &[i32], 2u32);
              <[i32] as Index<Foo<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:37:33
+  --> $DIR/multiple-impls.rs:36:33
    |
 LL |     Index::index(&[] as &[i32], Foo(2u32));
    |     ------------                ^^^^^^^^^ on impl for Foo
@@ -36,7 +36,7 @@ LL |     Index::index(&[] as &[i32], Foo(2u32));
              <[i32] as Index<Foo<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:37:5
+  --> $DIR/multiple-impls.rs:36:5
    |
 LL |     Index::index(&[] as &[i32], Foo(2u32));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ on impl for Foo
@@ -47,7 +47,7 @@ LL |     Index::index(&[] as &[i32], Foo(2u32));
              <[i32] as Index<Foo<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:41:33
+  --> $DIR/multiple-impls.rs:39:33
    |
 LL |     Index::index(&[] as &[i32], Bar(2u32));
    |     ------------                ^^^^^^^^^ on impl for Bar
@@ -60,7 +60,7 @@ LL |     Index::index(&[] as &[i32], Bar(2u32));
              <[i32] as Index<Foo<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:41:5
+  --> $DIR/multiple-impls.rs:39:5
    |
 LL |     Index::index(&[] as &[i32], Bar(2u32));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ on impl for Bar
@@ -70,39 +70,6 @@ LL |     Index::index(&[] as &[i32], Bar(2u32));
              <[i32] as Index<Bar<usize>>>
              <[i32] as Index<Foo<usize>>>
 
-error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
-  --> $DIR/multiple-impls.rs:33:5
-   |
-LL |     Index::index(&[] as &[i32], 2u32);
-   |     ^^^^^^^^^^^^ trait message
-   |
-   = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
-
-error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:37:5
-   |
-LL |     Index::index(&[] as &[i32], Foo(2u32));
-   |     ^^^^^^^^^^^^ on impl for Foo
-   |
-   = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
-
-error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:41:5
-   |
-LL |     Index::index(&[] as &[i32], Bar(2u32));
-   |     ^^^^^^^^^^^^ on impl for Bar
-   |
-   = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
-
-error: aborting due to 9 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/on-unimplemented/on-impl.rs
+++ b/tests/ui/on-unimplemented/on-impl.rs
@@ -22,5 +22,4 @@ fn main() {
     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
     //~^ ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/tests/ui/on-unimplemented/on-impl.stderr
+++ b/tests/ui/on-unimplemented/on-impl.stderr
@@ -18,15 +18,6 @@ LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
    = help: the trait `Index<u32>` is not implemented for `[i32]`
    = help: the trait `Index<usize>` is implemented for `[i32]`
 
-error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
-  --> $DIR/on-impl.rs:22:5
-   |
-LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
-   |     ^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
-   |
-   = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the trait `Index<usize>` is implemented for `[i32]`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/ufcs/ufcs-qpath-self-mismatch.rs
+++ b/tests/ui/ufcs/ufcs-qpath-self-mismatch.rs
@@ -3,7 +3,6 @@ use std::ops::Add;
 fn main() {
     <i32 as Add<u32>>::add(1, 2);
     //~^ ERROR cannot add `u32` to `i32`
-    //~| ERROR cannot add `u32` to `i32`
     <i32 as Add<i32>>::add(1u32, 2);
     //~^ ERROR mismatched types
     <i32 as Add<i32>>::add(1, 2u32);

--- a/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -14,7 +14,7 @@ LL |     <i32 as Add<u32>>::add(1, 2);
              <i32 as Add>
 
 error[E0308]: mismatched types
-  --> $DIR/ufcs-qpath-self-mismatch.rs:7:28
+  --> $DIR/ufcs-qpath-self-mismatch.rs:6:28
    |
 LL |     <i32 as Add<i32>>::add(1u32, 2);
    |     ---------------------- ^^^^ expected `i32`, found `u32`
@@ -22,7 +22,7 @@ LL |     <i32 as Add<i32>>::add(1u32, 2);
    |     arguments to this function are incorrect
    |
 help: the return type of this call is `u32` due to the type of the argument passed
-  --> $DIR/ufcs-qpath-self-mismatch.rs:7:5
+  --> $DIR/ufcs-qpath-self-mismatch.rs:6:5
    |
 LL |     <i32 as Add<i32>>::add(1u32, 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^----^^^^
@@ -36,7 +36,7 @@ LL |     <i32 as Add<i32>>::add(1i32, 2);
    |                             ~~~
 
 error[E0308]: mismatched types
-  --> $DIR/ufcs-qpath-self-mismatch.rs:9:31
+  --> $DIR/ufcs-qpath-self-mismatch.rs:8:31
    |
 LL |     <i32 as Add<i32>>::add(1, 2u32);
    |     ----------------------    ^^^^ expected `i32`, found `u32`
@@ -44,7 +44,7 @@ LL |     <i32 as Add<i32>>::add(1, 2u32);
    |     arguments to this function are incorrect
    |
 help: the return type of this call is `u32` due to the type of the argument passed
-  --> $DIR/ufcs-qpath-self-mismatch.rs:9:5
+  --> $DIR/ufcs-qpath-self-mismatch.rs:8:5
    |
 LL |     <i32 as Add<i32>>::add(1, 2u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^----^
@@ -57,20 +57,7 @@ help: change the type of the numeric literal from `u32` to `i32`
 LL |     <i32 as Add<i32>>::add(1, 2i32);
    |                                ~~~
 
-error[E0277]: cannot add `u32` to `i32`
-  --> $DIR/ufcs-qpath-self-mismatch.rs:4:5
-   |
-LL |     <i32 as Add<u32>>::add(1, 2);
-   |     ^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u32`
-   |
-   = help: the trait `Add<u32>` is not implemented for `i32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a i32 as Add<i32>>
-             <&i32 as Add<&i32>>
-             <i32 as Add<&i32>>
-             <i32 as Add>
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/unsized-locals/issue-105753.rs
+++ b/tests/ui/unsized-locals/issue-105753.rs
@@ -1,0 +1,9 @@
+fn foo() -> [i32] {
+    //~^ ERROR the size for values of type `[i32]` cannot be known at compilation time
+    todo!()
+}
+
+fn main() {
+    let x = foo();
+    //~^ ERROR the size for values of type `[i32]` cannot be known at compilation time
+}

--- a/tests/ui/unsized-locals/issue-105753.stderr
+++ b/tests/ui/unsized-locals/issue-105753.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
+  --> $DIR/issue-105753.rs:1:13
+   |
+LL | fn foo() -> [i32] {
+   |             ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[i32]`
+   = note: the return type of a function must have a statically known size
+
+error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
+  --> $DIR/issue-105753.rs:7:9
+   |
+LL |     let x = foo();
+   |         ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[i32]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #105753

~~Two points on the UI updates:~~
~~- most are de-duplicating trait errors (which I assume come from `instantiate_binder_with_fresh_vars`), this is invisible to the user regardless.~~
~~- `tests/ui/unsized-locals/unsized-exprs.rs`: seems to make sense within `unsized_fn_params`.~~

out of date