### PR TITLE
Only expect a GAT const param for `type_of` of GAT const arg

### DIFF
--- a/tests/ui/const-generics/generic_const_exprs/mismatched-gat-subst-kind.rs
+++ b/tests/ui/const-generics/generic_const_exprs/mismatched-gat-subst-kind.rs
@@ -1,0 +1,11 @@
+#![feature(generic_const_exprs)]
+//~^ WARN the feature `generic_const_exprs` is incomplete
+
+trait B {
+    type U<T>;
+}
+
+fn f<T: B<U<1i32> = ()>>() {}
+//~^ ERROR constant provided when a type was expected
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/mismatched-gat-subst-kind.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/mismatched-gat-subst-kind.stderr
@@ -1,0 +1,18 @@
+warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/mismatched-gat-subst-kind.rs:1:12
+   |
+LL | #![feature(generic_const_exprs)]
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0747]: constant provided when a type was expected
+  --> $DIR/mismatched-gat-subst-kind.rs:8:13
+   |
+LL | fn f<T: B<U<1i32> = ()>>() {}
+   |             ^^^^
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0747`.


### PR DESCRIPTION
IDK why we were account for both `is_ty_or_const` instead of just for a const param, since we're computing the `type_of` a const param specifically.

Fixes #109300