### PR TITLE
Ignore the vendor directory for tidy tests.

### DIFF
--- a/src/tools/tidy/src/walk.rs
+++ b/src/tools/tidy/src/walk.rs
@@ -29,6 +29,7 @@ pub fn filter_dirs(path: &Path) -> bool {
         // Filter RLS output directories
         "target/rls",
         "src/bootstrap/target",
+        "vendor",
     ];
     skip.iter().any(|p| path.ends_with(p))
 }


### PR DESCRIPTION
When running `x.py test` on a downloaded source distribution (e.g. https://static.rust-lang.org/dist/rustc-<version>-src.tar.gz), the crates in the vendor directory contain a number of executable files that cause the tidy test to fail with the following message:

tidy error: binary checked into source: <path>

I see 26 such errors with the 1.68.0 source distribution. A few of these are .rs source files with incorrect executable permission, but most are scripts that are correctly marked executable.