### PR TITLE
Use write_str() instead of write!() when possible

### DIFF
--- a/compiler/rustc_ast/src/util/literal.rs
+++ b/compiler/rustc_ast/src/util/literal.rs
@@ -210,7 +210,7 @@ impl fmt::Display for LitKind {
             LitKind::Err => {
                 // This only shows up in places like `-Zunpretty=hir` output, so we
                 // don't bother to produce something useful.
-                write!(f, "<bad-literal>")?;
+                f.write_str("<bad-literal>")?;
             }
         }
 

--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -37,9 +37,9 @@ impl fmt::Display for ConstEvalErrKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::ConstEvalErrKind::*;
         match self {
-            ConstAccessesStatic => write!(f, "constant accesses static"),
+            ConstAccessesStatic => f.write_str("constant accesses static"),
             ModifiedGlobal => {
-                write!(f, "modifying a static's initial value from another static's initializer")
+                f.write_str("modifying a static's initial value from another static's initializer")
             }
             AssertFailure(msg) => write!(f, "{:?}", msg),
             Panic { msg, line, col, file } => {

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -147,7 +147,7 @@ pub enum MemoryKind {
 impl fmt::Display for MemoryKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MemoryKind::Heap => write!(f, "heap allocation"),
+            MemoryKind::Heap => f.write_str("heap allocation"),
         }
     }
 }

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -265,7 +265,7 @@ impl<'tcx> fmt::Display for FrameInfo<'tcx> {
             if tcx.def_key(self.instance.def_id()).disambiguated_data.data
                 == DefPathData::ClosureExpr
             {
-                write!(f, "inside closure")
+                f.write_str("inside closure")
             } else {
                 // Note: this triggers a `good_path_bug` state, which means that if we ever get here
                 // we must emit a diagnostic. We should never display a `FrameInfo` unless we
@@ -987,12 +987,12 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> std::fmt::Debug
                 if frame != self.ecx.frame_idx() {
                     write!(fmt, " ({} frames up)", self.ecx.frame_idx() - frame)?;
                 }
-                write!(fmt, ":")?;
+                fmt.write_str(":")?;
 
                 match self.ecx.stack()[frame].locals[local].value {
-                    LocalValue::Dead => write!(fmt, " is dead")?,
+                    LocalValue::Dead => fmt.write_str(" is dead")?,
                     LocalValue::Live(Operand::Immediate(Immediate::Uninit)) => {
-                        write!(fmt, " is uninitialized")?
+                        fmt.write_str(" is uninitialized")?
                     }
                     LocalValue::Live(Operand::Indirect(mplace)) => {
                         write!(

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -50,8 +50,8 @@ impl<T: MayLeak> MayLeak for MemoryKind<T> {
 impl<T: fmt::Display> fmt::Display for MemoryKind<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MemoryKind::Stack => write!(f, "stack variable"),
-            MemoryKind::CallerLocation => write!(f, "caller location"),
+            MemoryKind::Stack => f.write_str("stack variable"),
+            MemoryKind::CallerLocation => f.write_str("caller location"),
             MemoryKind::Machine(m) => write!(f, "{}", m),
         }
     }
@@ -893,7 +893,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> std::fmt::Debug for DumpAllocs<'a, 
                     // global alloc
                     match self.ecx.tcx.try_get_global_alloc(id) {
                         Some(GlobalAlloc::Memory(alloc)) => {
-                            write!(fmt, " (unchanged global, ")?;
+                            fmt.write_str(" (unchanged global, ")?;
                             write_allocation_track_relocs(
                                 &mut *fmt,
                                 *self.ecx.tcx,
@@ -914,7 +914,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> std::fmt::Debug for DumpAllocs<'a, 
                             write!(fmt, " (static: {})", self.ecx.tcx.def_path_str(did))?;
                         }
                         None => {
-                            write!(fmt, " (deallocated)")?;
+                            fmt.write_str(" (deallocated)")?;
                         }
                     }
                 }

--- a/compiler/rustc_driver_impl/src/args.rs
+++ b/compiler/rustc_driver_impl/src/args.rs
@@ -41,7 +41,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Utf8Error(None) => write!(fmt, "Utf8 error"),
+            Error::Utf8Error(None) => fmt.write_str("Utf8 error"),
             Error::Utf8Error(Some(path)) => write!(fmt, "Utf8 error in {path}"),
             Error::IOError(path, err) => write!(fmt, "IO Error: {path}: {err}"),
         }

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -74,7 +74,7 @@ impl fmt::Display for TranslationBundleError {
                 write!(f, "could not parse ftl file: {}", e)
             }
             TranslationBundleError::AddResource(e) => write!(f, "failed to add resource: {}", e),
-            TranslationBundleError::MissingLocale => write!(f, "missing locale directory"),
+            TranslationBundleError::MissingLocale => f.write_str("missing locale directory"),
             TranslationBundleError::ReadLocalesDir(e) => {
                 write!(f, "could not read locales dir: {}", e)
             }
@@ -82,7 +82,7 @@ impl fmt::Display for TranslationBundleError {
                 write!(f, "could not read locales dir entry: {}", e)
             }
             TranslationBundleError::LocaleIsNotDir => {
-                write!(f, "`$sysroot/share/locales/$locale` is not a directory")
+                f.write_str("`$sysroot/share/locales/$locale` is not a directory")
             }
         }
     }

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -157,7 +157,7 @@ impl Display for MatcherLoc {
                 if let Some(kind) = kind {
                     write!(f, ":{}", kind)?;
                 }
-                write!(f, "`")?;
+                f.write_str("`")?;
                 Ok(())
             }
             MatcherLoc::Eof => f.write_str("end of macro"),

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -72,7 +72,7 @@ impl std::fmt::Debug for AttributeGate {
             Self::Gated(ref stab, name, expl, _) => {
                 write!(fmt, "Gated({stab:?}, {name}, {expl})")
             }
-            Self::Ungated => write!(fmt, "Ungated"),
+            Self::Ungated => fmt.write_str("Ungated"),
         }
     }
 }

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -38,10 +38,10 @@ pub enum State {
 impl fmt::Debug for State {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            State::Accepted { .. } => write!(f, "accepted"),
-            State::Active { .. } => write!(f, "active"),
-            State::Removed { .. } => write!(f, "removed"),
-            State::Stabilized { .. } => write!(f, "stabilized"),
+            State::Accepted { .. } => f.write_str("accepted"),
+            State::Active { .. } => f.write_str("active"),
+            State::Removed { .. } => f.write_str("removed"),
+            State::Stabilized { .. } => f.write_str("stabilized"),
         }
     }
 }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1620,9 +1620,9 @@ impl ConstContext {
 impl fmt::Display for ConstContext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Self::Const => write!(f, "constant"),
-            Self::Static(_) => write!(f, "static"),
-            Self::ConstFn => write!(f, "constant function"),
+            Self::Const => f.write_str("constant"),
+            Self::Static(_) => f.write_str("static"),
+            Self::ConstFn => f.write_str("constant function"),
         }
     }
 }

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -531,8 +531,8 @@ impl<'tcx> fmt::Display for FixupError<'tcx> {
                 "cannot determine the type of this number; \
                  add a suffix to specify the type explicitly"
             ),
