### PR TITLE
rustdoc: remove `std::` from primitive intra-doc link tooltips

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -771,6 +771,12 @@ pub(crate) fn link_tooltip(did: DefId, fragment: &Option<UrlFragment>, cx: &Cont
         .or_else(|| cache.external_paths.get(&did))
         else { return String::new() };
     let mut buf = Buffer::new();
+    let fqp = if *shortty == ItemType::Primitive {
+        // primitives are documented in a crate, but not actually part of it
+        &fqp[fqp.len() - 1..]
+    } else {
+        &fqp
+    };
     if let &Some(UrlFragment::Item(id)) = fragment {
         write!(buf, "{} ", cx.tcx().def_descr(id));
         for component in fqp {

--- a/tests/rustdoc/intra-doc/prim-methods.rs
+++ b/tests/rustdoc/intra-doc/prim-methods.rs
@@ -2,6 +2,8 @@
 
 // @has prim_methods/index.html
 // @has - '//*[@id="main-content"]//a[@href="{{channel}}/std/primitive.char.html"]' 'char'
+// @has - '//*[@id="main-content"]//a[@href="{{channel}}/std/primitive.char.html"]/@title' 'primitive char'
 // @has - '//*[@id="main-content"]//a[@href="{{channel}}/std/primitive.char.html#method.len_utf8"]' 'char::len_utf8'
+// @has - '//*[@id="main-content"]//a[@href="{{channel}}/std/primitive.char.html#method.len_utf8"]/@title' 'method char::len_utf8'
 
 //! A [`char`] and its [`char::len_utf8`].


### PR DESCRIPTION
Take the intra-doc link to the method `iter` from https://doc.rust-lang.org/nightly/std/slice/struct.Iter.html

Before: `method std::slice::iter`

After: `method slice::iter`
