### PR TITLE
Tweak illegal `Copy` impl message

### DIFF
--- a/compiler/rustc_hir_analysis/locales/en-US.ftl
+++ b/compiler/rustc_hir_analysis/locales/en-US.ftl
@@ -89,14 +89,14 @@ hir_analysis_missing_type_params =
     .note = because of the default `Self` reference, type parameters must be specified on object types
 
 hir_analysis_copy_impl_on_type_with_dtor =
-    the trait `Copy` may not be implemented for this type; the type has a destructor
+    the trait `Copy` cannot be implemented for this type; the type has a destructor
     .label = `Copy` not allowed on types with destructors
 
 hir_analysis_multiple_relaxed_default_bounds =
     type parameter has more than one relaxed default bound, only one is supported
 
 hir_analysis_copy_impl_on_non_adt =
-    the trait `Copy` may not be implemented for this type
+    the trait `Copy` cannot be implemented for this type
     .label = type is not a structure or enumeration
 
 hir_analysis_const_impl_for_non_const_trait =

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -86,7 +86,7 @@ fn visit_implementation_of_copy(tcx: TyCtxt<'_>, impl_did: LocalDefId) {
                 tcx.sess,
                 span,
                 E0204,
-                "the trait `Copy` may not be implemented for this type"
+                "the trait `Copy` cannot be implemented for this type"
             );
 
             // We'll try to suggest constraining type parameters to fulfill the requirements of

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -2,6 +2,7 @@
 //! up data structures required by type-checking/codegen.
 
 use crate::errors::{CopyImplOnNonAdt, CopyImplOnTypeWithDtor, DropImplOnWrongItem};