-            UnresolvedTy(_) => write!(f, "unconstrained type"),
-            UnresolvedConst(_) => write!(f, "unconstrained const value"),
+            UnresolvedTy(_) => f.write_str("unconstrained type"),
+            UnresolvedConst(_) => f.write_str("unconstrained const value"),
         }
     }
 }

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -702,7 +702,7 @@ impl<'tcx> RegionConstraintCollector<'_, 'tcx> {
 
 impl fmt::Debug for RegionSnapshot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "RegionSnapshot")
+        f.write_str("RegionSnapshot")
     }
 }
 

--- a/compiler/rustc_infer/src/traits/structural_impls.rs
+++ b/compiler/rustc_infer/src/traits/structural_impls.rs
@@ -46,7 +46,7 @@ impl<'tcx> fmt::Debug for traits::FulfillmentErrorCode<'tcx> {
             super::CodeConstEquateError(ref a, ref b) => {
                 write!(f, "CodeConstEquateError({:?}, {:?})", a, b)
             }
-            super::CodeAmbiguity => write!(f, "Ambiguity"),
+            super::CodeAmbiguity => f.write_str("Ambiguity"),
             super::CodeCycle(ref cycle) => write!(f, "Cycle({:?})", cycle),
         }
     }

--- a/compiler/rustc_interface/src/callbacks.rs
+++ b/compiler/rustc_interface/src/callbacks.rs
@@ -56,7 +56,7 @@ fn def_id_debug(def_id: rustc_hir::def_id::DefId, f: &mut fmt::Formatter<'_>) ->
         }
         Ok(())
     })?;
-    write!(f, ")")
+    f.write_str(")")
 }
 
 /// Sets up the callbacks in prior crates which we want to refer to the

--- a/compiler/rustc_macros/src/diagnostics/utils.rs
+++ b/compiler/rustc_macros/src/diagnostics/utils.rs
@@ -516,11 +516,11 @@ impl FromStr for SuggestionKind {
 impl fmt::Display for SuggestionKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SuggestionKind::Normal => write!(f, "normal"),
-            SuggestionKind::Short => write!(f, "short"),
-            SuggestionKind::Hidden => write!(f, "hidden"),
-            SuggestionKind::Verbose => write!(f, "verbose"),
-            SuggestionKind::ToolOnly => write!(f, "tool-only"),
+            SuggestionKind::Normal => f.write_str("normal"),
+            SuggestionKind::Short => f.write_str("short"),
+            SuggestionKind::Hidden => f.write_str("hidden"),
+            SuggestionKind::Verbose => f.write_str("verbose"),
+            SuggestionKind::ToolOnly => f.write_str("tool-only"),
         }
     }
 }
@@ -822,13 +822,13 @@ impl SubdiagnosticKind {
 impl quote::IdentFragment for SubdiagnosticKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SubdiagnosticKind::Label => write!(f, "label"),
-            SubdiagnosticKind::Note => write!(f, "note"),
-            SubdiagnosticKind::Help => write!(f, "help"),
-            SubdiagnosticKind::Warn => write!(f, "warn"),
-            SubdiagnosticKind::Suggestion { .. } => write!(f, "suggestions_with_style"),
+            SubdiagnosticKind::Label => f.write_str("label"),
+            SubdiagnosticKind::Note => f.write_str("note"),
+            SubdiagnosticKind::Help => f.write_str("help"),
+            SubdiagnosticKind::Warn => f.write_str("warn"),
+            SubdiagnosticKind::Suggestion { .. } => f.write_str("suggestions_with_style"),
             SubdiagnosticKind::MultipartSuggestion { .. } => {
-                write!(f, "multipart_suggestion_with_style")
+                f.write_str("multipart_suggestion_with_style")
             }
         }
     }

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -45,7 +45,7 @@ impl rustc_query_system::dep_graph::DepKind for DepKind {
             Ok(())
         })?;
 
-        write!(f, ")")
+        f.write_str(")")
     }
 
     fn with_deps<OP, R>(task_deps: TaskDepsRef<'_>, op: OP) -> R

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -141,7 +141,7 @@ impl Debug for CoverageKind {
                 },
                 rhs.index(),
             ),
-            Unreachable => write!(fmt, "Unreachable"),
+            Unreachable => fmt.write_str("Unreachable"),
         }
     }
 }

--- a/compiler/rustc_middle/src/mir/interpret/allocation.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation.rs
@@ -150,7 +150,7 @@ impl<'tcx> fmt::Debug for ConstAllocation<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // The debug representation of this is very verbose and basically useless,
         // so don't print it.
