### PR TITLE
rustdoc: DocFS: Replace rayon with threadpool and enable it for all targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5457,13 +5457,13 @@ dependencies = [
  "itertools",
  "minifier",
  "once_cell",
- "rayon",
  "regex",
  "rustdoc-json-types",
  "serde",
  "serde_json",
  "smallvec",
  "tempfile",
+ "threadpool",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
@@ -6206,6 +6206,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -20,14 +20,12 @@ smallvec = "1.8.1"
 tempfile = "3"
 tracing = "0.1"
 tracing-tree = "0.2.0"
+threadpool = "1.8.1"
 
 [dependencies.tracing-subscriber]
 version = "0.3.3"
 default-features = false
 features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"]
-
-[target.'cfg(windows)'.dependencies]
-rayon = "1.5.1"
 
 [dev-dependencies]
 expect-test = "1.4.0"

--- a/src/librustdoc/docfs.rs
+++ b/src/librustdoc/docfs.rs
@@ -2,7 +2,6 @@
 //!
 //! On Windows this indirects IO into threads to work around performance issues
 //! with Defender (and other similar virus scanners that do blocking operations).
-//! On other platforms this is a thin shim to fs.
 //!
 //! Only calls needed to permit this workaround have been abstracted: thus
 //! fs::read is still done directly via the fs module; if in future rustdoc

--- a/src/librustdoc/docfs.rs
+++ b/src/librustdoc/docfs.rs
@@ -9,11 +9,14 @@
 //! needs to read-after-write from a file, then it would be added to this
 //! abstraction.
 
+use std::cmp::max;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::string::ToString;
 use std::sync::mpsc::Sender;
+use std::thread::available_parallelism;
+use threadpool::ThreadPool;
 
 pub(crate) trait PathError {
     fn new<S, P: AsRef<Path>>(e: S, path: P) -> Self
@@ -24,11 +27,21 @@ pub(crate) trait PathError {
 pub(crate) struct DocFS {
     sync_only: bool,
     errors: Option<Sender<String>>,
+    pool: ThreadPool,
 }
 
 impl DocFS {
     pub(crate) fn new(errors: Sender<String>) -> DocFS {
-        DocFS { sync_only: false, errors: Some(errors) }
+        const MINIMUM_NB_THREADS: usize = 2;
+        DocFS {
+            sync_only: false,
+            errors: Some(errors),
+            pool: ThreadPool::new(
+                available_parallelism()
+                    .map(|nb| max(nb.get(), MINIMUM_NB_THREADS))
+                    .unwrap_or(MINIMUM_NB_THREADS),
+            ),
+        }
     }
 
     pub(crate) fn set_sync_only(&mut self, sync_only: bool) {
@@ -54,12 +67,11 @@ impl DocFS {
     where
         E: PathError,
     {
-        #[cfg(windows)]
         if !self.sync_only {
             // A possible future enhancement after more detailed profiling would
             // be to create the file sync so errors are reported eagerly.
             let sender = self.errors.clone().expect("can't write after closing");
-            rayon::spawn(move || {
+            self.pool.execute(move || {
                 fs::write(&path, contents).unwrap_or_else(|e| {
                     sender.send(format!("\"{}\": {}", path.display(), e)).unwrap_or_else(|_| {
                         panic!("failed to send error on \"{}\"", path.display())
@@ -70,9 +82,12 @@ impl DocFS {
             fs::write(&path, contents).map_err(|e| E::new(e, path))?;
         }
 
-        #[cfg(not(windows))]
-        fs::write(&path, contents).map_err(|e| E::new(e, path))?;
-
         Ok(())
+    }
+}
+
+impl Drop for DocFS {
+    fn drop(&mut self) {
+        self.pool.join();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/109060.

Switching to `threadpool` makes it a bit simpler for us to wait for all tasks in `DocFS` directly in the `Drop` implementation. I'm also curious if making all the writes into a thread pool could improve run time for rustdoc on all other platforms than Windows as well.

I'll run a perf check to see.

cc @ehuss 
r? @notriddle 