### PR TITLE
Force to use the stage 2 compiler  when config.download_rustc is set

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -910,14 +910,16 @@ impl<'a> Builder<'a> {
     /// new artifacts, it can't be used to rely on the presence of a particular
     /// sysroot.
     ///
-    /// See `force_use_stage1` for documentation on what each argument is.
+    /// See `force_use_stage1` and `force_use_stage2` for documentation on what each argument is.
     pub fn compiler_for(
         &self,
         stage: u32,
         host: TargetSelection,
         target: TargetSelection,
     ) -> Compiler {
-        if self.build.force_use_stage1(Compiler { stage, host }, target) {
+        if self.build.force_use_stage2() {
+            self.compiler(2, self.config.build)
+        } else if self.build.force_use_stage1(Compiler { stage, host }, target) {
             self.compiler(1, self.config.build)
         } else {
             self.compiler(stage, host)

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1209,6 +1209,15 @@ impl Build {
             && (self.hosts.iter().any(|h| *h == target) || target == self.build)
     }
 
+    /// Checks whether the `compiler` compiling for `target` should be forced to
+    /// use a stage2 compiler instead.
+    ///
+    /// When we download the pre-compiled version of rustc it should be forced to
+    /// use a stage2 compiler.
+    fn force_use_stage2(&self) -> bool {
+        self.config.download_rustc()
+    }
+
     /// Given `num` in the form "a.b.c" return a "release string" which
     /// describes the release version number.
     ///


### PR DESCRIPTION
Fixes #108768