### PR TITLE
move default backtrace setting to sys

### DIFF
--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -308,8 +308,7 @@ pub fn get_backtrace_style() -> Option<BacktraceStyle> {
                 BacktraceStyle::Short
             }
         })
-        .unwrap_or(if cfg!(target_os = "fuchsia") {
-            // Fuchsia components default to full backtrace.
+        .unwrap_or(if crate::sys::BACKTRACE_DEFAULT {
             BacktraceStyle::Full
         } else {
             BacktraceStyle::Off

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -308,7 +308,7 @@ pub fn get_backtrace_style() -> Option<BacktraceStyle> {
                 BacktraceStyle::Short
             }
         })
-        .unwrap_or(if crate::sys::BACKTRACE_DEFAULT {
+        .unwrap_or(if crate::sys::FULL_BACKTRACE_DEFAULT {
             BacktraceStyle::Full
         } else {
             BacktraceStyle::Off

--- a/library/std/src/sys/mod.rs
+++ b/library/std/src/sys/mod.rs
@@ -80,8 +80,8 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     // Fuchsia components default to full backtrace.
     if #[cfg(target_os = "fuchsia")] {
-        pub const BACKTRACE_DEFAULT: bool = true;
+        pub const FULL_BACKTRACE_DEFAULT: bool = true;
     } else {
-        pub const BACKTRACE_DEFAULT: bool = false;
+        pub const FULL_BACKTRACE_DEFAULT: bool = false;
     }
 }

--- a/library/std/src/sys/mod.rs
+++ b/library/std/src/sys/mod.rs
@@ -76,3 +76,12 @@ cfg_if::cfg_if! {
         pub mod c;
     }
 }
+
+cfg_if::cfg_if! {
+    // Fuchsia components default to full backtrace.
+    if #[cfg(target_os = "fuchsia")] {
+        pub const BACKTRACE_DEFAULT: bool = true;
+    } else {
+        pub const BACKTRACE_DEFAULT: bool = false;
+    }
+}

--- a/src/tools/tidy/src/pal.rs
+++ b/src/tools/tidy/src/pal.rs
@@ -59,7 +59,6 @@ const EXCEPTION_PATHS: &[&str] = &[
     "library/std/src/path.rs",
     "library/std/src/sys_common", // Should only contain abstractions over platforms
     "library/std/src/net/test.rs", // Utility helpers for tests
-    "library/std/src/panic.rs",   // fuchsia-specific panic backtrace handling
     "library/std/src/personality.rs",
     "library/std/src/personality/",
 ];


### PR DESCRIPTION
another PAL exception. moves the default backtrace setting to sys.