-        write!(f, "ConstAllocation {{ .. }}")
+        f.write_str("ConstAllocation { .. }")
     }
 }
 

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -140,7 +140,7 @@ impl fmt::Display for InvalidProgramInfo<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use InvalidProgramInfo::*;
         match self {
-            TooGeneric => write!(f, "encountered overly generic constant"),
+            TooGeneric => f.write_str("encountered overly generic constant"),
             AlreadyReported(ErrorGuaranteed { .. }) => {
                 write!(
                     f,
@@ -288,15 +288,15 @@ impl fmt::Display for UndefinedBehaviorInfo {
         use UndefinedBehaviorInfo::*;
         match self {
             Ub(msg) => write!(f, "{msg}"),
-            Unreachable => write!(f, "entering unreachable code"),
+            Unreachable => f.write_str("entering unreachable code"),
             BoundsCheckFailed { ref len, ref index } => {
                 write!(f, "indexing out of bounds: the len is {len} but the index is {index}")
             }
-            DivisionByZero => write!(f, "dividing by zero"),
-            RemainderByZero => write!(f, "calculating the remainder with a divisor of zero"),
-            DivisionOverflow => write!(f, "overflow in signed division (dividing MIN by -1)"),
-            RemainderOverflow => write!(f, "overflow in signed remainder (dividing MIN by -1)"),
-            PointerArithOverflow => write!(f, "overflowing in-bounds pointer arithmetic"),
+            DivisionByZero => f.write_str("dividing by zero"),
+            RemainderByZero => f.write_str("calculating the remainder with a divisor of zero"),
+            DivisionOverflow => f.write_str("overflow in signed division (dividing MIN by -1)"),
+            RemainderOverflow => f.write_str("overflow in signed remainder (dividing MIN by -1)"),
+            PointerArithOverflow => f.write_str("overflowing in-bounds pointer arithmetic"),
             InvalidMeta(msg) => write!(f, "invalid metadata in wide pointer: {msg}"),
             UnterminatedCString(p) => write!(
                 f,
@@ -367,13 +367,13 @@ impl fmt::Display for UndefinedBehaviorInfo {
                 f,
                 "using uninitialized data, but this operation requires initialized memory"
             ),
-            DeadLocal => write!(f, "accessing a dead local variable"),
+            DeadLocal => f.write_str("accessing a dead local variable"),
             ScalarSizeMismatch(self::ScalarSizeMismatch { target_size, data_size }) => write!(
                 f,
                 "scalar size mismatch: expected {target_size} bytes but got {data_size} bytes instead",
             ),
             UninhabitedEnumVariantWritten => {
-                write!(f, "writing discriminant of an uninhabited enum")
+                f.write_str("writing discriminant of an uninhabited enum")
             }
         }
     }
@@ -414,7 +414,7 @@ impl fmt::Display for UnsupportedOpInfo {
             PartialPointerCopy(ptr) => {
                 write!(f, "unable to copy parts of a pointer from memory at {ptr:?}")
             }
-            ReadPointerAsBytes => write!(f, "unable to turn pointer into raw bytes"),
+            ReadPointerAsBytes => f.write_str("unable to turn pointer into raw bytes"),
             ThreadLocalStatic(did) => write!(f, "cannot access thread local static ({did:?})"),
             ReadExternStatic(did) => write!(f, "cannot read from extern static ({did:?})"),
         }
@@ -441,16 +441,16 @@ impl fmt::Display for ResourceExhaustionInfo {
         use ResourceExhaustionInfo::*;
         match self {
             StackFrameLimitReached => {
-                write!(f, "reached the configured maximum number of stack frames")
+                f.write_str("reached the configured maximum number of stack frames")
             }
             StepLimitReached => {
-                write!(f, "exceeded interpreter step limit (see `#[const_eval_limit]`)")
+                f.write_str("exceeded interpreter step limit (see `#[const_eval_limit]`)")
             }
             MemoryExhausted => {
-                write!(f, "tried to allocate more memory than available to compiler")
+                f.write_str("tried to allocate more memory than available to compiler")
             }
             AddressSpaceFull => {
-                write!(f, "there are no more free addresses in the address space")
+                f.write_str("there are no more free addresses in the address space")
             }
         }
     }

--- a/compiler/rustc_middle/src/mir/interpret/pointer.rs
+++ b/compiler/rustc_middle/src/mir/interpret/pointer.rs
@@ -204,7 +204,7 @@ impl<Prov: Provenance> fmt::Debug for Pointer<Option<Prov>> {
 impl<Prov: Provenance> fmt::Display for Pointer<Option<Prov>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.provenance.is_none() && self.offset.bytes() == 0 {
-            write!(f, "null pointer")
+            f.write_str("null pointer")
         } else {
             fmt::Debug::fmt(self, f)
         }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1063,7 +1063,7 @@ impl<'tcx> Debug for VarDebugInfoContents<'tcx> {
                 for f in fragments.iter() {
                     write!(fmt, "{:?}, ", f)?;
                 }
-                write!(fmt, "}}")
+                fmt.write_str("}")
             }
         }
     }
@@ -1464,8 +1464,8 @@ impl Debug for Statement<'_> {
             }
             Coverage(box ref coverage) => write!(fmt, "Coverage::{:?}", coverage.kind),
             Intrinsic(box ref intrinsic) => write!(fmt, "{intrinsic}"),
-            ConstEvalCounter => write!(fmt, "ConstEvalCounter"),
-            Nop => write!(fmt, "nop"),
+            ConstEvalCounter => fmt.write_str("ConstEvalCounter"),
+            Nop => fmt.write_str("nop"),
         }
     }
 }
@@ -1703,10 +1703,10 @@ impl Debug for Place<'_> {
                 ProjectionElem::OpaqueCast(_)
                 | ProjectionElem::Downcast(_, _)
                 | ProjectionElem::Field(_, _) => {
-                    write!(fmt, "(").unwrap();
+                    fmt.write_str("(").unwrap();
                 }
                 ProjectionElem::Deref => {
-                    write!(fmt, "(*").unwrap();
+                    fmt.write_str("(*").unwrap();
                 }
                 ProjectionElem::Index(_)
                 | ProjectionElem::ConstantIndex { .. }
@@ -1728,7 +1728,7 @@ impl Debug for Place<'_> {
                     write!(fmt, " as variant#{:?})", index)?;
                 }
                 ProjectionElem::Deref => {
-                    write!(fmt, ")")?;
+                    fmt.write_str(")")?;
                 }
                 ProjectionElem::Field(field, ty) => {
                     write!(fmt, ".{:?}: {:?})", field.index(), ty)?;
@@ -2017,7 +2017,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
             Repeat(ref a, b) => {
                 write!(fmt, "[{:?}; ", a)?;
                 pretty_print_const(b, fmt, false)?;
-                write!(fmt, "]")
+                fmt.write_str("]")
             }
             Len(ref a) => write!(fmt, "Len({:?})", a),
             Cast(ref kind, ref place, ref ty) => {
@@ -2083,7 +2083,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
 
                     AggregateKind::Tuple => {
                         if places.is_empty() {
-                            write!(fmt, "()")
+                            fmt.write_str("()")
                         } else {
                             fmt_tuple(fmt, "")
                         }
@@ -2799,7 +2799,7 @@ impl<'tcx> Display for Constant<'tcx> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         match self.ty().kind() {
             ty::FnDef(..) => {}
-            _ => write!(fmt, "const ")?,
+            _ => fmt.write_str("const ")?,
         }
         Display::fmt(&self.literal, fmt)
     }
@@ -2971,7 +2971,7 @@ fn pretty_print_const_value<'tcx>(
                                         fmt.write_str(&format!("{}: {}", field_def.name, field))?;
                                         first = false;
                                     }
-                                    fmt.write_str(" }}")?;
+                                    fmt.write_str(" }")?;
                                 }
                             }
                         }

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -218,7 +218,7 @@ impl<'tcx> fmt::Display for MonoItem<'tcx> {
             MonoItem::Static(def_id) => {
                 write!(f, "static {}", Instance::new(def_id, InternalSubsts::empty()))
             }
-            MonoItem::GlobalAsm(..) => write!(f, "global_asm"),
+            MonoItem::GlobalAsm(..) => f.write_str("global_asm"),
         }
     }
 }

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -274,14 +274,14 @@ impl<'tcx> Debug for TerminatorKind<'tcx> {
             1 => write!(fmt, " -> {:?}", self.successors().next().unwrap()),
 
             _ => {
-                write!(fmt, " -> [")?;
+                fmt.write_str(" -> [")?;
                 for (i, target) in self.successors().enumerate() {
                     if i > 0 {
-                        write!(fmt, ", ")?;
+                        fmt.write_str(", ")?;
                     }
                     write!(fmt, "{}: {:?}", labels[i], target)?;
                 }
-                write!(fmt, "]")
+                fmt.write_str("]")
             }
         }
     }
