### PR TITLE
Add regression tests for issue 70919

### DIFF
--- a/tests/ui/borrowck/drop-in-loop.rs
+++ b/tests/ui/borrowck/drop-in-loop.rs
@@ -1,0 +1,24 @@
+// A version of `issue-70919-drop-in-loop`, but without
+// the necessary `drop` call.
+//
+// This should fail to compile, since the `Drop` impl
+// for `WrapperWithDrop` could observe the changed
+// `base` value.
+
+struct WrapperWithDrop<'a>(&'a mut bool);
+impl<'a> Drop for WrapperWithDrop<'a> {
+    fn drop(&mut self) {
+    }
+}
+
+fn drop_in_loop() {
+    let mut base = true;
+    let mut wrapper = WrapperWithDrop(&mut base);
+    loop {
+        base = false; //~ ERROR: cannot assign to `base`
+        wrapper = WrapperWithDrop(&mut base);
+    }
+}
+
+fn main() {
+}

--- a/tests/ui/borrowck/drop-in-loop.stderr
+++ b/tests/ui/borrowck/drop-in-loop.stderr
@@ -1,0 +1,14 @@
+error[E0506]: cannot assign to `base` because it is borrowed
+  --> $DIR/drop-in-loop.rs:18:9
+   |
+LL |     let mut wrapper = WrapperWithDrop(&mut base);
+   |                                       --------- `base` is borrowed here
+LL |     loop {
+LL |         base = false;
+   |         ^^^^^^^^^^^^ `base` is assigned to here but it was already borrowed
+LL |         wrapper = WrapperWithDrop(&mut base);
+   |         ------- borrow might be used here, when `wrapper` is dropped and runs the `Drop` code for type `WrapperWithDrop`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0506`.

--- a/tests/ui/borrowck/issue-70919-drop-in-loop.rs
+++ b/tests/ui/borrowck/issue-70919-drop-in-loop.rs
@@ -1,0 +1,25 @@
+// Regression test for issue #70919
+// Tests that we don't emit a spurious "borrow might be used" error
+// when we have an explicit `drop` in a loop
+
+// check-pass
+
+struct WrapperWithDrop<'a>(&'a mut bool);
+impl<'a> Drop for WrapperWithDrop<'a> {
+    fn drop(&mut self) {
+    }
+}
+
+fn drop_in_loop() {
+    let mut base = true;
+    let mut wrapper = WrapperWithDrop(&mut base);
+    loop {
+        drop(wrapper);
+
+        base = false;
+        wrapper = WrapperWithDrop(&mut base);
+    }
+}
+
+fn main() {
+}


### PR DESCRIPTION
Desugaring DropAndReplace at MIR build (#107844) fixed #70919. 
Add regressions tests, borrowed from #102078, to ensure we check for this in the future.

cc @Aaron1011 