### PR TITLE
Greatly improve the error messages when `run-make/translation` fails

### DIFF
--- a/tests/run-make/translation/Makefile
+++ b/tests/run-make/translation/Makefile
@@ -13,22 +13,22 @@ all: normal custom missing broken sysroot sysroot-invalid sysroot-missing
 
 # Check that the test works normally, using the built-in fallback bundle.
 normal: test.rs
-	$(RUSTC) $< 2>&1 | grep "struct literal body without path"
+	$(RUSTC) $< 2>&1 | $(CGREP) "struct literal body without path"
 
 # Check that a primary bundle can be loaded and will be preferentially used
 # where possible.
 custom: test.rs working.ftl
-	$(RUSTC) $< -Ztranslate-additional-ftl=$(CURDIR)/working.ftl 2>&1 | grep "this is a test message"
+	$(RUSTC) $< -Ztranslate-additional-ftl=$(CURDIR)/working.ftl 2>&1 | $(CGREP) "this is a test message"
 
 # Check that a primary bundle with a broken message (e.g. a interpolated
 # variable is missing) will use the fallback bundle.
 missing: test.rs missing.ftl
-	$(RUSTC) $< -Ztranslate-additional-ftl=$(CURDIR)/missing.ftl 2>&1 | grep "struct literal body without path"
+	$(RUSTC) $< -Ztranslate-additional-ftl=$(CURDIR)/missing.ftl 2>&1 | $(CGREP) "struct literal body without path"
 
 # Check that a primary bundle without the desired message will use the fallback
 # bundle.
 broken: test.rs broken.ftl
-	$(RUSTC) $< -Ztranslate-additional-ftl=$(CURDIR)/broken.ftl 2>&1 | grep "struct literal body without path"
+	$(RUSTC) $< -Ztranslate-additional-ftl=$(CURDIR)/broken.ftl 2>&1 | $(CGREP) "struct literal body without path"
 
 # Check that a locale can be loaded from the sysroot given a language
 # identifier by making a local copy of the sysroot and adding the custom locale
@@ -48,13 +48,13 @@ sysroot: test.rs working.ftl
 	ln -s $(SYSROOT)/lib/rustlib/src/* $(FAKEROOT)/lib/rustlib/src
 	mkdir -p $(FAKEROOT)/share/locale/zh-CN/
 	ln -s $(CURDIR)/working.ftl $(FAKEROOT)/share/locale/zh-CN/basic-translation.ftl
-	$(RUSTC) $< --sysroot $(FAKEROOT) -Ztranslate-lang=zh-CN 2>&1 | grep "this is a test message"
+	$(RUSTC) $< --sysroot $(FAKEROOT) -Ztranslate-lang=zh-CN 2>&1 | $(CGREP) "this is a test message"
 
 # Check that the compiler errors out when the sysroot requested cannot be
 # found. This test might start failing if there actually exists a Klingon
 # translation of rustc's error messages.
-sysroot-missing: 
-	$(RUSTC) $< -Ztranslate-lang=tlh 2>&1 | grep "missing locale directory"
+sysroot-missing:
+	$(RUSTC) $< -Ztranslate-lang=tlh 2>&1 | $(CGREP) "missing locale directory"
 
 # Check that the compiler errors out when the directory for the locale in the
 # sysroot is actually a file.
@@ -73,4 +73,4 @@ sysroot-invalid: test.rs working.ftl
 	ln -s $(SYSROOT)/lib/rustlib/src/* $(FAKEROOT)/lib/rustlib/src
 	mkdir -p $(FAKEROOT)/share/locale
 	touch $(FAKEROOT)/share/locale/zh-CN
-	$(RUSTC) $< --sysroot $(FAKEROOT) -Ztranslate-lang=zh-CN 2>&1 | grep "`\$sysroot/share/locales/\$locale` is not a directory"
+	$(RUSTC) $< --sysroot $(FAKEROOT) -Ztranslate-lang=zh-CN 2>&1 | $(CGREP) "`\$sysroot/share/locales/\$locale` is not a directory"


### PR DESCRIPTION
Before:
```
LD_LIBRARY_PATH="/home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/test/run-make/translation/translation:/home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/stage2/lib:/home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/stage0-bootstrap-tools/aarch64-unknown-linux-gnu/release/deps:/home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/stage0/lib" '/home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/stage2/bin/rustc' --out-dir /home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/test/run-make/translation/translation -L /home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/test/run-make/translation/translation  test.rs --sysroot /home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/test/run-make/translation/translation/fakeroot -Ztranslate-lang=zh-CN 2>&1 | grep "this is a test message"
------------------------------------------
--- stderr -------------------------------
make: *** [Makefile:51: sysroot] Error 1
------------------------------------------

failures:
    [run-make] tests/run-make/translation
```

After:

```
LD_LIBRARY_PATH="/home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/test/run-make/translation/translation:/home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/stage2/lib:/home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/stage0-bootstrap-tools/aarch64-unknown-linux-gnu/release/deps:/home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/stage0/lib" '/home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/stage2/bin/rustc' --out-dir /home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/test/run-make/translation/translation -L /home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/test/run-make/translation/translation  test.rs --sysroot /home/gh-jyn514/rust/build/aarch64-unknown-linux-gnu/test/run-make/translation/translation/fakeroot -Ztranslate-lang=zh-CN 2>&1 | grep "this is a test message"
[[[ begin stdout ]]]
error: failed to load fluent bundle: failed to add resource: Attempt to override an existing message: "parse_struct_literal_body_without_path".

[[[ end stdout ]]]
Error: cannot match: this is a test message
------------------------------------------
--- stderr -------------------------------
make: *** [Makefile:51: sysroot] Error 1
------------------------------------------

failures:
    [run-make] tests/run-make/translation
```