### PR TITLE
Custom MIR: Parse `ExprKind::Use` correctly

### DIFF
--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -166,6 +166,9 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
                 let cast_kind = mir_cast_kind(source_ty, expr.ty);
                 Ok(Rvalue::Cast(cast_kind, source, expr.ty))
             },
+            ExprKind::Use { source } => Ok(
+                Rvalue::Use(self.parse_operand(*source)?)
+            ),
             _ => self.parse_operand(expr_id).map(Rvalue::Use),
         )
     }

--- a/tests/mir-opt/building/custom/as_cast.identity.built.after.mir
+++ b/tests/mir-opt/building/custom/as_cast.identity.built.after.mir
@@ -1,0 +1,10 @@
+// MIR for `identity` after built
+
+fn identity(_1: i32) -> i32 {
+    let mut _0: i32;                     // return place in scope 0 at $DIR/as_cast.rs:+0:24: +0:27
+
+    bb0: {
+        _0 = _1;                         // scope 0 at $DIR/as_cast.rs:+3:13: +3:27
+        return;                          // scope 0 at $DIR/as_cast.rs:+4:13: +4:21
+    }
+}

--- a/tests/mir-opt/building/custom/as_cast.rs
+++ b/tests/mir-opt/building/custom/as_cast.rs
@@ -36,8 +36,20 @@ fn int_to_ptr(x: usize) -> *const i32 {
     )
 }
 
+// EMIT_MIR as_cast.identity.built.after.mir
+#[custom_mir(dialect = "built")]
+fn identity(x: i32) -> i32 {
+    mir!(
+        {
+            RET = x as i32;
+            Return()
+        }
+    )
+}
+
 fn main() {
     assert_eq!(int_to_int(5), 5);
     assert_eq!(float_to_int(5.), 5);
     assert_eq!(int_to_ptr(0), std::ptr::null());
+    assert_eq!(identity(5), 5);
 }


### PR DESCRIPTION
`ExprKind::Use` isn't parsed properly in the custom MIR builder as the fall-through case attempts to parse the whole `ExprId` as an operand, but only the `source` field inside the `Use` variant is.

One instance where `ExprKind::Use` is emitted is an identity `as` cast.

r? @oli-obk or @tmiasko or @JakobDegen