@@ -294,41 +294,41 @@ impl<'tcx> TerminatorKind<'tcx> {
     pub fn fmt_head<W: Write>(&self, fmt: &mut W) -> fmt::Result {
         use self::TerminatorKind::*;
         match self {
-            Goto { .. } => write!(fmt, "goto"),
+            Goto { .. } => fmt.write_str("goto"),
             SwitchInt { discr, .. } => write!(fmt, "switchInt({:?})", discr),
-            Return => write!(fmt, "return"),
-            GeneratorDrop => write!(fmt, "generator_drop"),
-            Resume => write!(fmt, "resume"),
-            Abort => write!(fmt, "abort"),
+            Return => fmt.write_str("return"),
+            GeneratorDrop => fmt.write_str("generator_drop"),
+            Resume => fmt.write_str("resume"),
+            Abort => fmt.write_str("abort"),
             Yield { value, resume_arg, .. } => write!(fmt, "{:?} = yield({:?})", resume_arg, value),
-            Unreachable => write!(fmt, "unreachable"),
+            Unreachable => fmt.write_str("unreachable"),
             Drop { place, .. } => write!(fmt, "drop({:?})", place),
             Call { func, args, destination, .. } => {
                 write!(fmt, "{:?} = ", destination)?;
                 write!(fmt, "{:?}(", func)?;
                 for (index, arg) in args.iter().enumerate() {
                     if index > 0 {
-                        write!(fmt, ", ")?;
+                        fmt.write_str(", ")?;
                     }
                     write!(fmt, "{:?}", arg)?;
                 }
-                write!(fmt, ")")
+                fmt.write_str(")")
             }
             Assert { cond, expected, msg, .. } => {
-                write!(fmt, "assert(")?;
+                fmt.write_str("assert(")?;
                 if !expected {
-                    write!(fmt, "!")?;
+                    fmt.write_str("!")?;
                 }
                 write!(fmt, "{:?}, ", cond)?;
                 msg.fmt_assert_args(fmt)?;
-                write!(fmt, ")")
+                fmt.write_str(")")
             }
-            FalseEdge { .. } => write!(fmt, "falseEdge"),
-            FalseUnwind { .. } => write!(fmt, "falseUnwind"),
+            FalseEdge { .. } => fmt.write_str("falseEdge"),
+            FalseUnwind { .. } => fmt.write_str("falseUnwind"),
             InlineAsm { template, ref operands, options, .. } => {
                 write!(fmt, "asm!(\"{}\"", InlineAsmTemplatePiece::to_string(template))?;
                 for op in operands {
-                    write!(fmt, ", ")?;
+                    fmt.write_str(", ")?;
                     let print_late = |&late| if late { "late" } else { "" };
                     match op {
                         InlineAsmOperand::In { reg, value } => {

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -727,18 +727,18 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
         let mut start_or_comma = || start_or_continue(", ");
 
         match self.kind {
-            PatKind::Wild => write!(f, "_"),
+            PatKind::Wild => f.write_str("_"),
             PatKind::AscribeUserType { ref subpattern, .. } => write!(f, "{}: _", subpattern),
             PatKind::Binding { mutability, name, mode, ref subpattern, .. } => {
                 let is_mut = match mode {
                     BindingMode::ByValue => mutability == Mutability::Mut,
                     BindingMode::ByRef(bk) => {
-                        write!(f, "ref ")?;
+                        f.write_str("ref ")?;
                         matches!(bk, BorrowKind::Mut { .. })
                     }
                 };
                 if is_mut {
-                    write!(f, "mut ")?;
+                    f.write_str("mut ")?;
                 }
                 write!(f, "{}", name)?;
                 if let Some(ref subpattern) = *subpattern {
@@ -777,7 +777,7 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
                     // Only for Adt we can have `S {...}`,
                     // which we handle separately here.
                     if variant.ctor.is_none() {
-                        write!(f, " {{ ")?;
+                        f.write_str(" { ")?;
 
                         let mut printed = 0;
                         for p in subpatterns {
@@ -793,14 +793,14 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
                             write!(f, "{}..", start_or_comma())?;
                         }
 
-                        return write!(f, " }}");
+                        return f.write_str(" }");
                     }
                 }
 
                 let num_fields =
                     variant_and_name.as_ref().map_or(subpatterns.len(), |(v, _)| v.fields.len());
                 if num_fields != 0 || variant_and_name.is_none() {
-                    write!(f, "(")?;
+                    f.write_str("(")?;
                     for i in 0..num_fields {
                         write!(f, "{}", start_or_comma())?;
 
@@ -816,17 +816,17 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
                         if let Some(p) = subpatterns.iter().find(|p| p.field.index() == i) {
                             write!(f, "{}", p.pattern)?;
                         } else {
-                            write!(f, "_")?;
+                            f.write_str("_")?;
                         }
                     }
-                    write!(f, ")")?;
+                    f.write_str(")")?;
                 }
 
                 Ok(())
             }
             PatKind::Deref { ref subpattern } => {
                 match self.ty.kind() {
-                    ty::Adt(def, _) if def.is_box() => write!(f, "box ")?,
+                    ty::Adt(def, _) if def.is_box() => f.write_str("box ")?,
                     ty::Ref(_, _, mutbl) => {
                         write!(f, "&{}", mutbl.prefix_str())?;
                     }
@@ -842,7 +842,7 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
             }
             PatKind::Slice { ref prefix, ref slice, ref suffix }
             | PatKind::Array { ref prefix, ref slice, ref suffix } => {
-                write!(f, "[")?;
+                f.write_str("[")?;
                 for p in prefix.iter() {
                     write!(f, "{}{}", start_or_comma(), p)?;
                 }
@@ -852,12 +852,12 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
                         PatKind::Wild => {}
                         _ => write!(f, "{}", slice)?,
                     }
-                    write!(f, "..")?;
+                    f.write_str("..")?;
                 }
                 for p in suffix.iter() {
                     write!(f, "{}{}", start_or_comma(), p)?;
                 }
-                write!(f, "]")
+                f.write_str("]")
             }
             PatKind::Or { ref pats } => {
                 for pat in pats.iter() {

--- a/compiler/rustc_middle/src/traits/chalk.rs
+++ b/compiler/rustc_middle/src/traits/chalk.rs
@@ -50,7 +50,7 @@ impl<'tcx> Eq for RustInterner<'tcx> {}
 
 impl fmt::Debug for RustInterner<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "RustInterner")
+        f.write_str("RustInterner")
     }
 }
 
@@ -94,7 +94,7 @@ impl<'tcx> chalk_ir::interner::Interner for RustInterner<'tcx> {
                 return Ok(());
             }
 
-            write!(fmt, " :- ")?;
+            fmt.write_str(" :- ")?;
 
             if conds != 0 {
                 for cond in &conditions[..conds - 1] {
@@ -104,7 +104,7 @@ impl<'tcx> chalk_ir::interner::Interner for RustInterner<'tcx> {
             }
 
             if conds != 0 && consts != 0 {
-                write!(fmt, " ; ")?;
+                fmt.write_str(" ; ")?;
             }
 
             if consts != 0 {
@@ -161,7 +161,7 @@ impl<'tcx> chalk_ir::interner::Interner for RustInterner<'tcx> {
             chalk_ir::TyKind::Slice(ty) => Some(write!(fmt, "[{:?}]", ty)),
             chalk_ir::TyKind::Tuple(len, substs) => Some(
                 try {
-                    write!(fmt, "(")?;
+                    fmt.write_str("(")?;
                     for (idx, substitution) in substs.interned().iter().enumerate() {
                         if idx == *len && *len != 1 {
                             // Don't add a trailing comma if the tuple has more than one element
@@ -170,7 +170,7 @@ impl<'tcx> chalk_ir::interner::Interner for RustInterner<'tcx> {
                             write!(fmt, "{:?},", substitution)?;
                         }
                     }
-                    write!(fmt, ")")?;
+                    fmt.write_str(")")?;
                 },
             ),
             _ => None,

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -121,9 +121,9 @@ impl AssocKind {
 impl std::fmt::Display for AssocKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AssocKind::Fn => write!(f, "method"),
-            AssocKind::Const => write!(f, "associated const"),
-            AssocKind::Type => write!(f, "associated type"),
+            AssocKind::Fn => f.write_str("method"),
+            AssocKind::Const => f.write_str("associated const"),
+            AssocKind::Type => f.write_str("associated type"),
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -35,22 +35,22 @@ impl std::fmt::Debug for ConstInt {
             let max = min - 1;
             if raw == min {
                 match (size, is_ptr_sized_integral) {
-                    (_, true) => write!(fmt, "isize::MIN"),
-                    (1, _) => write!(fmt, "i8::MIN"),
-                    (2, _) => write!(fmt, "i16::MIN"),
-                    (4, _) => write!(fmt, "i32::MIN"),
-                    (8, _) => write!(fmt, "i64::MIN"),
-                    (16, _) => write!(fmt, "i128::MIN"),
+                    (_, true) => fmt.write_str("isize::MIN"),
+                    (1, _) => fmt.write_str("i8::MIN"),
+                    (2, _) => fmt.write_str("i16::MIN"),
+                    (4, _) => fmt.write_str("i32::MIN"),
+                    (8, _) => fmt.write_str("i64::MIN"),
+                    (16, _) => fmt.write_str("i128::MIN"),
                     _ => bug!("ConstInt 0x{:x} with size = {} and signed = {}", raw, size, signed),
                 }
             } else if raw == max {
                 match (size, is_ptr_sized_integral) {
-                    (_, true) => write!(fmt, "isize::MAX"),
-                    (1, _) => write!(fmt, "i8::MAX"),
-                    (2, _) => write!(fmt, "i16::MAX"),
-                    (4, _) => write!(fmt, "i32::MAX"),
-                    (8, _) => write!(fmt, "i64::MAX"),
-                    (16, _) => write!(fmt, "i128::MAX"),
+                    (_, true) => fmt.write_str("isize::MAX"),
+                    (1, _) => fmt.write_str("i8::MAX"),
+                    (2, _) => fmt.write_str("i16::MAX"),
+                    (4, _) => fmt.write_str("i32::MAX"),
+                    (8, _) => fmt.write_str("i64::MAX"),
+                    (16, _) => fmt.write_str("i128::MAX"),
                     _ => bug!("ConstInt 0x{:x} with size = {} and signed = {}", raw, size, signed),
                 }
             } else {
@@ -64,12 +64,12 @@ impl std::fmt::Debug for ConstInt {
                 }
                 if fmt.alternate() {
                     match (size, is_ptr_sized_integral) {
-                        (_, true) => write!(fmt, "_isize")?,
-                        (1, _) => write!(fmt, "_i8")?,
-                        (2, _) => write!(fmt, "_i16")?,
-                        (4, _) => write!(fmt, "_i32")?,
-                        (8, _) => write!(fmt, "_i64")?,
-                        (16, _) => write!(fmt, "_i128")?,
+                        (_, true) => fmt.write_str("_isize")?,
+                        (1, _) => fmt.write_str("_i8")?,
+                        (2, _) => fmt.write_str("_i16")?,
+                        (4, _) => fmt.write_str("_i32")?,
+                        (8, _) => fmt.write_str("_i64")?,
+                        (16, _) => fmt.write_str("_i128")?,
                         _ => bug!(),
                     }
                 }
@@ -79,12 +79,12 @@ impl std::fmt::Debug for ConstInt {
             let max = Size::from_bytes(size).truncate(u128::MAX);
             if raw == max {
                 match (size, is_ptr_sized_integral) {
-                    (_, true) => write!(fmt, "usize::MAX"),
-                    (1, _) => write!(fmt, "u8::MAX"),
-                    (2, _) => write!(fmt, "u16::MAX"),
-                    (4, _) => write!(fmt, "u32::MAX"),
-                    (8, _) => write!(fmt, "u64::MAX"),
-                    (16, _) => write!(fmt, "u128::MAX"),
+                    (_, true) => fmt.write_str("usize::MAX"),
+                    (1, _) => fmt.write_str("u8::MAX"),
+                    (2, _) => fmt.write_str("u16::MAX"),
+                    (4, _) => fmt.write_str("u32::MAX"),
+                    (8, _) => fmt.write_str("u64::MAX"),
+                    (16, _) => fmt.write_str("u128::MAX"),
                     _ => bug!("ConstInt 0x{:x} with size = {} and signed = {}", raw, size, signed),
                 }
             } else {
@@ -98,12 +98,12 @@ impl std::fmt::Debug for ConstInt {
                 }
                 if fmt.alternate() {
                     match (size, is_ptr_sized_integral) {
-                        (_, true) => write!(fmt, "_usize")?,
-                        (1, _) => write!(fmt, "_u8")?,
-                        (2, _) => write!(fmt, "_u16")?,
-                        (4, _) => write!(fmt, "_u32")?,
-                        (8, _) => write!(fmt, "_u64")?,
-                        (16, _) => write!(fmt, "_u128")?,
+                        (_, true) => fmt.write_str("_usize")?,
+                        (1, _) => fmt.write_str("_u8")?,
+                        (2, _) => fmt.write_str("_u16")?,
+                        (4, _) => fmt.write_str("_u32")?,
+                        (8, _) => fmt.write_str("_u64")?,
+                        (16, _) => fmt.write_str("_u128")?,
                         _ => bug!(),
                     }
                 }
@@ -459,7 +459,7 @@ impl fmt::LowerHex for ScalarInt {
         self.check_data();
         if f.alternate() {
             // Like regular ints, alternate flag adds leading `0x`.
-            write!(f, "0x")?;
+            f.write_str("0x")?;
         }
         // Format as hex number wide enough to fit any value of the given `size`.
         // So data=20, size=1 will be "0x14", but with size=4 it'll be "0x00000014".

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -293,13 +293,13 @@ fn fmt_instance(
 
     match instance.def {
         InstanceDef::Item(_) => Ok(()),
-        InstanceDef::VTableShim(_) => write!(f, " - shim(vtable)"),
-        InstanceDef::ReifyShim(_) => write!(f, " - shim(reify)"),
-        InstanceDef::Intrinsic(_) => write!(f, " - intrinsic"),
+        InstanceDef::VTableShim(_) => f.write_str(" - shim(vtable)"),
+        InstanceDef::ReifyShim(_) => f.write_str(" - shim(reify)"),
+        InstanceDef::Intrinsic(_) => f.write_str(" - intrinsic"),
         InstanceDef::Virtual(_, num) => write!(f, " - virtual#{}", num),
         InstanceDef::FnPtrShim(_, ty) => write!(f, " - shim({})", ty),
-        InstanceDef::ClosureOnceShim { .. } => write!(f, " - shim"),
-        InstanceDef::DropGlue(_, None) => write!(f, " - shim(None)"),
+        InstanceDef::ClosureOnceShim { .. } => f.write_str(" - shim"),
+        InstanceDef::DropGlue(_, None) => f.write_str(" - shim(None)"),
         InstanceDef::DropGlue(_, Some(ty)) => write!(f, " - shim(Some({}))", ty),
         InstanceDef::CloneShim(_, ty) => write!(f, " - shim({})", ty),
     }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -76,7 +76,7 @@ impl fmt::Debug for ty::BoundRegionKind {
                     write!(f, "BrNamed({:?}, {})", did, name)
                 }
             }
-            ty::BrEnv => write!(f, "BrEnv"),
+            ty::BrEnv => f.write_str("BrEnv"),
         }
     }
 }
@@ -126,7 +126,7 @@ impl fmt::Debug for ty::ParamConst {
 impl<'tcx> fmt::Debug for ty::TraitPredicate<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let ty::BoundConstness::ConstIfConst = self.constness {
-            write!(f, "~const ")?;
+            f.write_str("~const ")?;
         }
         write!(f, "TraitPredicate({:?}, polarity:{:?})", self.trait_ref, self.polarity)
     }
@@ -176,7 +176,7 @@ impl<'tcx> fmt::Debug for ty::PredicateKind<'tcx> {
             ty::PredicateKind::TypeWellFormedFromEnv(ty) => {
                 write!(f, "TypeWellFormedFromEnv({:?})", ty)
             }
-            ty::PredicateKind::Ambiguous => write!(f, "Ambiguous"),
+            ty::PredicateKind::Ambiguous => f.write_str("Ambiguous"),
             ty::PredicateKind::AliasEq(t1, t2) => write!(f, "AliasEq({t1:?}, {t2:?})"),
         }
     }

--- a/compiler/rustc_middle/src/ty/vtable.rs
+++ b/compiler/rustc_middle/src/ty/vtable.rs
@@ -25,10 +25,10 @@ impl<'tcx> fmt::Debug for VtblEntry<'tcx> {
         // We want to call `Display` on `Instance` and `PolyTraitRef`,
         // so we implement this manually.
         match self {
-            VtblEntry::MetadataDropInPlace => write!(f, "MetadataDropInPlace"),
-            VtblEntry::MetadataSize => write!(f, "MetadataSize"),
-            VtblEntry::MetadataAlign => write!(f, "MetadataAlign"),
-            VtblEntry::Vacant => write!(f, "Vacant"),
+            VtblEntry::MetadataDropInPlace => f.write_str("MetadataDropInPlace"),
+            VtblEntry::MetadataSize => f.write_str("MetadataSize"),
+            VtblEntry::MetadataAlign => f.write_str("MetadataAlign"),
+            VtblEntry::Vacant => f.write_str("Vacant"),
             VtblEntry::Method(instance) => write!(f, "Method({})", instance),
             VtblEntry::TraitVPtr(trait_ref) => write!(f, "TraitVPtr({})", trait_ref),
         }

--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -1645,12 +1645,12 @@ impl<'p, 'tcx> fmt::Debug for DeconstructedPat<'p, 'tcx> {
                     // Without `cx`, we can't know which field corresponds to which, so we can't
                     // get the names of the fields. Instead we just display everything as a tuple
                     // struct, which should be good enough.
-                    write!(f, "(")?;
+                    f.write_str("(")?;
                     for p in self.iter_fields() {
                         write!(f, "{}", start_or_comma())?;
                         write!(f, "{:?}", p)?;
                     }
-                    write!(f, ")")
+                    f.write_str(")")
                 }
                 // Note: given the expansion of `&str` patterns done in `expand_pattern`, we should
                 // be careful to detect strings here. However a string literal pattern will never
@@ -1659,11 +1659,11 @@ impl<'p, 'tcx> fmt::Debug for DeconstructedPat<'p, 'tcx> {
                     let subpattern = self.iter_fields().next().unwrap();
                     write!(f, "&{}{:?}", mutbl.prefix_str(), subpattern)
                 }
-                _ => write!(f, "_"),
+                _ => f.write_str("_"),
             },
             Slice(slice) => {
                 let mut subpatterns = self.fields.iter_patterns();
-                write!(f, "[")?;
+                f.write_str("[")?;
                 match slice.kind {
                     FixedLen(_) => {
                         for p in subpatterns {
@@ -1675,13 +1675,13 @@ impl<'p, 'tcx> fmt::Debug for DeconstructedPat<'p, 'tcx> {
                             write!(f, "{}{:?}", start_or_comma(), p)?;
                         }
                         write!(f, "{}", start_or_comma())?;
-                        write!(f, "..")?;
+                        f.write_str("..")?;
                         for p in subpatterns {
                             write!(f, "{}{:?}", start_or_comma(), p)?;
                         }
                     }
                 }
-                write!(f, "]")
+                f.write_str("]")
             }
             &FloatRange(lo, hi, end) => {
                 write!(f, "{}", lo)?;
@@ -1697,7 +1697,7 @@ impl<'p, 'tcx> fmt::Debug for DeconstructedPat<'p, 'tcx> {
                 Ok(())
             }
             Str(value) => write!(f, "{}", value),
-            Opaque => write!(f, "<constant pattern>"),
+            Opaque => f.write_str("<constant pattern>"),
         }
     }
 }

--- a/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
@@ -439,7 +439,7 @@ impl<'p, 'tcx> PatStack<'p, 'tcx> {
 /// Pretty-printing for matrix row.
 impl<'p, 'tcx> fmt::Debug for PatStack<'p, 'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "+")?;
+        f.write_str("+")?;
         for pat in self.iter() {
             write!(f, " {:?} +", pat)?;
         }
@@ -508,7 +508,7 @@ impl<'p, 'tcx> Matrix<'p, 'tcx> {
 /// ```
 impl<'p, 'tcx> fmt::Debug for Matrix<'p, 'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "\n")?;
+        f.write_str("\n")?;
 
         let Matrix { patterns: m, .. } = self;
         let pretty_printed_matrix: Vec<Vec<String>> =
@@ -521,13 +521,13 @@ impl<'p, 'tcx> fmt::Debug for Matrix<'p, 'tcx> {
             .collect();
 
         for row in pretty_printed_matrix {
-            write!(f, "+")?;
+            f.write_str("+")?;
             for (column, pat_str) in row.into_iter().enumerate() {
-                write!(f, " ")?;
+                f.write_str(" ")?;
                 write!(f, "{:1$}", pat_str, column_widths[column])?;
-                write!(f, " +")?;
+                f.write_str(" +")?;
             }
-            write!(f, "\n")?;
+            f.write_str("\n")?;
         }
         Ok(())
     }

--- a/compiler/rustc_mir_dataflow/src/framework/fmt.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/fmt.rs
@@ -27,9 +27,9 @@ pub trait DebugWithContext<C>: Eq + fmt::Debug {
         self.fmt_with(ctxt, f)?;
 
         if f.alternate() {
-            write!(f, "\n")?;
+            f.write_str("\n")?;
         } else {
-            write!(f, "\t")?;
+            f.write_str("\t")?;
         }
 
         write!(f, "\u{001f}-")?;
@@ -151,7 +151,7 @@ where
     if !f.alternate() {
         first = true;
         if !inserted.is_empty() && !removed.is_empty() {
-            write!(f, "\t")?;
+            f.write_str("\t")?;
         }
     }
 

--- a/compiler/rustc_mir_dataflow/src/value_analysis.rs
+++ b/compiler/rustc_mir_dataflow/src/value_analysis.rs
@@ -1006,7 +1006,7 @@ where
     fn fmt_with(&self, ctxt: &ValueAnalysisWrapper<T>, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self.0 {
             StateData::Reachable(values) => debug_with_context(values, None, ctxt.0.map(), f),
-            StateData::Unreachable => write!(f, "unreachable"),
+            StateData::Unreachable => f.write_str("unreachable"),
         }
     }
 

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -192,8 +192,8 @@ impl IncOrDec {
 impl std::fmt::Display for UnaryFixity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Pre => write!(f, "prefix"),
-            Self::Post => write!(f, "postfix"),
+            Self::Pre => f.write_str("prefix"),
+            Self::Post => f.write_str("postfix"),
         }
     }
 }

--- a/compiler/rustc_session/src/cgu_reuse_tracker.rs
+++ b/compiler/rustc_session/src/cgu_reuse_tracker.rs
@@ -21,9 +21,9 @@ pub enum CguReuse {
 impl fmt::Display for CguReuse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            CguReuse::No => write!(f, "No"),
-            CguReuse::PreLto => write!(f, "PreLto "),
-            CguReuse::PostLto => write!(f, "PostLto "),
+            CguReuse::No => f.write_str("No"),
+            CguReuse::PreLto => f.write_str("PreLto "),
+            CguReuse::PostLto => f.write_str("PostLto "),
         }
     }
 }

--- a/compiler/rustc_span/src/fatal_error.rs
+++ b/compiler/rustc_span/src/fatal_error.rs
@@ -19,7 +19,7 @@ impl FatalError {
 
 impl std::fmt::Display for FatalError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "fatal error")
+        f.write_str("fatal error")
     }
 }
 

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -324,15 +324,15 @@ impl fmt::Display for FileNameDisplay<'_> {
             Real(ref name) => {
                 write!(fmt, "{}", name.to_string_lossy(self.display_pref))
             }
-            QuoteExpansion(_) => write!(fmt, "<quote expansion>"),
-            MacroExpansion(_) => write!(fmt, "<macro expansion>"),
-            Anon(_) => write!(fmt, "<anon>"),
-            ProcMacroSourceCode(_) => write!(fmt, "<proc-macro source code>"),
-            CfgSpec(_) => write!(fmt, "<cfgspec>"),
-            CliCrateAttr(_) => write!(fmt, "<crate attribute>"),
+            QuoteExpansion(_) => fmt.write_str("<quote expansion>"),
+            MacroExpansion(_) => fmt.write_str("<macro expansion>"),
+            Anon(_) => fmt.write_str("<anon>"),
+            ProcMacroSourceCode(_) => fmt.write_str("<proc-macro source code>"),
+            CfgSpec(_) => fmt.write_str("<cfgspec>"),
+            CliCrateAttr(_) => fmt.write_str("<crate attribute>"),
             Custom(ref s) => write!(fmt, "<{s}>"),
             DocTest(ref path, _) => write!(fmt, "{}", path.display()),
-            InlineAsm(_) => write!(fmt, "<inline asm>"),
+            InlineAsm(_) => fmt.write_str("<inline asm>"),
         }
     }
 }

--- a/compiler/rustc_traits/src/chalk/db.rs
+++ b/compiler/rustc_traits/src/chalk/db.rs
@@ -28,7 +28,7 @@ pub struct RustIrDatabase<'tcx> {
 
 impl fmt::Debug for RustIrDatabase<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "RustIrDatabase")
+        f.write_str("RustIrDatabase")
     }
 }
 

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -756,7 +756,7 @@ impl fmt::Display for InferTy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use InferTy::*;
         match *self {
-            TyVar(_) => write!(f, "_"),
+            TyVar(_) => f.write_str("_"),
             IntVar(_) => write!(f, "{}", "{integer}"),
             FloatVar(_) => write!(f, "{}", "{float}"),
             FreshTy(v) => write!(f, "FreshTy({v})"),

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -2200,7 +2200,7 @@ impl<'a, E: Error + 'a> From<E> for Box<dyn Error + 'a> {
     ///
     /// impl fmt::Display for AnError {
     ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    ///         write!(f, "An error")
+    ///         f.write_str("An error")
     ///     }
     /// }
     ///
@@ -2234,7 +2234,7 @@ impl<'a, E: Error + Send + Sync + 'a> From<E> for Box<dyn Error + Send + Sync + 
     ///
     /// impl fmt::Display for AnError {
     ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    ///         write!(f, "An error")
+    ///         f.write_str("An error")
     ///     }
     /// }
     ///

--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -970,7 +970,7 @@ impl fmt::Display for FromVecWithNulError {
                 write!(f, "data provided contains an interior nul byte at pos {pos}")
             }
             FromBytesWithNulErrorKind::NotNulTerminated => {
-                write!(f, "data provided is not nul terminated")
+                f.write_str("data provided is not nul terminated")
             }
         }
     }

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2581,7 +2581,7 @@ impl<T: ?Sized> Clone for Weak<T> {
 #[stable(feature = "rc_weak", since = "1.4.0")]
 impl<T: ?Sized> fmt::Debug for Weak<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(Weak)")
+        f.write_str("(Weak)")
     }
 }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -322,7 +322,7 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Weak<U>> for Weak<T> {}
 #[stable(feature = "arc_weak", since = "1.4.0")]
 impl<T: ?Sized> fmt::Debug for Weak<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(Weak)")
