### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1511,6 +1511,14 @@ fn opaque_type_cycle_error(
                     {
                         label_match(interior_ty.ty, interior_ty.span);
                     }
+                    if tcx.sess.opts.unstable_opts.drop_tracking_mir
+                        && let DefKind::Generator = tcx.def_kind(closure_def_id)
+                    {
+                        let generator_layout = tcx.mir_generator_witnesses(closure_def_id);
+                        for interior_ty in &generator_layout.field_tys {
+                            label_match(interior_ty.ty, interior_ty.source_info.span);
+                        }
+                    }
                 }
             }
         }

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -344,8 +344,8 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::EarlyBinder<Ty<'_>>
                     in_trait,
                     ..
                 }) => {
-                    if in_trait {
-                        assert!(tcx.impl_defaultness(owner).has_value());
+                    if in_trait && !tcx.impl_defaultness(owner).has_value() {
+                        span_bug!(tcx.def_span(def_id), "tried to get type of this RPITIT with no definition");
                     }
                     find_opaque_ty_constraints_for_rpit(tcx, def_id, owner)
                 }

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -1872,12 +1872,14 @@ fn check_must_not_suspend_def(
     data: SuspendCheckData<'_>,
 ) -> bool {
     if let Some(attr) = tcx.get_attr(def_id, sym::must_not_suspend) {
-        let msg = format!(
-            "{}`{}`{} held across a suspend point, but should not be",
-            data.descr_pre,
-            tcx.def_path_str(def_id),
-            data.descr_post,
-        );
+        let msg = rustc_errors::DelayDm(|| {
+            format!(
+                "{}`{}`{} held across a suspend point, but should not be",
+                data.descr_pre,
+                tcx.def_path_str(def_id),
+                data.descr_post,
+            )
+        });
         tcx.struct_span_lint_hir(
             rustc_session::lint::builtin::MUST_NOT_SUSPEND,
             hir_id,

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -149,6 +149,6 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
         &mut self,
         _: &InferCtxt<'tcx>,
     ) -> Vec<PredicateObligation<'tcx>> {
-        unimplemented!()
+        std::mem::take(&mut self.obligations)
     }
 }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -2200,7 +2200,8 @@ fn confirm_impl_trait_in_trait_candidate<'tcx>(
         Err(guar) => return Progress::error(tcx, guar),
     };
     // We don't support specialization for RPITITs anyways... yet.
