### PR TITLE
Document the resulting values produced when using `From<bool>` on floats

### DIFF
--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -182,7 +182,8 @@ impl const From<bool> for f32 {
 #[stable(feature = "float_from_bool", since = "1.68.0")]
 #[rustc_const_unstable(feature = "const_num_from_num", issue = "87852")]
 impl const From<bool> for f64 {
-    /// Converts `bool` to `f64` losslessly.
+    /// Converts `bool` to `f64` losslessly. The resulting value is positive
+    /// `0.0` for `false` and `1.0` for `true` values.
     #[inline]
     fn from(small: bool) -> Self {
         small as u8 as Self

--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -172,8 +172,8 @@ impl_from! { f32, f64, #[stable(feature = "lossless_float_conv", since = "1.6.0"
 #[stable(feature = "float_from_bool", since = "1.68.0")]
 #[rustc_const_unstable(feature = "const_num_from_num", issue = "87852")]
 impl const From<bool> for f32 {
-    /// Converts `bool` to `f32` losslessly. The resulting value is `0.0` for
-    /// `false` and `1.0` for `true` values.
+    /// Converts `bool` to `f32` losslessly. The resulting value is positive
+    /// `0.0` for `false` and `1.0` for `true` values.
     #[inline]
     fn from(small: bool) -> Self {
         small as u8 as Self

--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -174,6 +174,16 @@ impl_from! { f32, f64, #[stable(feature = "lossless_float_conv", since = "1.6.0"
 impl const From<bool> for f32 {
     /// Converts `bool` to `f32` losslessly. The resulting value is positive
     /// `0.0` for `false` and `1.0` for `true` values.
+    ///
+    /// # Examples
+    /// ```
+    /// let x: f32 = false.into();
+    /// assert_eq!(x, 0.0);
+    /// assert!(x.is_sign_positive());
+    ///
+    /// let y: f32 = true.into();
+    /// assert_eq!(y, 1.0);
+    /// ```
     #[inline]
     fn from(small: bool) -> Self {
         small as u8 as Self
@@ -184,6 +194,16 @@ impl const From<bool> for f32 {
 impl const From<bool> for f64 {
     /// Converts `bool` to `f64` losslessly. The resulting value is positive
     /// `0.0` for `false` and `1.0` for `true` values.
+    ///
+    /// # Examples
+    /// ```
+    /// let x: f64 = false.into();
+    /// assert_eq!(x, 0.0);
+    /// assert!(x.is_sign_positive());
+    ///
+    /// let y: f64 = true.into();
+    /// assert_eq!(y, 1.0);
+    /// ```
     #[inline]
     fn from(small: bool) -> Self {
         small as u8 as Self

--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -172,7 +172,8 @@ impl_from! { f32, f64, #[stable(feature = "lossless_float_conv", since = "1.6.0"
 #[stable(feature = "float_from_bool", since = "1.68.0")]
 #[rustc_const_unstable(feature = "const_num_from_num", issue = "87852")]
 impl const From<bool> for f32 {
-    /// Converts `bool` to `f32` losslessly.
+    /// Converts `bool` to `f32` losslessly. The resulting value is `0.0` for
+    /// `false` and `1.0` for `true` values.
     #[inline]
     fn from(small: bool) -> Self {
         small as u8 as Self


### PR DESCRIPTION
Have the documentation of the implementation of `From<bool>` on `f32` and `f64` indicate the output values (`0.0` for `false` and `1.0` for `true`).

closes #108939