+        f.write_str("(Weak)")
     }
 }
 

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -159,7 +159,7 @@ pub struct FromBytesUntilNulError(());
 #[stable(feature = "cstr_from_bytes_until_nul", since = "CURRENT_RUSTC_VERSION")]
 impl fmt::Display for FromBytesUntilNulError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "data provided does not contain a nul")
+        f.write_str("data provided does not contain a nul")
     }
 }
 

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -45,7 +45,7 @@ pub struct RangeFull;
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for RangeFull {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "..")
+        fmt.write_str("..")
     }
 }
 
@@ -90,7 +90,7 @@ pub struct Range<Idx> {
 impl<Idx: fmt::Debug> fmt::Debug for Range<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.start.fmt(fmt)?;
-        write!(fmt, "..")?;
+        fmt.write_str("..")?;
         self.end.fmt(fmt)?;
         Ok(())
     }
@@ -196,7 +196,7 @@ pub struct RangeFrom<Idx> {
 impl<Idx: fmt::Debug> fmt::Debug for RangeFrom<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.start.fmt(fmt)?;
-        write!(fmt, "..")?;
+        fmt.write_str("..")?;
         Ok(())
     }
 }
@@ -277,7 +277,7 @@ pub struct RangeTo<Idx> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<Idx: fmt::Debug> fmt::Debug for RangeTo<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "..")?;
+        fmt.write_str("..")?;
         self.end.fmt(fmt)?;
         Ok(())
     }
