### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "curl",


### PR DESCRIPTION
14 commits in 7d3033d2e59383fd76193daf9423c3d141972a7d..4a3c588b1f0a8e2dc8dd8789dbf3b6a71b02ed49
2023-03-08 17:05:08 +0000 to 2023-03-14 14:05:36 +0000
- ci: make clean-test-output a script for reuse (rust-lang/cargo#11848)
- Accurately show status when downgrading dependencies (rust-lang/cargo#11839)
- docs(contrib): Move Design Principles earlier in the book (rust-lang/cargo#11842)
- docs(contrib): Point compilation docs to doc comments (rust-lang/cargo#11841)
- `cargo install --git` multiple packages with binaries found hint (rust-lang/cargo#11835)
- Disable flaky auth tests when `gitoxide` runs them (rust-lang/cargo#11830)
- Add some documentation on writing cross-compilation tests (rust-lang/cargo#11825)
- chore: Use sparse protocol on stable CI (rust-lang/cargo#11829)
- Notice for potential unexpected shell expansions in help text of `cargo-add` (rust-lang/cargo#11826)
- Add tracking issue to gitoxide unstable docs (rust-lang/cargo#11822)
- Bump crates-io to 0.36.0 (rust-lang/cargo#11820)
- Bump to 0.71.0; update changelog (rust-lang/cargo#11815)
- docs(contrib): Move overview to lib (rust-lang/cargo#11809)
- Fix semver check for 1.68 (rust-lang/cargo#11817)





r? @ghost