### PR TITLE
simd-wide-sum test: adapt for LLVM 17 codegen change

### DIFF
--- a/tests/codegen/simd-wide-sum.rs
+++ b/tests/codegen/simd-wide-sum.rs
@@ -1,4 +1,4 @@
-// compile-flags: -C opt-level=3 --edition=2021
+// compile-flags: -C opt-level=3 -Z merge-functions=disabled --edition=2021
 // only-x86_64
 // ignore-debug: the debug assertions get in the way
 


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/commit/0d4a709bb876824a0afa5f86e138e8ffdcaf7661 LLVM becomes more clever and turns `@wider_reduce_loop` into an alias:

https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/17806#0186da6b-582c-46bf-a227-1565fa0859ac/743-766

This adapts the test to prevent this.