### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "curl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5139,6 +5139,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
+ "rustc_trait_selection",
  "tracing",
 ]
 

--- a/compiler/rustc_lint/src/map_unit_fn.rs
+++ b/compiler/rustc_lint/src/map_unit_fn.rs
@@ -56,6 +56,7 @@ impl<'tcx> LateLintPass<'tcx> for MapUnitFn {
                         return;
                     }
                     let arg_ty = cx.typeck_results().expr_ty(&args[0]);
+                    let default_span = args[0].span;
                     if let ty::FnDef(id, _) = arg_ty.kind() {
                         let fn_ty = cx.tcx.fn_sig(id).skip_binder();
                         let ret_ty = fn_ty.output().skip_binder();
@@ -64,7 +65,10 @@ impl<'tcx> LateLintPass<'tcx> for MapUnitFn {
                                 MAP_UNIT_FN,
                                 span,
                                 MappingToUnit {
-                                    function_label: cx.tcx.span_of_impl(*id).unwrap(),
+                                    function_label: cx
+                                        .tcx
+                                        .span_of_impl(*id)
+                                        .unwrap_or(default_span),
                                     argument_label: args[0].span,
                                     map_label: arg_ty.default_span(cx.tcx),
                                     suggestion: path.ident.span,
@@ -80,7 +84,10 @@ impl<'tcx> LateLintPass<'tcx> for MapUnitFn {
                                 MAP_UNIT_FN,
                                 span,
                                 MappingToUnit {
-                                    function_label: cx.tcx.span_of_impl(*id).unwrap(),
+                                    function_label: cx
+                                        .tcx
+                                        .span_of_impl(*id)
+                                        .unwrap_or(default_span),
                                     argument_label: args[0].span,
                                     map_label: arg_ty.default_span(cx.tcx),
                                     suggestion: path.ident.span,

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -226,7 +226,15 @@ provide! { tcx, def_id, other, cdata,
     lookup_default_body_stability => { table }
     lookup_deprecation_entry => { table }
     params_in_repr => { table }
-    unused_generic_params => { table }
+    // FIXME: Could be defaulted, but `LazyValue<UnusedGenericParams>` is not `FixedSizeEncoding`..
+    unused_generic_params => {
+        cdata
+            .root
+            .tables
+            .unused_generic_params
+            .get(cdata, def_id.index)
+            .map_or_else(|| ty::UnusedGenericParams::new_all_used(), |lazy| lazy.decode((cdata, tcx)))
+    }
     opt_def_kind => { table_direct }
     impl_parent => { table }
     impl_polarity => { table_direct }

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -63,7 +63,7 @@ impl<'tcx> Key for ty::InstanceDef<'tcx> {
 
     #[inline(always)]
     fn query_crate_is_local(&self) -> bool {
-        true
+        self.def_id().is_local()
     }
 
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
@@ -76,7 +76,7 @@ impl<'tcx> Key for ty::Instance<'tcx> {
 
     #[inline(always)]
     fn query_crate_is_local(&self) -> bool {
-        true
+        self.def_id().is_local()
     }
 
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {

--- a/compiler/rustc_monomorphize/src/polymorphize.rs
+++ b/compiler/rustc_monomorphize/src/polymorphize.rs
@@ -36,6 +36,8 @@ fn unused_generic_params<'tcx>(
     tcx: TyCtxt<'tcx>,
     instance: ty::InstanceDef<'tcx>,
 ) -> UnusedGenericParams {
+    assert!(instance.def_id().is_local());
+
     if !tcx.sess.opts.unstable_opts.polymorphize {
         // If polymorphization disabled, then all parameters are used.
         return UnusedGenericParams::new_all_used();
@@ -97,13 +99,6 @@ fn should_polymorphize<'tcx>(
 
     // Don't polymorphize intrinsics or virtual calls - calling `instance_mir` will panic.
     if matches!(instance, ty::InstanceDef::Intrinsic(..) | ty::InstanceDef::Virtual(..)) {
-        return false;
-    }
-
-    // Polymorphization results are stored in cross-crate metadata only when there are unused
-    // parameters, so assume that non-local items must have only used parameters (else this query
-    // would not be invoked, and the cross-crate metadata used instead).
-    if !def_id.is_local() {
         return false;
     }
 

--- a/compiler/rustc_passes/Cargo.toml
+++ b/compiler/rustc_passes/Cargo.toml
@@ -22,3 +22,4 @@ rustc_span = { path = "../rustc_span" }
 rustc_lexer = { path = "../rustc_lexer" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }
 rustc_feature = { path = "../rustc_feature" }
+rustc_trait_selection = { path = "../rustc_trait_selection" }

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -720,26 +720,7 @@ passes_ignored_derived_impls =
      *[other] traits {$trait_list}, but these are
     } intentionally ignored during dead code analysis
 
-passes_proc_macro_typeerror = mismatched {$kind} signature
-    .label = found {$found}, expected type `proc_macro::TokenStream`
-    .note = {$kind}s must have a signature of `{$expected_signature}`
-
-passes_proc_macro_diff_arg_count = mismatched {$kind} signature
-    .label = found unexpected {$count ->
-      [one] argument
-     *[other] arguments
-    }
-    .note = {$kind}s must have a signature of `{$expected_signature}`
-
-passes_proc_macro_missing_args = mismatched {$kind} signature
-    .label = {$kind} must have {$expected_input_count ->
-      [one] one argument
-     *[other] two arguments
-    } of type `proc_macro::TokenStream`
-
-passes_proc_macro_invalid_abi = proc macro functions may not be `extern "{$abi}"`
-
-passes_proc_macro_unsafe = proc macro functions may not be `unsafe`
+passes_proc_macro_bad_sig = {$kind} has incorrect signature
 
 passes_skipping_const_checks = skipping const checks
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -19,9 +19,10 @@ use rustc_hir::{
 use rustc_hir::{MethodKind, Target, Unsafety};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::middle::resolve_bound_vars::ObjectLifetimeDefault;
-use rustc_middle::ty::fast_reject::{DeepRejectCtxt, TreatParams};
+use rustc_middle::traits::ObligationCause;
+use rustc_middle::ty::error::ExpectedFound;
 use rustc_middle::ty::query::Providers;
-use rustc_middle::ty::{ParamEnv, TyCtxt};
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_session::lint::builtin::{
     CONFLICTING_REPR_HINTS, INVALID_DOC_ATTRIBUTES, INVALID_MACRO_EXPORT_ARGUMENTS,
     UNUSED_ATTRIBUTES,
@@ -30,6 +31,9 @@ use rustc_session::parse::feature_err;
 use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::{Span, DUMMY_SP};
 use rustc_target::spec::abi::Abi;
+use rustc_trait_selection::infer::{TyCtxtInferExt, ValuePairs};
+use rustc_trait_selection::traits::error_reporting::TypeErrCtxtExt;
+use rustc_trait_selection::traits::ObligationCtxt;
 use std::cell::Cell;
 use std::collections::hash_map::Entry;
 
@@ -2188,100 +2192,66 @@ impl CheckAttrVisitor<'_> {
     ///
     /// If this best effort goes wrong, it will just emit a worse error later (see #102923)
     fn check_proc_macro(&self, hir_id: HirId, target: Target, kind: ProcMacroKind) {
-        let expected_input_count = match kind {
-            ProcMacroKind::Attribute => 2,
-            ProcMacroKind::Derive | ProcMacroKind::FunctionLike => 1,
-        };
-
-        let expected_signature = match kind {
-            ProcMacroKind::Attribute => "fn(TokenStream, TokenStream) -> TokenStream",
-            ProcMacroKind::Derive | ProcMacroKind::FunctionLike => "fn(TokenStream) -> TokenStream",
-        };
+        if target != Target::Fn {
+            return;
+        }
 
         let tcx = self.tcx;
-        if target == Target::Fn {
-            let Some(tokenstream) = tcx.get_diagnostic_item(sym::TokenStream) else {return};
-            let tokenstream = tcx.type_of(tokenstream).subst_identity();
+        let Some(token_stream_def_id) = tcx.get_diagnostic_item(sym::TokenStream) else { return; };
+        let Some(token_stream) = tcx.type_of(token_stream_def_id).no_bound_vars() else { return; };
 
-            let id = hir_id.expect_owner();
-            let hir_sig = tcx.hir().fn_sig_by_hir_id(hir_id).unwrap();
+        let def_id = hir_id.expect_owner().def_id;
+        let param_env = ty::ParamEnv::empty();
 
-            let sig =
-                tcx.liberate_late_bound_regions(id.to_def_id(), tcx.fn_sig(id).subst_identity());
-            let sig = tcx.normalize_erasing_regions(ParamEnv::empty(), sig);
+        let infcx = tcx.infer_ctxt().build();
+        let ocx = ObligationCtxt::new(&infcx);
 
-            // We don't currently require that the function signature is equal to
-            // `fn(TokenStream) -> TokenStream`, but instead monomorphizes to
-            // `fn(TokenStream) -> TokenStream` after some substitution of generic arguments.
-            //
-            // Properly checking this means pulling in additional `rustc` crates, so we don't.
-            let drcx = DeepRejectCtxt { treat_obligation_params: TreatParams::AsCandidateKey };
+        let span = tcx.def_span(def_id);
+        let fresh_substs = infcx.fresh_substs_for_item(span, def_id.to_def_id());
+        let sig = tcx.liberate_late_bound_regions(
+            def_id.to_def_id(),
+            tcx.fn_sig(def_id).subst(tcx, fresh_substs),
+        );
 
-            if sig.abi != Abi::Rust {
-                tcx.sess.emit_err(errors::ProcMacroInvalidAbi {
-                    span: hir_sig.span,
-                    abi: sig.abi.name(),
-                });
-                self.abort.set(true);
-            }
+        let cause = ObligationCause::misc(span, def_id);
+        let sig = ocx.normalize(&cause, param_env, sig);
 
-            if sig.unsafety == Unsafety::Unsafe {
-                tcx.sess.emit_err(errors::ProcMacroUnsafe { span: hir_sig.span });
-                self.abort.set(true);
-            }
+        // proc macro is not WF.
+        let errors = ocx.select_where_possible();
+        if !errors.is_empty() {
+            return;
+        }
 
-            let output = sig.output();
+        let expected_sig = tcx.mk_fn_sig(
+            std::iter::repeat(token_stream).take(match kind {
+                ProcMacroKind::Attribute => 2,
+                ProcMacroKind::Derive | ProcMacroKind::FunctionLike => 1,
+            }),
+            token_stream,
+            false,
+            Unsafety::Normal,
+            Abi::Rust,
+        );
 
-            // Typecheck the output
-            if !drcx.types_may_unify(output, tokenstream) {
-                tcx.sess.emit_err(errors::ProcMacroTypeError {
-                    span: hir_sig.decl.output.span(),
-                    found: output,
-                    kind,
-                    expected_signature,
-                });
-                self.abort.set(true);
-            }
+        if let Err(terr) = ocx.eq(&cause, param_env, expected_sig, sig) {
+            let mut diag = tcx.sess.create_err(errors::ProcMacroBadSig { span, kind });
+            infcx.err_ctxt().note_type_err(
+                &mut diag,
+                &cause,
+                None,
+                Some(ValuePairs::Sigs(ExpectedFound { expected: expected_sig, found: sig })),
+                terr,
+                false,
+                false,
+            );
+            diag.emit();
+            self.abort.set(true);
+        }
 
-            if sig.inputs().len() < expected_input_count {
-                tcx.sess.emit_err(errors::ProcMacroMissingArguments {
-                    expected_input_count,
-                    span: hir_sig.span,
-                    kind,
-                    expected_signature,
-                });
-                self.abort.set(true);
-            }
-
-            // Check that the inputs are correct, if there are enough.
-            if sig.inputs().len() >= expected_input_count {
-                for (arg, input) in
-                    sig.inputs().iter().zip(hir_sig.decl.inputs).take(expected_input_count)
-                {
-                    if !drcx.types_may_unify(*arg, tokenstream) {
-                        tcx.sess.emit_err(errors::ProcMacroTypeError {
-                            span: input.span,
-                            found: *arg,
-                            kind,
-                            expected_signature,
-                        });
-                        self.abort.set(true);
-                    }
-                }
-            }
-
-            // Check that there are not too many arguments
-            let body_id = tcx.hir().body_owned_by(id.def_id);
-            let excess = tcx.hir().body(body_id).params.get(expected_input_count..);
-            if let Some(excess @ [begin @ end] | excess @ [begin, .., end]) = excess {
-                tcx.sess.emit_err(errors::ProcMacroDiffArguments {
-                    span: begin.span.to(end.span),
-                    count: excess.len(),
-                    kind,
-                    expected_signature,
-                });
-                self.abort.set(true);
-            }
+        let errors = ocx.select_all_or_error();
+        if !errors.is_empty() {
+            infcx.err_ctxt().report_fulfillment_errors(&errors);
+            self.abort.set(true);
         }
     }
 }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1546,52 +1546,11 @@ pub struct ChangeFieldsToBeOfUnitType {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes_proc_macro_typeerror)]
-#[note]
-pub(crate) struct ProcMacroTypeError<'tcx> {
+#[diag(passes_proc_macro_bad_sig)]
+pub(crate) struct ProcMacroBadSig {
     #[primary_span]
-    #[label]
     pub span: Span,
-    pub found: Ty<'tcx>,
     pub kind: ProcMacroKind,
-    pub expected_signature: &'static str,
-}
-
-#[derive(Diagnostic)]
-#[diag(passes_proc_macro_diff_arg_count)]
-pub(crate) struct ProcMacroDiffArguments {
-    #[primary_span]
-    #[label]
-    pub span: Span,
-    pub count: usize,
-    pub kind: ProcMacroKind,
-    pub expected_signature: &'static str,
-}
-
-#[derive(Diagnostic)]
-#[diag(passes_proc_macro_missing_args)]
-pub(crate) struct ProcMacroMissingArguments {
-    #[primary_span]
-    #[label]
-    pub span: Span,
-    pub expected_input_count: usize,
-    pub kind: ProcMacroKind,
-    pub expected_signature: &'static str,
-}
-
-#[derive(Diagnostic)]
-#[diag(passes_proc_macro_invalid_abi)]
-pub(crate) struct ProcMacroInvalidAbi {
-    #[primary_span]
-    pub span: Span,
-    pub abi: &'static str,
-}
-
-#[derive(Diagnostic)]
-#[diag(passes_proc_macro_unsafe)]
-pub(crate) struct ProcMacroUnsafe {
-    #[primary_span]
-    pub span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/config.example.toml
+++ b/config.example.toml
@@ -146,6 +146,9 @@ changelog-seen = 2
 # Whether to build the clang compiler.
 #clang = false
 
+# Whether to enable llvm compilation warnings.
+#enable-warnings = false
+
 # Custom CMake defines to set when building LLVM.
 #build-config = {}
 

--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - If you have Rust already installed, `x.py` will now infer the host target
   from the default rust toolchain. [#78513](https://github.com/rust-lang/rust/pull/78513)
 - Add options for enabling overflow checks, one for std (`overflow-checks-std`) and one for everything else (`overflow-checks`). Both default to false.
+- Add llvm option `enable-warnings` to have control on llvm compilation warnings. Default to false.
 
 
 ## [Version 2] - 2020-09-25

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -133,6 +133,7 @@ pub struct Config {
     pub llvm_allow_old_toolchain: bool,
     pub llvm_polly: bool,
     pub llvm_clang: bool,
+    pub llvm_enable_warnings: bool,
     pub llvm_from_ci: bool,
     pub llvm_build_config: HashMap<String, String>,
 
@@ -688,6 +689,7 @@ define_config! {
         allow_old_toolchain: Option<bool> = "allow-old-toolchain",
         polly: Option<bool> = "polly",
         clang: Option<bool> = "clang",
+        enable_warnings: Option<bool> = "enable-warnings",
         download_ci_llvm: Option<StringOrBool> = "download-ci-llvm",
         build_config: Option<HashMap<String, String>> = "build-config",
     }
@@ -1184,6 +1186,7 @@ impl Config {
             config.llvm_allow_old_toolchain = llvm.allow_old_toolchain.unwrap_or(false);
             config.llvm_polly = llvm.polly.unwrap_or(false);
             config.llvm_clang = llvm.clang.unwrap_or(false);
+            config.llvm_enable_warnings = llvm.enable_warnings.unwrap_or(false);
             config.llvm_build_config = llvm.build_config.clone().unwrap_or(Default::default());
 
             let asserts = llvm_assertions.unwrap_or(false);

--- a/src/bootstrap/defaults/config.codegen.toml
+++ b/src/bootstrap/defaults/config.codegen.toml
@@ -7,6 +7,8 @@ compiler-docs = true
 # This enables debug-assertions in LLVM,
 # catching logic errors in codegen much earlier in the process.
 assertions = true
+# enable warnings during the llvm compilation
+enable-warnings = true
 
 [rust]
 # This enables `RUSTC_LOG=debug`, avoiding confusing situations

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -495,6 +495,7 @@ impl Build {
 
         // Make a symbolic link so we can use a consistent directory in the documentation.
         let build_triple = build.out.join(&build.build.triple);
+        t!(fs::create_dir_all(&build_triple));
         let host = build.out.join("host");
         if let Err(e) = symlink_dir(&build.config, &build_triple, &host) {
             if e.kind() != ErrorKind::AlreadyExists {

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -304,6 +304,7 @@ impl Step for Llvm {
         let assertions = if builder.config.llvm_assertions { "ON" } else { "OFF" };
         let plugins = if builder.config.llvm_plugins { "ON" } else { "OFF" };
         let enable_tests = if builder.config.llvm_tests { "ON" } else { "OFF" };
+        let enable_warnings = if builder.config.llvm_enable_warnings { "ON" } else { "OFF" };
 
         cfg.out_dir(&out_dir)
             .profile(profile)
@@ -321,7 +322,8 @@ impl Step for Llvm {
             .define("LLVM_ENABLE_Z3_SOLVER", "OFF")
             .define("LLVM_PARALLEL_COMPILE_JOBS", builder.jobs().to_string())
             .define("LLVM_TARGET_ARCH", target_native.split('-').next().unwrap())
-            .define("LLVM_DEFAULT_TARGET_TRIPLE", target_native);
+            .define("LLVM_DEFAULT_TARGET_TRIPLE", target_native)
+            .define("LLVM_ENABLE_WARNINGS", enable_warnings);
 
         // Parts of our test suite rely on the `FileCheck` tool, which is built by default in
         // `build/$TARGET/llvm/build/bin` is but *not* then installed to `build/$TARGET/llvm/bin`.
@@ -482,11 +484,6 @@ impl Step for Llvm {
         for (key, val) in &builder.config.llvm_build_config {
             cfg.define(key, val);
         }
-
-        // FIXME: we don't actually need to build all LLVM tools and all LLVM
-        //        libraries here, e.g., we just want a few components and a few
-        //        tools. Figure out how to filter them down and only build the right
-        //        tools and libs on all platforms.
 
         if builder.config.dry_run() {
             return res;

--- a/tests/codegen-units/polymorphization/auxiliary/poly-dep.rs
+++ b/tests/codegen-units/polymorphization/auxiliary/poly-dep.rs
@@ -1,0 +1,4 @@
+// compile-flags: -Zpolymorphize=on
+
+#[inline(never)]
+pub fn foo<T>() {}

--- a/tests/codegen-units/polymorphization/poly-foreign.rs
+++ b/tests/codegen-units/polymorphization/poly-foreign.rs
@@ -1,0 +1,11 @@
+// aux-build:poly-dep.rs
+// compile-flags: --crate-type=lib -Zprint-mono-items=eager -Zpolymorphize=on
+
+extern crate poly_dep;
+
+pub static FN1: fn() = poly_dep::foo::<i32>;
+pub static FN2: fn() = poly_dep::foo::<u32>;
+
+//~ MONO_ITEM static FN1
+//~ MONO_ITEM static FN2
+//~ MONO_ITEM fn poly_dep::foo::<T>

--- a/tests/ui/lint/issue-109152.rs
+++ b/tests/ui/lint/issue-109152.rs
@@ -1,0 +1,7 @@
+#![deny(map_unit_fn)]
+
+#![crate_type = "lib"]
+fn _y() {
+    vec![42].iter().map(drop);
+    //~^ ERROR `Iterator::map` call that discard the iterator's values
+}

--- a/tests/ui/lint/issue-109152.stderr
+++ b/tests/ui/lint/issue-109152.stderr
@@ -1,0 +1,23 @@
+error: `Iterator::map` call that discard the iterator's values
+  --> $DIR/issue-109152.rs:5:21
+   |
+LL |     vec![42].iter().map(drop);
+   |                     ^^^^----^
+   |                     |   |
+   |                     |   this function returns `()`, which is likely not what you wanted
+   |                     |   called `Iterator::map` with callable that returns `()`
+   |                     after this call to map, the resulting iterator is `impl Iterator<Item = ()>`, which means the only information carried by the iterator is the number of items
+   |
+   = note: `Iterator::map`, like many of the methods on `Iterator`, gets executed lazily, meaning that its effects won't be visible until it is iterated
+note: the lint level is defined here
+  --> $DIR/issue-109152.rs:1:9
+   |
+LL | #![deny(map_unit_fn)]
+   |         ^^^^^^^^^^^
+help: you might have meant to use `Iterator::for_each`
+   |
+LL |     vec![42].iter().for_each(drop);
+   |                     ~~~~~~~~
+
+error: aborting due to previous error
+

--- a/tests/ui/proc-macro/bad-projection.rs
+++ b/tests/ui/proc-macro/bad-projection.rs
@@ -1,0 +1,15 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![allow(warnings)]
+
+extern crate proc_macro;
+
+trait Project {
+    type Assoc;
+}
+
+#[proc_macro]
+pub fn uwu() -> <() as Project>::Assoc {}
+//~^ ERROR the trait bound `(): Project` is not satisfied

--- a/tests/ui/proc-macro/bad-projection.stderr
+++ b/tests/ui/proc-macro/bad-projection.stderr
@@ -1,0 +1,9 @@
+error[E0277]: the trait bound `(): Project` is not satisfied
+  --> $DIR/bad-projection.rs:14:17
+   |
+LL | pub fn uwu() -> <() as Project>::Assoc {}
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ the trait `Project` is not implemented for `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/proc-macro/proc-macro-abi.rs
+++ b/tests/ui/proc-macro/proc-macro-abi.rs
@@ -9,19 +9,19 @@ use proc_macro::TokenStream;
 
 #[proc_macro]
 pub extern "C" fn abi(a: TokenStream) -> TokenStream {
-    //~^ ERROR proc macro functions may not be `extern "C"`
+    //~^ ERROR function-like proc macro has incorrect signature
     a
 }
 
 #[proc_macro]
 pub extern "system" fn abi2(a: TokenStream) -> TokenStream {
-    //~^ ERROR proc macro functions may not be `extern "system"`
+    //~^ ERROR function-like proc macro has incorrect signature
     a
 }
 
 #[proc_macro]
 pub extern fn abi3(a: TokenStream) -> TokenStream {
-    //~^ ERROR proc macro functions may not be `extern "C"`
+    //~^ ERROR function-like proc macro has incorrect signature
     a
 }
 

--- a/tests/ui/proc-macro/proc-macro-abi.stderr
+++ b/tests/ui/proc-macro/proc-macro-abi.stderr
@@ -1,20 +1,29 @@
-error: proc macro functions may not be `extern "C"`
+error: function-like proc macro has incorrect signature
   --> $DIR/proc-macro-abi.rs:11:1
    |
 LL | pub extern "C" fn abi(a: TokenStream) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "C" fn
+   |
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `extern "C" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
 
-error: proc macro functions may not be `extern "system"`
+error: function-like proc macro has incorrect signature
   --> $DIR/proc-macro-abi.rs:17:1
    |
 LL | pub extern "system" fn abi2(a: TokenStream) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "system" fn
+   |
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `extern "system" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
 
-error: proc macro functions may not be `extern "C"`
+error: function-like proc macro has incorrect signature
   --> $DIR/proc-macro-abi.rs:23:1
    |
 LL | pub extern fn abi3(a: TokenStream) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "C" fn
+   |
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `extern "C" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/proc-macro/signature-proc-macro-attribute.rs
+++ b/tests/ui/proc-macro/signature-proc-macro-attribute.rs
@@ -8,25 +8,23 @@ use proc_macro::TokenStream;
 
 #[proc_macro_attribute]
 pub fn bad_input(input: String) -> TokenStream {
-    //~^ ERROR mismatched attribute proc macro signature
+    //~^ ERROR attribute proc macro has incorrect signature
     ::proc_macro::TokenStream::new()
 }
 
 #[proc_macro_attribute]
 pub fn bad_output(input: TokenStream) -> String {
-    //~^ ERROR mismatched attribute proc macro signature
-    //~| ERROR mismatched attribute proc macro signature
+    //~^ ERROR attribute proc macro has incorrect signature
     String::from("blah")
 }
 
 #[proc_macro_attribute]
 pub fn bad_everything(input: String) -> String {
-    //~^ ERROR mismatched attribute proc macro signature
-    //~| ERROR mismatched attribute proc macro signature
+    //~^ ERROR attribute proc macro has incorrect signature
     input
 }
 
 #[proc_macro_attribute]
 pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
-    //~^ ERROR mismatched attribute proc macro signature
+    //~^ ERROR attribute proc macro has incorrect signature
 }

--- a/tests/ui/proc-macro/signature-proc-macro-attribute.stderr
+++ b/tests/ui/proc-macro/signature-proc-macro-attribute.stderr
@@ -1,42 +1,38 @@
-error: mismatched attribute proc macro signature
+error: attribute proc macro has incorrect signature
   --> $DIR/signature-proc-macro-attribute.rs:10:1
    |
 LL | pub fn bad_input(input: String) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attribute proc macro must have two arguments of type `proc_macro::TokenStream`
-
-error: mismatched attribute proc macro signature
-  --> $DIR/signature-proc-macro-attribute.rs:16:42
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
    |
-LL | pub fn bad_output(input: TokenStream) -> String {
-   |                                          ^^^^^^ found std::string::String, expected type `proc_macro::TokenStream`
-   |
-   = note: attribute proc macros must have a signature of `fn(TokenStream, TokenStream) -> TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(std::string::String) -> proc_macro::TokenStream`
 
-error: mismatched attribute proc macro signature
+error: attribute proc macro has incorrect signature
   --> $DIR/signature-proc-macro-attribute.rs:16:1
    |
 LL | pub fn bad_output(input: TokenStream) -> String {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attribute proc macro must have two arguments of type `proc_macro::TokenStream`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
+   |
+   = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(proc_macro::TokenStream) -> std::string::String`
 
-error: mismatched attribute proc macro signature
-  --> $DIR/signature-proc-macro-attribute.rs:23:41
+error: attribute proc macro has incorrect signature
+  --> $DIR/signature-proc-macro-attribute.rs:22:1
    |
 LL | pub fn bad_everything(input: String) -> String {
-   |                                         ^^^^^^ found std::string::String, expected type `proc_macro::TokenStream`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
    |
-   = note: attribute proc macros must have a signature of `fn(TokenStream, TokenStream) -> TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(std::string::String) -> std::string::String`
 
-error: mismatched attribute proc macro signature
-  --> $DIR/signature-proc-macro-attribute.rs:23:1
-   |
-LL | pub fn bad_everything(input: String) -> String {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attribute proc macro must have two arguments of type `proc_macro::TokenStream`
-
-error: mismatched attribute proc macro signature
-  --> $DIR/signature-proc-macro-attribute.rs:30:49
+error: attribute proc macro has incorrect signature
+  --> $DIR/signature-proc-macro-attribute.rs:28:1
    |
 LL | pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
-   |                                                 ^^^^^^^^^ found unexpected argument
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
+   |
+   = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> proc_macro::TokenStream`
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/proc-macro/signature-proc-macro-attribute.stderr
+++ b/tests/ui/proc-macro/signature-proc-macro-attribute.stderr
@@ -26,10 +26,10 @@ LL | pub fn bad_everything(input: String) -> String {
               found signature `fn(std::string::String) -> std::string::String`
 
 error: attribute proc macro has incorrect signature
-  --> $DIR/signature-proc-macro-attribute.rs:28:1
+  --> $DIR/signature-proc-macro-attribute.rs:28:52
    |
 LL | pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
+   |                                                    ^^^^^^ incorrect number of function parameters
    |
    = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> proc_macro::TokenStream`

--- a/tests/ui/proc-macro/signature-proc-macro-derive.rs
+++ b/tests/ui/proc-macro/signature-proc-macro-derive.rs
@@ -8,24 +8,23 @@ use proc_macro::TokenStream;
 
 #[proc_macro_derive(Blah)]
 pub fn bad_input(input: String) -> TokenStream {
-    //~^ ERROR mismatched derive proc macro signature
+    //~^ ERROR derive proc macro has incorrect signature
     TokenStream::new()
 }
 
 #[proc_macro_derive(Bleh)]
 pub fn bad_output(input: TokenStream) -> String {
-    //~^ ERROR mismatched derive proc macro signature
+    //~^ ERROR derive proc macro has incorrect signature
     String::from("blah")
 }
 
 #[proc_macro_derive(Bluh)]
 pub fn bad_everything(input: String) -> String {
-    //~^ ERROR mismatched derive proc macro signature
-    //~| ERROR mismatched derive proc macro signature
+    //~^ ERROR derive proc macro has incorrect signature
     input
 }
 
 #[proc_macro_derive(Blih)]
 pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
-    //~^ ERROR mismatched derive proc macro signature
+    //~^ ERROR derive proc macro has incorrect signature
 }

--- a/tests/ui/proc-macro/signature-proc-macro-derive.stderr
+++ b/tests/ui/proc-macro/signature-proc-macro-derive.stderr
@@ -1,35 +1,35 @@
 error: derive proc macro has incorrect signature
-  --> $DIR/signature-proc-macro-derive.rs:10:1
+  --> $DIR/signature-proc-macro-derive.rs:10:25
    |
 LL | pub fn bad_input(input: String) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
+   |                         ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
    = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `fn(std::string::String) -> proc_macro::TokenStream`
 
 error: derive proc macro has incorrect signature
-  --> $DIR/signature-proc-macro-derive.rs:16:1
+  --> $DIR/signature-proc-macro-derive.rs:16:42
    |
 LL | pub fn bad_output(input: TokenStream) -> String {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
+   |                                          ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
    = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `fn(proc_macro::TokenStream) -> std::string::String`
 
 error: derive proc macro has incorrect signature
-  --> $DIR/signature-proc-macro-derive.rs:22:1
+  --> $DIR/signature-proc-macro-derive.rs:22:30
    |
 LL | pub fn bad_everything(input: String) -> String {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
+   |                              ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
    = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `fn(std::string::String) -> std::string::String`
 
 error: derive proc macro has incorrect signature
-  --> $DIR/signature-proc-macro-derive.rs:28:1
+  --> $DIR/signature-proc-macro-derive.rs:28:36
    |
 LL | pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
+   |                                    ^^^^^^^^^^^ incorrect number of function parameters
    |
    = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> proc_macro::TokenStream`

--- a/tests/ui/proc-macro/signature-proc-macro-derive.stderr
+++ b/tests/ui/proc-macro/signature-proc-macro-derive.stderr
@@ -1,40 +1,38 @@
-error: mismatched derive proc macro signature
-  --> $DIR/signature-proc-macro-derive.rs:10:25
+error: derive proc macro has incorrect signature
+  --> $DIR/signature-proc-macro-derive.rs:10:1
    |
 LL | pub fn bad_input(input: String) -> TokenStream {
-   |                         ^^^^^^ found std::string::String, expected type `proc_macro::TokenStream`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
-   = note: derive proc macros must have a signature of `fn(TokenStream) -> TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(std::string::String) -> proc_macro::TokenStream`
 
-error: mismatched derive proc macro signature
-  --> $DIR/signature-proc-macro-derive.rs:16:42
+error: derive proc macro has incorrect signature
+  --> $DIR/signature-proc-macro-derive.rs:16:1
    |
 LL | pub fn bad_output(input: TokenStream) -> String {
-   |                                          ^^^^^^ found std::string::String, expected type `proc_macro::TokenStream`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
-   = note: derive proc macros must have a signature of `fn(TokenStream) -> TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(proc_macro::TokenStream) -> std::string::String`
 
-error: mismatched derive proc macro signature
-  --> $DIR/signature-proc-macro-derive.rs:22:41
+error: derive proc macro has incorrect signature
+  --> $DIR/signature-proc-macro-derive.rs:22:1
    |
 LL | pub fn bad_everything(input: String) -> String {
-   |                                         ^^^^^^ found std::string::String, expected type `proc_macro::TokenStream`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
-   = note: derive proc macros must have a signature of `fn(TokenStream) -> TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(std::string::String) -> std::string::String`
 
-error: mismatched derive proc macro signature
-  --> $DIR/signature-proc-macro-derive.rs:22:30
-   |
-LL | pub fn bad_everything(input: String) -> String {
-   |                              ^^^^^^ found std::string::String, expected type `proc_macro::TokenStream`
-   |
-   = note: derive proc macros must have a signature of `fn(TokenStream) -> TokenStream`
-
-error: mismatched derive proc macro signature
-  --> $DIR/signature-proc-macro-derive.rs:29:33
+error: derive proc macro has incorrect signature
+  --> $DIR/signature-proc-macro-derive.rs:28:1
    |
 LL | pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ found unexpected arguments
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
+   |
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> proc_macro::TokenStream`
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/proc-macro/signature-proc-macro.rs
+++ b/tests/ui/proc-macro/signature-proc-macro.rs
@@ -8,24 +8,23 @@ use proc_macro::TokenStream;
 
 #[proc_macro]
 pub fn bad_input(input: String) -> TokenStream {
-    //~^ ERROR mismatched function-like proc macro signature
+    //~^ ERROR function-like proc macro has incorrect signature
     ::proc_macro::TokenStream::new()
 }
 
 #[proc_macro]
 pub fn bad_output(input: TokenStream) -> String {
-    //~^ ERROR mismatched function-like proc macro signature
+    //~^ ERROR function-like proc macro has incorrect signature
     String::from("blah")
 }
 
 #[proc_macro]
 pub fn bad_everything(input: String) -> String {
-    //~^ ERROR mismatched function-like proc macro signature
-    //~| ERROR mismatched function-like proc macro signature
+    //~^ ERROR function-like proc macro has incorrect signature
     input
 }
 
 #[proc_macro]
 pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
-    //~^ ERROR mismatched function-like proc macro signature
+    //~^ ERROR function-like proc macro has incorrect signature
 }

--- a/tests/ui/proc-macro/signature-proc-macro.stderr
+++ b/tests/ui/proc-macro/signature-proc-macro.stderr
@@ -1,40 +1,38 @@
-error: mismatched function-like proc macro signature
-  --> $DIR/signature-proc-macro.rs:10:25
+error: function-like proc macro has incorrect signature
+  --> $DIR/signature-proc-macro.rs:10:1
    |
 LL | pub fn bad_input(input: String) -> TokenStream {
-   |                         ^^^^^^ found std::string::String, expected type `proc_macro::TokenStream`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
-   = note: function-like proc macros must have a signature of `fn(TokenStream) -> TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(std::string::String) -> proc_macro::TokenStream`
 
-error: mismatched function-like proc macro signature
-  --> $DIR/signature-proc-macro.rs:16:42
+error: function-like proc macro has incorrect signature
+  --> $DIR/signature-proc-macro.rs:16:1
    |
 LL | pub fn bad_output(input: TokenStream) -> String {
-   |                                          ^^^^^^ found std::string::String, expected type `proc_macro::TokenStream`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
-   = note: function-like proc macros must have a signature of `fn(TokenStream) -> TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(proc_macro::TokenStream) -> std::string::String`
 
-error: mismatched function-like proc macro signature
-  --> $DIR/signature-proc-macro.rs:22:41
+error: function-like proc macro has incorrect signature
+  --> $DIR/signature-proc-macro.rs:22:1
    |
 LL | pub fn bad_everything(input: String) -> String {
-   |                                         ^^^^^^ found std::string::String, expected type `proc_macro::TokenStream`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
-   = note: function-like proc macros must have a signature of `fn(TokenStream) -> TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(std::string::String) -> std::string::String`
 
-error: mismatched function-like proc macro signature
-  --> $DIR/signature-proc-macro.rs:22:30
-   |
-LL | pub fn bad_everything(input: String) -> String {
-   |                              ^^^^^^ found std::string::String, expected type `proc_macro::TokenStream`
-   |
-   = note: function-like proc macros must have a signature of `fn(TokenStream) -> TokenStream`
-
-error: mismatched function-like proc macro signature
-  --> $DIR/signature-proc-macro.rs:29:33
+error: function-like proc macro has incorrect signature
+  --> $DIR/signature-proc-macro.rs:28:1
    |
 LL | pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ found unexpected arguments
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
+   |
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> proc_macro::TokenStream`
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/proc-macro/signature-proc-macro.stderr
+++ b/tests/ui/proc-macro/signature-proc-macro.stderr
@@ -1,35 +1,35 @@
 error: function-like proc macro has incorrect signature
-  --> $DIR/signature-proc-macro.rs:10:1
+  --> $DIR/signature-proc-macro.rs:10:25
    |
 LL | pub fn bad_input(input: String) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
+   |                         ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
    = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `fn(std::string::String) -> proc_macro::TokenStream`
 
 error: function-like proc macro has incorrect signature
-  --> $DIR/signature-proc-macro.rs:16:1
+  --> $DIR/signature-proc-macro.rs:16:42
    |
 LL | pub fn bad_output(input: TokenStream) -> String {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
+   |                                          ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
    = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `fn(proc_macro::TokenStream) -> std::string::String`
 
 error: function-like proc macro has incorrect signature
-  --> $DIR/signature-proc-macro.rs:22:1
+  --> $DIR/signature-proc-macro.rs:22:30
    |
 LL | pub fn bad_everything(input: String) -> String {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
+   |                              ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
    = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `fn(std::string::String) -> std::string::String`
 
 error: function-like proc macro has incorrect signature
-  --> $DIR/signature-proc-macro.rs:28:1
+  --> $DIR/signature-proc-macro.rs:28:36
    |
 LL | pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
+   |                                    ^^^^^^^^^^^ incorrect number of function parameters
    |
    = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> proc_macro::TokenStream`

--- a/tests/ui/proc-macro/signature.rs
+++ b/tests/ui/proc-macro/signature.rs
@@ -8,10 +8,6 @@ extern crate proc_macro;
 
 #[proc_macro_derive(A)]
 pub unsafe extern "C" fn foo(a: i32, b: u32) -> u32 {
-    //~^ ERROR: mismatched derive proc macro signature
-    //~| mismatched derive proc macro signature
-    //~| mismatched derive proc macro signature
-    //~| proc macro functions may not be `extern
-    //~| proc macro functions may not be `unsafe
+    //~^ ERROR: derive proc macro has incorrect signature
     loop {}
 }

--- a/tests/ui/proc-macro/signature.stderr
+++ b/tests/ui/proc-macro/signature.stderr
@@ -1,36 +1,11 @@
-error: proc macro functions may not be `extern "C"`
+error: derive proc macro has incorrect signature
   --> $DIR/signature.rs:10:1
    |
 LL | pub unsafe extern "C" fn foo(a: i32, b: u32) -> u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected normal fn, found unsafe fn
+   |
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `unsafe extern "C" fn(i32, u32) -> u32`
 
-error: proc macro functions may not be `unsafe`
-  --> $DIR/signature.rs:10:1
-   |
-LL | pub unsafe extern "C" fn foo(a: i32, b: u32) -> u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: mismatched derive proc macro signature
-  --> $DIR/signature.rs:10:49
-   |
-LL | pub unsafe extern "C" fn foo(a: i32, b: u32) -> u32 {
-   |                                                 ^^^ found u32, expected type `proc_macro::TokenStream`
-   |
-   = note: derive proc macros must have a signature of `fn(TokenStream) -> TokenStream`
-
-error: mismatched derive proc macro signature
-  --> $DIR/signature.rs:10:33
-   |
-LL | pub unsafe extern "C" fn foo(a: i32, b: u32) -> u32 {
-   |                                 ^^^ found i32, expected type `proc_macro::TokenStream`
-   |
-   = note: derive proc macros must have a signature of `fn(TokenStream) -> TokenStream`
-
-error: mismatched derive proc macro signature
-  --> $DIR/signature.rs:10:38
-   |
-LL | pub unsafe extern "C" fn foo(a: i32, b: u32) -> u32 {
-   |                                      ^^^^^^ found unexpected argument
-
-error: aborting due to 5 previous errors
+error: aborting due to previous error
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -492,7 +492,6 @@ compiler-team = [
     "@oli-obk",
     "@lcnr",
     "@wesleywiser",
-    "@michaelwoerister",
 ]
 compiler-team-contributors = [
     "@compiler-errors",


### PR DESCRIPTION
Successful merges:

 - #108991 (add `enable-warnings` flag for llvm, and disable it by default.)
 - #109109 (Use `unused_generic_params` from crate metadata)
 - #109111 (Create dirs for build_triple)
 - #109136 (Simplify proc macro signature validity check)
 - #109150 (Update cargo)
 - #109154 (Fix MappingToUnit  to support no span of arg_ty)
 - #109157 (Remove mw from review rotation for a while)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=108991,109109,109111,109136,109150,109154,109157)
<!-- homu-ignore:end -->