### PR TITLE
fix: don't suggest similar method when unstable

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1027,6 +1027,15 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     true
                 }
             })
+            // ensure that we don't suggest unstable methods
+            .filter(|candidate| {
+                // note that `DUMMY_SP` is ok here because it is only used for
+                // suggestions and macro stuff which isn't applicable here.
+                !matches!(
+                    self.tcx.eval_stability(candidate.item.def_id, None, DUMMY_SP, None),
+                    stability::EvalResult::Deny { .. }
+                )
+            })
             .map(|candidate| candidate.item.ident(self.tcx))
             .filter(|&name| set.insert(name))
             .collect();

--- a/tests/ui/stability-attribute/auxiliary/similar-unstable-method.rs
+++ b/tests/ui/stability-attribute/auxiliary/similar-unstable-method.rs
@@ -1,0 +1,13 @@
+#![feature(staged_api)]
+#![stable(feature = "libfoo", since = "1.0.0")]
+
+#[unstable(feature = "foo", reason = "...", issue = "none")]
+pub fn foo() {}
+
+#[stable(feature = "libfoo", since = "1.0.0")]
+pub struct Foo;
+
+impl Foo {
+    #[unstable(feature = "foo", reason = "...", issue = "none")]
+    pub fn foo(&self) {}
+}

--- a/tests/ui/stability-attribute/issue-109177.rs
+++ b/tests/ui/stability-attribute/issue-109177.rs
@@ -1,0 +1,13 @@
+// aux-build: similar-unstable-method.rs
+
+extern crate similar_unstable_method;
+
+fn main() {
+    // FIXME: this function should not suggest the `foo` function.
+    similar_unstable_method::foo1();
+    //~^ ERROR cannot find function `foo1` in crate `similar_unstable_method` [E0425]
+
+    let foo = similar_unstable_method::Foo;
+    foo.foo1();
+    //~^ ERROR no method named `foo1` found for struct `Foo` in the current scope [E0599]
+}

--- a/tests/ui/stability-attribute/issue-109177.stderr
+++ b/tests/ui/stability-attribute/issue-109177.stderr
@@ -1,0 +1,21 @@
+error[E0425]: cannot find function `foo1` in crate `similar_unstable_method`
+  --> $DIR/issue-109177.rs:7:30
+   |
+LL |     similar_unstable_method::foo1();
+   |                              ^^^^ help: a function with a similar name exists: `foo`
+   |
+  ::: $DIR/auxiliary/similar-unstable-method.rs:5:1
+   |
+LL | pub fn foo() {}
+   | ------------ similarly named function `foo` defined here
+
+error[E0599]: no method named `foo1` found for struct `Foo` in the current scope
+  --> $DIR/issue-109177.rs:11:9
+   |
+LL |     foo.foo1();
+   |         ^^^^ method not found in `Foo`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0425, E0599.
+For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes #109177

Don't display typo suggestions for unstable things, unless the feature flag is enabled.

AFAIK, there are two places this occurs:
- `rustc_resolve`: before type checking, effectively just `FnCtxt::Free`.
- `rustc_hir_typck`: during type checking, for `FnCtxt::Assoc(..)`s.

The linked issue is about the latter, obviously the issue is applicable to both.

r? @estebank 