### PR TITLE
Rustdoc: don't hide anonymous reexport

### DIFF
--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -223,6 +223,11 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     ) -> bool {
         debug!("maybe_inline_local res: {:?}", res);
 
+        if renamed == Some(kw::Underscore) {
+            // We never inline `_` reexports.
+            return false;
+        }
+
         if self.cx.output_format.is_json() {
             return false;
         }
@@ -329,8 +334,8 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     self.visit_foreign_item_inner(item, None);
                 }
             }
-            // If we're inlining, skip private items or item reexported as "_".
-            _ if self.inlining && (!is_pub || renamed == Some(kw::Underscore)) => {}
+            // If we're inlining, skip private items.
+            _ if self.inlining && !is_pub => {}
             hir::ItemKind::GlobalAsm(..) => {}
             hir::ItemKind::Use(_, hir::UseKind::ListStem) => {}
             hir::ItemKind::Use(path, kind) => {

--- a/tests/rustdoc/anonymous-reexport.rs
+++ b/tests/rustdoc/anonymous-reexport.rs
@@ -4,9 +4,13 @@
 
 // @has 'foo/index.html'
 // @has - '//*[@id="main-content"]' ''
-// We check that the only "h2" present is for "Bla".
-// @count - '//*[@id="main-content"]/h2' 1
+// We check that the only "h2" present are "Structs" (for "Bla") and "Re-exports".
+// @count - '//*[@id="main-content"]/h2' 2
 // @has - '//*[@id="main-content"]/h2' 'Structs'
+// @has - '//*[@id="main-content"]/h2' 'Re-exports'
+// The 3 re-exports.
+// @count - '//*[@id="main-content"]//*[@class="item-table"]//li//code' 3
+// The public struct.
 // @count - '//*[@id="main-content"]//a[@class="struct"]' 1
 
 mod ext {

--- a/tests/rustdoc/issue-108931-anonymous-reexport.rs
+++ b/tests/rustdoc/issue-108931-anonymous-reexport.rs
@@ -1,0 +1,21 @@
+// Ensuring that anonymous re-exports are always inlined.
+
+#![crate_name = "foo"]
+
+pub mod foo {
+    pub struct Foo;
+}
+
+mod bar {
+    pub struct Bar;
+}
+
+// @has 'foo/index.html'
+// We check that the only "h2" present are "Re-exports" and "Modules".
+// @count - '//*[@id="main-content"]/h2' 2
+// @has - '//*[@id="main-content"]/h2' 'Re-exports'
+// @has - '//*[@id="main-content"]/h2' 'Modules'
+// @has - '//*[@id="main-content"]//*[@class="item-table"]//li//code' 'pub use foo::Foo as _;'
+// @has - '//*[@id="main-content"]//*[@class="item-table"]//li//code' 'pub use bar::Bar as _;'
+pub use foo::Foo as _;
+pub use bar::Bar as _;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/108931.

From https://github.com/rust-lang/rust/issues/108931, it appears that having anonymous re-exports for traits is actually used in some places, so instead of hiding them automatically, we should prevent them to be ever inlined.

r? @notriddle 