### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,46 +132,35 @@ checksum = "5a2f58b0bb10c380af2b26e57212856b8c9a59e0925b4c20f4a174a49734eaf7"
 
 [[package]]
 name = "askama"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8f355701c672c2ba3d718acbd213f740beea577cc4eae66accdffe15be1882"
+checksum = "47cbc3cf73fa8d9833727bbee4835ba5c421a0d65b72daf9a7b5d0e0f9cfb57e"
 dependencies = [
  "askama_derive",
  "askama_escape",
- "askama_shared",
 ]
 
 [[package]]
 name = "askama_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84704cab5b7ae0fd3a9f78ee5eb7b27f3749df445f04623db6633459ae283267"
-dependencies = [
- "askama_shared",
- "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "askama_escape"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1bb320f97e6edf9f756bf015900038e43c7700e059688e5724a928c8f3b8d5"
-
-[[package]]
-name = "askama_shared"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae03eebba55a2697a376e58b573a29fe36893157173ac8df312ad85f3c0e012"
+checksum = "e80b5ad1afe82872b7aa3e9de9b206ecb85584aa324f0f60fa4c903ce935936b"
 dependencies = [
- "askama_escape",
+ "basic-toml",
+ "mime",
+ "mime_guess",
  "nom",
  "proc-macro2",
  "quote",
  "serde",
  "syn",
- "toml 0.5.7",
 ]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "atty"
@@ -222,6 +211,15 @@ name = "base64ct"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0de75129aa8d0cceaf750b89013f0e08804d6ec61416da787b35ad0d7cddf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -2612,6 +2610,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -348,6 +348,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             err.downgrade_to_delayed_bug();
         }
 
