### PR TITLE
Allow tool lint levels to be set based on the build environment.

### DIFF
--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -99,6 +99,15 @@ impl UnstableFeatures {
         }
     }
 
+    /// This only takes the build environment into account.
+    pub const fn is_nightly_build_environment() -> bool {
+        match option_env!("CFG_DISABLE_UNSTABLE_FEATURES") {
+            Some(x) if matches!(x.as_bytes(), b"0") => true,
+            None => true,
+            Some(_) => false,
+        }
+    }
+
     pub fn is_nightly_build(&self) -> bool {
         match *self {
             UnstableFeatures::Allow | UnstableFeatures::Cheat => true,

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -663,15 +663,14 @@ pub type RegisteredTools = FxIndexSet<Ident>;
 /// commands to avoid rebuilding the compiler.
 #[macro_export]
 macro_rules! declare_lint {
-    ($(#[$attr:meta])* $vis: vis $NAME: ident, $Level: ident, $desc: expr) => (
-        $crate::declare_lint!(
-            $(#[$attr])* $vis $NAME, $Level, $desc,
-        );
-    );
-    ($(#[$attr:meta])* $vis: vis $NAME: ident, $Level: ident, $desc: expr,
-     $(@feature_gate = $gate:expr;)?
-     $(@future_incompatible = FutureIncompatibleInfo { $($field:ident : $val:expr),* $(,)*  }; )?
-     $($v:ident),*) => (
+    (
+        $(#[$attr:meta])* $vis: vis $NAME: ident, $Level: ident, $desc: expr
+        $(,
+            $(@feature_gate = $gate:expr;)?
+            $(@future_incompatible = FutureIncompatibleInfo { $($field:ident : $val:expr),* $(,)*  }; )?
+            $($v:ident),* $(,)?
+        )?
+    ) => (
         $(#[$attr])*
         $vis static $NAME: &$crate::Lint = &$crate::Lint {
             name: stringify!($NAME),
@@ -679,12 +678,14 @@ macro_rules! declare_lint {
             desc: $desc,
             edition_lint_opts: None,
             is_plugin: false,
-            $($v: true,)*
-            $(feature_gate: Some($gate),)*
-            $(future_incompatible: Some($crate::FutureIncompatibleInfo {
-                $($field: $val,)*
-                ..$crate::FutureIncompatibleInfo::default_fields_for_macro()
-            }),)*
+            $(
+                $($v: true,)*
+                $(feature_gate: Some($gate),)?
+                $(future_incompatible: Some($crate::FutureIncompatibleInfo {
+                    $($field: $val,)*
+                    ..$crate::FutureIncompatibleInfo::default_fields_for_macro()
+                }),)?
+            )?
             ..$crate::Lint::default_fields_for_macro()
         };
     );

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -707,30 +707,39 @@ macro_rules! declare_lint {
 #[macro_export]
 macro_rules! declare_tool_lint {
     (
-        $(#[$attr:meta])* $vis:vis $tool:ident ::$NAME:ident, $Level: ident, $desc: expr
+        $(#[$attr:meta])* $vis:vis $tool:ident ::$NAME:ident, $Level:ident, $desc:expr
+        $(, report_in_external_macro: $rep:expr)?
         $(, @feature_gate = $gate:expr;)?
     ) => (
-        $crate::declare_tool_lint!{$(#[$attr])* $vis $tool::$NAME, $Level, $desc, false $(, @feature_gate = $gate;)?}
-    );
-    (
-        $(#[$attr:meta])* $vis:vis $tool:ident ::$NAME:ident, $Level:ident, $desc:expr,
-        report_in_external_macro: $rep:expr
-        $(, @feature_gate = $gate:expr;)?
-    ) => (
-         $crate::declare_tool_lint!{$(#[$attr])* $vis $tool::$NAME, $Level, $desc, $rep $(, @feature_gate = $gate;)?}
+        $crate::declare_tool_lint!{
+            $(#[$attr])* $vis $tool::$NAME, $crate::$Level, $desc
+            $(, report_in_external_macro: $rep)?
+            $(, @feature_gate = $gate;)?
+        }
     );
     (
         $(#[$attr:meta])* $vis:vis $tool:ident ::$NAME:ident, $Level:ident, $desc:expr,
         $external:expr
         $(, @feature_gate = $gate:expr;)?
     ) => (
+        $crate::declare_tool_lint!{
+            $(#[$attr])* $vis $tool::$NAME, $crate::$Level, $desc
+            $(, report_in_external_macro: $external)?
+            $(, @feature_gate = $gate;)?
+        }
+    );
+    (
+        $(#[$attr:meta])* $vis:vis $tool:ident ::$NAME:ident, $Level:expr, $desc:expr
+        $(, report_in_external_macro: $external:expr)?
+        $(, @feature_gate = $gate:expr;)?
+    ) => (
         $(#[$attr])*
         $vis static $NAME: &$crate::Lint = &$crate::Lint {
             name: &concat!(stringify!($tool), "::", stringify!($NAME)),
-            default_level: $crate::$Level,
+            default_level: $Level,
             desc: $desc,
             edition_lint_opts: None,
-            report_in_external_macro: $external,
+            $(report_in_external_macro: $external,)?
             future_incompatible: None,
             is_plugin: true,
             $(feature_gate: Some($gate),)?


### PR DESCRIPTION
Changes to allow tool lints to have their default lint level determined by the current build type. Allows using:
```rust
declare_tool_lint! {
/// Docs
pub LINT_NAME,
if UnstableFeatures::is_nightly_build_environment() {
    Level::Warn
} else {
    Level::Allow
},
"description"
}
```

There's still the question of whether this is the best way to go about this.

cc @rust-lang/clippy