@@ -465,10 +465,10 @@ impl RangeInclusive<usize> {
 impl<Idx: fmt::Debug> fmt::Debug for RangeInclusive<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.start.fmt(fmt)?;
-        write!(fmt, "..=")?;
+        fmt.write_str("..=")?;
         self.end.fmt(fmt)?;
         if self.exhausted {
-            write!(fmt, " (exhausted)")?;
+            fmt.write_str(" (exhausted)")?;
         }
         Ok(())
     }
@@ -599,7 +599,7 @@ pub struct RangeToInclusive<Idx> {
 #[stable(feature = "inclusive_range", since = "1.26.0")]
 impl<Idx: fmt::Debug> fmt::Debug for RangeToInclusive<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "..=")?;
+        fmt.write_str("..=")?;
         self.end.fmt(fmt)?;
         Ok(())
     }

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -68,9 +68,9 @@ impl<'a> Iterator for Chars<'a> {
 #[stable(feature = "chars_debug_impl", since = "1.38.0")]
 impl fmt::Debug for Chars<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Chars(")?;
+        f.write_str("Chars(")?;
         f.debug_list().entries(self.clone()).finish()?;
-        write!(f, ")")?;
+        f.write_str(")")?;
         Ok(())
     }
 }

--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -184,7 +184,7 @@ impl fmt::Debug for Backtrace {
 
         let frames = &capture.frames[capture.actual_start..];
 
-        write!(fmt, "Backtrace ")?;
+        fmt.write_str("Backtrace ")?;
 
         let mut dbg = fmt.debug_list();
 
@@ -215,12 +215,12 @@ impl fmt::Debug for BacktraceSymbol {
         // FIXME: Also, include column numbers into the debug format as Display already has them.
         // Until there are stable per-frame accessors, the format shouldn't be changed:
         // https://github.com/rust-lang/rust/issues/65280#issuecomment-638966585
-        write!(fmt, "{{ ")?;
+        fmt.write_str("{ ")?;
 
         if let Some(fn_name) = self.name.as_ref().map(|b| backtrace_rs::SymbolName::new(b)) {
             write!(fmt, "fn: \"{:#}\"", fn_name)?;
         } else {
-            write!(fmt, "fn: <unknown>")?;
+            fmt.write_str("fn: <unknown>")?;
         }
 
         if let Some(fname) = self.filename.as_ref() {
@@ -231,7 +231,7 @@ impl fmt::Debug for BacktraceSymbol {
             write!(fmt, ", line: {:?}", line)?;
         }
 
-        write!(fmt, " }}")
+        fmt.write_str(" }")
     }
 }
 

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -296,7 +296,7 @@ pub enum VarError {
 impl fmt::Display for VarError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            VarError::NotPresent => write!(f, "environment variable not found"),
+            VarError::NotPresent => f.write_str("environment variable not found"),
             VarError::NotUnicode(ref s) => {
                 write!(f, "environment variable was not valid unicode: {:?}", s)
             }

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -490,7 +490,7 @@ where
         write!(f, "{error}")?;
 
         if let Some(cause) = error.source() {
-            write!(f, "\n\nCaused by:")?;
+            f.write_str("\n\nCaused by:")?;
 
             let multiple = cause.source().is_some();
 

--- a/library/std/src/error/tests.rs
+++ b/library/std/src/error/tests.rs
@@ -9,12 +9,12 @@ struct B;
 
 impl fmt::Display for A {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "A")
+        f.write_str("A")
     }
 }
 impl fmt::Display for B {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "B")
+        f.write_str("B")
     }
 }
 
