### PR TITLE
Fetch the value of has_ffi_unwind_calls before stealing mir_built.

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -284,8 +284,12 @@ fn mir_const(tcx: TyCtxt<'_>, def: ty::WithOptConstParam<LocalDefId>) -> &Steal<
         }
     }
 
-    // has_ffi_unwind_calls query uses the raw mir, so make sure it is run.
-    tcx.ensure().has_ffi_unwind_calls(def.did);
+    // has_ffi_unwind_calls query uses `mir_built(WithOptConstParam::unknown(def.did))`,
+    // so make sure it is run.
+    if def.const_param_did.is_none() {
+        // Actually fetch the value, to avoid having to compute the query later.
+        let _ = tcx.has_ffi_unwind_calls(def.did);
+    }
 
     let mut body = tcx.mir_built(def).steal();
 


### PR DESCRIPTION
Just calling `ensure` is not enough, as it does not verify that the value can be loaded from the on-disk cache. Later code could then try to get the value, fail to find it in the cache, and call the `has_ffi_unwind_calls` function, and boom.

Fixes https://github.com/rust-lang/rust/issues/104423
Fixes https://github.com/rust-lang/rust/issues/105157
Fixes https://github.com/rust-lang/rust/issues/107797
Fixes https://github.com/rust-lang/rust/issues/108411
Fixes https://github.com/rust-lang/rust/issues/108633