### PR TITLE
Regression test `println!()` panic message on `ErrorKind::BrokenPipe`

### DIFF
--- a/tests/ui/process/println-with-broken-pipe.rs
+++ b/tests/ui/process/println-with-broken-pipe.rs
@@ -1,0 +1,44 @@
+// run-pass
+// check-run-results
+// ignore-windows
+// ignore-emscripten
+// ignore-fuchsia
+// ignore-horizon
+// ignore-android
+// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
+
+// Test what the error message looks like when `println!()` panics because of
+// `std::io::ErrorKind::BrokenPipe`
+
+#![feature(unix_sigpipe)]
+
+use std::env;
+use std::process::{Command, Stdio};
+
+#[unix_sigpipe = "sig_ign"]
+fn main() {
+    let mut args = env::args();
+    let me = args.next().unwrap();
+
+    if let Some(arg) = args.next() {
+        // More than enough iterations to fill any pipe buffer. Normally this
+        // loop will end with a panic more or less immediately.
+        for _ in 0..65536 * 64 {
+            println!("{arg}");
+        }
+        unreachable!("should have panicked because of BrokenPipe");
+    }
+
+    // Set up a pipeline with a short-lived consumer and wait for it to finish.
+    // This will produce the `println!()` panic message on stderr.
+    let mut producer = Command::new(&me)
+        .arg("this line shall appear exactly once on stdout")
+        .env("RUST_BACKTRACE", "0")
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut consumer =
+        Command::new("head").arg("-n1").stdin(producer.stdout.take().unwrap()).spawn().unwrap();
+    consumer.wait().unwrap();
+    producer.wait().unwrap();
+}

--- a/tests/ui/process/println-with-broken-pipe.run.stderr
+++ b/tests/ui/process/println-with-broken-pipe.run.stderr
@@ -1,0 +1,2 @@
+thread 'main' panicked at 'failed printing to stdout: Broken pipe (os error 32)', library/std/src/io/stdio.rs:LL:CC
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/process/println-with-broken-pipe.run.stdout
+++ b/tests/ui/process/println-with-broken-pipe.run.stdout
@@ -1,0 +1,1 @@
+this line shall appear exactly once on stdout


### PR DESCRIPTION
No existing test (that I could find) failed if the `panic!()` of the `println!()` family of functions was removed, or if its message was changed:

https://github.com/rust-lang/rust/blob/104f4300cfddbd956e32820ef202a732f06ec848/library/std/src/io/stdio.rs#L1007-L1009

So add such a test.

This is in preparation of adding a hint about the existence of [`unix_sigpipe`](https://github.com/rust-lang/rust/issues/97889) if that is the reason for the panic.

Even if we don't end up adding a hint, this is still a sensible test to have, I think.

@rustbot label +A-testsuite +A-io +T-libs +O-unix 