### PR TITLE
Validate proc macro attributes in AST validation

### DIFF
--- a/compiler/rustc_ast_passes/src/lib.rs
+++ b/compiler/rustc_ast_passes/src/lib.rs
@@ -10,8 +10,6 @@
 #![feature(iter_is_partitioned)]
 #![feature(let_chains)]
 #![recursion_limit = "256"]
-#![deny(rustc::untranslatable_diagnostic)]
-#![deny(rustc::diagnostic_outside_of_impl)]
 
 use rustc_errors::{DiagnosticMessage, SubdiagnosticMessage};
 use rustc_macros::fluent_messages;

--- a/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.rs
@@ -11,7 +11,7 @@
 //~^ ERROR the `#[proc_macro_derive]` attribute may only be used on bare functions
 mod proc_macro_derive1 {
     mod inner { #![proc_macro_derive()] }
-    // (no error issued here if there was one on outer module)
+    //~^ ERROR the `#[proc_macro_derive]` attribute may only be used on bare functions
 }
 
 mod proc_macro_derive2 {

--- a/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.stderr
@@ -5,6 +5,12 @@ LL | #[proc_macro_derive()]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: the `#[proc_macro_derive]` attribute may only be used on bare functions
+  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:13:17
+   |
+LL |     mod inner { #![proc_macro_derive()] }
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: the `#[proc_macro_derive]` attribute may only be used on bare functions
   --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:18:17
    |
 LL |     mod inner { #![proc_macro_derive()] }
@@ -34,5 +40,5 @@ error: the `#[proc_macro_derive]` attribute may only be used on bare functions
 LL |     #[proc_macro_derive()] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
This avoids visiting the crate in proc-macro expansion just for error reporting.

I'm not sure what to do in the `#[test]` case.

r? @petrochenkov 