### PR TITLE
When HIR auto-refs a comparison operator, clean it up in MIR

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1931,9 +1931,13 @@ impl<'tcx> Operand<'tcx> {
     ///
     /// While this is unlikely in general, it's the normal case of what you'll
     /// find as the `func` in a [`TerminatorKind::Call`].
-    pub fn const_fn_def(&self) -> Option<(DefId, SubstsRef<'tcx>)> {
-        let const_ty = self.constant()?.literal.ty();
-        if let ty::FnDef(def_id, substs) = *const_ty.kind() { Some((def_id, substs)) } else { None }
+    pub fn const_fn_def(&self) -> Option<(DefId, SubstsRef<'tcx>, Span)> {
+        let constant = self.constant()?;
+        if let ty::FnDef(def_id, substs) = *constant.literal.ty().kind() {
+            Some((def_id, substs, constant.span))
+        } else {
+            None
+        }
     }
 }
 

--- a/compiler/rustc_mir_transform/src/instcombine.rs
+++ b/compiler/rustc_mir_transform/src/instcombine.rs
@@ -168,7 +168,7 @@ impl<'tcx> InstCombineContext<'tcx, '_> {
         else { return };
 
         // Only bother looking more if it's easy to know what we're calling
-        let Some((fn_def_id, fn_substs)) = func.const_fn_def()
+        let Some((fn_def_id, fn_substs, _span)) = func.const_fn_def()
         else { return };
 
         // Clone needs one subst, so we can cheaply rule out other stuff

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -94,6 +94,7 @@ mod ssa;
 pub mod simplify;
 mod simplify_branches;
 mod simplify_comparison_integral;
+mod simplify_ref_comparisons;
 mod sroa;
 mod uninhabited_enum_branching;
 mod unreachable_prop;
@@ -497,6 +498,8 @@ fn run_analysis_cleanup_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         &cleanup_post_borrowck::CleanupPostBorrowck,
         &remove_noop_landing_pads::RemoveNoopLandingPads,
         &simplify::SimplifyCfg::new("early-opt"),
+        // Adds more `Deref`s, so needs to be before `Derefer`.
+        &simplify_ref_comparisons::SimplifyRefComparisons,
         &deref_separator::Derefer,
     ];
 

--- a/compiler/rustc_mir_transform/src/simplify_ref_comparisons.rs
+++ b/compiler/rustc_mir_transform/src/simplify_ref_comparisons.rs
@@ -1,0 +1,86 @@
+use crate::MirPass;
+use rustc_middle::mir::*;
+use rustc_middle::ty::{self, Ty, TyCtxt};
+
+/// This pass replaces `x OP y` with `*x OP *y` when `OP` is a comparison operator.
+///
+/// The goal is to make is so that it's never better for the user to write
+/// `***x == ***y` than to write the obvious `x == y` (when `x` and `y` are
+/// references and thus those do the same thing). This is particularly
+/// important because the type-checker will auto-ref any comparison that's not
+/// done directly on a primitive. That means that `a_ref == b_ref` doesn't
+/// become `PartialEq::eq(a_ref, b_ref)`, even though that would work, but rather
+/// ```no_run
+/// # fn foo(a_ref: &i32, b_ref: &i32) -> bool {
+/// let temp1 = &a_ref;
+/// let temp2 = &b_ref;
+/// PartialEq::eq(temp1, temp2)
+/// # }
+/// ```
+/// Thus this pass means it directly calls the *interesting* `impl` directly,
+/// rather than needing to monomorphize and/or inline it later.  (And when this
+/// comment was written in March 2023, the MIR inliner seemed to only inline
+/// one level of `==`, so if the comparison is on something like `&&i32` the
+/// extra forwarding impls needed to be monomorphized even in an optimized build.)
+///
+/// Make sure this runs before the `Derefer`, since it might add multiple levels
+/// of dereferences in the `Operand`s that are arguments to the `Call`.
+pub struct SimplifyRefComparisons;
+
+impl<'tcx> MirPass<'tcx> for SimplifyRefComparisons {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        // Despite the method name, this is `PartialEq`, not `Eq`.
+        let Some(partial_eq) = tcx.lang_items().eq_trait() else { return };
+        let Some(partial_ord) = tcx.lang_items().partial_ord_trait() else { return };
+
+        for block in body.basic_blocks.as_mut() {
+            let terminator = block.terminator.as_mut().unwrap();
+            let TerminatorKind::Call { func, args, from_hir_call: false, .. } =
+                &mut terminator.kind
+            else { continue };
+
+            // Quickly skip unary operators
+            if args.len() != 2 {
+                continue;
+            }
+            let (Some(left_place), Some(right_place)) = (args[0].place(), args[1].place())
+            else { continue };
+
+            let (fn_def, fn_substs, fn_span) =
+                func.const_fn_def().expect("HIR operators to always call the traits directly");
+            let substs =
+                fn_substs.try_as_type_list().expect("HIR operators only have type parameters");
+            let [left_ty, right_ty] = *substs.as_slice() else { continue };
+            let (depth, new_left_ty, new_right_ty) = find_ref_depth(left_ty, right_ty);
+            if depth == 0 {
+                // Already dereffed as far as possible.
+                continue;
+            }
+
+            // Check it's a comparison, not `+`/`&`/etc.
+            let trait_def = tcx.trait_of_item(fn_def);
+            if trait_def != Some(partial_eq) && trait_def != Some(partial_ord) {
+                continue;
+            }
+
+            let derefs = vec![ProjectionElem::Deref; depth];
+            let new_substs = [new_left_ty.into(), new_right_ty.into()];
+
+            *func = Operand::function_handle(tcx, fn_def, new_substs, fn_span);
+            args[0] = Operand::Copy(left_place.project_deeper(&derefs, tcx));
+            args[1] = Operand::Copy(right_place.project_deeper(&derefs, tcx));
+        }
+    }
+}
+
+fn find_ref_depth<'tcx>(mut left: Ty<'tcx>, mut right: Ty<'tcx>) -> (usize, Ty<'tcx>, Ty<'tcx>) {
+    let mut depth = 0;
+    while let (ty::Ref(_, new_left, Mutability::Not), ty::Ref(_, new_right, Mutability::Not)) =
+        (left.kind(), right.kind())
+    {
+        depth += 1;
+        (left, right) = (*new_left, *new_right);
+    }
+
+    (depth, left, right)
+}

