### PR TITLE
Rpath is not supported on AIX

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1554,7 +1554,7 @@ impl<'a> Builder<'a> {
                 // flesh out rpath support more fully in the future.
                 rustflags.arg("-Zosx-rpath-install-name");
                 Some("-Wl,-rpath,@loader_path/../lib")
-            } else if !target.contains("windows") {
+            } else if !target.contains("windows") && !target.contains("aix") {
                 rustflags.arg("-Clink-args=-Wl,-z,origin");
                 Some("-Wl,-rpath,$ORIGIN/../lib")
             } else {


### PR DESCRIPTION
Both `-Wl,-rapth` and `-Wl,-z,origin` are not supported on AIX.

AIX linker is documented in https://www.ibm.com/docs/en/aix/7.1?topic=l-ld-command.