### PR TITLE
For compiletests, use the linker if present.

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1897,6 +1897,10 @@ impl<'test> TestCx<'test> {
         // Use a single thread for efficiency and a deterministic error message order
         rustc.arg("-Zthreads=1");
 
+        if let Some(ref linker) = self.config.linker {
+            rustc.arg(format!("-Clinker={}", linker));
+        }
+
         // Optionally prevent default --target if specified in test compile-flags.
         let custom_target = self.props.compile_flags.iter().any(|x| x.starts_with("--target"));
 


### PR DESCRIPTION
When running `x.py test tests/ui` with a custom linker script, we found that 204 tests actually invoke the default linker (/usr/bin/ld) instead of the linker script. Depending on the system linker, this will cause those tests to fail. Many of the failing tests (196) use `// aux-build:...` directives. One such example is tests/ui/annotate-snippet/multispan.rs.

In cases where there were failures, we ran with -v and confirmed that we saw "`linker: Some(<path deleted>)`" when the compiletest configuration was dumped. Nevertheless, the rustc command lines for the failing tests did not contain `-Clinker=XXX`, resulting in errors like the following:

```
= note: /usr/bin/ld: /path/to/libunwind.a(UnwindLevel1-gcc-ext.o): unrecognized relocation (0x2a) in section `.text._Unwind_GetDataRelBase'
        /usr/bin/ld: final link failed: Bad value
	collect2: error: ld returned 1 exit status
```