### PR TITLE
Upgrade to LLVM 16, again

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/15.0-2022-12-07
+	branch = rustc/16.0-2023-03-06
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
@@ -3,7 +3,7 @@ set -ex
 
 source shared.sh
 
-GCC=7.5.0
+GCC=8.5.0
 
 curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.xz | xzcat | tar xf -
 cd gcc-$GCC

--- a/tests/codegen/array-map.rs
+++ b/tests/codegen/array-map.rs
@@ -38,10 +38,10 @@ pub fn short_integer_zip_map(x: [u32; 8], y: [u32; 8]) -> [u32; 8] {
 //
 // CHECK-LABEL: @long_integer_map
 #[no_mangle]
-pub fn long_integer_map(x: [u32; 64]) -> [u32; 64] {
+pub fn long_integer_map(x: [u32; 512]) -> [u32; 512] {
     // CHECK: start:
-    // CHECK-NEXT: alloca [64 x i32]
-    // CHECK-NEXT: alloca %"core::mem::manually_drop::ManuallyDrop<[u32; 64]>"
+    // CHECK-NEXT: alloca [512 x i32]
+    // CHECK-NEXT: alloca %"core::mem::manually_drop::ManuallyDrop<[u32; 512]>"
     // CHECK-NOT: alloca
     // CHECK: mul <{{[0-9]+}} x i32>
     // CHECK: add <{{[0-9]+}} x i32>


### PR DESCRIPTION
Relative to the previous attempt in https://github.com/rust-lang/rust/pull/107224:
 * Update to GCC 8.5 on dist-x86_64-linux, to avoid std::optional ABI-incompatibility between libstdc++ 7 and 8.
 * Cherry-pick https://github.com/llvm/llvm-project/commit/96df79af029b85616ab90e73143e0e8ae89c7b46.
 * Cherry-pick https://github.com/llvm/llvm-project/commit/6fc670e5e370e90759b5adecd9980b63609dc2f8.

r? @cuviper 