### PR TITLE
Implement `fs_native_path`

### DIFF
--- a/library/std/src/os/unix/ffi/mod.rs
+++ b/library/std/src/os/unix/ffi/mod.rs
@@ -38,5 +38,24 @@
 
 mod os_str;
 
+use crate::ffi::CStr;
+use crate::path::NativePath;
+
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::os_str::{OsStrExt, OsStringExt};
+
+#[unstable(feature = "fs_native_path", issue = "108979")]
+pub trait NativePathExt: crate::sealed::Sealed {
+    fn from_cstr(cstr: &CStr) -> &NativePath;
+    fn into_cstr(&self) -> &CStr;
+}
+
+#[unstable(feature = "fs_native_path", issue = "108979")]
+impl NativePathExt for NativePath {
+    fn from_cstr(cstr: &CStr) -> &NativePath {
+        unsafe { &*(cstr as *const CStr as *const NativePath) }
+    }
+    fn into_cstr(&self) -> &CStr {
+        unsafe { &*(self as *const Self as *const CStr) }
+    }
+}

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -8,7 +8,7 @@ use super::platform::fs::MetadataExt as _;
 use crate::fs::{self, OpenOptions, Permissions};
 use crate::io;
 use crate::os::unix::io::{AsFd, AsRawFd};
-use crate::path::Path;
+use crate::path::{AsPath, Path};
 use crate::sys;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner};
 // Used for `File::read` on intra-doc links
