### PR TITLE
LIBPATH is used as dylib's path environment variable on AIX

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -741,6 +741,9 @@ class RustBuild(object):
         env["LIBRARY_PATH"] = os.path.join(self.bin_root(), "lib") + \
             (os.pathsep + env["LIBRARY_PATH"]) \
             if "LIBRARY_PATH" in env else ""
+        env["LIBPATH"] = os.path.join(self.bin_root(), "lib") + \
+            (os.pathsep + env["LIBPATH"]) \
+            if "LIBPATH" in env else ""
 
         # Export Stage0 snapshot compiler related env variables
         build_section = "target.{}".format(self.build)

--- a/src/bootstrap/dylib_util.rs
+++ b/src/bootstrap/dylib_util.rs
@@ -12,6 +12,8 @@ pub fn dylib_path_var() -> &'static str {
         "DYLD_LIBRARY_PATH"
     } else if cfg!(target_os = "haiku") {
         "LIBRARY_PATH"
+    } else if cfg!(target_os = "aix") {
+        "LIBPATH"
     } else {
         "LD_LIBRARY_PATH"
     }

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -156,6 +156,8 @@ pub fn dylib_env_var() -> &'static str {
         "DYLD_LIBRARY_PATH"
     } else if cfg!(target_os = "haiku") {
         "LIBRARY_PATH"
+    } else if cfg!(target_os = "aix") {
+        "LIBPATH"
     } else {
         "LD_LIBRARY_PATH"
     }


### PR DESCRIPTION
See https://4js.com/online_documentation/fjs-fgl-3.00.05-manual-html/c_fgl_installation_017.html.