### PR TITLE
Do not ICE when failing to normalize in ConstProp.

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -7,7 +7,7 @@ use either::{Either, Left, Right};
 use rustc_hir::{self as hir, def_id::DefId, definitions::DefPathData};
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir;
-use rustc_middle::mir::interpret::{ErrorHandled, InterpError, InvalidProgramInfo};
+use rustc_middle::mir::interpret::{ErrorHandled, InterpError};
 use rustc_middle::ty::layout::{
     self, FnAbiError, FnAbiOfHelpers, FnAbiRequest, LayoutError, LayoutOf, LayoutOfHelpers,
     TyAndLayout,
@@ -508,14 +508,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         frame
             .instance
             .try_subst_mir_and_normalize_erasing_regions(*self.tcx, self.param_env, value)
-            .map_err(|e| {
-                self.tcx.sess.delay_span_bug(
-                    self.cur_span(),
-                    format!("failed to normalize {}", e.get_type_for_failure()).as_str(),
-                );
-
-                InterpError::InvalidProgram(InvalidProgramInfo::TooGeneric)
-            })
+            .map_err(|_| err_inval!(TooGeneric))
     }
 
     /// The `substs` are assumed to already be in our interpreter "universe" (param_env).

--- a/tests/ui/associated-types/issue-67684.rs
+++ b/tests/ui/associated-types/issue-67684.rs
@@ -1,4 +1,10 @@
-// check-pass
+// revisions: check build
+// [check]check-pass
+//
+// This second configuration aims to verify that we do not ICE in ConstProp because of
+// normalization failure.
+// [build]build-pass
+// [build]compile-flags: -Zmir-opt-level=3 --emit=mir
 
 #![allow(dead_code)]
 


### PR DESCRIPTION
There is no reason to delay a bug there, as we bubble up the failure as TooGeneric.

Fixes https://github.com/rust-lang/rust/issues/97728