+use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{struct_span_err, MultiSpan};
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -94,7 +95,14 @@ fn visit_implementation_of_copy(tcx: TyCtxt<'_>, impl_did: LocalDefId) {
             let mut errors: BTreeMap<_, Vec<_>> = Default::default();
             let mut bounds = vec![];
 
+            let mut seen_tys = FxHashSet::default();
+
             for (field, ty, reason) in fields {
+                // Only report an error once per type.
+                if !seen_tys.insert(ty) {
+                    continue;
+                }
+
                 let field_span = tcx.def_span(field.did);
                 err.span_label(field_span, "this field does not implement `Copy`");
 

--- a/compiler/rustc_hir_typeck/locales/en-US.ftl
+++ b/compiler/rustc_hir_typeck/locales/en-US.ftl
@@ -4,14 +4,14 @@ hir_typeck_field_multiply_specified_in_initializer =
     .previous_use_label = first use of `{$ident}`
 
 hir_typeck_copy_impl_on_type_with_dtor =
-    the trait `Copy` may not be implemented for this type; the type has a destructor
+    the trait `Copy` cannot be implemented for this type; the type has a destructor
     .label = `Copy` not allowed on types with destructors
 
 hir_typeck_multiple_relaxed_default_bounds =
     type parameter has more than one relaxed default bound, only one is supported
 
 hir_typeck_copy_impl_on_non_adt =
-    the trait `Copy` may not be implemented for this type
+    the trait `Copy` cannot be implemented for this type
     .label = type is not a structure or enumeration
 
 hir_typeck_trait_object_declared_with_no_traits =

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -324,7 +324,7 @@ pub trait StructuralEq {
 /// attempt to derive a `Copy` implementation, we'll get an error:
 ///
 /// ```text
-/// the trait `Copy` may not be implemented for this type; field `points` does not implement `Copy`
+/// the trait `Copy` cannot be implemented for this type; field `points` does not implement `Copy`
 /// ```
 ///
 /// Shared references (`&T`) are also `Copy`, so a type can be `Copy`, even when it holds

--- a/tests/ui/coherence/coherence-impls-copy.stderr
+++ b/tests/ui/coherence/coherence-impls-copy.stderr
@@ -52,19 +52,19 @@ LL | impl Copy for [MyType] {}
    |
    = note: define and implement a trait or new type instead
 
-error[E0206]: the trait `Copy` may not be implemented for this type
+error[E0206]: the trait `Copy` cannot be implemented for this type
   --> $DIR/coherence-impls-copy.rs:21:15
    |
 LL | impl Copy for &'static mut MyType {}
    |               ^^^^^^^^^^^^^^^^^^^ type is not a structure or enumeration
 
-error[E0206]: the trait `Copy` may not be implemented for this type
+error[E0206]: the trait `Copy` cannot be implemented for this type
   --> $DIR/coherence-impls-copy.rs:25:15
    |
 LL | impl Copy for (MyType, MyType) {}
    |               ^^^^^^^^^^^^^^^^ type is not a structure or enumeration
 
-error[E0206]: the trait `Copy` may not be implemented for this type
+error[E0206]: the trait `Copy` cannot be implemented for this type
   --> $DIR/coherence-impls-copy.rs:30:15
    |
 LL | impl Copy for [MyType] {}

--- a/tests/ui/coherence/deep-bad-copy-reason.rs
+++ b/tests/ui/coherence/deep-bad-copy-reason.rs
@@ -31,7 +31,7 @@ impl<'tcx, T> Clone for List<'tcx, T> {
 }
 
 impl<'tcx, T> Copy for List<'tcx, T> {}
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` cannot be implemented for this type
 
 fn assert_is_copy<T: Copy>() {}
 

--- a/tests/ui/coherence/deep-bad-copy-reason.stderr
+++ b/tests/ui/coherence/deep-bad-copy-reason.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/deep-bad-copy-reason.rs:33:24
    |
 LL | pub struct List<'tcx, T>(Interned<'tcx, ListS<T>>);

--- a/tests/ui/error-codes/E0184.stderr
+++ b/tests/ui/error-codes/E0184.stderr
@@ -1,4 +1,4 @@
-error[E0184]: the trait `Copy` may not be implemented for this type; the type has a destructor
+error[E0184]: the trait `Copy` cannot be implemented for this type; the type has a destructor
   --> $DIR/E0184.rs:1:10
    |
 LL | #[derive(Copy)]

--- a/tests/ui/error-codes/E0206.rs
+++ b/tests/ui/error-codes/E0206.rs
@@ -2,7 +2,7 @@
 struct Bar;
 
 impl Copy for &'static mut Bar { }
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` cannot be implemented for this type
 
 fn main() {
 }

--- a/tests/ui/error-codes/E0206.stderr
+++ b/tests/ui/error-codes/E0206.stderr
@@ -1,4 +1,4 @@
-error[E0206]: the trait `Copy` may not be implemented for this type
+error[E0206]: the trait `Copy` cannot be implemented for this type
   --> $DIR/E0206.rs:4:15
    |
 LL | impl Copy for &'static mut Bar { }

--- a/tests/ui/exclusive-drop-and-copy.rs
+++ b/tests/ui/exclusive-drop-and-copy.rs
@@ -1,13 +1,13 @@
 // issue #20126
 
-#[derive(Copy, Clone)] //~ ERROR the trait `Copy` may not be implemented
+#[derive(Copy, Clone)] //~ ERROR the trait `Copy` cannot be implemented
 struct Foo;
 
 impl Drop for Foo {
     fn drop(&mut self) {}
 }
 
-#[derive(Copy, Clone)] //~ ERROR the trait `Copy` may not be implemented
+#[derive(Copy, Clone)] //~ ERROR the trait `Copy` cannot be implemented
 struct Bar<T>(::std::marker::PhantomData<T>);
 
 impl<T> Drop for Bar<T> {

--- a/tests/ui/exclusive-drop-and-copy.stderr
+++ b/tests/ui/exclusive-drop-and-copy.stderr
@@ -1,4 +1,4 @@
-error[E0184]: the trait `Copy` may not be implemented for this type; the type has a destructor
+error[E0184]: the trait `Copy` cannot be implemented for this type; the type has a destructor
   --> $DIR/exclusive-drop-and-copy.rs:3:10
    |
 LL | #[derive(Copy, Clone)]
@@ -6,7 +6,7 @@ LL | #[derive(Copy, Clone)]
    |
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0184]: the trait `Copy` may not be implemented for this type; the type has a destructor
+error[E0184]: the trait `Copy` cannot be implemented for this type; the type has a destructor
   --> $DIR/exclusive-drop-and-copy.rs:10:10
    |
 LL | #[derive(Copy, Clone)]

--- a/tests/ui/issues/issue-27340.rs
+++ b/tests/ui/issues/issue-27340.rs
@@ -1,6 +1,6 @@
 struct Foo;
 #[derive(Copy, Clone)]
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` cannot be implemented for this type
 struct Bar(Foo);
 
 fn main() {}

--- a/tests/ui/issues/issue-27340.stderr
+++ b/tests/ui/issues/issue-27340.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/issue-27340.rs:2:10
    |
 LL | #[derive(Copy, Clone)]

--- a/tests/ui/opt-in-copy.rs
+++ b/tests/ui/opt-in-copy.rs
@@ -5,7 +5,7 @@ struct IWantToCopyThis {
 }
 
 impl Copy for IWantToCopyThis {}
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` cannot be implemented for this type
 
 enum CantCopyThisEither {
     A,
@@ -17,6 +17,6 @@ enum IWantToCopyThisToo {
 }
 
 impl Copy for IWantToCopyThisToo {}
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` cannot be implemented for this type
 
 fn main() {}

--- a/tests/ui/opt-in-copy.stderr
+++ b/tests/ui/opt-in-copy.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/opt-in-copy.rs:7:15
    |
 LL |     but_i_cant: CantCopyThis,
@@ -7,7 +7,7 @@ LL |     but_i_cant: CantCopyThis,
 LL | impl Copy for IWantToCopyThis {}
    |               ^^^^^^^^^^^^^^^
 
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/opt-in-copy.rs:19:15
    |
 LL |     ButICant(CantCopyThisEither),

--- a/tests/ui/range/range_traits-2.stderr
+++ b/tests/ui/range/range_traits-2.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/range_traits-2.rs:3:10
    |
 LL | #[derive(Copy, Clone)]

--- a/tests/ui/range/range_traits-3.stderr
+++ b/tests/ui/range/range_traits-3.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/range_traits-3.rs:3:10
    |
 LL | #[derive(Copy, Clone)]

--- a/tests/ui/range/range_traits-6.stderr
+++ b/tests/ui/range/range_traits-6.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/range_traits-6.rs:3:10
    |
 LL | #[derive(Copy, Clone)]

--- a/tests/ui/span/E0204.rs
+++ b/tests/ui/span/E0204.rs
@@ -2,9 +2,9 @@ struct Foo {
     foo: Vec<u32>,
 }
 
-impl Copy for Foo { } //~ ERROR may not be implemented for this type
+impl Copy for Foo { } //~ ERROR cannot be implemented for this type
 
-#[derive(Copy)] //~ ERROR may not be implemented for this type
+#[derive(Copy)] //~ ERROR cannot be implemented for this type
 struct Foo2<'a> {
     ty: &'a mut bool,
 }
@@ -14,9 +14,9 @@ enum EFoo {
     Baz,
 }
 
-impl Copy for EFoo { } //~ ERROR may not be implemented for this type
+impl Copy for EFoo { } //~ ERROR cannot be implemented for this type
 
-#[derive(Copy)] //~ ERROR may not be implemented for this type
+#[derive(Copy)] //~ ERROR cannot be implemented for this type
 enum EFoo2<'a> {
     Bar(&'a mut bool),
     Baz,

--- a/tests/ui/span/E0204.stderr
+++ b/tests/ui/span/E0204.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/E0204.rs:5:15
    |
 LL |     foo: Vec<u32>,
@@ -7,7 +7,7 @@ LL |     foo: Vec<u32>,
 LL | impl Copy for Foo { }
    |               ^^^
 
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/E0204.rs:7:10
    |
 LL | #[derive(Copy)]
@@ -18,7 +18,7 @@ LL |     ty: &'a mut bool,
    |
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/E0204.rs:17:15
    |
 LL |     Bar { x: Vec<u32> },
@@ -27,7 +27,7 @@ LL |     Bar { x: Vec<u32> },
 LL | impl Copy for EFoo { }
    |               ^^^^
 
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/E0204.rs:19:10
    |
 LL | #[derive(Copy)]

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.fixed
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.fixed
@@ -7,7 +7,7 @@ pub struct Vector2<T: Debug + Copy + Clone>{
     pub y: T
 }
 
-#[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` may not be implemented for this type
+#[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` cannot be implemented for this type
 pub struct AABB<K: Copy + Debug>{
     pub loc: Vector2<K>,
     pub size: Vector2<K>

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.rs
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.rs
@@ -7,7 +7,7 @@ pub struct Vector2<T: Debug + Copy + Clone>{
     pub y: T
 }
 
-#[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` may not be implemented for this type
+#[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` cannot be implemented for this type
 pub struct AABB<K: Copy>{
     pub loc: Vector2<K>,
     pub size: Vector2<K>

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
@@ -6,16 +6,12 @@ LL | #[derive(Debug, Copy, Clone)]
 LL | pub struct AABB<K: Copy>{
 LL |     pub loc: Vector2<K>,
    |     ------------------- this field does not implement `Copy`
-LL |     pub size: Vector2<K>
-   |     -------------------- this field does not implement `Copy`
    |
 note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
   --> $DIR/missing-bound-in-derive-copy-impl-3.rs:12:14
    |
 LL |     pub loc: Vector2<K>,
    |              ^^^^^^^^^^
-LL |     pub size: Vector2<K>
-   |               ^^^^^^^^^^
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/missing-bound-in-derive-copy-impl-3.rs:10:17
    |
 LL | #[derive(Debug, Copy, Clone)]

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl.rs
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl.rs
@@ -6,7 +6,7 @@ pub struct Vector2<T: Debug + Copy + Clone>{
     pub y: T
 }
 
-#[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` may not be implemented for this type
+#[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` cannot be implemented for this type
 pub struct AABB<K>{
     pub loc: Vector2<K>,
     pub size: Vector2<K>

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
@@ -6,16 +6,12 @@ LL | #[derive(Debug, Copy, Clone)]
 LL | pub struct AABB<K>{
 LL |     pub loc: Vector2<K>,
    |     ------------------- this field does not implement `Copy`
-LL |     pub size: Vector2<K>
-   |     -------------------- this field does not implement `Copy`
    |
 note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
   --> $DIR/missing-bound-in-derive-copy-impl.rs:11:14
    |
 LL |     pub loc: Vector2<K>,
    |              ^^^^^^^^^^
-LL |     pub size: Vector2<K>
-   |               ^^^^^^^^^^
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `K`
    |

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/missing-bound-in-derive-copy-impl.rs:9:17
    |
 LL | #[derive(Debug, Copy, Clone)]

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.fixed
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.fixed
@@ -14,6 +14,6 @@ impl<T: std::fmt::Display> Clone for OnlyCopyIfDisplay<T> {
 impl<T: std::fmt::Display> Copy for OnlyCopyIfDisplay<T> {}
 
 impl<S: std::fmt::Display> Copy for Wrapper<OnlyCopyIfDisplay<S>> {}
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` cannot be implemented for this type
 
 fn main() {}

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.rs
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.rs
@@ -14,6 +14,6 @@ impl<T: std::fmt::Display> Clone for OnlyCopyIfDisplay<T> {
 impl<T: std::fmt::Display> Copy for OnlyCopyIfDisplay<T> {}
 
 impl<S> Copy for Wrapper<OnlyCopyIfDisplay<S>> {}
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` cannot be implemented for this type
 
 fn main() {}

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/missing-bound-in-manual-copy-impl-2.rs:16:18
    |
 LL | struct Wrapper<T>(T);

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl.fixed
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl.fixed
@@ -4,6 +4,6 @@
 struct Wrapper<T>(T);
 
 impl<S: Copy> Copy for Wrapper<S> {}
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` cannot be implemented for this type
 
 fn main() {}

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl.rs
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl.rs
@@ -4,6 +4,6 @@
 struct Wrapper<T>(T);
 
 impl<S> Copy for Wrapper<S> {}
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` cannot be implemented for this type
 
 fn main() {}

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl.stderr
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/missing-bound-in-manual-copy-impl.rs:6:18
    |
 LL | struct Wrapper<T>(T);

--- a/tests/ui/traits/copy-is-not-modulo-regions.not_static.stderr
+++ b/tests/ui/traits/copy-is-not-modulo-regions.not_static.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/copy-is-not-modulo-regions.rs:13:21
    |
 LL | struct Bar<'lt>(Foo<'lt>);

--- a/tests/ui/traits/copy-is-not-modulo-regions.rs
+++ b/tests/ui/traits/copy-is-not-modulo-regions.rs
@@ -11,7 +11,7 @@ struct Bar<'lt>(Foo<'lt>);
 
 #[cfg(not_static)]
 impl<'any> Copy for Bar<'any> {}
-//[not_static]~^ the trait `Copy` may not be implemented for this type
+//[not_static]~^ the trait `Copy` cannot be implemented for this type
 
 #[cfg(yes_static)]
 impl<'any> Copy for Bar<'static> {}

--- a/tests/ui/traits/issue-50480.rs
+++ b/tests/ui/traits/issue-50480.rs
@@ -1,5 +1,5 @@
 #[derive(Clone, Copy)]
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` cannot be implemented for this type
 struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
 //~^ ERROR cannot find type `NotDefined` in this scope
 //~| ERROR cannot find type `NotDefined` in this scope
@@ -7,7 +7,7 @@ struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
 //~| ERROR cannot find type `N` in this scope
 
 #[derive(Clone, Copy)]
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` cannot be implemented for this type
 struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
 //~^ ERROR cannot find type `NotDefined` in this scope
 //~| ERROR cannot find type `N` in this scope

--- a/tests/ui/traits/issue-50480.stderr
+++ b/tests/ui/traits/issue-50480.stderr
@@ -60,7 +60,7 @@ error[E0412]: cannot find type `NotDefined` in this scope
 LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                     ^^^^^^^^^^ not found in this scope
 
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/issue-50480.rs:1:17
    |
 LL | #[derive(Clone, Copy)]
@@ -73,7 +73,7 @@ LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/issue-50480.rs:9:17
    |
 LL | #[derive(Clone, Copy)]

--- a/tests/ui/union/union-copy.rs
+++ b/tests/ui/union/union-copy.rs
@@ -9,6 +9,6 @@ union W {
 }
 
 impl Copy for U {} // OK
-impl Copy for W {} //~ ERROR the trait `Copy` may not be implemented for this type
+impl Copy for W {} //~ ERROR the trait `Copy` cannot be implemented for this type
 
 fn main() {}

--- a/tests/ui/union/union-copy.stderr
+++ b/tests/ui/union/union-copy.stderr
@@ -1,4 +1,4 @@
-error[E0204]: the trait `Copy` may not be implemented for this type
+error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/union-copy.rs:12:15
    |
 LL |     a: std::mem::ManuallyDrop<String>


### PR DESCRIPTION
The phrase "may not" can both mean "is not able to" and "possibly does not". Disambiguate this by just using "cannot".
@Lokathor expressed being annoyed by this [here](https://twitter.com/Lokathor/status/1633200313544089602?s=20).

Also drive-by fix for this extremely noisy message: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=6a37275bc810f7846bfe191845b7d11d.

r? diagnostics