### PR TITLE
Suppress copy impl error when post-normalized type references errors

### DIFF
--- a/tests/ui/coherence/illegal-copy-bad-projection.rs
+++ b/tests/ui/coherence/illegal-copy-bad-projection.rs
@@ -1,0 +1,16 @@
+trait AsPtr {
+    type Ptr;
+}
+
+impl AsPtr for () {
+    type Ptr = *const void;
+    //~^ ERROR cannot find type `void` in this scope
+}
+
+#[derive(Copy, Clone)]
+struct Foo {
+    p: <() as AsPtr>::Ptr,
+    // Do not report a "`Copy` cannot be implemented" here.
+}
+
+fn main() {}

--- a/tests/ui/coherence/illegal-copy-bad-projection.stderr
+++ b/tests/ui/coherence/illegal-copy-bad-projection.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `void` in this scope
+  --> $DIR/illegal-copy-bad-projection.rs:6:23
+   |
+LL |     type Ptr = *const void;
+   |                       ^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/const-generics/bad-generic-in-copy-impl.rs
+++ b/tests/ui/const-generics/bad-generic-in-copy-impl.rs
@@ -1,0 +1,9 @@
+#[derive(Copy, Clone)]
+pub struct Foo {
+    x: [u8; SIZE],
+    //~^ ERROR mismatched types
+}
+
+const SIZE: u32 = 1;
+
+fn main() {}

--- a/tests/ui/const-generics/bad-generic-in-copy-impl.stderr
+++ b/tests/ui/const-generics/bad-generic-in-copy-impl.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/bad-generic-in-copy-impl.rs:3:13
+   |
+LL |     x: [u8; SIZE],
+   |             ^^^^ expected `usize`, found `u32`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Suppress spurious errors from the `Copy` impl validity check when fields have bad types *post*-normalization, instead of just pre-normalization.

----

The const-generics test regressed recently due to #107965, cc @BoxyUwU.
 * I think it's because `[_; 0u32]: Copy` now fails to hold because a nested obligation `ConstArgHasType(0u32, usize)` fails.
 * It's interesting that `[const_error]` shows up in the type only after normalization, though, but I'm pretty sure that it's due to the evaluate call that happens when normalizing unevaluated consts.