### PR TITLE
sync LVI tests

### DIFF
--- a/tests/assembly/is_aligned.rs
+++ b/tests/assembly/is_aligned.rs
@@ -1,6 +1,7 @@
 // assembly-output: emit-asm
 // min-llvm-version: 15.0
 // only-x86_64
+// ignore-sgx
 // revisions: opt-speed opt-size
 // [opt-speed] compile-flags: -Copt-level=1
 // [opt-size] compile-flags: -Copt-level=s

--- a/tests/assembly/strict_provenance.rs
+++ b/tests/assembly/strict_provenance.rs
@@ -1,6 +1,7 @@
 // assembly-output: emit-asm
 // compile-flags: -Copt-level=1
 // only-x86_64
+// ignore-sgx
 // min-llvm-version: 15.0
 #![crate_type = "rlib"]
 

--- a/tests/assembly/x86_64-floating-point-clamp.rs
+++ b/tests/assembly/x86_64-floating-point-clamp.rs
@@ -4,6 +4,7 @@
 // assembly-output: emit-asm
 // compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel
 // only-x86_64
+// ignore-sgx
 
 // CHECK-LABEL: clamp_demo:
 #[no_mangle]

--- a/tests/assembly/x86_64-fortanix-unknown-sgx-lvi-generic-load.rs
+++ b/tests/assembly/x86_64-fortanix-unknown-sgx-lvi-generic-load.rs
@@ -11,7 +11,7 @@ pub extern fn plus_one(r: &mut u64) {
 
 // CHECK: plus_one
 // CHECK: lfence
-// CHECK-NEXT: addq
+// CHECK-NEXT: incq
 // CHECK: popq [[REGISTER:%[a-z]+]]
 // CHECK-NEXT: lfence
 // CHECK-NEXT: jmpq *[[REGISTER]]

--- a/tests/assembly/x86_64-fortanix-unknown-sgx-lvi-inline-assembly.rs
+++ b/tests/assembly/x86_64-fortanix-unknown-sgx-lvi-inline-assembly.rs
@@ -10,9 +10,7 @@ use std::arch::asm;
 pub extern "C" fn get(ptr: *const u64) -> u64 {
     let value: u64;
     unsafe {
-        asm!(".start_inline_asm:",
-            "mov {}, [{}]",
-            ".end_inline_asm:",
+        asm!("mov {}, [{}]",
             out(reg) value,
             in(reg) ptr);
     }
@@ -20,24 +18,17 @@ pub extern "C" fn get(ptr: *const u64) -> u64 {
 }
 
 // CHECK: get
-// CHECK: .start_inline_asm
-// CHECK-NEXT: movq
+// CHECK: movq
 // CHECK-NEXT: lfence
-// CHECK-NEXT: .end_inline_asm
 
 #[no_mangle]
 pub extern "C" fn myret() {
     unsafe {
-        asm!(
-            ".start_myret_inline_asm:",
-            "ret",
-            ".end_myret_inline_asm:",
-        );
+        asm!("ret");
     }
 }
 
 // CHECK: myret
-// CHECK: .start_myret_inline_asm
-// CHECK-NEXT: shlq $0, (%rsp)
+// CHECK: shlq $0, (%rsp)
 // CHECK-NEXT: lfence
 // CHECK-NEXT: retq

--- a/tests/assembly/x86_64-no-jump-tables.rs
+++ b/tests/assembly/x86_64-no-jump-tables.rs
@@ -6,6 +6,7 @@
 // compile-flags: -O
 // [set] compile-flags: -Zno-jump-tables
 // only-x86_64
+// ignore-sgx
 
 #![crate_type = "lib"]
 

--- a/tests/run-make/issue-36710/Makefile
+++ b/tests/run-make/issue-36710/Makefile
@@ -4,6 +4,7 @@
 # ignore-nvptx64-nvidia-cuda FIXME: can't find crate for `std`
 # ignore-musl FIXME: this makefile needs teaching how to use a musl toolchain
 #                    (see dist-i586-gnu-i586-i686-musl Dockerfile)
+# ignore-sgx
 
 include ../../run-make-fulldeps/tools.mk
 

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_asm.checks
@@ -1,8 +1,7 @@
 CHECK: cc_plus_one_asm
 CHECK-NEXT: movl
 CHECK-NEXT: lfence
-CHECK-NEXT: inc
-CHECK-NEXT: notq (%rsp)
-CHECK-NEXT: notq (%rsp)
+CHECK-NEXT: incl
+CHECK-NEXT: shlq $0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/jumpto.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/jumpto.checks
@@ -1,8 +1,24 @@
-CHECK: libunwind::Registers_x86_64::jumpto
+CHECK: __libunwind_Registers_x86_64_jumpto
 CHECK:      lfence
 CHECK:      lfence
 CHECK:      lfence
 CHECK:      lfence
-CHECK:      shlq    $0, (%rsp)
+CHECK:      lfence
+CHECK:      lfence
+CHECK:      lfence
+CHECK:      lfence
+CHECK:      lfence
+CHECK:      lfence
+CHECK:      lfence
+CHECK:      lfence
+CHECK:      lfence
+CHECK:      lfence
+CHECK:      lfence
+CHECK:      lfence
+CHECK:      lfence
+CHECK:      lfence
+CHECK-NEXT: popq [[REGISTER:%[a-z]+]]
 CHECK-NEXT: lfence
-CHECK-NEXT: retq
+CHECK-NEXT: popq [[REGISTER:%[a-z]+]]
+CHECK-NEXT: lfence
+CHECK-NEXT: jmpq *[[REGISTER]]

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/print.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/print.checks
@@ -2,6 +2,5 @@ CHECK: print
 CHECK:      lfence
 CHECK:      lfence
 CHECK:      lfence
-CHECK:      popq
 CHECK:      callq 0x{{[[:xdigit:]]*}} <_Unwind_Resume>
 CHECK-NEXT: ud2


### PR DESCRIPTION
The LVI tests for the `x86_64-fortanix-unknown-sgx` target have gotten out of sync. LVI is still mitigated correctly, but the LVI tests need minor modifications. Other (non LVI-related) tests fail when the target applies LVI mitigations as they assume the generated code contains forbidden instructions such as `retq`. These tests are ignored for the sgx environment.

cc: @jethrogb