### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -12,7 +12,7 @@ use rustc_ast::visit::{self, AssocCtxt, BoundKind, FnCtxt, FnKind, Visitor};
 use rustc_ast::walk_list;
 use rustc_ast::*;
 use rustc_ast_pretty::pprust::{self, State};
-use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::fx::FxIndexMap;
 use rustc_macros::Subdiagnostic;
 use rustc_parse::validate_attr;
 use rustc_session::lint::builtin::{
@@ -643,7 +643,7 @@ fn validate_generic_param_order(
     span: Span,
 ) {
     let mut max_param: Option<ParamKindOrd> = None;
-    let mut out_of_order = FxHashMap::default();
+    let mut out_of_order = FxIndexMap::default();
     let mut param_idents = Vec::with_capacity(generics.len());
 
     for (idx, param) in generics.iter().enumerate() {

--- a/compiler/rustc_ast_passes/src/lib.rs
+++ b/compiler/rustc_ast_passes/src/lib.rs
@@ -4,7 +4,6 @@
 //!
 //! The crate also contains other misc AST visitors, e.g. `node_count` and `show_span`.
 
-#![allow(rustc::potential_query_instability)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
 #![feature(iter_is_partitioned)]

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1895,7 +1895,7 @@ impl EmitterWriter {
                         self.draw_code_line(
                             &mut buffer,
                             &mut row_num,
-                            &Vec::new(),
+                            &[],
                             p + line_start,
                             l,
                             show_code_change,
@@ -1919,7 +1919,7 @@ impl EmitterWriter {
                             self.draw_code_line(
                                 &mut buffer,
                                 &mut row_num,
-                                &Vec::new(),
+                                &[],
                                 p + line_start,
                                 l,
                                 show_code_change,
@@ -1936,7 +1936,7 @@ impl EmitterWriter {
                             self.draw_code_line(
                                 &mut buffer,
                                 &mut row_num,
-                                &Vec::new(),
+                                &[],
                                 p + line_start,
                                 l,
                                 show_code_change,
@@ -1951,7 +1951,7 @@ impl EmitterWriter {
                 self.draw_code_line(
                     &mut buffer,
                     &mut row_num,
-                    highlight_parts,
+                    &highlight_parts,
                     line_pos + line_start,
                     line,
                     show_code_change,
@@ -2176,7 +2176,7 @@ impl EmitterWriter {
         &self,
         buffer: &mut StyledBuffer,
         row_num: &mut usize,
-        highlight_parts: &Vec<SubstitutionHighlight>,
+        highlight_parts: &[SubstitutionHighlight],
         line_num: usize,
         line_to_add: &str,
         show_code_change: DisplaySuggestion,

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -331,7 +331,7 @@ impl CodeSuggestion {
                     });
                     buf.push_str(&part.snippet);
                     let cur_hi = sm.lookup_char_pos(part.span.hi());
-                    if prev_hi.line == cur_lo.line && cur_hi.line == cur_lo.line {
+                    if cur_hi.line == cur_lo.line {
                         // Account for the difference between the width of the current code and the
                         // snippet being suggested, so that the *later* suggestions are correctly
                         // aligned on the screen.

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -94,10 +94,10 @@ pub(crate) type UnificationTable<'a, 'tcx, T> = ut::UnificationTable<
 /// call to `start_snapshot` and `rollback_to`.
 #[derive(Clone)]
 pub struct InferCtxtInner<'tcx> {
-    /// Cache for projections. This cache is snapshotted along with the infcx.
+    /// Cache for projections.
     ///
-    /// Public so that `traits::project` can use it.
-    pub projection_cache: traits::ProjectionCacheStorage<'tcx>,
+    /// This cache is snapshotted along with the infcx.
+    projection_cache: traits::ProjectionCacheStorage<'tcx>,
 
     /// We instantiate `UnificationTable` with `bounds<Ty>` because the types
     /// that might instantiate a general type variable have an order,

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1389,19 +1389,6 @@ impl<'a> Parser<'a> {
             self.parse_expr_let()
         } else if self.eat_keyword(kw::Underscore) {
             Ok(self.mk_expr(self.prev_token.span, ExprKind::Underscore))
-        } else if !self.unclosed_delims.is_empty() && self.check(&token::Semi) {
-            // Don't complain about bare semicolons after unclosed braces
-            // recovery in order to keep the error count down. Fixing the
-            // delimiters will possibly also fix the bare semicolon found in
-            // expression context. For example, silence the following error:
-            //
-            //     error: expected expression, found `;`
-            //      --> file.rs:2:13
-            //       |
-            //     2 |     foo(bar(;
-            //       |             ^ expected expression
-            self.bump();
-            Ok(self.mk_expr_err(self.token.span))
         } else if self.token.uninterpolated_span().rust_2018() {
             // `Span::rust_2018()` is somewhat expensive; don't get it repeatedly.
             if self.check_keyword(kw::Async) {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -125,16 +125,13 @@ impl<'a> Parser<'a> {
             return Ok(Some(item.into_inner()));
         };
 
-        let mut unclosed_delims = vec![];
         let item =
             self.collect_tokens_trailing_token(attrs, force_collect, |this: &mut Self, attrs| {
                 let item =
                     this.parse_item_common_(attrs, mac_allowed, attrs_allowed, fn_parse_mode);
-                unclosed_delims.append(&mut this.unclosed_delims);
                 Ok((item?, TrailingToken::None))
             })?;
 
-        self.unclosed_delims.append(&mut unclosed_delims);
         Ok(item)
     }
 
@@ -1960,21 +1957,12 @@ impl<'a> Parser<'a> {
         // FIXME: This will make us not emit the help even for declarative
         // macros within the same crate (that we can fix), which is sad.
         if !span.from_expansion() {
-            if self.unclosed_delims.is_empty() {
-                let DelimSpan { open, close } = args.dspan;
-                err.multipart_suggestion(
-                    "change the delimiters to curly braces",
-                    vec![(open, "{".to_string()), (close, '}'.to_string())],
-                    Applicability::MaybeIncorrect,
-                );
-            } else {
-                err.span_suggestion(
-                    span,
-                    "change the delimiters to curly braces",
-                    " { /* items */ }",
-                    Applicability::HasPlaceholders,
-                );
-            }
+            let DelimSpan { open, close } = args.dspan;
+            err.multipart_suggestion(
+                "change the delimiters to curly braces",
+                vec![(open, "{".to_string()), (close, '}'.to_string())],
+                Applicability::MaybeIncorrect,
+            );
             err.span_suggestion(
                 span.shrink_to_hi(),
                 "add a semicolon",

--- a/config.toml.example
+++ b/config.toml.example
@@ -164,6 +164,7 @@ changelog-seen = 2
 # General build configuration options
 # =============================================================================
 [build]
+
 # The default stage to use for the `check` subcommand
 #check-stage = 0
 

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -486,6 +486,22 @@ for section_key, section_config in config.items():
     else:
         configure_section(sections[section_key], section_config)
 
+def write_uncommented(target, f):
+    block = []
+    is_comment = True
+
+    for line in target:
+        block.append(line)
+        if len(line) == 0:
+            if not is_comment:
+                for l in block:
+                    f.write(l + "\n")
+            block = []
+            is_comment = True
+            continue
+        is_comment = is_comment and line.startswith('#')
+    return f
+
 # Now that we've built up our `config.toml`, write it all out in the same
 # order that we read it in.
 p("")
@@ -494,11 +510,9 @@ with bootstrap.output('config.toml') as f:
     for section in section_order:
         if section == 'target':
             for target in targets:
-                for line in targets[target]:
-                    f.write(line + "\n")
+                f = write_uncommented(targets[target], f)
         else:
-            for line in sections[section]:
-                f.write(line + "\n")
+            f = write_uncommented(sections[section], f)
 
 with bootstrap.output('Makefile') as f:
     contents = os.path.join(rust_dir, 'src', 'bootstrap', 'mk', 'Makefile.in')

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1839,6 +1839,12 @@ fn document_type_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
         } else {
             let size = layout.size.bytes() - tag_size;
             write!(w, "{size} byte{pl}", pl = if size == 1 { "" } else { "s" },);
+            if layout.abi.is_uninhabited() {
+                write!(
+                    w,
+                    " (<a href=\"https://doc.rust-lang.org/stable/reference/glossary.html#uninhabited\">uninhabited</a>)"
+                );
+            }
         }
     }
 

--- a/tests/rustdoc-js-std/option-type-signatures.js
+++ b/tests/rustdoc-js-std/option-type-signatures.js
@@ -1,0 +1,7 @@
+const QUERY = 'option, fnonce -> option';
+
+const EXPECTED = {
+    'others': [
+        { 'path': 'std::option::Option', 'name': 'map' },
+    ],
+};

--- a/tests/rustdoc-js/where-clause.js
+++ b/tests/rustdoc-js/where-clause.js
@@ -1,0 +1,19 @@
+const QUERY = ['trait<nested>', '-> trait<nested>', 't1, t2'];
+
+const EXPECTED = [
+    {
+        'in_args': [
+           { 'path': 'where_clause', 'name': 'abracadabra' },
+        ],
+    },
+    {
+        'others': [
+            { 'path': 'where_clause', 'name': 'alacazam' },
+        ],
+    },
+    {
+        'others': [
+            { 'path': 'where_clause', 'name': 'presto' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/where-clause.rs
+++ b/tests/rustdoc-js/where-clause.rs
@@ -1,0 +1,16 @@
+pub struct Nested;
+
+pub trait Trait<T> {
+    fn thank_you(x: T);
+}
+
+pub fn abracadabra<X>(_: X) where X: Trait<Nested> {}
+
+pub fn alacazam<X>() -> X where X: Trait<Nested> {}
+
+pub trait T1 {}
+pub trait T2<'a, T> {
+    fn please(_: &'a T);
+}
+
+pub fn presto<A, B>(_: A, _: B) where A: T1, B: for <'b> T2<'b, Nested> {}

--- a/tests/rustdoc/type-layout.rs
+++ b/tests/rustdoc/type-layout.rs
@@ -83,3 +83,11 @@ pub enum WithNiche {
     None,
     Some(std::num::NonZeroU32),
 }
+
+// @hasraw type_layout/enum.Uninhabited.html 'Size: '
+// @hasraw - '0 bytes (<a href="https://doc.rust-lang.org/stable/reference/glossary.html#uninhabited">uninhabited</a>)'
+pub enum Uninhabited {}
+
+// @hasraw type_layout/struct.Uninhabited2.html 'Size: '
+// @hasraw - '8 bytes (<a href="https://doc.rust-lang.org/stable/reference/glossary.html#uninhabited">uninhabited</a>)'
+pub struct Uninhabited2(std::convert::Infallible, u64);

--- a/tests/ui/suggestions/multiline-multipart-suggestion.rs
+++ b/tests/ui/suggestions/multiline-multipart-suggestion.rs
@@ -1,0 +1,19 @@
+// compile-flags: --error-format=human --color=always
+// ignore-windows
+
+fn short(foo_bar: &Vec<&i32>) -> &i32 { //~ ERROR missing lifetime specifier
+    &12
+}
+
+fn long( //~ ERROR missing lifetime specifier
+    foo_bar: &Vec<&i32>,
+    something_very_long_so_that_the_line_will_wrap_around__________: i32,
+) -> &i32 {
+    &12
+}
+
+fn long2( //~ ERROR missing lifetime specifier
+    foo_bar: &Vec<&i32>) -> &i32 {
+    &12
+}
+fn main() {}

--- a/tests/ui/suggestions/multiline-multipart-suggestion.stderr
+++ b/tests/ui/suggestions/multiline-multipart-suggestion.stderr
@@ -1,0 +1,46 @@
+[0m[1m[38;5;9merror[E0106][0m[0m[1m: missing lifetime specifier[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/multiline-multipart-suggestion.rs:4:34[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0mfn short(foo_bar: &Vec<&i32>) -> &i32 {
+[0m   [0m[0m[1m[38;5;12m| [0m[0m                  [0m[0m[1m[38;5;12m----------[0m[0m     [0m[0m[1m[38;5;9m^[0m[0m [0m[0m[1m[38;5;9mexpected named lifetime parameter[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mhelp[0m[0m: this function's return type contains a borrowed value, but the signature does not say which one of `foo_bar`'s 2 lifetimes it is borrowed from[0m
+[0m[1m[38;5;14mhelp[0m[0m: consider introducing a named lifetime parameter[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m| [0m[0mfn short[0m[0m[38;5;10m<'a>[0m[0m(foo_bar: &[0m[0m[38;5;10m'a [0m[0mVec<&[0m[0m[38;5;10m'a [0m[0mi32>) -> &[0m[0m[38;5;10m'a [0m[0mi32 {
+[0m   [0m[0m[1m[38;5;12m|[0m[0m         [0m[0m[38;5;10m++++[0m[0m           [0m[0m[38;5;10m++[0m[0m      [0m[0m[38;5;10m++[0m[0m           [0m[0m[38;5;10m++[0m
+
+[0m[1m[38;5;9merror[E0106][0m[0m[1m: missing lifetime specifier[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/multiline-multipart-suggestion.rs:11:6[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    foo_bar: &Vec<&i32>,[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m             [0m[0m[1m[38;5;12m----------[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    something_very_long_so_that_the_line_will_wrap_around__________: i32,[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m) -> &i32 {[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m     [0m[0m[1m[38;5;9m^[0m[0m [0m[0m[1m[38;5;9mexpected named lifetime parameter[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mhelp[0m[0m: this function's return type contains a borrowed value, but the signature does not say which one of `foo_bar`'s 2 lifetimes it is borrowed from[0m
+[0m[1m[38;5;14mhelp[0m[0m: consider introducing a named lifetime parameter[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[38;5;10m~ [0m[0mfn long[0m[0m[38;5;10m<'a>[0m[0m(
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[38;5;10m~ [0m[0m    foo_bar: &[0m[0m[38;5;10m'a [0m[0mVec<&[0m[0m[38;5;10m'a [0m[0mi32>,[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m| [0m[0m    something_very_long_so_that_the_line_will_wrap_around__________: i32,[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[38;5;10m~ [0m[0m) -> &[0m[0m[38;5;10m'a [0m[0mi32 {[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+
+[0m[1m[38;5;9merror[E0106][0m[0m[1m: missing lifetime specifier[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/multiline-multipart-suggestion.rs:16:29[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    foo_bar: &Vec<&i32>) -> &i32 {[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m             [0m[0m[1m[38;5;12m----------[0m[0m     [0m[0m[1m[38;5;9m^[0m[0m [0m[0m[1m[38;5;9mexpected named lifetime parameter[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mhelp[0m[0m: this function's return type contains a borrowed value, but the signature does not say which one of `foo_bar`'s 2 lifetimes it is borrowed from[0m
+[0m[1m[38;5;14mhelp[0m[0m: consider introducing a named lifetime parameter[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[38;5;10m~ [0m[0mfn long2[0m[0m[38;5;10m<'a>[0m[0m(
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[38;5;10m~ [0m[0m    foo_bar: &[0m[0m[38;5;10m'a [0m[0mVec<&[0m[0m[38;5;10m'a [0m[0mi32>) -> &[0m[0m[38;5;10m'a [0m[0mi32 {[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+
+[0m[1m[38;5;9merror[0m[0m[1m: aborting due to 3 previous errors[0m
+
+[0m[1mFor more information about this error, try `rustc --explain E0106`.[0m


### PR DESCRIPTION
Successful merges:

 - #108627 (Properly colorize multi-part suggestions in the same line)
 - #108632 (Omit unchanged options from config.toml in `configure.py`)
 - #108715 (Remove unclosed_delims from parser)
 - #108723 (rustdoc: function signature search with traits in `where` clause)
 - #108724 (field is not used outside the crate)
 - #108734 (rustdoc: Note in a type's layout/size if it is uninhabited)
 - #108736 (Remove `allow(potential_query_instability)` from `ast_passes`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=108627,108632,108715,108723,108724,108734,108736)
<!-- homu-ignore:end -->