### PR TITLE
Resolve visibility paths as modules not as types.

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0577.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0577.md
@@ -3,7 +3,7 @@ Something other than a module was found in visibility scope.
 Erroneous code example:
 
 ```compile_fail,E0577,edition2018
-pub struct Sea;
+pub enum Sea {}
 
 pub (in crate::Sea) struct Shark; // error!
 

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -278,7 +278,7 @@ impl<'a, 'b, 'tcx> BuildReducedGraphVisitor<'a, 'b, 'tcx> {
                 };
                 match self.r.resolve_path(
                     &segments,
-                    Some(TypeNS),
+                    None,
                     parent_scope,
                     finalize.then(|| Finalize::new(id, path.span)),
                     None,

--- a/tests/ui/resolve/unresolved-segments-visibility.rs
+++ b/tests/ui/resolve/unresolved-segments-visibility.rs
@@ -1,0 +1,11 @@
+// Check that we do not ICE due to unresolved segments in visibility path.
+#![crate_type = "lib"]
+
+extern crate alloc as b;
+
+mod foo {
+    mod bar {
+        pub(in b::string::String::newy) extern crate alloc as e;
+        //~^ ERROR failed to resolve: `String` is a struct, not a module [E0433]
+    }
+}

--- a/tests/ui/resolve/unresolved-segments-visibility.stderr
+++ b/tests/ui/resolve/unresolved-segments-visibility.stderr
@@ -1,0 +1,9 @@
+error[E0433]: failed to resolve: `String` is a struct, not a module
+  --> $DIR/unresolved-segments-visibility.rs:8:27
+   |
+LL |         pub(in b::string::String::newy) extern crate alloc as e;
+   |                           ^^^^^^ `String` is a struct, not a module
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/span/visibility-ty-params.rs
+++ b/tests/ui/span/visibility-ty-params.rs
@@ -4,7 +4,7 @@ macro_rules! m {
 
 struct S<T>(T);
 m!{ S<u8> } //~ ERROR unexpected generic arguments in path
-            //~| ERROR expected module, found struct `S`
+            //~| ERROR failed to resolve: `S` is a struct, not a module [E0433]
 
 mod m {
     m!{ m<> } //~ ERROR unexpected generic arguments in path

--- a/tests/ui/span/visibility-ty-params.stderr
+++ b/tests/ui/span/visibility-ty-params.stderr
@@ -4,11 +4,11 @@ error: unexpected generic arguments in path
 LL | m!{ S<u8> }
    |      ^^^^
 
-error[E0577]: expected module, found struct `S`
+error[E0433]: failed to resolve: `S` is a struct, not a module
   --> $DIR/visibility-ty-params.rs:6:5
    |
 LL | m!{ S<u8> }
-   |     ^^^^^ not a module
+   |     ^ `S` is a struct, not a module
 
 error: unexpected generic arguments in path
   --> $DIR/visibility-ty-params.rs:10:10
@@ -18,4 +18,4 @@ LL |     m!{ m<> }
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0577`.
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/use/use-self-type.stderr
+++ b/tests/ui/use/use-self-type.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+error[E0433]: failed to resolve: `Self` cannot be used in imports
   --> $DIR/use-self-type.rs:7:16
    |
 LL |         pub(in Self::f) struct Z;
-   |                ^^^^ `Self` is only available in impls, traits, and type definitions
+   |                ^^^^ `Self` cannot be used in imports
 
 error[E0432]: unresolved import `Self`
   --> $DIR/use-self-type.rs:6:13


### PR DESCRIPTION
Asking for a resolution with `opt_ns = Some(TypeNS)` allows path resolution to look for type-relative paths, leaving unresolved segments behind. However, for visibility paths we really need to look for a module, so we need to pass `opt_ns = None`.

Fixes https://github.com/rust-lang/rust/issues/109146

r? @petrochenkov 