### PR TITLE
Add support for big archive format

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -552,6 +552,7 @@ pub enum ArchiveKind {
     K_BSD,
     K_DARWIN,
     K_COFF,
+    K_AIXBIG,
 }
 
 // LLVMRustThinLTOData

--- a/compiler/rustc_codegen_llvm/src/llvm/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/mod.rs
@@ -137,6 +137,7 @@ impl FromStr for ArchiveKind {
             "bsd" => Ok(ArchiveKind::K_BSD),
             "darwin" => Ok(ArchiveKind::K_DARWIN),
             "coff" => Ok(ArchiveKind::K_COFF),
+            "aix_big" => Ok(ArchiveKind::K_AIXBIG),
             _ => Err(()),
         }
     }

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -233,6 +233,7 @@ impl<'a> ArArchiveBuilder<'a> {
             "bsd" => ArchiveKind::Bsd,
             "darwin" => ArchiveKind::Darwin,
             "coff" => ArchiveKind::Coff,
+            "aix_big" => ArchiveKind::AixBig,
             kind => {
                 self.sess.emit_fatal(UnknownArchiveKind { kind });
             }

--- a/compiler/rustc_llvm/llvm-wrapper/ArchiveWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/ArchiveWrapper.cpp
@@ -39,6 +39,7 @@ enum class LLVMRustArchiveKind {
   BSD,
   DARWIN,
   COFF,
+  AIXBIG,
 };
 
 static Archive::Kind fromRust(LLVMRustArchiveKind Kind) {
@@ -51,6 +52,8 @@ static Archive::Kind fromRust(LLVMRustArchiveKind Kind) {
     return Archive::K_DARWIN;
   case LLVMRustArchiveKind::COFF:
     return Archive::K_COFF;
+  case LLVMRustArchiveKind::AIXBIG:
+    return Archive::K_AIXBIG;
   default:
     report_fatal_error("Bad ArchiveKind.");
   }


### PR DESCRIPTION
This helps generating static libraries on AIX. Change in ar_archive_writer is already merged https://github.com/rust-lang/ar_archive_writer/pull/2.