### PR TITLE
rustdoc: skip `// some variants omitted` if enum is `#[non_exhaustive]`

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1234,7 +1234,7 @@ fn item_enum(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, e: &clean::
                 w.write_str(",\n");
             }
 
-            if variants_stripped {
+            if variants_stripped && !it.is_non_exhaustive() {
                 w.write_str("    // some variants omitted\n");
             }
             if toggle {

--- a/tests/rustdoc/issue-108925.rs
+++ b/tests/rustdoc/issue-108925.rs
@@ -1,0 +1,11 @@
+// @has issue_108925/enum.MyThing.html
+// @has - '//code' 'Shown'
+// @!has - '//code' 'NotShown'
+// @!has - '//code' '// some variants omitted'
+#[non_exhaustive]
+pub enum MyThing {
+    Shown,
+    #[doc(hidden)]
+    NotShown,
+}
+


### PR DESCRIPTION
Fixes #108925 

Never touched rustdoc before so probably not the best code.

cc @dtolnay