### PR TITLE
Make `x test tidy` less noisy

### DIFF
--- a/src/bootstrap/format.rs
+++ b/src/bootstrap/format.rs
@@ -144,8 +144,10 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
             let untracked_paths = untracked_paths_output
                 .lines()
                 .filter(|entry| entry.starts_with("??"))
-                .map(|entry| {
-                    entry.split(' ').nth(1).expect("every git status entry should list a path")
+                .filter_map(|entry| {
+                    let path =
+                        entry.split(' ').nth(1).expect("every git status entry should list a path");
+                    path.ends_with(".rs").then_some(path)
                 });
             for untracked_path in untracked_paths {
                 println!("skip untracked path {} during rustfmt invocations", untracked_path);

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -46,8 +46,10 @@ pub fn check(root_path: &Path, search_paths: &[&Path], verbose: bool, bad: &mut 
 
     // Stage 1: create list
     let error_codes = extract_error_codes(root_path, &mut errors);
-    println!("Found {} error codes", error_codes.len());
-    println!("Highest error code: `{}`", error_codes.iter().max().unwrap());
+    if verbose {
+        println!("Found {} error codes", error_codes.len());
+        println!("Highest error code: `{}`", error_codes.iter().max().unwrap());
+    }
 
     // Stage 2: check list has docs
     let no_longer_emitted = check_error_codes_docs(root_path, &error_codes, &mut errors, verbose);

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -219,8 +219,6 @@ pub fn check(
         for line in lines {
             println!("* {line}");
         }
-    } else {
-        println!("* {} features", features.len());
     }
 
     CollectedFeatures { lib: lib_features, lang: features }


### PR DESCRIPTION
Before:
```
Building tool tidy (stage0)
    Finished release [optimized + debuginfo] target(s) in 0.29s
fmt check
skip untracked path chrome_profiler.json during rustfmt invocations
skip untracked path query_impl-default,args.mm_profdata during rustfmt invocations
skip untracked path query_impl-llvm.txt during rustfmt invocations
skip untracked path query_impl-mono_items.txt during rustfmt invocations
skip untracked path query_impl-summarize.txt during rustfmt invocations
skip untracked path rustc.svg during rustfmt invocations
skip untracked path rustc_middle.mono_items.json during rustfmt invocations
skip untracked path rustc_middle.mono_items.md during rustfmt invocations
skip untracked path rustc_query_impl.mono_items-thread_local_attr.json during rustfmt invocations
skip untracked path rustc_query_impl.mono_items-thread_local_macro.json during rustfmt invocations
skip untracked path rustc_query_impl.mono_items.md during rustfmt invocations
tidy check
Found 505 error codes
Highest error code: `E0793`
* 397 features
Ensuring the YAML anchors in the GitHub Actions config were expanded
Building tool expand-yaml-anchors (stage0)
    Finished release [optimized + debuginfo] target(s) in 0.14s
Build completed successfully in 0:00:54
```

After:
```
Building tool tidy (stage0)
    Finished release [optimized + debuginfo] target(s) in 2.24s
fmt check
tidy check
Ensuring the YAML anchors in the GitHub Actions config were expanded
Building tool expand-yaml-anchors (stage0)
    Finished release [optimized + debuginfo] target(s) in 0.14s
Build completed successfully in 0:00:04
```