-    if !leaf_def.is_final() {
+    // Also don't try to project to an RPITIT that has no value
+    if !leaf_def.is_final() || !leaf_def.item.defaultness(tcx).has_value() {
         return Progress { term: tcx.ty_error_misc().into(), obligations };
     }
 

--- a/src/bootstrap/format.rs
+++ b/src/bootstrap/format.rs
@@ -144,8 +144,10 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
             let untracked_paths = untracked_paths_output
                 .lines()
                 .filter(|entry| entry.starts_with("??"))
-                .map(|entry| {
-                    entry.split(' ').nth(1).expect("every git status entry should list a path")
+                .filter_map(|entry| {
+                    let path =
+                        entry.split(' ').nth(1).expect("every git status entry should list a path");
+                    path.ends_with(".rs").then_some(path)
                 });
             for untracked_path in untracked_paths {
                 println!("skip untracked path {} during rustfmt invocations", untracked_path);

--- a/src/bootstrap/format.rs
+++ b/src/bootstrap/format.rs
@@ -2,6 +2,7 @@
 
 use crate::builder::Builder;
 use crate::util::{output, program_out_of_date, t};
+use build_helper::ci::CiEnv;
 use build_helper::git::get_git_modified_files;
 use ignore::WalkBuilder;
 use std::collections::VecDeque;
@@ -156,7 +157,10 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
                 // preventing the latter from being formatted.
                 ignore_fmt.add(&format!("!/{}", untracked_path)).expect(&untracked_path);
             }
-            if !check && paths.is_empty() {
+            // Only check modified files locally to speed up runtime.
+            // We still check all files in CI to avoid bugs in `get_modified_rs_files` letting regressions slip through;
+            // we also care about CI time less since this is still very fast compared to building the compiler.
+            if !CiEnv::is_ci() && paths.is_empty() {
                 match get_modified_rs_files(build) {
                     Ok(Some(files)) => {
                         for file in files {

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -46,8 +46,10 @@ pub fn check(root_path: &Path, search_paths: &[&Path], verbose: bool, bad: &mut 
 
     // Stage 1: create list
     let error_codes = extract_error_codes(root_path, &mut errors);
-    println!("Found {} error codes", error_codes.len());
-    println!("Highest error code: `{}`", error_codes.iter().max().unwrap());
+    if verbose {
+        println!("Found {} error codes", error_codes.len());
+        println!("Highest error code: `{}`", error_codes.iter().max().unwrap());
+    }
 
     // Stage 2: check list has docs
     let no_longer_emitted = check_error_codes_docs(root_path, &error_codes, &mut errors, verbose);

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -219,8 +219,6 @@ pub fn check(
         for line in lines {
             println!("* {line}");
         }
-    } else {
-        println!("* {} features", features.len());
     }
 
     CollectedFeatures { lib: lib_features, lang: features }

--- a/tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.rs
+++ b/tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.rs
@@ -1,0 +1,16 @@
+#![feature(return_position_impl_trait_in_trait)]
+//~^ WARN the feature `return_position_impl_trait_in_trait` is incomplete
+
+trait MyTrait {
+    fn foo(&self) -> impl Sized;
+    fn bar(&self) -> impl Sized;
+}
+
+impl MyTrait for i32 {
+//~^ ERROR not all trait items implemented, missing: `foo`
+    fn bar(&self) -> impl Sized {
+        self.foo()
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.stderr
+++ b/tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.stderr
@@ -1,0 +1,21 @@
+warning: the feature `return_position_impl_trait_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/dont-project-to-rpitit-with-no-value.rs:1:12
+   |
+LL | #![feature(return_position_impl_trait_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0046]: not all trait items implemented, missing: `foo`
+  --> $DIR/dont-project-to-rpitit-with-no-value.rs:9:1
+   |
+LL |     fn foo(&self) -> impl Sized;
+   |     ---------------------------- `foo` from trait
+...
+LL | impl MyTrait for i32 {
+   | ^^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0046`.

--- a/tests/ui/impl-trait/recursive-impl-trait-type-indirect.drop_tracking_mir.stderr
+++ b/tests/ui/impl-trait/recursive-impl-trait-type-indirect.drop_tracking_mir.stderr
@@ -114,6 +114,9 @@ error[E0720]: cannot resolve opaque type
    |
 LL | fn generator_hold() -> impl Sized {
    |                        ^^^^^^^^^^ recursive opaque type
+...
+LL |         let x = generator_hold();
+   |             - generator captures itself here
 
 error[E0720]: cannot resolve opaque type
   --> $DIR/recursive-impl-trait-type-indirect.rs:90:26

--- a/tests/ui/parser/issues/issue-108242-semicolon-recovery.rs
+++ b/tests/ui/parser/issues/issue-108242-semicolon-recovery.rs
@@ -1,0 +1,5 @@
+fn foo() {}
+fn main() {
+    foo(;
+    foo(;
+} //~ ERROR mismatched closing delimiter

--- a/tests/ui/parser/issues/issue-108242-semicolon-recovery.stderr
+++ b/tests/ui/parser/issues/issue-108242-semicolon-recovery.stderr
@@ -1,0 +1,13 @@
+error: mismatched closing delimiter: `}`
+  --> $DIR/issue-108242-semicolon-recovery.rs:4:8
+   |
+LL | fn main() {
+   |           - closing delimiter possibly meant for this
+LL |     foo(;
+LL |     foo(;
+   |        ^ unclosed delimiter
+LL | }
+   | ^ mismatched closing delimiter
+
+error: aborting due to previous error
+

--- a/tests/ui/suggestions/issue-107860.rs
+++ b/tests/ui/suggestions/issue-107860.rs
@@ -1,0 +1,6 @@
+// edition: 2021
+
+async fn str<T>(T: &str) -> &str { &str }
+//~^ ERROR mismatched types
+
+fn main() {}

--- a/tests/ui/suggestions/issue-107860.stderr
+++ b/tests/ui/suggestions/issue-107860.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-107860.rs:3:36
+   |
+LL | async fn str<T>(T: &str) -> &str { &str }
+   |                                    ^^^^ expected `&str`, found `&fn(&str) -> ... {str::<...>}`
+   |
+   = note: expected reference `&str`
+              found reference `&for<'a> fn(&'a str) -> impl Future<Output = &'a str> {str::<_>}`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #108244 (Add test for semicolon recovery ICE)
 - #108746 (Don't project to RPITIT that has no default value)
 - #108764 (Tweaks to -Zdrop-tracking-mir)
 - #108770 (Improve documentation and argument naming of some TyCtxt methods)
 - #108773 (x fmt: Only check modified files locally)
 - #108775 (Use the correct bound vars in return type suggestion.)
 - #108776 (Make `x test tidy` less noisy)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=108244,108746,108764,108770,108773,108775,108776)
<!-- homu-ignore:end -->