### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0206.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0206.md
@@ -1,5 +1,5 @@
 The `Copy` trait was implemented on a type which is neither a struct nor an
-enum.
+enum nor a union.
 
 Erroneous code example:
 
@@ -10,6 +10,6 @@ struct Bar;
 impl Copy for &'static mut Bar { } // error!
 ```
 
-You can only implement `Copy` for a struct or an enum.
+You can only implement `Copy` for a struct, a union, or an enum.
 The previous example will fail because `&'static mut Bar`
 is not a struct or enum.

--- a/compiler/rustc_error_codes/src/error_codes/E0206.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0206.md
@@ -1,4 +1,5 @@
-The `Copy` trait was implemented on a type which is neither a struct nor an enum nor a union.
+The `Copy` trait was implemented on a type which is neither a struct, an 
+enum, nor a union.
 
 Erroneous code example:
 
@@ -9,6 +10,6 @@ struct Bar;
 impl Copy for &'static mut Bar { } // error!
 ```
 
-You can only implement `Copy` for a struct, a union, or an enum.
+You can only implement `Copy` for a struct, an enum, or a union.
 The previous example will fail because `&'static mut Bar`
-is not a struct or enum.
+is not a struct, an enum, or a union.

--- a/compiler/rustc_error_codes/src/error_codes/E0206.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0206.md
@@ -1,5 +1,4 @@
-The `Copy` trait was implemented on a type which is neither a struct nor an
-enum nor a union.
+The `Copy` trait was implemented on a type which is neither a struct nor an enum nor a union.
 
 Erroneous code example:
 

--- a/compiler/rustc_error_codes/src/error_codes/E0206.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0206.md
@@ -1,4 +1,4 @@
-The `Copy` trait was implemented on a type which is neither a struct, an 
+The `Copy` trait was implemented on a type which is neither a struct, an
 enum, nor a union.
 
 Erroneous code example:

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -245,12 +245,24 @@ pub(super) fn emit_frag_parse_err(
                 e.note(
                     "the macro call doesn't expand to an expression, but it can expand to a statement",
                 );
-                e.span_suggestion_verbose(
-                    site_span.shrink_to_hi(),
-                    "add `;` to interpret the expansion as a statement",
-                    ";",
-                    Applicability::MaybeIncorrect,
-                );
+
+                if parser.token == token::Semi {
+                    if let Ok(snippet) = parser.sess.source_map().span_to_snippet(site_span) {
+                        e.span_suggestion_verbose(
+                            site_span,
+                            "surround the macro invocation with `{}` to interpret the expansion as a statement",
+                            format!("{{ {}; }}", snippet),
+                            Applicability::MaybeIncorrect,
+                        );
+                    }
+                } else {
+                    e.span_suggestion_verbose(
+                        site_span.shrink_to_hi(),
+                        "add `;` to interpret the expansion as a statement",
+                        ";",
+                        Applicability::MaybeIncorrect,
+                    );
+                }
             }
         },
         _ => annotate_err_with_kind(&mut e, kind, site_span),

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -3317,10 +3317,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             tcx,
             trait_ref.substs.extend_to(tcx, assoc.def_id, |param, _| tcx.mk_param_from_def(param)),
         );
+        let fn_sig = tcx.liberate_late_bound_regions(fn_hir_id.expect_owner().to_def_id(), fn_sig);
 
-        let ty = if let Some(arg_idx) = arg_idx { fn_sig.input(arg_idx) } else { fn_sig.output() };
-
-        Some(tcx.liberate_late_bound_regions(fn_hir_id.expect_owner().to_def_id(), ty))
+        Some(if let Some(arg_idx) = arg_idx {
+            *fn_sig.inputs().get(arg_idx)?
+        } else {
+            fn_sig.output()
+        })
     }
 
     #[instrument(level = "trace", skip(self, generate_err))]

