### PR TITLE
rustdoc: Fix missing private inlining

### DIFF
--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -265,10 +265,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             return false;
         }
 
-        if !self.view_item_stack.insert(res_did) {
-            return false;
-        }
-
         if !please_inline &&
             let mut visitor = OneLevelVisitor::new(self.cx.tcx.hir(), res_did) &&
             let Some(item) = visitor.find_target(self.cx.tcx, def_id.to_def_id(), path) &&
@@ -282,6 +278,10 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             !inherits_doc_hidden(self.cx.tcx, item_def_id)
         {
             // The imported item is public and not `doc(hidden)` so no need to inline it.
+            return false;
+        }
+
+        if !self.view_item_stack.insert(res_did) {
             return false;
         }
 

--- a/tests/rustdoc/issue-109258-missing-private-inlining.rs
+++ b/tests/rustdoc/issue-109258-missing-private-inlining.rs
@@ -1,0 +1,27 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/109258>.
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html'
+// We should only have a "Re-exports" and a "Modules" headers.
+// @count - '//*[@id="main-content"]/h2[@class="small-section-header"]' 2
+// @has - '//*[@id="main-content"]/h2[@class="small-section-header"]' 'Re-exports'
+// @has - '//*[@id="main-content"]/h2[@class="small-section-header"]' 'Modules'
+
+// @has - '//*[@id="reexport.Foo"]' 'pub use crate::issue_109258::Foo;'
+// @has - '//*[@id="reexport.Foo"]//a[@href="issue_109258/struct.Foo.html"]' 'Foo'
+// @!has 'foo/struct.Foo.html'
+pub use crate::issue_109258::Foo;
+
+// @has 'foo/issue_109258/index.html'
+// We should only have a "Structs" header.
+// @count - '//*[@id="main-content"]/h2[@class="small-section-header"]' 1
+// @has - '//*[@id="main-content"]/h2[@class="small-section-header"]' 'Structs'
+// @has - '//*[@id="main-content"]//a[@href="struct.Foo.html"]' 'Foo'
+// @has 'foo/issue_109258/struct.Foo.html'
+pub mod issue_109258 {
+    mod priv_mod {
+        pub struct Foo;
+    }
+    pub use self::priv_mod::Foo;
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/109258.

If the item isn't inlined, it shouldn't have been added into `view_item_stack`. The problem here was that it was not removed, preventing sub items to be inlined if they have a re-export in "upper levels".

cc @epage 
r? @notriddle 