--- a/tests/mir-opt/simplify_cmp.multi_ref_prim.SimplifyRefComparisons.diff
+++ b/tests/mir-opt/simplify_cmp.multi_ref_prim.SimplifyRefComparisons.diff
@@ -1,0 +1,168 @@
+- // MIR for `multi_ref_prim` before SimplifyRefComparisons
++ // MIR for `multi_ref_prim` after SimplifyRefComparisons
+  
+  fn multi_ref_prim(_1: &&&i32, _2: &&&i32) -> () {
+      debug x => _1;                       // in scope 0 at $DIR/simplify_cmp.rs:+0:23: +0:24
+      debug y => _2;                       // in scope 0 at $DIR/simplify_cmp.rs:+0:34: +0:35
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify_cmp.rs:+0:45: +0:45
+      let _3: bool;                        // in scope 0 at $DIR/simplify_cmp.rs:+1:9: +1:11
+      let mut _4: &&&&i32;                 // in scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:15
+      let mut _5: &&&&i32;                 // in scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+      let mut _7: &&&&i32;                 // in scope 0 at $DIR/simplify_cmp.rs:+2:14: +2:15
+      let mut _8: &&&&i32;                 // in scope 0 at $DIR/simplify_cmp.rs:+2:19: +2:20
+      let mut _10: &&&&i32;                // in scope 0 at $DIR/simplify_cmp.rs:+3:14: +3:15
+      let mut _11: &&&&i32;                // in scope 0 at $DIR/simplify_cmp.rs:+3:18: +3:19
+      let _12: &&&i32;                     // in scope 0 at $DIR/simplify_cmp.rs:+3:18: +3:19
+      let mut _14: &&&&i32;                // in scope 0 at $DIR/simplify_cmp.rs:+4:14: +4:15
+      let mut _15: &&&&i32;                // in scope 0 at $DIR/simplify_cmp.rs:+4:19: +4:20
+      let _16: &&&i32;                     // in scope 0 at $DIR/simplify_cmp.rs:+4:19: +4:20
+      let mut _18: &&&&i32;                // in scope 0 at $DIR/simplify_cmp.rs:+5:14: +5:15
+      let mut _19: &&&&i32;                // in scope 0 at $DIR/simplify_cmp.rs:+5:18: +5:19
+      let _20: &&&i32;                     // in scope 0 at $DIR/simplify_cmp.rs:+5:18: +5:19
+      let mut _22: &&&&i32;                // in scope 0 at $DIR/simplify_cmp.rs:+6:14: +6:15
+      let mut _23: &&&&i32;                // in scope 0 at $DIR/simplify_cmp.rs:+6:19: +6:20
+      let _24: &&&i32;                     // in scope 0 at $DIR/simplify_cmp.rs:+6:19: +6:20
+      scope 1 {
+          debug _a => _3;                  // in scope 1 at $DIR/simplify_cmp.rs:+1:9: +1:11
+          let _6: bool;                    // in scope 1 at $DIR/simplify_cmp.rs:+2:9: +2:11
+          scope 2 {
+              debug _b => _6;              // in scope 2 at $DIR/simplify_cmp.rs:+2:9: +2:11
+              let _9: bool;                // in scope 2 at $DIR/simplify_cmp.rs:+3:9: +3:11
+              scope 3 {
+                  debug _c => _9;          // in scope 3 at $DIR/simplify_cmp.rs:+3:9: +3:11
+                  let _13: bool;           // in scope 3 at $DIR/simplify_cmp.rs:+4:9: +4:11
+                  scope 4 {
+                      debug _d => _13;     // in scope 4 at $DIR/simplify_cmp.rs:+4:9: +4:11
+                      let _17: bool;       // in scope 4 at $DIR/simplify_cmp.rs:+5:9: +5:11
+                      scope 5 {
+                          debug _e => _17; // in scope 5 at $DIR/simplify_cmp.rs:+5:9: +5:11
+                          let _21: bool;   // in scope 5 at $DIR/simplify_cmp.rs:+6:9: +6:11
+                          scope 6 {
+                              debug _f => _21; // in scope 6 at $DIR/simplify_cmp.rs:+6:9: +6:11
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_3);                 // scope 0 at $DIR/simplify_cmp.rs:+1:9: +1:11
+          StorageLive(_4);                 // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:15
+          _4 = &_1;                        // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:15
+          StorageLive(_5);                 // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+          _5 = &_2;                        // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+-         _3 = <&&&i32 as PartialEq>::eq(move _4, move _5) -> bb1; // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:20
++         _3 = <i32 as PartialEq>::eq((*(*(*_4))), (*(*(*_5)))) -> bb1; // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:18:14: 18:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &&&i32, &'b &&&i32) -> bool {<&&&i32 as PartialEq>::eq}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as PartialEq>::eq}, val: Value(<ZST>) }
+      }
+  
+      bb1: {
+          StorageDead(_5);                 // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+          StorageDead(_4);                 // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+          StorageLive(_6);                 // scope 1 at $DIR/simplify_cmp.rs:+2:9: +2:11
+          StorageLive(_7);                 // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:15
+          _7 = &_1;                        // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:15
+          StorageLive(_8);                 // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+          _8 = &_2;                        // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+-         _6 = <&&&i32 as PartialEq>::ne(move _7, move _8) -> bb2; // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:20
++         _6 = <i32 as PartialEq>::ne((*(*(*_7))), (*(*(*_8)))) -> bb2; // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:19:14: 19:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &&&i32, &'b &&&i32) -> bool {<&&&i32 as PartialEq>::ne}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as PartialEq>::ne}, val: Value(<ZST>) }
+      }
+  
+      bb2: {
+          StorageDead(_8);                 // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+          StorageDead(_7);                 // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+          StorageLive(_9);                 // scope 2 at $DIR/simplify_cmp.rs:+3:9: +3:11
+          StorageLive(_10);                // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:15
+          _10 = &_1;                       // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:15
+          StorageLive(_11);                // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          StorageLive(_12);                // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          _12 = &(*_2);                    // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          _11 = &_12;                      // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+-         _9 = <&&&i32 as PartialOrd>::lt(move _10, move _11) -> bb3; // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:19
++         _9 = <i32 as PartialOrd>::lt((*(*(*_10))), (*(*(*_11)))) -> bb3; // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:19
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:20:14: 20:19
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &&&i32, &'b &&&i32) -> bool {<&&&i32 as PartialOrd>::lt}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as PartialOrd>::lt}, val: Value(<ZST>) }
+      }
+  
+      bb3: {
+          StorageDead(_11);                // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          StorageDead(_10);                // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          StorageDead(_12);                // scope 2 at $DIR/simplify_cmp.rs:+3:19: +3:20
+          StorageLive(_13);                // scope 3 at $DIR/simplify_cmp.rs:+4:9: +4:11
+          StorageLive(_14);                // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:15
+          _14 = &_1;                       // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:15
+          StorageLive(_15);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          StorageLive(_16);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          _16 = &(*_2);                    // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          _15 = &_16;                      // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+-         _13 = <&&&i32 as PartialOrd>::le(move _14, move _15) -> bb4; // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:20
++         _13 = <i32 as PartialOrd>::le((*(*(*_14))), (*(*(*_15)))) -> bb4; // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:21:14: 21:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &&&i32, &'b &&&i32) -> bool {<&&&i32 as PartialOrd>::le}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as PartialOrd>::le}, val: Value(<ZST>) }
+      }
+  
+      bb4: {
+          StorageDead(_15);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          StorageDead(_14);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          StorageDead(_16);                // scope 3 at $DIR/simplify_cmp.rs:+4:20: +4:21
+          StorageLive(_17);                // scope 4 at $DIR/simplify_cmp.rs:+5:9: +5:11
+          StorageLive(_18);                // scope 4 at $DIR/simplify_cmp.rs:+5:14: +5:15
+          _18 = &_1;                       // scope 4 at $DIR/simplify_cmp.rs:+5:14: +5:15
+          StorageLive(_19);                // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          StorageLive(_20);                // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          _20 = &(*_2);                    // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          _19 = &_20;                      // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+-         _17 = <&&&i32 as PartialOrd>::gt(move _18, move _19) -> bb5; // scope 4 at $DIR/simplify_cmp.rs:+5:14: +5:19
++         _17 = <i32 as PartialOrd>::gt((*(*(*_18))), (*(*(*_19)))) -> bb5; // scope 4 at $DIR/simplify_cmp.rs:+5:14: +5:19
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:22:14: 22:19
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &&&i32, &'b &&&i32) -> bool {<&&&i32 as PartialOrd>::gt}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as PartialOrd>::gt}, val: Value(<ZST>) }
+      }
+  
+      bb5: {
+          StorageDead(_19);                // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          StorageDead(_18);                // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          StorageDead(_20);                // scope 4 at $DIR/simplify_cmp.rs:+5:19: +5:20
+          StorageLive(_21);                // scope 5 at $DIR/simplify_cmp.rs:+6:9: +6:11
+          StorageLive(_22);                // scope 5 at $DIR/simplify_cmp.rs:+6:14: +6:15
+          _22 = &_1;                       // scope 5 at $DIR/simplify_cmp.rs:+6:14: +6:15
+          StorageLive(_23);                // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          StorageLive(_24);                // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          _24 = &(*_2);                    // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          _23 = &_24;                      // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+-         _21 = <&&&i32 as PartialOrd>::ge(move _22, move _23) -> bb6; // scope 5 at $DIR/simplify_cmp.rs:+6:14: +6:20
++         _21 = <i32 as PartialOrd>::ge((*(*(*_22))), (*(*(*_23)))) -> bb6; // scope 5 at $DIR/simplify_cmp.rs:+6:14: +6:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:23:14: 23:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &&&i32, &'b &&&i32) -> bool {<&&&i32 as PartialOrd>::ge}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as PartialOrd>::ge}, val: Value(<ZST>) }
+      }
+  
+      bb6: {
+          StorageDead(_23);                // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          StorageDead(_22);                // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          StorageDead(_24);                // scope 5 at $DIR/simplify_cmp.rs:+6:20: +6:21
+          _0 = const ();                   // scope 0 at $DIR/simplify_cmp.rs:+0:45: +7:2
+          StorageDead(_21);                // scope 5 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_17);                // scope 4 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_13);                // scope 3 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_9);                 // scope 2 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_6);                 // scope 1 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_3);                 // scope 0 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          return;                          // scope 0 at $DIR/simplify_cmp.rs:+7:2: +7:2
+      }
+  }
+  

--- a/tests/mir-opt/simplify_cmp.ref_different_levels.SimplifyRefComparisons.diff
+++ b/tests/mir-opt/simplify_cmp.ref_different_levels.SimplifyRefComparisons.diff
@@ -1,0 +1,106 @@
+- // MIR for `ref_different_levels` before SimplifyRefComparisons
++ // MIR for `ref_different_levels` after SimplifyRefComparisons
+  
+  fn ref_different_levels(_1: &&str, _2: &String) -> () {
+      debug x => _1;                       // in scope 0 at $DIR/simplify_cmp.rs:+0:29: +0:30
+      debug y => _2;                       // in scope 0 at $DIR/simplify_cmp.rs:+0:39: +0:40
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify_cmp.rs:+0:51: +0:51
+      let _3: bool;                        // in scope 0 at $DIR/simplify_cmp.rs:+1:9: +1:11
+      let mut _4: &&&str;                  // in scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:15
+      let mut _5: &&std::string::String;   // in scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+      let mut _7: &&&str;                  // in scope 0 at $DIR/simplify_cmp.rs:+2:14: +2:15
+      let mut _8: &&std::string::String;   // in scope 0 at $DIR/simplify_cmp.rs:+2:19: +2:20
+      let mut _10: &&std::string::String;  // in scope 0 at $DIR/simplify_cmp.rs:+3:14: +3:15
+      let mut _11: &&&str;                 // in scope 0 at $DIR/simplify_cmp.rs:+3:19: +3:20
+      let mut _13: &&std::string::String;  // in scope 0 at $DIR/simplify_cmp.rs:+4:14: +4:15
+      let mut _14: &&&str;                 // in scope 0 at $DIR/simplify_cmp.rs:+4:19: +4:20
+      scope 1 {
+          debug _a => _3;                  // in scope 1 at $DIR/simplify_cmp.rs:+1:9: +1:11
+          let _6: bool;                    // in scope 1 at $DIR/simplify_cmp.rs:+2:9: +2:11
+          scope 2 {
+              debug _b => _6;              // in scope 2 at $DIR/simplify_cmp.rs:+2:9: +2:11
+              let _9: bool;                // in scope 2 at $DIR/simplify_cmp.rs:+3:9: +3:11
+              scope 3 {
+                  debug _c => _9;          // in scope 3 at $DIR/simplify_cmp.rs:+3:9: +3:11
+                  let _12: bool;           // in scope 3 at $DIR/simplify_cmp.rs:+4:9: +4:11
+                  scope 4 {
+                      debug _d => _12;     // in scope 4 at $DIR/simplify_cmp.rs:+4:9: +4:11
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_3);                 // scope 0 at $DIR/simplify_cmp.rs:+1:9: +1:11
+          StorageLive(_4);                 // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:15
+          _4 = &_1;                        // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:15
+          StorageLive(_5);                 // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+          _5 = &_2;                        // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+-         _3 = <&&str as PartialEq<&String>>::eq(move _4, move _5) -> bb1; // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:20
++         _3 = <&str as PartialEq<String>>::eq((*_4), (*_5)) -> bb1; // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:38:14: 38:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &&str, &'b &String) -> bool {<&&str as PartialEq<&String>>::eq}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &str, &'b String) -> bool {<&str as PartialEq<String>>::eq}, val: Value(<ZST>) }
+      }
+  
+      bb1: {
+          StorageDead(_5);                 // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+          StorageDead(_4);                 // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+          StorageLive(_6);                 // scope 1 at $DIR/simplify_cmp.rs:+2:9: +2:11
+          StorageLive(_7);                 // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:15
+          _7 = &_1;                        // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:15
+          StorageLive(_8);                 // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+          _8 = &_2;                        // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+-         _6 = <&&str as PartialEq<&String>>::ne(move _7, move _8) -> bb2; // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:20
++         _6 = <&str as PartialEq<String>>::ne((*_7), (*_8)) -> bb2; // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:39:14: 39:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &&str, &'b &String) -> bool {<&&str as PartialEq<&String>>::ne}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &str, &'b String) -> bool {<&str as PartialEq<String>>::ne}, val: Value(<ZST>) }
+      }
+  
+      bb2: {
+          StorageDead(_8);                 // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+          StorageDead(_7);                 // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+          StorageLive(_9);                 // scope 2 at $DIR/simplify_cmp.rs:+3:9: +3:11
+          StorageLive(_10);                // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:15
+          _10 = &_2;                       // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:15
+          StorageLive(_11);                // scope 2 at $DIR/simplify_cmp.rs:+3:19: +3:20
+          _11 = &_1;                       // scope 2 at $DIR/simplify_cmp.rs:+3:19: +3:20
+-         _9 = <&String as PartialEq<&&str>>::eq(move _10, move _11) -> bb3; // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:20
++         _9 = <String as PartialEq<&str>>::eq((*_10), (*_11)) -> bb3; // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:40:14: 40:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &String, &'b &&str) -> bool {<&String as PartialEq<&&str>>::eq}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a String, &'b &str) -> bool {<String as PartialEq<&str>>::eq}, val: Value(<ZST>) }
+      }
+  
+      bb3: {
+          StorageDead(_11);                // scope 2 at $DIR/simplify_cmp.rs:+3:19: +3:20
+          StorageDead(_10);                // scope 2 at $DIR/simplify_cmp.rs:+3:19: +3:20
+          StorageLive(_12);                // scope 3 at $DIR/simplify_cmp.rs:+4:9: +4:11
+          StorageLive(_13);                // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:15
+          _13 = &_2;                       // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:15
+          StorageLive(_14);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          _14 = &_1;                       // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+-         _12 = <&String as PartialEq<&&str>>::ne(move _13, move _14) -> bb4; // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:20
++         _12 = <String as PartialEq<&str>>::ne((*_13), (*_14)) -> bb4; // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:41:14: 41:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &String, &'b &&str) -> bool {<&String as PartialEq<&&str>>::ne}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a String, &'b &str) -> bool {<String as PartialEq<&str>>::ne}, val: Value(<ZST>) }
+      }
+  
+      bb4: {
+          StorageDead(_14);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          StorageDead(_13);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          _0 = const ();                   // scope 0 at $DIR/simplify_cmp.rs:+0:51: +5:2
+          StorageDead(_12);                // scope 3 at $DIR/simplify_cmp.rs:+5:1: +5:2
+          StorageDead(_9);                 // scope 2 at $DIR/simplify_cmp.rs:+5:1: +5:2
+          StorageDead(_6);                 // scope 1 at $DIR/simplify_cmp.rs:+5:1: +5:2
+          StorageDead(_3);                 // scope 0 at $DIR/simplify_cmp.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/simplify_cmp.rs:+5:2: +5:2
+      }
+  }
+  

--- a/tests/mir-opt/simplify_cmp.ref_prim.SimplifyRefComparisons.diff
+++ b/tests/mir-opt/simplify_cmp.ref_prim.SimplifyRefComparisons.diff
@@ -1,0 +1,168 @@
+- // MIR for `ref_prim` before SimplifyRefComparisons
++ // MIR for `ref_prim` after SimplifyRefComparisons
+  
+  fn ref_prim(_1: &i32, _2: &i32) -> () {
+      debug x => _1;                       // in scope 0 at $DIR/simplify_cmp.rs:+0:17: +0:18
+      debug y => _2;                       // in scope 0 at $DIR/simplify_cmp.rs:+0:26: +0:27
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify_cmp.rs:+0:35: +0:35
+      let _3: bool;                        // in scope 0 at $DIR/simplify_cmp.rs:+1:9: +1:11
+      let mut _4: &&i32;                   // in scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:15
+      let mut _5: &&i32;                   // in scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+      let mut _7: &&i32;                   // in scope 0 at $DIR/simplify_cmp.rs:+2:14: +2:15
+      let mut _8: &&i32;                   // in scope 0 at $DIR/simplify_cmp.rs:+2:19: +2:20
+      let mut _10: &&i32;                  // in scope 0 at $DIR/simplify_cmp.rs:+3:14: +3:15
+      let mut _11: &&i32;                  // in scope 0 at $DIR/simplify_cmp.rs:+3:18: +3:19
+      let _12: &i32;                       // in scope 0 at $DIR/simplify_cmp.rs:+3:18: +3:19
+      let mut _14: &&i32;                  // in scope 0 at $DIR/simplify_cmp.rs:+4:14: +4:15
+      let mut _15: &&i32;                  // in scope 0 at $DIR/simplify_cmp.rs:+4:19: +4:20
+      let _16: &i32;                       // in scope 0 at $DIR/simplify_cmp.rs:+4:19: +4:20
+      let mut _18: &&i32;                  // in scope 0 at $DIR/simplify_cmp.rs:+5:14: +5:15
+      let mut _19: &&i32;                  // in scope 0 at $DIR/simplify_cmp.rs:+5:18: +5:19
+      let _20: &i32;                       // in scope 0 at $DIR/simplify_cmp.rs:+5:18: +5:19
+      let mut _22: &&i32;                  // in scope 0 at $DIR/simplify_cmp.rs:+6:14: +6:15
+      let mut _23: &&i32;                  // in scope 0 at $DIR/simplify_cmp.rs:+6:19: +6:20
+      let _24: &i32;                       // in scope 0 at $DIR/simplify_cmp.rs:+6:19: +6:20
+      scope 1 {
+          debug _a => _3;                  // in scope 1 at $DIR/simplify_cmp.rs:+1:9: +1:11
+          let _6: bool;                    // in scope 1 at $DIR/simplify_cmp.rs:+2:9: +2:11
+          scope 2 {
+              debug _b => _6;              // in scope 2 at $DIR/simplify_cmp.rs:+2:9: +2:11
+              let _9: bool;                // in scope 2 at $DIR/simplify_cmp.rs:+3:9: +3:11
+              scope 3 {
+                  debug _c => _9;          // in scope 3 at $DIR/simplify_cmp.rs:+3:9: +3:11
+                  let _13: bool;           // in scope 3 at $DIR/simplify_cmp.rs:+4:9: +4:11
+                  scope 4 {
+                      debug _d => _13;     // in scope 4 at $DIR/simplify_cmp.rs:+4:9: +4:11
+                      let _17: bool;       // in scope 4 at $DIR/simplify_cmp.rs:+5:9: +5:11
+                      scope 5 {
+                          debug _e => _17; // in scope 5 at $DIR/simplify_cmp.rs:+5:9: +5:11
+                          let _21: bool;   // in scope 5 at $DIR/simplify_cmp.rs:+6:9: +6:11
+                          scope 6 {
+                              debug _f => _21; // in scope 6 at $DIR/simplify_cmp.rs:+6:9: +6:11
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_3);                 // scope 0 at $DIR/simplify_cmp.rs:+1:9: +1:11
+          StorageLive(_4);                 // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:15
+          _4 = &_1;                        // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:15
+          StorageLive(_5);                 // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+          _5 = &_2;                        // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+-         _3 = <&i32 as PartialEq>::eq(move _4, move _5) -> bb1; // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:20
++         _3 = <i32 as PartialEq>::eq((*_4), (*_5)) -> bb1; // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:8:14: 8:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &i32, &'b &i32) -> bool {<&i32 as PartialEq>::eq}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as PartialEq>::eq}, val: Value(<ZST>) }
+      }
+  
+      bb1: {
+          StorageDead(_5);                 // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+          StorageDead(_4);                 // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+          StorageLive(_6);                 // scope 1 at $DIR/simplify_cmp.rs:+2:9: +2:11
+          StorageLive(_7);                 // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:15
+          _7 = &_1;                        // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:15
+          StorageLive(_8);                 // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+          _8 = &_2;                        // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+-         _6 = <&i32 as PartialEq>::ne(move _7, move _8) -> bb2; // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:20
++         _6 = <i32 as PartialEq>::ne((*_7), (*_8)) -> bb2; // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:9:14: 9:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &i32, &'b &i32) -> bool {<&i32 as PartialEq>::ne}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as PartialEq>::ne}, val: Value(<ZST>) }
+      }
+  
+      bb2: {
+          StorageDead(_8);                 // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+          StorageDead(_7);                 // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+          StorageLive(_9);                 // scope 2 at $DIR/simplify_cmp.rs:+3:9: +3:11
+          StorageLive(_10);                // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:15
+          _10 = &_1;                       // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:15
+          StorageLive(_11);                // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          StorageLive(_12);                // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          _12 = &(*_2);                    // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          _11 = &_12;                      // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+-         _9 = <&i32 as PartialOrd>::lt(move _10, move _11) -> bb3; // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:19
++         _9 = <i32 as PartialOrd>::lt((*_10), (*_11)) -> bb3; // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:19
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:10:14: 10:19
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &i32, &'b &i32) -> bool {<&i32 as PartialOrd>::lt}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as PartialOrd>::lt}, val: Value(<ZST>) }
+      }
+  
+      bb3: {
+          StorageDead(_11);                // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          StorageDead(_10);                // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          StorageDead(_12);                // scope 2 at $DIR/simplify_cmp.rs:+3:19: +3:20
+          StorageLive(_13);                // scope 3 at $DIR/simplify_cmp.rs:+4:9: +4:11
+          StorageLive(_14);                // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:15
+          _14 = &_1;                       // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:15
+          StorageLive(_15);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          StorageLive(_16);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          _16 = &(*_2);                    // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          _15 = &_16;                      // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+-         _13 = <&i32 as PartialOrd>::le(move _14, move _15) -> bb4; // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:20
++         _13 = <i32 as PartialOrd>::le((*_14), (*_15)) -> bb4; // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:11:14: 11:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &i32, &'b &i32) -> bool {<&i32 as PartialOrd>::le}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as PartialOrd>::le}, val: Value(<ZST>) }
+      }
+  
+      bb4: {
+          StorageDead(_15);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          StorageDead(_14);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          StorageDead(_16);                // scope 3 at $DIR/simplify_cmp.rs:+4:20: +4:21
+          StorageLive(_17);                // scope 4 at $DIR/simplify_cmp.rs:+5:9: +5:11
+          StorageLive(_18);                // scope 4 at $DIR/simplify_cmp.rs:+5:14: +5:15
+          _18 = &_1;                       // scope 4 at $DIR/simplify_cmp.rs:+5:14: +5:15
+          StorageLive(_19);                // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          StorageLive(_20);                // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          _20 = &(*_2);                    // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          _19 = &_20;                      // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+-         _17 = <&i32 as PartialOrd>::gt(move _18, move _19) -> bb5; // scope 4 at $DIR/simplify_cmp.rs:+5:14: +5:19
++         _17 = <i32 as PartialOrd>::gt((*_18), (*_19)) -> bb5; // scope 4 at $DIR/simplify_cmp.rs:+5:14: +5:19
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:12:14: 12:19
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &i32, &'b &i32) -> bool {<&i32 as PartialOrd>::gt}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as PartialOrd>::gt}, val: Value(<ZST>) }
+      }
+  
+      bb5: {
+          StorageDead(_19);                // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          StorageDead(_18);                // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          StorageDead(_20);                // scope 4 at $DIR/simplify_cmp.rs:+5:19: +5:20
+          StorageLive(_21);                // scope 5 at $DIR/simplify_cmp.rs:+6:9: +6:11
+          StorageLive(_22);                // scope 5 at $DIR/simplify_cmp.rs:+6:14: +6:15
+          _22 = &_1;                       // scope 5 at $DIR/simplify_cmp.rs:+6:14: +6:15
+          StorageLive(_23);                // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          StorageLive(_24);                // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          _24 = &(*_2);                    // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          _23 = &_24;                      // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+-         _21 = <&i32 as PartialOrd>::ge(move _22, move _23) -> bb6; // scope 5 at $DIR/simplify_cmp.rs:+6:14: +6:20
++         _21 = <i32 as PartialOrd>::ge((*_22), (*_23)) -> bb6; // scope 5 at $DIR/simplify_cmp.rs:+6:14: +6:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:13:14: 13:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &i32, &'b &i32) -> bool {<&i32 as PartialOrd>::ge}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as PartialOrd>::ge}, val: Value(<ZST>) }
+      }
+  
+      bb6: {
+          StorageDead(_23);                // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          StorageDead(_22);                // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          StorageDead(_24);                // scope 5 at $DIR/simplify_cmp.rs:+6:20: +6:21
+          _0 = const ();                   // scope 0 at $DIR/simplify_cmp.rs:+0:35: +7:2
+          StorageDead(_21);                // scope 5 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_17);                // scope 4 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_13);                // scope 3 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_9);                 // scope 2 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_6);                 // scope 1 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_3);                 // scope 0 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          return;                          // scope 0 at $DIR/simplify_cmp.rs:+7:2: +7:2
+      }
+  }
+  

--- a/tests/mir-opt/simplify_cmp.ref_slice.SimplifyRefComparisons.diff
+++ b/tests/mir-opt/simplify_cmp.ref_slice.SimplifyRefComparisons.diff
@@ -1,0 +1,168 @@
+- // MIR for `ref_slice` before SimplifyRefComparisons
++ // MIR for `ref_slice` after SimplifyRefComparisons
+  
+  fn ref_slice(_1: &str, _2: &str) -> () {
+      debug x => _1;                       // in scope 0 at $DIR/simplify_cmp.rs:+0:18: +0:19
+      debug y => _2;                       // in scope 0 at $DIR/simplify_cmp.rs:+0:27: +0:28
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify_cmp.rs:+0:36: +0:36
+      let _3: bool;                        // in scope 0 at $DIR/simplify_cmp.rs:+1:9: +1:11
+      let mut _4: &&str;                   // in scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:15
+      let mut _5: &&str;                   // in scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+      let mut _7: &&str;                   // in scope 0 at $DIR/simplify_cmp.rs:+2:14: +2:15
+      let mut _8: &&str;                   // in scope 0 at $DIR/simplify_cmp.rs:+2:19: +2:20
+      let mut _10: &&str;                  // in scope 0 at $DIR/simplify_cmp.rs:+3:14: +3:15
+      let mut _11: &&str;                  // in scope 0 at $DIR/simplify_cmp.rs:+3:18: +3:19
+      let _12: &str;                       // in scope 0 at $DIR/simplify_cmp.rs:+3:18: +3:19
+      let mut _14: &&str;                  // in scope 0 at $DIR/simplify_cmp.rs:+4:14: +4:15
+      let mut _15: &&str;                  // in scope 0 at $DIR/simplify_cmp.rs:+4:19: +4:20
+      let _16: &str;                       // in scope 0 at $DIR/simplify_cmp.rs:+4:19: +4:20
+      let mut _18: &&str;                  // in scope 0 at $DIR/simplify_cmp.rs:+5:14: +5:15
+      let mut _19: &&str;                  // in scope 0 at $DIR/simplify_cmp.rs:+5:18: +5:19
+      let _20: &str;                       // in scope 0 at $DIR/simplify_cmp.rs:+5:18: +5:19
+      let mut _22: &&str;                  // in scope 0 at $DIR/simplify_cmp.rs:+6:14: +6:15
+      let mut _23: &&str;                  // in scope 0 at $DIR/simplify_cmp.rs:+6:19: +6:20
+      let _24: &str;                       // in scope 0 at $DIR/simplify_cmp.rs:+6:19: +6:20
+      scope 1 {
+          debug _a => _3;                  // in scope 1 at $DIR/simplify_cmp.rs:+1:9: +1:11
+          let _6: bool;                    // in scope 1 at $DIR/simplify_cmp.rs:+2:9: +2:11
+          scope 2 {
+              debug _b => _6;              // in scope 2 at $DIR/simplify_cmp.rs:+2:9: +2:11
+              let _9: bool;                // in scope 2 at $DIR/simplify_cmp.rs:+3:9: +3:11
+              scope 3 {
+                  debug _c => _9;          // in scope 3 at $DIR/simplify_cmp.rs:+3:9: +3:11
+                  let _13: bool;           // in scope 3 at $DIR/simplify_cmp.rs:+4:9: +4:11
+                  scope 4 {
+                      debug _d => _13;     // in scope 4 at $DIR/simplify_cmp.rs:+4:9: +4:11
+                      let _17: bool;       // in scope 4 at $DIR/simplify_cmp.rs:+5:9: +5:11
+                      scope 5 {
+                          debug _e => _17; // in scope 5 at $DIR/simplify_cmp.rs:+5:9: +5:11
+                          let _21: bool;   // in scope 5 at $DIR/simplify_cmp.rs:+6:9: +6:11
+                          scope 6 {
+                              debug _f => _21; // in scope 6 at $DIR/simplify_cmp.rs:+6:9: +6:11
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_3);                 // scope 0 at $DIR/simplify_cmp.rs:+1:9: +1:11
+          StorageLive(_4);                 // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:15
+          _4 = &_1;                        // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:15
+          StorageLive(_5);                 // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+          _5 = &_2;                        // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+-         _3 = <&str as PartialEq>::eq(move _4, move _5) -> bb1; // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:20
++         _3 = <str as PartialEq>::eq((*_4), (*_5)) -> bb1; // scope 0 at $DIR/simplify_cmp.rs:+1:14: +1:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:28:14: 28:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &str, &'b &str) -> bool {<&str as PartialEq>::eq}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a str, &'b str) -> bool {<str as PartialEq>::eq}, val: Value(<ZST>) }
+      }
+  
+      bb1: {
+          StorageDead(_5);                 // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+          StorageDead(_4);                 // scope 0 at $DIR/simplify_cmp.rs:+1:19: +1:20
+          StorageLive(_6);                 // scope 1 at $DIR/simplify_cmp.rs:+2:9: +2:11
+          StorageLive(_7);                 // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:15
+          _7 = &_1;                        // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:15
+          StorageLive(_8);                 // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+          _8 = &_2;                        // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+-         _6 = <&str as PartialEq>::ne(move _7, move _8) -> bb2; // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:20
++         _6 = <str as PartialEq>::ne((*_7), (*_8)) -> bb2; // scope 1 at $DIR/simplify_cmp.rs:+2:14: +2:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:29:14: 29:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &str, &'b &str) -> bool {<&str as PartialEq>::ne}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a str, &'b str) -> bool {<str as PartialEq>::ne}, val: Value(<ZST>) }
+      }
+  
+      bb2: {
+          StorageDead(_8);                 // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+          StorageDead(_7);                 // scope 1 at $DIR/simplify_cmp.rs:+2:19: +2:20
+          StorageLive(_9);                 // scope 2 at $DIR/simplify_cmp.rs:+3:9: +3:11
+          StorageLive(_10);                // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:15
+          _10 = &_1;                       // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:15
+          StorageLive(_11);                // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          StorageLive(_12);                // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          _12 = &(*_2);                    // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          _11 = &_12;                      // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+-         _9 = <&str as PartialOrd>::lt(move _10, move _11) -> bb3; // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:19
++         _9 = <str as PartialOrd>::lt((*_10), (*_11)) -> bb3; // scope 2 at $DIR/simplify_cmp.rs:+3:14: +3:19
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:30:14: 30:19
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &str, &'b &str) -> bool {<&str as PartialOrd>::lt}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a str, &'b str) -> bool {<str as PartialOrd>::lt}, val: Value(<ZST>) }
+      }
+  
+      bb3: {
+          StorageDead(_11);                // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          StorageDead(_10);                // scope 2 at $DIR/simplify_cmp.rs:+3:18: +3:19
+          StorageDead(_12);                // scope 2 at $DIR/simplify_cmp.rs:+3:19: +3:20
+          StorageLive(_13);                // scope 3 at $DIR/simplify_cmp.rs:+4:9: +4:11
+          StorageLive(_14);                // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:15
+          _14 = &_1;                       // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:15
+          StorageLive(_15);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          StorageLive(_16);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          _16 = &(*_2);                    // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          _15 = &_16;                      // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+-         _13 = <&str as PartialOrd>::le(move _14, move _15) -> bb4; // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:20
++         _13 = <str as PartialOrd>::le((*_14), (*_15)) -> bb4; // scope 3 at $DIR/simplify_cmp.rs:+4:14: +4:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:31:14: 31:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &str, &'b &str) -> bool {<&str as PartialOrd>::le}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a str, &'b str) -> bool {<str as PartialOrd>::le}, val: Value(<ZST>) }
+      }
+  
+      bb4: {
+          StorageDead(_15);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          StorageDead(_14);                // scope 3 at $DIR/simplify_cmp.rs:+4:19: +4:20
+          StorageDead(_16);                // scope 3 at $DIR/simplify_cmp.rs:+4:20: +4:21
+          StorageLive(_17);                // scope 4 at $DIR/simplify_cmp.rs:+5:9: +5:11
+          StorageLive(_18);                // scope 4 at $DIR/simplify_cmp.rs:+5:14: +5:15
+          _18 = &_1;                       // scope 4 at $DIR/simplify_cmp.rs:+5:14: +5:15
+          StorageLive(_19);                // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          StorageLive(_20);                // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          _20 = &(*_2);                    // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          _19 = &_20;                      // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+-         _17 = <&str as PartialOrd>::gt(move _18, move _19) -> bb5; // scope 4 at $DIR/simplify_cmp.rs:+5:14: +5:19
++         _17 = <str as PartialOrd>::gt((*_18), (*_19)) -> bb5; // scope 4 at $DIR/simplify_cmp.rs:+5:14: +5:19
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:32:14: 32:19
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &str, &'b &str) -> bool {<&str as PartialOrd>::gt}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a str, &'b str) -> bool {<str as PartialOrd>::gt}, val: Value(<ZST>) }
+      }
+  
+      bb5: {
+          StorageDead(_19);                // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          StorageDead(_18);                // scope 4 at $DIR/simplify_cmp.rs:+5:18: +5:19
+          StorageDead(_20);                // scope 4 at $DIR/simplify_cmp.rs:+5:19: +5:20
+          StorageLive(_21);                // scope 5 at $DIR/simplify_cmp.rs:+6:9: +6:11
+          StorageLive(_22);                // scope 5 at $DIR/simplify_cmp.rs:+6:14: +6:15
+          _22 = &_1;                       // scope 5 at $DIR/simplify_cmp.rs:+6:14: +6:15
+          StorageLive(_23);                // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          StorageLive(_24);                // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          _24 = &(*_2);                    // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          _23 = &_24;                      // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+-         _21 = <&str as PartialOrd>::ge(move _22, move _23) -> bb6; // scope 5 at $DIR/simplify_cmp.rs:+6:14: +6:20
++         _21 = <str as PartialOrd>::ge((*_22), (*_23)) -> bb6; // scope 5 at $DIR/simplify_cmp.rs:+6:14: +6:20
+                                           // mir::Constant
+                                           // + span: $DIR/simplify_cmp.rs:33:14: 33:20
+-                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &str, &'b &str) -> bool {<&str as PartialOrd>::ge}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: for<'a, 'b> fn(&'a str, &'b str) -> bool {<str as PartialOrd>::ge}, val: Value(<ZST>) }
+      }
+  
+      bb6: {
+          StorageDead(_23);                // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          StorageDead(_22);                // scope 5 at $DIR/simplify_cmp.rs:+6:19: +6:20
+          StorageDead(_24);                // scope 5 at $DIR/simplify_cmp.rs:+6:20: +6:21
+          _0 = const ();                   // scope 0 at $DIR/simplify_cmp.rs:+0:36: +7:2
+          StorageDead(_21);                // scope 5 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_17);                // scope 4 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_13);                // scope 3 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_9);                 // scope 2 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_6);                 // scope 1 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          StorageDead(_3);                 // scope 0 at $DIR/simplify_cmp.rs:+7:1: +7:2
+          return;                          // scope 0 at $DIR/simplify_cmp.rs:+7:2: +7:2
+      }
+  }
+  

--- a/tests/mir-opt/simplify_cmp.rs
+++ b/tests/mir-opt/simplify_cmp.rs
@@ -1,0 +1,42 @@
+// unit-test: SimplifyAutorefComparisons
+// ignore-wasm32 compiled with panic=abort by default
+
+#![crate_type = "lib"]
+
+// EMIT_MIR simplify_cmp.ref_prim.SimplifyRefComparisons.diff
+pub fn ref_prim(x: &i32, y: &i32) {
+    let _a = x == y;
+    let _b = x != y;
+    let _c = x < y;
+    let _d = x <= y;
+    let _e = x > y;
+    let _f = x >= y;
+}
+
+// EMIT_MIR simplify_cmp.multi_ref_prim.SimplifyRefComparisons.diff
+pub fn multi_ref_prim(x: &&&i32, y: &&&i32) {
+    let _a = x == y;
+    let _b = x != y;
+    let _c = x < y;
+    let _d = x <= y;
+    let _e = x > y;
+    let _f = x >= y;
+}
+
+// EMIT_MIR simplify_cmp.ref_slice.SimplifyRefComparisons.diff
+pub fn ref_slice(x: &str, y: &str) {
+    let _a = x == y;
+    let _b = x != y;
+    let _c = x < y;
+    let _d = x <= y;
+    let _e = x > y;
+    let _f = x >= y;
+}
+
+// EMIT_MIR simplify_cmp.ref_different_levels.SimplifyRefComparisons.diff
+pub fn ref_different_levels(x: &&str, y: &String) {
+    let _a = x == y;
+    let _b = x != y;
+    let _c = y == x;
+    let _d = y != x;
+}

--- a/tests/mir-opt/slice_filter.variant_a-{closure#0}.CopyProp.diff
+++ b/tests/mir-opt/slice_filter.variant_a-{closure#0}.CopyProp.diff
@@ -29,74 +29,42 @@
       let mut _26: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
       let mut _27: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
       let mut _28: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
-      let mut _31: &usize;                 // in scope 0 at $SRC_DIR/core/src/cmp.rs:LL:COL
-      let mut _32: &usize;                 // in scope 0 at $SRC_DIR/core/src/cmp.rs:LL:COL
-      let mut _37: &usize;                 // in scope 0 at $SRC_DIR/core/src/cmp.rs:LL:COL
-      let mut _38: &usize;                 // in scope 0 at $SRC_DIR/core/src/cmp.rs:LL:COL
-      let mut _43: &usize;                 // in scope 0 at $SRC_DIR/core/src/cmp.rs:LL:COL
-      let mut _44: &usize;                 // in scope 0 at $SRC_DIR/core/src/cmp.rs:LL:COL
-      let mut _49: &usize;                 // in scope 0 at $SRC_DIR/core/src/cmp.rs:LL:COL
-      let mut _50: &usize;                 // in scope 0 at $SRC_DIR/core/src/cmp.rs:LL:COL
+      let mut _29: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:40: +0:46
+      let mut _30: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:40: +0:46
+      let mut _33: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:66
+      let mut _34: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:66
+      let mut _37: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:50: +0:56
+      let mut _38: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:50: +0:56
+      let mut _41: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:70: +0:76
+      let mut _42: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:70: +0:76
       scope 1 {
           debug a => _3;                   // in scope 1 at $DIR/slice_filter.rs:+0:27: +0:28
           debug b => _4;                   // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
           debug c => _5;                   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
           debug d => _6;                   // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
-          scope 2 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:40: 8:46
-              debug self => _9;            // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _10;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _29: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _30: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              scope 3 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
--                 debug self => _31;       // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
--                 debug other => _32;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+                 debug self => _29;       // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+                 debug other => _30;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _33: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _34: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              }
+          scope 2 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $DIR/slice_filter.rs:8:40: 8:46
+              debug self => _29;           // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => _30;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _31: usize;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _32: usize;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
           }
-          scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:60: 8:66
-              debug self => _18;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _19;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _35: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _36: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              scope 5 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
--                 debug self => _37;       // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
--                 debug other => _38;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+                 debug self => _35;       // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+                 debug other => _36;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _39: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _40: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              }
+          scope 3 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $DIR/slice_filter.rs:8:60: 8:66
+              debug self => _33;           // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => _34;          // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _35: usize;          // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _36: usize;          // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
           }
-          scope 6 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:50: 8:56
-              debug self => _13;           // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _14;          // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _41: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _42: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              scope 7 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
--                 debug self => _43;       // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
--                 debug other => _44;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+                 debug self => _41;       // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+                 debug other => _42;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _45: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _46: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              }
+          scope 4 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $DIR/slice_filter.rs:8:50: 8:56
+              debug self => _37;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => _38;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _39: usize;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _40: usize;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
           }
-          scope 8 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:70: 8:76
-              debug self => _22;           // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _23;          // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _47: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _48: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
--                 debug self => _49;       // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
--                 debug other => _50;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+                 debug self => _47;       // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+                 debug other => _48;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _51: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _52: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              }
+          scope 5 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $DIR/slice_filter.rs:8:70: 8:76
+              debug self => _41;           // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => _42;          // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _43: usize;          // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _44: usize;          // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
           }
       }
   
@@ -121,23 +89,19 @@
           StorageLive(_11);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           _11 = _5;                        // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           _10 = &_11;                      // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-          _29 = deref_copy (*_9);          // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _30 = deref_copy (*_10);         // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageLive(_31);                // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _31 = _29;                       // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageLive(_32);                // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _32 = _30;                       // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_33);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _33 = (*_31);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _33 = (*_29);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_34);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _34 = (*_32);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _34 = (*_30);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _8 = Le(move _33, move _34);     // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_34);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_33);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_32);                // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_31);                // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_29);                // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
+          _29 = (*_9);                     // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
+          StorageLive(_30);                // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
+          _30 = (*_10);                    // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
+          StorageLive(_31);                // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _31 = (*_29);                    // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_32);                // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _32 = (*_30);                    // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _8 = Le(move _31, move _32);     // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_32);                // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_31);                // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_30);                // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
+          StorageDead(_29);                // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
           StorageDead(_11);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           StorageDead(_10);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           StorageDead(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
@@ -158,23 +122,19 @@
           StorageLive(_20);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
           _20 = _3;                        // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
           _19 = &_20;                      // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-          _35 = deref_copy (*_18);         // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _36 = deref_copy (*_19);         // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageLive(_37);                // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _37 = _35;                       // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageLive(_38);                // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _38 = _36;                       // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_39);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _39 = (*_37);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _39 = (*_35);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_40);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _40 = (*_38);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _40 = (*_36);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _17 = Le(move _39, move _40);    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_40);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_39);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_38);                // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_37);                // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_33);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
+          _33 = (*_18);                    // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
+          StorageLive(_34);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
+          _34 = (*_19);                    // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
+          StorageLive(_35);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _35 = (*_33);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_36);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _36 = (*_34);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _17 = Le(move _35, move _36);    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_36);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_35);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_34);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
+          StorageDead(_33);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
           StorageDead(_20);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
           StorageDead(_19);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
           StorageDead(_18);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
@@ -206,23 +166,19 @@
           StorageLive(_15);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           _15 = _4;                        // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           _14 = &_15;                      // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-          _41 = deref_copy (*_13);         // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _42 = deref_copy (*_14);         // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageLive(_43);                // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _43 = _41;                       // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageLive(_44);                // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _44 = _42;                       // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_45);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _45 = (*_43);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _45 = (*_41);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_46);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _46 = (*_44);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _46 = (*_42);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _12 = Le(move _45, move _46);    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_46);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_45);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_44);                // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_43);                // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_37);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
+          _37 = (*_13);                    // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
+          StorageLive(_38);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
+          _38 = (*_14);                    // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
+          StorageLive(_39);                // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _39 = (*_37);                    // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_40);                // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _40 = (*_38);                    // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _12 = Le(move _39, move _40);    // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_40);                // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_39);                // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_38);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
+          StorageDead(_37);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
           StorageDead(_15);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           StorageDead(_14);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           StorageDead(_13);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
@@ -245,23 +201,19 @@
           StorageLive(_24);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           _24 = _6;                        // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           _23 = &_24;                      // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-          _47 = deref_copy (*_22);         // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _48 = deref_copy (*_23);         // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageLive(_49);                // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _49 = _47;                       // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageLive(_50);                // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _50 = _48;                       // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_51);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _51 = (*_49);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _51 = (*_47);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_52);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _52 = (*_50);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _52 = (*_48);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _21 = Le(move _51, move _52);    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_52);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_51);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_50);                // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_49);                // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_41);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
+          _41 = (*_22);                    // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
+          StorageLive(_42);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
+          _42 = (*_23);                    // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
+          StorageLive(_43);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _43 = (*_41);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_44);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _44 = (*_42);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _21 = Le(move _43, move _44);    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_44);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_43);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_42);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
+          StorageDead(_41);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
           StorageDead(_24);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           StorageDead(_23);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           StorageDead(_22);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76

--- a/tests/mir-opt/slice_filter.variant_a-{closure#0}.DestinationPropagation.diff
+++ b/tests/mir-opt/slice_filter.variant_a-{closure#0}.DestinationPropagation.diff
@@ -29,58 +29,42 @@
       let mut _26: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
       let mut _27: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
       let mut _28: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
+      let mut _29: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:40: +0:46
+      let mut _30: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:40: +0:46
+      let mut _33: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:66
+      let mut _34: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:66
+      let mut _37: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:50: +0:56
+      let mut _38: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:50: +0:56
+      let mut _41: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:70: +0:76
+      let mut _42: &usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:70: +0:76
       scope 1 {
           debug a => _3;                   // in scope 1 at $DIR/slice_filter.rs:+0:27: +0:28
           debug b => _4;                   // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
           debug c => _5;                   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
           debug d => _6;                   // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
-          scope 2 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:40: 8:46
-              debug self => _9;            // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _10;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _29: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _30: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              scope 3 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _29;       // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _30;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _31: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _32: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              }
+          scope 2 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $DIR/slice_filter.rs:8:40: 8:46
+              debug self => _29;           // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => _30;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _31: usize;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _32: usize;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
           }
-          scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:60: 8:66
-              debug self => _18;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _19;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _33: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _34: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              scope 5 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _33;       // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _34;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _35: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _36: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              }
+          scope 3 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $DIR/slice_filter.rs:8:60: 8:66
+              debug self => _33;           // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => _34;          // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _35: usize;          // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _36: usize;          // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
           }
-          scope 6 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:50: 8:56
-              debug self => _13;           // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _14;          // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _37: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _38: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              scope 7 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _37;       // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _38;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _39: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _40: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              }
+          scope 4 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $DIR/slice_filter.rs:8:50: 8:56
+              debug self => _37;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => _38;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _39: usize;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _40: usize;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
           }
-          scope 8 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:70: 8:76
-              debug self => _22;           // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _23;          // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _41: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _42: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _41;       // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _42;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _43: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _44: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              }
+          scope 5 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $DIR/slice_filter.rs:8:70: 8:76
+              debug self => _41;           // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => _42;          // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _43: usize;          // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _44: usize;          // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
           }
       }
   
