### PR TITLE
Expand on the allocator comment in `rustc-main`

### DIFF
--- a/compiler/rustc/src/main.rs
+++ b/compiler/rustc/src/main.rs
@@ -31,7 +31,7 @@
 //
 // NOTE: if you are reading this comment because you want to replace jemalloc with another allocator
 // to compare their performance, see
-// https://github.com/fee1-dead-contrib/rust/commit/b90cfc887c31c3e7a9e6d462e2464db1fe506175#diff-43914724af6e464c1da2171e4a9b6c7e607d5bc1203fa95c0ab85be4122605ef
+// https://github.com/rust-lang/rust/commit/b90cfc887c31c3e7a9e6d462e2464db1fe506175#diff-43914724af6e464c1da2171e4a9b6c7e607d5bc1203fa95c0ab85be4122605ef
 // for an example of how to do so.
 
 #[unix_sigpipe = "sig_dfl"]

--- a/compiler/rustc/src/main.rs
+++ b/compiler/rustc/src/main.rs
@@ -24,6 +24,15 @@
 // The two crates we link to here, `std` and `rustc_driver`, are both dynamic
 // libraries. So we must reference jemalloc symbols one way or another, because
 // this file is the only object code in the rustc executable.
+//
+// NOTE: if you are reading this comment because you want to set a custom `global_allocator` for
+// benchmarking, consider using the benchmarks in the `rustc-perf` collector suite instead:
+// https://github.com/rust-lang/rustc-perf/blob/master/collector/README.md#profiling
+//
+// NOTE: if you are reading this comment because you want to replace jemalloc with another allocator
+// to compare their performance, see
+// https://github.com/fee1-dead-contrib/rust/commit/b90cfc887c31c3e7a9e6d462e2464db1fe506175#diff-43914724af6e464c1da2171e4a9b6c7e607d5bc1203fa95c0ab85be4122605ef
+// for an example of how to do so.
 
 #[unix_sigpipe = "sig_dfl"]
 fn main() {


### PR DESCRIPTION
Before, it said "global_allocator does nothing". Now it gives you suggestions for what to do if you want to change the global allocator (which is likely the main reason you'd be reading the comment).

cc https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/improving.20rustc.20memory.20usage