### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -117,7 +117,7 @@ pub fn suggest_arbitrary_trait_bound<'tcx>(
     }
 
     let param_name = trait_pred.skip_binder().self_ty().to_string();
-    let mut constraint = trait_pred.print_modifiers_and_trait_path().to_string();
+    let mut constraint = trait_pred.to_string();
 
     if let Some((name, term)) = associated_ty {
         // FIXME: this case overlaps with code in TyCtxt::note_and_explain_type_err.
@@ -144,7 +144,7 @@ pub fn suggest_arbitrary_trait_bound<'tcx>(
              this requirement",
             if generics.where_clause_span.is_empty() { "introducing a" } else { "extending the" },
         ),
-        format!("{} {}: {}", generics.add_where_or_trailing_comma(), param_name, constraint),
+        format!("{} {constraint}", generics.add_where_or_trailing_comma()),
         Applicability::MaybeIncorrect,
     );
     true

--- a/compiler/rustc_parse/locales/en-US.ftl
+++ b/compiler/rustc_parse/locales/en-US.ftl
@@ -412,8 +412,7 @@ parse_fn_ptr_with_generics = function pointer types may not have generic paramet
         *[false] a
     } `for` parameter list
 
-parse_invalid_identifier_with_leading_number = expected identifier, found number literal
-    .label = identifiers cannot start with a number
+parse_invalid_identifier_with_leading_number = identifiers cannot start with a number
 
 parse_maybe_fn_typo_with_impl = you might have meant to write `impl` instead of `fn`
     .suggestion = replace `fn` with `impl` here

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -939,6 +939,7 @@ pub(crate) struct ExpectedIdentifier {
     pub token: Token,
     pub suggest_raw: Option<SuggEscapeToUseAsIdentifier>,
     pub suggest_remove_comma: Option<SuggRemoveComma>,
+    pub help_cannot_start_number: Option<HelpIdentifierStartsWithNumber>,
 }
 
 impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for ExpectedIdentifier {
@@ -975,9 +976,17 @@ impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for ExpectedIdentifier {
             sugg.add_to_diagnostic(&mut diag);
         }
 
+        if let Some(help) = self.help_cannot_start_number {
+            help.add_to_diagnostic(&mut diag);
+        }
+
         diag
     }
 }