@@ -102,15 +86,19 @@
           StorageLive(_11);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           _11 = _5;                        // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           _10 = &_11;                      // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-          _29 = deref_copy (*_9);          // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _30 = deref_copy (*_10);         // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_31);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _31 = (*_29);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_32);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _32 = (*_30);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _8 = Le(move _31, move _32);     // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_32);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_31);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_29);                // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
+          _29 = (*_9);                     // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
+          StorageLive(_30);                // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
+          _30 = (*_10);                    // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
+          StorageLive(_31);                // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _31 = (*_29);                    // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_32);                // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _32 = (*_30);                    // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _8 = Le(move _31, move _32);     // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_32);                // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_31);                // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_30);                // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
+          StorageDead(_29);                // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
           StorageDead(_11);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           StorageDead(_10);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           StorageDead(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
@@ -132,15 +120,19 @@
           StorageLive(_20);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
           _20 = _3;                        // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
           _19 = &_20;                      // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-          _33 = deref_copy (*_18);         // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _34 = deref_copy (*_19);         // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_35);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _35 = (*_33);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_36);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _36 = (*_34);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _17 = Le(move _35, move _36);    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_36);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_35);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_33);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
+          _33 = (*_18);                    // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
+          StorageLive(_34);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
+          _34 = (*_19);                    // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
+          StorageLive(_35);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _35 = (*_33);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_36);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _36 = (*_34);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _17 = Le(move _35, move _36);    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_36);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_35);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_34);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
+          StorageDead(_33);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
           StorageDead(_20);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
           StorageDead(_19);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
           StorageDead(_18);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
