### PR TITLE
Set `CMAKE_SYSTEM_NAME` for Linux targets

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -570,6 +570,8 @@ fn configure_cmake(
             cfg.define("CMAKE_SYSTEM_NAME", "Haiku");
         } else if target.contains("solaris") || target.contains("illumos") {
             cfg.define("CMAKE_SYSTEM_NAME", "SunOS");
+        } else if target.contains("linux") {
+            cfg.define("CMAKE_SYSTEM_NAME", "Linux");
         }
         // When cross-compiling we should also set CMAKE_SYSTEM_VERSION, but in
         // that case like CMake we cannot easily determine system version either.


### PR DESCRIPTION
When bootstrap compiles native dependencies like LLVM, it should set `CMAKE_SYSTEM_NAME` for the target system; otherwise cmake may not identify that it is cross-compiling.

In particular, when building a Linux rustc on a macOS host, cmake was including `-isysroot /path/to/macOS.sdk` options that caused things to break.  By setting `CMAKE_SYSTEM_NAME=Linux` when building for Linux targets, the macOS SDK is no longer passed as sysroot to the compiler.

r? bootstrap