@@ -368,7 +368,7 @@ fn errors_with_string_interpolation_formats_correctly() {
     impl fmt::Display for MyMessage {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "Got an error code: ({}). ", self.0)?;
-            write!(f, "What would you like to do in response?")
+            f.write_str("What would you like to do in response?")
         }
     }
 

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -287,7 +287,7 @@ impl linux_ext::addr::SocketAddrExt for SocketAddr {
 impl fmt::Debug for SocketAddr {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.address() {
-            AddressKind::Unnamed => write!(fmt, "(unnamed)"),
+            AddressKind::Unnamed => fmt.write_str("(unnamed)"),
             AddressKind::Abstract(name) => write!(fmt, "\"{}\" (abstract)", name.escape_ascii()),
             AddressKind::Pathname(path) => write!(fmt, "{path:?} (pathname)"),
         }

--- a/library/std/src/sys/unix/l4re.rs
+++ b/library/std/src/sys/unix/l4re.rs
@@ -292,7 +292,7 @@ pub mod net {
 
     impl fmt::Debug for TcpStream {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "No networking support available on L4Re")
+            f.write_str("No networking support available on L4Re")
         }
     }
 
@@ -358,7 +358,7 @@ pub mod net {
 
     impl fmt::Debug for TcpListener {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "No networking support available on L4Re.")
+            f.write_str("No networking support available on L4Re.")
         }
     }
 
