### PR TITLE
x fmt: Don't print all modified files if there's more than 10

### DIFF
--- a/src/bootstrap/format.rs
+++ b/src/bootstrap/format.rs
@@ -159,8 +159,14 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
             if !check && paths.is_empty() {
                 match get_modified_rs_files(build) {
                     Ok(Some(files)) => {
+                        if files.len() <= 10 {
+                            for file in &files {
+                                println!("formatting modified file {file}");
+                            }
+                        } else {
+                            println!("formatting {} modified files", files.len());
+                        }
                         for file in files {
-                            println!("formatting modified file {file}");
                             ignore_fmt.add(&format!("/{file}")).expect(&file);
                         }
                     }


### PR DESCRIPTION
This avoids spam for dozens of modified files.

Fixes https://github.com/rust-lang/rust/issues/106920.