### PR TITLE
Do not ICE when failing to resolve for rustdoc.

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1860,10 +1860,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         match self.maybe_resolve_path(&segments, Some(ns), &parent_scope) {
             PathResult::Module(ModuleOrUniformRoot::Module(module)) => Some(module.res().unwrap()),
             PathResult::NonModule(path_res) => path_res.full_res(),
-            PathResult::Module(ModuleOrUniformRoot::ExternPrelude) | PathResult::Failed { .. } => {
-                None
-            }
-            PathResult::Module(..) | PathResult::Indeterminate => unreachable!(),
+            PathResult::Module(..) | PathResult::Failed { .. } | PathResult::Indeterminate => None,
         }
     }
 

--- a/tests/ui/resolve/issue-109343.rs
+++ b/tests/ui/resolve/issue-109343.rs
@@ -1,0 +1,13 @@
+// Verify that we do not ICE when failing to resolve a doc-link.
+#![crate_type = "lib"]
+
+extern crate f;
+//~^ ERROR E0463
+
+pub use inner::f;
+//~^ ERROR E0432
+
+/// [mod@std::env] [g]
+pub use f as g;
+//~^ ERROR pub_use_of_private_extern_crate
+//~| WARN this was previously accepted by the compiler

--- a/tests/ui/resolve/issue-109343.stderr
+++ b/tests/ui/resolve/issue-109343.stderr
@@ -1,0 +1,28 @@
+error[E0463]: can't find crate for `f`
+  --> $DIR/issue-109343.rs:4:1
+   |
+LL | extern crate f;
+   | ^^^^^^^^^^^^^^^ can't find crate
+
+error[E0432]: unresolved import `inner`
+  --> $DIR/issue-109343.rs:7:9
+   |
+LL | pub use inner::f;
+   |         ^^^^^ maybe a missing crate `inner`?
+   |
+   = help: consider adding `extern crate inner` to use the `inner` crate
+
+error: extern crate `f` is private, and cannot be re-exported (error E0365), consider declaring with `pub`
+  --> $DIR/issue-109343.rs:11:9
+   |
+LL | pub use f as g;
+   |         ^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+   = note: `#[deny(pub_use_of_private_extern_crate)]` on by default
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0432, E0463.
+For more information about an error, try `rustc --explain E0432`.


### PR DESCRIPTION
Path resolution may fail and return `Indeterminate` if there are already errors that obscure the name space.
In that case, we shouldn't ICE, and report that resolution failed to rustdoc.

Fixes https://github.com/rust-lang/rust/issues/109343
r? @petrochenkov 