### PR TITLE
Permit MIR inlining without #[inline]

### DIFF
--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -350,14 +350,8 @@ impl<'tcx> Inliner<'tcx> {
         callsite: &CallSite<'tcx>,
         callee_attrs: &CodegenFnAttrs,
     ) -> Result<(), &'static str> {
-        match callee_attrs.inline {
-            InlineAttr::Never => return Err("never inline hint"),
-            InlineAttr::Always | InlineAttr::Hint => {}
-            InlineAttr::None => {
-                if self.tcx.sess.mir_opt_level() <= 2 {
-                    return Err("at mir-opt-level=2, only #[inline] is inlined");
-                }
-            }
+        if let InlineAttr::Never = callee_attrs.inline {
+            return Err("never inline hint");
         }
 
         // Only inline local functions if they would be eligible for cross-crate

--- a/tests/codegen-units/item-collection/cross-crate-trait-method.rs
+++ b/tests/codegen-units/item-collection/cross-crate-trait-method.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Zprint-mono-items=eager
+// compile-flags:-Zprint-mono-items=eager -Zinline-mir=no
 
 #![deny(dead_code)]
 #![feature(start)]

--- a/tests/codegen-units/item-collection/function-as-argument.rs
+++ b/tests/codegen-units/item-collection/function-as-argument.rs
@@ -1,5 +1,4 @@
-//
-// compile-flags:-Zprint-mono-items=eager
+// compile-flags:-Zprint-mono-items=eager -Zinline-mir=no
 
 #![deny(dead_code)]
 #![feature(start)]

--- a/tests/codegen-units/item-collection/generic-functions.rs
+++ b/tests/codegen-units/item-collection/generic-functions.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Zprint-mono-items=eager
+// compile-flags:-Zprint-mono-items=eager -Zinline-mir=no
 
 #![deny(dead_code)]
 #![feature(start)]

--- a/tests/codegen-units/item-collection/generic-impl.rs
+++ b/tests/codegen-units/item-collection/generic-impl.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Zprint-mono-items=eager
+// compile-flags:-Zprint-mono-items=eager -Zinline-mir=no
 
 #![deny(dead_code)]
 #![feature(start)]

--- a/tests/codegen-units/item-collection/trait-implementations.rs
+++ b/tests/codegen-units/item-collection/trait-implementations.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Zprint-mono-items=eager
+// compile-flags:-Zprint-mono-items=eager -Zinline-mir=no
 
 #![deny(dead_code)]
 #![feature(start)]

--- a/tests/codegen-units/item-collection/trait-method-as-argument.rs
+++ b/tests/codegen-units/item-collection/trait-method-as-argument.rs
@@ -1,5 +1,4 @@
-//
-// compile-flags:-Zprint-mono-items=eager
+// compile-flags:-Zprint-mono-items=eager -Zinline-mir=no
 
 #![deny(dead_code)]
 #![feature(start)]

--- a/tests/codegen-units/item-collection/trait-method-default-impl.rs
+++ b/tests/codegen-units/item-collection/trait-method-default-impl.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Zprint-mono-items=eager -Zpolymorphize=on
+// compile-flags:-Zprint-mono-items=eager -Zpolymorphize=on -Zinline-mir=no
 
 #![deny(dead_code)]
 #![feature(start)]

--- a/tests/codegen/array-map.rs
+++ b/tests/codegen/array-map.rs
@@ -21,7 +21,7 @@ pub fn short_integer_map(x: [u32; 8]) -> [u32; 8] {
 pub fn short_integer_zip_map(x: [u32; 8], y: [u32; 8]) -> [u32; 8] {
     // CHECK: %[[A:.+]] = load <8 x i32>
     // CHECK: %[[B:.+]] = load <8 x i32>
-    // CHECK: sub <8 x i32> %[[A]], %[[B]]
+    // CHECK: sub <8 x i32> %[[B]], %[[A]]
     // CHECK: store <8 x i32>
     x.zip(y).map(|(x, y)| x - y)
 }

--- a/tests/codegen/inline-hint.rs
+++ b/tests/codegen/inline-hint.rs
@@ -1,7 +1,7 @@
 // Checks that closures, constructors, and shims except
 // for a drop glue receive inline hint by default.
 //
-// compile-flags: -Cno-prepopulate-passes -Csymbol-mangling-version=v0
+// compile-flags: -Cno-prepopulate-passes -Csymbol-mangling-version=v0 -Zinline-mir=no
 #![crate_type = "lib"]
 
 pub fn f() {

--- a/tests/codegen/local-generics-in-exe-internalized.rs
+++ b/tests/codegen/local-generics-in-exe-internalized.rs
@@ -1,4 +1,4 @@
-// compile-flags: -C no-prepopulate-passes -Zshare-generics=yes
+// compile-flags: -C no-prepopulate-passes -Zshare-generics=yes -Zinline-mir=no
 
 // Check that local generics are internalized if they are in the same CGU
 

--- a/tests/codegen/remap_path_prefix/auxiliary/xcrate-generic.rs
+++ b/tests/codegen/remap_path_prefix/auxiliary/xcrate-generic.rs
@@ -3,4 +3,6 @@
 
 #![crate_type = "lib"]
 
-pub fn foo<T>() {}
+pub fn foo<T: Default>() -> T {
+    T::default()
+}

--- a/tests/codegen/remap_path_prefix/xcrate-generic.rs
+++ b/tests/codegen/remap_path_prefix/xcrate-generic.rs
@@ -7,7 +7,7 @@
 extern crate xcrate_generic;
 
 pub fn foo() {
-    xcrate_generic::foo::<u32>();
+    println!("{}", xcrate_generic::foo::<u32>());
 }
 
 // Here we check that local debuginfo is mapped correctly.


### PR DESCRIPTION
I noticed that there are at least a handful of portable-simd functions that have no `#[inline]` but compile to an assign + return.

I locally benchmarked inlining thresholds between 0 and 50 in increments of 5, and 50 seems to be the best. Interesting. That didn't include check builds though, ~maybe perf will have something to say about that~.

Perf has little useful to say about this. We generally regress all the check builds, as best as I can tell, due to a number of small codegen changes in a particular hot function in the compiler. Probably this is because we've nudged the inlining outcomes all over, and uses of `#[inline(always)]`/`#[inline(never)]` might need to be adjusted.