### PR TITLE
compare_impl_item: remove trivial bounds

### DIFF
--- a/tests/ui/implied-bounds/issue-108544-1.rs
+++ b/tests/ui/implied-bounds/issue-108544-1.rs
@@ -1,0 +1,21 @@
+
+// check-pass
+
+use std::borrow::Cow;
+
+pub trait Trait {
+    fn method(self) -> Option<Cow<'static, str>>
+    where
+        Self: Sized;
+}
+
+impl<'a> Trait for Cow<'a, str> {
+    // We have to check `WF(return-type)` which requires `Cow<'static, str>: Sized`.
+    // If we use the `Self: Sized` bound from the trait method we end up equating
+    // `Cow<'a, str>` with `Cow<'static, str>`, causing an error.
+    fn method(self) -> Option<Cow<'static, str>> {
+        None
+    }
+}
+
+fn main() {}

--- a/tests/ui/implied-bounds/issue-108544-2.rs
+++ b/tests/ui/implied-bounds/issue-108544-2.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+// Similar to issue-108544.rs except that we have a generic `T` which
+// previously caused an overeager fast-path to trigger.
+use std::borrow::Cow;
+
+pub trait Trait<T: Clone> {
+    fn method(self) -> Option<Cow<'static, T>>
+    where
+        Self: Sized;
+}
+
+impl<'a, T: Clone> Trait<T> for Cow<'a, T> {
+    fn method(self) -> Option<Cow<'static, T>> {
+        None
+    }
+}
+
+fn main() {}

--- a/tests/ui/implied-bounds/trait-where-clause-implied.rs
+++ b/tests/ui/implied-bounds/trait-where-clause-implied.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+pub trait Trait<'a, 'b> {
+    fn method(self, _: &'static &'static ())
+    where
+        'a: 'b;
+}
+
+impl<'a> Trait<'a, 'static> for () {
+    // On first glance, this seems like we have the extra implied bound that
+    // `'a: 'static`, but we know this from the trait method where clause.
+    fn method(self, _: &'static &'a ()) {}
+}
+
+fn main() {}


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/108544, alternative to #109356

whenever we instantiate a `param_env` with non-identity substs it's very easy to end up with trivial bounds which can cause the trait solver to break :<

still needs comments n stuff but I wanted to get this PR up today.

r? types cc @compiler-errors @jackh726 