### PR TITLE
x fmt: Only check modified files locally

### DIFF
--- a/src/bootstrap/format.rs
+++ b/src/bootstrap/format.rs
@@ -2,6 +2,7 @@
 
 use crate::builder::Builder;
 use crate::util::{output, program_out_of_date, t};
+use build_helper::ci::CiEnv;
 use build_helper::git::get_git_modified_files;
 use ignore::WalkBuilder;
 use std::collections::VecDeque;
@@ -156,7 +157,10 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
                 // preventing the latter from being formatted.
                 ignore_fmt.add(&format!("!/{}", untracked_path)).expect(&untracked_path);
             }
-            if !check && paths.is_empty() {
+            // Only check modified files locally to speed up runtime.
+            // We still check all files in CI to avoid bugs in `get_modified_rs_files` letting regressions slip through;
+            // we also care about CI time less since this is still very fast compared to building the compiler.
+            if !CiEnv::is_ci() && paths.is_empty() {
                 match get_modified_rs_files(build) {
                     Ok(Some(files)) => {
                         for file in files {


### PR DESCRIPTION
Previously, `x fmt` would only format modified files, while `x fmt .` and `x fmt --check` would still look at all files. After this change, `x fmt --check` only looks at modified files locally.

I feel pretty confident in this change - other than https://github.com/rust-lang/rust/issues/106261, no one has reported bugs in `get_modified_rs_files` since it was added in https://github.com/rust-lang/rust/pull/105702.

Combined with the changes in https://github.com/rust-lang/rust/pull/108772, this brings the time for me to run `x t tidy` with a hot FS cache down from 5 to 2 seconds (and moves the majority of the time spent back to `tidy check`, which means it can be sped up more in the future).