### PR TITLE
Replace `yes` command by `while-echo` in test `tests/ui/process/process-sigpipe.rs`

### DIFF
--- a/tests/ui/process/process-sigpipe.rs
+++ b/tests/ui/process/process-sigpipe.rs
@@ -8,14 +8,14 @@
 // libstd ignores SIGPIPE, and other libraries may set signal masks.
 // Make sure that these behaviors don't get inherited to children
 // spawned via std::process, since they're needed for traditional UNIX
-// filter behavior. This test checks that `yes | head` terminates
+// filter behavior.
+// This test checks that `while echo y ; do : ; done | head` terminates
 // (instead of running forever), and that it does not print an error
 // message about a broken pipe.
 
 // ignore-emscripten no threads support
 // ignore-vxworks no 'sh'
 // ignore-fuchsia no 'sh'
-// ignore-nto no 'yes'
 
 use std::process;
 use std::thread;
@@ -27,7 +27,11 @@ fn main() {
         thread::sleep_ms(5000);
         process::exit(1);
     });
-    let output = process::Command::new("sh").arg("-c").arg("yes | head").output().unwrap();
+    let output = process::Command::new("sh")
+        .arg("-c")
+        .arg("while echo y ; do : ; done | head")
+        .output()
+        .unwrap();
     assert!(output.status.success());
     assert!(output.stderr.len() == 0);
 }


### PR DESCRIPTION
The `yes` command is not available on all platforms.

Fixes #108596.

Inviting @mvf as he contributed to this patch. Thanks! This issue has been discussed in https://github.com/rust-lang/rust/pull/106673 but was moved to #108596 to get going.

CC @gh-tr

r? @workingjubilee
@rustbot label +O-neutrino

Notes about the comments https://github.com/rust-lang/rust/pull/106673#discussion_r1117324265:
- The `echo` command is `/proc/boot/echo` (not built-in)
- `/bin/sh` is a symlink to `/proc/boot/ksh`
```sh
# ls -l /bin/sh /proc/boot/ksh /proc/boot/echo
lrwxrwxrwx   1 root      root             14 Mar 20 07:52 /bin/sh -> /proc/boot/ksh
-r-xr-xr-x   1 root      root           9390 Sep 12  2022 /proc/boot/echo
-r-xr-xr-x   1 root      root         308114 Sep 12  2022 /proc/boot/ksh
```