### PR TITLE
Give return-position impl traits in trait a (synthetic) name to avoid name collisions with new lowering strategy 

### DIFF
--- a/compiler/rustc_hir/src/definitions.rs
+++ b/compiler/rustc_hir/src/definitions.rs
@@ -404,12 +404,8 @@ impl DefPathData {
         match *self {
             TypeNs(name) | ValueNs(name) | MacroNs(name) | LifetimeNs(name) => Some(name),
 
-            // We use this name when collecting `ModChild`s.
-            // FIXME this could probably be removed with some refactoring to the name resolver.
-            ImplTraitAssocTy => Some(kw::Empty),
-
             Impl | ForeignMod | CrateRoot | Use | GlobalAsm | ClosureExpr | Ctor | AnonConst
-            | ImplTrait => None,
+            | ImplTrait | ImplTraitAssocTy => None,
         }
     }
 

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1021,7 +1021,9 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
             } else {
                 // Iterate over all children.
                 for child_index in self.root.tables.children.get(self, id).unwrap().decode(self) {
-                    yield self.get_mod_child(child_index, sess);
+                    if self.root.tables.opt_rpitit_info.get(self, child_index).is_none() {
+                        yield self.get_mod_child(child_index, sess);
+                    }
                 }
 
                 if let Some(reexports) = self.root.tables.module_reexports.get(self, id) {
@@ -1067,8 +1069,11 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
     }
 
     fn get_associated_item(self, id: DefIndex, sess: &'a Session) -> ty::AssocItem {
-        let name = self.item_name(id);
-
+        let name = if self.root.tables.opt_rpitit_info.get(self, id).is_some() {
+            kw::Empty
+        } else {
+            self.item_name(id)
+        };
         let (kind, has_self) = match self.def_kind(id) {
             DefKind::AssocConst => (ty::AssocKind::Const, false),
             DefKind::AssocFn => (ty::AssocKind::Fn, self.get_fn_has_self_parameter(id, sess)),

--- a/tests/ui/impl-trait/in-trait/auxiliary/rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/auxiliary/rpitit.rs
@@ -2,12 +2,13 @@
 
 #![feature(return_position_impl_trait_in_trait)]
 
+use std::ops::Deref;
+
 pub trait Foo {
-    fn bar() -> impl Sized;
+    fn bar() -> impl Deref<Target = impl Sized>;
 }
 
 pub struct Foreign;
-
 impl Foo for Foreign {
-    fn bar() {}
+    fn bar() -> &'static () { &() }
 }

--- a/tests/ui/impl-trait/in-trait/doesnt-satisfy.next.stderr
+++ b/tests/ui/impl-trait/in-trait/doesnt-satisfy.next.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Foo::{opaque#0}`
   --> $DIR/doesnt-satisfy.rs:8:22
    |
 LL |     fn bar() -> impl std::fmt::Display;
-   |                      ^^^^^^^^^^^^^^^^^ required by this bound in `Foo::`
+   |                      ^^^^^^^^^^^^^^^^^ required by this bound in `Foo::{opaque#0}`
 
 error: aborting due to previous error
 

--- a/tests/ui/impl-trait/in-trait/foreign.rs
+++ b/tests/ui/impl-trait/in-trait/foreign.rs
@@ -5,7 +5,17 @@
 
 extern crate rpitit;
 
+use std::sync::Arc;
+
+// Implement an RPITIT from another crate.
+struct Local;
+impl rpitit::Foo for Local {
+    fn bar() -> Arc<String> { Arc::new(String::new()) }
+}
+
 fn main() {
-    // Witness an RPITIT from another crate
-    let () = <rpitit::Foreign as rpitit::Foo>::bar();
+    // Witness an RPITIT from another crate.
+    let &() = <rpitit::Foreign as rpitit::Foo>::bar();
+
+    let x: Arc<String> = <Local as rpitit::Foo>::bar();
 }

--- a/tests/ui/impl-trait/in-trait/nested-rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/nested-rpitit.rs
@@ -1,4 +1,6 @@
 // check-pass
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(return_position_impl_trait_in_trait)]
 #![allow(incomplete_features)]

--- a/tests/ui/rfc-1937-termination-trait/issue-103052-2.current.stderr
+++ b/tests/ui/rfc-1937-termination-trait/issue-103052-2.current.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `Something: Termination` is not satisfied
+  --> $DIR/issue-103052-2.rs:15:22
+   |
+LL |         fn main() -> Something {
+   |                      ^^^^^^^^^ the trait `Termination` is not implemented for `Something`
+   |
+note: required by a bound in `Main::main::{opaque#0}`
+  --> $DIR/issue-103052-2.rs:9:27
+   |
+LL |         fn main() -> impl std::process::Termination;
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Main::main::{opaque#0}`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/rfc-1937-termination-trait/issue-103052-2.next.stderr
+++ b/tests/ui/rfc-1937-termination-trait/issue-103052-2.next.stderr
@@ -1,14 +1,14 @@
 error[E0277]: the trait bound `Something: Termination` is not satisfied
-  --> $DIR/issue-103052-2.rs:12:22
+  --> $DIR/issue-103052-2.rs:15:22
    |
 LL |         fn main() -> Something {
    |                      ^^^^^^^^^ the trait `Termination` is not implemented for `Something`
    |
-note: required by a bound in `Main::main::{opaque#0}`
-  --> $DIR/issue-103052-2.rs:6:27
+note: required by a bound in `Main::{opaque#0}`
+  --> $DIR/issue-103052-2.rs:9:27
    |
 LL |         fn main() -> impl std::process::Termination;
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Main::main::{opaque#0}`
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Main::{opaque#0}`
 
 error: aborting due to previous error
 

--- a/tests/ui/rfc-1937-termination-trait/issue-103052-2.rs
+++ b/tests/ui/rfc-1937-termination-trait/issue-103052-2.rs
@@ -1,3 +1,6 @@
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
+
 #![feature(return_position_impl_trait_in_trait)]
 #![allow(incomplete_features)]
 
@@ -9,7 +12,8 @@ mod child {
     struct Something;
 
     impl Main for () {
-        fn main() -> Something { //~ ERROR the trait bound `Something: Termination` is not satisfied
+        fn main() -> Something {
+            //~^ ERROR the trait bound `Something: Termination` is not satisfied
             Something
         }
     }


### PR DESCRIPTION
The only needed commit from this PR is the last one.

r? @compiler-errors 

Needs #109455.