### PR TITLE
split_array: remove runtime panics

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -639,9 +639,9 @@ impl<T, const N: usize> [T; N] {
     /// let v = [1, 2, 3, 4, 5, 6];
     ///
     /// {
-    ///    let (left, right) = v.split_array_ref::<0>();
-    ///    assert_eq!(left, &[]);
-    ///    assert_eq!(right, &[1, 2, 3, 4, 5, 6]);
+    ///     let (left, right) = v.split_array_ref::<0>();
+    ///     assert_eq!(left, &[]);
+    ///     assert_eq!(right, &[1, 2, 3, 4, 5, 6]);
     /// }
     ///
     /// {
@@ -713,9 +713,9 @@ impl<T, const N: usize> [T; N] {
     /// let v = [1, 2, 3, 4, 5, 6];
     ///
     /// {
-    ///    let (left, right) = v.rsplit_array_ref::<0>();
-    ///    assert_eq!(left, &[1, 2, 3, 4, 5, 6]);
-    ///    assert_eq!(right, &[]);
+    ///     let (left, right) = v.rsplit_array_ref::<0>();
+    ///     assert_eq!(left, &[1, 2, 3, 4, 5, 6]);
+    ///     assert_eq!(right, &[]);
     /// }
     ///
     /// {

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -667,7 +667,7 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn split_array_ref<const M: usize>(&self) -> (&[T; M], &[T]) {
-        (&self[..]).split_array_ref::<M>()
+        (&self[..]).split_array_ref::<M>().unwrap()
     }
 
     /// Divides one mutable array reference into two at an index.
@@ -700,7 +700,7 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn split_array_mut<const M: usize>(&mut self) -> (&mut [T; M], &mut [T]) {
-        (&mut self[..]).split_array_mut::<M>()
+        (&mut self[..]).split_array_mut::<M>().unwrap()
     }
 
     /// Divides one array reference into two at an index from the end.
@@ -745,7 +745,7 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn rsplit_array_ref<const M: usize>(&self) -> (&[T], &[T; M]) {
-        (&self[..]).rsplit_array_ref::<M>()
+        (&self[..]).rsplit_array_ref::<M>().unwrap()
     }
 
     /// Divides one mutable array reference into two at an index from the end.
@@ -778,7 +778,7 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn rsplit_array_mut<const M: usize>(&mut self) -> (&mut [T], &mut [T; M]) {
-        (&mut self[..]).rsplit_array_mut::<M>()
+        (&mut self[..]).rsplit_array_mut::<M>().unwrap()
     }
 }
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -631,10 +631,6 @@ impl<T, const N: usize> [T; N] {
     /// the index `M` itself) and the second will contain all
     /// indices from `[M, N)` (excluding the index `N` itself).
     ///
-    /// # Panics
-    ///
-    /// Panics if `M > N`.
-    ///
     /// # Examples
     ///
     /// ```
@@ -667,6 +663,8 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn split_array_ref<const M: usize>(&self) -> (&[T; M], &[T]) {
+        // FIXME: remove once constraint is encoded in return type
+        const { assert!(M <= N) }
         (&self[..]).split_array_ref::<M>().unwrap()
     }
 
@@ -675,10 +673,6 @@ impl<T, const N: usize> [T; N] {
     /// The first will contain all indices from `[0, M)` (excluding
     /// the index `M` itself) and the second will contain all
     /// indices from `[M, N)` (excluding the index `N` itself).
-    ///
-    /// # Panics
-    ///
-    /// Panics if `M > N`.
     ///
     /// # Examples
     ///
@@ -700,6 +694,8 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn split_array_mut<const M: usize>(&mut self) -> (&mut [T; M], &mut [T]) {
+        // FIXME: remove once constraint is encoded in return type
+        const { assert!(M <= N) }
         (&mut self[..]).split_array_mut::<M>().unwrap()
     }
 
@@ -708,10 +704,6 @@ impl<T, const N: usize> [T; N] {
     /// The first will contain all indices from `[0, N - M)` (excluding
     /// the index `N - M` itself) and the second will contain all
     /// indices from `[N - M, N)` (excluding the index `N` itself).
-    ///
-    /// # Panics
-    ///
-    /// Panics if `M > N`.
     ///
     /// # Examples
     ///
@@ -745,6 +737,8 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn rsplit_array_ref<const M: usize>(&self) -> (&[T], &[T; M]) {
+        // FIXME: remove once constraint is encoded in return type
+        const { assert!(M <= N) }
         (&self[..]).rsplit_array_ref::<M>().unwrap()
     }
 
@@ -753,10 +747,6 @@ impl<T, const N: usize> [T; N] {
     /// The first will contain all indices from `[0, N - M)` (excluding
     /// the index `N - M` itself) and the second will contain all
     /// indices from `[N - M, N)` (excluding the index `N` itself).
-    ///
-    /// # Panics
-    ///
-    /// Panics if `M > N`.
     ///
     /// # Examples
     ///
@@ -778,6 +768,8 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn rsplit_array_mut<const M: usize>(&mut self) -> (&mut [T], &mut [T; M]) {
+        // FIXME: remove once constraint is encoded in return type
+        const { assert!(M <= N) }
         (&mut self[..]).rsplit_array_mut::<M>().unwrap()
     }
 }

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -662,10 +662,10 @@ impl<T, const N: usize> [T; N] {
         issue = "90091"
     )]
     #[inline]
-    pub fn split_array_ref<const M: usize>(&self) -> (&[T; M], &[T]) {
+    pub const fn split_array_ref<const M: usize>(&self) -> (&[T; M], &[T]) {
         // FIXME: remove once constraint is encoded in return type
         const { assert!(M <= N) }
-        (&self[..]).split_array_ref::<M>().unwrap()
+        self.as_slice().split_array_ref::<M>().unwrap()
     }
 
     /// Divides one mutable array reference into two at an index.
@@ -693,10 +693,10 @@ impl<T, const N: usize> [T; N] {
         issue = "90091"
     )]
     #[inline]
-    pub fn split_array_mut<const M: usize>(&mut self) -> (&mut [T; M], &mut [T]) {
+    pub const fn split_array_mut<const M: usize>(&mut self) -> (&mut [T; M], &mut [T]) {
         // FIXME: remove once constraint is encoded in return type
         const { assert!(M <= N) }
-        (&mut self[..]).split_array_mut::<M>().unwrap()
+        (self as &mut [T]).split_array_mut::<M>().unwrap()
     }
 
     /// Divides one array reference into two at an index from the end.
@@ -736,10 +736,10 @@ impl<T, const N: usize> [T; N] {
         issue = "90091"
     )]
     #[inline]
-    pub fn rsplit_array_ref<const M: usize>(&self) -> (&[T], &[T; M]) {
+    pub const fn rsplit_array_ref<const M: usize>(&self) -> (&[T], &[T; M]) {
         // FIXME: remove once constraint is encoded in return type
         const { assert!(M <= N) }
-        (&self[..]).rsplit_array_ref::<M>().unwrap()
+        self.as_slice().rsplit_array_ref::<M>().unwrap()
     }
 
     /// Divides one mutable array reference into two at an index from the end.
@@ -767,10 +767,10 @@ impl<T, const N: usize> [T; N] {
         issue = "90091"
     )]
     #[inline]
-    pub fn rsplit_array_mut<const M: usize>(&mut self) -> (&mut [T], &mut [T; M]) {
+    pub const fn rsplit_array_mut<const M: usize>(&mut self) -> (&mut [T], &mut [T; M]) {
         // FIXME: remove once constraint is encoded in return type
         const { assert!(M <= N) }
-        (&mut self[..]).rsplit_array_mut::<M>().unwrap()
+        (self as &mut [T]).rsplit_array_mut::<M>().unwrap()
     }
 }
 

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1774,9 +1774,9 @@ impl<T> [T] {
     /// let v = &[1, 2, 3, 4, 5, 6][..];
     ///
     /// {
-    ///    let (left, right) = v.split_array_ref::<0>().unwrap();
-    ///    assert_eq!(left, &[]);
-    ///    assert_eq!(right, [1, 2, 3, 4, 5, 6]);
+    ///     let (left, right) = v.split_array_ref::<0>().unwrap();
+    ///     assert_eq!(left, &[]);
+    ///     assert_eq!(right, [1, 2, 3, 4, 5, 6]);
     /// }
     ///
     /// {
@@ -1863,9 +1863,9 @@ impl<T> [T] {
     /// let v = &[1, 2, 3, 4, 5, 6][..];
     ///
     /// {
-    ///    let (left, right) = v.rsplit_array_ref::<0>().unwrap();
-    ///    assert_eq!(left, [1, 2, 3, 4, 5, 6]);
-    ///    assert_eq!(right, &[]);
+    ///     let (left, right) = v.rsplit_array_ref::<0>().unwrap();
+    ///     assert_eq!(left, [1, 2, 3, 4, 5, 6]);
+    ///     assert_eq!(right, &[]);
     /// }
     ///
     /// {

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1797,7 +1797,7 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
-    pub fn split_array_ref<const N: usize>(&self) -> Option<(&[T; N], &[T])> {
+    pub const fn split_array_ref<const N: usize>(&self) -> Option<(&[T; N], &[T])> {
         if N > self.len() {
             None
         } else {
@@ -1835,7 +1835,7 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
-    pub fn split_array_mut<const N: usize>(&mut self) -> Option<(&mut [T; N], &mut [T])> {
+    pub const fn split_array_mut<const N: usize>(&mut self) -> Option<(&mut [T; N], &mut [T])> {
         if N > self.len() {
             None
         } else {
@@ -1885,7 +1885,7 @@ impl<T> [T] {
     #[unstable(feature = "split_array", reason = "new API", issue = "90091")]
     #[inline]
     #[must_use]
-    pub fn rsplit_array_ref<const N: usize>(&self) -> Option<(&[T], &[T; N])> {
+    pub const fn rsplit_array_ref<const N: usize>(&self) -> Option<(&[T], &[T; N])> {
         if N > self.len() {
             None
         } else {
@@ -1923,7 +1923,7 @@ impl<T> [T] {
     #[unstable(feature = "split_array", reason = "new API", issue = "90091")]
     #[inline]
     #[must_use]
-    pub fn rsplit_array_mut<const N: usize>(&mut self) -> Option<(&mut [T], &mut [T; N])> {
+    pub const fn rsplit_array_mut<const N: usize>(&mut self) -> Option<(&mut [T], &mut [T; N])> {
         if N > self.len() {
             None
         } else {

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -488,38 +488,6 @@ fn array_rsplit_array_mut() {
     }
 }
 
-#[should_panic]
-#[test]
-fn array_split_array_ref_out_of_bounds() {
-    let v = [1, 2, 3, 4, 5, 6];
-
-    v.split_array_ref::<7>();
-}
-
-#[should_panic]
-#[test]
-fn array_split_array_mut_out_of_bounds() {
-    let mut v = [1, 2, 3, 4, 5, 6];
-
-    v.split_array_mut::<7>();
-}
-
-#[should_panic]
-#[test]
-fn array_rsplit_array_ref_out_of_bounds() {
-    let v = [1, 2, 3, 4, 5, 6];
-
-    v.rsplit_array_ref::<7>();
-}
-
-#[should_panic]
-#[test]
-fn array_rsplit_array_mut_out_of_bounds() {
-    let mut v = [1, 2, 3, 4, 5, 6];
-
-    v.rsplit_array_mut::<7>();
-}
-
 #[test]
 fn array_intoiter_advance_by() {
     use std::cell::Cell;

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2375,13 +2375,13 @@ fn slice_split_array_mut() {
     let v = &mut [1, 2, 3, 4, 5, 6][..];
 
     {
-        let (left, right) = v.split_array_mut::<0>();
+        let (left, right) = v.split_array_mut::<0>().unwrap();
         assert_eq!(left, &mut []);
         assert_eq!(right, [1, 2, 3, 4, 5, 6]);
     }
 
     {
-        let (left, right) = v.split_array_mut::<6>();
+        let (left, right) = v.split_array_mut::<6>().unwrap();
         assert_eq!(left, &mut [1, 2, 3, 4, 5, 6]);
         assert_eq!(right, []);
     }
@@ -2392,13 +2392,13 @@ fn slice_rsplit_array_mut() {
     let v = &mut [1, 2, 3, 4, 5, 6][..];
 
     {
-        let (left, right) = v.rsplit_array_mut::<0>();
+        let (left, right) = v.rsplit_array_mut::<0>().unwrap();
         assert_eq!(left, [1, 2, 3, 4, 5, 6]);
         assert_eq!(right, &mut []);
     }
 
     {
-        let (left, right) = v.rsplit_array_mut::<6>();
+        let (left, right) = v.rsplit_array_mut::<6>().unwrap();
         assert_eq!(left, []);
         assert_eq!(right, &mut [1, 2, 3, 4, 5, 6]);
     }
@@ -2416,36 +2416,32 @@ fn split_as_slice() {
     assert_eq!(split.as_slice(), &[]);
 }
 
-#[should_panic]
 #[test]
 fn slice_split_array_ref_out_of_bounds() {
     let v = &[1, 2, 3, 4, 5, 6][..];
 
-    let _ = v.split_array_ref::<7>();
+    assert!(v.split_array_ref::<7>().is_none());
 }
 
-#[should_panic]
 #[test]
 fn slice_split_array_mut_out_of_bounds() {
     let v = &mut [1, 2, 3, 4, 5, 6][..];
 
-    let _ = v.split_array_mut::<7>();
+    assert!(v.split_array_mut::<7>().is_none());
 }
 
-#[should_panic]
 #[test]
 fn slice_rsplit_array_ref_out_of_bounds() {
     let v = &[1, 2, 3, 4, 5, 6][..];
 
-    let _ = v.rsplit_array_ref::<7>();
+    assert!(v.rsplit_array_ref::<7>().is_none());
 }
 
-#[should_panic]
 #[test]
 fn slice_rsplit_array_mut_out_of_bounds() {
     let v = &mut [1, 2, 3, 4, 5, 6][..];
 
-    let _ = v.rsplit_array_mut::<7>();
+    assert!(v.rsplit_array_mut::<7>().is_none());
 }
 
 macro_rules! take_tests {


### PR DESCRIPTION
This is an update to #90091 implementing https://github.com/rust-lang/rust/issues/90091#issuecomment-1130349259, which removes runtime panics by:
- making slice-splitting methods return an `Option`
- asserting the index bounds of array-splitting methods using a `const` assert.

The latter is a temporary measure needed because generic const expressions are not yet advanced enough to represent this restriction at the type level. As such it is not supposed to be stabilized as-is. It is however an improvement over the previous behaviour, which was an unconditional runtime panic instead of a compile-time error.