@@ -508,7 +508,7 @@ pub mod net {
 
     impl fmt::Debug for UdpSocket {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "No networking support on L4Re available.")
+            f.write_str("No networking support on L4Re available.")
         }
     }
 

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -867,7 +867,7 @@ impl fmt::Display for ExitStatus {
             let signal_string = signal_string(signal);
             write!(f, "stopped (not terminated) by signal: {signal}{signal_string}")
         } else if self.continued() {
-            write!(f, "continued (WIFCONTINUED)")
+            f.write_str("continued (WIFCONTINUED)")
         } else {
             write!(f, "unrecognised wait status: {} {:#x}", self.0, self.0)
         }

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -677,7 +677,7 @@ impl Error for SystemTimeError {
 #[stable(feature = "time2", since = "1.8.0")]
 impl fmt::Display for SystemTimeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "second time provided was later than self")
+        f.write_str("second time provided was later than self")
     }
 }
 

--- a/src/tools/compiletest/src/errors.rs
+++ b/src/tools/compiletest/src/errors.rs
@@ -39,11 +39,11 @@ impl FromStr for ErrorKind {
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            ErrorKind::Help => write!(f, "help message"),
-            ErrorKind::Error => write!(f, "error"),
-            ErrorKind::Note => write!(f, "note"),
-            ErrorKind::Suggestion => write!(f, "suggestion"),
-            ErrorKind::Warning => write!(f, "warning"),
+            ErrorKind::Help => f.write_str("help message"),
+            ErrorKind::Error => f.write_str("error"),
+            ErrorKind::Note => f.write_str("note"),
+            ErrorKind::Suggestion => f.write_str("suggestion"),
+            ErrorKind::Warning => f.write_str("warning"),
         }
     }
 }


### PR DESCRIPTION
`write!(formatter, "literal")` needlessly constructs `fmt::Arguments::new_v1` that [doesn't fully optimize out](https://rust.godbolt.org/z/Te4Y1qxjP). OTOH `formatter.write_str("literal")` compiles to just a function call, so it's quicker to compile and results in smaller binaries.

I took care to correct uses of `{{` and `}}` in the formatting string.