### PR TITLE
Eagerly instantiate `Fn`-like obligations in old solver

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -302,22 +302,22 @@ pub fn generator_trait_ref_and_outputs<'tcx>(
     tcx: TyCtxt<'tcx>,
     fn_trait_def_id: DefId,
     self_ty: Ty<'tcx>,
-    sig: ty::PolyGenSig<'tcx>,
-) -> ty::Binder<'tcx, (ty::TraitRef<'tcx>, Ty<'tcx>, Ty<'tcx>)> {
+    sig: ty::GenSig<'tcx>,
+) -> (ty::TraitRef<'tcx>, Ty<'tcx>, Ty<'tcx>) {
     assert!(!self_ty.has_escaping_bound_vars());
-    let trait_ref = tcx.mk_trait_ref(fn_trait_def_id, [self_ty, sig.skip_binder().resume_ty]);
-    sig.map_bound(|sig| (trait_ref, sig.yield_ty, sig.return_ty))
+    let trait_ref = tcx.mk_trait_ref(fn_trait_def_id, [self_ty, sig.resume_ty]);
+    (trait_ref, sig.yield_ty, sig.return_ty)
 }
 
 pub fn future_trait_ref_and_outputs<'tcx>(
     tcx: TyCtxt<'tcx>,
     fn_trait_def_id: DefId,
     self_ty: Ty<'tcx>,
-    sig: ty::PolyGenSig<'tcx>,
-) -> ty::Binder<'tcx, (ty::TraitRef<'tcx>, Ty<'tcx>)> {
+    sig: ty::GenSig<'tcx>,
+) -> (ty::TraitRef<'tcx>, Ty<'tcx>) {
     assert!(!self_ty.has_escaping_bound_vars());
     let trait_ref = tcx.mk_trait_ref(fn_trait_def_id, [self_ty]);
-    sig.map_bound(|sig| (trait_ref, sig.return_ty))
+    (trait_ref, sig.return_ty)
 }
 
 pub fn impl_item_is_final(tcx: TyCtxt<'_>, assoc_item: &ty::AssocItem) -> bool {

--- a/tests/ui/generator/resume-arg-late-bound.rs
+++ b/tests/ui/generator/resume-arg-late-bound.rs
@@ -13,5 +13,5 @@ fn main() {
         *arg = true;
     };
     test(gen);
-    //~^ ERROR mismatched types
+    //~^ ERROR implementation of `Generator` is not general enough
 }

--- a/tests/ui/generator/resume-arg-late-bound.stderr
+++ b/tests/ui/generator/resume-arg-late-bound.stderr
@@ -1,17 +1,11 @@
-error[E0308]: mismatched types
+error: implementation of `Generator` is not general enough
   --> $DIR/resume-arg-late-bound.rs:15:5
    |
 LL |     test(gen);
-   |     ^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^ implementation of `Generator` is not general enough
    |
-   = note: expected trait `for<'a> Generator<&'a mut bool>`
-              found trait `Generator<&mut bool>`
-note: the lifetime requirement is introduced here
-  --> $DIR/resume-arg-late-bound.rs:8:17
-   |
-LL | fn test(a: impl for<'a> Generator<&'a mut bool>) {}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `[generator@$DIR/resume-arg-late-bound.rs:11:15: 11:31]` must implement `Generator<&'1 mut bool>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Generator<&'2 mut bool>`, for some specific lifetime `'2`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/generic-associated-types/bugs/issue-88382.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-88382.stderr
@@ -1,22 +1,14 @@
-error[E0631]: type mismatch in function arguments
+error[E0282]: type annotations needed
   --> $DIR/issue-88382.rs:26:40
    |
 LL |     do_something(SomeImplementation(), test);
-   |     ------------                       ^^^^ expected due to this
-   |     |
-   |     required by a bound introduced by this call
-...
-LL | fn test<'a, I: Iterable>(_: &mut I::Iterator<'a>) {}
-   | ------------------------------------------------- found signature defined here
+   |                                        ^^^^ cannot infer type of the type parameter `I` declared on the function `test`
    |
-   = note: expected function signature `for<'a> fn(&'a mut std::iter::Empty<usize>) -> _`
-              found function signature `for<'a, 'b> fn(&'b mut <_ as Iterable>::Iterator<'a>) -> _`
-note: required by a bound in `do_something`
-  --> $DIR/issue-88382.rs:20:48
+help: consider specifying the generic argument
    |
