### PR TITLE
Remove some direct calls to local_def_id_to_hir_id on diagnostics

### DIFF
--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -316,7 +316,7 @@ impl<'hir> Map<'hir> {
     /// Retrieves the `Node` corresponding to `id`, returning `None` if cannot be found.
     #[inline]
     pub fn find_by_def_id(self, id: LocalDefId) -> Option<Node<'hir>> {
-        self.find(self.local_def_id_to_hir_id(id))
+        self.find(self.tcx.opt_local_def_id_to_hir_id(id)?)
     }
 
     /// Retrieves the `Node` corresponding to `id`, panicking if it cannot be found.
@@ -333,7 +333,7 @@ impl<'hir> Map<'hir> {
     }
 
     pub fn get_if_local(self, id: DefId) -> Option<Node<'hir>> {
-        id.as_local().and_then(|id| self.find(self.local_def_id_to_hir_id(id)))
+        id.as_local().and_then(|id| self.find(self.tcx.opt_local_def_id_to_hir_id(id)?))
     }
 
     pub fn get_generics(self, id: LocalDefId) -> Option<&'hir Generics<'hir>> {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
@@ -144,6 +144,10 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         trait_ref: ty::PolyTraitRef<'tcx>,
         obligation: &PredicateObligation<'tcx>,
     ) -> OnUnimplementedNote {
+        if self.tcx.opt_rpitit_info(obligation.cause.body_id.to_def_id()).is_some() {
+            return OnUnimplementedNote::default();
+        }
+
         let (def_id, substs) = self
             .impl_similar_to(trait_ref, obligation)
             .unwrap_or_else(|| (trait_ref.def_id(), trait_ref.skip_binder().substs));


### PR DESCRIPTION
Was playing with `tests/ui/impl-trait/in-trait/default-body-with-rpit.rs` and was able to remove some ICEs. Still getting ...

```
error[E0277]: `impl Future<Output = Foo::{opaque#0}>` is not a future
  --> tests/ui/impl-trait/in-trait/default-body-with-rpit.rs:10:28
   |
10 |     async fn baz(&self) -> impl Debug {
   |                            ^^^^^^^^^^ `impl Future<Output = Foo::{opaque#0}>` is not a future
   |
   = help: the trait `Future` is not implemented for `impl Future<Output = Foo::{opaque#0}>`
   = note: impl Future<Output = Foo::{opaque#0}> must be a future or must implement `IntoFuture` to be awaited
note: required by a bound in `Foo::{opaque#1}`
  --> tests/ui/impl-trait/in-trait/default-body-with-rpit.rs:10:28
   |
10 |     async fn baz(&self) -> impl Debug {
   |                            ^^^^^^^^^^ required by this bound in `Foo::{opaque#1}`

error[E0277]: the size for values of type `impl Future<Output = Foo::{opaque#0}>` cannot be known at compilation time
  --> tests/ui/impl-trait/in-trait/default-body-with-rpit.rs:10:28
   |
10 |     async fn baz(&self) -> impl Debug {
   |                            ^^^^^^^^^^ doesn't have a size known at compile-time
   |
   = help: the trait `Sized` is not implemented for `impl Future<Output = Foo::{opaque#0}>`
note: required by a bound in `Foo::{opaque#1}`
  --> tests/ui/impl-trait/in-trait/default-body-with-rpit.rs:10:28
   |
10 |     async fn baz(&self) -> impl Debug {
   |                            ^^^^^^^^^^ required by this bound in `Foo::{opaque#1}`

error: internal compiler error: compiler/rustc_hir_typeck/src/closure.rs:724:18: async fn generator return type not an inference variable: Foo::{opaque#1}<'_>
  --> tests/ui/impl-trait/in-trait/default-body-with-rpit.rs:10:39
   |
10 |       async fn baz(&self) -> impl Debug {
   |  _______________________________________^
11 | |         ""
12 | |     }
   | |_____^
```

But I guess this is a little bit of progress anyway.

This one goes on top of #108700 and #108945
r? @compiler-errors