### PR TITLE
Fix linker detection for clang with prefix

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1199,7 +1199,7 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                     .and_then(|(lhs, rhs)| rhs.chars().all(char::is_numeric).then_some(lhs))
                     .unwrap_or(stem);
 
-                // GCC can have an optional target prefix.
+                // GCC/Clang can have an optional target prefix.
                 let flavor = if stem == "emcc" {
                     LinkerFlavor::EmCc
                 } else if stem == "gcc"
@@ -1207,7 +1207,9 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                     || stem == "g++"
                     || stem.ends_with("-g++")
                     || stem == "clang"
+                    || stem.ends_with("-clang")
                     || stem == "clang++"
+                    || stem.ends_with("-clang++")
                 {
                     LinkerFlavor::from_cli(LinkerFlavorCli::Gcc, &sess.target)
                 } else if stem == "wasm-ld" || stem.ends_with("-wasm-ld") {


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/106489 removed check for clang with prefix. It says:

> Also remove the check for -clang, since there are no architecture specific variants of clang (to my knowledge).

However, when doing cross-compilation, a wrapper script for clang with the target name as a prefix is sometimes used.

https://github.com/rust-lang/rust/blob/1716932743a7b3705cbf0c34db0c4e070ed1930d/src/ci/docker/host-x86_64/dist-various-2/Dockerfile#L62

https://github.com/rust-lang/rust/blob/1716932743a7b3705cbf0c34db0c4e070ed1930d/src/ci/docker/scripts/freebsd-toolchain.sh#L76-L80

https://github.com/rust-lang/rust/blob/1716932743a7b3705cbf0c34db0c4e070ed1930d/src/ci/docker/host-x86_64/dist-various-2/Dockerfile#L40

https://github.com/rust-lang/rust/blob/1716932743a7b3705cbf0c34db0c4e070ed1930d/compiler/rustc_target/src/spec/aarch64_pc_windows_gnullvm.rs#L7

It seems the regression did not occur on the targets mentioned above because the default linker flavor is gcc, but it did occur on targets where the default linker flavor is not gcc (https://github.com/taiki-e/setup-cross-toolchain-action/commit/fd352f3ffabd00daf2759ab4a3276729e52eeb10).

r? @petrochenkov

