### PR TITLE
interpret region vars as universals in implied bounds query

### DIFF
--- a/tests/ui/implied-bounds/normalization-preserve-equality.rs
+++ b/tests/ui/implied-bounds/normalization-preserve-equality.rs
@@ -1,0 +1,18 @@
+// check-pass
+// issue: #106569
+
+struct Equal<'a, 'b>(&'a &'b (), &'b &'a ()); // implies 'a == 'b
+
+trait Trait { type Ty; }
+
+impl<'x> Trait for Equal<'x, 'x> { type Ty = (); }
+
+fn test1<'a, 'b>(_: (<Equal<'a, 'b> as Trait>::Ty, Equal<'a, 'b>)) {
+    let _ = None::<Equal<'a, 'b>>;
+}
+
+fn test2<'a, 'b>(_: <Equal<'a, 'b> as Trait>::Ty, _: Equal<'a, 'b>) {
+    let _ = None::<Equal<'a, 'b>>;
+}
+
+fn main() {}


### PR DESCRIPTION
Implied bounds query is different to other canonical trait queries in that we should treat all region variables as universals. This fixes #106569.

To illustrate the problem in #106569:
- query: `implied_outlives_bounds(Canonical<Equal<'^1, '^2>)`
- instantiate the query: `implied_outlives_bounds(Equal<'?1, '?2>)`
- unify `'?1 == '?2` during normalization.
- query response: `['?1: '?2, '?2: ?1]` (as expected)
- when canonicalizing the query response we resolve unified region vars opportunistically. The query response is now: `['?1: '?1, '?1: '?1]`

This PR mitigates this problem by mapping every existential region to a unique universal one before executing the query.

cc @lcnr
r? types