### PR TITLE
Link against libc++ on AIX

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -333,6 +333,7 @@ fn main() {
     } else if target.contains("darwin")
         || target.contains("freebsd")
         || target.contains("windows-gnullvm")
+        || target.contains("aix")
     {
         "c++"
     } else if target.contains("netbsd") && llvm_static_stdcpp.is_some() {


### PR DESCRIPTION
LLVM on AIX currently is utilizing runtimes in llvm-project, such as libc++, libc++abi and libunwind.