### PR TITLE
Add auto notification for changes to stable mir

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -451,6 +451,10 @@ cc = ["@davidtwco", "@compiler-errors", "@JohnTitor", "@TaKO8Ki"]
 message = "`rustc_macros::diagnostics` was changed"
 cc = ["@davidtwco", "@compiler-errors", "@JohnTitor", "@TaKO8Ki"]
 
+[mentions."compiler/rustc_smir"]
+message = "This PR changes Stable MIR"
+cc = ["@oli-obk", "@celinval"]
+
 [mentions."compiler/rustc_target/src/spec"]
 message = """
 These commits modify **compiler targets**.


### PR DESCRIPTION
Adds a new entry to the triagebot configuration file to notify subscribers about changes to the stable MIR. I added myself and @oli-obk for now.

r?oli-obk