### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/fn_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/fn_queries.rs
@@ -1,3 +1,4 @@
+use rustc_attr as attr;
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -5,11 +6,17 @@ use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{DefIdTree, TyCtxt};
 use rustc_span::symbol::Symbol;
 
-/// Whether the `def_id` is an unstable const fn and what feature gate is necessary to enable it
-pub fn is_unstable_const_fn(tcx: TyCtxt<'_>, def_id: DefId) -> Option<Symbol> {
+/// Whether the `def_id` is an unstable const fn and what feature gate(s) are necessary to enable
+/// it.
+pub fn is_unstable_const_fn(tcx: TyCtxt<'_>, def_id: DefId) -> Option<(Symbol, Option<Symbol>)> {
     if tcx.is_const_fn_raw(def_id) {
         let const_stab = tcx.lookup_const_stability(def_id)?;
-        if const_stab.is_const_unstable() { Some(const_stab.feature) } else { None }
+        match const_stab.level {
+            attr::StabilityLevel::Unstable { implied_by, .. } => {
+                Some((const_stab.feature, implied_by))
+            }
+            attr::StabilityLevel::Stable { .. } => None,
+        }
     } else {
         None
     }

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -67,12 +67,12 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             Pointer(PointerCast::ReifyFnPointer) => {
+                // All reifications must be monomorphic, bail out otherwise.
+                ensure_monomorphic_enough(*self.tcx, src.layout.ty)?;
+
                 // The src operand does not matter, just its type
                 match *src.layout.ty.kind() {
                     ty::FnDef(def_id, substs) => {
-                        // All reifications must be monomorphic, bail out otherwise.
-                        ensure_monomorphic_enough(*self.tcx, src.layout.ty)?;
-
                         let instance = ty::Instance::resolve_for_fn_ptr(
                             *self.tcx,
                             self.param_env,
@@ -100,12 +100,12 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             Pointer(PointerCast::ClosureFnPointer(_)) => {
+                // All reifications must be monomorphic, bail out otherwise.
+                ensure_monomorphic_enough(*self.tcx, src.layout.ty)?;
+
                 // The src operand does not matter, just its type
                 match *src.layout.ty.kind() {
                     ty::Closure(def_id, substs) => {
-                        // All reifications must be monomorphic, bail out otherwise.
-                        ensure_monomorphic_enough(*self.tcx, src.layout.ty)?;
-
                         let instance = ty::Instance::resolve_closure(
                             *self.tcx,
                             def_id,
@@ -359,8 +359,11 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let val = Immediate::new_dyn_trait(ptr, vtable, &*self.tcx);
                 self.write_immediate(val, dest)
             }
-
             _ => {
+                // Do not ICE if we are not monomorphic enough.
+                ensure_monomorphic_enough(*self.tcx, src.layout.ty)?;
+                ensure_monomorphic_enough(*self.tcx, cast_ty)?;
+
                 span_bug!(
                     self.cur_span(),
                     "invalid pointer unsizing {:?} -> {:?}",
@@ -404,12 +407,18 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 }
                 Ok(())
             }
-            _ => span_bug!(
-                self.cur_span(),
-                "unsize_into: invalid conversion: {:?} -> {:?}",
-                src.layout,
-                dest.layout
-            ),
+            _ => {
+                // Do not ICE if we are not monomorphic enough.
+                ensure_monomorphic_enough(*self.tcx, src.layout.ty)?;
+                ensure_monomorphic_enough(*self.tcx, cast_ty.ty)?;
+
+                span_bug!(
+                    self.cur_span(),
+                    "unsize_into: invalid conversion: {:?} -> {:?}",
+                    src.layout,
+                    dest.layout
+                )
+            }
         }
     }
 }

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -7,7 +7,7 @@ use either::{Either, Left, Right};
 use rustc_hir::{self as hir, def_id::DefId, definitions::DefPathData};
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir;
-use rustc_middle::mir::interpret::{ErrorHandled, InterpError, InvalidProgramInfo};
+use rustc_middle::mir::interpret::{ErrorHandled, InterpError};
 use rustc_middle::ty::layout::{
     self, FnAbiError, FnAbiOfHelpers, FnAbiRequest, LayoutError, LayoutOf, LayoutOfHelpers,
     TyAndLayout,
@@ -508,14 +508,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         frame
             .instance
             .try_subst_mir_and_normalize_erasing_regions(*self.tcx, self.param_env, value)
-            .map_err(|e| {
-                self.tcx.sess.delay_span_bug(
-                    self.cur_span(),
-                    format!("failed to normalize {}", e.get_type_for_failure()).as_str(),
-                );
-
-                InterpError::InvalidProgram(InvalidProgramInfo::TooGeneric)
-            })
+            .map_err(|_| err_inval!(TooGeneric))
     }
 
     /// The `substs` are assumed to already be in our interpreter "universe" (param_env).

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -72,6 +72,17 @@ impl<'tcx> MirPass<'tcx> for Validator {
         };
         checker.visit_body(body);
         checker.check_cleanup_control_flow();
+
+        if let MirPhase::Runtime(_) = body.phase {
+            if let ty::InstanceDef::Item(_) = body.source.instance {
+                if body.has_free_regions() {
+                    checker.fail(
+                        Location::START,
+                        format!("Free regions in optimized {} MIR", body.phase.name()),
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -478,10 +478,6 @@ fn lint_auto_trait_impl<'tcx>(
     trait_ref: ty::TraitRef<'tcx>,
     impl_def_id: LocalDefId,
 ) {
-    if tcx.impl_polarity(impl_def_id) != ImplPolarity::Positive {
-        return;
-    }
-
     assert_eq!(trait_ref.substs.len(), 1);
     let self_ty = trait_ref.self_ty();
     let (self_type_did, substs) = match self_ty.kind() {

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -118,7 +118,7 @@ pub fn suggest_arbitrary_trait_bound<'tcx>(
     }
 
     let param_name = trait_pred.skip_binder().self_ty().to_string();
-    let mut constraint = trait_pred.print_modifiers_and_trait_path().to_string();
+    let mut constraint = trait_pred.to_string();
 
     if let Some((name, term)) = associated_ty {
         // FIXME: this case overlaps with code in TyCtxt::note_and_explain_type_err.
@@ -145,7 +145,7 @@ pub fn suggest_arbitrary_trait_bound<'tcx>(
              this requirement",
             if generics.where_clause_span.is_empty() { "introducing a" } else { "extending the" },
         ),
-        format!("{} {}: {}", generics.add_where_or_trailing_comma(), param_name, constraint),
+        format!("{} {constraint}", generics.add_where_or_trailing_comma()),
         Applicability::MaybeIncorrect,
     );
     true

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -416,8 +416,6 @@ fn inner_mir_for_ctfe(tcx: TyCtxt<'_>, def: ty::WithOptConstParam<LocalDefId>) -
 
     pm::run_passes(tcx, &mut body, &[&ctfe_limit::CtfeLimit], None);
 
-    debug_assert!(!body.has_free_regions(), "Free regions in MIR for CTFE");
-
     body
 }
 
@@ -626,8 +624,6 @@ fn inner_optimized_mir(tcx: TyCtxt<'_>, did: LocalDefId) -> Body<'_> {
     debug!("body: {:#?}", body);
     run_optimization_passes(tcx, &mut body);
 
-    debug_assert!(!body.has_free_regions(), "Free regions in optimized MIR");
-
     body
 }
 
@@ -650,8 +646,6 @@ fn promoted_mir(
         }
         run_analysis_to_runtime_passes(tcx, body);
     }
-
-    debug_assert!(!promoted.has_free_regions(), "Free regions in promoted MIR");
 
     tcx.arena.alloc(promoted)
 }

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -265,6 +265,15 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
                 self.index.implications.insert(implied_by, feature);
             }
 
+            if let Some(ConstStability {
+                level: Unstable { implied_by: Some(implied_by), .. },
+                feature,
+                ..
+            }) = const_stab
+            {
+                self.index.implications.insert(implied_by, feature);
+            }
+
             self.index.stab_map.insert(def_id, stab);
             stab
         });

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -158,7 +158,7 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
         self.infcx
             .at(cause, param_env)
             .define_opaque_types(true)
-            .sup(expected, actual)
+            .sub(expected, actual)
             .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
     }
 

--- a/tests/ui/associated-types/issue-67684.rs
+++ b/tests/ui/associated-types/issue-67684.rs
@@ -1,4 +1,10 @@
-// check-pass
+// revisions: check build
+// [check]check-pass
+//
+// This second configuration aims to verify that we do not ICE in ConstProp because of
+// normalization failure.
+// [build]build-pass
+// [build]compile-flags: -Zmir-opt-level=3 --emit=mir
 
 #![allow(dead_code)]
 

--- a/tests/ui/auto-traits/suspicious-impls-lint.rs
+++ b/tests/ui/auto-traits/suspicious-impls-lint.rs
@@ -1,4 +1,3 @@
-#![feature(negative_impls)]
 #![deny(suspicious_auto_trait_impls)]
 
 use std::marker::PhantomData;
@@ -22,9 +21,6 @@ struct ContainsVec<T>(Vec<T>);
 unsafe impl Send for ContainsVec<i32> {}
 //~^ ERROR
 //~| WARNING this will change its meaning
-impl !Send for ContainsVec<u32> {}
-//~^ ERROR
-//~| WARNING this will change its meaning
 
 struct TwoParams<T, U>(T, U);
 unsafe impl<T: Send, U: Send> Send for TwoParams<T, U> {} // ok
@@ -44,16 +40,10 @@ pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
 unsafe impl<T> Send for WithPhantomDataSend<*const T, i8> {}
 //~^ ERROR
 //~| WARNING this will change its meaning
-impl<T> !Send for WithPhantomDataSend<*const T, u8> {}
-//~^ ERROR
-//~| WARNING this will change its meaning
 
 pub struct WithLifetime<'a, T>(&'a (), T);
 unsafe impl<T> Send for WithLifetime<'static, T> {} // ok
 unsafe impl<T> Sync for WithLifetime<'static, Vec<T>> {}
-//~^ ERROR
-//~| WARNING this will change its meaning
-impl<T> !Sync for WithLifetime<'static, Option<T>> {}
 //~^ ERROR
 //~| WARNING this will change its meaning
 

--- a/tests/ui/auto-traits/suspicious-impls-lint.rs
+++ b/tests/ui/auto-traits/suspicious-impls-lint.rs
@@ -1,3 +1,4 @@
+#![feature(negative_impls)]
 #![deny(suspicious_auto_trait_impls)]
 
 use std::marker::PhantomData;
@@ -21,6 +22,9 @@ struct ContainsVec<T>(Vec<T>);
 unsafe impl Send for ContainsVec<i32> {}
 //~^ ERROR
 //~| WARNING this will change its meaning
+impl !Send for ContainsVec<u32> {}
+//~^ ERROR
+//~| WARNING this will change its meaning
 
 struct TwoParams<T, U>(T, U);
 unsafe impl<T: Send, U: Send> Send for TwoParams<T, U> {} // ok
@@ -40,10 +44,16 @@ pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
 unsafe impl<T> Send for WithPhantomDataSend<*const T, i8> {}
 //~^ ERROR
 //~| WARNING this will change its meaning
+impl<T> !Send for WithPhantomDataSend<*const T, u8> {}
+//~^ ERROR
+//~| WARNING this will change its meaning
 
 pub struct WithLifetime<'a, T>(&'a (), T);
 unsafe impl<T> Send for WithLifetime<'static, T> {} // ok
 unsafe impl<T> Sync for WithLifetime<'static, Vec<T>> {}
+//~^ ERROR
+//~| WARNING this will change its meaning
+impl<T> !Sync for WithLifetime<'static, Option<T>> {}
 //~^ ERROR
 //~| WARNING this will change its meaning
 

--- a/tests/ui/auto-traits/suspicious-impls-lint.stderr
+++ b/tests/ui/auto-traits/suspicious-impls-lint.stderr
@@ -1,5 +1,5 @@
 error: cross-crate traits with a default impl, like `Send`, should not be specialized
-  --> $DIR/suspicious-impls-lint.rs:9:1
+  --> $DIR/suspicious-impls-lint.rs:10:1
    |
 LL | unsafe impl<T: Send> Send for MayImplementSendErr<&T> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,18 +8,18 @@ LL | unsafe impl<T: Send> Send for MayImplementSendErr<&T> {}
    = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
    = note: `&T` is not a generic parameter
 note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-impls-lint.rs:8:1
+  --> $DIR/suspicious-impls-lint.rs:9:1
    |
 LL | struct MayImplementSendErr<T>(T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: the lint level is defined here
-  --> $DIR/suspicious-impls-lint.rs:1:9
+  --> $DIR/suspicious-impls-lint.rs:2:9
    |
 LL | #![deny(suspicious_auto_trait_impls)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: cross-crate traits with a default impl, like `Send`, should not be specialized
-  --> $DIR/suspicious-impls-lint.rs:21:1
+  --> $DIR/suspicious-impls-lint.rs:22:1
    |
 LL | unsafe impl Send for ContainsVec<i32> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,13 +28,28 @@ LL | unsafe impl Send for ContainsVec<i32> {}
    = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
    = note: `i32` is not a generic parameter
 note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-impls-lint.rs:20:1
+  --> $DIR/suspicious-impls-lint.rs:21:1
    |
 LL | struct ContainsVec<T>(Vec<T>);
    | ^^^^^^^^^^^^^^^^^^^^^
 
 error: cross-crate traits with a default impl, like `Send`, should not be specialized
-  --> $DIR/suspicious-impls-lint.rs:32:1
+  --> $DIR/suspicious-impls-lint.rs:25:1
+   |
+LL | impl !Send for ContainsVec<u32> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
+   = note: `u32` is not a generic parameter
+note: try using the same sequence of generic parameters as the struct definition
+  --> $DIR/suspicious-impls-lint.rs:21:1
+   |
+LL | struct ContainsVec<T>(Vec<T>);
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: cross-crate traits with a default impl, like `Send`, should not be specialized
+  --> $DIR/suspicious-impls-lint.rs:36:1
    |
 LL | unsafe impl<T: Send> Send for TwoParamsSame<T, T> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -43,13 +58,13 @@ LL | unsafe impl<T: Send> Send for TwoParamsSame<T, T> {}
    = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
    = note: `T` is mentioned multiple times
 note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-impls-lint.rs:31:1
+  --> $DIR/suspicious-impls-lint.rs:35:1
    |
 LL | struct TwoParamsSame<T, U>(T, U);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: cross-crate traits with a default impl, like `Send`, should not be specialized
-  --> $DIR/suspicious-impls-lint.rs:40:1
+  --> $DIR/suspicious-impls-lint.rs:44:1
    |
 LL | unsafe impl<T> Send for WithPhantomDataSend<*const T, i8> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,13 +73,28 @@ LL | unsafe impl<T> Send for WithPhantomDataSend<*const T, i8> {}
    = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
    = note: `*const T` is not a generic parameter
 note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-impls-lint.rs:39:1
+  --> $DIR/suspicious-impls-lint.rs:43:1
+   |
+LL | pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cross-crate traits with a default impl, like `Send`, should not be specialized
+  --> $DIR/suspicious-impls-lint.rs:47:1
+   |
+LL | impl<T> !Send for WithPhantomDataSend<*const T, u8> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
+   = note: `*const T` is not a generic parameter
+note: try using the same sequence of generic parameters as the struct definition
+  --> $DIR/suspicious-impls-lint.rs:43:1
    |
 LL | pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: cross-crate traits with a default impl, like `Sync`, should not be specialized
-  --> $DIR/suspicious-impls-lint.rs:46:1
+  --> $DIR/suspicious-impls-lint.rs:53:1
    |
 LL | unsafe impl<T> Sync for WithLifetime<'static, Vec<T>> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,10 +103,25 @@ LL | unsafe impl<T> Sync for WithLifetime<'static, Vec<T>> {}
    = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
    = note: `Vec<T>` is not a generic parameter
 note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-impls-lint.rs:44:1
+  --> $DIR/suspicious-impls-lint.rs:51:1
    |
 LL | pub struct WithLifetime<'a, T>(&'a (), T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: cross-crate traits with a default impl, like `Sync`, should not be specialized
+  --> $DIR/suspicious-impls-lint.rs:56:1
+   |
+LL | impl<T> !Sync for WithLifetime<'static, Option<T>> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
+   = note: `Option<T>` is not a generic parameter
+note: try using the same sequence of generic parameters as the struct definition
+  --> $DIR/suspicious-impls-lint.rs:51:1
+   |
+LL | pub struct WithLifetime<'a, T>(&'a (), T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/auto-traits/suspicious-negative-impls-lint.rs
+++ b/tests/ui/auto-traits/suspicious-negative-impls-lint.rs
@@ -1,0 +1,21 @@
+#![feature(negative_impls)]
+#![deny(suspicious_auto_trait_impls)]
+
+use std::marker::PhantomData;
+
+struct ContainsVec<T>(Vec<T>);
+impl !Send for ContainsVec<u32> {}
+//~^ ERROR
+//~| WARNING this will change its meaning
+
+pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
+impl<T> !Send for WithPhantomDataSend<*const T, u8> {}
+//~^ ERROR
+//~| WARNING this will change its meaning
+
+pub struct WithLifetime<'a, T>(&'a (), T);
+impl<T> !Sync for WithLifetime<'static, Option<T>> {}
+//~^ ERROR
+//~| WARNING this will change its meaning
+
+fn main() {}

--- a/tests/ui/auto-traits/suspicious-negative-impls-lint.stderr
+++ b/tests/ui/auto-traits/suspicious-negative-impls-lint.stderr
@@ -21,21 +21,6 @@ LL | #![deny(suspicious_auto_trait_impls)]
 error: cross-crate traits with a default impl, like `Send`, should not be specialized
   --> $DIR/suspicious-negative-impls-lint.rs:12:1
    |
-LL | unsafe impl<T> Send for WithPhantomDataSend<*const T, i8> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this will change its meaning in a future release!
-   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
-   = note: `*const T` is not a generic parameter
-note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-negative-impls-lint.rs:11:1
-   |
-LL | pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: cross-crate traits with a default impl, like `Send`, should not be specialized
-  --> $DIR/suspicious-negative-impls-lint.rs:15:1
-   |
 LL | impl<T> !Send for WithPhantomDataSend<*const T, u8> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -49,22 +34,7 @@ LL | pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: cross-crate traits with a default impl, like `Sync`, should not be specialized
-  --> $DIR/suspicious-negative-impls-lint.rs:21:1
-   |
-LL | unsafe impl<T> Sync for WithLifetime<'static, Vec<T>> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this will change its meaning in a future release!
-   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
-   = note: `Vec<T>` is not a generic parameter
-note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-negative-impls-lint.rs:19:1
-   |
-LL | pub struct WithLifetime<'a, T>(&'a (), T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: cross-crate traits with a default impl, like `Sync`, should not be specialized
-  --> $DIR/suspicious-negative-impls-lint.rs:24:1
+  --> $DIR/suspicious-negative-impls-lint.rs:17:1
    |
 LL | impl<T> !Sync for WithLifetime<'static, Option<T>> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,10 +43,10 @@ LL | impl<T> !Sync for WithLifetime<'static, Option<T>> {}
    = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
    = note: `Option<T>` is not a generic parameter
 note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-negative-impls-lint.rs:19:1
+  --> $DIR/suspicious-negative-impls-lint.rs:16:1
    |
 LL | pub struct WithLifetime<'a, T>(&'a (), T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/auto-traits/suspicious-negative-impls-lint.stderr
+++ b/tests/ui/auto-traits/suspicious-negative-impls-lint.stderr
@@ -1,55 +1,25 @@
 error: cross-crate traits with a default impl, like `Send`, should not be specialized
-  --> $DIR/suspicious-impls-lint.rs:9:1
+  --> $DIR/suspicious-negative-impls-lint.rs:7:1
    |
-LL | unsafe impl<T: Send> Send for MayImplementSendErr<&T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | impl !Send for ContainsVec<u32> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
-   = note: `&T` is not a generic parameter
+   = note: `u32` is not a generic parameter
 note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-impls-lint.rs:8:1
+  --> $DIR/suspicious-negative-impls-lint.rs:6:1
    |
-LL | struct MayImplementSendErr<T>(T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | struct ContainsVec<T>(Vec<T>);
+   | ^^^^^^^^^^^^^^^^^^^^^
 note: the lint level is defined here
-  --> $DIR/suspicious-impls-lint.rs:1:9
+  --> $DIR/suspicious-negative-impls-lint.rs:2:9
    |
 LL | #![deny(suspicious_auto_trait_impls)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: cross-crate traits with a default impl, like `Send`, should not be specialized
-  --> $DIR/suspicious-impls-lint.rs:21:1
-   |
-LL | unsafe impl Send for ContainsVec<i32> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this will change its meaning in a future release!
-   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
-   = note: `i32` is not a generic parameter
-note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-impls-lint.rs:20:1
-   |
-LL | struct ContainsVec<T>(Vec<T>);
-   | ^^^^^^^^^^^^^^^^^^^^^
-
-error: cross-crate traits with a default impl, like `Send`, should not be specialized
-  --> $DIR/suspicious-impls-lint.rs:32:1
-   |
-LL | unsafe impl<T: Send> Send for TwoParamsSame<T, T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this will change its meaning in a future release!
-   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
-   = note: `T` is mentioned multiple times
-note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-impls-lint.rs:31:1
-   |
-LL | struct TwoParamsSame<T, U>(T, U);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: cross-crate traits with a default impl, like `Send`, should not be specialized
-  --> $DIR/suspicious-impls-lint.rs:40:1
+  --> $DIR/suspicious-negative-impls-lint.rs:12:1
    |
 LL | unsafe impl<T> Send for WithPhantomDataSend<*const T, i8> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,13 +28,28 @@ LL | unsafe impl<T> Send for WithPhantomDataSend<*const T, i8> {}
    = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
    = note: `*const T` is not a generic parameter
 note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-impls-lint.rs:39:1
+  --> $DIR/suspicious-negative-impls-lint.rs:11:1
+   |
+LL | pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cross-crate traits with a default impl, like `Send`, should not be specialized
+  --> $DIR/suspicious-negative-impls-lint.rs:15:1
+   |
+LL | impl<T> !Send for WithPhantomDataSend<*const T, u8> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
+   = note: `*const T` is not a generic parameter
+note: try using the same sequence of generic parameters as the struct definition
+  --> $DIR/suspicious-negative-impls-lint.rs:11:1
    |
 LL | pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: cross-crate traits with a default impl, like `Sync`, should not be specialized
-  --> $DIR/suspicious-impls-lint.rs:46:1
+  --> $DIR/suspicious-negative-impls-lint.rs:21:1
    |
 LL | unsafe impl<T> Sync for WithLifetime<'static, Vec<T>> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +58,22 @@ LL | unsafe impl<T> Sync for WithLifetime<'static, Vec<T>> {}
    = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
    = note: `Vec<T>` is not a generic parameter
 note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-impls-lint.rs:44:1
+  --> $DIR/suspicious-negative-impls-lint.rs:19:1
+   |
+LL | pub struct WithLifetime<'a, T>(&'a (), T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cross-crate traits with a default impl, like `Sync`, should not be specialized
+  --> $DIR/suspicious-negative-impls-lint.rs:24:1
+   |
+LL | impl<T> !Sync for WithLifetime<'static, Option<T>> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
+   = note: `Option<T>` is not a generic parameter
+note: try using the same sequence of generic parameters as the struct definition
+  --> $DIR/suspicious-negative-impls-lint.rs:19:1
    |
 LL | pub struct WithLifetime<'a, T>(&'a (), T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/borrowck/drop-in-loop.rs
+++ b/tests/ui/borrowck/drop-in-loop.rs
@@ -1,0 +1,24 @@
+// A version of `issue-70919-drop-in-loop`, but without
+// the necessary `drop` call.
+//
+// This should fail to compile, since the `Drop` impl
+// for `WrapperWithDrop` could observe the changed
+// `base` value.
+
+struct WrapperWithDrop<'a>(&'a mut bool);
+impl<'a> Drop for WrapperWithDrop<'a> {
+    fn drop(&mut self) {
+    }
+}
+
+fn drop_in_loop() {
+    let mut base = true;
+    let mut wrapper = WrapperWithDrop(&mut base);
+    loop {
+        base = false; //~ ERROR: cannot assign to `base`
+        wrapper = WrapperWithDrop(&mut base);
+    }
+}
+
+fn main() {
+}

--- a/tests/ui/borrowck/drop-in-loop.stderr
+++ b/tests/ui/borrowck/drop-in-loop.stderr
@@ -1,0 +1,14 @@
+error[E0506]: cannot assign to `base` because it is borrowed
+  --> $DIR/drop-in-loop.rs:18:9
+   |
+LL |     let mut wrapper = WrapperWithDrop(&mut base);
+   |                                       --------- `base` is borrowed here
+LL |     loop {
+LL |         base = false;
+   |         ^^^^^^^^^^^^ `base` is assigned to here but it was already borrowed
+LL |         wrapper = WrapperWithDrop(&mut base);
+   |         ------- borrow might be used here, when `wrapper` is dropped and runs the `Drop` code for type `WrapperWithDrop`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0506`.

--- a/tests/ui/borrowck/issue-70919-drop-in-loop.rs
+++ b/tests/ui/borrowck/issue-70919-drop-in-loop.rs
@@ -1,0 +1,25 @@
+// Regression test for issue #70919
+// Tests that we don't emit a spurious "borrow might be used" error
+// when we have an explicit `drop` in a loop
+
+// check-pass
+
+struct WrapperWithDrop<'a>(&'a mut bool);
+impl<'a> Drop for WrapperWithDrop<'a> {
+    fn drop(&mut self) {
+    }
+}
+
+fn drop_in_loop() {
+    let mut base = true;
+    let mut wrapper = WrapperWithDrop(&mut base);
+    loop {
+        drop(wrapper);
+
+        base = false;
+        wrapper = WrapperWithDrop(&mut base);
+    }
+}
+
+fn main() {
+}

--- a/tests/ui/coherence/coherence-conflicting-negative-trait-impl.rs
+++ b/tests/ui/coherence/coherence-conflicting-negative-trait-impl.rs
@@ -13,5 +13,7 @@ impl<T: MyTrait> !Send for TestType<T> {} //~ ERROR found both positive and nega
 unsafe impl<T: 'static> Send for TestType<T> {} //~ ERROR conflicting implementations
 
 impl !Send for TestType<i32> {}
+//~^ WARNING
+//~| WARNING this will change its meaning
 
 fn main() {}

--- a/tests/ui/coherence/coherence-conflicting-negative-trait-impl.stderr
+++ b/tests/ui/coherence/coherence-conflicting-negative-trait-impl.stderr
@@ -16,7 +16,23 @@ LL | unsafe impl<T: MyTrait + 'static> Send for TestType<T> {}
 LL | unsafe impl<T: 'static> Send for TestType<T> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `TestType<_>`
 
-error: aborting due to 2 previous errors
+warning: cross-crate traits with a default impl, like `Send`, should not be specialized
+  --> $DIR/coherence-conflicting-negative-trait-impl.rs:15:1
+   |
+LL | impl !Send for TestType<i32> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
+   = note: `i32` is not a generic parameter
+note: try using the same sequence of generic parameters as the struct definition
+  --> $DIR/coherence-conflicting-negative-trait-impl.rs:7:1
+   |
+LL | struct TestType<T>(::std::marker::PhantomData<T>);
+   | ^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(suspicious_auto_trait_impls)]` on by default
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0119, E0751.
 For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/coherence/coherence-orphan.rs
+++ b/tests/ui/coherence/coherence-orphan.rs
@@ -14,7 +14,8 @@ impl TheTrait<TheType> for isize { }
 
 impl TheTrait<isize> for TheType { }
 
-impl !Send for Vec<isize> { }
-//~^ ERROR E0117
+impl !Send for Vec<isize> { } //~ ERROR E0117
+//~^ WARNING
+//~| WARNING this will change its meaning
 
 fn main() { }

--- a/tests/ui/coherence/coherence-orphan.stderr
+++ b/tests/ui/coherence/coherence-orphan.stderr
@@ -21,6 +21,19 @@ LL | impl !Send for Vec<isize> { }
    |
    = note: define and implement a trait or new type instead
 
-error: aborting due to 2 previous errors
+warning: cross-crate traits with a default impl, like `Send`, should not be specialized
+  --> $DIR/coherence-orphan.rs:17:1
+   |
+LL | impl !Send for Vec<isize> { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
+   = note: `isize` is not a generic parameter
+note: try using the same sequence of generic parameters as the struct definition
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   = note: `#[warn(suspicious_auto_trait_impls)]` on by default
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0117`.

--- a/tests/ui/issues/issue-106755.rs
+++ b/tests/ui/issues/issue-106755.rs
@@ -15,5 +15,7 @@ impl<T: MyTrait> !Send for TestType<T> {} //~ ERROR found both positive and nega
 unsafe impl<T: 'static> Send for TestType<T> {} //~ ERROR conflicting implementations
 
 impl !Send for TestType<i32> {}
+//~^ WARNING
+//~| WARNING this will change its meaning
 
 fn main() {}

--- a/tests/ui/issues/issue-106755.stderr
+++ b/tests/ui/issues/issue-106755.stderr
@@ -16,7 +16,23 @@ LL | unsafe impl<T: MyTrait + 'static> Send for TestType<T> {}
 LL | unsafe impl<T: 'static> Send for TestType<T> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `TestType<_>`
 
-error: aborting due to 2 previous errors
+warning: cross-crate traits with a default impl, like `Send`, should not be specialized
+  --> $DIR/issue-106755.rs:17:1
+   |
+LL | impl !Send for TestType<i32> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
+   = note: `i32` is not a generic parameter
+note: try using the same sequence of generic parameters as the struct definition
+  --> $DIR/issue-106755.rs:9:1
+   |
+LL | struct TestType<T>(::std::marker::PhantomData<T>);
+   | ^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(suspicious_auto_trait_impls)]` on by default
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0119, E0751.
 For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/mir/unsize-trait.rs
+++ b/tests/ui/mir/unsize-trait.rs
@@ -1,0 +1,15 @@
+// Check that the interpreter does not ICE when trying to unsize `B` to `[u8]`.
+// This is a `build` test to ensure that const-prop-lint runs.
+// build-pass
+
+#![feature(unsize)]
+
+fn foo<B>(buffer: &mut [B; 2])
+    where B: std::marker::Unsize<[u8]>,
+{
+    let buffer: &[u8] = &buffer[0];
+}
+
+fn main() {
+    foo(&mut [[0], [5]]);
+}

--- a/tests/ui/stability-attribute/auxiliary/const-stability-attribute-implies.rs
+++ b/tests/ui/stability-attribute/auxiliary/const-stability-attribute-implies.rs
@@ -1,0 +1,12 @@
+#![crate_type = "lib"]
+#![feature(staged_api)]
+#![stable(feature = "stability_attribute_implies", since = "1.0.0")]
+#![rustc_const_stable(feature = "stability_attribute_implies", since = "1.0.0")]
+
+#[stable(feature = "stability_attribute_implies", since = "1.0.0")]
+#[rustc_const_stable(feature = "const_foo", since = "1.62.0")]
+pub const fn foo() {}
+
+#[stable(feature = "stability_attribute_implies", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_foobar", issue = "1", implied_by = "const_foo")]
+pub const fn foobar() {}

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-missing.rs
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-missing.rs
@@ -1,0 +1,16 @@
+#![crate_type = "lib"]
+#![feature(staged_api)]
+#![stable(feature = "stability_attribute_implies", since = "1.0.0")]
+#![rustc_const_stable(feature = "stability_attribute_implies", since = "1.0.0")]
+
+// Tests that `implied_by = "const_bar"` results in an error being emitted if `const_bar` does not
+// exist.
+
+#[stable(feature = "stability_attribute_implies", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_foobar", issue = "1", implied_by = "const_bar")]
+//~^ ERROR feature `const_bar` implying `const_foobar` does not exist
+pub const fn foobar() -> u32 {
+    0
+}
+
+const VAR: u32 = foobar();

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-missing.stderr
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-missing.stderr
@@ -1,0 +1,8 @@
+error: feature `const_bar` implying `const_foobar` does not exist
+  --> $DIR/const-stability-attribute-implies-missing.rs:10:1
+   |
+LL | #[rustc_const_unstable(feature = "const_foobar", issue = "1", implied_by = "const_bar")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-no-feature.rs
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-no-feature.rs
@@ -1,0 +1,16 @@
+// aux-build:const-stability-attribute-implies.rs
+#![crate_type = "lib"]
+
+// Tests that despite the `const_foobar` feature being implied by now-stable feature `const_foo`,
+// if `const_foobar` isn't allowed in this crate then an error will be emitted.
+
+extern crate const_stability_attribute_implies;
+use const_stability_attribute_implies::{foo, foobar};
+
+pub const fn bar() -> u32 {
+    foo(); // no error - stable
+    foobar(); //~ ERROR `foobar` is not yet stable as a const fn
+    0
+}
+
+pub const VAR: u32 = bar();

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-no-feature.stderr
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-no-feature.stderr
@@ -1,0 +1,10 @@
+error: `foobar` is not yet stable as a const fn
+  --> $DIR/const-stability-attribute-implies-no-feature.rs:12:5
+   |
+LL |     foobar();
+   |     ^^^^^^^^
+   |
+   = help: add `#![feature(const_foobar)]` to the crate attributes to enable
+
+error: aborting due to previous error
+

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-using-stable.rs
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-using-stable.rs
@@ -1,0 +1,19 @@
+// aux-build:const-stability-attribute-implies.rs
+#![crate_type = "lib"]
+#![deny(stable_features)]
+#![feature(const_foo)]
+//~^ ERROR the feature `const_foo` has been partially stabilized since 1.62.0 and is succeeded by the feature `const_foobar`
+
+// Tests that the use of `implied_by` in the `#[rustc_const_unstable]` attribute results in a
+// diagnostic mentioning partial stabilization, and that given the implied unstable feature is
+// unused (there is no `foobar` call), that the compiler suggests removing the flag.
+
+extern crate const_stability_attribute_implies;
+use const_stability_attribute_implies::foo;
+
+pub const fn bar() -> u32 {
+    foo();
+    0
+}
+
+pub const VAR: u32 = bar();

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-using-stable.stderr
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-using-stable.stderr
@@ -1,0 +1,22 @@
+error: the feature `const_foo` has been partially stabilized since 1.62.0 and is succeeded by the feature `const_foobar`
+  --> $DIR/const-stability-attribute-implies-using-stable.rs:4:12
+   |
+LL | #![feature(const_foo)]
+   |            ^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/const-stability-attribute-implies-using-stable.rs:3:9
+   |
+LL | #![deny(stable_features)]
+   |         ^^^^^^^^^^^^^^^
+help: if you are using features which are still unstable, change to using `const_foobar`
+   |
+LL | #![feature(const_foobar)]
+   |            ~~~~~~~~~~~~
+help: if you are using features which are now stable, remove this line
+   |
+LL - #![feature(const_foo)]
+   |
+
+error: aborting due to previous error
+

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-using-unstable.rs
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-using-unstable.rs
@@ -1,0 +1,21 @@
+// aux-build:const-stability-attribute-implies.rs
+#![crate_type = "lib"]
+#![deny(stable_features)]
+#![feature(const_foo)]
+//~^ ERROR the feature `const_foo` has been partially stabilized since 1.62.0 and is succeeded by the feature `const_foobar`
+
+// Tests that the use of `implied_by` in the `#[rustc_const_unstable]` attribute results in a
+// diagnostic mentioning partial stabilization and that given the implied unstable feature is
+// used (there is a `const_foobar` call), that the compiler suggests changing to that feature and
+// doesn't error about its use.
+
+extern crate const_stability_attribute_implies;
+use const_stability_attribute_implies::{foo, foobar};
+
+pub const fn bar() -> u32 {
+    foo();
+    foobar(); // no error!
+    0
+}
+
+pub const VAR: u32 = bar();

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-using-unstable.stderr
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-using-unstable.stderr
@@ -1,0 +1,22 @@
+error: the feature `const_foo` has been partially stabilized since 1.62.0 and is succeeded by the feature `const_foobar`
+  --> $DIR/const-stability-attribute-implies-using-unstable.rs:4:12
+   |
+LL | #![feature(const_foo)]
+   |            ^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/const-stability-attribute-implies-using-unstable.rs:3:9
+   |
+LL | #![deny(stable_features)]
+   |         ^^^^^^^^^^^^^^^
+help: if you are using features which are still unstable, change to using `const_foobar`
+   |
+LL | #![feature(const_foobar)]
+   |            ~~~~~~~~~~~~
+help: if you are using features which are now stable, remove this line
+   |
+LL - #![feature(const_foo)]
+   |
+
+error: aborting due to previous error
+

--- a/tests/ui/suggestions/correct-binder-for-arbitrary-bound-sugg.rs
+++ b/tests/ui/suggestions/correct-binder-for-arbitrary-bound-sugg.rs
@@ -1,0 +1,16 @@
+trait Foo
+where
+    for<'a> &'a Self: Bar,
+{
+}
+
+impl Foo for () {}
+
+trait Bar {}
+
+impl Bar for &() {}
+
+fn foo<T: Foo>() {}
+//~^ ERROR the trait bound `for<'a> &'a T: Bar` is not satisfied
+
+fn main() {}

--- a/tests/ui/suggestions/correct-binder-for-arbitrary-bound-sugg.stderr
+++ b/tests/ui/suggestions/correct-binder-for-arbitrary-bound-sugg.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `for<'a> &'a T: Bar` is not satisfied
+  --> $DIR/correct-binder-for-arbitrary-bound-sugg.rs:13:11
+   |
+LL | fn foo<T: Foo>() {}
+   |           ^^^ the trait `for<'a> Bar` is not implemented for `&'a T`
+   |
+note: required by a bound in `Foo`
+  --> $DIR/correct-binder-for-arbitrary-bound-sugg.rs:3:23
+   |
+LL | trait Foo
+   |       --- required by a bound in this
+LL | where
+LL |     for<'a> &'a Self: Bar,
+   |                       ^^^ required by this bound in `Foo`
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | fn foo<T: Foo>() where for<'a> &'a T: Bar {}
+   |                  ++++++++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #107801 (const_eval: `implies_by` in `rustc_const_unstable`)
 - #108294 (Place binder correctly for arbitrary trait bound suggestion)
 - #108750 (Fix `ObligationCtxt::sub`)
 - #108780 (Add regression tests for issue 70919)
 - #108786 (Check for free regions in MIR validation)
 - #108790 (Do not ICE when interpreting a cast between non-monomorphic types)
 - #108803 (Do not ICE when failing to normalize in ConstProp.)
 - #108807 (Emit the suspicious_auto_trait_impls for negative impls as well)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=107801,108294,108750,108780,108786,108790,108803,108807)
<!-- homu-ignore:end -->