### PR TITLE
rustdoc: Correctly merge import's and its target's docs in one more case

### DIFF
--- a/tests/rustdoc-ui/intra-doc/import-inline-merge.rs
+++ b/tests/rustdoc-ui/intra-doc/import-inline-merge.rs
@@ -1,0 +1,16 @@
+// Import for `A` is inlined and doc comments on the import and `A` itself are merged.
+// After the merge they still have correct parent scopes to resolve both `[A]` and `[B]`.
+
+// check-pass
+
+#![allow(rustdoc::private_intra_doc_links)]
+
+mod m {
+    /// [B]
+    pub struct A {}
+
+    pub struct B {}
+}
+
+/// [A]
+pub use m::A;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/108061.
Fixes https://github.com/rust-lang/rust/issues/108334.
Fixes https://github.com/rust-lang/rust/issues/108378.
Fixes https://github.com/rust-lang/rust/issues/108658.