### PR TITLE
fix: fix ICE in `custom-test-frameworks` feature

### DIFF
--- a/tests/ui/test-attrs/custom-test-frameworks/issue-107454.rs
+++ b/tests/ui/test-attrs/custom-test-frameworks/issue-107454.rs
@@ -1,0 +1,10 @@
+// compile-flags: --test
+
+#![feature(custom_test_frameworks)]
+#![deny(unnameable_test_items)]
+
+fn foo() {
+    #[test_case]
+    //~^ ERROR cannot test inner items [unnameable_test_items]
+    fn test2() {}
+}

--- a/tests/ui/test-attrs/custom-test-frameworks/issue-107454.stderr
+++ b/tests/ui/test-attrs/custom-test-frameworks/issue-107454.stderr
@@ -1,0 +1,15 @@
+error: cannot test inner items
+  --> $DIR/issue-107454.rs:7:5
+   |
+LL |     #[test_case]
+   |     ^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-107454.rs:4:9
+   |
+LL | #![deny(unnameable_test_items)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `test_case` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #107454

Simple fix to emit error instead of ICEing. At some point, all the code in `tests.rs` should be refactored, there is a bit of duplication (this PR's code is repeated five times over lol).

r? @Nilstrieb (active on the linked issue?)