### PR TITLE
fix ignore header in MSVC test

### DIFF
--- a/tests/ui/panic-runtime/unwind-tables-target-required.rs
+++ b/tests/ui/panic-runtime/unwind-tables-target-required.rs
@@ -4,6 +4,7 @@
 // only-x86_64-pc-windows-msvc
 // compile-flags: -C force-unwind-tables=no
 //
+// dont-check-compiler-stderr
 // error-pattern: target requires unwind tables, they cannot be disabled with `-C force-unwind-tables=no`
 
 pub fn main() {

--- a/tests/ui/panic-runtime/unwind-tables-target-required.rs
+++ b/tests/ui/panic-runtime/unwind-tables-target-required.rs
@@ -1,7 +1,7 @@
 // Tests that the compiler errors if the user tries to turn off unwind tables
 // when they are required.
 //
-// only-x86_64-windows-msvc
+// only-x86_64-pc-windows-msvc
 // compile-flags: -C force-unwind-tables=no
 //
 // error-pattern: target requires unwind tables, they cannot be disabled with `-C force-unwind-tables=no`.

--- a/tests/ui/panic-runtime/unwind-tables-target-required.rs
+++ b/tests/ui/panic-runtime/unwind-tables-target-required.rs
@@ -4,7 +4,7 @@
 // only-x86_64-pc-windows-msvc
 // compile-flags: -C force-unwind-tables=no
 //
-// error-pattern: target requires unwind tables, they cannot be disabled with `-C force-unwind-tables=no`.
+// error-pattern: target requires unwind tables, they cannot be disabled with `-C force-unwind-tables=no`
 
 pub fn main() {
 }


### PR DESCRIPTION
From @pietroalbini's [zulip message](https://rust-lang.zulipchat.com/#narrow/stream/326414-t-infra.2Fbootstrap/topic/better.20compiletest.20ignore.20messages/near/339845864)

> there are tests like `tests/ui/panic-runtime/unwind-tables-target-required.rs` which have `only-x86_64-windows-msvc` which I'm pretty sure is invalid

This test is currently ignored on x64 MSVC CI because of this incorrect target. We'll see if it still passes.

r? @pietroalbini 