-LL | fn do_something<I: Iterable>(i: I, mut f: impl for<'a> Fn(&mut I::Iterator<'a>)) {
-   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `do_something`
+LL |     do_something(SomeImplementation(), test::<I>);
+   |                                            +++++
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0631`.
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/higher-rank-trait-bounds/fn-ptr.rs
+++ b/tests/ui/higher-rank-trait-bounds/fn-ptr.rs
@@ -1,0 +1,13 @@
+// revisions: classic next
+//[next] compile-flags: -Ztrait-solver=next
+//check-pass
+
+fn ice()
+where
+    for<'w> fn(&'w ()): Fn(&'w ()),
+{
+}
+
+fn main() {
+    ice();
+}

--- a/tests/ui/higher-rank-trait-bounds/normalize-under-binder/issue-71955.rs
+++ b/tests/ui/higher-rank-trait-bounds/normalize-under-binder/issue-71955.rs
@@ -43,9 +43,9 @@ fn main() {
     }
 
     foo(bar, "string", |s| s.len() == 5);
-    //~^ ERROR mismatched types
-    //~| ERROR mismatched types
+    //~^ ERROR implementation of `FnOnce` is not general enough
+    //~| ERROR implementation of `FnOnce` is not general enough
     foo(baz, "string", |s| s.0.len() == 5);
-    //~^ ERROR mismatched types
-    //~| ERROR mismatched types
+    //~^ ERROR implementation of `FnOnce` is not general enough
+    //~| ERROR implementation of `FnOnce` is not general enough
 }

--- a/tests/ui/higher-rank-trait-bounds/normalize-under-binder/issue-71955.stderr
+++ b/tests/ui/higher-rank-trait-bounds/normalize-under-binder/issue-71955.stderr
@@ -1,79 +1,38 @@
-error[E0308]: mismatched types
+error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-71955.rs:45:5
    |
 LL |     foo(bar, "string", |s| s.len() == 5);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
    |
-   = note: expected trait `for<'a, 'b> FnOnce<(&'a &'b str,)>`
-              found trait `for<'a> FnOnce<(&'a &str,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-71955.rs:45:24
-   |
-LL |     foo(bar, "string", |s| s.len() == 5);
-   |                        ^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-71955.rs:25:9
-   |
-LL |     F2: FnOnce(&<F1 as Parser>::Output) -> bool
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: closure with signature `for<'a> fn(&'a &'2 str) -> bool` must implement `FnOnce<(&&'1 str,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&&'2 str,)>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-71955.rs:45:5
    |
 LL |     foo(bar, "string", |s| s.len() == 5);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
    |
-   = note: expected trait `for<'a, 'b> FnOnce<(&'a &'b str,)>`
-              found trait `for<'a> FnOnce<(&'a &str,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-71955.rs:45:24
-   |
-LL |     foo(bar, "string", |s| s.len() == 5);
-   |                        ^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-71955.rs:25:44
-   |
-LL |     F2: FnOnce(&<F1 as Parser>::Output) -> bool
-   |                                            ^^^^
+   = note: closure with signature `for<'a> fn(&'a &'2 str) -> bool` must implement `FnOnce<(&&'1 str,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&&'2 str,)>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-71955.rs:48:5
    |
 LL |     foo(baz, "string", |s| s.0.len() == 5);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
    |
-   = note: expected trait `for<'a, 'b> FnOnce<(&'a Wrapper<'b>,)>`
-              found trait `for<'a> FnOnce<(&'a Wrapper<'_>,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-71955.rs:48:24
-   |
-LL |     foo(baz, "string", |s| s.0.len() == 5);
-   |                        ^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-71955.rs:25:9
-   |
-LL |     F2: FnOnce(&<F1 as Parser>::Output) -> bool
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: closure with signature `for<'a> fn(&'a Wrapper<'2>) -> bool` must implement `FnOnce<(&Wrapper<'1>,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&Wrapper<'2>,)>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-71955.rs:48:5
    |
 LL |     foo(baz, "string", |s| s.0.len() == 5);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
    |
-   = note: expected trait `for<'a, 'b> FnOnce<(&'a Wrapper<'b>,)>`
-              found trait `for<'a> FnOnce<(&'a Wrapper<'_>,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-71955.rs:48:24
-   |
-LL |     foo(baz, "string", |s| s.0.len() == 5);
-   |                        ^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-71955.rs:25:44
-   |
-LL |     F2: FnOnce(&<F1 as Parser>::Output) -> bool
-   |                                            ^^^^
+   = note: closure with signature `for<'a> fn(&'a Wrapper<'2>) -> bool` must implement `FnOnce<(&Wrapper<'1>,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&Wrapper<'2>,)>`, for some specific lifetime `'2`
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/lifetimes/issue-79187-2.rs
+++ b/tests/ui/lifetimes/issue-79187-2.rs
@@ -7,7 +7,7 @@ fn take_foo(_: impl Foo) {}
 fn main() {
     take_foo(|a| a);
     //~^ ERROR implementation of `FnOnce` is not general enough
-    //~| ERROR mismatched types
+    //~| ERROR implementation of `Fn` is not general enough
     take_foo(|a: &i32| a);
     //~^ ERROR lifetime may not live long enough
     //~| ERROR mismatched types

--- a/tests/ui/lifetimes/issue-79187-2.stderr
+++ b/tests/ui/lifetimes/issue-79187-2.stderr
@@ -25,24 +25,14 @@ LL |     take_foo(|a| a);
    = note: closure with signature `fn(&'2 i32) -> &i32` must implement `FnOnce<(&'1 i32,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 i32,)>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/issue-79187-2.rs:8:5
    |
 LL |     take_foo(|a| a);
-   |     ^^^^^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^^^^^ implementation of `Fn` is not general enough
    |
-   = note: expected trait `for<'a> Fn<(&'a i32,)>`
-              found trait `Fn<(&i32,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-79187-2.rs:8:14
-   |
-LL |     take_foo(|a| a);
-   |              ^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-79187-2.rs:5:21
-   |
-LL | fn take_foo(_: impl Foo) {}
-   |                     ^^^
+   = note: closure with signature `fn(&'2 i32) -> &i32` must implement `Fn<(&'1 i32,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&'2 i32,)>`, for some specific lifetime `'2`
 
 error[E0308]: mismatched types
   --> $DIR/issue-79187-2.rs:11:5

--- a/tests/ui/lifetimes/issue-79187.rs
+++ b/tests/ui/lifetimes/issue-79187.rs
@@ -3,6 +3,6 @@ fn thing(x: impl FnOnce(&u32)) {}
 fn main() {
     let f = |_| ();
     thing(f);
-    //~^ ERROR mismatched types
-    //~^^ ERROR implementation of `FnOnce` is not general enough
+    //~^ ERROR implementation of `FnOnce` is not general enough
+    //~| ERROR implementation of `FnOnce` is not general enough
 }

--- a/tests/ui/lifetimes/issue-79187.stderr
+++ b/tests/ui/lifetimes/issue-79187.stderr
@@ -1,21 +1,11 @@
-error[E0308]: mismatched types
+error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-79187.rs:5:5
    |
 LL |     thing(f);
-   |     ^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^ implementation of `FnOnce` is not general enough
    |
-   = note: expected trait `for<'a> FnOnce<(&'a u32,)>`
-              found trait `FnOnce<(&u32,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-79187.rs:4:13
-   |
-LL |     let f = |_| ();
-   |             ^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-79187.rs:1:18
-   |
-LL | fn thing(x: impl FnOnce(&u32)) {}
-   |                  ^^^^^^^^^^^^
+   = note: closure with signature `fn(&'2 u32)` must implement `FnOnce<(&'1 u32,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&'2 u32,)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-79187.rs:5:5
@@ -28,4 +18,3 @@ LL |     thing(f);
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/lifetimes/lifetime-errors/issue_74400.rs
+++ b/tests/ui/lifetimes/lifetime-errors/issue_74400.rs
@@ -11,6 +11,6 @@ fn f<T, S>(data: &[T], key: impl Fn(&T) -> S) {
 fn g<T>(data: &[T]) {
     f(data, identity)
     //~^ ERROR the parameter type
-    //~| ERROR mismatched types
+    //~| ERROR implementation of `Fn` is not general enough
     //~| ERROR implementation of `FnOnce` is not general
 }

--- a/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
@@ -9,19 +9,14 @@ help: consider adding an explicit lifetime bound...
 LL | fn g<T: 'static>(data: &[T]) {
    |       +++++++++
 
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/issue_74400.rs:12:5
    |
 LL |     f(data, identity)
-   |     ^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^^^^^^^ implementation of `Fn` is not general enough
    |
-   = note: expected trait `for<'a> Fn<(&'a T,)>`
-              found trait `Fn<(&T,)>`
-note: the lifetime requirement is introduced here
-  --> $DIR/issue_74400.rs:8:34
-   |
-LL | fn f<T, S>(data: &[T], key: impl Fn(&T) -> S) {
-   |                                  ^^^^^^^^^^^
+   = note: `fn(&'2 T) -> &'2 T {identity::<&'2 T>}` must implement `Fn<(&'1 T,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&'2 T,)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
   --> $DIR/issue_74400.rs:12:5
@@ -34,5 +29,4 @@ LL |     f(data, identity)
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0308, E0310.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0310`.

--- a/tests/ui/mismatched_types/closure-mismatch.rs
+++ b/tests/ui/mismatched_types/closure-mismatch.rs
@@ -7,5 +7,5 @@ fn baz<T: Foo>(_: T) {}
 fn main() {
     baz(|_| ());
     //~^ ERROR implementation of `FnOnce` is not general enough
-    //~| ERROR mismatched types
+    //~| ERROR implementation of `Fn` is not general enough
 }

--- a/tests/ui/mismatched_types/closure-mismatch.stderr
+++ b/tests/ui/mismatched_types/closure-mismatch.stderr
@@ -7,25 +7,14 @@ LL |     baz(|_| ());
    = note: closure with signature `fn(&'2 ())` must implement `FnOnce<(&'1 (),)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 (),)>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/closure-mismatch.rs:8:5
    |
 LL |     baz(|_| ());
-   |     ^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^ implementation of `Fn` is not general enough
    |
-   = note: expected trait `for<'a> Fn<(&'a (),)>`
-              found trait `Fn<(&(),)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/closure-mismatch.rs:8:9
-   |
-LL |     baz(|_| ());
-   |         ^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/closure-mismatch.rs:5:11
-   |
-LL | fn baz<T: Foo>(_: T) {}
-   |           ^^^
+   = note: closure with signature `fn(&'2 ())` must implement `Fn<(&'1 (),)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&'2 (),)>`, for some specific lifetime `'2`
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/rfcs/rfc1623-2.rs
+++ b/tests/ui/rfcs/rfc1623-2.rs
@@ -26,8 +26,8 @@ static SOME_STRUCT: &SomeStruct = &SomeStruct {
     foo: &Foo { bools: &[false, true] },
     bar: &Bar { bools: &[true, true] },
     f: &id,
-    //~^ ERROR mismatched types
-    //~| ERROR mismatched types
+    //~^ ERROR implementation of `Fn` is not general enough
+    //~| ERROR implementation of `Fn` is not general enough
     //~| ERROR implementation of `FnOnce` is not general enough
     //~| ERROR implementation of `FnOnce` is not general enough
 };

--- a/tests/ui/rfcs/rfc1623-2.stderr
+++ b/tests/ui/rfcs/rfc1623-2.stderr
@@ -1,20 +1,20 @@
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/rfc1623-2.rs:28:8
    |
 LL |     f: &id,
-   |        ^^^ one type is more general than the other
+   |        ^^^ implementation of `Fn` is not general enough
    |
-   = note: expected trait `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
-              found trait `Fn<(&Foo<'_>,)>`
+   = note: `fn(&'2 Foo<'_>) -> &'2 Foo<'_> {id::<&'2 Foo<'_>>}` must implement `Fn<(&'1 Foo<'b>,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&'2 Foo<'_>,)>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/rfc1623-2.rs:28:8
    |
 LL |     f: &id,
-   |        ^^^ one type is more general than the other
+   |        ^^^ implementation of `Fn` is not general enough
    |
-   = note: expected trait `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
-              found trait `Fn<(&Foo<'_>,)>`
+   = note: `fn(&Foo<'2>) -> &Foo<'2> {id::<&Foo<'2>>}` must implement `Fn<(&'a Foo<'1>,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&Foo<'2>,)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
   --> $DIR/rfc1623-2.rs:28:8
@@ -36,4 +36,3 @@ LL |     f: &id,
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Alternative approach to (actually) fixing #108832. Mostly just up for demonstration, probably needs some cleaning + re-consolidation into a helper fn like the one I removed.

cc @jackh726's comment https://github.com/rust-lang/rust/pull/108834#issuecomment-1460705160 -- was this what you were asking for?

The only problem with this approach is that you can construct higher-ranked `Fn` obligations with GATs that *relies* on the "don't normalize GATs with escaping bound vars" behavior to fall back to relating projections via substs. See test `tests/ui/generic-associated-types/issue-93340.rs` (#93340) which fails to compile, so this would need a types FCP to confirm we're ok with the breakage :)