### PR TITLE
Implement owned ops for `HashSet` and `BTreeSet`

### DIFF
--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -1139,15 +1139,8 @@ where
     /// let a = HashSet::from([1, 2, 3]);
     /// let b = HashSet::from([3, 4, 5]);
     ///
-    /// let set = &a | &b;
-    ///
-    /// let mut i = 0;
-    /// let expected = [1, 2, 3, 4, 5];
-    /// for x in &set {
-    ///     assert!(expected.contains(x));
-    ///     i += 1;
-    /// }
-    /// assert_eq!(i, expected.len());
+    /// let result = &a | &b;
+    /// assert_eq!(result, HashSet::from([1, 2, 3, 4, 5]));
     /// ```
     fn bitor(self, rhs: &HashSet<T, S>) -> HashSet<T, S> {
         self.union(rhs).cloned().collect()
@@ -1172,15 +1165,8 @@ where
     /// let a = HashSet::from([1, 2, 3]);
     /// let b = HashSet::from([2, 3, 4]);
     ///
-    /// let set = &a & &b;
-    ///
-    /// let mut i = 0;
-    /// let expected = [2, 3];
-    /// for x in &set {
-    ///     assert!(expected.contains(x));
-    ///     i += 1;
-    /// }
-    /// assert_eq!(i, expected.len());
+    /// let result = &a & &b;
+    /// assert_eq!(result, HashSet::from([2, 3]));
     /// ```
     fn bitand(self, rhs: &HashSet<T, S>) -> HashSet<T, S> {
         self.intersection(rhs).cloned().collect()
@@ -1205,15 +1191,8 @@ where
     /// let a = HashSet::from([1, 2, 3]);
     /// let b = HashSet::from([3, 4, 5]);
     ///
-    /// let set = &a ^ &b;
-    ///
-    /// let mut i = 0;
-    /// let expected = [1, 2, 4, 5];
-    /// for x in &set {
-    ///     assert!(expected.contains(x));
-    ///     i += 1;
-    /// }
-    /// assert_eq!(i, expected.len());
+    /// let result = &a ^ &b;
+    /// assert_eq!(result, HashSet::from([1, 2, 4, 5]));
     /// ```
     fn bitxor(self, rhs: &HashSet<T, S>) -> HashSet<T, S> {
         self.symmetric_difference(rhs).cloned().collect()
@@ -1238,15 +1217,8 @@ where
     /// let a = HashSet::from([1, 2, 3]);
     /// let b = HashSet::from([3, 4, 5]);
     ///
-    /// let set = &a - &b;
-    ///
-    /// let mut i = 0;
-    /// let expected = [1, 2];
-    /// for x in &set {
-    ///     assert!(expected.contains(x));
-    ///     i += 1;
-    /// }
-    /// assert_eq!(i, expected.len());
+    /// let result = &a - &b;
+    /// assert_eq!(result, HashSet::from([1, 2]));
     /// ```
     fn sub(self, rhs: &HashSet<T, S>) -> HashSet<T, S> {
         self.difference(rhs).cloned().collect()


### PR DESCRIPTION
This PR implements `ops::{BitAnd, BitOr, BitXor, Sub}` where one, or both arguments are owned (previously we only had impls for references to sets).

The main advantage of these impls is lifted `T: Clone` bounds (and, in case of `HashSet`, lifted `S: Default`). The secondary one is being able to reuse allocations. Lastly, they may (or may not) be more performant.

Added public APIs (**insta-stable**):
```rust
#![stable(feature = "set_owned_ops", since = "CURRENT_RUSTC_VERSION")]

impl<T: Eq + Hash, S: BuildHasher> BitOr<HashSet<T, S>> for HashSet<T, S>;
impl<T: Eq + Hash, S: BuildHasher> BitXor<HashSet<T, S>> for HashSet<T, S>;
impl<T: Eq + Hash, S: BuildHasher> BitAnd<&HashSet<T, S>> for HashSet<T, S>;
impl<T: Eq + Hash, S: BuildHasher> Sub<&HashSet<T, S>> for HashSet<T, S>;

impl<T: Ord, A: Allocator + Clone> BitOr<BTreeSet<T, A>> for BTreeSet<T, A>;
impl<T: Ord, A: Allocator + Clone> BitXor<BTreeSet<T, A>> for BTreeSet<T, A>;
impl<T: Ord, A: Allocator + Clone> BitAnd<&BTreeSet<T, A>> for BTreeSet<T, A>;
impl<T: Ord, A: Allocator + Clone> Sub<&BTreeSet<T, A>> for BTreeSet<T, A>;

// For all of the above, `type Output = Self;`
```

I only added the "important" impls, i.e. such that allow lifting the bounds. Thus union-like ops (or, xor) have both arguments owned (because they need elements from both sets), while difference-like ops (sub, and) have only `self` owned (that's sufficient to not clone elements).

Other potentially interesting implementations (in the order of most to least interesting according to myself):
1. `BitAnd<Set<T, ...>> for Set<T, ...>` — optimization potential (can keep either allocation/iterate either set)
2. `BitOr<&Set<T, ...>> for Set<T, ...>` and `BitOr<&Set<T, ...>> for Set<T, ...>` — still require `T: Clone`, but can keep the allocation/hasher
    - Symmetric `BitOr<Set<T, ...>> for &Set<T, ...>` and `BitOr<Set<T, ...>> for &Set<T, ...>` could be added for completeness
3. `BitAnd<Set<T, ...>> for &Set<T, ...>` — symmetry for completeness
4. `Sub<Set<T, ...>> for Set<T, ...>` and `Sub<Set<T, ...>> for &Set<T, ...>` — completeness (no bounds lifting/optimization gains)

r? libs-api