### PR TITLE
Clarify that RUST_MIN_STACK may be internally cached

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -131,8 +131,8 @@
 //!
 //! * Build the thread with [`Builder`] and pass the desired stack size to [`Builder::stack_size`].
 //! * Set the `RUST_MIN_STACK` environment variable to an integer representing the desired stack
-//!   size (in bytes). Note that setting [`Builder::stack_size`] will override this. Also, note
-//!   that `RUST_MIN_STACK` is cached internally so should be set before any threads are started.
+//!   size (in bytes). Note that setting [`Builder::stack_size`] will override this. Be aware that
+//!   changes to `RUST_MIN_STACK` may be ignored after program start.
 //!
 //! Note that the stack size of the main thread is *not* determined by Rust.
 //!

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -131,7 +131,8 @@
 //!
 //! * Build the thread with [`Builder`] and pass the desired stack size to [`Builder::stack_size`].
 //! * Set the `RUST_MIN_STACK` environment variable to an integer representing the desired stack
-//!   size (in bytes). Note that setting [`Builder::stack_size`] will override this.
+//!   size (in bytes). Note that setting [`Builder::stack_size`] will override this. Also, note
+//!   that `RUST_MIN_STACK` is cached internally so should be set before any threads are started.
 //!
 //! Note that the stack size of the main thread is *not* determined by Rust.
 //!


### PR DESCRIPTION
For larger applications it's important that users set `RUST_MIN_STACK` at the start of their program because [`min_stack`](https://github.com/rust-lang/rust/blob/7d3e03666a93bd2b0f78b3933f9305832af771a5/library/std/src/sys_common/thread.rs) caches the value. Not doing so can lead to their `env::set_var` call surprisingly not having any effect.

In my own testing `RUST_MIN_STACK` had no effect until I moved it to the top of `main()`. Hopefully this clarification in the docs will help others going forward.