### PR TITLE
Change text -> rust highlighting in sanitizer.md

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/sanitizer.md
+++ b/src/doc/unstable-book/src/compiler-flags/sanitizer.md
@@ -213,7 +213,7 @@ See the [Clang ControlFlowIntegrity documentation][clang-cfi] for more details.
 
 ## Example
 
-```text
+```rust,ignore
 #![feature(naked_functions)]
 
 use std::arch::asm;
@@ -238,7 +238,7 @@ pub extern "C" fn add_two(x: i32) {
              nop
              nop
              nop
-             lea rax, [rdi+2]
+             lea eax, [edi+2]
              ret
         ",
             options(noreturn)


### PR DESCRIPTION
Not sure why this has syntax highlighting turned off, but it doesn't need to be

Relevant page: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html