### PR TITLE
Gate usages of `dyn*` and const closures in macros

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -337,9 +337,6 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             ast::TyKind::Never => {
                 gate_feature_post!(&self, never_type, ty.span, "the `!` type is experimental");
             }
-            ast::TyKind::TraitObject(_, ast::TraitObjectSyntax::DynStar, ..) => {
-                gate_feature_post!(&self, dyn_star, ty.span, "dyn* trait objects are unstable");
-            }
             _ => {}
         }
         visit::walk_ty(self, ty)
@@ -594,6 +591,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session) {
     gate_all!(inline_const_pat, "inline-const in pattern position is experimental");
     gate_all!(associated_const_equality, "associated const equality is incomplete");
     gate_all!(yeet_expr, "`do yeet` expression is experimental");
+    gate_all!(dyn_star, "`dyn*` trait objects are experimental");
 
     // All uses of `gate_all!` below this point were added in #65742,
     // and subsequently disabled (with the non-early gating readded).

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -422,14 +422,6 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             ast::ExprKind::TryBlock(_) => {
                 gate_feature_post!(&self, try_blocks, e.span, "`try` expression is experimental");
             }
-            ast::ExprKind::Closure(box ast::Closure { constness: ast::Const::Yes(_), .. }) => {
-                gate_feature_post!(
-                    &self,
-                    const_closures,
-                    e.span,
-                    "const closures are experimental"
-                );
-            }
             _ => {}
         }
         visit::walk_expr(self, e)
