### PR TITLE
rustdoc: implement bag semantics for function parameter search

### DIFF
--- a/tests/rustdoc-js/search-bag-semantics.js
+++ b/tests/rustdoc-js/search-bag-semantics.js
@@ -1,0 +1,20 @@
+// exact-check
+
+const QUERY = [
+    'P',
+    'P, P',
+];
+
+const EXPECTED = [
+    {
+        'in_args': [
+            { 'path': 'search_bag_semantics', 'name': 'alacazam' },
+            { 'path': 'search_bag_semantics', 'name': 'abracadabra' },
+        ],
+    },
+    {
+        'others': [
+            { 'path': 'search_bag_semantics', 'name': 'abracadabra' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/search-bag-semantics.rs
+++ b/tests/rustdoc-js/search-bag-semantics.rs
@@ -1,0 +1,4 @@
+pub struct P;
+
+pub fn abracadabra(a: P, b: P) {}
+pub fn alacazam(a: P) {}


### PR DESCRIPTION
This tweak to the function signature search engine makes things so that, if a type is repeated in the search query, it'll only match if the function actually includes it that many times.