+        if tcx.ty_is_opaque_future(rcvr_ty) && item_name.name == sym::poll {
+            err.help(&format!(
+                "method `poll` found on `Pin<&mut {ty_str}>`, \
+                see documentation for `std::pin::Pin`"
+            ));
+            err.help("self type must be pinned to call `Future::poll`, \
+                see https://rust-lang.github.io/async-book/04_pinning/01_chapter.html#pinning-in-practice"
+            );
+        }
+
         if let Mode::MethodCall = mode && let SelfSource::MethodCall(cal) = source {
             self.suggest_await_before_method(
                 &mut err, item_name, rcvr_ty, cal, span, expected.only_has_type(self),

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -114,24 +114,26 @@ pub struct InferCtxtInner<'tcx> {
     float_unification_storage: ut::UnificationTableStorage<ty::FloatVid>,
 
     /// Tracks the set of region variables and the constraints between them.
+    ///
     /// This is initially `Some(_)` but when
     /// `resolve_regions_and_report_errors` is invoked, this gets set to `None`
     /// -- further attempts to perform unification, etc., may fail if new
     /// region constraints would've been added.
     region_constraint_storage: Option<RegionConstraintStorage<'tcx>>,
 
-    /// A set of constraints that regionck must validate. Each
-    /// constraint has the form `T:'a`, meaning "some type `T` must
+    /// A set of constraints that regionck must validate.
+    ///
+    /// Each constraint has the form `T:'a`, meaning "some type `T` must
     /// outlive the lifetime 'a". These constraints derive from
     /// instantiated type parameters. So if you had a struct defined
-    /// like
+    /// like the following:
     /// ```ignore (illustrative)
-    ///     struct Foo<T:'static> { ... }
+    /// struct Foo<T: 'static> { ... }
     /// ```
-    /// then in some expression `let x = Foo { ... }` it will
+    /// In some expression `let x = Foo { ... }`, it will
     /// instantiate the type parameter `T` with a fresh type `$0`. At
     /// the same time, it will record a region obligation of
-    /// `$0:'static`. This will get checked later by regionck. (We
+    /// `$0: 'static`. This will get checked later by regionck. (We
     /// can't generally check these things right away because we have
     /// to wait until types are resolved.)
     ///
@@ -268,7 +270,7 @@ pub struct InferCtxt<'tcx> {
     /// Caches the results of trait evaluation.
     pub evaluation_cache: select::EvaluationCache<'tcx>,
 
-    /// the set of predicates on which errors have been reported, to
+    /// The set of predicates on which errors have been reported, to
     /// avoid reporting the same error twice.
     pub reported_trait_errors: RefCell<FxIndexMap<Span, Vec<ty::Predicate<'tcx>>>>,
 
@@ -291,7 +293,7 @@ pub struct InferCtxt<'tcx> {
     tainted_by_errors: Cell<Option<ErrorGuaranteed>>,
 
     /// Track how many errors were reported when this infcx is created.
-    /// If the number of errors increases, that's also a sign (line
+    /// If the number of errors increases, that's also a sign (like
     /// `tainted_by_errors`) to avoid reporting certain kinds of errors.
     // FIXME(matthewjasper) Merge into `tainted_by_errors`
     err_count_on_creation: usize,
@@ -313,7 +315,7 @@ pub struct InferCtxt<'tcx> {
     /// During coherence we have to assume that other crates may add
     /// additional impls which we currently don't know about.
     ///
-    /// To deal with this evaluation should be conservative
+    /// To deal with this evaluation, we should be conservative
     /// and consider the possibility of impls from outside this crate.
     /// This comes up primarily when resolving ambiguity. Imagine
     /// there is some trait reference `$0: Bar` where `$0` is an
@@ -323,7 +325,7 @@ pub struct InferCtxt<'tcx> {
     /// bound to some type that in a downstream crate that implements
     /// `Bar`.
     ///
-    /// Outside of coherence we set this to false because we are only
+    /// Outside of coherence, we set this to false because we are only
     /// interested in types that the user could actually have written.
     /// In other words, we consider `$0: Bar` to be unimplemented if
     /// there is no type that the user could *actually name* that
@@ -373,7 +375,7 @@ pub enum SubregionOrigin<'tcx> {
     Subtype(Box<TypeTrace<'tcx>>),
 
     /// When casting `&'a T` to an `&'b Trait` object,
-    /// relating `'a` to `'b`
+    /// relating `'a` to `'b`.
     RelateObjectBound(Span),
 
     /// Some type parameter was instantiated with the given type,
@@ -384,7 +386,7 @@ pub enum SubregionOrigin<'tcx> {
     /// that must outlive some other region.
     RelateRegionParamBound(Span),
 
-    /// Creating a pointer `b` to contents of another reference
+    /// Creating a pointer `b` to contents of another reference.
     Reborrow(Span),
 
     /// (&'a &'b T) where a >= b
@@ -398,7 +400,7 @@ pub enum SubregionOrigin<'tcx> {
         trait_item_def_id: DefId,
     },
 
-    /// Checking that the bounds of a trait's associated type hold for a given impl
+    /// Checking that the bounds of a trait's associated type hold for a given impl.
     CheckAssociatedTypeBounds {
         parent: Box<SubregionOrigin<'tcx>>,
         impl_item_def_id: LocalDefId,
@@ -435,32 +437,33 @@ pub enum LateBoundRegionConversionTime {
     AssocTypeProjection(DefId),
 }
 
-/// Reasons to create a region inference variable
+/// Reasons to create a region inference variable.
 ///
-/// See `error_reporting` module for more details
+/// See `error_reporting` module for more details.
 #[derive(Copy, Clone, Debug)]
 pub enum RegionVariableOrigin {
-    /// Region variables created for ill-categorized reasons,
-    /// mostly indicates places in need of refactoring
+    /// Region variables created for ill-categorized reasons.
+    ///
+    /// They mostly indicate places in need of refactoring.
     MiscVariable(Span),
 
-    /// Regions created by a `&P` or `[...]` pattern
+    /// Regions created by a `&P` or `[...]` pattern.
     PatternRegion(Span),
 
-    /// Regions created by `&` operator
+    /// Regions created by `&` operator.
+    ///
     AddrOfRegion(Span),
-
-    /// Regions created as part of an autoref of a method receiver
+    /// Regions created as part of an autoref of a method receiver.
     Autoref(Span),
 
-    /// Regions created as part of an automatic coercion
+    /// Regions created as part of an automatic coercion.
     Coercion(Span),
 
-    /// Region variables created as the values for early-bound regions
+    /// Region variables created as the values for early-bound regions.
     EarlyBoundRegion(Span, Symbol),
 
     /// Region variables created for bound regions
-    /// in a function or method that is called
+    /// in a function or method that is called.
     LateBoundRegion(Span, ty::BoundRegionKind, LateBoundRegionConversionTime),
 
     UpvarRegion(ty::UpvarId, Span),
@@ -534,7 +537,7 @@ impl<'tcx> fmt::Display for FixupError<'tcx> {
     }
 }
 
-/// Used to configure inference contexts before their creation
+/// Used to configure inference contexts before their creation.
 pub struct InferCtxtBuilder<'tcx> {
     tcx: TyCtxt<'tcx>,
     defining_use_anchor: DefiningAnchor,
@@ -835,9 +838,9 @@ impl<'tcx> InferCtxt<'tcx> {
 
     /// Scan the constraints produced since `snapshot` began and returns:
     ///
-    /// - `None` -- if none of them involve "region outlives" constraints
-    /// - `Some(true)` -- if there are `'a: 'b` constraints where `'a` or `'b` is a placeholder
-    /// - `Some(false)` -- if there are `'a: 'b` constraints but none involve placeholders
+    /// - `None` -- if none of them involves "region outlives" constraints.
+    /// - `Some(true)` -- if there are `'a: 'b` constraints where `'a` or `'b` is a placeholder.
+    /// - `Some(false)` -- if there are `'a: 'b` constraints but none involve placeholders.
     pub fn region_constraints_added_in_snapshot(
         &self,
         snapshot: &CombinedSnapshot<'tcx>,
@@ -1770,7 +1773,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
     }
 }
 
-/// Helper for `ty_or_const_infer_var_changed` (see comment on that), currently
+/// Helper for [InferCtxt::ty_or_const_infer_var_changed] (see comment on that), currently
 /// used only for `traits::fulfill`'s list of `stalled_on` inference variables.
 #[derive(Copy, Clone, Debug)]
 pub enum TyOrConstInferVar<'tcx> {

--- a/config.toml.example
+++ b/config.toml.example
@@ -81,11 +81,6 @@ changelog-seen = 2
 # or alternatively ...
 #ccache = "/path/to/ccache"
 
-# If an external LLVM root is specified, we automatically check the version by
-# default to make sure it's within the range that we're expecting, but setting
-# this flag will indicate that this version check should not be done.
-#version-check = true
-
 # When true, link libstdc++ statically into the rustc_llvm.
 # This is useful if you don't want to use the dynamic version of that
 # library provided by LLVM.

--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `remote-test-server`'s `verbose` argument has been removed in favor of the `--verbose` flag
 - `remote-test-server`'s `remote` argument has been removed in favor of the `--bind` flag. Use `--bind 0.0.0.0:12345` to replicate the behavior of the `remote` argument.
 - `x.py fmt` now formats only files modified between the merge-base of HEAD and the last commit in the master branch of the rust-lang repository and the current working directory. To restore old behaviour, use `x.py fmt .`. The check mode is not affected by this change. [#105702](https://github.com/rust-lang/rust/pull/105702)
+- The `llvm.version-check` config option has been removed. Older versions were never supported. If you still need to support older versions (e.g. you are applying custom patches), patch `check_llvm_version` in bootstrap to change the minimum version. [#108619](https://github.com/rust-lang/rust/pull/108619)
 
 ### Non-breaking changes
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -119,7 +119,6 @@ pub struct Config {
     pub llvm_optimize: bool,
     pub llvm_thin_lto: bool,
     pub llvm_release_debuginfo: bool,
-    pub llvm_version_check: bool,
     pub llvm_static_stdcpp: bool,
     /// `None` if `llvm_from_ci` is true and we haven't yet downloaded llvm.
     #[cfg(not(test))]
@@ -674,7 +673,6 @@ define_config! {
         tests: Option<bool> = "tests",
         plugins: Option<bool> = "plugins",
         ccache: Option<StringOrBool> = "ccache",
-        version_check: Option<bool> = "version-check",
         static_libstdcpp: Option<bool> = "static-libstdcpp",
         ninja: Option<bool> = "ninja",
         targets: Option<String> = "targets",
@@ -806,7 +804,6 @@ impl Config {
         let mut config = Config::default();
         config.llvm_optimize = true;
         config.ninja_in_file = true;
-        config.llvm_version_check = true;
         config.llvm_static_stdcpp = false;
         config.backtrace = true;
         config.rust_optimize = true;
@@ -1174,7 +1171,6 @@ impl Config {
             set(&mut config.llvm_optimize, llvm.optimize);
             set(&mut config.llvm_thin_lto, llvm.thin_lto);
             set(&mut config.llvm_release_debuginfo, llvm.release_debuginfo);
-            set(&mut config.llvm_version_check, llvm.version_check);
             set(&mut config.llvm_static_stdcpp, llvm.static_libstdcpp);
             if let Some(v) = llvm.link_shared {
                 config.llvm_link_shared.set(Some(v));

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -44,7 +44,6 @@ o("local-rebuild", "build.local-rebuild", "assume local-rust matches the current
 o("llvm-static-stdcpp", "llvm.static-libstdcpp", "statically link to libstdc++ for LLVM")
 o("llvm-link-shared", "llvm.link-shared", "prefer shared linking to LLVM (llvm-config --link-shared)")
 o("rpath", "rust.rpath", "build rpaths into rustc itself")
-o("llvm-version-check", "llvm.version-check", "check if the LLVM version is supported, build anyway")
 o("codegen-tests", "rust.codegen-tests", "run the tests/codegen tests")
 o("option-checking", None, "complain about unrecognized options in this configure script")
 o("ninja", "llvm.ninja", "build LLVM using the Ninja generator (for MSVC, requires building in the correct environment)")

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -549,10 +549,6 @@ fn get_built_llvm_lib_path(llvm_config_path: &Path) -> PathBuf {
 }
 
 fn check_llvm_version(builder: &Builder<'_>, llvm_config: &Path) {
-    if !builder.config.llvm_version_check {
-        return;
-    }
-
     if builder.config.dry_run() {
         return;
     }

--- a/src/doc/unstable-book/src/compiler-flags/cf-protection.md
+++ b/src/doc/unstable-book/src/compiler-flags/cf-protection.md
@@ -1,5 +1,9 @@
 # `cf-protection`
 
+The tracking issue for this feature is: [#93754](https://github.com/rust-lang/rust/issues/93754).
+
+------------------------
+
 This option enables control-flow enforcement technology (CET) on x86; a more detailed description of
 CET is available [here]. Similar to `clang`, this flag takes one of the following values:
 

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -8,7 +8,7 @@ path = "lib.rs"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
-askama = { version = "0.11", default-features = false, features = ["config"] }
+askama = { version = "0.12", default-features = false, features = ["config"] }
 itertools = "0.10.1"
 minifier = "0.2.2"
 once_cell = "1.10.0"

--- a/src/librustdoc/askama.toml
+++ b/src/librustdoc/askama.toml
@@ -1,2 +1,3 @@
 [general]
 dirs = ["html/templates"]
+whitespace = "suppress"

--- a/src/librustdoc/html/templates/STYLE.md
+++ b/src/librustdoc/html/templates/STYLE.md
@@ -10,28 +10,29 @@ similar to [Jinja2](jinjadoc) and [Django](djangodoc) templates, and also to [As
 
 We want our rendered output to have as little unnecessary whitespace as
 possible, so that pages load quickly. To achieve that we use Tera's
-[whitespace control] features. At the end of most lines, we put an empty comment
-tag with the whitespace control characters: `{#- -#}`. This causes all
-whitespace between the end of the line and the beginning of the next, including
-indentation, to be omitted on render. Sometimes we want to preserve a single
-space. In those cases we put the space at the end of the line, followed by
-`{# -#}`, which is a directive to remove following whitespace but not preceding.
-We also use the whitespace control characters in most instances of tags with
-control flow, for example `{%- if foo -%}`.
+[whitespace control] features. By default, whitespace characters are removed
+around jinja tags (`{% %}` for example). At the end of most lines, we put an
+empty comment tag: `{# #}`. This causes all whitespace between the end of the
+line and the beginning of the next, including indentation, to be omitted on
+render. Sometimes we want to preserve a single space. In those cases we put the
+space at the end of the line, followed by `{#+ #}`, which is a directive to
+remove following whitespace but not preceding. We also use the whitespace
+control characters in most instances of tags with control flow, for example
+`{% if foo %}`.
 
 [whitespace control]: https://tera.netlify.app/docs/#whitespace-control
 
 We want our templates to be readable, so we use indentation and newlines
-liberally. We indent by four spaces after opening an HTML tag _or_ a Tera
+liberally. We indent by four spaces after opening an HTML tag _or_ a Jinja
 tag. In most cases an HTML tag should be followed by a newline, but if the
 tag has simple contents and fits with its close tag on a single line, the
 contents don't necessarily need a new line.
 
-Tera templates support quite sophisticated control flow. To keep our templates
+Askama templates support quite sophisticated control flow. To keep our templates
 simple and understandable, we use only a subset: `if` and `for`. In particular
-we avoid [assignments in the template logic](assignments) and [Tera
+we avoid [assignments in the template logic](assignments) and [Askama
 macros](macros). This also may make things easier if we switch to a different
 Jinja-style template system, like Askama, in the future.
 
-[assignments]: https://tera.netlify.app/docs/#assignments
-[macros]: https://tera.netlify.app/docs/#macros
+[assignments]: https://djc.github.io/askama/template_syntax.html#assignments
+[macros]: https://djc.github.io/askama/template_syntax.html#macros

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -1,148 +1,148 @@
-<!DOCTYPE html> {#- -#}
-<html lang="en"> {#- -#}
-<head> {#- -#}
-    <meta charset="utf-8"> {#- -#}
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"> {#- -#}
-    <meta name="generator" content="rustdoc"> {#- -#}
-    <meta name="description" content="{{page.description}}"> {#- -#}
-    <title>{{page.title}}</title> {#- -#}
-    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_serif_4_regular}}"> {#- -#}
-    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.fira_sans_regular}}"> {#- -#}
-    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.fira_sans_medium}}"> {#- -#}
-    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_code_pro_regular}}"> {#- -#}
-    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_serif_4_bold}}"> {#- -#}
-    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_code_pro_semibold}}"> {#- -#}
-    <link rel="stylesheet" {# -#}
-          href="{{static_root_path|safe}}{{files.normalize_css}}"> {#- -#}
-    <link rel="stylesheet" {# -#}
-          href="{{static_root_path|safe}}{{files.rustdoc_css}}" {# -#}
-          id="mainThemeStyle"> {#- -#}
-    <link rel="stylesheet" id="themeStyle" href="{{static_root_path|safe}}{{files.theme_light_css}}"> {#- -#}
-    <link rel="stylesheet" disabled href="{{static_root_path|safe}}{{files.theme_dark_css}}"> {#- -#}
-    <link rel="stylesheet" disabled href="{{static_root_path|safe}}{{files.theme_ayu_css}}"> {#- -#}
-    {%- for theme in themes -%}
-        <link rel="stylesheet" disabled href="{{page.root_path|safe}}{{theme}}{{page.resource_suffix}}.css"> {#- -#}
-    {%- endfor -%}
-    {%- if !layout.default_settings.is_empty() -%}
-    <script id="default-settings" {# -#}
-      {% for (k, v) in layout.default_settings %}
+<!DOCTYPE html> {# #}
+<html lang="en"> {# #}
+<head> {# #}
+    <meta charset="utf-8"> {# #}
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"> {# #}
+    <meta name="generator" content="rustdoc"> {# #}
+    <meta name="description" content="{{page.description}}"> {# #}
+    <title>{{page.title}}</title> {# #}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_serif_4_regular}}"> {# #}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.fira_sans_regular}}"> {# #}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.fira_sans_medium}}"> {# #}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_code_pro_regular}}"> {# #}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_serif_4_bold}}"> {# #}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_code_pro_semibold}}"> {# #}
+    <link rel="stylesheet" {#+ #}
+          href="{{static_root_path|safe}}{{files.normalize_css}}"> {# #}
+    <link rel="stylesheet" {#+ #}
+          href="{{static_root_path|safe}}{{files.rustdoc_css}}" {#+ #}
+          id="mainThemeStyle"> {# #}
+    <link rel="stylesheet" id="themeStyle" href="{{static_root_path|safe}}{{files.theme_light_css}}"> {# #}
+    <link rel="stylesheet" disabled href="{{static_root_path|safe}}{{files.theme_dark_css}}"> {# #}
+    <link rel="stylesheet" disabled href="{{static_root_path|safe}}{{files.theme_ayu_css}}"> {# #}
+    {% for theme in themes %}
+        <link rel="stylesheet" disabled href="{{page.root_path|safe}}{{theme}}{{page.resource_suffix}}.css"> {# #}
+    {% endfor %}
+    {% if !layout.default_settings.is_empty() %}
+    <script id="default-settings" {#+ #}
+      {%~ for (k, v) in layout.default_settings ~%}
         data-{{k}}="{{v}}"
-      {%- endfor -%}
-    ></script> {#- -#}
-    {%- endif -%}
-    <script src="{{static_root_path|safe}}{{files.storage_js}}"></script> {#- -#}
-    {%- if page.css_class.contains("crate") -%}
-    <script defer src="{{page.root_path|safe}}crates{{page.resource_suffix}}.js"></script> {#- -#}
-    {%- else if page.css_class == "source" -%}
-    <script defer src="{{static_root_path|safe}}{{files.source_script_js}}"></script> {#- -#}
-    <script defer src="{{page.root_path|safe}}source-files{{page.resource_suffix}}.js"></script> {#- -#}
-    {%- else if !page.css_class.contains("mod") -%}
-    <script defer src="sidebar-items{{page.resource_suffix}}.js"></script> {#- -#}
-    {%- endif -%}
-    <script defer src="{{static_root_path|safe}}{{files.main_js}}"></script> {#- -#}
-    {%- if layout.scrape_examples_extension -%}
-    <script defer src="{{static_root_path|safe}}{{files.scrape_examples_js}}"></script> {#- -#}
-    {%- endif -%}
-    <noscript> {#- -#}
-        <link rel="stylesheet" {# -#}
-           href="{{static_root_path|safe}}{{files.noscript_css}}"> {#- -#}
-    </noscript> {#- -#}
-    {%- if layout.css_file_extension.is_some() -%}
-        <link rel="stylesheet" {# -#}
-            href="{{static_root_path|safe}}theme{{page.resource_suffix}}.css"> {#- -#}
-    {%- endif -%}
-    {%- if !layout.favicon.is_empty() -%}
-        <link rel="icon" href="{{layout.favicon}}"> {#- -#}
-    {%- else -%}
-        <link rel="alternate icon" type="image/png" {# -#}
-            href="{{static_root_path|safe}}{{files.rust_favicon_png_16}}"> {#- -#}
-        <link rel="alternate icon" type="image/png" {# -#}
-            href="{{static_root_path|safe}}{{files.rust_favicon_png_32}}"> {#- -#}
-        <link rel="icon" type="image/svg+xml" {# -#}
-            href="{{static_root_path|safe}}{{files.rust_favicon_svg}}"> {#- -#}
-    {%- endif -%}
-    {{- layout.external_html.in_header|safe -}}
-</head> {#- -#}
-<body class="rustdoc {{page.css_class}}"> {#- -#}
-    <!--[if lte IE 11]> {#- -#}
-    <div class="warning"> {#- -#}
-        This old browser is unsupported and will most likely display funky things. {#- -#}
-    </div> {#- -#}
-    <![endif]--> {#- -#}
-    {{- layout.external_html.before_content|safe -}}
-    {%- if page.css_class != "source" -%}
-    <nav class="mobile-topbar"> {#- -#}
-        <button class="sidebar-menu-toggle">&#9776;</button> {#- -#}
-        <a class="logo-container" href="{{page.root_path|safe}}{{krate_with_trailing_slash|safe}}index.html"> {#- -#}
-        {%- if !layout.logo.is_empty() -%}
-            <img src="{{layout.logo}}" alt="logo"> {#- -#}
-        {%- else -%}
-            <img class="rust-logo" src="{{static_root_path|safe}}{{files.rust_logo_svg}}" alt="logo"> {#- -#}
-        {%- endif -%}
-        </a> {#- -#}
-        <h2></h2> {#- -#}
-    </nav> {#- -#}
-    {%- endif -%}
-    <nav class="sidebar"> {#- -#}
-        {%- if page.css_class != "source" -%}
-        <a class="logo-container" href="{{page.root_path|safe}}{{krate_with_trailing_slash|safe}}index.html"> {#- -#}
-            {%- if !layout.logo.is_empty()  %}
-                <img src="{{layout.logo}}" alt="logo"> {#- -#}
-            {%- else -%}
-                <img class="rust-logo" src="{{static_root_path|safe}}{{files.rust_logo_svg}}" alt="logo"> {#- -#}
-            {%- endif -%}
-        </a> {#- -#}
-        {%- endif -%}
-        {{- sidebar|safe -}}
-    </nav> {#- -#}
-    <main> {#- -#}
-        {%- if page.css_class != "source" -%}<div class="width-limiter">{%- endif -%}
-            <nav class="sub"> {#- -#}
-                {%- if page.css_class == "source" -%}
-                <a class="sub-logo-container" href="{{page.root_path|safe}}{{krate_with_trailing_slash|safe}}index.html"> {#- -#}
-                    {%- if !layout.logo.is_empty()  %}
-                        <img src="{{layout.logo}}" alt="logo"> {#- -#}
-                    {%- else -%}
-                        <img class="rust-logo" src="{{static_root_path|safe}}{{files.rust_logo_svg}}" alt="logo"> {#- -#}
-                    {%- endif -%}
-                </a> {#- -#}
-                {%- endif -%}
-                <form class="search-form"> {#- -#}
-                    <span></span> {#- This empty span is a hacky fix for Safari - See #93184 -#}
-                    <input {# -#}
-                        class="search-input" {# -#}
-                        name="search" {# -#}
-                        aria-label="Run search in the documentation" {# -#}
-                        autocomplete="off" {# -#}
-                        spellcheck="false" {# -#}
-                        placeholder="Click or press ‘S’ to search, ‘?’ for more options…" {# -#}
-                        type="search"> {#- -#}
-                    <div id="help-button" title="help" tabindex="-1"> {#- -#}
-                        <a href="{{page.root_path|safe}}help.html">?</a> {#- -#}
-                    </div> {#- -#}
-                    <div id="settings-menu" tabindex="-1"> {#- -#}
-                        <a href="{{page.root_path|safe}}settings.html" title="settings"> {#- -#}
-                            <img width="22" height="22" alt="Change settings" {# -#}
-                            src="{{static_root_path|safe}}{{files.wheel_svg}}"> {#- -#}
-                        </a> {#- -#}
-                    </div> {#- -#}
-                </form> {#- -#}
-            </nav> {#- -#}
-            <section id="main-content" class="content">{{- content|safe -}}</section> {#- -#}
-        {%- if page.css_class != "source" -%}</div>{%- endif -%}
-    </main> {#- -#}
-    {{- layout.external_html.after_content|safe -}}
-    <div id="rustdoc-vars" {# -#}
-         data-root-path="{{page.root_path|safe}}" {# -#}
-         data-static-root-path="{{static_root_path|safe}}" {# -#}
-         data-current-crate="{{layout.krate}}" {# -#}
-         data-themes="{{themes|join(",") }}" {# -#}
-         data-resource-suffix="{{page.resource_suffix}}" {# -#}
-         data-rustdoc-version="{{rustdoc_version}}" {# -#}
-         data-search-js="{{files.search_js}}" {# -#}
-         data-settings-js="{{files.settings_js}}" {# -#}
-         data-settings-css="{{files.settings_css}}" {# -#}
-    > {#- -#}
-    </div> {#- -#}
-</body> {#- -#}
-</html> {#- -#}
+      {% endfor %}
+    ></script> {# #}
+    {% endif %}
+    <script src="{{static_root_path|safe}}{{files.storage_js}}"></script> {# #}
+    {% if page.css_class.contains("crate") %}
+    <script defer src="{{page.root_path|safe}}crates{{page.resource_suffix}}.js"></script> {# #}
+    {% else if page.css_class == "source" %}
+    <script defer src="{{static_root_path|safe}}{{files.source_script_js}}"></script> {# #}
+    <script defer src="{{page.root_path|safe}}source-files{{page.resource_suffix}}.js"></script> {# #}
+    {% else if !page.css_class.contains("mod") %}
+    <script defer src="sidebar-items{{page.resource_suffix}}.js"></script> {# #}
+    {% endif %}
+    <script defer src="{{static_root_path|safe}}{{files.main_js}}"></script> {# #}
+    {% if layout.scrape_examples_extension %}
+    <script defer src="{{static_root_path|safe}}{{files.scrape_examples_js}}"></script> {# #}
+    {% endif %}
+    <noscript> {# #}
+        <link rel="stylesheet" {#+ #}
+           href="{{static_root_path|safe}}{{files.noscript_css}}"> {# #}
+    </noscript> {# #}
+    {% if layout.css_file_extension.is_some() %}
+        <link rel="stylesheet" {#+ #}
+            href="{{static_root_path|safe}}theme{{page.resource_suffix}}.css"> {# #}
+    {% endif %}
+    {% if !layout.favicon.is_empty() %}
+        <link rel="icon" href="{{layout.favicon}}"> {# #}
+    {% else %}
+        <link rel="alternate icon" type="image/png" {#+ #}
+            href="{{static_root_path|safe}}{{files.rust_favicon_png_16}}"> {# #}
+        <link rel="alternate icon" type="image/png" {#+ #}
+            href="{{static_root_path|safe}}{{files.rust_favicon_png_32}}"> {# #}
+        <link rel="icon" type="image/svg+xml" {#+ #}
+            href="{{static_root_path|safe}}{{files.rust_favicon_svg}}"> {# #}
+    {% endif %}
+    {{ layout.external_html.in_header|safe }}
+</head> {# #}
+<body class="rustdoc {{+page.css_class}}"> {# #}
+    <!--[if lte IE 11]> {# #}
+    <div class="warning"> {# #}
+        This old browser is unsupported and will most likely display funky things. {# #}
+    </div> {# #}
+    <![endif]--> {# #}
+    {{ layout.external_html.before_content|safe }}
+    {% if page.css_class != "source" %}
+    <nav class="mobile-topbar"> {# #}
+        <button class="sidebar-menu-toggle">&#9776;</button> {# #}
+        <a class="logo-container" href="{{page.root_path|safe}}{{krate_with_trailing_slash|safe}}index.html"> {# #}
+        {% if !layout.logo.is_empty() %}
+            <img src="{{layout.logo}}" alt="logo"> {# #}
+        {% else %}
+            <img class="rust-logo" src="{{static_root_path|safe}}{{files.rust_logo_svg}}" alt="logo"> {# #}
+        {% endif %}
+        </a> {# #}
+        <h2></h2> {# #}
+    </nav> {# #}
+    {% endif %}
+    <nav class="sidebar"> {# #}
+        {% if page.css_class != "source" %}
+        <a class="logo-container" href="{{page.root_path|safe}}{{krate_with_trailing_slash|safe}}index.html"> {# #}
+            {% if !layout.logo.is_empty() %}
+                <img src="{{layout.logo}}" alt="logo"> {# #}
+            {% else %}
+                <img class="rust-logo" src="{{static_root_path|safe}}{{files.rust_logo_svg}}" alt="logo"> {# #}
+            {% endif %}
+        </a> {# #}
+        {% endif %}
+        {{ sidebar|safe }}
+    </nav> {# #}
+    <main> {# #}
+        {% if page.css_class != "source" %}<div class="width-limiter">{% endif %}
+            <nav class="sub"> {# #}
+                {% if page.css_class == "source" %}
+                <a class="sub-logo-container" href="{{page.root_path|safe}}{{krate_with_trailing_slash|safe}}index.html"> {# #}
+                    {% if !layout.logo.is_empty() %}
+                        <img src="{{layout.logo}}" alt="logo"> {# #}
+                    {% else %}
+                        <img class="rust-logo" src="{{static_root_path|safe}}{{files.rust_logo_svg}}" alt="logo"> {# #}
+                    {% endif %}
+                </a> {# #}
+                {% endif %}
+                <form class="search-form"> {# #}
+                    <span></span> {# This empty span is a hacky fix for Safari - See #93184 #}
+                    <input {#+ #}
+                        class="search-input" {#+ #}
+                        name="search" {#+ #}
+                        aria-label="Run search in the documentation" {#+ #}
+                        autocomplete="off" {#+ #}
+                        spellcheck="false" {#+ #}
+                        placeholder="Click or press ‘S’ to search, ‘?’ for more options…" {#+ #}
+                        type="search"> {# #}
+                    <div id="help-button" title="help" tabindex="-1"> {# #}
+                        <a href="{{page.root_path|safe}}help.html">?</a> {# #}
+                    </div> {# #}
+                    <div id="settings-menu" tabindex="-1"> {# #}
+                        <a href="{{page.root_path|safe}}settings.html" title="settings"> {# #}
+                            <img width="22" height="22" alt="Change settings" {#+ #}
+                            src="{{static_root_path|safe}}{{files.wheel_svg}}"> {# #}
+                        </a> {# #}
+                    </div> {# #}
+                </form> {# #}
+            </nav> {# #}
+            <section id="main-content" class="content">{{ content|safe }}</section> {# #}
+        {% if page.css_class != "source" %}</div>{% endif %}
+    </main> {# #}
+    {{ layout.external_html.after_content|safe }}
+    <div id="rustdoc-vars" {#+ #}
+         data-root-path="{{page.root_path|safe}}" {#+ #}
+         data-static-root-path="{{static_root_path|safe}}" {#+ #}
+         data-current-crate="{{layout.krate}}" {#+ #}
+         data-themes="{{themes|join(",") }}" {#+ #}
+         data-resource-suffix="{{page.resource_suffix}}" {#+ #}
+         data-rustdoc-version="{{rustdoc_version}}" {#+ #}
+         data-search-js="{{files.search_js}}" {#+ #}
+         data-settings-js="{{files.settings_js}}" {#+ #}
+         data-settings-css="{{files.settings_css}}" {#+ #}
+    > {# #}
+    </div> {# #}
+</body> {# #}
+</html> {# #}

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -1,28 +1,28 @@
-<div class="main-heading"> {#- -#}
-    <h1> {#- -#}
-        {{-typ-}}
-        {#- The breadcrumbs of the item path, like std::string -#}
-        {%- for component in path_components -%}
-        <a href="{{component.path|safe}}index.html">{{component.name}}</a>::<wbr>
-        {%- endfor -%}
-        <a class="{{item_type}}" href="#">{{name}}</a> {#- -#}
-        <button id="copy-path" title="Copy item path to clipboard"> {#- -#}
-        <img src="{{static_root_path|safe}}{{clipboard_svg}}" {# -#}
-                width="19" height="18" {# -#}
-                alt="Copy item path"> {#- -#}
-        </button> {#- -#}
-    </h1> {#- -#}
-    <span class="out-of-band"> {#- -#}
+<div class="main-heading"> {# #}
+    <h1> {# #}
+        {{typ}}
+        {# The breadcrumbs of the item path, like std::string #}
+        {% for component in path_components %}
+            <a href="{{component.path|safe}}index.html">{{component.name}}</a>::<wbr>
+        {% endfor %}
+        <a class="{{item_type}}" href="#">{{name}}</a> {# #}
+        <button id="copy-path" title="Copy item path to clipboard"> {# #}
+        <img src="{{static_root_path|safe}}{{clipboard_svg}}" {#+ #}
+                width="19" height="18" {#+ #}
+                alt="Copy item path"> {# #}
+        </button> {# #}
+    </h1> {# #}
+    <span class="out-of-band"> {# #}
         {% if !stability_since_raw.is_empty() %}
-        {{- stability_since_raw|safe }} · {# -#}
+        {{ stability_since_raw|safe +}} · {#+ #}
         {% endif %}
-        {%- match src_href -%}
-            {%- when Some with (href) -%}
-                <a class="srclink" href="{{href|safe}}">source</a> · {# -#}
-            {%- else -%}
-        {%- endmatch -%}
-        <button id="toggle-all-docs" title="collapse all docs"> {#- -#}
-            [<span>&#x2212;</span>] {#- -#}
-        </button> {#- -#}
-    </span> {#- -#}
-</div> {#- -#}
+        {% match src_href %}
+            {% when Some with (href) %}
+                <a class="srclink" href="{{href|safe}}">source</a> · {#+ #}
+            {% else %}
+        {% endmatch %}
+        <button id="toggle-all-docs" title="collapse all docs"> {# #}
+            [<span>&#x2212;</span>] {# #}
+        </button> {# #}
+    </span> {# #}
+</div> {# #}

--- a/tests/mir-opt/building/custom/as_cast.float_to_int.built.after.mir
+++ b/tests/mir-opt/building/custom/as_cast.float_to_int.built.after.mir
@@ -1,0 +1,10 @@
+// MIR for `float_to_int` after built
+
+fn float_to_int(_1: f32) -> i32 {
+    let mut _0: i32;                     // return place in scope 0 at $DIR/as_cast.rs:+0:28: +0:31
+
+    bb0: {
+        _0 = _1 as i32 (FloatToInt);     // scope 0 at $DIR/as_cast.rs:+3:13: +3:27
+        return;                          // scope 0 at $DIR/as_cast.rs:+4:13: +4:21
+    }
+}

--- a/tests/mir-opt/building/custom/as_cast.int_to_int.built.after.mir
+++ b/tests/mir-opt/building/custom/as_cast.int_to_int.built.after.mir
@@ -1,0 +1,10 @@
+// MIR for `int_to_int` after built
+
+fn int_to_int(_1: u32) -> i32 {
+    let mut _0: i32;                     // return place in scope 0 at $DIR/as_cast.rs:+0:26: +0:29
+
+    bb0: {
+        _0 = _1 as i32 (IntToInt);       // scope 0 at $DIR/as_cast.rs:+3:13: +3:27
+        return;                          // scope 0 at $DIR/as_cast.rs:+4:13: +4:21
+    }
+}

--- a/tests/mir-opt/building/custom/as_cast.int_to_ptr.built.after.mir
+++ b/tests/mir-opt/building/custom/as_cast.int_to_ptr.built.after.mir
@@ -1,0 +1,10 @@
+// MIR for `int_to_ptr` after built
+
+fn int_to_ptr(_1: usize) -> *const i32 {
+    let mut _0: *const i32;              // return place in scope 0 at $DIR/as_cast.rs:+0:28: +0:38
+
+    bb0: {
+        _0 = _1 as *const i32 (PointerFromExposedAddress); // scope 0 at $DIR/as_cast.rs:+3:13: +3:34
+        return;                          // scope 0 at $DIR/as_cast.rs:+4:13: +4:21
+    }
+}

--- a/tests/mir-opt/building/custom/as_cast.rs
+++ b/tests/mir-opt/building/custom/as_cast.rs
@@ -1,0 +1,43 @@
+#![feature(custom_mir, core_intrinsics)]
+
+extern crate core;
+use core::intrinsics::mir::*;
+
+// EMIT_MIR as_cast.int_to_int.built.after.mir
+#[custom_mir(dialect = "built")]
+fn int_to_int(x: u32) -> i32 {
+    mir!(
+        {
+            RET = x as i32;
+            Return()
+        }
+    )
+}
+
+// EMIT_MIR as_cast.float_to_int.built.after.mir
+#[custom_mir(dialect = "built")]
+fn float_to_int(x: f32) -> i32 {
+    mir!(
+        {
+            RET = x as i32;
+            Return()
+        }
+    )
+}
+
+// EMIT_MIR as_cast.int_to_ptr.built.after.mir
+#[custom_mir(dialect = "built")]
+fn int_to_ptr(x: usize) -> *const i32 {
+    mir!(
+        {
+            RET = x as *const i32;
+            Return()
+        }
+    )
+}
+
+fn main() {
+    assert_eq!(int_to_int(5), 5);
+    assert_eq!(float_to_int(5.), 5);
+    assert_eq!(int_to_ptr(0), std::ptr::null());
+}

--- a/tests/run-make/translation/Makefile
+++ b/tests/run-make/translation/Makefile
@@ -13,22 +13,22 @@ all: normal custom missing broken sysroot sysroot-invalid sysroot-missing
 
 # Check that the test works normally, using the built-in fallback bundle.
 normal: test.rs
-	$(RUSTC) $< 2>&1 | grep "struct literal body without path"
+	$(RUSTC) $< 2>&1 | $(CGREP) "struct literal body without path"
 
 # Check that a primary bundle can be loaded and will be preferentially used
 # where possible.
 custom: test.rs working.ftl
-	$(RUSTC) $< -Ztranslate-additional-ftl=$(CURDIR)/working.ftl 2>&1 | grep "this is a test message"
+	$(RUSTC) $< -Ztranslate-additional-ftl=$(CURDIR)/working.ftl 2>&1 | $(CGREP) "this is a test message"
 
 # Check that a primary bundle with a broken message (e.g. a interpolated
 # variable is missing) will use the fallback bundle.
 missing: test.rs missing.ftl
-	$(RUSTC) $< -Ztranslate-additional-ftl=$(CURDIR)/missing.ftl 2>&1 | grep "struct literal body without path"
+	$(RUSTC) $< -Ztranslate-additional-ftl=$(CURDIR)/missing.ftl 2>&1 | $(CGREP) "struct literal body without path"
 
 # Check that a primary bundle without the desired message will use the fallback
 # bundle.
 broken: test.rs broken.ftl
-	$(RUSTC) $< -Ztranslate-additional-ftl=$(CURDIR)/broken.ftl 2>&1 | grep "struct literal body without path"
+	$(RUSTC) $< -Ztranslate-additional-ftl=$(CURDIR)/broken.ftl 2>&1 | $(CGREP) "struct literal body without path"
 
 # Check that a locale can be loaded from the sysroot given a language
 # identifier by making a local copy of the sysroot and adding the custom locale
@@ -48,13 +48,13 @@ sysroot: test.rs working.ftl
 	ln -s $(SYSROOT)/lib/rustlib/src/* $(FAKEROOT)/lib/rustlib/src
 	mkdir -p $(FAKEROOT)/share/locale/zh-CN/
 	ln -s $(CURDIR)/working.ftl $(FAKEROOT)/share/locale/zh-CN/basic-translation.ftl
-	$(RUSTC) $< --sysroot $(FAKEROOT) -Ztranslate-lang=zh-CN 2>&1 | grep "this is a test message"
+	$(RUSTC) $< --sysroot $(FAKEROOT) -Ztranslate-lang=zh-CN 2>&1 | $(CGREP) "this is a test message"
 
 # Check that the compiler errors out when the sysroot requested cannot be
 # found. This test might start failing if there actually exists a Klingon
 # translation of rustc's error messages.
-sysroot-missing: 
-	$(RUSTC) $< -Ztranslate-lang=tlh 2>&1 | grep "missing locale directory"
+sysroot-missing:
+	$(RUSTC) $< -Ztranslate-lang=tlh 2>&1 | $(CGREP) "missing locale directory"
 
 # Check that the compiler errors out when the directory for the locale in the
 # sysroot is actually a file.
@@ -73,4 +73,4 @@ sysroot-invalid: test.rs working.ftl
 	ln -s $(SYSROOT)/lib/rustlib/src/* $(FAKEROOT)/lib/rustlib/src
 	mkdir -p $(FAKEROOT)/share/locale
 	touch $(FAKEROOT)/share/locale/zh-CN
-	$(RUSTC) $< --sysroot $(FAKEROOT) -Ztranslate-lang=zh-CN 2>&1 | grep "`\$sysroot/share/locales/\$locale` is not a directory"
+	$(RUSTC) $< --sysroot $(FAKEROOT) -Ztranslate-lang=zh-CN 2>&1 | $(CGREP) "`\$sysroot/share/locales/\$locale` is not a directory"

--- a/tests/ui/async-await/issue-108572.rs
+++ b/tests/ui/async-await/issue-108572.rs
@@ -1,0 +1,12 @@
+// edition: 2021
+
+use std::future::Future;
+fn foo() -> impl Future<Output=()> {
+    async { }
+}
+
+fn main() {
+    let fut = foo();
+    fut.poll();
+    //~^ ERROR no method named `poll` found for opaque type `impl Future<Output = ()>` in the current scope [E0599]
+}

--- a/tests/ui/async-await/issue-108572.stderr
+++ b/tests/ui/async-await/issue-108572.stderr
@@ -1,0 +1,12 @@
+error[E0599]: no method named `poll` found for opaque type `impl Future<Output = ()>` in the current scope
+  --> $DIR/issue-108572.rs:10:9
+   |
+LL |     fut.poll();
+   |         ^^^^ method not found in `impl Future<Output = ()>`
+   |
+   = help: method `poll` found on `Pin<&mut impl Future<Output = ()>>`, see documentation for `std::pin::Pin`
+   = help: self type must be pinned to call `Future::poll`, see https://rust-lang.github.io/async-book/04_pinning/01_chapter.html#pinning-in-practice
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Successful merges:

 - #108619 (Remove the option to disable `llvm-version-check`)
 - #108728 (infer: fix and improve comments)
 - #108731 (feat: impl better help for `.poll()` not found on `impl Future`)
 - #108774 (Greatly improve the error messages when `run-make/translation` fails)
 - #108805 (Update askama to 0.12 and improve whitespace control)
 - #108823 (Add tracking issue for cf-protection to unstable book)
 - #108855 (Custom MIR: Support `as` casts)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=108619,108728,108731,108774,108805,108823,108855)
<!-- homu-ignore:end -->