@@ -592,6 +584,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session) {
     gate_all!(associated_const_equality, "associated const equality is incomplete");
     gate_all!(yeet_expr, "`do yeet` expression is experimental");
     gate_all!(dyn_star, "`dyn*` trait objects are experimental");
+    gate_all!(const_closures, "const closures are experimental");
 
     // All uses of `gate_all!` below this point were added in #65742,
     // and subsequently disabled (with the non-early gating readded).

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2105,7 +2105,7 @@ impl<'a> Parser<'a> {
             ClosureBinder::NotPresent
         };
 
-        let constness = self.parse_closure_constness(Case::Sensitive);
+        let constness = self.parse_closure_constness();
 
         let movability =
             if self.eat_keyword(kw::Static) { Movability::Static } else { Movability::Movable };

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1196,9 +1196,13 @@ impl<'a> Parser<'a> {
         self.parse_constness_(case, false)
     }
 
-    /// Parses constness for closures
-    fn parse_closure_constness(&mut self, case: Case) -> Const {
-        self.parse_constness_(case, true)
+    /// Parses constness for closures (case sensitive, feature-gated)
+    fn parse_closure_constness(&mut self) -> Const {
+        let constness = self.parse_constness_(Case::Sensitive, true);
+        if let Const::Yes(span) = constness {
+            self.sess.gated_spans.gate(sym::const_closures, span);
+        }
+        constness
     }
 
     fn parse_constness_(&mut self, case: Case, is_closure: bool) -> Const {

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -624,10 +624,12 @@ impl<'a> Parser<'a> {
     ///
     /// Note that this does *not* parse bare trait objects.
     fn parse_dyn_ty(&mut self, impl_dyn_multi: &mut bool) -> PResult<'a, TyKind> {
+        let lo = self.token.span;
         self.bump(); // `dyn`
 
         // parse dyn* types
         let syntax = if self.eat(&TokenKind::BinOp(token::Star)) {
+            self.sess.gated_spans.gate(sym::dyn_star, lo.to(self.prev_token.span));
             TraitObjectSyntax::DynStar
         } else {
             TraitObjectSyntax::Dyn

--- a/tests/ui/dyn-star/feature-gate-dyn_star.rs
+++ b/tests/ui/dyn-star/feature-gate-dyn_star.rs
@@ -3,7 +3,7 @@
 /// dyn* is not necessarily the final surface syntax (if we have one at all),
 /// but for now we will support it to aid in writing tests independently.
 pub fn dyn_star_parameter(_: &dyn* Send) {
-    //~^ dyn* trait objects are unstable
+    //~^ `dyn*` trait objects are experimental
 }
 
 fn main() {}

--- a/tests/ui/dyn-star/gated-span.rs
+++ b/tests/ui/dyn-star/gated-span.rs
@@ -1,0 +1,8 @@
+macro_rules! t {
+    ($t:ty) => {}
+}
+
+t!(dyn* Send);
+//~^ ERROR `dyn*` trait objects are experimental
+
+fn main() {}

--- a/tests/ui/dyn-star/gated-span.stderr
+++ b/tests/ui/dyn-star/gated-span.stderr
@@ -1,8 +1,8 @@
 error[E0658]: `dyn*` trait objects are experimental
-  --> $DIR/feature-gate-dyn_star.rs:5:31
+  --> $DIR/gated-span.rs:5:4
    |
-LL | pub fn dyn_star_parameter(_: &dyn* Send) {
-   |                               ^^^^
+LL | t!(dyn* Send);
+   |    ^^^^
    |
    = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = help: add `#![feature(dyn_star)]` to the crate attributes to enable

--- a/tests/ui/dyn-star/no-explicit-dyn-star-cast.rs
+++ b/tests/ui/dyn-star/no-explicit-dyn-star-cast.rs
@@ -4,8 +4,8 @@ fn make_dyn_star() {
     let i = 42usize;
     let dyn_i: dyn* Debug = i as dyn* Debug;
     //~^ ERROR casting `usize` as `dyn* Debug` is invalid
-    //~| ERROR dyn* trait objects are unstable
-    //~| ERROR dyn* trait objects are unstable
+    //~| ERROR `dyn*` trait objects are experimental
+    //~| ERROR `dyn*` trait objects are experimental
 }
 
 fn main() {

--- a/tests/ui/dyn-star/no-explicit-dyn-star-cast.stderr
+++ b/tests/ui/dyn-star/no-explicit-dyn-star-cast.stderr
@@ -1,17 +1,17 @@
-error[E0658]: dyn* trait objects are unstable
+error[E0658]: `dyn*` trait objects are experimental
   --> $DIR/no-explicit-dyn-star-cast.rs:5:16
    |
 LL |     let dyn_i: dyn* Debug = i as dyn* Debug;
-   |                ^^^^^^^^^^
+   |                ^^^^
    |
    = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = help: add `#![feature(dyn_star)]` to the crate attributes to enable
 
-error[E0658]: dyn* trait objects are unstable
+error[E0658]: `dyn*` trait objects are experimental
   --> $DIR/no-explicit-dyn-star-cast.rs:5:34
    |
 LL |     let dyn_i: dyn* Debug = i as dyn* Debug;
-   |                                  ^^^^^^^^^^
+   |                                  ^^^^
    |
    = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = help: add `#![feature(dyn_star)]` to the crate attributes to enable

--- a/tests/ui/rfc-2632-const-trait-impl/gate.rs
+++ b/tests/ui/rfc-2632-const-trait-impl/gate.rs
@@ -1,5 +1,13 @@
 // gate-test-const_closures
+
 fn main() {
     (const || {})();
     //~^ ERROR: const closures are experimental
 }
+
+macro_rules! e {
+    ($e:expr) => {}
+}
+
+e!((const || {}));
+//~^ ERROR const closures are experimental

--- a/tests/ui/rfc-2632-const-trait-impl/gate.stderr
+++ b/tests/ui/rfc-2632-const-trait-impl/gate.stderr
@@ -1,12 +1,21 @@
 error[E0658]: const closures are experimental
-  --> $DIR/gate.rs:3:6
+  --> $DIR/gate.rs:4:6
    |
 LL |     (const || {})();
-   |      ^^^^^^^^^^^
+   |      ^^^^^
    |
    = note: see issue #106003 <https://github.com/rust-lang/rust/issues/106003> for more information
    = help: add `#![feature(const_closures)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0658]: const closures are experimental
+  --> $DIR/gate.rs:12:5
+   |
+LL | e!((const || {}));
+   |     ^^^^^
+   |
+   = note: see issue #106003 <https://github.com/rust-lang/rust/issues/106003> for more information
+   = help: add `#![feature(const_closures)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
We silently accepted `dyn*` and const closures in macros as long as they didn't expand to anything containing these experimental features, unlike other gated features such as `for<'a>` binders on closures, etc. Let's not do that, to make sure nobody begins relying on this.