@@ -171,15 +163,19 @@
           StorageLive(_15);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           _15 = _4;                        // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           _14 = &_15;                      // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-          _37 = deref_copy (*_13);         // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _38 = deref_copy (*_14);         // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_39);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _39 = (*_37);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_40);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _40 = (*_38);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _12 = Le(move _39, move _40);    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_40);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_39);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_37);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
+          _37 = (*_13);                    // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
+          StorageLive(_38);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
+          _38 = (*_14);                    // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
+          StorageLive(_39);                // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _39 = (*_37);                    // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_40);                // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _40 = (*_38);                    // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _12 = Le(move _39, move _40);    // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_40);                // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_39);                // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_38);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
+          StorageDead(_37);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
           StorageDead(_15);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           StorageDead(_14);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           StorageDead(_13);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
@@ -207,16 +203,20 @@
           StorageLive(_24);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           _24 = _6;                        // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           _23 = &_24;                      // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-          _41 = deref_copy (*_22);         // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _42 = deref_copy (*_23);         // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_43);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _43 = (*_41);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_44);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _44 = (*_42);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _21 = Le(move _43, move _44);    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _0 = Le(move _43, move _44);     // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_44);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_43);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_41);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
+          _41 = (*_22);                    // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
+          StorageLive(_42);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
+          _42 = (*_23);                    // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
+          StorageLive(_43);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _43 = (*_41);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_44);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _44 = (*_42);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _21 = Le(move _43, move _44);    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
++         _0 = Le(move _43, move _44);     // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_44);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_43);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_42);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
+          StorageDead(_41);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
           StorageDead(_24);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           StorageDead(_23);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           StorageDead(_22);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76


### PR DESCRIPTION
Today, if you're comparing `&&T`s, it ends up auto-reffing in HIR.  So the MIR ends up calling `PartialEq/Cmp` with `&&&T`, and the MIR inliner can only get that down to `&T`: <https://rust.godbolt.org/z/hje6jd4Yf>.

So this adds an always-run pass to look at `Call`s in MIR with `from_hir_call: false` to just call the correct `Partial{Eq,Cmp}` implementation directly, even if it's debug and we're not running the inliner, to avoid needing to ever monomorphize a bunch of useless forwarding impls.

This hopes to avoid ever needing something like #108372 where we'd tell people to manually dereference the sides of their comparisons.

r? @ghost