### PR TITLE
Add intrinsic for Option::Some(_) offset

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -110,6 +110,7 @@ pub fn intrinsic_operation_unsafety(tcx: TyCtxt<'_>, intrinsic_id: DefId) -> hir
         | sym::rustc_peek
         | sym::maxnumf64
         | sym::type_name
+        | sym::option_some_offset
         | sym::forget
         | sym::black_box
         | sym::variant_count
@@ -214,6 +215,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
 
             sym::type_name => (1, Vec::new(), tcx.mk_static_str()),
             sym::type_id => (1, Vec::new(), tcx.types.u64),
+            sym::option_some_offset => (1, Vec::new(), tcx.types.usize),
             sym::offset | sym::arith_offset => (
                 1,
                 vec![

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1044,6 +1044,7 @@ symbols! {
         optin_builtin_traits,
         option,
         option_env,
+        option_some_offset,
         options,
         or,
         or_patterns,

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1303,6 +1303,16 @@ extern "rust-intrinsic" {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
 
+    #[cfg(not(bootstrap))]
+    /// The offset of the `Some(_)` value of an `Option<T>`. Used internally for
+    /// `Option::as_slice` and `Option::as_mut_slice`. This needs to be called with an
+    /// `Option<_>` type.
+    // FIXME: This should be replaced once we get a stable public method for getting
+    // the offset of enum variant's fields (e.g. an extension of `offset_of!` to enums)
+    #[rustc_const_stable(feature = "const_option_some_offset", since = "1.68.0")]
+    #[rustc_safe_intrinsic]
+    pub fn option_some_offset<T>() -> usize;
+
     /// Masks out bits of the pointer according to a mask.
     ///
     /// Note that, unlike most intrinsics, this is safe to call;


### PR DESCRIPTION
This replaces the prior hacky calculation with an `option_some_offset` intrinsic that directly gets the offset from the type layout.

cc @scottmcm #108545