### PR TITLE
make param bound vars visibly bound vars with -Zverbose

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -704,7 +704,11 @@ pub trait PrettyPrinter<'tcx>:
                 ty::BoundTyKind::Anon(bv) => {
                     self.pretty_print_bound_var(debruijn, ty::BoundVar::from_u32(bv))?
                 }
-                ty::BoundTyKind::Param(_, s) => p!(write("{}", s)),
+                ty::BoundTyKind::Param(_, s) => match self.should_print_verbose() {
+                    true if debruijn == ty::INNERMOST => p!(write("^{}", s)),
+                    true => p!(write("^{}_{}", debruijn.index(), s)),
+                    false => p!(write("{}", s)),
+                },
             },
             ty::Adt(def, substs) => {
                 p!(print_def_path(def.did(), substs));


### PR DESCRIPTION
I was trying to debug some type/const bound var stuff and it was shockingly tricky due to the fact that even with `-Zverbose` enabled the `T` in `for<T> T: Trait` prints as `T` making it seem like its `TyKind::Param` when it is infact `TyKind::Bound`. This PR "fixes" this when `-Zverbose` is set to allow rendering it as `^T` or `^1_T` depending on binder depth.

r? @compiler-errors 