### PR TITLE
Added byte position range for `proc_macro::Span`

### DIFF
--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -640,10 +640,7 @@ impl server::Span for Rustc<'_, '_> {
         let relative_start_pos = source_map.lookup_byte_offset(span.lo()).pos;
         let relative_end_pos = source_map.lookup_byte_offset(span.hi()).pos;
 
-        Range {
-            start: relative_start_pos.0 as usize,
-            end: relative_end_pos.0 as usize
-        }
+        Range { start: relative_start_pos.0 as usize, end: relative_end_pos.0 as usize }
     }
 
     fn start(&mut self, span: Self::Span) -> LineColumn {

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -635,7 +635,15 @@ impl server::Span for Rustc<'_, '_> {
     }
 
     fn byte_range(&mut self, span: Self::Span) -> Range<usize> {
-        Range { start: span.lo().0 as usize, end: span.hi().0 as usize }
+        let source_map = self.sess().source_map();
+
+        let relative_start_pos = source_map.lookup_byte_offset(span.lo()).pos;
+        let relative_end_pos = source_map.lookup_byte_offset(span.hi()).pos;
+
+        Range {
+            start: relative_start_pos.0 as usize,
+            end: relative_end_pos.0 as usize
+        }
     }
 
     fn start(&mut self, span: Self::Span) -> LineColumn {

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -635,7 +635,7 @@ impl server::Span for Rustc<'_, '_> {
     }
 
     fn position(&mut self, span: Self::Span) -> Range<u32> {
-        Range { start: span.lo().0, end: span.lo().0 }
+        Range { start: span.lo().0, end: span.hi().0 }
     }
 
     fn start(&mut self, span: Self::Span) -> LineColumn {

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -18,7 +18,7 @@ use rustc_span::def_id::CrateNum;
 use rustc_span::symbol::{self, sym, Symbol};
 use rustc_span::{BytePos, FileName, Pos, SourceFile, Span};
 use smallvec::{smallvec, SmallVec};
-use std::ops::Bound;
+use std::ops::{Bound, Range};
 
 trait FromInternal<T> {
     fn from_internal(x: T) -> Self;
@@ -632,6 +632,10 @@ impl server::Span for Rustc<'_, '_> {
 
     fn source(&mut self, span: Self::Span) -> Self::Span {
         span.source_callsite()
+    }
+
+    fn position(&mut self, span: Self::Span) -> Range<u32> {
+        Range { start: span.lo().0, end: span.lo().0 }
     }
 
     fn start(&mut self, span: Self::Span) -> LineColumn {

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -634,8 +634,8 @@ impl server::Span for Rustc<'_, '_> {
         span.source_callsite()
     }
 
-    fn position(&mut self, span: Self::Span) -> Range<u32> {
-        Range { start: span.lo().0, end: span.hi().0 }
+    fn byte_range(&mut self, span: Self::Span) -> Range<usize> {
+        Range { start: span.lo().0 as usize, end: span.hi().0 as usize }
     }
 
     fn start(&mut self, span: Self::Span) -> LineColumn {

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -14,6 +14,7 @@ use std::hash::Hash;
 use std::marker;
 use std::mem;
 use std::ops::Bound;
+use std::ops::Range;
 use std::panic;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Once;
@@ -93,6 +94,7 @@ macro_rules! with_api {
                 fn source_file($self: $S::Span) -> $S::SourceFile;
                 fn parent($self: $S::Span) -> Option<$S::Span>;
                 fn source($self: $S::Span) -> $S::Span;
+                fn position($self: $S::Span) -> Range<u32>;
                 fn start($self: $S::Span) -> LineColumn;
                 fn end($self: $S::Span) -> LineColumn;
                 fn before($self: $S::Span) -> $S::Span;
@@ -293,6 +295,7 @@ mark_noop! {
     &'_ str,
     String,
     u8,
+    u32,
     usize,
     Delimiter,
     LitKind,
@@ -518,4 +521,8 @@ pub struct ExpnGlobals<Span> {
 
 compound_traits!(
     struct ExpnGlobals<Span> { def_site, call_site, mixed_site }
+);
+
+compound_traits!(
+    struct Range<T> { start, end }
 );

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -94,7 +94,7 @@ macro_rules! with_api {
                 fn source_file($self: $S::Span) -> $S::SourceFile;
                 fn parent($self: $S::Span) -> Option<$S::Span>;
                 fn source($self: $S::Span) -> $S::Span;
-                fn position($self: $S::Span) -> Range<u32>;
+                fn byte_range($self: $S::Span) -> Range<usize>;
                 fn start($self: $S::Span) -> LineColumn;
                 fn end($self: $S::Span) -> LineColumn;
                 fn before($self: $S::Span) -> $S::Span;
@@ -295,7 +295,6 @@ mark_noop! {
     &'_ str,
     String,
     u8,
-    u32,
     usize,
     Delimiter,
     LitKind,

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -490,8 +490,8 @@ impl Span {
 
     /// Returns the span's byte position range in the source file.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
-    pub fn position(&self) -> Range<u32> {
-        self.0.position()
+    pub fn byte_range(&self) -> Range<usize> {
+        self.0.byte_range()
     }
 
     /// Gets the starting line/column in the source file for this span.

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -488,7 +488,7 @@ impl Span {
         Span(self.0.source())
     }
 
-    /// Returns the spans byte position range in the source file.
+    /// Returns the span's byte position range in the source file.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn position(&self) -> Range<u32> {
         self.0.position()

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -44,7 +44,7 @@ mod diagnostic;
 pub use diagnostic::{Diagnostic, Level, MultiSpan};
 
 use std::cmp::Ordering;
-use std::ops::RangeBounds;
+use std::ops::{Range, RangeBounds};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::{error, fmt, iter};
@@ -486,6 +486,12 @@ impl Span {
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn source(&self) -> Span {
         Span(self.0.source())
+    }
+
+    /// Returns the spans byte position range in the source file.
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    pub fn position(&self) -> Range<u32> {
+        self.0.position()
     }
 
     /// Gets the starting line/column in the source file for this span.

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/abis/abi_sysroot/ra_server.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/abis/abi_sysroot/ra_server.rs
@@ -20,7 +20,7 @@ use token_stream::TokenStreamBuilder;
 mod symbol;
 pub use symbol::*;
 
-use std::ops::Bound;
+use std::ops::{Bound, Range};
 
 use crate::tt;
 
@@ -297,6 +297,10 @@ impl server::Span for RustAnalyzer {
     fn source(&mut self, span: Self::Span) -> Self::Span {
         // FIXME handle span
         span
+    }
+    fn position(&mut self, _span: Self::Span) -> Range<u32> {
+        // FIXME handle span
+        Range { start: 0, end: 0 }
     }
     fn start(&mut self, _span: Self::Span) -> LineColumn {
         // FIXME handle span

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/abis/abi_sysroot/ra_server.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/abis/abi_sysroot/ra_server.rs
@@ -298,7 +298,7 @@ impl server::Span for RustAnalyzer {
         // FIXME handle span
         span
     }
-    fn position(&mut self, _span: Self::Span) -> Range<u32> {
+    fn byte_range(&mut self, _span: Self::Span) -> Range<usize> {
         // FIXME handle span
         Range { start: 0, end: 0 }
     }


### PR DESCRIPTION
Currently, the [`Debug`](https://doc.rust-lang.org/beta/proc_macro/struct.Span.html#impl-Debug-for-Span) implementation for [`proc_macro::Span`](https://doc.rust-lang.org/beta/proc_macro/struct.Span.html#) calls the debug function implemented in the trait implementation of `server::Span` for the type `Rustc` in the `rustc-expand` crate.

The current implementation, of the referenced function, looks something like this: 
```rust
fn debug(&mut self, span: Self::Span) -> String {
    if self.ecx.ecfg.span_debug {
        format!("{:?}", span)
    } else {
        format!("{:?} bytes({}..{})", span.ctxt(), span.lo().0, span.hi().0)
    }
}
```

It returns the byte position of the [`Span`](https://doc.rust-lang.org/beta/proc_macro/struct.Span.html#) as an interpolated string.

Because this is currently the only way to get a spans position in the file, I might lead someone, who is interested in this information, to parsing this interpolated string back into a range of bytes, which I think is a very non-rusty way.

The proposed `position()`, method implemented in this PR, gives the ability to directly get this info.
It returns a [`std::ops::Range`](https://doc.rust-lang.org/std/ops/struct.Range.html#) wrapping the lowest and highest byte of the [`Span`](https://doc.rust-lang.org/beta/proc_macro/struct.Span.html#).

I put it behind the `proc_macro_span` feature flag because many of the other functions that have a similar footprint also are annotated with it, I don't actually know if this is right.

It would be great if somebody could take a look at this, thank you very much in advanced.