### PR TITLE
Do not emit alias-eq when instantiating a type var from a canonical response in the new solver

### DIFF
--- a/compiler/rustc_infer/src/infer/equate.rs
+++ b/compiler/rustc_infer/src/infer/equate.rs
@@ -144,6 +144,13 @@ impl<'tcx> TypeRelation<'tcx> for Equate<'_, '_, 'tcx> {
                 }
             }
 
+            // Inside the generalizer, we want to related projections by substs eagerly.
+            (&ty::Alias(ty::Projection, a_data), &ty::Alias(ty::Projection, b_data))
+                if self.fields.relate_projections_via_substs =>
+            {
+                self.relate(a_data, b_data)?;
+            }
+
             _ => {
                 self.fields.infcx.super_combine_tys(self, a, b)?;
             }

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -738,6 +738,7 @@ impl<'tcx> InferCtxt<'tcx> {
             param_env,
             obligations: PredicateObligations::new(),
             define_opaque_types,
+            relate_projections_via_substs: false,
         }
     }
 

--- a/compiler/rustc_infer/src/infer/sub.rs
+++ b/compiler/rustc_infer/src/infer/sub.rs
@@ -172,6 +172,14 @@ impl<'tcx> TypeRelation<'tcx> for Sub<'_, '_, 'tcx> {
                 }
             }
 
+            // Inside the generalizer, we want to related projections by substs eagerly.
+            (&ty::Alias(ty::Projection, a_data), &ty::Alias(ty::Projection, b_data))
+                if self.fields.relate_projections_via_substs =>
+            {
+                let projection_ty = self.relate(a_data, b_data)?;
+                Ok(self.tcx().mk_alias(ty::Projection, projection_ty))
+            }
+
             _ => {
                 self.fields.infcx.super_combine_tys(self, a, b)?;
                 Ok(a)

--- a/tests/ui/traits/new-solver/generalize-shouldnt-emit-alias-eq.rs
+++ b/tests/ui/traits/new-solver/generalize-shouldnt-emit-alias-eq.rs
@@ -1,0 +1,40 @@
+// check-pass
+// compile-flags: -Ztrait-solver=next
+
+trait Foo {
+    type Gat<'a>
+    where
+        Self: 'a;
+    fn bar(&self) -> Self::Gat<'_>;
+}
+
+enum Option<T> {
+    Some(T),
+    None,
+}
+
+impl<T> Option<T> {
+    fn as_ref(&self) -> Option<&T> {
+        match self {
+            Option::Some(t) => Option::Some(t),
+            Option::None => Option::None,
+        }
+    }
+
+    fn map<U>(self, f: impl FnOnce(T) -> U) -> Option<U> {
+        match self {
+            Option::Some(t) => Option::Some(f(t)),
+            Option::None => Option::None,
+        }
+    }
+}
+
+impl<T: Foo + 'static> Foo for Option<T> {
+    type Gat<'a> = Option<<T as Foo>::Gat<'a>> where Self: 'a;
+
+    fn bar(&self) -> Self::Gat<'_> {
+        self.as_ref().map(Foo::bar)
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
When instantiating a canonical response, don't emit an alias-eq goals if the response type is a projection that is generalized in `Equate`.

I think a smaller repro could be crafted if I were smarter, but I am not, so I just took this from #105878.
