### PR TITLE
Make late_bound_lifetime_arguments a hard error.

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/generics.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/generics.rs
@@ -6,7 +6,7 @@ use crate::astconv::{
 use crate::errors::AssocTypeBindingNotAllowed;
 use crate::structured_errors::{GenericArgsInfo, StructuredDiagnostic, WrongNumberOfGenericArgs};
 use rustc_ast::ast::ParamKindOrd;
-use rustc_errors::{struct_span_err, Applicability, Diagnostic, ErrorGuaranteed, MultiSpan};
+use rustc_errors::{struct_span_err, Applicability, Diagnostic, ErrorGuaranteed};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
@@ -14,7 +14,6 @@ use rustc_hir::GenericArg;
 use rustc_middle::ty::{
     self, subst, subst::SubstsRef, GenericParamDef, GenericParamDefKind, IsSuggestable, Ty, TyCtxt,
 };
-use rustc_session::lint::builtin::LATE_BOUND_LIFETIME_ARGUMENTS;
 use rustc_span::{symbol::kw, Span};
 use smallvec::SmallVec;
 
@@ -602,7 +601,6 @@ pub(crate) fn prohibit_explicit_late_bound_lifetimes(
     args: &hir::GenericArgs<'_>,
     position: GenericArgPosition,
 ) -> ExplicitLateBound {
-    let param_counts = def.own_counts();
     let infer_lifetimes = position != GenericArgPosition::Type && !args.has_lifetime_params();
 
     if infer_lifetimes {
@@ -611,27 +609,22 @@ pub(crate) fn prohibit_explicit_late_bound_lifetimes(
 
     if let Some(span_late) = def.has_late_bound_regions {
         let msg = "cannot specify lifetime arguments explicitly \
-                       if late bound lifetime parameters are present";
+                   if late bound lifetime parameters are present";
         let note = "the late bound lifetime parameter is introduced here";
-        let span = args.args[0].span();
+        let help = format!(
+            "remove the explicit lifetime argument{}",
+            rustc_errors::pluralize!(args.num_lifetime_params())
+        );
+        let spans: Vec<_> = args
+            .args
+            .iter()
+            .filter_map(|arg| match arg {
+                hir::GenericArg::Lifetime(l) => Some(l.ident.span),
+                _ => None,
+            })
+            .collect();
 
-        if position == GenericArgPosition::Value
-            && args.num_lifetime_params() != param_counts.lifetimes
-        {
-            let mut err = tcx.sess.struct_span_err(span, msg);
-            err.span_note(span_late, note);
-            err.emit();
-        } else {
-            let mut multispan = MultiSpan::from_span(span);
-            multispan.push_span_label(span_late, note);
-            tcx.struct_span_lint_hir(
-                LATE_BOUND_LIFETIME_ARGUMENTS,
-                args.args[0].hir_id(),
-                multispan,
-                msg,
-                |lint| lint,
-            );
-        }
+        tcx.sess.struct_span_err(spans, msg).span_note(span_late, note).help(help).emit();
 
         ExplicitLateBound::Yes
     } else {

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -57,6 +57,7 @@ This API is completely unstable and subject to change.
 
 #![allow(rustc::potential_query_instability)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
+#![feature(array_windows)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(drain_filter)]

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -504,6 +504,11 @@ fn register_builtins(store: &mut LintStore) {
         "converted into hard error, see issue #82523 \
          <https://github.com/rust-lang/rust/issues/82523> for more information",
     );
+    store.register_removed(
+        "late_bound_lifetime_arguments",
+        "converted into hard error, see issue #42868 \
+         <https://github.com/rust-lang/rust/issues/42868> for more information",
+    );
 }
 
 fn register_internals(store: &mut LintStore) {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1351,47 +1351,6 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `late_bound_lifetime_arguments` lint detects generic lifetime
-    /// arguments in path segments with late bound lifetime parameters.
-    ///
-    /// ### Example
-    ///
-    /// ```rust
-    /// struct S;
-    ///
-    /// impl S {
-    ///     fn late(self, _: &u8, _: &u8) {}
-    /// }
-    ///
-    /// fn main() {
-    ///     S.late::<'static>(&0, &0);
-    /// }
-    /// ```
-    ///
-    /// {{produces}}
-    ///
-    /// ### Explanation
-    ///
-    /// It is not clear how to provide arguments for early-bound lifetime
-    /// parameters if they are intermixed with late-bound parameters in the
-    /// same list. For now, providing any explicit arguments will trigger this
-    /// lint if late-bound parameters are present, so in the future a solution
-    /// can be adopted without hitting backward compatibility issues. This is
-    /// a [future-incompatible] lint to transition this to a hard error in the
-    /// future. See [issue #42868] for more details, along with a description
-    /// of the difference between early and late-bound parameters.
-    ///
-    /// [issue #42868]: https://github.com/rust-lang/rust/issues/42868
-    /// [future-incompatible]: ../index.md#future-incompatible-lints
-    pub LATE_BOUND_LIFETIME_ARGUMENTS,
-    Warn,
-    "detects generic lifetime arguments in path segments with late bound lifetime parameters",
-    @future_incompatible = FutureIncompatibleInfo {
-        reference: "issue #42868 <https://github.com/rust-lang/rust/issues/42868>",
-    };
-}
-
-declare_lint! {
     /// The `order_dependent_trait_objects` lint detects a trait coherency
     /// violation that would allow creating two trait impls for the same
     /// dynamic trait object involving marker traits.
@@ -3266,7 +3225,6 @@ declare_lint_pass! {
         CONST_ITEM_MUTATION,
         PATTERNS_IN_FNS_WITHOUT_BODY,
         MISSING_FRAGMENT_SPECIFIER,
-        LATE_BOUND_LIFETIME_ARGUMENTS,
         ORDER_DEPENDENT_TRAIT_OBJECTS,
         COHERENCE_LEAK_CHECK,
         DEPRECATED,

--- a/tests/ui/const-generics/const-arg-in-const-arg.full.stderr
+++ b/tests/ui/const-generics/const-arg-in-const-arg.full.stderr
@@ -9,6 +9,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:21:23
@@ -21,6 +22,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:41:24
@@ -33,6 +35,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:44:24
@@ -45,6 +48,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: unconstrained generic constant
   --> $DIR/const-arg-in-const-arg.rs:13:12
@@ -105,6 +109,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:33:23
@@ -117,6 +122,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: unconstrained generic constant
   --> $DIR/const-arg-in-const-arg.rs:47:19
@@ -145,6 +151,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:55:27
@@ -157,6 +164,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui/const-generics/const-arg-in-const-arg.full.stderr
+++ b/tests/ui/const-generics/const-arg-in-const-arg.full.stderr
@@ -9,7 +9,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _: [u8; faz::<'a>(&())];
+LL +     let _: [u8; faz(&())];
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:21:23
@@ -22,7 +26,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _: [u8; faz::<'b>(&())];
+LL +     let _: [u8; faz(&())];
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:41:24
@@ -35,7 +43,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _: Foo<{ faz::<'a>(&()) }>;
+LL +     let _: Foo<{ faz(&()) }>;
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:44:24
@@ -48,7 +60,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _: Foo<{ faz::<'b>(&()) }>;
+LL +     let _: Foo<{ faz(&()) }>;
+   |
 
 error: unconstrained generic constant
   --> $DIR/const-arg-in-const-arg.rs:13:12
@@ -109,7 +125,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _ = [0; faz::<'a>(&())];
+LL +     let _ = [0; faz(&())];
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:33:23
@@ -122,7 +142,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _ = [0; faz::<'b>(&())];
+LL +     let _ = [0; faz(&())];
+   |
 
 error: unconstrained generic constant
   --> $DIR/const-arg-in-const-arg.rs:47:19
@@ -151,7 +175,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _ = Foo::<{ faz::<'a>(&()) }>;
+LL +     let _ = Foo::<{ faz(&()) }>;
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:55:27
@@ -164,7 +192,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _ = Foo::<{ faz::<'b>(&()) }>;
+LL +     let _ = Foo::<{ faz(&()) }>;
+   |
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
+++ b/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
@@ -227,6 +227,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:21:23
@@ -239,6 +240,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/const-arg-in-const-arg.rs:38:24
@@ -262,6 +264,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:44:24
@@ -274,6 +277,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: constant expression depends on a generic parameter
   --> $DIR/const-arg-in-const-arg.rs:25:17
@@ -305,6 +309,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:33:23
@@ -317,6 +322,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/const-arg-in-const-arg.rs:49:27
@@ -340,6 +346,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:55:27
@@ -352,6 +359,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
+   = help: remove the explicit lifetime argument
 
 error: aborting due to 36 previous errors
 

--- a/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
+++ b/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
@@ -227,7 +227,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _: [u8; faz::<'a>(&())];
+LL +     let _: [u8; faz(&())];
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:21:23
@@ -240,7 +244,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _: [u8; faz::<'b>(&())];
+LL +     let _: [u8; faz(&())];
+   |
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/const-arg-in-const-arg.rs:38:24
@@ -264,7 +272,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _: Foo<{ faz::<'a>(&()) }>;
+LL +     let _: Foo<{ faz(&()) }>;
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:44:24
@@ -277,7 +289,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _: Foo<{ faz::<'b>(&()) }>;
+LL +     let _: Foo<{ faz(&()) }>;
+   |
 
 error: constant expression depends on a generic parameter
   --> $DIR/const-arg-in-const-arg.rs:25:17
@@ -309,7 +325,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _ = [0; faz::<'a>(&())];
+LL +     let _ = [0; faz(&())];
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:33:23
@@ -322,7 +342,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _ = [0; faz::<'b>(&())];
+LL +     let _ = [0; faz(&())];
+   |
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/const-arg-in-const-arg.rs:49:27
@@ -346,7 +370,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _ = Foo::<{ faz::<'a>(&()) }>;
+LL +     let _ = Foo::<{ faz(&()) }>;
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/const-arg-in-const-arg.rs:55:27
@@ -359,7 +387,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     let _ = Foo::<{ faz::<'b>(&()) }>;
+LL +     let _ = Foo::<{ faz(&()) }>;
+   |
 
 error: aborting due to 36 previous errors
 

--- a/tests/ui/const-generics/issues/issue-83466.rs
+++ b/tests/ui/const-generics/issues/issue-83466.rs
@@ -9,9 +9,8 @@ impl S {
 }
 fn dont_crash<'a, U>() {
     S.func::<'a, 10_u32>()
-    //~^ WARNING cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-    //~^^ WARNING this was previously accepted by
-    //~^^^ ERROR constant provided when a type was expected [E0747]
+    //~^ ERROR cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+    //~| ERROR constant provided when a type was expected [E0747]
 }
 
 fn main() {}

--- a/tests/ui/const-generics/issues/issue-83466.stderr
+++ b/tests/ui/const-generics/issues/issue-83466.stderr
@@ -1,15 +1,15 @@
-warning: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/issue-83466.rs:11:14
    |
-LL |     fn func<'a, U>(self) -> U {
-   |             -- the late bound lifetime parameter is introduced here
-...
 LL |     S.func::<'a, 10_u32>()
    |              ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-   = note: `#[warn(late_bound_lifetime_arguments)]` on by default
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/issue-83466.rs:6:13
+   |
+LL |     fn func<'a, U>(self) -> U {
+   |             ^^
+   = help: remove the explicit lifetime argument
 
 error[E0747]: constant provided when a type was expected
   --> $DIR/issue-83466.rs:11:18
@@ -17,6 +17,6 @@ error[E0747]: constant provided when a type was expected
 LL |     S.func::<'a, 10_u32>()
    |                  ^^^^^^
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0747`.

--- a/tests/ui/const-generics/issues/issue-83466.stderr
+++ b/tests/ui/const-generics/issues/issue-83466.stderr
@@ -9,7 +9,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn func<'a, U>(self) -> U {
    |             ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S.func::<'a, 10_u32>()
+LL +     S.func::<10_u32>()
+   |
 
 error[E0747]: constant provided when a type was expected
   --> $DIR/issue-83466.rs:11:18

--- a/tests/ui/issues/issue-60622.rs
+++ b/tests/ui/issues/issue-60622.rs
@@ -10,7 +10,6 @@ fn run_wild<T>(b: &Borked) {
     b.a::<'_, T>();
     //~^ ERROR cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
     //~| ERROR method takes 0 generic arguments but 1 generic argument
-    //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-60622.stderr
+++ b/tests/ui/issues/issue-60622.stderr
@@ -1,20 +1,15 @@
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/issue-60622.rs:10:11
    |
-LL |     fn a(&self) {}
-   |          - the late bound lifetime parameter is introduced here
-...
 LL |     b.a::<'_, T>();
    |           ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-note: the lint level is defined here
-  --> $DIR/issue-60622.rs:1:9
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/issue-60622.rs:6:10
    |
-LL | #![deny(warnings)]
-   |         ^^^^^^^^
-   = note: `#[deny(late_bound_lifetime_arguments)]` implied by `#[deny(warnings)]`
+LL |     fn a(&self) {}
+   |          ^
+   = help: remove the explicit lifetime argument
 
 error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-60622.rs:10:7

--- a/tests/ui/issues/issue-60622.stderr
+++ b/tests/ui/issues/issue-60622.stderr
@@ -9,7 +9,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn a(&self) {}
    |          ^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     b.a::<'_, T>();
+LL +     b.a::<T>();
+   |
 
 error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-60622.rs:10:7

--- a/tests/ui/issues/issue-72278.rs
+++ b/tests/ui/issues/issue-72278.rs
@@ -1,5 +1,3 @@
-// run-pass
-
 #![allow(unused)]
 
 struct S;
@@ -12,8 +10,7 @@ impl S {
 
 fn dont_crash<'a, U>() -> U {
     S.func::<'a, U>()
-    //~^ WARN cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
+    //~^ ERROR cannot specify lifetime arguments explicitly
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-72278.stderr
+++ b/tests/ui/issues/issue-72278.stderr
@@ -1,15 +1,15 @@
-warning: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/issue-72278.rs:14:14
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/issue-72278.rs:12:14
    |
-LL |     fn func<'a, U>(&'a self) -> U {
-   |             -- the late bound lifetime parameter is introduced here
-...
 LL |     S.func::<'a, U>()
    |              ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-   = note: `#[warn(late_bound_lifetime_arguments)]` on by default
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/issue-72278.rs:6:13
+   |
+LL |     fn func<'a, U>(&'a self) -> U {
+   |             ^^
+   = help: remove the explicit lifetime argument
 
-warning: 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/ui/issues/issue-72278.stderr
+++ b/tests/ui/issues/issue-72278.stderr
@@ -9,7 +9,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn func<'a, U>(&'a self) -> U {
    |             ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S.func::<'a, U>()
+LL +     S.func::<U>()
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/methods/method-call-lifetime-args-fail.fixed
+++ b/tests/ui/methods/method-call-lifetime-args-fail.fixed
@@ -16,9 +16,9 @@ impl S {
 
 fn method_call() {
     S.early(); // OK
-    S.early::<'static>();
+    S.early::<'static, 'static>();
     //~^ ERROR method takes 2 lifetime arguments but 1 lifetime argument
-    S.early::<'static, 'static, 'static>();
+    S.early::<'static, 'static, >();
     //~^ ERROR method takes 2 lifetime arguments but 3 lifetime arguments were supplied
     let _: &u8 = S.life_and_type::<'static>();
     S.life_and_type::<u8>();
@@ -27,45 +27,45 @@ fn method_call() {
 
 fn ufcs() {
     S::late(S, &0, &0); // OK
-    S::late::<'static>(S, &0, &0);
+    S::late(S, &0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    S::late::<'static, 'static>(S, &0, &0);
+    S::late(S, &0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    S::late::<'static, 'static, 'static>(S, &0, &0);
+    S::late(S, &0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     S::late_early(S, &0); // OK
-    S::late_early::<'static, 'static>(S, &0);
+    S::late_early(S, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    S::late_early::<'static, 'static, 'static>(S, &0);
+    S::late_early(S, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
 
     S::late_implicit(S, &0, &0); // OK
-    S::late_implicit::<'static>(S, &0, &0);
+    S::late_implicit(S, &0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    S::late_implicit::<'static, 'static>(S, &0, &0);
+    S::late_implicit(S, &0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    S::late_implicit::<'static, 'static, 'static>(S, &0, &0);
+    S::late_implicit(S, &0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     S::late_implicit_early(S, &0); // OK
-    S::late_implicit_early::<'static, 'static>(S, &0);
+    S::late_implicit_early(S, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    S::late_implicit_early::<'static, 'static, 'static>(S, &0);
+    S::late_implicit_early(S, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     S::late_implicit_self_early(&S); // OK
-    S::late_implicit_self_early::<'static, 'static>(&S);
+    S::late_implicit_self_early(&S);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    S::late_implicit_self_early::<'static, 'static, 'static>(&S);
+    S::late_implicit_self_early(&S);
     //~^ ERROR cannot specify lifetime arguments explicitly
     S::late_unused_early(S); // OK
-    S::late_unused_early::<'static, 'static>(S);
+    S::late_unused_early(S);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    S::late_unused_early::<'static, 'static, 'static>(S);
+    S::late_unused_early(S);
     //~^ ERROR cannot specify lifetime arguments explicitly
 
     S::early(S); // OK
-    S::early::<'static>(S);
+    S::early::<'static, 'static>(S);
     //~^ ERROR method takes 2 lifetime arguments but 1 lifetime argument
-    S::early::<'static, 'static, 'static>(S);
+    S::early::<'static, 'static, >(S);
     //~^ ERROR method takes 2 lifetime arguments but 3 lifetime arguments were supplied
     let _: &u8 = S::life_and_type::<'static>(S);
     S::life_and_type::<u8>(S);

--- a/tests/ui/methods/method-call-lifetime-args-fail.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-fail.stderr
@@ -41,54 +41,59 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:29:15
    |
 LL |     S::late::<'static, 'static>(S, &0, &0);
-   |               ^^^^^^^
+   |               ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
   --> $DIR/method-call-lifetime-args-fail.rs:4:13
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             ^^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:31:15
    |
 LL |     S::late::<'static, 'static, 'static>(S, &0, &0);
-   |               ^^^^^^^
+   |               ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
   --> $DIR/method-call-lifetime-args-fail.rs:4:13
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             ^^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:34:21
    |
 LL |     S::late_early::<'static, 'static>(S, &0);
-   |                     ^^^^^^^
+   |                     ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
   --> $DIR/method-call-lifetime-args-fail.rs:7:19
    |
 LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
    |                   ^^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:36:21
    |
 LL |     S::late_early::<'static, 'static, 'static>(S, &0);
-   |                     ^^^^^^^
+   |                     ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
   --> $DIR/method-call-lifetime-args-fail.rs:7:19
    |
 LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
    |                   ^^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:40:24
@@ -101,102 +106,111 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               ^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:42:24
    |
 LL |     S::late_implicit::<'static, 'static>(S, &0, &0);
-   |                        ^^^^^^^
+   |                        ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
   --> $DIR/method-call-lifetime-args-fail.rs:5:31
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               ^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:44:24
    |
 LL |     S::late_implicit::<'static, 'static, 'static>(S, &0, &0);
-   |                        ^^^^^^^
+   |                        ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
   --> $DIR/method-call-lifetime-args-fail.rs:5:31
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               ^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:47:30
    |
 LL |     S::late_implicit_early::<'static, 'static>(S, &0);
-   |                              ^^^^^^^
+   |                              ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
   --> $DIR/method-call-lifetime-args-fail.rs:8:41
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
    |                                         ^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:49:30
    |
 LL |     S::late_implicit_early::<'static, 'static, 'static>(S, &0);
-   |                              ^^^^^^^
+   |                              ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
   --> $DIR/method-call-lifetime-args-fail.rs:8:41
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
    |                                         ^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:52:35
    |
 LL |     S::late_implicit_self_early::<'static, 'static>(&S);
-   |                                   ^^^^^^^
+   |                                   ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
   --> $DIR/method-call-lifetime-args-fail.rs:9:37
    |
 LL |     fn late_implicit_self_early<'b>(&self) -> &'b u8 { loop {} }
    |                                     ^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:54:35
    |
 LL |     S::late_implicit_self_early::<'static, 'static, 'static>(&S);
-   |                                   ^^^^^^^
+   |                                   ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
   --> $DIR/method-call-lifetime-args-fail.rs:9:37
    |
 LL |     fn late_implicit_self_early<'b>(&self) -> &'b u8 { loop {} }
    |                                     ^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:57:28
    |
 LL |     S::late_unused_early::<'static, 'static>(S);
-   |                            ^^^^^^^
+   |                            ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
   --> $DIR/method-call-lifetime-args-fail.rs:10:26
    |
 LL |     fn late_unused_early<'a, 'b>(self) -> &'b u8 { loop {} }
    |                          ^^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:59:28
    |
 LL |     S::late_unused_early::<'static, 'static, 'static>(S);
-   |                            ^^^^^^^
+   |                            ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
   --> $DIR/method-call-lifetime-args-fail.rs:10:26
    |
 LL |     fn late_unused_early<'a, 'b>(self) -> &'b u8 { loop {} }
    |                          ^^
+   = help: remove the explicit lifetime arguments
 
 error[E0107]: method takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/method-call-lifetime-args-fail.rs:63:8

--- a/tests/ui/methods/method-call-lifetime-args-fail.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-fail.stderr
@@ -1,5 +1,5 @@
 error[E0107]: method takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/method-call-lifetime-args-fail.rs:16:7
+  --> $DIR/method-call-lifetime-args-fail.rs:19:7
    |
 LL |     S.early::<'static>();
    |       ^^^^^   ------- supplied 1 lifetime argument
@@ -7,7 +7,7 @@ LL |     S.early::<'static>();
    |       expected 2 lifetime arguments
    |
 note: method defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/method-call-lifetime-args-fail.rs:6:8
+  --> $DIR/method-call-lifetime-args-fail.rs:9:8
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
    |        ^^^^^ --  --
@@ -17,7 +17,7 @@ LL |     S.early::<'static, 'static>();
    |                      +++++++++
 
 error[E0107]: method takes 2 lifetime arguments but 3 lifetime arguments were supplied
-  --> $DIR/method-call-lifetime-args-fail.rs:18:7
+  --> $DIR/method-call-lifetime-args-fail.rs:21:7
    |
 LL |     S.early::<'static, 'static, 'static>();
    |       ^^^^^                     ------- help: remove this lifetime argument
@@ -25,195 +25,251 @@ LL |     S.early::<'static, 'static, 'static>();
    |       expected 2 lifetime arguments
    |
 note: method defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/method-call-lifetime-args-fail.rs:6:8
+  --> $DIR/method-call-lifetime-args-fail.rs:9:8
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
    |        ^^^^^ --  --
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:27:15
+  --> $DIR/method-call-lifetime-args-fail.rs:30:15
    |
 LL |     S::late::<'static>(S, &0, &0);
    |               ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:4:13
+  --> $DIR/method-call-lifetime-args-fail.rs:7:13
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S::late::<'static>(S, &0, &0);
+LL +     S::late(S, &0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:29:15
+  --> $DIR/method-call-lifetime-args-fail.rs:32:15
    |
 LL |     S::late::<'static, 'static>(S, &0, &0);
    |               ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:4:13
+  --> $DIR/method-call-lifetime-args-fail.rs:7:13
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             ^^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S::late::<'static, 'static>(S, &0, &0);
+LL +     S::late(S, &0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:31:15
+  --> $DIR/method-call-lifetime-args-fail.rs:34:15
    |
 LL |     S::late::<'static, 'static, 'static>(S, &0, &0);
    |               ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:4:13
+  --> $DIR/method-call-lifetime-args-fail.rs:7:13
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             ^^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S::late::<'static, 'static, 'static>(S, &0, &0);
+LL +     S::late(S, &0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:34:21
+  --> $DIR/method-call-lifetime-args-fail.rs:37:21
    |
 LL |     S::late_early::<'static, 'static>(S, &0);
    |                     ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:7:19
+  --> $DIR/method-call-lifetime-args-fail.rs:10:19
    |
 LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
    |                   ^^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S::late_early::<'static, 'static>(S, &0);
+LL +     S::late_early(S, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:36:21
+  --> $DIR/method-call-lifetime-args-fail.rs:39:21
    |
 LL |     S::late_early::<'static, 'static, 'static>(S, &0);
    |                     ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:7:19
+  --> $DIR/method-call-lifetime-args-fail.rs:10:19
    |
 LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
    |                   ^^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S::late_early::<'static, 'static, 'static>(S, &0);
+LL +     S::late_early(S, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:40:24
+  --> $DIR/method-call-lifetime-args-fail.rs:43:24
    |
 LL |     S::late_implicit::<'static>(S, &0, &0);
    |                        ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:5:31
+  --> $DIR/method-call-lifetime-args-fail.rs:8:31
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               ^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S::late_implicit::<'static>(S, &0, &0);
+LL +     S::late_implicit(S, &0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:42:24
+  --> $DIR/method-call-lifetime-args-fail.rs:45:24
    |
 LL |     S::late_implicit::<'static, 'static>(S, &0, &0);
    |                        ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:5:31
+  --> $DIR/method-call-lifetime-args-fail.rs:8:31
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               ^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S::late_implicit::<'static, 'static>(S, &0, &0);
+LL +     S::late_implicit(S, &0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:44:24
+  --> $DIR/method-call-lifetime-args-fail.rs:47:24
    |
 LL |     S::late_implicit::<'static, 'static, 'static>(S, &0, &0);
    |                        ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:5:31
+  --> $DIR/method-call-lifetime-args-fail.rs:8:31
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               ^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S::late_implicit::<'static, 'static, 'static>(S, &0, &0);
+LL +     S::late_implicit(S, &0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:47:30
+  --> $DIR/method-call-lifetime-args-fail.rs:50:30
    |
 LL |     S::late_implicit_early::<'static, 'static>(S, &0);
    |                              ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:8:41
+  --> $DIR/method-call-lifetime-args-fail.rs:11:41
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
    |                                         ^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S::late_implicit_early::<'static, 'static>(S, &0);
+LL +     S::late_implicit_early(S, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:49:30
+  --> $DIR/method-call-lifetime-args-fail.rs:52:30
    |
 LL |     S::late_implicit_early::<'static, 'static, 'static>(S, &0);
    |                              ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:8:41
+  --> $DIR/method-call-lifetime-args-fail.rs:11:41
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
    |                                         ^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S::late_implicit_early::<'static, 'static, 'static>(S, &0);
+LL +     S::late_implicit_early(S, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:52:35
+  --> $DIR/method-call-lifetime-args-fail.rs:55:35
    |
 LL |     S::late_implicit_self_early::<'static, 'static>(&S);
    |                                   ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:9:37
+  --> $DIR/method-call-lifetime-args-fail.rs:12:37
    |
 LL |     fn late_implicit_self_early<'b>(&self) -> &'b u8 { loop {} }
    |                                     ^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S::late_implicit_self_early::<'static, 'static>(&S);
+LL +     S::late_implicit_self_early(&S);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:54:35
+  --> $DIR/method-call-lifetime-args-fail.rs:57:35
    |
 LL |     S::late_implicit_self_early::<'static, 'static, 'static>(&S);
    |                                   ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:9:37
+  --> $DIR/method-call-lifetime-args-fail.rs:12:37
    |
 LL |     fn late_implicit_self_early<'b>(&self) -> &'b u8 { loop {} }
    |                                     ^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S::late_implicit_self_early::<'static, 'static, 'static>(&S);
+LL +     S::late_implicit_self_early(&S);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:57:28
+  --> $DIR/method-call-lifetime-args-fail.rs:60:28
    |
 LL |     S::late_unused_early::<'static, 'static>(S);
    |                            ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:10:26
+  --> $DIR/method-call-lifetime-args-fail.rs:13:26
    |
 LL |     fn late_unused_early<'a, 'b>(self) -> &'b u8 { loop {} }
    |                          ^^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S::late_unused_early::<'static, 'static>(S);
+LL +     S::late_unused_early(S);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-fail.rs:59:28
+  --> $DIR/method-call-lifetime-args-fail.rs:62:28
    |
 LL |     S::late_unused_early::<'static, 'static, 'static>(S);
    |                            ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
 note: the late bound lifetime parameter is introduced here
-  --> $DIR/method-call-lifetime-args-fail.rs:10:26
+  --> $DIR/method-call-lifetime-args-fail.rs:13:26
    |
 LL |     fn late_unused_early<'a, 'b>(self) -> &'b u8 { loop {} }
    |                          ^^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S::late_unused_early::<'static, 'static, 'static>(S);
+LL +     S::late_unused_early(S);
+   |
 
 error[E0107]: method takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/method-call-lifetime-args-fail.rs:63:8
+  --> $DIR/method-call-lifetime-args-fail.rs:66:8
    |
 LL |     S::early::<'static>(S);
    |        ^^^^^   ------- supplied 1 lifetime argument
@@ -221,7 +277,7 @@ LL |     S::early::<'static>(S);
    |        expected 2 lifetime arguments
    |
 note: method defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/method-call-lifetime-args-fail.rs:6:8
+  --> $DIR/method-call-lifetime-args-fail.rs:9:8
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
    |        ^^^^^ --  --
@@ -231,7 +287,7 @@ LL |     S::early::<'static, 'static>(S);
    |                       +++++++++
 
 error[E0107]: method takes 2 lifetime arguments but 3 lifetime arguments were supplied
-  --> $DIR/method-call-lifetime-args-fail.rs:65:8
+  --> $DIR/method-call-lifetime-args-fail.rs:68:8
    |
 LL |     S::early::<'static, 'static, 'static>(S);
    |        ^^^^^                     ------- help: remove this lifetime argument
@@ -239,7 +295,7 @@ LL |     S::early::<'static, 'static, 'static>(S);
    |        expected 2 lifetime arguments
    |
 note: method defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/method-call-lifetime-args-fail.rs:6:8
+  --> $DIR/method-call-lifetime-args-fail.rs:9:8
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
    |        ^^^^^ --  --

--- a/tests/ui/methods/method-call-lifetime-args-lint-fail.rs
+++ b/tests/ui/methods/method-call-lifetime-args-lint-fail.rs
@@ -1,4 +1,3 @@
-#![deny(late_bound_lifetime_arguments)]
 #![allow(unused)]
 
 struct S;
@@ -22,44 +21,32 @@ fn method_call() {
     S.late(&0, &0); // OK
     S.late::<'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
     S.late::<'static, 'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
     S.late::<'static, 'static, 'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
     S.late_early(&0); // OK
     S.late_early::<'static>(&0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
     S.late_early::<'static, 'static>(&0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
     S.late_early::<'static, 'static, 'static>(&0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
 
     S.late_implicit(&0, &0); // OK
     S.late_implicit::<'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
     S.late_implicit::<'static, 'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
     S.late_implicit::<'static, 'static, 'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
     S.late_implicit_early(&0); // OK
     S.late_implicit_early::<'static>(&0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
     S.late_implicit_early::<'static, 'static>(&0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
     S.late_implicit_early::<'static, 'static, 'static>(&0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
 
     S::early_tricky_explicit::<'static>(loop {}, loop {}); // OK
     S::early_tricky_implicit::<'static>(loop {}, loop {}); // OK
@@ -68,11 +55,9 @@ fn method_call() {
 fn ufcs() {
     S::late_early::<'static>(S, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
 
     S::late_implicit_early::<'static>(S, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
 }
 
 fn lint_not_inference_error() {
@@ -81,7 +66,6 @@ fn lint_not_inference_error() {
     // Make sure `u8` is substituted and not replaced with an inference variable
     f::<'static, u8>;
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
 }
 
 fn main() {}

--- a/tests/ui/methods/method-call-lifetime-args-lint-fail.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-lint-fail.stderr
@@ -1,187 +1,197 @@
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:23:14
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:22:14
    |
-LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
-   |             -- the late bound lifetime parameter is introduced here
-...
 LL |     S.late::<'static>(&0, &0);
    |              ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-note: the lint level is defined here
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:1:9
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:6:13
    |
-LL | #![deny(late_bound_lifetime_arguments)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
+   |             ^^
+   = help: remove the explicit lifetime argument
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:24:14
+   |
+LL |     S.late::<'static, 'static>(&0, &0);
+   |              ^^^^^^^  ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:6:13
+   |
+LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
+   |             ^^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:26:14
    |
-LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
-   |             -- the late bound lifetime parameter is introduced here
-...
-LL |     S.late::<'static, 'static>(&0, &0);
-   |              ^^^^^^^
+LL |     S.late::<'static, 'static, 'static>(&0, &0);
+   |              ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:6:13
+   |
+LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
+   |             ^^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:29:14
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:29:20
    |
-LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
-   |             -- the late bound lifetime parameter is introduced here
-...
-LL |     S.late::<'static, 'static, 'static>(&0, &0);
-   |              ^^^^^^^
+LL |     S.late_early::<'static>(&0);
+   |                    ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:8:19
+   |
+LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
+   |                   ^^
+   = help: remove the explicit lifetime argument
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:31:20
+   |
+LL |     S.late_early::<'static, 'static>(&0);
+   |                    ^^^^^^^  ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:8:19
+   |
+LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
+   |                   ^^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:33:20
    |
-LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
-   |                   -- the late bound lifetime parameter is introduced here
-...
-LL |     S.late_early::<'static>(&0);
-   |                    ^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-
-error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:36:20
-   |
-LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
-   |                   -- the late bound lifetime parameter is introduced here
-...
-LL |     S.late_early::<'static, 'static>(&0);
-   |                    ^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-
-error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:39:20
-   |
-LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
-   |                   -- the late bound lifetime parameter is introduced here
-...
 LL |     S.late_early::<'static, 'static, 'static>(&0);
-   |                    ^^^^^^^
+   |                    ^^^^^^^  ^^^^^^^  ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:8:19
+   |
+LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
+   |                   ^^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:44:23
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:37:23
    |
-LL |     fn late_implicit(self, _: &u8, _: &u8) {}
-   |                               - the late bound lifetime parameter is introduced here
-...
 LL |     S.late_implicit::<'static>(&0, &0);
    |                       ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-
-error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:47:23
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:7:31
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
-   |                               - the late bound lifetime parameter is introduced here
-...
+   |                               ^
+   = help: remove the explicit lifetime argument
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:39:23
+   |
 LL |     S.late_implicit::<'static, 'static>(&0, &0);
-   |                       ^^^^^^^
+   |                       ^^^^^^^  ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-
-error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:50:23
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:7:31
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
-   |                               - the late bound lifetime parameter is introduced here
-...
-LL |     S.late_implicit::<'static, 'static, 'static>(&0, &0);
-   |                       ^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+   |                               ^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:54:29
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:41:23
    |
-LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
-   |                                         - the late bound lifetime parameter is introduced here
-...
+LL |     S.late_implicit::<'static, 'static, 'static>(&0, &0);
+   |                       ^^^^^^^  ^^^^^^^  ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:7:31
+   |
+LL |     fn late_implicit(self, _: &u8, _: &u8) {}
+   |                               ^
+   = help: remove the explicit lifetime arguments
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:44:29
+   |
 LL |     S.late_implicit_early::<'static>(&0);
    |                             ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-
-error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:57:29
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:9:41
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
-   |                                         - the late bound lifetime parameter is introduced here
-...
+   |                                         ^
+   = help: remove the explicit lifetime argument
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:46:29
+   |
 LL |     S.late_implicit_early::<'static, 'static>(&0);
-   |                             ^^^^^^^
+   |                             ^^^^^^^  ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-
-error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:60:29
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:9:41
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
-   |                                         - the late bound lifetime parameter is introduced here
-...
-LL |     S.late_implicit_early::<'static, 'static, 'static>(&0);
-   |                             ^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+   |                                         ^
+   = help: remove the explicit lifetime arguments
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:69:21
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:48:29
    |
-LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
-   |                   -- the late bound lifetime parameter is introduced here
-...
+LL |     S.late_implicit_early::<'static, 'static, 'static>(&0);
+   |                             ^^^^^^^  ^^^^^^^  ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:9:41
+   |
+LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
+   |                                         ^
+   = help: remove the explicit lifetime arguments
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:56:21
+   |
 LL |     S::late_early::<'static>(S, &0);
    |                     ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:8:19
+   |
+LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
+   |                   ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:73:30
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:59:30
    |
-LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
-   |                                         - the late bound lifetime parameter is introduced here
-...
 LL |     S::late_implicit_early::<'static>(S, &0);
    |                              ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:9:41
+   |
+LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
+   |                                         ^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:82:9
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:67:9
    |
-LL |     fn f<'early, 'late, T: 'early>() {}
-   |                  ----- the late bound lifetime parameter is introduced here
-...
 LL |     f::<'static, u8>;
    |         ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:64:18
+   |
+LL |     fn f<'early, 'late, T: 'early>() {}
+   |                  ^^^^^
+   = help: remove the explicit lifetime argument
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/methods/method-call-lifetime-args-lint-fail.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-lint-fail.stderr
@@ -9,7 +9,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S.late::<'static>(&0, &0);
+LL +     S.late(&0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:24:14
@@ -22,7 +26,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             ^^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S.late::<'static, 'static>(&0, &0);
+LL +     S.late(&0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:26:14
@@ -35,7 +43,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             ^^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S.late::<'static, 'static, 'static>(&0, &0);
+LL +     S.late(&0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:29:20
@@ -48,7 +60,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
    |                   ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S.late_early::<'static>(&0);
+LL +     S.late_early(&0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:31:20
@@ -61,7 +77,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
    |                   ^^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S.late_early::<'static, 'static>(&0);
+LL +     S.late_early(&0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:33:20
@@ -74,7 +94,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
    |                   ^^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S.late_early::<'static, 'static, 'static>(&0);
+LL +     S.late_early(&0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:37:23
@@ -87,7 +111,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               ^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S.late_implicit::<'static>(&0, &0);
+LL +     S.late_implicit(&0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:39:23
@@ -100,7 +128,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               ^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S.late_implicit::<'static, 'static>(&0, &0);
+LL +     S.late_implicit(&0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:41:23
@@ -113,7 +145,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               ^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S.late_implicit::<'static, 'static, 'static>(&0, &0);
+LL +     S.late_implicit(&0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:44:29
@@ -126,7 +162,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
    |                                         ^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S.late_implicit_early::<'static>(&0);
+LL +     S.late_implicit_early(&0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:46:29
@@ -139,7 +179,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
    |                                         ^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S.late_implicit_early::<'static, 'static>(&0);
+LL +     S.late_implicit_early(&0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:48:29
@@ -152,7 +196,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
    |                                         ^
-   = help: remove the explicit lifetime arguments
+help: remove the explicit lifetime arguments
+   |
+LL -     S.late_implicit_early::<'static, 'static, 'static>(&0);
+LL +     S.late_implicit_early(&0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:56:21
@@ -165,7 +213,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
    |                   ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S::late_early::<'static>(S, &0);
+LL +     S::late_early(S, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:59:30
@@ -178,7 +230,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
    |                                         ^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S::late_implicit_early::<'static>(S, &0);
+LL +     S::late_implicit_early(S, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint-fail.rs:67:9
@@ -191,7 +247,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn f<'early, 'late, T: 'early>() {}
    |                  ^^^^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     f::<'static, u8>;
+LL +     f::<u8>;
+   |
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/methods/method-call-lifetime-args-lint.rs
+++ b/tests/ui/methods/method-call-lifetime-args-lint.rs
@@ -1,4 +1,3 @@
-#![deny(late_bound_lifetime_arguments)]
 #![allow(unused)]
 
 struct S;
@@ -11,11 +10,9 @@ impl S {
 fn method_call() {
     S.late::<'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
 
     S.late_implicit::<'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
-    //~| WARN this was previously accepted
 }
 
 fn main() {}

--- a/tests/ui/methods/method-call-lifetime-args-lint.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-lint.stderr
@@ -1,31 +1,28 @@
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint.rs:12:14
+  --> $DIR/method-call-lifetime-args-lint.rs:11:14
    |
-LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
-   |             -- the late bound lifetime parameter is introduced here
-...
 LL |     S.late::<'static>(&0, &0);
    |              ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-note: the lint level is defined here
-  --> $DIR/method-call-lifetime-args-lint.rs:1:9
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint.rs:6:13
    |
-LL | #![deny(late_bound_lifetime_arguments)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
+   |             ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint.rs:16:23
+  --> $DIR/method-call-lifetime-args-lint.rs:14:23
    |
-LL |     fn late_implicit(self, _: &u8, _: &u8) {}
-   |                               - the late bound lifetime parameter is introduced here
-...
 LL |     S.late_implicit::<'static>(&0, &0);
    |                       ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/method-call-lifetime-args-lint.rs:7:31
+   |
+LL |     fn late_implicit(self, _: &u8, _: &u8) {}
+   |                               ^
+   = help: remove the explicit lifetime argument
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/methods/method-call-lifetime-args-lint.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-lint.stderr
@@ -9,7 +9,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S.late::<'static>(&0, &0);
+LL +     S.late(&0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-lint.rs:14:23
@@ -22,7 +26,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               ^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S.late_implicit::<'static>(&0, &0);
+LL +     S.late_implicit(&0, &0);
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/methods/method-call-lifetime-args-unresolved.rs
+++ b/tests/ui/methods/method-call-lifetime-args-unresolved.rs
@@ -1,6 +1,5 @@
 fn main() {
     0.clone::<'a>();
     //~^ ERROR use of undeclared lifetime name `'a`
-    //~| WARN cannot specify lifetime arguments explicitly if late bound
-    //~| WARN this was previously accepted by the compiler
+    //~| ERROR cannot specify lifetime arguments explicitly if late bound
 }

--- a/tests/ui/methods/method-call-lifetime-args-unresolved.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-unresolved.stderr
@@ -6,19 +6,16 @@ LL | fn main() {
 LL |     0.clone::<'a>();
    |               ^^ undeclared lifetime
 
-warning: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-unresolved.rs:2:15
    |
 LL |     0.clone::<'a>();
    |               ^^
+   |
+note: the late bound lifetime parameter is introduced here
   --> $SRC_DIR/core/src/clone.rs:LL:COL
-   |
-   = note: the late bound lifetime parameter is introduced here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-   = note: `#[warn(late_bound_lifetime_arguments)]` on by default
+   = help: remove the explicit lifetime argument
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0261`.

--- a/tests/ui/methods/method-call-lifetime-args-unresolved.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-unresolved.stderr
@@ -14,7 +14,11 @@ LL |     0.clone::<'a>();
    |
 note: the late bound lifetime parameter is introduced here
   --> $SRC_DIR/core/src/clone.rs:LL:COL
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     0.clone::<'a>();
+LL +     0.clone();
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/methods/method-call-lifetime-args.stderr
+++ b/tests/ui/methods/method-call-lifetime-args.stderr
@@ -9,6 +9,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             ^^
+   = help: remove the explicit lifetime argument
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args.rs:11:24
@@ -21,6 +22,7 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               ^
+   = help: remove the explicit lifetime argument
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/methods/method-call-lifetime-args.stderr
+++ b/tests/ui/methods/method-call-lifetime-args.stderr
@@ -9,7 +9,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             ^^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S::late::<'static>(S, &0, &0);
+LL +     S::late(S, &0, &0);
+   |
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args.rs:11:24
@@ -22,7 +26,11 @@ note: the late bound lifetime parameter is introduced here
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               ^
-   = help: remove the explicit lifetime argument
+help: remove the explicit lifetime argument
+   |
+LL -     S::late_implicit::<'static>(S, &0, &0);
+LL +     S::late_implicit(S, &0, &0);
+   |
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Split from https://github.com/rust-lang/rust/pull/103448

That lint has been there for 5 years.

Fixes https://github.com/rust-lang/rust/issues/42868