### PR TITLE
Filter out RPITITs when checking for missing associated types

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -1440,6 +1440,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             tcx.associated_items(pred.def_id())
                                 .in_definition_order()
                                 .filter(|item| item.kind == ty::AssocKind::Type)
+                                .filter(|item| tcx.opt_rpitit_info(item.def_id).is_none())
                                 .map(|item| item.def_id),
                         );
                     }

--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -157,6 +157,7 @@ fn object_safety_violations_for_trait(
                 .in_definition_order()
                 .filter(|item| item.kind == ty::AssocKind::Type)
                 .filter(|item| !tcx.generics_of(item.def_id).params.is_empty())
+                .filter(|item| tcx.opt_rpitit_info(item.def_id).is_none())
                 .map(|item| {
                     let ident = item.ident(tcx);
                     ObjectSafetyViolation::GAT(ident.name, ident.span)

--- a/tests/ui/async-await/in-trait/object-safety.current.stderr
+++ b/tests/ui/async-await/in-trait/object-safety.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/object-safety.rs:3:12
+  --> $DIR/object-safety.rs:5:12
    |
 LL | #![feature(async_fn_in_trait)]
    |            ^^^^^^^^^^^^^^^^^
@@ -8,13 +8,13 @@ LL | #![feature(async_fn_in_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0038]: the trait `Foo` cannot be made into an object
-  --> $DIR/object-safety.rs:11:12
+  --> $DIR/object-safety.rs:13:12
    |
 LL |     let x: &dyn Foo = todo!();
    |            ^^^^^^^^ `Foo` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/object-safety.rs:7:14
+  --> $DIR/object-safety.rs:9:14
    |
 LL | trait Foo {
    |       --- this trait cannot be made into an object...

--- a/tests/ui/async-await/in-trait/object-safety.next.stderr
+++ b/tests/ui/async-await/in-trait/object-safety.next.stderr
@@ -1,0 +1,27 @@
+warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/object-safety.rs:5:12
+   |
+LL | #![feature(async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-safety.rs:13:12
+   |
+LL |     let x: &dyn Foo = todo!();
+   |            ^^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety.rs:9:14
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     async fn foo(&self);
+   |              ^^^ ...because method `foo` is `async`
+   = help: consider moving `foo` to another trait
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/async-await/in-trait/object-safety.rs
+++ b/tests/ui/async-await/in-trait/object-safety.rs
@@ -1,4 +1,6 @@
 // edition:2021
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(async_fn_in_trait)]
 //~^ WARN the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes

--- a/tests/ui/impl-trait/in-trait/issue-102140.current.stderr
+++ b/tests/ui/impl-trait/in-trait/issue-102140.current.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
-  --> $DIR/issue-102140.rs:23:22
+  --> $DIR/issue-102140.rs:26:22
    |
 LL |         MyTrait::foo(&self)
    |         ------------ ^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
@@ -13,7 +13,7 @@ LL +         MyTrait::foo(self)
    |
 
 error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
-  --> $DIR/issue-102140.rs:23:9
+  --> $DIR/issue-102140.rs:26:9
    |
 LL |         MyTrait::foo(&self)
    |         ^^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
@@ -21,7 +21,7 @@ LL |         MyTrait::foo(&self)
    = help: the trait `MyTrait` is implemented for `Outer`
 
 error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
-  --> $DIR/issue-102140.rs:23:9
+  --> $DIR/issue-102140.rs:26:9
    |
 LL |         MyTrait::foo(&self)
    |         ^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`

--- a/tests/ui/impl-trait/in-trait/issue-102140.next.stderr
+++ b/tests/ui/impl-trait/in-trait/issue-102140.next.stderr
@@ -1,0 +1,33 @@
+error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
+  --> $DIR/issue-102140.rs:26:22
+   |
+LL |         MyTrait::foo(&self)
+   |         ------------ ^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
+   |         |
+   |         required by a bound introduced by this call
+   |
+help: consider removing the leading `&`-reference
+   |
+LL -         MyTrait::foo(&self)
+LL +         MyTrait::foo(self)
+   |
+
+error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
+  --> $DIR/issue-102140.rs:26:9
+   |
+LL |         MyTrait::foo(&self)
+   |         ^^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
+   |
+   = help: the trait `MyTrait` is implemented for `Outer`
+
+error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
+  --> $DIR/issue-102140.rs:26:9
+   |
+LL |         MyTrait::foo(&self)
+   |         ^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
+   |
+   = help: the trait `MyTrait` is implemented for `Outer`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/in-trait/issue-102140.rs
+++ b/tests/ui/impl-trait/in-trait/issue-102140.rs
@@ -1,3 +1,6 @@
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
+
 #![feature(return_position_impl_trait_in_trait)]
 #![allow(incomplete_features)]
 


### PR DESCRIPTION
This goes on top of other already approved PRs not merged yet. Going to rebase when they are merged. The only useful commit is the last one https://github.com/rust-lang/rust/commit/faa15d28080a9cf6b9f898c424fcf057e585daec

r? @compiler-errors 

The included test is a copy of `tests/ui/impl-trait/in-trait/issue-102140.rs` which fails with the `-Zlower-impl-trait-in-trait-to-assoc-ty` currently.

Current master does the following ...

```
error[E0191]: the value of the associated type `` (from trait `MyTrait`) must be specified
  --> tests/ui/impl-trait/in-trait/new-lowering-strategy/trait-object-impl-trait.rs:23:10
   |
10 |     fn foo(&self) -> impl Marker
   |                      ----------- `` defined here
...
23 | impl dyn MyTrait {
   |          ^^^^^^^ help: specify the associated type: `MyTrait< = Type>`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0191`.
```

And this PR behaves correctly, same output as current RPITIT code ...

```
gh-spastorino@dev-desktop-us-1:~/rust4$ rustc +rust4-stage1 tests/ui/impl-trait/in-trait/new-lowering-strategy/trait-object-impl-trait.rs
error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
  --> tests/ui/impl-trait/in-trait/new-lowering-strategy/trait-object-impl-trait.rs:23:22
   |
23 |         MyTrait::foo(&self)
   |         ------------ ^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
   |         |
   |         required by a bound introduced by this call
   |
help: consider removing the leading `&`-reference
   |
23 -         MyTrait::foo(&self)
23 +         MyTrait::foo(self)
   |

error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
  --> tests/ui/impl-trait/in-trait/new-lowering-strategy/trait-object-impl-trait.rs:23:9
   |
23 |         MyTrait::foo(&self)
   |         ^^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
   |
   = help: the trait `MyTrait` is implemented for `Outer`

error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
  --> tests/ui/impl-trait/in-trait/new-lowering-strategy/trait-object-impl-trait.rs:23:9
   |
23 |         MyTrait::foo(&self)
   |         ^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
   |
   = help: the trait `MyTrait` is implemented for `Outer`

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0277`.
```