### PR TITLE
Preserve argument indexes when inlining MIR

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1115,6 +1115,11 @@ pub struct VarDebugInfo<'tcx> {
 
     /// Where the data for this user variable is to be found.
     pub value: VarDebugInfoContents<'tcx>,
+
+    /// When present, indicates what argument number this variable is in the function that it
+    /// originated from (starting from 1). Note, if MIR inlining is enabled, then this is the
+    /// argument number in the original function before it was inlined.
+    pub argument_index: Option<u16>,
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -832,6 +832,7 @@ macro_rules! make_mir_visitor {
                     name: _,
                     source_info,
                     value,
+                    argument_index: _,
                 } = var_debug_info;
 
                 self.visit_source_info(source_info);

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -2242,6 +2242,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             name,
             source_info: debug_source_info,
             value: VarDebugInfoContents::Place(for_arm_body.into()),
+            argument_index: None,
         });
         let locals = if has_guard.0 {
             let ref_for_guard = self.local_decls.push(LocalDecl::<'tcx> {
@@ -2260,6 +2261,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 name,
                 source_info: debug_source_info,
                 value: VarDebugInfoContents::Place(ref_for_guard.into()),
+                argument_index: None,
             });
             LocalsForNode::ForGuard { ref_for_guard, for_arm_body }
         } else {

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -811,6 +811,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     name,
                     source_info: SourceInfo::outermost(captured_place.var_ident.span),
                     value: VarDebugInfoContents::Place(use_place),
+                    argument_index: None,
                 });
 
                 let capture = Capture { captured_place, use_place, mutability };
@@ -827,7 +828,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         expr: &Expr<'tcx>,
     ) -> BlockAnd<()> {
         // Allocate locals for the function arguments
-        for param in arguments.iter() {
+        for (argument_index, param) in arguments.iter().enumerate() {
             let source_info =
                 SourceInfo::outermost(param.pat.as_ref().map_or(self.fn_span, |pat| pat.span));
             let arg_local =
@@ -839,6 +840,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     name,
                     source_info,
                     value: VarDebugInfoContents::Place(arg_local.into()),
+                    argument_index: Some(argument_index as u16 + 1),
                 });
             }
         }

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -1556,6 +1556,13 @@ impl<'tcx> MirPass<'tcx> for StateTransform {
         body.arg_count = 2; // self, resume arg
         body.spread_arg = None;
 
+        // The original arguments to the function are no longer arguments, mark them as such.
+        // Otherwise they'll conflict with our new arguments, which although they don't have
+        // argument_index set, will get emitted as unnamed arguments.
+        for var in &mut body.var_debug_info {
+            var.argument_index = None;
+        }
+
         body.generator.as_mut().unwrap().yield_ty = None;
         body.generator.as_mut().unwrap().generator_layout = Some(layout);
 

--- a/tests/codegen/inline-function-args-debug-info.rs
+++ b/tests/codegen/inline-function-args-debug-info.rs
@@ -1,0 +1,20 @@
+// This test checks that debug information includes function argument indexes even if the function
+// gets inlined by MIR inlining. Without function argument indexes, `info args` in gdb won't show
+// arguments and their values for the current function.
+
+// compile-flags: -Zinline-mir=yes -Cdebuginfo=2 --edition=2021
+
+#![crate_type = "lib"]
+
+pub fn outer_function(x: usize, y: usize) -> usize {
+    inner_function(x, y) + 1
+}
+
+#[inline]
+fn inner_function(aaaa: usize, bbbb: usize) -> usize {
+    // CHECK: !DILocalVariable(name: "aaaa", arg: 1
+    // CHECK-SAME: line: 14
+    // CHECK: !DILocalVariable(name: "bbbb", arg: 2
+    // CHECK-SAME: line: 14
+    aaaa + bbbb
+}

--- a/tests/ui/async-await/task-context-arg.rs
+++ b/tests/ui/async-await/task-context-arg.rs
@@ -1,0 +1,25 @@
+// Checks that we don't get conflicting arguments in our debug info with a particular async function
+// structure.
+
+// edition:2021
+// compile-flags: -Cdebuginfo=2
+// build-pass
+
+#![crate_type = "lib"]
+
+use std::future::Future;
+
+// The compiler produces a closure as part of this function. That closure initially takes an
+// argument _task_context. Later, when the MIR for that closure is transformed into a generator
+// state machine, _task_context is demoted to not be an argument, but just part of an unnamed
+// argument. If we emit debug info saying that both _task_context and the unnamed argument are both
+// argument number 2, then LLVM will fail with "conflicting debug info for argument". See
+// https://github.com/rust-lang/rust/pull/109466#issuecomment-1500879195 for details.
+async fn recv_unit() {
+    std::future::ready(()).await;
+}
+
+pub fn poll_recv() {
+    // This box is necessary in order to reproduce the problem.
+    let _: Box<dyn Future<Output = ()>> = Box::new(recv_unit());
+}


### PR DESCRIPTION
We store argument indexes on VarDebugInfo. Unlike the previous method of relying on the variable index to know whether a variable is an argument, this survives MIR inlining.

We also no longer check if var.source_info.scope is the outermost scope. When a function gets inlined, the arguments to the inner function will no longer be in the outermost scope. What we care about though is whether they were in the outermost scope prior to inlining, which we know by whether we assigned an argument index.

Fixes #83217

I considered using `Option<NonZeroU16>` instead of `Option<u16>` to store the index. I didn't because `TypeFoldable` isn't implemented for `NonZeroU16` and because it looks like due to padding, it currently wouldn't make any difference. But I indexed from 1 anyway because (a) it'll make it easier if later it becomes worthwhile to use a `NonZeroU16` and because the arguments were previously indexed from 1, so it made for a smaller change.

This is my first PR on rust-lang/rust, so apologies if I've gotten anything not quite right.