### PR TITLE
Do not consider synthesized RPITITs on missing items checks

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -202,8 +202,11 @@ fn missing_items_err(
     missing_items: &[ty::AssocItem],
     full_impl_span: Span,
 ) {
+    let missing_items =
+        missing_items.iter().filter(|trait_item| tcx.opt_rpitit_info(trait_item.def_id).is_none());
+
     let missing_items_msg = missing_items
-        .iter()
+        .clone()
         .map(|trait_item| trait_item.name.to_string())
         .collect::<Vec<_>>()
         .join("`, `");

--- a/tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.current.stderr
+++ b/tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_position_impl_trait_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/dont-project-to-rpitit-with-no-value.rs:1:12
+  --> $DIR/dont-project-to-rpitit-with-no-value.rs:4:12
    |
 LL | #![feature(return_position_impl_trait_in_trait)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | #![feature(return_position_impl_trait_in_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0046]: not all trait items implemented, missing: `foo`
-  --> $DIR/dont-project-to-rpitit-with-no-value.rs:9:1
+  --> $DIR/dont-project-to-rpitit-with-no-value.rs:12:1
    |
 LL |     fn foo(&self) -> impl Sized;
    |     ---------------------------- `foo` from trait

--- a/tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.next.stderr
+++ b/tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.next.stderr
@@ -1,0 +1,21 @@
+warning: the feature `return_position_impl_trait_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/dont-project-to-rpitit-with-no-value.rs:4:12
+   |
+LL | #![feature(return_position_impl_trait_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0046]: not all trait items implemented, missing: `foo`
+  --> $DIR/dont-project-to-rpitit-with-no-value.rs:12:1
+   |
+LL |     fn foo(&self) -> impl Sized;
+   |     ---------------------------- `foo` from trait
+...
+LL | impl MyTrait for i32 {
+   | ^^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0046`.

--- a/tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.rs
+++ b/tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.rs
@@ -1,3 +1,6 @@
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
+
 #![feature(return_position_impl_trait_in_trait)]
 //~^ WARN the feature `return_position_impl_trait_in_trait` is incomplete
 
@@ -7,7 +10,7 @@ trait MyTrait {
 }
 
 impl MyTrait for i32 {
-//~^ ERROR not all trait items implemented, missing: `foo`
+    //~^ ERROR not all trait items implemented, missing: `foo`
     fn bar(&self) -> impl Sized {
         self.foo()
     }


### PR DESCRIPTION
Without this patch for `tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.rs` we get ...

```
warning: the feature `return_position_impl_trait_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
 --> tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.rs:4:12
  |
4 | #![feature(return_position_impl_trait_in_trait)]
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
  = note: `#[warn(incomplete_features)]` on by default

error[E0046]: not all trait items implemented, missing: `foo`, ``
  --> tests/ui/impl-trait/in-trait/dont-project-to-rpitit-with-no-value.rs:12:1
   |
8  |     fn foo(&self) -> impl Sized;
   |     ----------------------------
   |     |                |
   |     |                `` from trait
   |     `foo` from trait
...
12 | impl MyTrait for i32 {
   | ^^^^^^^^^^^^^^^^^^^^ missing `foo`, `` in implementation

error: aborting due to previous error; 1 warning emitted

For more information about this error, try `rustc --explain E0046`.
```

instead of ...

```
warning: the feature `return_position_impl_trait_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
  --> $DIR/dont-project-to-rpitit-with-no-value.rs:4:12
   |
LL | #![feature(return_position_impl_trait_in_trait)]
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
   = note: `#[warn(incomplete_features)]` on by default

error[E0046]: not all trait items implemented, missing: `foo`
  --> $DIR/dont-project-to-rpitit-with-no-value.rs:12:1
   |
LL |     fn foo(&self) -> impl Sized;
   |     ---------------------------- `foo` from trait
...
LL | impl MyTrait for i32 {
   | ^^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation

error: aborting due to previous error; 1 warning emitted

For more information about this error, try `rustc --explain E0046`.
```

r? @compiler-errors