### PR TITLE
Update host compiler to LLVM 16

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-15.0.0
+LLVM=llvmorg-16.0.0-rc4
 
 mkdir llvm-project
 cd llvm-project


### PR DESCRIPTION
Update the host compiler for dist-x86_64-linux to LLVM 16. In particular, this pulls in https://github.com/llvm/llvm-project/commit/1de305da428598d79b7d2d9e70962130142f7ca4, which is needed to update Rust's own LLVM (https://github.com/rust-lang/rust/pull/107224).