+
+#[derive(Subdiagnostic)]
+#[help(parse_invalid_identifier_with_leading_number)]
+pub(crate) struct HelpIdentifierStartsWithNumber;
 
 pub(crate) struct ExpectedSemi {
     pub span: Span,
@@ -1202,14 +1211,6 @@ pub(crate) struct PatternMethodParamWithoutBody {
 #[derive(Diagnostic)]
 #[diag(parse_self_param_not_first)]
 pub(crate) struct SelfParamNotFirst {
-    #[primary_span]
-    #[label]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag(parse_invalid_identifier_with_leading_number)]
-pub(crate) struct InvalidIdentiferStartsWithNumber {
     #[primary_span]
     #[label]
     pub span: Span,

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -348,6 +348,10 @@ impl<'a> Parser<'a> {
             lo = self.token.span;
         }
 
+        if self.is_lit_bad_ident() {
+            return Err(self.expected_ident_found());
+        }
+
         let pat = if self.check(&token::BinOp(token::And)) || self.token.kind == token::AndAnd {
             self.parse_pat_deref(expected)?
         } else if self.check(&token::OpenDelim(Delimiter::Parenthesis)) {

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -273,7 +273,6 @@ impl<'a> Parser<'a> {
             self.bump();
         }
 
-        self.report_invalid_identifier_error()?;
         let (pat, colon) =
             self.parse_pat_before_ty(None, RecoverComma::Yes, PatternLocation::LetBinding)?;
 
@@ -364,17 +363,6 @@ impl<'a> Parser<'a> {
         };
         let hi = if self.token == token::Semi { self.token.span } else { self.prev_token.span };
         Ok(P(ast::Local { ty, pat, kind, id: DUMMY_NODE_ID, span: lo.to(hi), attrs, tokens: None }))
-    }
-
-    /// report error for `let 1x = 123`
-    pub fn report_invalid_identifier_error(&mut self) -> PResult<'a, ()> {
-        if let token::Literal(lit) = self.token.uninterpolate().kind &&
-            rustc_ast::MetaItemLit::from_token(&self.token).is_none() &&
-            (lit.kind == token::LitKind::Integer || lit.kind == token::LitKind::Float) &&
-            self.look_ahead(1, |t| matches!(t.kind, token::Eq) || matches!(t.kind, token::Colon ) ) {
-                return Err(self.sess.create_err(errors::InvalidIdentiferStartsWithNumber { span: self.token.span }));
-        }
-        Ok(())
     }
 
     fn check_let_else_init_bool_expr(&self, init: &ast::Expr) {

--- a/src/bootstrap/format.rs
+++ b/src/bootstrap/format.rs
@@ -159,8 +159,14 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
             if !check && paths.is_empty() {
                 match get_modified_rs_files(build) {
                     Ok(Some(files)) => {
+                        if files.len() <= 10 {
+                            for file in &files {
+                                println!("formatting modified file {file}");
+                            }
+                        } else {
+                            println!("formatting {} modified files", files.len());
+                        }
                         for file in files {
-                            println!("formatting modified file {file}");
                             ignore_fmt.add(&format!("/{file}")).expect(&file);
                         }
                     }

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -649,11 +649,35 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                      </noscript>\
                      <link rel=\"stylesheet\" \
                          href=\"{static_root_path}{settings_css}\">\
-                     <script defer src=\"{static_root_path}{settings_js}\"></script>",
+                     <script defer src=\"{static_root_path}{settings_js}\"></script>\
+                     <link rel=\"preload\" href=\"{static_root_path}{theme_light_css}\" \
+                         as=\"style\">\
+                     <link rel=\"preload\" href=\"{static_root_path}{theme_dark_css}\" \
+                         as=\"style\">\
+                     <link rel=\"preload\" href=\"{static_root_path}{theme_ayu_css}\" \
+                         as=\"style\">",
                     static_root_path = page.get_static_root_path(),
                     settings_css = static_files::STATIC_FILES.settings_css,
                     settings_js = static_files::STATIC_FILES.settings_js,
-                )
+                    theme_light_css = static_files::STATIC_FILES.theme_light_css,
+                    theme_dark_css = static_files::STATIC_FILES.theme_dark_css,
+                    theme_ayu_css = static_files::STATIC_FILES.theme_ayu_css,
+                );
+                // Pre-load all theme CSS files, so that switching feels seamless.
+                //
+                // When loading settings.html as a popover, the equivalent HTML is
+                // generated in main.js.
+                for file in &shared.style_files {
+                    if let Ok(theme) = file.basename() {
+                        write!(
+                            buf,
+                            "<link rel=\"preload\" href=\"{root_path}{theme}{suffix}.css\" \
+                                as=\"style\">",
+                            root_path = page.static_root_path.unwrap_or(""),
+                            suffix = page.resource_suffix,
+                        );
+                    }
+                }
             },
             &shared.style_files,
         );

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -29,12 +29,12 @@ pub(crate) enum LinkFromSrc {
 
 /// This function will do at most two things:
 ///
-/// 1. Generate a `span` correspondance map which links an item `span` to its definition `span`.
+/// 1. Generate a `span` correspondence map which links an item `span` to its definition `span`.
 /// 2. Collect the source code files.
 ///
-/// It returns the `krate`, the source code files and the `span` correspondance map.
+/// It returns the `krate`, the source code files and the `span` correspondence map.
 ///
-/// Note about the `span` correspondance map: the keys are actually `(lo, hi)` of `span`s. We don't
+/// Note about the `span` correspondence map: the keys are actually `(lo, hi)` of `span`s. We don't
 /// need the `span` context later on, only their position, so instead of keep a whole `Span`, we
 /// only keep the `lo` and `hi`.
 pub(crate) fn collect_spans_and_sources(

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1,19 +1,8 @@
 // Local js definitions:
 /* global addClass, getSettingValue, hasClass, searchState */
-/* global onEach, onEachLazy, removeClass */
+/* global onEach, onEachLazy, removeClass, getVar */
 
 "use strict";
-
-// Get a value from the rustdoc-vars div, which is used to convey data from
-// Rust to the JS. If there is no such element, return null.
-function getVar(name) {
-    const el = document.getElementById("rustdoc-vars");
-    if (el) {
-        return el.attributes["data-" + name].value;
-    } else {
-        return null;
-    }
-}
 
 // Given a basename (e.g. "storage") and an extension (e.g. ".js"), return a URL
 // for a resource under the root-path, with the resource-suffix.
@@ -187,6 +176,15 @@ function loadCss(cssUrl) {
     document.getElementsByTagName("head")[0].appendChild(link);
 }
 
+function preLoadCss(cssUrl) {
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload
+    const link = document.createElement("link");
+    link.href = cssUrl;
+    link.rel = "preload";
+    link.as = "style";
+    document.getElementsByTagName("head")[0].appendChild(link);
+}
+
 (function() {
     const isHelpPage = window.location.pathname.endsWith("/help.html");
 
@@ -207,6 +205,23 @@ function loadCss(cssUrl) {
         // hopefully be loaded when the JS will generate the settings content.
         loadCss(getVar("static-root-path") + getVar("settings-css"));
         loadScript(getVar("static-root-path") + getVar("settings-js"));
+        preLoadCss(getVar("static-root-path") + getVar("theme-light-css"));
+        preLoadCss(getVar("static-root-path") + getVar("theme-dark-css"));
+        preLoadCss(getVar("static-root-path") + getVar("theme-ayu-css"));
+        // Pre-load all theme CSS files, so that switching feels seamless.
+        //
+        // When loading settings.html as a standalone page, the equivalent HTML is
+        // generated in context.rs.
+        setTimeout(() => {
+            const themes = getVar("themes").split(",");
+            for (const theme of themes) {
+                // if there are no themes, do nothing
+                // "".split(",") == [""]
+                if (theme !== "") {
+                    preLoadCss(getVar("root-path") + theme + ".css");
+                }
+            }
+        }, 0);
     };
 
     window.searchState = {

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -150,7 +150,7 @@ function switchTheme(newThemeName, saveTheme) {
     }
 
     if (!window.currentTheme) {
-        document.write("<link rel=\"stylesheet\" id=\"themeStyle\" href=\"" + newHref + "\">");
+        document.write(`<link rel="stylesheet" id="themeStyle" href="${newHref}">`);
         window.currentTheme = document.getElementById("themeStyle");
     } else if (newHref !== window.currentTheme.href) {
         window.currentTheme.href = newHref;

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -99,6 +99,7 @@ function onEach(arr, func, reversed) {
  * @param {function(?)}                   func       - The callback
  * @param {boolean}                       [reversed] - Whether to iterate in reverse
  */
+// eslint-disable-next-line no-unused-vars
 function onEachLazy(lazyArray, func, reversed) {
     return onEach(
         Array.prototype.slice.call(lazyArray),

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -7,7 +7,6 @@
 
 const darkThemes = ["dark", "ayu"];
 window.currentTheme = document.getElementById("themeStyle");
-window.mainTheme = document.getElementById("mainThemeStyle");
 
 // WARNING: RUSTDOC_MOBILE_BREAKPOINT MEDIA QUERY
 // If you update this line, then you also need to update the media query with the same
@@ -43,8 +42,6 @@ function getSettingValue(settingName) {
 }
 
 const localStoredTheme = getSettingValue("theme");
-
-const savedHref = [];
 
 // eslint-disable-next-line no-unused-vars
 function hasClass(elem, className) {
@@ -125,30 +122,37 @@ function getCurrentValue(name) {
     }
 }
 
-function switchTheme(styleElem, mainStyleElem, newThemeName, saveTheme) {
+// Get a value from the rustdoc-vars div, which is used to convey data from
+// Rust to the JS. If there is no such element, return null.
+const getVar = (function getVar(name) {
+    const el = document.getElementById("rustdoc-vars");
+    if (el) {
+        return el.attributes["data-" + name].value;
+    } else {
+        return null;
+    }
+});
+
+function switchTheme(newThemeName, saveTheme) {
     // If this new value comes from a system setting or from the previously
     // saved theme, no need to save it.
     if (saveTheme) {
         updateLocalStorage("theme", newThemeName);
     }
 
-    if (savedHref.length === 0) {
-        onEachLazy(document.getElementsByTagName("link"), el => {
-            savedHref.push(el.href);
-        });
+    let newHref;
+
+    if (newThemeName === "light" || newThemeName === "dark" || newThemeName === "ayu") {
+        newHref = getVar("static-root-path") + getVar("theme-" + newThemeName + "-css");
+    } else {
+        newHref = getVar("root-path") + newThemeName + getVar("resource-suffix") + ".css";
     }
-    const newHref = savedHref.find(url => {
-        const m = url.match(/static\.files\/(.*)-[a-f0-9]{16}\.css$/);
-        if (m && m[1] === newThemeName) {
-            return true;
-        }
-        const m2 = url.match(/\/([^/]*)\.css$/);
-        if (m2 && m2[1].startsWith(newThemeName)) {
-            return true;
-        }
-    });
-    if (newHref && newHref !== styleElem.href) {
-        styleElem.href = newHref;
+
+    if (!window.currentTheme) {
+        document.write("<link rel=\"stylesheet\" id=\"themeStyle\" href=\"" + newHref + "\">");
+        window.currentTheme = document.getElementById("themeStyle");
+    } else if (newHref !== window.currentTheme.href) {
+        window.currentTheme.href = newHref;
     }
 }
 
@@ -164,7 +168,7 @@ const updateTheme = (function() {
      */
     function updateTheme() {
         const use = (theme, saveTheme) => {
-            switchTheme(window.currentTheme, window.mainTheme, theme, saveTheme);
+            switchTheme(theme, saveTheme);
         };
 
         // maybe the user has disabled the setting in the meantime!

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -17,12 +17,6 @@
     <link rel="stylesheet" {#+ #}
           href="{{static_root_path|safe}}{{files.rustdoc_css}}" {#+ #}
           id="mainThemeStyle"> {# #}
-    <link rel="stylesheet" id="themeStyle" href="{{static_root_path|safe}}{{files.theme_light_css}}"> {# #}
-    <link rel="stylesheet" disabled href="{{static_root_path|safe}}{{files.theme_dark_css}}"> {# #}
-    <link rel="stylesheet" disabled href="{{static_root_path|safe}}{{files.theme_ayu_css}}"> {# #}
-    {% for theme in themes %}
-        <link rel="stylesheet" disabled href="{{page.root_path|safe}}{{theme}}{{page.resource_suffix}}.css"> {# #}
-    {% endfor %}
     {% if !layout.default_settings.is_empty() %}
     <script id="default-settings" {#+ #}
       {%~ for (k, v) in layout.default_settings ~%}
@@ -30,6 +24,21 @@
       {% endfor %}
     ></script> {# #}
     {% endif %}
+    <div id="rustdoc-vars" {#+ #}
+         data-root-path="{{page.root_path|safe}}" {#+ #}
+         data-static-root-path="{{static_root_path|safe}}" {#+ #}
+         data-current-crate="{{layout.krate}}" {#+ #}
+         data-themes="{{themes|join(",") }}" {#+ #}
+         data-resource-suffix="{{page.resource_suffix}}" {#+ #}
+         data-rustdoc-version="{{rustdoc_version}}" {#+ #}
+         data-search-js="{{files.search_js}}" {#+ #}
+         data-settings-js="{{files.settings_js}}" {#+ #}
+         data-settings-css="{{files.settings_css}}" {#+ #}
+         data-theme-light-css="{{files.theme_light_css}}" {#+ #}
+         data-theme-dark-css="{{files.theme_dark_css}}" {#+ #}
+         data-theme-ayu-css="{{files.theme_ayu_css}}" {#+ #}
+    > {# #}
+    </div> {# #}
     <script src="{{static_root_path|safe}}{{files.storage_js}}"></script> {# #}
     {% if page.css_class.contains("crate") %}
     <script defer src="{{page.root_path|safe}}crates{{page.resource_suffix}}.js"></script> {# #}
@@ -44,6 +53,12 @@
     <script defer src="{{static_root_path|safe}}{{files.scrape_examples_js}}"></script> {# #}
     {% endif %}
     <noscript> {# #}
+        <link rel="stylesheet" {#+ #}
+           media="(prefers-color-scheme:light)" {#+ #}
+           href="{{static_root_path|safe}}{{files.theme_light_css}}"> {# #}
+        <link rel="stylesheet" {#+ #}
+           media="(prefers-color-scheme:dark)" {#+ #}
+           href="{{static_root_path|safe}}{{files.theme_dark_css}}"> {# #}
         <link rel="stylesheet" {#+ #}
            href="{{static_root_path|safe}}{{files.noscript_css}}"> {# #}
     </noscript> {# #}
@@ -132,17 +147,5 @@
         {% if page.css_class != "source" %}</div>{% endif %}
     </main> {# #}
     {{ layout.external_html.after_content|safe }}
-    <div id="rustdoc-vars" {#+ #}
-         data-root-path="{{page.root_path|safe}}" {#+ #}
-         data-static-root-path="{{static_root_path|safe}}" {#+ #}
-         data-current-crate="{{layout.krate}}" {#+ #}
-         data-themes="{{themes|join(",") }}" {#+ #}
-         data-resource-suffix="{{page.resource_suffix}}" {#+ #}
-         data-rustdoc-version="{{rustdoc_version}}" {#+ #}
-         data-search-js="{{files.search_js}}" {#+ #}
-         data-settings-js="{{files.settings_js}}" {#+ #}
-         data-settings-css="{{files.settings_css}}" {#+ #}
-    > {# #}
-    </div> {# #}
 </body> {# #}
 </html> {# #}

--- a/src/tools/tidy/src/pal.rs
+++ b/src/tools/tidy/src/pal.rs
@@ -62,6 +62,8 @@ const EXCEPTION_PATHS: &[&str] = &[
     "library/std/src/panic.rs",   // fuchsia-specific panic backtrace handling
     "library/std/src/personality.rs",
     "library/std/src/personality/",
+    "library/std/src/thread/mod.rs",
+    "library/std/src/thread/local.rs",
 ];
 
 pub fn check(path: &Path, bad: &mut bool) {
@@ -128,6 +130,7 @@ fn check_cfgs(
             || cfg.contains("target_env")
             || cfg.contains("target_abi")
             || cfg.contains("target_vendor")
+            || cfg.contains("target_family")
             || cfg.contains("unix")
             || cfg.contains("windows");
 

--- a/tests/run-make-fulldeps/rustdoc-themes/foo.rs
+++ b/tests/run-make-fulldeps/rustdoc-themes/foo.rs
@@ -1,4 +1,4 @@
 // @has test.css
 // @has foo/struct.Foo.html
-// @has - '//link[@rel="stylesheet"]/@href' '../test.css'
+// @has - '//*[@id="rustdoc-vars"]/@data-themes' 'test'
 pub struct Foo;

--- a/tests/rustdoc-gui/scrape-examples-button-focus.goml
+++ b/tests/rustdoc-gui/scrape-examples-button-focus.goml
@@ -8,24 +8,24 @@ focus: ".scraped-example-list > .scraped-example .next"
 press-key: "Enter"
 assert-property-false: (".scraped-example-list > .scraped-example pre", {
     "scrollTop": |initialScrollTop|
-})
+}, NEAR)
 focus: ".scraped-example-list > .scraped-example .prev"
 press-key: "Enter"
 assert-property: (".scraped-example-list > .scraped-example pre", {
     "scrollTop": |initialScrollTop|
-})
+}, NEAR)
 
 // The expand button increases the scrollHeight of the minimized code viewport
 store-property: (smallOffsetHeight, ".scraped-example-list > .scraped-example pre", "offsetHeight")
 assert-property-false: (".scraped-example-list > .scraped-example pre", {
     "scrollHeight": |smallOffsetHeight|
-})
+}, NEAR)
 focus: ".scraped-example-list > .scraped-example .expand"
 press-key: "Enter"
 assert-property-false: (".scraped-example-list > .scraped-example pre", {
     "offsetHeight": |smallOffsetHeight|
-})
+}, NEAR)
 store-property: (fullOffsetHeight, ".scraped-example-list > .scraped-example pre", "offsetHeight")
 assert-property: (".scraped-example-list > .scraped-example pre", {
     "scrollHeight": |fullOffsetHeight|
-})
+}, NEAR)

--- a/tests/rustdoc/issue-108679-reexport-of-reexport.rs
+++ b/tests/rustdoc/issue-108679-reexport-of-reexport.rs
@@ -1,0 +1,29 @@
+// This test ensures that the `struct.B.html` only exists in `a`:
+// since `a::B` is public (and inlined too), `self::a::B` doesn't
+// need to be inlined as well.
+
+#![crate_name = "foo"]
+
+pub mod a {
+    // @has 'foo/a/index.html'
+    // Should only contain "Structs".
+    // @count - '//*[@id="main-content"]//*[@class="item-table"]' 1
+    // @has - '//*[@id="structs"]' 'Structs'
+    // @has - '//*[@id="main-content"]//a[@href="struct.A.html"]' 'A'
+    // @has - '//*[@id="main-content"]//a[@href="struct.B.html"]' 'B'
+    mod b {
+        pub struct B;
+    }
+    pub use self::b::B;
+    pub struct A;
+}
+
+// @has 'foo/index.html'
+// @!has - '//*[@id="structs"]' 'Structs'
+// @has - '//*[@id="reexports"]' 'Re-exports'
+// @has - '//*[@id="modules"]' 'Modules'
+// @has - '//*[@id="main-content"]//*[@id="reexport.A"]' 'pub use self::a::A;'
+// @has - '//*[@id="main-content"]//*[@id="reexport.B"]' 'pub use self::a::B;'
+// Should only contain "Modules" and "Re-exports".
+// @count - '//*[@id="main-content"]//*[@class="item-table"]' 2
+pub use self::a::{A, B};

--- a/tests/ui/parser/integer-literal-start-ident.rs
+++ b/tests/ui/parser/integer-literal-start-ident.rs
@@ -1,0 +1,2 @@
+fn 1main() {}
+//~^ ERROR expected identifier, found `1main`

--- a/tests/ui/parser/integer-literal-start-ident.stderr
+++ b/tests/ui/parser/integer-literal-start-ident.stderr
@@ -1,0 +1,10 @@
+error: expected identifier, found `1main`
+  --> $DIR/integer-literal-start-ident.rs:1:4
+   |
+LL | fn 1main() {}
+   |    ^^^^^ expected identifier
+   |
+   = help: identifiers cannot start with a number
+
+error: aborting due to previous error
+

--- a/tests/ui/parser/issues/issue-104088.rs
+++ b/tests/ui/parser/issues/issue-104088.rs
@@ -4,12 +4,12 @@ fn test() {
 
 fn test_2() {
     let 1x = 123;
-    //~^ ERROR expected identifier, found number literal
+    //~^ ERROR expected identifier, found `1x`
 }
 
 fn test_3() {
     let 2x: i32 = 123;
-    //~^ ERROR expected identifier, found number literal
+    //~^ ERROR expected identifier, found `2x`
 }
 
 fn test_4() {
@@ -20,7 +20,7 @@ fn test_4() {
 
 fn test_5() {
     let 23name = 123;
-    //~^ ERROR expected identifier, found number literal
+    //~^ ERROR expected identifier, found `23name`
 }
 
 fn main() {}

--- a/tests/ui/parser/issues/issue-104088.stderr
+++ b/tests/ui/parser/issues/issue-104088.stderr
@@ -1,20 +1,26 @@
-error: expected identifier, found number literal
+error: expected identifier, found `1x`
   --> $DIR/issue-104088.rs:6:9
    |
 LL |     let 1x = 123;
-   |         ^^ identifiers cannot start with a number
+   |         ^^ expected identifier
+   |
+   = help: identifiers cannot start with a number
 
-error: expected identifier, found number literal
+error: expected identifier, found `2x`
   --> $DIR/issue-104088.rs:11:9
    |
 LL |     let 2x: i32 = 123;
-   |         ^^ identifiers cannot start with a number
+   |         ^^ expected identifier
+   |
+   = help: identifiers cannot start with a number
 
-error: expected identifier, found number literal
+error: expected identifier, found `23name`
   --> $DIR/issue-104088.rs:22:9
    |
 LL |     let 23name = 123;
-   |         ^^^^^^ identifiers cannot start with a number
+   |         ^^^^^^ expected identifier
+   |
+   = help: identifiers cannot start with a number
 
 error[E0308]: mismatched types
   --> $DIR/issue-104088.rs:16:12

--- a/tests/ui/suggestions/correct-binder-for-arbitrary-bound-sugg.rs
+++ b/tests/ui/suggestions/correct-binder-for-arbitrary-bound-sugg.rs
@@ -1,0 +1,16 @@
+trait Foo
+where
+    for<'a> &'a Self: Bar,
+{
+}
+
+impl Foo for () {}
+
+trait Bar {}
+
+impl Bar for &() {}
+
+fn foo<T: Foo>() {}
+//~^ ERROR the trait bound `for<'a> &'a T: Bar` is not satisfied
+
+fn main() {}

--- a/tests/ui/suggestions/correct-binder-for-arbitrary-bound-sugg.stderr
+++ b/tests/ui/suggestions/correct-binder-for-arbitrary-bound-sugg.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `for<'a> &'a T: Bar` is not satisfied
+  --> $DIR/correct-binder-for-arbitrary-bound-sugg.rs:13:11
+   |
+LL | fn foo<T: Foo>() {}
+   |           ^^^ the trait `for<'a> Bar` is not implemented for `&'a T`
+   |
+note: required by a bound in `Foo`
+  --> $DIR/correct-binder-for-arbitrary-bound-sugg.rs:3:23
+   |
+LL | trait Foo
+   |       --- required by a bound in this trait
+LL | where
+LL |     for<'a> &'a Self: Bar,
+   |                       ^^^ required by this bound in `Foo`
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | fn foo<T: Foo>() where for<'a> &'a T: Bar {}
+   |                  ++++++++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -451,6 +451,10 @@ cc = ["@davidtwco", "@compiler-errors", "@JohnTitor", "@TaKO8Ki"]
 message = "`rustc_macros::diagnostics` was changed"
 cc = ["@davidtwco", "@compiler-errors", "@JohnTitor", "@TaKO8Ki"]
 
+[mentions."compiler/rustc_smir"]
+message = "This PR changes Stable MIR"
+cc = ["@oli-obk", "@celinval"]
+
 [mentions."compiler/rustc_target/src/spec"]
 message = """
 These commits modify **compiler targets**.


### PR DESCRIPTION
Successful merges:

 - #106915 (Only load one CSS theme by default)
 - #108294 (Place binder correctly for arbitrary trait bound suggestion)
 - #108778 (x fmt: Don't print all modified files if there's more than 10)
 - #108854 (feat/refactor: improve errors in case of ident with number at start)
 - #108870 (Fix invalid inlining of reexport of reexport of private item)
 - #108917 (Consider target_family as pal)
 - #108922 (Add auto notification for changes to stable mir)
 - #108929 (Fix typo in span_map.rs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=106915,108294,108778,108854,108870,108917,108922,108929)
<!-- homu-ignore:end -->