### PR TITLE
Optimize `LazyCell` size

### DIFF
--- a/library/core/src/cell/lazy.rs
+++ b/library/core/src/cell/lazy.rs
@@ -86,8 +86,8 @@ impl<T, F: FnOnce() -> T> LazyCell<T, F> {
         // SAFETY:
         // This invalidates any mutable references to the data. The resulting
         // reference lives either until the end of the borrow of `this` (in the
-        // initialized case) or is invalidates in `really_init` (in the
-        // uninitialized case).
+        // initialized case) or is invalidated in `really_init` (in the
+        // uninitialized case; `really_init` will create and return a fresh reference).
         let state = unsafe { &*this.state.get() };
         match state {
             State::Init(data) => data,


### PR DESCRIPTION
`LazyCell` can only store either the initializing function or the data it produces, so it does not need to reserve the space for both. Similar to #107329, but uses an `enum` instead of a `union`. 