### PR TITLE
Fall back to old metadata computation when type references errors

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -730,7 +730,11 @@ where
                         */
                     };
 
-                    let metadata = if let Some(metadata_def_id) = tcx.lang_items().metadata_type() {
+                    let metadata = if let Some(metadata_def_id) = tcx.lang_items().metadata_type()
+                        // Projection eagerly bails out when the pointee references errors,
+                        // fall back to structurally deducing metadata.
+                        && !pointee.references_error()
+                    {
                         let metadata = tcx.normalize_erasing_regions(
                             cx.param_env(),
                             tcx.mk_projection(metadata_def_id, [pointee]),

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -156,7 +156,11 @@ fn layout_of_uncached<'tcx>(
 
             let unsized_part = tcx.struct_tail_erasing_lifetimes(pointee, param_env);
 
-            let metadata = if let Some(metadata_def_id) = tcx.lang_items().metadata_type() {
+            let metadata = if let Some(metadata_def_id) = tcx.lang_items().metadata_type()
+                // Projection eagerly bails out when the pointee references errors,
+                // fall back to structurally deducing metadata.
+                && !pointee.references_error()
+            {
                 let metadata_ty = tcx.normalize_erasing_regions(
                     param_env,
                     tcx.mk_projection(metadata_def_id, [pointee]),

--- a/tests/ui/layout/transmute-to-tail-with-err.rs
+++ b/tests/ui/layout/transmute-to-tail-with-err.rs
@@ -1,0 +1,8 @@
+trait Trait<T> {}
+
+struct Bar(Box<dyn Trait<T>>);
+//~^ ERROR cannot find type `T` in this scope
+
+fn main() {
+    let x: Bar = unsafe { std::mem::transmute(()) };
+}

--- a/tests/ui/layout/transmute-to-tail-with-err.stderr
+++ b/tests/ui/layout/transmute-to-tail-with-err.stderr
@@ -1,0 +1,14 @@
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/transmute-to-tail-with-err.rs:3:26
+   |
+LL | struct Bar(Box<dyn Trait<T>>);
+   |                          ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | struct Bar<T>(Box<dyn Trait<T>>);
+   |           +++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Projection is a bit too aggressive normalizing `<dyn Trait<[type error]> as Pointee>::Metadata` to `[type error]`, rather than to `DynMetadata<..>`. Side-step that by just falling back to the old structural metadata computation.

Fixes #109078