### PR TITLE
Update dist-x86_64-linux to GCC 8.5

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
@@ -3,7 +3,7 @@ set -ex
 
 source shared.sh
 
-GCC=7.5.0
+GCC=8.5.0
 
 curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.xz | xzcat | tar xf -
 cd gcc-$GCC


### PR DESCRIPTION
Update dist-x86_64-linux to GCC 8. While we don't use GCC for the LLVM build, we do use its libstdc++, and there has been an `std::optional` ABI break in this version. This makes the libLLVM.so for LLVM 16 ABI-incompatible with newer libstdc++ versions, which we use on all other builders, and which download-ci-llvm users are likely to use.

r? @ghost