### PR TITLE
Less `as *` in library/core

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -253,7 +253,7 @@ impl<'a, T, const N: usize> TryFrom<&'a [T]> for &'a [T; N] {
 
     fn try_from(slice: &[T]) -> Result<&[T; N], TryFromSliceError> {
         if slice.len() == N {
-            let ptr = slice.as_ptr() as *const [T; N];
+            let ptr = slice.as_ptr().cast::<[T; N]>();
             // SAFETY: ok because we just checked that the length fits
             unsafe { Ok(&*ptr) }
         } else {
@@ -280,7 +280,7 @@ impl<'a, T, const N: usize> TryFrom<&'a mut [T]> for &'a mut [T; N] {
 
     fn try_from(slice: &mut [T]) -> Result<&mut [T; N], TryFromSliceError> {
         if slice.len() == N {
-            let ptr = slice.as_mut_ptr() as *mut [T; N];
+            let ptr = slice.as_mut_ptr().cast::<[T; N]>();
             // SAFETY: ok because we just checked that the length fits
             unsafe { Ok(&mut *ptr) }
         } else {

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -624,7 +624,7 @@ impl<T, const N: usize> Cell<[T; N]> {
     #[unstable(feature = "as_array_of_cells", issue = "88248")]
     pub fn as_array_of_cells(&self) -> &[Cell<T>; N] {
         // SAFETY: `Cell<T>` has the same memory layout as `T`.
-        unsafe { &*(self as *const Cell<[T; N]> as *const [Cell<T>; N]) }
+        unsafe { &*ptr::from_ref(self).cast::<[Cell<T>; N]>() }
     }
 }
 

--- a/library/core/src/hash/mod.rs
+++ b/library/core/src/hash/mod.rs
@@ -835,7 +835,7 @@ mod impls {
                 #[inline]
                 fn hash_slice<H: ~const Hasher>(data: &[$ty], state: &mut H) {
                     let newlen = mem::size_of_val(data);
-                    let ptr = data.as_ptr() as *const u8;
+                    let ptr = data.as_ptr().cast::<u8>();
                     // SAFETY: `ptr` is valid and aligned, as this macro is only used
                     // for numeric primitives which have no padding. The new slice only
                     // spans across `data` and is never mutated, and its total size is the

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -223,7 +223,7 @@ where
             unsafe {
                 ptr::copy_nonoverlapping(
                     self.as_ref().as_ptr(),
-                    raw_array.as_mut_ptr() as *mut T,
+                    raw_array.as_mut_ptr().cast::<T>(),
                     len,
                 );
                 let _ = self.advance_by(len);
@@ -234,7 +234,7 @@ where
         // SAFETY: `len` is larger than the array size. Copy a fixed amount here to fully initialize
         // the array.
         unsafe {
-            ptr::copy_nonoverlapping(self.as_ref().as_ptr(), raw_array.as_mut_ptr() as *mut T, N);
+            ptr::copy_nonoverlapping(self.as_ref().as_ptr(), raw_array.as_mut_ptr().cast::<T>(), N);
             let _ = self.advance_by(N);
             Ok(MaybeUninit::array_assume_init(raw_array))
         }

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1054,12 +1054,12 @@ pub const unsafe fn transmute_copy<Src, Dst>(src: &Src) -> Dst {
     if align_of::<Dst>() > align_of::<Src>() {
         // SAFETY: `src` is a reference which is guaranteed to be valid for reads.
         // The caller must guarantee that the actual transmutation is safe.
-        unsafe { ptr::read_unaligned(src as *const Src as *const Dst) }
+        unsafe { ptr::from_ref(src).cast::<Dst>().read_unaligned() }
     } else {
         // SAFETY: `src` is a reference which is guaranteed to be valid for reads.
         // We just checked that `src as *const Dst` was properly aligned.
         // The caller must guarantee that the actual transmutation is safe.
-        unsafe { ptr::read(src as *const Src as *const Dst) }
+        unsafe { ptr::from_ref(src).cast::<Dst>().read() }
     }
 }
 

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -48,7 +48,7 @@ impl<T: ?Sized> *const T {
         }
 
         // SAFETY: The two versions are equivalent at runtime.
-        unsafe { const_eval_select((self as *const u8,), const_impl, runtime_impl) }
+        unsafe { const_eval_select((self.cast::<u8>(),), const_impl, runtime_impl) }
     }
 
     /// Casts to a pointer of another type.
@@ -95,7 +95,7 @@ impl<T: ?Sized> *const T {
     where
         U: ?Sized,
     {
-        from_raw_parts::<U>(self as *const (), metadata(meta))
+        from_raw_parts::<U>(self.cast::<()>(), metadata(meta))
     }
 
     /// Changes constness without changing the type.
@@ -400,7 +400,7 @@ impl<T: ?Sized> *const T {
     {
         // SAFETY: the caller must guarantee that `self` meets all the
         // requirements for a reference.
-        if self.is_null() { None } else { Some(unsafe { &*(self as *const MaybeUninit<T>) }) }
+        if self.is_null() { None } else { Some(unsafe { &*self.cast::<MaybeUninit<T>>() }) }
     }
 
     /// Calculates the offset from a pointer.
@@ -822,7 +822,7 @@ impl<T: ?Sized> *const T {
     where
         T: Sized,
     {
-        match intrinsics::ptr_guaranteed_cmp(self as _, other as _) {
+        match intrinsics::ptr_guaranteed_cmp(self, other) {
             2 => None,
             other => Some(other == 1),
         }

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1278,7 +1278,7 @@ pub const unsafe fn read_unaligned<T>(src: *const T) -> T {
     // Also, since we just wrote a valid value into `tmp`, it is guaranteed
     // to be properly initialized.
     unsafe {
-        copy_nonoverlapping(src as *const u8, tmp.as_mut_ptr() as *mut u8, mem::size_of::<T>());
+        copy_nonoverlapping(src.cast::<u8>(), tmp.as_mut_ptr().cast::<u8>(), mem::size_of::<T>());
         tmp.assume_init()
     }
 }
@@ -1473,7 +1473,7 @@ pub const unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
     // `dst` cannot overlap `src` because the caller has mutable access
     // to `dst` while `src` is owned by this function.
     unsafe {
-        copy_nonoverlapping(&src as *const T as *const u8, dst as *mut u8, mem::size_of::<T>());
+        copy_nonoverlapping(addr_of!(src).cast::<u8>(), dst.cast::<u8>(), mem::size_of::<T>());
         // We are calling the intrinsic directly to avoid function calls in the generated code.
         intrinsics::forget(src);
     }

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -412,7 +412,7 @@ impl<T: ?Sized> *mut T {
     {
         // SAFETY: the caller must guarantee that `self` meets all the
         // requirements for a reference.
-        if self.is_null() { None } else { Some(unsafe { &*(self as *const MaybeUninit<T>) }) }
+        unsafe { self.cast_const().as_uninit_ref() }
     }
 
     /// Calculates the offset from a pointer.
@@ -476,7 +476,7 @@ impl<T: ?Sized> *mut T {
         // SAFETY: the caller must uphold the safety contract for `offset`.
         // The obtained pointer is valid for writes since the caller must
         // guarantee that it points to the same allocated object as `self`.
-        unsafe { intrinsics::offset(self, count) as *mut T }
+        unsafe { intrinsics::offset(self, count).cast_mut() }
     }
 
     /// Calculates the offset from a pointer in bytes.
@@ -555,7 +555,7 @@ impl<T: ?Sized> *mut T {
         T: Sized,
     {
         // SAFETY: the `arith_offset` intrinsic has no prerequisites to be called.
-        unsafe { intrinsics::arith_offset(self, count) as *mut T }
+        unsafe { intrinsics::arith_offset(self, count).cast_mut() }
     }
 
     /// Calculates the offset from a pointer in bytes using wrapping arithmetic.
@@ -717,7 +717,7 @@ impl<T: ?Sized> *mut T {
     {
         // SAFETY: the caller must guarantee that `self` meets all the
         // requirements for a reference.
-        if self.is_null() { None } else { Some(unsafe { &mut *(self as *mut MaybeUninit<T>) }) }
+        if self.is_null() { None } else { Some(unsafe { &mut *self.cast::<MaybeUninit<T>>() }) }
     }
 
     /// Returns whether two pointers are guaranteed to be equal.
@@ -744,7 +744,7 @@ impl<T: ?Sized> *mut T {
     where
         T: Sized,
     {
-        (self as *const T).guaranteed_eq(other as _)
+        self.cast_const().guaranteed_eq(other.cast_const())
     }
 
     /// Returns whether two pointers are guaranteed to be inequal.
@@ -771,7 +771,7 @@ impl<T: ?Sized> *mut T {
     where
         T: Sized,
     {
-        (self as *const T).guaranteed_ne(other as _)
+        self.cast_const().guaranteed_ne(other.cast_const())
     }
 
     /// Calculates the distance between two pointers. The returned value is in
@@ -864,7 +864,7 @@ impl<T: ?Sized> *mut T {
         T: Sized,
     {
         // SAFETY: the caller must uphold the safety contract for `offset_from`.
-        unsafe { (self as *const T).offset_from(origin) }
+        unsafe { self.cast_const().offset_from(origin) }
     }
 
     /// Calculates the distance between two pointers. The returned value is in
@@ -955,7 +955,7 @@ impl<T: ?Sized> *mut T {
         T: Sized,
     {
         // SAFETY: the caller must uphold the safety contract for `sub_ptr`.
-        unsafe { (self as *const T).sub_ptr(origin) }
+        unsafe { self.cast_const().sub_ptr(origin) }
     }
 
     /// Calculates the offset from a pointer (convenience for `.offset(count as isize)`).

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -271,7 +271,7 @@ fn is_ascii(s: &[u8]) -> bool {
 
     let start = s.as_ptr();
     // SAFETY: We verify `len < USIZE_SIZE` above.
-    let first_word = unsafe { (start as *const usize).read_unaligned() };
+    let first_word = unsafe { start.cast::<usize>().read_unaligned() };
 
     if contains_nonascii(first_word) {
         return false;
@@ -283,7 +283,7 @@ fn is_ascii(s: &[u8]) -> bool {
 
     // SAFETY: word_ptr is the (properly aligned) usize ptr we use to read the
     // middle chunk of the slice.
-    let mut word_ptr = unsafe { start.add(offset_to_aligned) as *const usize };
+    let mut word_ptr = unsafe { start.add(offset_to_aligned).cast::<usize>() };
 
     // `byte_pos` is the byte index of `word_ptr`, used for loop end checks.
     let mut byte_pos = offset_to_aligned;
@@ -322,7 +322,7 @@ fn is_ascii(s: &[u8]) -> bool {
     debug_assert!(byte_pos <= len && len - byte_pos <= USIZE_SIZE);
 
     // SAFETY: This relies on `len >= USIZE_SIZE`, which we check at the start.
-    let last_word = unsafe { (start.add(len - USIZE_SIZE) as *const usize).read_unaligned() };
+    let last_word = unsafe { start.add(len - USIZE_SIZE).cast::<usize>().read_unaligned() };
 
     !contains_nonascii(last_word)
 }

--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -88,7 +88,7 @@ where
         // The two slices have been checked to have the same size above.
         unsafe {
             let size = mem::size_of_val(self);
-            memcmp(self.as_ptr() as *const u8, other.as_ptr() as *const u8, size) == 0
+            memcmp(self.as_ptr().cast::<u8>(), other.as_ptr().cast::<u8>(), size) == 0
         }
     }
 }
@@ -231,7 +231,7 @@ impl SliceContains for i8 {
         // as `*const u8` is safe. The `x.as_ptr()` comes from a reference and is thus guaranteed
         // to be valid for reads for the length of the slice `x.len()`, which cannot be larger
         // than `isize::MAX`. The returned slice is never mutated.
-        let bytes: &[u8] = unsafe { from_raw_parts(x.as_ptr() as *const u8, x.len()) };
+        let bytes: &[u8] = unsafe { from_raw_parts(x.as_ptr().cast::<u8>(), x.len()) };
         memchr::memchr(byte, bytes).is_some()
     }
 }

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -90,7 +90,7 @@ impl<'a, T> Iter<'a, T> {
             let end =
                 if T::IS_ZST { ptr.wrapping_byte_add(slice.len()) } else { ptr.add(slice.len()) };
 
-            Self { ptr: NonNull::new_unchecked(ptr as *mut T), end, _marker: PhantomData }
+            Self { ptr: NonNull::new_unchecked(ptr.cast_mut()), end, _marker: PhantomData }
         }
     }
 

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1800,7 +1800,7 @@ impl<T> [T] {
     pub fn split_array_ref<const N: usize>(&self) -> (&[T; N], &[T]) {
         let (a, b) = self.split_at(N);
         // SAFETY: a points to [T; N]? Yes it's [T] of length N (checked by split_at)
-        unsafe { (&*(a.as_ptr() as *const [T; N]), b) }
+        unsafe { (&*a.as_ptr().cast::<[T; N]>(), b) }
     }
 
     /// Divides one mutable slice into an array and a remainder slice at an index.
@@ -1833,7 +1833,7 @@ impl<T> [T] {
     pub fn split_array_mut<const N: usize>(&mut self) -> (&mut [T; N], &mut [T]) {
         let (a, b) = self.split_at_mut(N);
         // SAFETY: a points to [T; N]? Yes it's [T] of length N (checked by split_at_mut)
-        unsafe { (&mut *(a.as_mut_ptr() as *mut [T; N]), b) }
+        unsafe { (&mut *a.as_mut_ptr().cast::<[T; N]>(), b) }
     }
 
     /// Divides one slice into an array and a remainder slice at an index from
@@ -1879,7 +1879,7 @@ impl<T> [T] {
         assert!(N <= self.len());
         let (a, b) = self.split_at(self.len() - N);
         // SAFETY: b points to [T; N]? Yes it's [T] of length N (checked by split_at)
-        unsafe { (a, &*(b.as_ptr() as *const [T; N])) }
+        unsafe { (a, &*b.as_ptr().cast::<[T; N]>()) }
     }
 
     /// Divides one mutable slice into an array and a remainder slice at an
@@ -1913,7 +1913,7 @@ impl<T> [T] {
         assert!(N <= self.len());
         let (a, b) = self.split_at_mut(self.len() - N);
         // SAFETY: b points to [T; N]? Yes it's [T] of length N (checked by split_at_mut)
-        unsafe { (a, &mut *(b.as_mut_ptr() as *mut [T; N])) }
+        unsafe { (a, &mut *b.as_mut_ptr().cast::<[T; N]>()) }
     }
 
     /// Returns an iterator over subslices separated by elements that match
@@ -3582,7 +3582,7 @@ impl<T> [T] {
             unsafe {
                 (
                     left,
-                    from_raw_parts(rest.as_ptr() as *const U, us_len),
+                    from_raw_parts(rest.as_ptr().cast::<U>(), us_len),
                     from_raw_parts(rest.as_ptr().add(rest.len() - ts_len), ts_len),
                 )
             }
@@ -3652,7 +3652,7 @@ impl<T> [T] {
             unsafe {
                 (
                     left,
-                    from_raw_parts_mut(mut_ptr as *mut U, us_len),
+                    from_raw_parts_mut(mut_ptr.cast::<U>(), us_len),
                     from_raw_parts_mut(mut_ptr.add(rest_len - ts_len), ts_len),
                 )
             }

--- a/library/core/src/slice/rotate.rs
+++ b/library/core/src/slice/rotate.rs
@@ -162,7 +162,7 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mut mid: *mut T, mut right: usize) 
             // Algorithm 2
             // The `[T; 0]` here is to ensure this is appropriately aligned for T
             let mut rawarray = MaybeUninit::<(BufType, [T; 0])>::uninit();
-            let buf = rawarray.as_mut_ptr() as *mut T;
+            let buf = rawarray.as_mut_ptr().cast::<T>();
             // SAFETY: `mid-left <= mid-left+right < mid+right`
             let dim = unsafe { mid.sub(left).add(right) };
             if left <= right {

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -1905,16 +1905,16 @@ unsafe fn small_slice_eq(x: &[u8], y: &[u8]) -> bool {
         let (mut px, mut py) = (x.as_ptr(), y.as_ptr());
         let (pxend, pyend) = (px.add(x.len() - 4), py.add(y.len() - 4));
         while px < pxend {
-            let vx = (px as *const u32).read_unaligned();
-            let vy = (py as *const u32).read_unaligned();
+            let vx = px.cast::<u32>().read_unaligned();
+            let vy = py.cast::<u32>().read_unaligned();
             if vx != vy {
                 return false;
             }
             px = px.add(4);
             py = py.add(4);
         }
-        let vx = (pxend as *const u32).read_unaligned();
-        let vy = (pyend as *const u32).read_unaligned();
+        let vx = pxend.cast::<u32>().read_unaligned();
+        let vy = pyend.cast::<u32>().read_unaligned();
         vx == vy
     }
 }

--- a/library/core/src/str/validations.rs
+++ b/library/core/src/str/validations.rs
@@ -218,7 +218,7 @@ pub(super) const fn run_utf8_validation(v: &[u8]) -> Result<(), Utf8Error> {
                     // always aligned with a `usize` so it's safe to dereference
                     // both `block` and `block.add(1)`.
                     unsafe {
-                        let block = ptr.add(index) as *const usize;
+                        let block = ptr.add(index).cast::<usize>();
                         // break if there is a nonascii byte
                         let zu = contains_nonascii(*block);
                         let zv = contains_nonascii(*block.add(1));

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -126,8 +126,8 @@
 use self::Ordering::*;
 
 use crate::cell::UnsafeCell;
-use crate::fmt;
 use crate::intrinsics;
+use crate::{fmt, ptr};
 
 use crate::hint::spin_loop;
 
@@ -368,7 +368,7 @@ impl AtomicBool {
     #[stable(feature = "atomic_access", since = "1.15.0")]
     pub fn get_mut(&mut self) -> &mut bool {
         // SAFETY: the mutable reference guarantees unique ownership.
-        unsafe { &mut *(self.v.get() as *mut bool) }
+        unsafe { &mut *self.v.get().cast::<bool>() }
     }
 
     /// Get atomic access to a `&mut bool`.
@@ -390,7 +390,7 @@ impl AtomicBool {
     pub fn from_mut(v: &mut bool) -> &mut Self {
         // SAFETY: the mutable reference guarantees unique ownership, and
         // alignment of both `bool` and `Self` is 1.
-        unsafe { &mut *(v as *mut bool as *mut Self) }
+        unsafe { &mut *ptr::from_mut(v).cast::<Self>() }
     }
 
     /// Get non-atomic access to a `&mut [AtomicBool]` slice.
@@ -1154,7 +1154,7 @@ impl<T> AtomicPtr<T> {
         //  - the mutable reference guarantees unique ownership.
         //  - the alignment of `*mut T` and `Self` is the same on all platforms
         //    supported by rust, as verified above.
-        unsafe { &mut *(v as *mut *mut T as *mut Self) }
+        unsafe { &mut *ptr::from_mut(v).cast::<Self>() }
     }
 
     /// Get non-atomic access to a `&mut [AtomicPtr]` slice.
@@ -2147,7 +2147,7 @@ macro_rules! atomic_int {
                 //  - the mutable reference guarantees unique ownership.
                 //  - the alignment of `$int_type` and `Self` is the
                 //    same, as promised by $cfg_align and verified above.
-                unsafe { &mut *(v as *mut $int_type as *mut Self) }
+                unsafe { &mut *ptr::from_mut(v).cast::<Self>() }
             }
 
             #[doc = concat!("Get non-atomic access to a `&mut [", stringify!($atomic_type), "]` slice")]


### PR DESCRIPTION
`cast`/`cast_const`/`cast_mut` have been stable and const-stable for a while, so let's use them instead of `as`, for clarity about what the cast is doing and to emphasize `as` casts doing anything else.

After all, if it had existed back then, using `.cast::<T>()` instead of `as *mut T` might have helped catch the soundness bug back in <https://blog.rust-lang.org/2017/02/09/Rust-1.15.1.html#whats-in-1151-stable>, as the copy-paste wouldn't have compiled (since `cast` would have given a `*const` not a `*mut`).

I'm working on a lint to enforce this in future, which I used to find all these places.

Old zulip conversation about moving things off `as` where feasible: <https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Adding.20methods.20as.20more.20specific.20versions.20of.20.60as.60/near/238374585>.