### PR TITLE
rustdoc: Note in a type's layout/size if it is uninhabited

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1839,6 +1839,12 @@ fn document_type_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
         } else {
             let size = layout.size.bytes() - tag_size;
             write!(w, "{size} byte{pl}", pl = if size == 1 { "" } else { "s" },);
+            if layout.abi.is_uninhabited() {
+                write!(
+                    w,
+                    " (<a href=\"https://doc.rust-lang.org/stable/reference/glossary.html#uninhabited\">uninhabited</a>)"
+                );
+            }
         }
     }
 

--- a/tests/rustdoc/type-layout.rs
+++ b/tests/rustdoc/type-layout.rs
@@ -83,3 +83,11 @@ pub enum WithNiche {
     None,
     Some(std::num::NonZeroU32),
 }
+
+// @hasraw type_layout/enum.Uninhabited.html 'Size: '
+// @hasraw - '0 bytes (<a href="https://doc.rust-lang.org/stable/reference/glossary.html#uninhabited">uninhabited</a>)'
+pub enum Uninhabited {}
+
+// @hasraw type_layout/struct.Uninhabited2.html 'Size: '
+// @hasraw - '8 bytes (<a href="https://doc.rust-lang.org/stable/reference/glossary.html#uninhabited">uninhabited</a>)'
+pub struct Uninhabited2(std::convert::Infallible, u64);


### PR DESCRIPTION
Closes #87008

![image](https://user-images.githubusercontent.com/13556931/222900244-8e326d51-8d3b-4700-a935-96830179e2e9.png)
