### PR TITLE
Remove an extraneous include

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/SymbolWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/SymbolWrapper.cpp
@@ -9,7 +9,6 @@
 
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Object/ObjectFile.h"
-#include "llvm/ADT/Optional.h"
 
 using namespace llvm;
 using namespace llvm::sys;


### PR DESCRIPTION
SymbolWrapper.cpp doesn't use std::optional or llvm::Optional, so this patch removes the extraneous include.  Note that llvm/ADT/Optional.h has been deprecated upstream.  This patch ensures that SymbolWrapper.cpp continues to compile even after the upcoming removal of Optional.h.