@@ -954,8 +954,8 @@ impl DirEntryExt2 for fs::DirEntry {
 /// }
 /// ```
 #[stable(feature = "symlink", since = "1.1.0")]
-pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
-    sys::fs::symlink(original.as_ref(), link.as_ref())
+pub fn symlink<P: AsPath, Q: AsPath>(original: P, link: Q) -> io::Result<()> {
+    sys::fs::fs_imp::soft_link(original, link)
 }
 
 /// Unix-specific extensions to [`fs::DirBuilder`].

--- a/library/std/src/os/wasi/fs.rs
+++ b/library/std/src/os/wasi/fs.rs
@@ -563,7 +563,9 @@ pub fn symlink<P: AsRef<Path>, U: AsRef<Path>>(
 /// This is a convenience API similar to `std::os::unix::fs::symlink` and
 /// `std::os::windows::fs::symlink_file` and `std::os::windows::fs::symlink_dir`.
 pub fn symlink_path<P: AsRef<Path>, U: AsRef<Path>>(old_path: P, new_path: U) -> io::Result<()> {
-    crate::sys::fs::symlink(old_path.as_ref(), new_path.as_ref())
+    crate::sys::common::small_c_string::run_path_with_cstr(new_path.as_ref(), &|new_path| {
+        crate::sys::fs::symlink(old_path.as_ref(), new_path)
+    })
 }
 
 fn osstr2str(f: &OsStr) -> io::Result<&str> {

--- a/library/std/src/os/windows/fs.rs
+++ b/library/std/src/os/windows/fs.rs
@@ -6,7 +6,7 @@
 
 use crate::fs::{self, Metadata, OpenOptions};
 use crate::io;
-use crate::path::Path;
+use crate::path::AsPath;
 use crate::sealed::Sealed;
 use crate::sys;
 use crate::sys_common::{AsInner, AsInnerMut, IntoInner};
@@ -578,8 +578,9 @@ impl FileTimesExt for fs::FileTimes {
 ///
 /// [symlink-security]: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links
 #[stable(feature = "symlink", since = "1.1.0")]
-pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
-    sys::fs::symlink_inner(original.as_ref(), link.as_ref(), false)
+pub fn symlink_file<P: AsPath, Q: AsPath>(original: P, link: Q) -> io::Result<()> {
+    original
+        .with_path(|original| link.with_path(|link| sys::fs::symlink_inner(original, link, false)))
 }
 
 /// Creates a new symlink to a directory on the filesystem.
@@ -617,6 +618,7 @@ pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io:
 ///
 /// [symlink-security]: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links
 #[stable(feature = "symlink", since = "1.1.0")]
-pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
-    sys::fs::symlink_inner(original.as_ref(), link.as_ref(), true)
+pub fn symlink_dir<P: AsPath, Q: AsPath>(original: P, link: Q) -> io::Result<()> {
+    original
+        .with_path(|original| link.with_path(|link| sys::fs::symlink_inner(original, link, true)))
 }

--- a/library/std/src/sys/pal/unix/process/process_common.rs
+++ b/library/std/src/sys/pal/unix/process/process_common.rs
@@ -481,7 +481,7 @@ impl Stdio {
                 let mut opts = OpenOptions::new();
                 opts.read(readable);
                 opts.write(!readable);
-                let fd = File::open_c(DEV_NULL, &opts)?;
+                let fd = File::open_native(DEV_NULL, &opts)?;
                 Ok((ChildStdio::Owned(fd.into_inner()), None))
             }
 

--- a/library/std/src/sys/pal/unsupported/fs.rs
+++ b/library/std/src/sys/pal/unsupported/fs.rs
@@ -1,4 +1,4 @@
-use crate::ffi::OsString;
+use crate::ffi::{CStr, OsString};
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, SeekFrom};
@@ -13,6 +13,60 @@ pub struct FileAttr(!);
 pub struct ReadDir(!);
 
 pub struct DirEntry(!);
+
+#[allow(unused_variables)]
+pub(crate) mod fs_imp {
+    use super::unsupported;
+    pub(crate) use super::{
+        DirBuilder, DirEntry, File, FileAttr, FilePermissions, FileTimes, FileType, OpenOptions,
+        ReadDir,
+    };
+    use crate::io;
+    use crate::path::{AsPath, PathBuf};
+
+    pub(crate) fn remove_file<P: AsPath>(path: P) -> io::Result<()> {
+        unsupported()
+    }
+    pub(crate) fn symlink_metadata<P: AsPath>(path: P) -> io::Result<FileAttr> {
+        unsupported()
+    }
+    pub(crate) fn metadata<P: AsPath>(path: P) -> io::Result<FileAttr> {
+        unsupported()
+    }
+    pub(crate) fn rename<P: AsPath, Q: AsPath>(from: P, to: Q) -> io::Result<()> {
+        unsupported()
+    }
+    pub(crate) fn hard_link<P: AsPath, Q: AsPath>(original: P, link: Q) -> io::Result<()> {
+        unsupported()
+    }
+    pub(crate) fn soft_link<P: AsPath, Q: AsPath>(original: P, link: Q) -> io::Result<()> {
+        unsupported()
+    }
+    pub(crate) fn remove_dir<P: AsPath>(path: P) -> io::Result<()> {
+        unsupported()
+    }
+    pub(crate) fn read_dir<P: AsPath>(path: P) -> io::Result<ReadDir> {
+        unsupported()
+    }
+    pub(crate) fn set_permissions<P: AsPath>(path: P, perms: FilePermissions) -> io::Result<()> {
+        unsupported()
+    }
+    pub(crate) fn copy<P: AsPath, Q: AsPath>(from: P, to: Q) -> io::Result<u64> {
+        unsupported()
+    }
+    pub(crate) fn canonicalize<P: AsPath>(path: P) -> io::Result<PathBuf> {
+        unsupported()
+    }
+    pub(crate) fn remove_dir_all<P: AsPath>(path: P) -> io::Result<()> {
+        unsupported()
+    }
+    pub(crate) fn read_link<P: AsPath>(path: P) -> io::Result<PathBuf> {
+        unsupported()
+    }
+    pub(crate) fn try_exists<P: AsPath>(path: P) -> io::Result<bool> {
+        unsupported()
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct OpenOptions {}
@@ -182,7 +236,7 @@ impl OpenOptions {
 }
 
 impl File {
-    pub fn open(_path: &Path, _opts: &OpenOptions) -> io::Result<File> {
+    pub fn open_native(_path: &CStr, _opts: &OpenOptions) -> io::Result<File> {
         unsupported()
     }
 
@@ -265,60 +319,4 @@ impl fmt::Debug for File {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0
     }
-}
-
-pub fn readdir(_p: &Path) -> io::Result<ReadDir> {
-    unsupported()
-}
-
-pub fn unlink(_p: &Path) -> io::Result<()> {
-    unsupported()
-}
-
-pub fn rename(_old: &Path, _new: &Path) -> io::Result<()> {
-    unsupported()
-}
-
-pub fn set_perm(_p: &Path, perm: FilePermissions) -> io::Result<()> {
-    match perm.0 {}
-}
-
-pub fn rmdir(_p: &Path) -> io::Result<()> {
-    unsupported()
-}
-
-pub fn remove_dir_all(_path: &Path) -> io::Result<()> {
-    unsupported()
-}
-
-pub fn try_exists(_path: &Path) -> io::Result<bool> {
-    unsupported()
-}
-
-pub fn readlink(_p: &Path) -> io::Result<PathBuf> {
-    unsupported()
-}
-
-pub fn symlink(_original: &Path, _link: &Path) -> io::Result<()> {
-    unsupported()
-}
-
-pub fn link(_src: &Path, _dst: &Path) -> io::Result<()> {
-    unsupported()
-}
-
-pub fn stat(_p: &Path) -> io::Result<FileAttr> {
-    unsupported()
-}
-
-pub fn lstat(_p: &Path) -> io::Result<FileAttr> {
-    unsupported()
-}
-
-pub fn canonicalize(_p: &Path) -> io::Result<PathBuf> {
-    unsupported()
-}
-
-pub fn copy(_from: &Path, _to: &Path) -> io::Result<u64> {
-    unsupported()
 }

--- a/library/std/src/sys/pal/windows/pipe.rs
+++ b/library/std/src/sys/pal/windows/pipe.rs
@@ -3,7 +3,6 @@ use crate::os::windows::prelude::*;
 use crate::ffi::OsStr;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, Read};
 use crate::mem;
-use crate::path::Path;
 use crate::ptr;
 use crate::slice;
 use crate::sync::atomic::AtomicUsize;
@@ -12,6 +11,7 @@ use crate::sys::c;
 use crate::sys::fs::{File, OpenOptions};
 use crate::sys::handle::Handle;
 use crate::sys::hashmap_random_keys;
+use crate::sys::path::NativePathBuf;
 use crate::sys_common::{FromInner, IntoInner};
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -161,7 +161,8 @@ pub fn anon_pipe(ours_readable: bool, their_handle_inheritable: bool) -> io::Res
             bInheritHandle: their_handle_inheritable as i32,
         };
         opts.security_attributes(&mut sa);
-        let theirs = File::open(Path::new(&name), &opts)?;
+        let path = NativePathBuf::from_os_str(&name)?;
+        let theirs = File::open_native(&path, &opts)?;
         let theirs = AnonPipe { inner: theirs.into_inner() };
 
         Ok(Pipes {

--- a/library/std/src/sys/pal/windows/process.rs
+++ b/library/std/src/sys/pal/windows/process.rs
@@ -23,7 +23,7 @@ use crate::sys::c::{self, NonZeroDWORD, EXIT_FAILURE, EXIT_SUCCESS};
 use crate::sys::cvt;
 use crate::sys::fs::{File, OpenOptions};
 use crate::sys::handle::Handle;
-use crate::sys::path;
+use crate::sys::path::{self, NativePathBuf};
 use crate::sys::pipe::{self, AnonPipe};
 use crate::sys::stdio;
 use crate::sys_common::process::{CommandEnv, CommandEnvs};
@@ -597,7 +597,8 @@ impl Stdio {
                 opts.read(stdio_id == c::STD_INPUT_HANDLE);
                 opts.write(stdio_id != c::STD_INPUT_HANDLE);
                 opts.security_attributes(&mut sa);
-                File::open(Path::new(r"\\.\NUL"), &opts).map(|file| file.into_inner())
+                File::open_native(&NativePathBuf::from_os_str(r"\\.\NUL")?, &opts)
+                    .map(|file| file.into_inner())
             }
         }
     }

--- a/library/std/src/sys/path/cstr_native.rs
+++ b/library/std/src/sys/path/cstr_native.rs
@@ -1,0 +1,35 @@
+use crate::ffi::CStr;
+use crate::io;
+use crate::mem;
+use crate::path::{AsPath, Path};
+use crate::sys::common::small_c_string::run_path_with_cstr;
+
+pub type NativePath = CStr;
+
+#[unstable(feature = "fs_native_path_internals", issue = "none")]
+impl<P: AsRef<Path>> AsPath for P {
+    #[doc(hidden)]
+    fn with_path<T, F: FnOnce(&Path) -> io::Result<T>>(self, f: F) -> io::Result<T> {
+        f(self.as_ref())
+    }
+    #[doc(hidden)]
+    fn with_native_path<T, F: Fn(&NativePath) -> io::Result<T>>(self, f: F) -> io::Result<T> {
+        run_path_with_cstr(self.as_ref(), &f)
+    }
+}
+
+#[unstable(feature = "fs_native_path_internals", issue = "none")]
+impl AsPath for &crate::path::NativePath {
+    #[doc(hidden)]
+    fn with_path<T, F: FnOnce(&Path) -> io::Result<T>>(self, f: F) -> io::Result<T> {
+        // SAFETY: OsStr is a byte slice on platforms with CStr paths.
+        // Note: We can't use os::unix::OsStrExt because that isn't necessarily
+        // available for all platforms that use CStr paths.
+        let osstr: &Path = unsafe { mem::transmute(self.0.to_bytes()) };
+        f(osstr)
+    }
+    #[doc(hidden)]
+    fn with_native_path<T, F: Fn(&NativePath) -> io::Result<T>>(self, f: F) -> io::Result<T> {
+        f(&self.0)
+    }
+}

--- a/library/std/src/sys/path/mod.rs
+++ b/library/std/src/sys/path/mod.rs
@@ -1,4 +1,11 @@
 cfg_if::cfg_if! {
+    if #[cfg(not(target_os = "windows"))] {
+        mod cstr_native;
+        pub use cstr_native::NativePath;
+    }
+}
+
+cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {
         mod windows;
         pub use windows::*;

--- a/library/std/src/sys/path/windows/tests.rs
+++ b/library/std/src/sys/path/windows/tests.rs
@@ -38,7 +38,7 @@ fn verbatim() {
     use crate::path::Path;
     fn check(path: &str, expected: &str) {
         let verbatim = maybe_verbatim(Path::new(path)).unwrap();
-        let verbatim = String::from_utf16_lossy(verbatim.strip_suffix(&[0]).unwrap());
+        let verbatim = String::from_utf16_lossy(verbatim.0.strip_suffix(&[0]).unwrap());
         assert_eq!(&verbatim, expected, "{}", path);
     }
 

--- a/src/tools/miri/tests/fail/shims/fs/isolated_file.stderr
+++ b/src/tools/miri/tests/fail/shims/fs/isolated_file.stderr
@@ -8,15 +8,15 @@ LL |         let fd = cvt_r(|| unsafe { open64(path.as_ptr(), flags, opts.mode a
    = help: or pass `-Zmiri-isolation-error=warn` to configure Miri to return an error code from isolated operations (if supported for that operation) and continue with a warning
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/sys/pal/PLATFORM/fs.rs:LL:CC
-   = note: inside `std::sys::pal::PLATFORM::cvt_r::<i32, {closure@std::sys::pal::PLATFORM::fs::File::open_c::{closure#0}}>` at RUSTLIB/std/src/sys/pal/PLATFORM/mod.rs:LL:CC
-   = note: inside `std::sys::pal::PLATFORM::fs::File::open_c` at RUSTLIB/std/src/sys/pal/PLATFORM/fs.rs:LL:CC
-   = note: inside closure at RUSTLIB/std/src/sys/pal/PLATFORM/fs.rs:LL:CC
-   = note: inside `std::sys::pal::PLATFORM::small_c_string::run_with_cstr_stack::<std::sys::pal::PLATFORM::fs::File>` at RUSTLIB/std/src/sys/pal/PLATFORM/small_c_string.rs:LL:CC
-   = note: inside `std::sys::pal::PLATFORM::small_c_string::run_with_cstr::<std::sys::pal::PLATFORM::fs::File>` at RUSTLIB/std/src/sys/pal/PLATFORM/small_c_string.rs:LL:CC
-   = note: inside `std::sys::pal::PLATFORM::small_c_string::run_path_with_cstr::<std::sys::pal::PLATFORM::fs::File>` at RUSTLIB/std/src/sys/pal/PLATFORM/small_c_string.rs:LL:CC
-   = note: inside `std::sys::pal::PLATFORM::fs::File::open` at RUSTLIB/std/src/sys/pal/PLATFORM/fs.rs:LL:CC
+   = note: inside `std::sys::pal::PLATFORM::cvt_r::<i32, {closure@std::sys::pal::PLATFORM::fs::File::open_native::{closure#0}}>` at RUSTLIB/std/src/sys/pal/PLATFORM/mod.rs:LL:CC
+   = note: inside `std::sys::pal::PLATFORM::fs::File::open_native` at RUSTLIB/std/src/sys/pal/PLATFORM/fs.rs:LL:CC
    = note: inside `std::fs::OpenOptions::_open` at RUSTLIB/std/src/fs.rs:LL:CC
-   = note: inside `std::fs::OpenOptions::open::<&std::path::Path>` at RUSTLIB/std/src/fs.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/fs.rs:LL:CC
+   = note: inside `std::sys::pal::PLATFORM::small_c_string::run_with_cstr_stack::<std::fs::File>` at RUSTLIB/std/src/sys/pal/PLATFORM/small_c_string.rs:LL:CC
+   = note: inside `std::sys::pal::PLATFORM::small_c_string::run_with_cstr::<std::fs::File>` at RUSTLIB/std/src/sys/pal/PLATFORM/small_c_string.rs:LL:CC
+   = note: inside `std::sys::pal::PLATFORM::small_c_string::run_path_with_cstr::<std::fs::File>` at RUSTLIB/std/src/sys/pal/PLATFORM/small_c_string.rs:LL:CC
+   = note: inside `std::sys::path::cstr_native::<impl std::path::AsPath for &str>::with_native_path::<std::fs::File, {closure@std::fs::OpenOptions::open<&str>::{closure#0}}>` at RUSTLIB/std/src/sys/path/cstr_native.rs:LL:CC
+   = note: inside `std::fs::OpenOptions::open::<&str>` at RUSTLIB/std/src/fs.rs:LL:CC
    = note: inside `std::fs::File::open::<&str>` at RUSTLIB/std/src/fs.rs:LL:CC
 note: inside `main`
   --> $DIR/isolated_file.rs:LL:CC

--- a/tests/ui/async-await/issue-72442.stderr
+++ b/tests/ui/async-await/issue-72442.stderr
@@ -1,11 +1,13 @@
-error[E0277]: the trait bound `Option<&str>: AsRef<Path>` is not satisfied
+error[E0277]: the trait bound `Option<&str>: AsPath` is not satisfied
   --> $DIR/issue-72442.rs:12:36
    |
 LL |             let mut f = File::open(path.to_str())?;
-   |                         ---------- ^^^^^^^^^^^^^ the trait `AsRef<Path>` is not implemented for `Option<&str>`
+   |                         ---------- ^^^^^^^^^^^^^ the trait `AsRef<Path>` is not implemented for `Option<&str>`, which is required by `Option<&str>: AsPath`
    |                         |
    |                         required by a bound introduced by this call
    |
+   = help: the trait `AsPath` is implemented for `&NativePath`
+   = note: required for `Option<&str>` to implement `AsPath`
 note: required by a bound in `File::open`
   --> $SRC_DIR/std/src/fs.rs:LL:COL
 help: consider removing this method call, as the receiver has type `&Path` and `&Path: AsRef<Path>` trivially holds


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/108981)*
<!-- homu-ignore:end -->

Implements the [`fs_native_path`](https://github.com/rust-lang/rust/issues/108979) feature. See also https://github.com/rust-lang/libs-team/issues/62.

### Internal changes

Ultimately, I'd envision that Unix filesystem functions (for example) would simply take either an `&CStr` or maybe an internal `&PosixPath` type with relevant helper methods. However, as much as I'd love to transition immediately, I think it's more prudent to take it slower. If nothing else it'll be easier on reviewers. So this PR just moves the responsibility for creating concrete types into `sys::fs` while touching as little existing code as possible, which should then allow platforms to make changes at their own pace.
