### PR TITLE
Do not suggest bounds restrictions for synthesized RPITITs

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -420,6 +420,7 @@ fn suggest_restriction<'tcx>(
 ) {
     if hir_generics.where_clause_span.from_expansion()
         || hir_generics.where_clause_span.desugaring_kind().is_some()
+        || projection.map_or(false, |projection| tcx.opt_rpitit_info(projection.def_id).is_some())
     {
         return;
     }

--- a/tests/ui/async-await/in-trait/missing-send-bound.current.stderr
+++ b/tests/ui/async-await/in-trait/missing-send-bound.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/missing-send-bound.rs:3:12
+  --> $DIR/missing-send-bound.rs:5:12
    |
 LL | #![feature(async_fn_in_trait)]
    |            ^^^^^^^^^^^^^^^^^
@@ -8,19 +8,19 @@ LL | #![feature(async_fn_in_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: future cannot be sent between threads safely
-  --> $DIR/missing-send-bound.rs:15:20
+  --> $DIR/missing-send-bound.rs:17:20
    |
 LL |     assert_is_send(test::<T>());
    |                    ^^^^^^^^^^^ future returned by `test` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `impl Future<Output = ()>`
 note: future is not `Send` as it awaits another future which is not `Send`
-  --> $DIR/missing-send-bound.rs:11:5
+  --> $DIR/missing-send-bound.rs:13:5
    |
 LL |     T::bar().await;
    |     ^^^^^^^^ await occurs here on type `impl Future<Output = ()>`, which is not `Send`
 note: required by a bound in `assert_is_send`
-  --> $DIR/missing-send-bound.rs:19:27
+  --> $DIR/missing-send-bound.rs:21:27
    |
 LL | fn assert_is_send(_: impl Send) {}
    |                           ^^^^ required by this bound in `assert_is_send`

--- a/tests/ui/async-await/in-trait/missing-send-bound.next.stderr
+++ b/tests/ui/async-await/in-trait/missing-send-bound.next.stderr
@@ -1,0 +1,29 @@
+warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/missing-send-bound.rs:5:12
+   |
+LL | #![feature(async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: future cannot be sent between threads safely
+  --> $DIR/missing-send-bound.rs:17:20
+   |
+LL |     assert_is_send(test::<T>());
+   |                    ^^^^^^^^^^^ future returned by `test` is not `Send`
+   |
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `impl Future<Output = ()>`
+note: future is not `Send` as it awaits another future which is not `Send`
+  --> $DIR/missing-send-bound.rs:13:5
+   |
+LL |     T::bar().await;
+   |     ^^^^^^^^ await occurs here on type `impl Future<Output = ()>`, which is not `Send`
+note: required by a bound in `assert_is_send`
+  --> $DIR/missing-send-bound.rs:21:27
+   |
+LL | fn assert_is_send(_: impl Send) {}
+   |                           ^^^^ required by this bound in `assert_is_send`
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/async-await/in-trait/missing-send-bound.rs
+++ b/tests/ui/async-await/in-trait/missing-send-bound.rs
@@ -1,4 +1,6 @@
 // edition:2021
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(async_fn_in_trait)]
 //~^ WARN the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes


### PR DESCRIPTION
Before this PR we were getting ...

```
warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
 --> tests/ui/async-await/in-trait/missing-send-bound.rs:5:12
  |
5 | #![feature(async_fn_in_trait)]
  |            ^^^^^^^^^^^^^^^^^
  |
  = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
  = note: `#[warn(incomplete_features)]` on by default

error: future cannot be sent between threads safely
  --> tests/ui/async-await/in-trait/missing-send-bound.rs:17:20
   |
17 |     assert_is_send(test::<T>());
   |                    ^^^^^^^^^^^ future returned by `test` is not `Send`
   |
   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `impl Future<Output = ()>`
note: future is not `Send` as it awaits another future which is not `Send`
  --> tests/ui/async-await/in-trait/missing-send-bound.rs:13:5
   |
13 |     T::bar().await;
   |     ^^^^^^^^ await occurs here on type `impl Future<Output = ()>`, which is not `Send`
note: required by a bound in `assert_is_send`
  --> tests/ui/async-await/in-trait/missing-send-bound.rs:21:27
   |
21 | fn assert_is_send(_: impl Send) {}
   |                           ^^^^ required by this bound in `assert_is_send`
help: consider further restricting the associated type
   |
16 | fn test2<T: Foo>() where impl Future<Output = ()>: Send {
   |                    ++++++++++++++++++++++++++++++++++++

error: aborting due to previous error; 1 warning emitted
```

and we want this output ...

```
warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
  --> $DIR/missing-send-bound.rs:5:12
   |
LL | #![feature(async_fn_in_trait)]
   |            ^^^^^^^^^^^^^^^^^
   |
   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
   = note: `#[warn(incomplete_features)]` on by default

error: future cannot be sent between threads safely
  --> $DIR/missing-send-bound.rs:17:20
   |
LL |     assert_is_send(test::<T>());
   |                    ^^^^^^^^^^^ future returned by `test` is not `Send`
   |
   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `impl Future<Output = ()>`
note: future is not `Send` as it awaits another future which is not `Send`
  --> $DIR/missing-send-bound.rs:13:5
   |
LL |     T::bar().await;
   |     ^^^^^^^^ await occurs here on type `impl Future<Output = ()>`, which is not `Send`
note: required by a bound in `assert_is_send`
  --> $DIR/missing-send-bound.rs:21:27
   |
LL | fn assert_is_send(_: impl Send) {}
   |                           ^^^^ required by this bound in `assert_is_send`

error: aborting due to previous error; 1 warning emitted
```

r? @compiler-errors 