### PR TITLE
rustdoc: Migrate `document_item_info` to Askama

### DIFF
--- a/src/librustdoc/html/templates/item_info.html
+++ b/src/librustdoc/html/templates/item_info.html
@@ -1,0 +1,7 @@
+{% if !items.is_empty() %}
+    <span class="item-info"> {# #}
+        {% for item in items %}
+            {{item|safe}} {# #}
+        {% endfor %}
+    </span>
+{% endif %}

--- a/src/librustdoc/html/templates/short_item_info.html
+++ b/src/librustdoc/html/templates/short_item_info.html
@@ -1,0 +1,23 @@
+{% match self %}
+    {% when Self::Deprecation with { message } %}
+        <div class="stab deprecated"> {# #}
+            <span class="emoji">👎</span> {# #}
+            <span>{{message}}</span> {# #}
+        </div> {# #}
+    {% when Self::Unstable with { feature, tracking } %}
+        <div class="stab unstable"> {# #}
+            <span class="emoji">🔬</span> {# #}
+            <span> {# #}
+                This is a nightly-only experimental API. ({# #}
+                <code>{{feature}}</code> {# #}
+                {% match tracking %}
+                    {% when Some with ((url, num)) %}
+                        &nbsp;<a href="{{url}}{{num}}">#{{num}}</a> {# #}
+                    {% when None %}
+                {% endmatch %}
+                ) {# #}
+            </span> {# #}
+        </div> {# #}
+    {% when Self::Portability with { message } %}
+        <div class="stab portability">{{message|safe}}</div> {# #}
+{% endmatch %}


### PR DESCRIPTION
https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/rustdoc.20allocations.20are.20slow

Hoping to piece-by-piece migrate things to template. Had a few failed attempts at more complex parts of the code, so this is just a start.