### PR TITLE
Fix invalid missing documentation lint reporting for re-exports

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -370,6 +370,7 @@ lint_builtin_decl_unsafe_method = declaration of an `unsafe` method
 lint_builtin_impl_unsafe_method = implementation of an `unsafe` method
 
 lint_builtin_missing_doc = missing documentation for {$article} {$desc}
+    .note = because it is re-exported here
 
 lint_builtin_missing_copy_impl = type could implement `Copy`; consider adding `impl Copy`
 

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -120,6 +120,8 @@ pub enum BuiltinUnsafe {
 pub struct BuiltinMissingDoc<'a> {
     pub article: &'a str,
     pub desc: &'a str,
+    #[note]
+    pub reexport: Option<Span>,
 }
 
 #[derive(LintDiagnostic)]

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -77,11 +77,13 @@ pub use core::slice::{SplitInclusive, SplitInclusiveMut};
 // HACK(japaric) needed for the implementation of `vec!` macro during testing
 // N.B., see the `hack` module in this file for more details.
 #[cfg(test)]
+#[allow(missing_docs)]
 pub use hack::into_vec;
 
 // HACK(japaric) needed for the implementation of `Vec::clone` during testing
 // N.B., see the `hack` module in this file for more details.
 #[cfg(test)]
+#[allow(missing_docs)]
 pub use hack::to_vec;
 
 // HACK(japaric): With cfg(test) `impl [T]` is not available, these three

--- a/src/librustdoc/passes/check_doc_test_visibility.rs
+++ b/src/librustdoc/passes/check_doc_test_visibility.rs
@@ -11,7 +11,6 @@ use crate::clean::*;
 use crate::core::DocContext;
 use crate::html::markdown::{find_testable_code, ErrorCodes, Ignore, LangString};
 use crate::visit::DocVisitor;
-use crate::visit_ast::inherits_doc_hidden;
 use rustc_hir as hir;
 use rustc_middle::lint::LintLevelSource;
 use rustc_session::lint;
@@ -95,7 +94,7 @@ pub(crate) fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -
     }
 
     if cx.tcx.is_doc_hidden(def_id.to_def_id())
-        || inherits_doc_hidden(cx.tcx, def_id)
+        || cx.tcx.inherits_doc_hidden(def_id)
         || cx.tcx.def_span(def_id.to_def_id()).in_derive_expansion()
     {
         return false;

--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -9,7 +9,6 @@ use crate::clean::{Item, ItemIdSet, NestedAttributesExt};
 use crate::core::DocContext;
 use crate::fold::{strip_item, DocFolder};
 use crate::passes::{ImplStripper, Pass};
-use crate::visit_ast::inherits_doc_hidden;
 
 pub(crate) const STRIP_HIDDEN: Pass = Pass {
     name: "strip-hidden",
@@ -92,7 +91,7 @@ impl<'a, 'tcx> DocFolder for Stripper<'a, 'tcx> {
                     .item_id
                     .as_def_id()
                     .and_then(|def_id| def_id.as_local())
-                    .map(|def_id| inherits_doc_hidden(self.tcx, def_id))
+                    .map(|def_id| self.tcx.inherits_doc_hidden(def_id))
                     .unwrap_or(false);
             }
         }

--- a/tests/ui/lint/issue-108570-missing-docs-on-hidden.rs
+++ b/tests/ui/lint/issue-108570-missing-docs-on-hidden.rs
@@ -1,0 +1,17 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/108570>.
+// If a `#[doc(hidden)]` item is re-exported or if a private item is re-exported
+// with a `#[doc(hidden)]` re-export, it shouldn't complain.
+
+// check-pass
+
+#![crate_type = "lib"]
+
+mod priv_mod {
+    pub struct Foo;
+    #[doc(hidden)]
+    pub struct Bar;
+}
+
+#[doc(hidden)]
+pub use priv_mod::Foo;
+pub use priv_mod::Bar;

--- a/tests/ui/lint/lint-missing-doc.stderr
+++ b/tests/ui/lint/lint-missing-doc.stderr
@@ -117,18 +117,36 @@ error: missing documentation for a function
    |
 LL |     pub fn undocumented1() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: because it is re-exported here
+  --> $DIR/lint-missing-doc.rs:183:5
+   |
+LL |     pub use internal_impl::undocumented1 as bar;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
   --> $DIR/lint-missing-doc.rs:170:5
    |
 LL |     pub fn undocumented2() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: because it is re-exported here
+  --> $DIR/lint-missing-doc.rs:184:41
+   |
+LL |     pub use internal_impl::{documented, undocumented2};
+   |                                         ^^^^^^^^^^^^^
 
 error: missing documentation for a function
   --> $DIR/lint-missing-doc.rs:176:9
    |
 LL |         pub fn also_undocumented1() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: because it is re-exported here
+  --> $DIR/lint-missing-doc.rs:185:5
+   |
+LL |     pub use internal_impl::globbed::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
   --> $DIR/lint-missing-doc.rs:191:5

--- a/tests/ui/privacy/auxiliary/ctor_aux.rs
+++ b/tests/ui/privacy/auxiliary/ctor_aux.rs
@@ -3,7 +3,7 @@
 //! Use the lint to additionally verify that items are reachable
 //! but not exported.
 #![allow(non_camel_case_types)]
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
 
 mod hidden {
     pub struct s;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/108570.

The problem was that, if an item is re-exported, we don't check if it's actually displayed into the documentation. To do so, I changed the check this way:

 * If it's directly public, check for it.
 * For re-exports, check the re-exported item directly.

Like that, if an item is re-exported, it'll just be checked on the re-export directly.

Not sure who should be set as reviewer here so I'll just ping @notriddle and wait for bors to assign someone.