### PR TITLE
rustdoc: Unsupport importing `doc(primitive)` and `doc(keyword)` modules

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -232,14 +232,6 @@ impl ExternalCrate {
                         hir::ItemKind::Mod(_) => {
                             as_keyword(Res::Def(DefKind::Mod, id.owner_id.to_def_id()))
                         }
-                        hir::ItemKind::Use(path, hir::UseKind::Single)
-                            if tcx.visibility(id.owner_id).is_public() =>
-                        {
-                            path.res
-                                .iter()
-                                .find_map(|res| as_keyword(res.expect_non_local()))
-                                .map(|(_, prim)| (id.owner_id.to_def_id(), prim))
-                        }
                         _ => None,
                     }
                 })
@@ -301,15 +293,6 @@ impl ExternalCrate {
                     match item.kind {
                         hir::ItemKind::Mod(_) => {
                             as_primitive(Res::Def(DefKind::Mod, id.owner_id.to_def_id()))
-                        }
-                        hir::ItemKind::Use(path, hir::UseKind::Single)
-                            if tcx.visibility(id.owner_id).is_public() =>
-                        {
-                            path.res
-                                .iter()
-                                .find_map(|res| as_primitive(res.expect_non_local()))
-                                // Pretend the primitive is local.
-                                .map(|(_, prim)| (id.owner_id.to_def_id(), prim))
                         }
                         _ => None,
                     }

--- a/tests/rustdoc/issue-15318-2.rs
+++ b/tests/rustdoc/issue-15318-2.rs
@@ -6,7 +6,7 @@ extern crate issue_15318;
 
 pub use issue_15318::ptr;
 
-// @has issue_15318_2/fn.bar.html \
+// @!has issue_15318_2/fn.bar.html \
 //          '//*[@href="primitive.pointer.html"]' \
 //          '*mut T'
 pub fn bar<T>(ptr: *mut T) {}


### PR DESCRIPTION
These are internal features used for a specific purpose, and modules without imports are enough for that purpose.