### PR TITLE
fix(lexer): print whitespace warning for \x0c

### DIFF
--- a/compiler/rustc_lexer/src/unescape.rs
+++ b/compiler/rustc_lexer/src/unescape.rs
@@ -298,10 +298,10 @@ where
         }
         let tail = &tail[first_non_space..];
         if let Some(c) = tail.chars().nth(0) {
-            // For error reporting, we would like the span to contain the character that was not
-            // skipped. The +1 is necessary to account for the leading \ that started the escape.
-            let end = start + first_non_space + c.len_utf8() + 1;
             if c.is_whitespace() {
+                // For error reporting, we would like the span to contain the character that was not
+                // skipped. The +1 is necessary to account for the leading \ that started the escape.
+                let end = start + first_non_space + c.len_utf8() + 1;
                 callback(start..end, Err(EscapeError::UnskippedWhitespaceWarning));
             }
         }

--- a/compiler/rustc_parse/locales/en-US.ftl
+++ b/compiler/rustc_parse/locales/en-US.ftl
@@ -710,7 +710,7 @@ parse_zero_chars = empty character literal
 parse_lone_slash = invalid trailing slash in literal
     .label = {parse_lone_slash}
 
-parse_unskipped_whitespace = non-ASCII whitespace symbol '{$ch}' is not skipped
+parse_unskipped_whitespace = whitespace symbol '{$ch}' is not skipped
     .label = {parse_unskipped_whitespace}
 
 parse_multiple_skipped_lines = multiple lines skipped by escaped newline

--- a/tests/ui/str/str-escape.rs
+++ b/tests/ui/str/str-escape.rs
@@ -1,11 +1,31 @@
 // check-pass
+// ignore-tidy-tab
+
 fn main() {
     let s = "\
 
              ";
     //~^^^ WARNING multiple lines skipped by escaped newline
+    assert_eq!(s, "");
+
     let s = "foo\
              bar
              ";
-    //~^^^ WARNING non-ASCII whitespace symbol '\u{a0}' is not skipped
+    //~^^^ WARNING whitespace symbol '\u{a0}' is not skipped
+    assert_eq!(s, "foo           bar\n             ");
+
+    let s = "a\
+ b";
+    assert_eq!(s, "ab");
+
+    let s = "a\
+	b";
+    assert_eq!(s, "ab");
+
+    let s = "a\
+    b";
+    //~^^ WARNING whitespace symbol '\u{c}' is not skipped
+    // '\x0c' is ASCII whitespace, but it may not need skipped
+    // discussion: https://github.com/rust-lang/rust/pull/108403
+    assert_eq!(s, "a\x0cb");
 }

--- a/tests/ui/str/str-escape.stderr
+++ b/tests/ui/str/str-escape.stderr
@@ -1,5 +1,5 @@
 warning: multiple lines skipped by escaped newline
-  --> $DIR/str-escape.rs:3:14
+  --> $DIR/str-escape.rs:5:14
    |
 LL |       let s = "\
    |  ______________^
@@ -7,15 +7,25 @@ LL | |
 LL | |              ";
    | |_____________^ skipping everything up to and including this point
 
-warning: non-ASCII whitespace symbol '\u{a0}' is not skipped
-  --> $DIR/str-escape.rs:7:17
+warning: whitespace symbol '\u{a0}' is not skipped
+  --> $DIR/str-escape.rs:11:17
    |
 LL |       let s = "foo\
    |  _________________^
 LL | |              bar
-   | |   ^ non-ASCII whitespace symbol '\u{a0}' is not skipped
+   | |   ^ whitespace symbol '\u{a0}' is not skipped
    | |___|
    | 
 
-warning: 2 warnings emitted
+warning: whitespace symbol '\u{c}' is not skipped
+  --> $DIR/str-escape.rs:25:15
+   |
+LL |       let s = "a\
+   |  _______________^
+LL | |     b";
+   | |    ^- whitespace symbol '\u{c}' is not skipped
+   | |____|
+   | 
+
+warning: 3 warnings emitted
 


### PR DESCRIPTION
- close https://github.com/rust-lang/rust/issues/108275
- discussion: https://github.com/rust-lang/rust/pull/108403