### PR TITLE
[beta-1.69] cargo beta backports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "curl",


### PR DESCRIPTION
3 commits in 9880b408a3af50c08fab3dbf4aa2a972df71e951..7b18c85808a6b45ec8364bf730617b6f13e0f9f8
2023-02-28 19:39:39 +0000 to 2023-03-17 12:29:33 +0000
- [beta-1.69] backport rust-lang/cargo#11824 (rust-lang/cargo#11863)
- [beta-1.69] backport rust-lang/cargo#11820 (rust-lang/cargo#11823)
- chore: Backport rust-lang/cargo#11630 to `1.69.0` (rust-lang/cargo#11806)

r? @ghost
