### PR TITLE
use `adt_const_params` to make `simplify_type` faster

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
@@ -99,12 +99,11 @@ impl<'tcx> InherentCollect<'tcx> {
                 }
             }
 
-            if let Some(simp) = simplify_type(
-                self.tcx,
-                self_ty,
-                TreatParams::AsCandidateKey,
-                TreatProjections::AsCandidateKey,
-            ) {
+            if let Some(simp) = simplify_type::<
+                { TreatParams::AsCandidateKey },
+                { TreatProjections::AsCandidateKey },
+            >(self.tcx, self_ty)
+            {
                 self.impls_map.incoherent_impls.entry(simp).or_default().push(impl_def_id);
             } else {
                 bug!("unexpected self type: {:?}", self_ty);
@@ -164,12 +163,11 @@ impl<'tcx> InherentCollect<'tcx> {
             }
         }
 
-        if let Some(simp) = simplify_type(
-            self.tcx,
-            ty,
-            TreatParams::AsCandidateKey,
-            TreatProjections::AsCandidateKey,
-        ) {
+        if let Some(simp) = simplify_type::<
+            { TreatParams::AsCandidateKey },
+            { TreatProjections::AsCandidateKey },
+        >(self.tcx, ty)
+        {
             self.impls_map.incoherent_impls.entry(simp).or_default().push(impl_def_id);
         } else {
             bug!("unexpected primitive type: {:?}", ty);

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -700,7 +700,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     }
 
     fn assemble_inherent_candidates_for_incoherent_ty(&mut self, self_ty: Ty<'tcx>) {
-        let Some(simp) = simplify_type(self.tcx, self_ty, TreatParams::AsCandidateKey, TreatProjections::AsCandidateKey) else {
+        let Some(simp) = simplify_type::<{TreatParams::AsCandidateKey}, {TreatProjections::AsCandidateKey}>(self.tcx, self_ty) else {
             bug!("unexpected incoherent type: {:?}", self_ty)
         };
         for &impl_def_id in self.tcx.incoherent_impls(simp) {

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1855,12 +1855,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 if let Some(trait_ref) = tcx.impl_trait_ref(id.owner_id) {
                     let trait_ref = trait_ref.subst_identity();
 
-                    let simplified_self_ty = fast_reject::simplify_type(
-                        self.tcx,
-                        trait_ref.self_ty(),
-                        TreatParams::AsCandidateKey,
-                        TreatProjections::AsCandidateKey,
-                    );
+                    let simplified_self_ty = fast_reject::simplify_type::<
+                        { TreatParams::AsCandidateKey },
+                        { TreatProjections::AsCandidateKey },
+                    >(self.tcx, trait_ref.self_ty());
 
                     fx_hash_map
                         .entry(trait_ref.def_id)

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -23,6 +23,8 @@
 //! This API is completely unstable and subject to change.
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
+#![allow(incomplete_features)]
+#![feature(adt_const_params)]
 #![feature(allocator_api)]
 #![feature(array_windows)]
 #![feature(assert_matches)]

--- a/compiler/rustc_middle/src/ty/fast_reject.rs
+++ b/compiler/rustc_middle/src/ty/fast_reject.rs
@@ -103,11 +103,13 @@ pub enum TreatProjections {
 /// is only correct if they are fully normalized.
 ///
 /// ¹ meaning that if the outermost layers are different, then the whole types are also different.
-pub fn simplify_type<'tcx>(
+pub fn simplify_type<
+    'tcx,
+    const TREAT_PARAMS: TreatParams,
+    const TREAT_PROJECTIONS: TreatProjections,
+>(
     tcx: TyCtxt<'tcx>,
     ty: Ty<'tcx>,
-    treat_params: TreatParams,
-    treat_projections: TreatProjections,
 ) -> Option<SimplifiedType> {
     match *ty.kind() {
         ty::Bool => Some(BoolSimplifiedType),
@@ -135,11 +137,11 @@ pub fn simplify_type<'tcx>(
         ty::Tuple(tys) => Some(TupleSimplifiedType(tys.len())),
         ty::FnPtr(f) => Some(FunctionSimplifiedType(f.skip_binder().inputs().len())),
         ty::Placeholder(..) => Some(PlaceholderSimplifiedType),
-        ty::Param(_) => match treat_params {
+        ty::Param(_) => match TREAT_PARAMS {
             TreatParams::ForLookup => Some(PlaceholderSimplifiedType),
             TreatParams::AsCandidateKey => None,
         },
-        ty::Alias(..) => match treat_projections {
+        ty::Alias(..) => match TREAT_PROJECTIONS {
             TreatProjections::ForLookup if !ty.needs_infer() => Some(PlaceholderSimplifiedType),
             TreatProjections::NextSolverLookup => Some(PlaceholderSimplifiedType),
             TreatProjections::AsCandidateKey | TreatProjections::ForLookup => None,

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -364,11 +364,10 @@ impl<'tcx> TyCtxt<'tcx> {
         self.ensure().coherent_trait(drop_trait);
 
         let ty = self.type_of(adt_did).subst_identity();
-        let (did, constness) = self.find_map_relevant_impl(
+        // FIXME: This could also be some other mode, like "unexpected"
+        let (did, constness) = self.find_map_relevant_impl::<_, { TreatProjections::ForLookup }>(
             drop_trait,
             ty,
-            // FIXME: This could also be some other mode, like "unexpected"
-            TreatProjections::ForLookup,
             |impl_did| {
                 if let Some(item_id) = self.associated_item_def_ids(impl_did).first() {
                     if validate(self, impl_did).is_ok() {

--- a/compiler/rustc_trait_selection/src/solve/assembly.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly.rs
@@ -300,10 +300,9 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         candidates: &mut Vec<Candidate<'tcx>>,
     ) {
         let tcx = self.tcx();
-        tcx.for_each_relevant_impl_treating_projections(
+        tcx.for_each_relevant_impl_treating_projections::<{ TreatProjections::NextSolverLookup }>(
             goal.predicate.trait_def_id(tcx),
             goal.predicate.self_ty(),
-            TreatProjections::NextSolverLookup,
             |impl_def_id| match G::consider_impl_candidate(self, goal, impl_def_id) {
                 Ok(result) => candidates
                     .push(Candidate { source: CandidateSource::Impl(impl_def_id), result }),

--- a/compiler/rustc_trait_selection/src/solve/trait_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals.rs
@@ -140,12 +140,13 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
         // `instantiate_constituent_tys_for_auto_trait` returns nothing for
         // projection types anyways. So it doesn't really matter what we do
         // here, and this is faster.
-        if let Some(def_id) = ecx.tcx().find_map_relevant_impl(
-            goal.predicate.def_id(),
-            goal.predicate.self_ty(),
-            TreatProjections::NextSolverLookup,
-            Some,
-        ) {
+        if let Some(def_id) =
+            ecx.tcx().find_map_relevant_impl::<_, { TreatProjections::NextSolverLookup }>(
+                goal.predicate.def_id(),
+                goal.predicate.self_ty(),
+                Some,
+            )
+        {
             debug!(?def_id, ?goal, "disqualified auto-trait implementation");
             return Err(NoSolution);
         }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1800,10 +1800,9 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     })
                     .and_then(|(trait_assoc_item, id)| {
                         let trait_assoc_ident = trait_assoc_item.ident(self.tcx);
-                        self.tcx.find_map_relevant_impl(
+                        self.tcx.find_map_relevant_impl::<_, { TreatProjections::ForLookup }>(
                             id,
                             proj.projection_ty.self_ty(),
-                            TreatProjections::ForLookup,
                             |did| {
                                 self.tcx
                                     .associated_items(did)
@@ -2182,10 +2181,9 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         trait_ref: &ty::PolyTraitRef<'tcx>,
     ) -> bool {
         let get_trait_impl = |trait_def_id| {
-            self.tcx.find_map_relevant_impl(
+            self.tcx.find_map_relevant_impl::<_, { TreatProjections::ForLookup }>(
                 trait_def_id,
                 trait_ref.skip_binder().self_ty(),
-                TreatProjections::ForLookup,
                 Some,
             )
         };

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -781,12 +781,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
             ty::Adt(..) => {
                 // Find a custom `impl Drop` impl, if it exists
-                let relevant_impl = self.tcx().find_map_relevant_impl(
-                    self.tcx().require_lang_item(LangItem::Drop, None),
-                    obligation.predicate.skip_binder().trait_ref.self_ty(),
-                    TreatProjections::ForLookup,
-                    Some,
-                );
+                let relevant_impl =
+                    self.tcx().find_map_relevant_impl::<_, { TreatProjections::ForLookup }>(
+                        self.tcx().require_lang_item(LangItem::Drop, None),
+                        obligation.predicate.skip_binder().trait_ref.self_ty(),
+                        Some,
+                    );
 
                 if let Some(impl_def_id) = relevant_impl {
                     // Check that `impl Drop` is actually const, if there is a custom impl

--- a/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
@@ -49,12 +49,11 @@ impl<'tcx> ChildrenExt<'tcx> for Children {
     /// Insert an impl into this set of children without comparing to any existing impls.
     fn insert_blindly(&mut self, tcx: TyCtxt<'tcx>, impl_def_id: DefId) {
         let trait_ref = tcx.impl_trait_ref(impl_def_id).unwrap().skip_binder();
-        if let Some(st) = fast_reject::simplify_type(
-            tcx,
-            trait_ref.self_ty(),
-            TreatParams::AsCandidateKey,
-            TreatProjections::AsCandidateKey,
-        ) {
+        if let Some(st) = fast_reject::simplify_type::<
+            { TreatParams::AsCandidateKey },
+            { TreatProjections::AsCandidateKey },
+        >(tcx, trait_ref.self_ty())
+        {
             debug!("insert_blindly: impl_def_id={:?} st={:?}", impl_def_id, st);
             self.non_blanket_impls.entry(st).or_default().push(impl_def_id)
         } else {
@@ -69,12 +68,11 @@ impl<'tcx> ChildrenExt<'tcx> for Children {
     fn remove_existing(&mut self, tcx: TyCtxt<'tcx>, impl_def_id: DefId) {
         let trait_ref = tcx.impl_trait_ref(impl_def_id).unwrap().skip_binder();
         let vec: &mut Vec<DefId>;
-        if let Some(st) = fast_reject::simplify_type(
-            tcx,
-            trait_ref.self_ty(),
-            TreatParams::AsCandidateKey,
-            TreatProjections::AsCandidateKey,
-        ) {
+        if let Some(st) = fast_reject::simplify_type::<
+            { TreatParams::AsCandidateKey },
+            { TreatProjections::AsCandidateKey },
+        >(tcx, trait_ref.self_ty())
+        {
             debug!("remove_existing: impl_def_id={:?} st={:?}", impl_def_id, st);
             vec = self.non_blanket_impls.get_mut(&st).unwrap();
         } else {
@@ -310,12 +308,10 @@ impl<'tcx> GraphExt<'tcx> for Graph {
 
         let mut parent = trait_def_id;
         let mut last_lint = None;
-        let simplified = fast_reject::simplify_type(
-            tcx,
-            trait_ref.self_ty(),
-            TreatParams::AsCandidateKey,
-            TreatProjections::AsCandidateKey,
-        );
+        let simplified = fast_reject::simplify_type::<
+            { TreatParams::AsCandidateKey },
+            { TreatProjections::AsCandidateKey },
+        >(tcx, trait_ref.self_ty());
 
         // Descend the specialization tree, where `parent` is the current parent node.
         loop {

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -735,7 +735,7 @@ fn trait_impls_for<'a>(
         trace!("considering explicit impl for trait {:?}", trait_);
 
         // Look at each trait implementation to see if it's an impl for `did`
-        tcx.find_map_relevant_impl(trait_, ty, TreatProjections::ForLookup, |impl_| {
+        tcx.find_map_relevant_impl::<_, { TreatProjections::ForLookup }>(trait_, ty, |impl_| {
             let trait_ref = tcx.impl_trait_ref(impl_).expect("this is not an inherent impl");
             // Check if these are the same type.
             let impl_type = trait_ref.skip_binder().self_ty();


### PR DESCRIPTION
Attempt to speed up https://github.com/rust-lang/rust/pull/109097#issuecomment-1468047332

:fearful: I know it's an incomplete feature -- if this turns out to be a perf improvement, then I can try to do something like [`NestedFilter`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/intravisit/nested_filter/trait.NestedFilter.html) to avoid the feature.

r? @ghost