### PR TITLE
Infer async block return type from future expectation

### DIFF
--- a/tests/ui/async-await/expectation.rs
+++ b/tests/ui/async-await/expectation.rs
@@ -1,0 +1,11 @@
+// check-pass
+// edition: 2021
+
+use std::fmt::Debug;
+use std::future::Future;
+
+fn needs_future(_: impl Future<Output = Box<dyn Debug>>) {}
+
+fn main() {
+    needs_future(async { Box::new(()) })
+}

--- a/tests/ui/impl-trait/issues/issue-78722.rs
+++ b/tests/ui/impl-trait/issues/issue-78722.rs
@@ -7,8 +7,8 @@ type F = impl core::future::Future<Output = u8>;
 struct Bug {
     V1: [(); {
         fn concrete_use() -> F {
-            //~^ ERROR to be a future that resolves to `u8`, but it resolves to `()`
             async {}
+            //~^ ERROR mismatched types
         }
         let f: F = async { 1 };
         //~^ ERROR `async` blocks are not allowed in constants

--- a/tests/ui/impl-trait/issues/issue-78722.stderr
+++ b/tests/ui/impl-trait/issues/issue-78722.stderr
@@ -7,13 +7,13 @@ LL |         let f: F = async { 1 };
    = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
    = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
 
-error[E0271]: expected `[async block@$DIR/issue-78722.rs:11:13: 11:21]` to be a future that resolves to `u8`, but it resolves to `()`
-  --> $DIR/issue-78722.rs:9:30
+error[E0308]: mismatched types
+  --> $DIR/issue-78722.rs:10:19
    |
-LL |         fn concrete_use() -> F {
-   |                              ^ expected `()`, found `u8`
+LL |             async {}
+   |                   ^^ expected `u8`, found `()`
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0271, E0658.
-For more information about an error, try `rustc --explain E0271`.
+Some errors have detailed explanations: E0308, E0658.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/traits/new-solver/async.fail.stderr
+++ b/tests/ui/traits/new-solver/async.fail.stderr
@@ -1,17 +1,9 @@
-error[E0271]: expected `[async block@$DIR/async.rs:12:17: 12:25]` to be a future that resolves to `i32`, but it resolves to `()`
-  --> $DIR/async.rs:12:17
+error[E0308]: mismatched types
+  --> $DIR/async.rs:12:23
    |
 LL |     needs_async(async {});
-   |     ----------- ^^^^^^^^ expected `i32`, found `()`
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: required by a bound in `needs_async`
-  --> $DIR/async.rs:8:31
-   |
-LL | fn needs_async(_: impl Future<Output = i32>) {}
-   |                               ^^^^^^^^^^^^ required by this bound in `needs_async`
+   |                       ^^ expected `i32`, found `()`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/traits/new-solver/async.rs
+++ b/tests/ui/traits/new-solver/async.rs
@@ -10,7 +10,7 @@ fn needs_async(_: impl Future<Output = i32>) {}
 #[cfg(fail)]
 fn main() {
     needs_async(async {});
-    //[fail]~^ ERROR to be a future that resolves to `i32`, but it resolves to `()`
+    //[fail]~^ mismatched types
 }
 
 #[cfg(pass)]


### PR DESCRIPTION
Fixes #106527

r? types

This needs an FCP, since it makes async block return type inference stronger. This may have interactions with the new solver (since we want to avoid using pending obligations to do closure inference), but it's something that wg-async expects to work (https://github.com/rust-lang/rust/issues/106527#issuecomment-1408972090). I'm ambivalent :smile_cat: 