--- a/compiler/rustc_hir_typeck/src/_match.rs
+++ b/compiler/rustc_hir_typeck/src/_match.rs
@@ -299,7 +299,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             {
                 // check that the `if` expr without `else` is the fn body's expr
                 if expr.span == sp {
-                    return self.get_fn_decl(hir_id).and_then(|(fn_decl, _)| {
+                    return self.get_fn_decl(hir_id).and_then(|(_, fn_decl, _)| {
                         let span = fn_decl.output.span();
                         let snippet = self.tcx.sess.source_map().span_to_snippet(span).ok()?;
                         Some((span, format!("expected `{snippet}` because of this return type")))

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -799,7 +799,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.ret_coercion_span.set(Some(expr.span));
             }
             let cause = self.cause(expr.span, ObligationCauseCode::ReturnNoExpression);
-            if let Some((fn_decl, _)) = self.get_fn_decl(expr.hir_id) {
+            if let Some((_, fn_decl, _)) = self.get_fn_decl(expr.hir_id) {
                 coercion.coerce_forced_unit(
                     self,
                     &cause,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1669,7 +1669,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// Given a function block's `HirId`, returns its `FnDecl` if it exists, or `None` otherwise.
     fn get_parent_fn_decl(&self, blk_id: hir::HirId) -> Option<(&'tcx hir::FnDecl<'tcx>, Ident)> {
         let parent = self.tcx.hir().get_by_def_id(self.tcx.hir().get_parent_item(blk_id).def_id);
-        self.get_node_fn_decl(parent).map(|(fn_decl, ident, _)| (fn_decl, ident))
+        self.get_node_fn_decl(parent).map(|(_, fn_decl, ident, _)| (fn_decl, ident))
     }
 
     /// If `expr` is a `match` expression that has only one non-`!` arm, use that arm's tail

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -64,8 +64,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let expr = expr.peel_drop_temps();
         self.suggest_missing_semicolon(err, expr, expected, false);
         let mut pointing_at_return_type = false;
-        if let Some((fn_decl, can_suggest)) = self.get_fn_decl(blk_id) {
-            let fn_id = self.tcx.hir().get_return_block(blk_id).unwrap();
+        if let Some((fn_id, fn_decl, can_suggest)) = self.get_fn_decl(blk_id) {
             pointing_at_return_type = self.suggest_missing_return_type(
                 err,
                 &fn_decl,

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -85,20 +85,28 @@ impl<'a> std::fmt::Debug for ImportKind<'a> {
             Single {
                 ref source,
                 ref target,
+                ref source_bindings,
+                ref target_bindings,
                 ref type_ns_only,
                 ref nested,
                 ref id,
-                // Ignore the following to avoid an infinite loop while printing.
-                source_bindings: _,
-                target_bindings: _,
             } => f
                 .debug_struct("Single")
                 .field("source", source)
                 .field("target", target)
+                // Ignore the nested bindings to avoid an infinite loop while printing.
+                .field(
+                    "source_bindings",
+                    &source_bindings.clone().map(|b| b.into_inner().map(|_| format_args!(".."))),
+                )
+                .field(
+                    "target_bindings",
+                    &target_bindings.clone().map(|b| b.into_inner().map(|_| format_args!(".."))),
+                )
                 .field("type_ns_only", type_ns_only)
                 .field("nested", nested)
                 .field("id", id)
-                .finish_non_exhaustive(),
+                .finish(),
             Glob { ref is_prelude, ref max_vis, ref id } => f
                 .debug_struct("Glob")
                 .field("is_prelude", is_prelude)

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1478,8 +1478,9 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
                                     } else {
                                         LifetimeUseSet::Many
                                     }),
-                                    LifetimeRibKind::Generics { .. } => None,
-                                    LifetimeRibKind::ConstGeneric | LifetimeRibKind::AnonConst => {
+                                    LifetimeRibKind::Generics { .. }
+                                    | LifetimeRibKind::ConstGeneric => None,
+                                    LifetimeRibKind::AnonConst => {
                                         span_bug!(ident.span, "unexpected rib kind: {:?}", rib.kind)
                                     }
                                 })

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -1246,7 +1246,7 @@ pub fn stat(path: &Path) -> io::Result<FileAttr> {
                 }
             }
             Err(err)
-        },
+        }
         Ok(attrs) => Ok(attrs),
     }
 }

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -1236,7 +1236,19 @@ pub fn link(_original: &Path, _link: &Path) -> io::Result<()> {
 }
 
 pub fn stat(path: &Path) -> io::Result<FileAttr> {
-    metadata(path, ReparsePoint::Follow)
+    match metadata(path, ReparsePoint::Follow) {
+        Err(err) => {
+            if err.raw_os_error() == Some(c::ERROR_CANT_ACCESS_FILE as i32) {
+                if let Ok(attrs) = lstat(path) {
+                    if !attrs.file_type().is_symlink() {
+                        return Ok(attrs);
+                    }
+                }
+            }
+            Err(err)
+        },
+        Ok(attrs) => Ok(attrs),
+    }
 }
 
 pub fn lstat(path: &Path) -> io::Result<FileAttr> {

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -1237,17 +1237,15 @@ pub fn link(_original: &Path, _link: &Path) -> io::Result<()> {
 
 pub fn stat(path: &Path) -> io::Result<FileAttr> {
     match metadata(path, ReparsePoint::Follow) {
-        Err(err) => {
-            if err.raw_os_error() == Some(c::ERROR_CANT_ACCESS_FILE as i32) {
-                if let Ok(attrs) = lstat(path) {
-                    if !attrs.file_type().is_symlink() {
-                        return Ok(attrs);
-                    }
+        Err(err) if err.raw_os_error() == Some(c::ERROR_CANT_ACCESS_FILE as i32) => {
+            if let Ok(attrs) = lstat(path) {
+                if !attrs.file_type().is_symlink() {
+                    return Ok(attrs);
                 }
             }
             Err(err)
         }
-        Ok(attrs) => Ok(attrs),
+        result => result,
     }
 }
 

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -210,10 +210,13 @@ install!((self, builder, _config),
         }
     };
     LlvmTools, alias = "llvm-tools", Self::should_build(_config), only_hosts: true, {
-        let tarball = builder
-            .ensure(dist::LlvmTools { target: self.target })
-            .expect("missing llvm-tools");
-        install_sh(builder, "llvm-tools", self.compiler.stage, Some(self.target), &tarball);
+        if let Some(tarball) = builder.ensure(dist::LlvmTools { target: self.target }) {
+            install_sh(builder, "llvm-tools", self.compiler.stage, Some(self.target), &tarball);
+        } else {
+            builder.info(
+                &format!("skipping llvm-tools stage{} ({}): external LLVM", self.compiler.stage, self.target),
+            );
+        }
     };
     Rustfmt, alias = "rustfmt", Self::should_build(_config), only_hosts: true, {
         if let Some(tarball) = builder.ensure(dist::Rustfmt {

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -265,10 +265,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             return false;
         }
 
-        if !self.view_item_stack.insert(res_did) {
-            return false;
-        }
-
         if !please_inline &&
             let mut visitor = OneLevelVisitor::new(self.cx.tcx.hir(), res_did) &&
             let Some(item) = visitor.find_target(self.cx.tcx, def_id.to_def_id(), path) &&
@@ -282,6 +278,10 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             !inherits_doc_hidden(self.cx.tcx, item_def_id)
         {
             // The imported item is public and not `doc(hidden)` so no need to inline it.
+            return false;
+        }
+
+        if !self.view_item_stack.insert(res_did) {
             return false;
         }
 

--- a/tests/rustdoc/issue-109258-missing-private-inlining.rs
+++ b/tests/rustdoc/issue-109258-missing-private-inlining.rs
@@ -1,0 +1,27 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/109258>.
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html'
+// We should only have a "Re-exports" and a "Modules" headers.
+// @count - '//*[@id="main-content"]/h2[@class="small-section-header"]' 2
+// @has - '//*[@id="main-content"]/h2[@class="small-section-header"]' 'Re-exports'
+// @has - '//*[@id="main-content"]/h2[@class="small-section-header"]' 'Modules'
+
+// @has - '//*[@id="reexport.Foo"]' 'pub use crate::issue_109258::Foo;'
+// @has - '//*[@id="reexport.Foo"]//a[@href="issue_109258/struct.Foo.html"]' 'Foo'
+// @!has 'foo/struct.Foo.html'
+pub use crate::issue_109258::Foo;
+
+// @has 'foo/issue_109258/index.html'
+// We should only have a "Structs" header.
+// @count - '//*[@id="main-content"]/h2[@class="small-section-header"]' 1
+// @has - '//*[@id="main-content"]/h2[@class="small-section-header"]' 'Structs'
+// @has - '//*[@id="main-content"]//a[@href="struct.Foo.html"]' 'Foo'
+// @has 'foo/issue_109258/struct.Foo.html'
+pub mod issue_109258 {
+    mod priv_mod {
+        pub struct Foo;
+    }
+    pub use self::priv_mod::Foo;
+}

--- a/tests/ui/async-await/async-trait-fn.current.stderr
+++ b/tests/ui/async-await/async-trait-fn.current.stderr
@@ -1,5 +1,5 @@
 error[E0706]: functions in traits cannot be declared `async`
-  --> $DIR/async-trait-fn.rs:3:5
+  --> $DIR/async-trait-fn.rs:6:5
    |
 LL |     async fn foo() {}
    |     -----^^^^^^^^^
@@ -12,7 +12,7 @@ LL |     async fn foo() {}
    = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
-  --> $DIR/async-trait-fn.rs:4:5
+  --> $DIR/async-trait-fn.rs:7:5
    |
 LL |     async fn bar(&self) {}
    |     -----^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     async fn bar(&self) {}
    = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
-  --> $DIR/async-trait-fn.rs:5:5
+  --> $DIR/async-trait-fn.rs:8:5
    |
 LL |     async fn baz() {
    |     -----^^^^^^^^^

--- a/tests/ui/async-await/async-trait-fn.next.stderr
+++ b/tests/ui/async-await/async-trait-fn.next.stderr
@@ -1,0 +1,42 @@
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/async-trait-fn.rs:6:5
+   |
+LL |     async fn foo() {}
+   |     -----^^^^^^^^^
+   |     |
+   |     `async` because of this
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
+
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/async-trait-fn.rs:7:5
+   |
+LL |     async fn bar(&self) {}
+   |     -----^^^^^^^^^^^^^^
+   |     |
+   |     `async` because of this
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
+
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/async-trait-fn.rs:8:5
+   |
+LL |     async fn baz() {
+   |     -----^^^^^^^^^
+   |     |
+   |     `async` because of this
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0706`.

--- a/tests/ui/async-await/async-trait-fn.rs
+++ b/tests/ui/async-await/async-trait-fn.rs
@@ -1,4 +1,7 @@
 // edition:2018
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
+
 trait T {
     async fn foo() {} //~ ERROR functions in traits cannot be declared `async`
     async fn bar(&self) {} //~ ERROR functions in traits cannot be declared `async`

--- a/tests/ui/async-await/edition-deny-async-fns-2015.current.stderr
+++ b/tests/ui/async-await/edition-deny-async-fns-2015.current.stderr
@@ -1,5 +1,5 @@
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/edition-deny-async-fns-2015.rs:3:1
+  --> $DIR/edition-deny-async-fns-2015.rs:5:1
    |
 LL | async fn foo() {}
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -8,7 +8,7 @@ LL | async fn foo() {}
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/edition-deny-async-fns-2015.rs:5:12
+  --> $DIR/edition-deny-async-fns-2015.rs:7:12
    |
 LL | fn baz() { async fn foo() {} }
    |            ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -17,7 +17,7 @@ LL | fn baz() { async fn foo() {} }
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/edition-deny-async-fns-2015.rs:7:1
+  --> $DIR/edition-deny-async-fns-2015.rs:9:1
    |
 LL | async fn async_baz() {
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -26,7 +26,7 @@ LL | async fn async_baz() {
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/edition-deny-async-fns-2015.rs:8:5
+  --> $DIR/edition-deny-async-fns-2015.rs:10:5
    |
 LL |     async fn bar() {}
    |     ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -35,7 +35,7 @@ LL |     async fn bar() {}
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/edition-deny-async-fns-2015.rs:14:5
+  --> $DIR/edition-deny-async-fns-2015.rs:16:5
    |
 LL |     async fn foo() {}
    |     ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -44,7 +44,7 @@ LL |     async fn foo() {}
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/edition-deny-async-fns-2015.rs:18:5
+  --> $DIR/edition-deny-async-fns-2015.rs:20:5
    |
 LL |     async fn foo() {}
    |     ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -53,7 +53,7 @@ LL |     async fn foo() {}
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/edition-deny-async-fns-2015.rs:36:9
+  --> $DIR/edition-deny-async-fns-2015.rs:38:9
    |
 LL |         async fn bar() {}
    |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -62,7 +62,7 @@ LL |         async fn bar() {}
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/edition-deny-async-fns-2015.rs:26:9
+  --> $DIR/edition-deny-async-fns-2015.rs:28:9
    |
 LL |         async fn foo() {}
    |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -71,7 +71,7 @@ LL |         async fn foo() {}
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/edition-deny-async-fns-2015.rs:31:13
+  --> $DIR/edition-deny-async-fns-2015.rs:33:13
    |
 LL |             async fn bar() {}
    |             ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -80,7 +80,7 @@ LL |             async fn bar() {}
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0706]: functions in traits cannot be declared `async`
-  --> $DIR/edition-deny-async-fns-2015.rs:18:5
+  --> $DIR/edition-deny-async-fns-2015.rs:20:5
    |
 LL |     async fn foo() {}
    |     -----^^^^^^^^^

--- a/tests/ui/async-await/edition-deny-async-fns-2015.next.stderr
+++ b/tests/ui/async-await/edition-deny-async-fns-2015.next.stderr
@@ -1,0 +1,98 @@
+error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/edition-deny-async-fns-2015.rs:5:1
+   |
+LL | async fn foo() {}
+   | ^^^^^ to use `async fn`, switch to Rust 2018 or later
+   |
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/edition-deny-async-fns-2015.rs:7:12
+   |
+LL | fn baz() { async fn foo() {} }
+   |            ^^^^^ to use `async fn`, switch to Rust 2018 or later
+   |
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/edition-deny-async-fns-2015.rs:9:1
+   |
+LL | async fn async_baz() {
+   | ^^^^^ to use `async fn`, switch to Rust 2018 or later
+   |
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/edition-deny-async-fns-2015.rs:10:5
+   |
+LL |     async fn bar() {}
+   |     ^^^^^ to use `async fn`, switch to Rust 2018 or later
+   |
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/edition-deny-async-fns-2015.rs:16:5
+   |
+LL |     async fn foo() {}
+   |     ^^^^^ to use `async fn`, switch to Rust 2018 or later
+   |
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/edition-deny-async-fns-2015.rs:20:5
+   |
+LL |     async fn foo() {}
+   |     ^^^^^ to use `async fn`, switch to Rust 2018 or later
+   |
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/edition-deny-async-fns-2015.rs:38:9
+   |
+LL |         async fn bar() {}
+   |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
+   |
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/edition-deny-async-fns-2015.rs:28:9
+   |
+LL |         async fn foo() {}
+   |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
+   |
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/edition-deny-async-fns-2015.rs:33:13
+   |
+LL |             async fn bar() {}
+   |             ^^^^^ to use `async fn`, switch to Rust 2018 or later
+   |
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/edition-deny-async-fns-2015.rs:20:5
+   |
+LL |     async fn foo() {}
+   |     -----^^^^^^^^^
+   |     |
+   |     `async` because of this
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
+
+error: aborting due to 10 previous errors
+
+Some errors have detailed explanations: E0670, E0706.
+For more information about an error, try `rustc --explain E0670`.

--- a/tests/ui/async-await/edition-deny-async-fns-2015.rs
+++ b/tests/ui/async-await/edition-deny-async-fns-2015.rs
@@ -1,4 +1,6 @@
 // edition:2015
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 async fn foo() {} //~ ERROR `async fn` is not permitted in Rust 2015
 

--- a/tests/ui/async-await/in-trait/generics-mismatch.current.stderr
+++ b/tests/ui/async-await/in-trait/generics-mismatch.current.stderr
@@ -1,0 +1,16 @@
+error[E0053]: method `foo` has an incompatible generic parameter for trait `Foo`
+  --> $DIR/generics-mismatch.rs:13:18
+   |
+LL | trait Foo {
+   |       ---
+LL |     async fn foo<T>();
+   |                  - expected type parameter
+...
+LL | impl Foo for () {
+   | ---------------
+LL |     async fn foo<const N: usize>() {}
+   |                  ^^^^^^^^^^^^^^ found const parameter of type `usize`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0053`.

--- a/tests/ui/async-await/in-trait/generics-mismatch.next.stderr
+++ b/tests/ui/async-await/in-trait/generics-mismatch.next.stderr
@@ -1,0 +1,16 @@
+error[E0053]: method `foo` has an incompatible generic parameter for trait `Foo`
+  --> $DIR/generics-mismatch.rs:13:18
+   |
+LL | trait Foo {
+   |       ---
+LL |     async fn foo<T>();
+   |                  - expected type parameter
+...
+LL | impl Foo for () {
+   | ---------------
+LL |     async fn foo<const N: usize>() {}
+   |                  ^^^^^^^^^^^^^^ found const parameter of type `usize`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0053`.

--- a/tests/ui/async-await/in-trait/generics-mismatch.rs
+++ b/tests/ui/async-await/in-trait/generics-mismatch.rs
@@ -1,0 +1,17 @@
+// edition: 2021
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
+
+#![feature(async_fn_in_trait)]
+#![allow(incomplete_features)]
+
+trait Foo {
+    async fn foo<T>();
+}
+
+impl Foo for () {
+    async fn foo<const N: usize>() {}
+    //~^ ERROR: method `foo` has an incompatible generic parameter for trait `Foo` [E0053]
+}
+
+fn main() {}

--- a/tests/ui/async-await/in-trait/return-type-suggestion.current.stderr
+++ b/tests/ui/async-await/in-trait/return-type-suggestion.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/return-type-suggestion.rs:3:12
+  --> $DIR/return-type-suggestion.rs:5:12
    |
 LL | #![feature(async_fn_in_trait)]
    |            ^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | #![feature(async_fn_in_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0308]: mismatched types
-  --> $DIR/return-type-suggestion.rs:8:9
+  --> $DIR/return-type-suggestion.rs:10:9
    |
 LL |         Ok(())
    |         ^^^^^^- help: consider using a semicolon here: `;`

--- a/tests/ui/async-await/in-trait/return-type-suggestion.next.stderr
+++ b/tests/ui/async-await/in-trait/return-type-suggestion.next.stderr
@@ -1,0 +1,23 @@
+warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/return-type-suggestion.rs:5:12
+   |
+LL | #![feature(async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0308]: mismatched types
+  --> $DIR/return-type-suggestion.rs:10:9
+   |
+LL |         Ok(())
+   |         ^^^^^^- help: consider using a semicolon here: `;`
+   |         |
+   |         expected `()`, found `Result<(), _>`
+   |
+   = note: expected unit type `()`
+                   found enum `Result<(), _>`
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/in-trait/return-type-suggestion.rs
+++ b/tests/ui/async-await/in-trait/return-type-suggestion.rs
@@ -1,4 +1,6 @@
 // edition: 2021
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(async_fn_in_trait)]
 //~^ WARN the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes

--- a/tests/ui/impl-trait/in-trait/default-body-with-rpit.current.stderr
+++ b/tests/ui/impl-trait/in-trait/default-body-with-rpit.current.stderr
@@ -1,11 +1,11 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/default-body-with-rpit.rs:11:9
+  --> $DIR/default-body-with-rpit.rs:13:9
    |
 LL |         ""
    |         ^^ expected `impl Debug`, got `&'static str`
    |
 note: previous use here
-  --> $DIR/default-body-with-rpit.rs:10:39
+  --> $DIR/default-body-with-rpit.rs:12:39
    |
 LL |       async fn baz(&self) -> impl Debug {
    |  _______________________________________^
@@ -14,7 +14,7 @@ LL | |     }
    | |_____^
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/default-body-with-rpit.rs:10:28
+  --> $DIR/default-body-with-rpit.rs:12:28
    |
 LL |     async fn baz(&self) -> impl Debug {
    |                            ^^^^^^^^^^ cannot resolve opaque type

--- a/tests/ui/impl-trait/in-trait/default-body-with-rpit.next.stderr
+++ b/tests/ui/impl-trait/in-trait/default-body-with-rpit.next.stderr
@@ -1,0 +1,24 @@
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/default-body-with-rpit.rs:13:9
+   |
+LL |         ""
+   |         ^^ expected `impl Debug`, got `&'static str`
+   |
+note: previous use here
+  --> $DIR/default-body-with-rpit.rs:12:39
+   |
+LL |       async fn baz(&self) -> impl Debug {
+   |  _______________________________________^
+LL | |         ""
+LL | |     }
+   | |_____^
+
+error[E0720]: cannot resolve opaque type
+  --> $DIR/default-body-with-rpit.rs:12:28
+   |
+LL |     async fn baz(&self) -> impl Debug {
+   |                            ^^^^^^^^^^ cannot resolve opaque type
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0720`.

--- a/tests/ui/impl-trait/in-trait/default-body-with-rpit.rs
+++ b/tests/ui/impl-trait/in-trait/default-body-with-rpit.rs
@@ -1,5 +1,7 @@
 // edition:2021
 // known-bug: #108304
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(async_fn_in_trait, return_position_impl_trait_in_trait)]
 #![allow(incomplete_features)]

--- a/tests/ui/impl-trait/in-trait/doesnt-satisfy.current.stderr
+++ b/tests/ui/impl-trait/in-trait/doesnt-satisfy.current.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `()` doesn't implement `std::fmt::Display`
-  --> $DIR/doesnt-satisfy.rs:9:17
+  --> $DIR/doesnt-satisfy.rs:12:17
    |
 LL |     fn bar() -> () {}
    |                 ^^ `()` cannot be formatted with the default formatter
@@ -7,7 +7,7 @@ LL |     fn bar() -> () {}
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 note: required by a bound in `Foo::bar::{opaque#0}`
-  --> $DIR/doesnt-satisfy.rs:5:22
+  --> $DIR/doesnt-satisfy.rs:8:22
    |
 LL |     fn bar() -> impl std::fmt::Display;
    |                      ^^^^^^^^^^^^^^^^^ required by this bound in `Foo::bar::{opaque#0}`

--- a/tests/ui/impl-trait/in-trait/doesnt-satisfy.next.stderr
+++ b/tests/ui/impl-trait/in-trait/doesnt-satisfy.next.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `()` doesn't implement `std::fmt::Display`
+  --> $DIR/doesnt-satisfy.rs:12:17
+   |
+LL |     fn bar() -> () {}
+   |                 ^^ `()` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `()`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Foo::{opaque#0}`
+  --> $DIR/doesnt-satisfy.rs:8:22
+   |
+LL |     fn bar() -> impl std::fmt::Display;
+   |                      ^^^^^^^^^^^^^^^^^ required by this bound in `Foo::`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/in-trait/doesnt-satisfy.rs
+++ b/tests/ui/impl-trait/in-trait/doesnt-satisfy.rs
@@ -1,3 +1,6 @@
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
+
 #![feature(return_position_impl_trait_in_trait)]
 #![allow(incomplete_features)]
 

--- a/tests/ui/lifetimes/unusual-rib-combinations.rs
+++ b/tests/ui/lifetimes/unusual-rib-combinations.rs
@@ -25,4 +25,9 @@ fn d<const C: S>() {}
 //~^ ERROR missing lifetime specifier
 //~| ERROR `S<'_>` is forbidden as the type of a const generic parameter
 
+trait Foo<'a> {}
+struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
+//~^ ERROR use of non-static lifetime `'a` in const generic
+//~| ERROR `&dyn for<'a> Foo<'a>` is forbidden as the type of a const generic parameter
+
 fn main() {}

--- a/tests/ui/lifetimes/unusual-rib-combinations.stderr
+++ b/tests/ui/lifetimes/unusual-rib-combinations.stderr
@@ -9,6 +9,14 @@ help: consider introducing a named lifetime parameter
 LL | fn d<'a, const C: S<'a>>() {}
    |      +++           ++++
 
+error[E0771]: use of non-static lifetime `'a` in const generic
+  --> $DIR/unusual-rib-combinations.rs:29:22
+   |
+LL | struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
+   |                      ^^
+   |
+   = note: for more information, see issue #74052 <https://github.com/rust-lang/rust/issues/74052>
+
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/unusual-rib-combinations.rs:7:16
    |
@@ -55,7 +63,16 @@ LL | fn d<const C: S>() {}
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(adt_const_params)]`
 
-error: aborting due to 7 previous errors
+error: `&dyn for<'a> Foo<'a>` is forbidden as the type of a const generic parameter
+  --> $DIR/unusual-rib-combinations.rs:29:21
+   |
+LL | struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: more complex types are supported with `#![feature(adt_const_params)]`
 
-Some errors have detailed explanations: E0106, E0214, E0308.
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0106, E0214, E0308, E0771.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/macros/issue-109237.rs
+++ b/tests/ui/macros/issue-109237.rs
@@ -1,0 +1,7 @@
+macro_rules! statement {
+    () => {;}; //~ ERROR expected expression
+}
+
+fn main() {
+    let _ = statement!();
+}

--- a/tests/ui/macros/issue-109237.stderr
+++ b/tests/ui/macros/issue-109237.stderr
@@ -1,0 +1,18 @@
+error: expected expression, found `;`
+  --> $DIR/issue-109237.rs:2:12
+   |
+LL |     () => {;};
+   |            ^ expected expression
+...
+LL |     let _ = statement!();
+   |             ------------ in this macro invocation
+   |
+   = note: the macro call doesn't expand to an expression, but it can expand to a statement
+   = note: this error originates in the macro `statement` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: surround the macro invocation with `{}` to interpret the expansion as a statement
+   |
+LL |     let _ = { statement!(); };
+   |             ~~~~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+

--- a/tests/ui/suggestions/bad-infer-in-trait-impl.rs
+++ b/tests/ui/suggestions/bad-infer-in-trait-impl.rs
@@ -1,0 +1,10 @@
+trait Foo {
+    fn bar();
+}
+
+impl Foo for () {
+    fn bar(s: _) {}
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+}
+
+fn main() {}

--- a/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
+++ b/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
@@ -1,0 +1,14 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-infer-in-trait-impl.rs:6:15
+   |
+LL |     fn bar(s: _) {}
+   |               ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL |     fn bar<T>(s: T) {}
+   |           +++    ~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/suggestions/suggest-ret-on-async-w-late.rs
+++ b/tests/ui/suggestions/suggest-ret-on-async-w-late.rs
@@ -1,0 +1,11 @@
+// edition: 2021
+
+// Make sure we don't ICE when suggesting a return type
+// for an async fn that has late-bound vars...
+
+async fn ice(_: &i32) {
+    true
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/suggestions/suggest-ret-on-async-w-late.stderr
+++ b/tests/ui/suggestions/suggest-ret-on-async-w-late.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/suggest-ret-on-async-w-late.rs:7:5
+   |
+LL | async fn ice(_: &i32) {
+   |                       - help: try adding a return type: `-> bool`
+LL |     true
+   |     ^^^^ expected `()`, found `bool`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/traits/non_lifetime_binders/missing-assoc-item.rs
+++ b/tests/ui/traits/non_lifetime_binders/missing-assoc-item.rs
@@ -1,0 +1,11 @@
+#![feature(non_lifetime_binders)]
+//~^ WARN the feature `non_lifetime_binders` is incomplete
+
+fn f()
+where
+    for<B> B::Item: Send,
+    //~^ ERROR ambiguous associated type
+{
+}
+
+fn main() {}

--- a/tests/ui/traits/non_lifetime_binders/missing-assoc-item.stderr
+++ b/tests/ui/traits/non_lifetime_binders/missing-assoc-item.stderr
@@ -1,0 +1,18 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/missing-assoc-item.rs:1:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0223]: ambiguous associated type
+  --> $DIR/missing-assoc-item.rs:6:12
+   |
+LL |     for<B> B::Item: Send,
+   |            ^^^^^^^ help: use the fully-qualified path: `<B as IntoIterator>::Item`
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0223`.


### PR DESCRIPTION
Successful merges:

 - #109102 (Erase escaping late-bound regions when probing for ambiguous associated types)
 - #109193 (Add revisions for -Zlower-impl-trait-in-trait-to-assoc-ty fixed tests)
 - #109200 (Fix index out of bounds in `suggest_trait_fn_ty_for_impl_fn_infer`)
 - #109211 (E0206 - update description )
 - #109222 (Do not ICE for unexpected lifetime with ConstGeneric rib)
 - #109235 (fallback to lstat when stat fails on Windows)
 - #109248 (Pass the right HIR back from `get_fn_decl`)
 - #109251 (Suggest surrounding the macro with `{}` to interpret as a statement)
 - #109256 (Check for llvm-tools before install)
 - #109257 (resolve: Improve debug impls for `NameBinding`)
 - #109259 (rustdoc: Fix missing private inlining)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=109102,109193,109200,109211,109222,109235,109248,109251,109256,109257,109259)
<!-- homu-ignore:end -->