### PR TITLE
fix typo in documentation for std::fs::Permissions

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1406,11 +1406,11 @@ impl Permissions {
     /// On Unix-based platforms this checks if *any* of the owner, group or others
     /// write permission bits are set. It does not check if the current
     /// user is in the file's assigned group. It also does not check ACLs.
-    /// Therefore even if this returns false you may not be able to write to the
-    /// file, and vice versa. The [`PermissionsExt`] trait gives direct access
-    /// to the permission bits but also does not read ACLs. If you need to
-    /// accurately know whether or not a file is writable use the `access()`
-    /// function from libc.
+    /// Therefore the return value of this function cannot be relied upon
+    /// to predict whether attempts to read or write the file will actually succeed.
+    /// The [`PermissionsExt`] trait gives direct access to the permission bits but
+    /// also does not read ACLs. If you need to accurately know whether or not a file
+    /// is writable use the `access()` function from libc.
     ///
     /// [`PermissionsExt`]: crate::os::unix::fs::PermissionsExt
     ///

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1406,7 +1406,7 @@ impl Permissions {
     /// On Unix-based platforms this checks if *any* of the owner, group or others
     /// write permission bits are set. It does not check if the current
     /// user is in the file's assigned group. It also does not check ACLs.
-    /// Therefore even if this returns true you may not be able to write to the
+    /// Therefore even if this returns false you may not be able to write to the
     /// file, and vice versa. The [`PermissionsExt`] trait gives direct access
     /// to the permission bits but also does not read ACLs. If you need to
     /// accurately know whether or not a file is writable use the `access()`

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1409,8 +1409,7 @@ impl Permissions {
     /// Therefore the return value of this function cannot be relied upon
     /// to predict whether attempts to read or write the file will actually succeed.
     /// The [`PermissionsExt`] trait gives direct access to the permission bits but
-    /// also does not read ACLs. If you need to accurately know whether or not a file
-    /// is writable use the `access()` function from libc.
+    /// also does not read ACLs.
     ///
     /// [`PermissionsExt`]: crate::os::unix::fs::PermissionsExt
     ///


### PR DESCRIPTION
Please check and re-check this PR carefully to see if I got this right.

But by my logic, if the `read_only` function returns `true`, I would not expect be able to write to the file (it being read only); so this text is meant to clarify that `read_only` being `false` doesn't mean *you* can actually write to the file, just that "in general" someone is able to.