### PR TITLE
Add tier 3 no_std x86 support for QNX Neutrino RTOS, version 7.0

### DIFF
--- a/compiler/rustc_target/src/spec/aarch64_unknown_nto_qnx_710.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_nto_qnx_710.rs
@@ -23,6 +23,7 @@ pub fn target() -> Target {
                 LinkerFlavor::Gnu(Cc::Yes, Lld::No),
                 &["-Vgcc_ntoaarch64le_cxx"],
             ),
+            env: "nto71".into(),
             ..nto_qnx_base::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/i586_pc_nto_qnx700.rs
+++ b/compiler/rustc_target/src/spec/i586_pc_nto_qnx700.rs
@@ -1,0 +1,24 @@
+use super::nto_qnx_base;
+use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "i586-pc-unknown".into(),
+        pointer_width: 32,
+        data_layout: "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-\
+            f64:32:64-f80:32-n8:16:32-S128"
+            .into(),
+        arch: "x86".into(),
+        options: TargetOptions {
+            cpu: "pentium4".into(),
+            max_atomic_width: Some(64),
+            pre_link_args: TargetOptions::link_args(
+                LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+                &["-Vgcc_ntox86_cxx"],
+            ),
+            env: "nto70".into(),
+            stack_probes: StackProbeType::X86,
+            ..nto_qnx_base::opts()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1261,6 +1261,7 @@ supported_targets! {
 
     ("aarch64-unknown-nto-qnx710", aarch64_unknown_nto_qnx_710),
     ("x86_64-pc-nto-qnx710", x86_64_pc_nto_qnx710),
+    ("i586-pc-nto-qnx700", i586_pc_nto_qnx700),
 
     ("aarch64-unknown-linux-ohos", aarch64_unknown_linux_ohos),
     ("armv7-unknown-linux-ohos", armv7_unknown_linux_ohos),

--- a/compiler/rustc_target/src/spec/nto_qnx_base.rs
+++ b/compiler/rustc_target/src/spec/nto_qnx_base.rs
@@ -4,7 +4,6 @@ pub fn opts() -> TargetOptions {
     TargetOptions {
         crt_static_respected: true,
         dynamic_linking: true,
-        env: "nto71".into(),
         executables: true,
         families: cvs!["unix"],
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/x86_64_pc_nto_qnx710.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pc_nto_qnx710.rs
@@ -15,6 +15,7 @@ pub fn target() -> Target {
                 LinkerFlavor::Gnu(Cc::Yes, Lld::No),
                 &["-Vgcc_ntox86_64_cxx"],
             ),
+            env: "nto71".into(),
             ..nto_qnx_base::opts()
         },
     }

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -257,6 +257,7 @@ target | std | host | notes
 `bpfel-unknown-none` | * |  | BPF (little endian)
 `hexagon-unknown-linux-musl` | ? |  |
 `i386-apple-ios` | ✓ |  | 32-bit x86 iOS
+[`i586-pc-nto-qnx700`](platform-support/nto-qnx.md) | * |  | 32-bit x86 QNX Neutrino 7.0 RTOS |
 `i686-apple-darwin` | ✓ | ✓ | 32-bit macOS (10.7+, Lion+)
 `i686-pc-windows-msvc` | * |  | 32-bit Windows XP support
 `i686-unknown-haiku` | ✓ | ✓ | 32-bit Haiku

--- a/src/doc/rustc/src/platform-support/nto-qnx.md
+++ b/src/doc/rustc/src/platform-support/nto-qnx.md
@@ -16,10 +16,18 @@ and [Blackberry QNX][BlackBerry].
 
 ## Requirements
 
-Currently, only cross-compilation for QNX Neutrino on AArch64 and x86_64 are supported (little endian).
+Currently, the following QNX Neutrino versions and compilation targets are supported:
+
+| QNX Neutrino Version | Target Architecture | Full support | `no_std` support |
+|----------------------|---------------------|:------------:|:----------------:|
+| 7.1 | AArch64 | ✓ | ✓ |
+| 7.1 | x86_64  | ✓ | ✓ |
+| 7.0 | x86     |   | ✓ |
+
 Adding other architectures that are supported by QNX Neutrino is possible.
 
-The standard library, including `core` and `alloc` (with default allocator) are supported.
+In the table above, 'full support' indicates support for building Rust applications with the full standard library.
+'`no_std` support' indicates that only `core` and `alloc` are available.
 
 For building or using the Rust toolchain for QNX Neutrino, the
 [QNX Software Development Platform (SDP)](https://blackberry.qnx.com/en/products/foundation-software/qnx-software-development-platform)
@@ -70,7 +78,7 @@ fn panic(_panic: &PanicInfo<'_>) -> ! {
 pub extern "C" fn rust_eh_personality() {}
 ```
 
-The QNX Neutrino support of Rust has been tested with QNX Neutrino 7.1.
+The QNX Neutrino support of Rust has been tested with QNX Neutrino 7.0 and 7.1.
 
 There are no further known requirements.
 
@@ -80,6 +88,7 @@ For conditional compilation, following QNX Neutrino specific attributes are defi
 
 - `target_os` = `"nto"`
 - `target_env` = `"nto71"` (for QNX Neutrino 7.1)
+- `target_env` = `"nto70"` (for QNX Neutrino 7.0)
 
 ## Building the target
 


### PR DESCRIPTION
This PR adds the target `i586-pc-nto-qnx700`, which targets QNX Neutrino RTOS version 7.0 on x86 32-bit targets.

cc: @flba-eb @gh-tr

This target falls under the umbrella of Tier 3 QNX Neutrino RTOS support documented in `nto-qnx.md` and previously started with #102701.