### PR TITLE
allow ReError in CanonicalUserTypeAnnotation

### DIFF
--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -230,9 +230,9 @@ impl CanonicalizeMode for CanonicalizeUserTypeAnnotation {
         r: ty::Region<'tcx>,
     ) -> ty::Region<'tcx> {
         match *r {
-            ty::ReEarlyBound(_) | ty::ReFree(_) | ty::ReErased | ty::ReStatic => r,
+            ty::ReEarlyBound(_) | ty::ReFree(_) | ty::ReErased | ty::ReStatic | ty::ReError(_) => r,
             ty::ReVar(_) => canonicalizer.canonical_var_for_region_in_root_universe(r),
-            _ => {
+            ty::RePlaceholder(..) | ty::ReLateBound(..) => {
                 // We only expect region names that the user can type.
                 bug!("unexpected region in query response: `{:?}`", r)
             }

--- a/tests/ui/nll/user-annotations/region-error-ice-109072.rs
+++ b/tests/ui/nll/user-annotations/region-error-ice-109072.rs
@@ -1,0 +1,14 @@
+// Regression test for #109072.
+// Check that we don't ICE when canonicalizing user annotation.
+
+trait Lt<'a> {
+    type T;
+}
+
+impl Lt<'missing> for () { //~ ERROR undeclared lifetime
+    type T = &'missing (); //~ ERROR undeclared lifetime
+}
+
+fn main() {
+    let _: <() as Lt<'_>>::T = &();
+}

--- a/tests/ui/nll/user-annotations/region-error-ice-109072.stderr
+++ b/tests/ui/nll/user-annotations/region-error-ice-109072.stderr
@@ -1,0 +1,26 @@
+error[E0261]: use of undeclared lifetime name `'missing`
+  --> $DIR/region-error-ice-109072.rs:8:9
+   |
+LL | impl Lt<'missing> for () {
+   |     -   ^^^^^^^^ undeclared lifetime
+   |     |
+   |     help: consider introducing lifetime `'missing` here: `<'missing>`
+
+error[E0261]: use of undeclared lifetime name `'missing`
+  --> $DIR/region-error-ice-109072.rs:9:15
+   |
+LL |     type T = &'missing ();
+   |               ^^^^^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'missing` here
+   |
+LL |     type T<'missing> = &'missing ();
+   |           ++++++++++
+help: consider introducing lifetime `'missing` here
+   |
+LL | impl<'missing> Lt<'missing> for () {
+   |     ++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0261`.


### PR DESCRIPTION
Why not? we already allow `TyKind::Error`.

Fixes #109072.