### PR TITLE
inherit_overflow: adapt pattern to also work with v0 mangling

### DIFF
--- a/tests/codegen/inherit_overflow.rs
+++ b/tests/codegen/inherit_overflow.rs
@@ -4,7 +4,7 @@
 //[NOASSERT] compile-flags: -Coverflow-checks=off
 
 // CHECK-LABEL: define{{.*}} @assertion
-// ASSERT: call void @_ZN4core9panicking5panic17h
+// ASSERT: call void @{{.*4core9panicking5panic}}
 // NOASSERT: ret i8 0
 #[no_mangle]
 pub fn assertion() -> u8 {


### PR DESCRIPTION
This test was failing under new-symbol-mangling = true. Adapt pattern to work in both cases.

Related to #106002 from December.