### PR TITLE
rustdoc: Remove footnote references from doc summary

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -556,7 +556,15 @@ fn check_if_allowed_tag(t: &Tag<'_>) -> bool {
 }
 
 fn is_forbidden_tag(t: &Tag<'_>) -> bool {
-    matches!(t, Tag::CodeBlock(_) | Tag::Table(_) | Tag::TableHead | Tag::TableRow | Tag::TableCell)
+    matches!(
+        t,
+        Tag::CodeBlock(_)
+            | Tag::Table(_)
+            | Tag::TableHead
+            | Tag::TableRow
+            | Tag::TableCell
+            | Tag::FootnoteDefinition(_)
+    )
 }
 
 impl<'a, I: Iterator<Item = Event<'a>>> Iterator for SummaryLine<'a, I> {
@@ -588,6 +596,10 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for SummaryLine<'a, I> {
                     self.depth -= 1;
                     is_start = false;
                     check_if_allowed_tag(c)
+                }
+                Event::FootnoteReference(_) => {
+                    self.skipped_tags += 1;
+                    false
                 }
                 _ => true,
             };

--- a/tests/rustdoc/footnote-in-summary.rs
+++ b/tests/rustdoc/footnote-in-summary.rs
@@ -1,0 +1,17 @@
+// This test ensures that no footnote reference is generated inside
+// summary doc.
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html'
+// @has - '//*[@class="desc docblock-short"]' 'hello bla'
+// @!has - '//*[@class="desc docblock-short"]/sup' '1'
+
+// @has 'foo/struct.S.html'
+// @has - '//*[@class="docblock"]//sup' '1'
+// @has - '//*[@class="docblock"]' 'hello 1 bla'
+
+/// hello [^foot] bla
+///
+/// [^foot]: blabla
+pub struct S;


### PR DESCRIPTION
Since it's one line, we don't have the footnote definition so it doesn't make sense to have the reference.

Part of https://github.com/rust-lang/rust/issues/109024.

r? @notriddle 