### PR TITLE
rustdoc: Fix improper escaping of deprecation reasons

### DIFF
--- a/src/librustdoc/html/templates/short_item_info.html
+++ b/src/librustdoc/html/templates/short_item_info.html
@@ -2,7 +2,7 @@
     {% when Self::Deprecation with { message } %}
         <div class="stab deprecated"> {# #}
             <span class="emoji">👎</span> {# #}
-            <span>{{message}}</span> {# #}
+            <span>{{message|safe}}</span> {# #}
         </div> {# #}
     {% when Self::Unstable with { feature, tracking } %}
         <div class="stab unstable"> {# #}

--- a/tests/rustdoc/deprecated.rs
+++ b/tests/rustdoc/deprecated.rs
@@ -28,6 +28,6 @@ pub struct V;
 pub struct W;
 
 // @matches deprecated/struct.X.html '//*[@class="stab deprecated"]' \
-//      'Deprecated: shorthand reason$'
-#[deprecated = "shorthand reason"]
+//      'Deprecated: shorthand reason: code$'
+#[deprecated = "shorthand reason: `code`"]
 pub struct X;


### PR DESCRIPTION
Fix #109374

r? @jsha 