### PR TITLE
Retry `pred_known_to_hold_modulo_regions` with fulfillment if ambiguous

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -155,10 +155,12 @@ fn pred_known_to_hold_modulo_regions<'tcx>(
         predicate: pred.to_predicate(infcx.tcx),
     };
 
-    let result = infcx.predicate_must_hold_modulo_regions(&obligation);
+    let result = infcx.evaluate_obligation_no_overflow(&obligation);
     debug!(?result);
 
-    if result && has_non_region_infer {
+    if result.must_apply_modulo_regions() && !has_non_region_infer {
+        true
+    } else if result.may_apply() {
         // Because of inference "guessing", selection can sometimes claim
         // to succeed while the success requires a guess. To ensure
         // this function's result remains infallible, we must confirm
@@ -179,7 +181,7 @@ fn pred_known_to_hold_modulo_regions<'tcx>(
             }
         }
     } else {
-        result
+        false
     }
 }
 


### PR DESCRIPTION
Fixes #108721 

The problem here is that when we're checking `is_sized_raw` during codegen on some type that has a lot of opaques in it, something emits several nested obligations that are individually ambiguous, but when processed together in a loop then apply modulo regions. Since the `evaluate_predicates_recursively` inner loop doesn't process predicates until they stop changing, we return `EvaluatedToAmbig`, which makes the sized check return false incorrectly. See:

https://github.com/rust-lang/rust/blob/f15f0ea73972786e426732c5b92ba9a904b866c4/compiler/rustc_trait_selection/src/traits/select/mod.rs#L596-L606

... Compared to the analogous loop in the new solver:

https://github.com/rust-lang/rust/blob/f15f0ea73972786e426732c5b92ba9a904b866c4/compiler/rustc_trait_selection/src/solve/mod.rs#L481-L512

To fix this, if we get ambiguous during `pred_known_to_hold_modulo_regions`, just retry the obligation in a fulfillment context.

--

Unfortunately... I don't have a test for this. I've only tested this locally. Pending minimization :/

r? types