### PR TITLE
Enforce that `PointerLike` requires a pointer-like ABI

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1522,6 +1522,16 @@ impl<'a> Layout<'a> {
     pub fn size(self) -> Size {
         self.0.0.size
     }
+
+    /// Whether the layout is from a type that implements [`std::marker::PointerLike`].
+    ///
+    /// Currently, that means that the type is pointer-sized, pointer-aligned,
+    /// and has a scalar ABI.
+    pub fn is_pointer_like(self, data_layout: &TargetDataLayout) -> bool {
+        self.size() == data_layout.pointer_size
+            && self.align().abi == data_layout.pointer_align.abi
+            && matches!(self.abi(), Abi::Scalar(..))
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/compiler/rustc_trait_selection/src/solve/trait_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals.rs
@@ -221,8 +221,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
         let self_ty = tcx.erase_regions(goal.predicate.self_ty());
 
         if let Ok(layout) = tcx.layout_of(goal.param_env.and(self_ty))
-            && layout.layout.size() == tcx.data_layout.pointer_size
-            && layout.layout.align().abi == tcx.data_layout.pointer_align.abi
+            && layout.layout.is_pointer_like(&tcx.data_layout)
         {
             // FIXME: We could make this faster by making a no-constraints response
             ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -879,7 +879,7 @@ pub trait Tuple {}
 #[unstable(feature = "pointer_like_trait", issue = "none")]
 #[lang = "pointer_like"]
 #[rustc_on_unimplemented(
-    message = "`{Self}` needs to have the same alignment and size as a pointer",
+    message = "`{Self}` needs to have the same ABI as a pointer",
     label = "`{Self}` needs to be a pointer-like type"
 )]
 pub trait PointerLike {}

--- a/tests/ui/dyn-star/align.normal.stderr
+++ b/tests/ui/dyn-star/align.normal.stderr
@@ -1,5 +1,5 @@
 warning: the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/align.rs:4:12
+  --> $DIR/align.rs:3:12
    |
 LL | #![feature(dyn_star)]
    |            ^^^^^^^^
@@ -7,5 +7,14 @@ LL | #![feature(dyn_star)]
    = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-warning: 1 warning emitted
+error[E0277]: `AlignedUsize` needs to have the same ABI as a pointer
+  --> $DIR/align.rs:14:13
+   |
+LL |     let x = AlignedUsize(12) as dyn* Debug;
+   |             ^^^^^^^^^^^^^^^^ `AlignedUsize` needs to be a pointer-like type
+   |
+   = help: the trait `PointerLike` is not implemented for `AlignedUsize`
 
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/dyn-star/align.over_aligned.stderr
+++ b/tests/ui/dyn-star/align.over_aligned.stderr
@@ -1,5 +1,5 @@
 warning: the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/align.rs:4:12
+  --> $DIR/align.rs:3:12
    |
 LL | #![feature(dyn_star)]
    |            ^^^^^^^^
@@ -7,8 +7,8 @@ LL | #![feature(dyn_star)]
    = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0277]: `AlignedUsize` needs to have the same alignment and size as a pointer
-  --> $DIR/align.rs:15:13
+error[E0277]: `AlignedUsize` needs to have the same ABI as a pointer
+  --> $DIR/align.rs:14:13
    |
 LL |     let x = AlignedUsize(12) as dyn* Debug;
    |             ^^^^^^^^^^^^^^^^ `AlignedUsize` needs to be a pointer-like type

--- a/tests/ui/dyn-star/align.rs
+++ b/tests/ui/dyn-star/align.rs
@@ -1,5 +1,4 @@
 // revisions: normal over_aligned
-//[normal] check-pass
 
 #![feature(dyn_star)]
 //~^ WARN the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
@@ -13,5 +12,5 @@ struct AlignedUsize(usize);
 
 fn main() {
     let x = AlignedUsize(12) as dyn* Debug;
-    //[over_aligned]~^ ERROR `AlignedUsize` needs to have the same alignment and size as a pointer
+    //~^ ERROR `AlignedUsize` needs to have the same ABI as a pointer
 }

--- a/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.rs
+++ b/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.rs
@@ -9,7 +9,7 @@ fn dyn_debug(_: (dyn* Debug + '_)) {
 
 fn polymorphic<T: Debug + ?Sized>(t: &T) {
     dyn_debug(t);
-    //~^ ERROR `&T` needs to have the same alignment and size as a pointer
+    //~^ ERROR `&T` needs to have the same ABI as a pointer
 }
 
 fn main() {}

--- a/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.stderr
+++ b/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.stderr
@@ -1,4 +1,4 @@
-error[E0277]: `&T` needs to have the same alignment and size as a pointer
+error[E0277]: `&T` needs to have the same ABI as a pointer
   --> $DIR/check-size-at-cast-polymorphic-bad.rs:11:15
    |
 LL |     dyn_debug(t);

--- a/tests/ui/dyn-star/check-size-at-cast.rs
+++ b/tests/ui/dyn-star/check-size-at-cast.rs
@@ -5,6 +5,6 @@ use std::fmt::Debug;
 
 fn main() {
     let i = [1, 2, 3, 4] as dyn* Debug;
-    //~^ ERROR `[i32; 4]` needs to have the same alignment and size as a pointer
+    //~^ ERROR `[i32; 4]` needs to have the same ABI as a pointer
     dbg!(i);
 }

--- a/tests/ui/dyn-star/check-size-at-cast.stderr
+++ b/tests/ui/dyn-star/check-size-at-cast.stderr
@@ -1,4 +1,4 @@
-error[E0277]: `[i32; 4]` needs to have the same alignment and size as a pointer
+error[E0277]: `[i32; 4]` needs to have the same ABI as a pointer
   --> $DIR/check-size-at-cast.rs:7:13
    |
 LL |     let i = [1, 2, 3, 4] as dyn* Debug;

--- a/tests/ui/dyn-star/upcast.stderr
+++ b/tests/ui/dyn-star/upcast.stderr
@@ -7,7 +7,7 @@ LL | #![feature(dyn_star, trait_upcasting)]
    = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0277]: `dyn* Foo` needs to have the same alignment and size as a pointer
+error[E0277]: `dyn* Foo` needs to have the same ABI as a pointer
   --> $DIR/upcast.rs:30:23
    |
 LL |     let w: dyn* Bar = w;

--- a/tests/ui/traits/new-solver/pointer-like.rs
+++ b/tests/ui/traits/new-solver/pointer-like.rs
@@ -9,6 +9,6 @@ fn require_(_: impl PointerLike) {}
 fn main() {
     require_(1usize);
     require_(1u16);
-    //~^ ERROR `u16` needs to have the same alignment and size as a pointer
+    //~^ ERROR `u16` needs to have the same ABI as a pointer
     require_(&1i16);
 }

--- a/tests/ui/traits/new-solver/pointer-like.stderr
+++ b/tests/ui/traits/new-solver/pointer-like.stderr
@@ -1,4 +1,4 @@
-error[E0277]: `u16` needs to have the same alignment and size as a pointer
+error[E0277]: `u16` needs to have the same ABI as a pointer
   --> $DIR/pointer-like.rs:11:14
    |
 LL |     require_(1u16);


### PR DESCRIPTION
At least temporarily, let's ban coercing things that are pointer-sized and pointer-aligned but *not* `Abi::Scalar(..)` into `dyn*`. See: https://github.com/rust-lang/rust/pull/104694#discussion_r1142522073

This can be lifted in the future if we decie that we *want* to be able to coerce something `repr(C)` into a `dyn*`, but we'll have to figure out what to do with Miri and codegen...

r? compiler