### PR TITLE
Return nested obligations from canonical response var unification

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
@@ -1,9 +1,8 @@
-use rustc_middle::traits::solve::{Certainty, Goal, MaybeCause};
+use rustc_infer::traits::{TraitEngine, TraitEngineExt};
 use rustc_middle::ty;
 
 use crate::infer::canonical::OriginalQueryValues;
 use crate::infer::InferCtxt;
-use crate::solve::InferCtxtEvalExt;
 use crate::traits::{EvaluationResult, OverflowError, PredicateObligation, SelectionContext};
 
 pub trait InferCtxtExt<'tcx> {
@@ -81,35 +80,20 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
 
         if self.tcx.trait_solver_next() {
             self.probe(|snapshot| {
-                if let Ok((_, certainty, nested_goals)) =
-                    self.evaluate_root_goal(Goal::new(self.tcx, param_env, obligation.predicate))
-                {
-                    match certainty {
-                        // If we have nested obligations from instantiating the canonical
-                        // response from this goal, just treat the response as ambiguous.
-                        //
-                        // FIXME(deferred_projection_equality): We need to process this
-                        // in a loop probably... can't be worse than an ICE though
-                        Certainty::Yes if !nested_goals.is_empty() => {
-                            Ok(EvaluationResult::EvaluatedToAmbig)
-                        }
-                        Certainty::Yes => {
-                            if self.opaque_types_added_in_snapshot(snapshot) {
-                                Ok(EvaluationResult::EvaluatedToOkModuloOpaqueTypes)
-                            } else if self.region_constraints_added_in_snapshot(snapshot).is_some()
-                            {
-                                Ok(EvaluationResult::EvaluatedToOkModuloRegions)
-                            } else {
-                                Ok(EvaluationResult::EvaluatedToOk)
-                            }
-                        }
-                        Certainty::Maybe(MaybeCause::Ambiguity) => {
-                            Ok(EvaluationResult::EvaluatedToAmbig)
-                        }
-                        Certainty::Maybe(MaybeCause::Overflow) => Err(OverflowError::Canonical),
-                    }
-                } else {
+                let mut fulfill_cx = crate::solve::FulfillmentCtxt::new();
+                fulfill_cx.register_predicate_obligation(self, obligation.clone());
+                // True errors
+                // FIXME(-Ztrait-solver=next): Overflows are reported as ambig here, is that OK?
+                if !fulfill_cx.select_where_possible(self).is_empty() {
                     Ok(EvaluationResult::EvaluatedToErr)
+                } else if !fulfill_cx.select_all_or_error(self).is_empty() {
+                    Ok(EvaluationResult::EvaluatedToAmbig)
+                } else if self.opaque_types_added_in_snapshot(snapshot) {
+                    Ok(EvaluationResult::EvaluatedToOkModuloOpaqueTypes)
+                } else if self.region_constraints_added_in_snapshot(snapshot).is_some() {
+                    Ok(EvaluationResult::EvaluatedToOkModuloRegions)
+                } else {
+                    Ok(EvaluationResult::EvaluatedToOk)
                 }
             })
         } else {

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -618,6 +618,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let mut fulfill_cx = crate::solve::FulfillmentCtxt::new();
         fulfill_cx.register_predicate_obligations(self.infcx, predicates);
         // True errors
+        // FIXME(-Ztrait-solver=next): Overflows are reported as ambig here, is that OK?
         if !fulfill_cx.select_where_possible(self.infcx).is_empty() {
             return Ok(EvaluatedToErr);
         }

--- a/tests/ui/traits/new-solver/alias-eq-in-canonical-response.rs
+++ b/tests/ui/traits/new-solver/alias-eq-in-canonical-response.rs
@@ -1,0 +1,40 @@
+// check-pass
+// compile-flags: -Ztrait-solver=next
+
+trait Foo {
+    type Gat<'a>
+    where
+        Self: 'a;
+    fn bar(&self) -> Self::Gat<'_>;
+}
+
+enum Option<T> {
+    Some(T),
+    None,
+}
+
+impl<T> Option<T> {
+    fn as_ref(&self) -> Option<&T> {
+        match self {
+            Option::Some(t) => Option::Some(t),
+            Option::None => Option::None,
+        }
+    }
+
+    fn map<U>(self, f: impl FnOnce(T) -> U) -> Option<U> {
+        match self {
+            Option::Some(t) => Option::Some(f(t)),
+            Option::None => Option::None,
+        }
+    }
+}
+
+impl<T: Foo + 'static> Foo for Option<T> {
+    type Gat<'a> = Option<<T as Foo>::Gat<'a>> where Self: 'a;
+
+    fn bar(&self) -> Self::Gat<'_> {
+        self.as_ref().map(Foo::bar)
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Handle alias-eq obligations being emitted from `instantiate_and_apply_query_response` in:
* `EvalCtxt` - by processing the nested obligations in the next loop by `new_goals`
* `FulfillCtxt` - by adding the nested obligations to the fulfillment's pending obligations
* `InferCtxt::evaluate_obligation` - ~~by returning `EvaluationResult::EvaluatedToAmbig` (boo :-1:, see the FIXME)~~ same behavior as above, since we use fulfillment and `select_where_possible`

The only one that's truly sketchy is `evaluate_obligation`, but it's not hard to modify this behavior moving forward.

From #109037, I think a smaller repro could be crafted if I were smarter, but I am not, so I just took this from #105878.

r? @lcnr cc @BoxyUwU 