### PR TITLE
fix typo in the creation of OpenOption for RustyHermit

### DIFF
--- a/library/std/src/sys/hermit/fs.rs
+++ b/library/std/src/sys/hermit/fs.rs
@@ -202,7 +202,7 @@ impl OpenOptions {
             create: false,
             create_new: false,
             // system-specific
-            mode: 0x777,
+            mode: 0o777,
         }
     }
 


### PR DESCRIPTION
Due to this typo we have to build a workaround for issue hermitcore/libhermit-rs#191.

RustyHermit is a tier 3 platform and backward compatibility does not have to be guaranteed.