### PR TITLE
remove spans from instantiated predicates if not used

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -880,7 +880,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
             .infcx
             .tcx
             .predicates_of(self.body.source.def_id())
-            .instantiate_identity(self.infcx.tcx)
+            .instantiate_identity_without_spans(self.infcx.tcx)
             .predicates;
 
         if let Some(upvar_index) = self

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -173,7 +173,7 @@ fn compare_method_predicate_entailment<'tcx>(
     // however, because we want to replace all late-bound regions with
     // region variables.
     let impl_predicates = tcx.predicates_of(impl_m_predicates.parent.unwrap());
-    let mut hybrid_preds = impl_predicates.instantiate_identity(tcx);
+    let mut hybrid_preds = impl_predicates.instantiate_identity_without_spans(tcx);
 
     debug!("compare_impl_method: impl_bounds={:?}", hybrid_preds);
 
@@ -1799,7 +1799,7 @@ fn compare_type_predicate_entailment<'tcx>(
     // The predicates declared by the impl definition, the trait and the
     // associated type in the trait are assumed.
     let impl_predicates = tcx.predicates_of(impl_ty_predicates.parent.unwrap());
-    let mut hybrid_preds = impl_predicates.instantiate_identity(tcx);
+    let mut hybrid_preds = impl_predicates.instantiate_identity_without_spans(tcx);
     hybrid_preds.predicates.extend(
         trait_ty_predicates
             .instantiate_own(tcx, trait_to_impl_substs)

--- a/compiler/rustc_hir_analysis/src/check/dropck.rs
+++ b/compiler/rustc_hir_analysis/src/check/dropck.rs
@@ -141,7 +141,8 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
     // hold.
     let generic_assumptions = tcx.predicates_of(self_type_did);
 
-    let assumptions_in_impl_context = generic_assumptions.instantiate(tcx, &self_to_impl_substs);
+    let assumptions_in_impl_context =
+        generic_assumptions.instantiate_without_spans(tcx, &self_to_impl_substs);
     let assumptions_in_impl_context = assumptions_in_impl_context.predicates;
 
     debug!(?assumptions_in_impl_context, ?dtor_predicates.predicates);

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1441,8 +1441,8 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
 
     let predicates = wfcx.normalize(span, None, predicates);
 
-    debug!(?predicates.predicates);
-    assert_eq!(predicates.predicates.len(), predicates.spans.len());
+    debug!(?predicates.predicates_alongside_spans);
+    assert_eq!(predicates.predicates_alongside_spans.len(), predicates.spans.len());
     let wf_obligations = predicates.into_iter().flat_map(|(p, sp)| {
         traits::wf::predicate_obligations(
             infcx,

--- a/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
@@ -321,7 +321,7 @@ fn check_predicates<'tcx>(
     let impl1_predicates: Vec<_> = traits::elaborate_predicates_with_span(
         tcx,
         std::iter::zip(
-            instantiated.predicates,
+            instantiated.predicates_alongside_spans,
             // Don't drop predicates (unsound!) because `spans` is too short
             instantiated.spans.into_iter().chain(std::iter::repeat(span)),
         ),
@@ -337,7 +337,7 @@ fn check_predicates<'tcx>(
         traits::elaborate_predicates(
             tcx,
             tcx.predicates_of(impl2_node.def_id())
-                .instantiate(tcx, impl2_substs)
+                .instantiate_without_spans(tcx, impl2_substs)
                 .predicates
                 .into_iter(),
         )

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
@@ -20,7 +20,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let hir::Node::Expr(expr) = hir.get(hir_id) else { return false; };
 
         let Some(unsubstituted_pred) =
-            self.tcx.predicates_of(def_id).instantiate_identity(self.tcx).predicates.into_iter().nth(idx)
+            self.tcx.predicates_of(def_id).instantiate_identity_without_spans(self.tcx).predicates.into_iter().nth(idx)
             else { return false; };
 
         let generics = self.tcx.generics_of(def_id);

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -158,7 +158,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
 
             let where_clause_bounds = tcx
                 .predicates_of(impl_def_id)
-                .instantiate(tcx, impl_substs)
+                .instantiate_without_spans(tcx, impl_substs)
                 .predicates
                 .into_iter()
                 .map(|pred| goal.with(tcx, pred));

--- a/compiler/rustc_trait_selection/src/solve/trait_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals.rs
@@ -70,7 +70,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
             ecx.eq(goal.param_env, goal.predicate.trait_ref, impl_trait_ref)?;
             let where_clause_bounds = tcx
                 .predicates_of(impl_def_id)
-                .instantiate(tcx, impl_substs)
+                .instantiate_without_spans(tcx, impl_substs)
                 .predicates
                 .into_iter()
                 .map(|pred| goal.with(tcx, pred));
@@ -184,7 +184,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
         ecx.probe(|ecx| {
             let nested_obligations = tcx
                 .predicates_of(goal.predicate.def_id())
-                .instantiate(tcx, goal.predicate.trait_ref.substs);
+                .instantiate_without_spans(tcx, goal.predicate.trait_ref.substs);
             ecx.add_goals(nested_obligations.predicates.into_iter().map(|p| goal.with(tcx, p)));
             ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
         })

--- a/compiler/rustc_trait_selection/src/solve/trait_goals/structural_traits.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals/structural_traits.rs
@@ -294,7 +294,9 @@ pub(crate) fn predicates_for_object_candidate<'tcx>(
     let tcx = ecx.tcx();
     let mut requirements = vec![];
     requirements.extend(
-        tcx.super_predicates_of(trait_ref.def_id).instantiate(tcx, trait_ref.substs).predicates,
+        tcx.super_predicates_of(trait_ref.def_id)
+            .instantiate_without_spans(tcx, trait_ref.substs)
+            .predicates,
     );
     for item in tcx.associated_items(trait_ref.def_id).in_definition_order() {
         // FIXME(associated_const_equality): Also add associated consts to

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -132,7 +132,10 @@ fn with_fresh_ty_vars<'cx, 'tcx>(
         impl_def_id,
         self_ty: tcx.type_of(impl_def_id).subst(tcx, impl_substs),
         trait_ref: tcx.impl_trait_ref(impl_def_id).map(|i| i.subst(tcx, impl_substs)),
-        predicates: tcx.predicates_of(impl_def_id).instantiate(tcx, impl_substs).predicates,
+        predicates: tcx
+            .predicates_of(impl_def_id)
+            .instantiate_without_spans(tcx, impl_substs)
+            .predicates,
     };
 
     let InferOk { value: mut header, obligations } =

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/ambiguity.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/ambiguity.rs
@@ -36,7 +36,8 @@ pub fn recompute_applicable_impls<'tcx>(
             return false;
         }
 
-        let impl_predicates = tcx.predicates_of(impl_def_id).instantiate(tcx, impl_substs);
+        let impl_predicates =
+            tcx.predicates_of(impl_def_id).instantiate_without_spans(tcx, impl_substs);
         ocx.register_obligations(impl_predicates.predicates.iter().map(|&predicate| {
             Obligation::new(tcx, ObligationCause::dummy(), param_env, predicate)
         }));

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2111,7 +2111,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         // that the predicate that we failed to satisfy is a `Fn`-like trait.
         if let ObligationCauseCode::ExprBindingObligation(def_id, _, _, idx) = cause
             && let predicates = self.tcx.predicates_of(def_id).instantiate_identity(self.tcx)
-            && let Some(pred) = predicates.predicates.get(*idx)
+            && let Some(pred) = predicates.predicates_alongside_spans.get(*idx)
             && let ty::PredicateKind::Clause(ty::Clause::Trait(trait_pred)) = pred.kind().skip_binder()
             && self.tcx.is_fn_trait(trait_pred.def_id())
         {
@@ -3573,7 +3573,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
             if let ObligationCauseCode::ExprBindingObligation(def_id, _, _, idx) = parent_code.deref()
                 && let Some(node_substs) = typeck_results.node_substs_opt(call_hir_id)
-                && let where_clauses = self.tcx.predicates_of(def_id).instantiate(self.tcx, node_substs)
+                && let where_clauses = self.tcx.predicates_of(def_id).instantiate_without_spans(self.tcx, node_substs)
                 && let Some(where_pred) = where_clauses.predicates.get(*idx)
             {
                 if let Some(where_pred) = where_pred.to_opt_poly_trait_pred()

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -410,7 +410,7 @@ fn subst_and_check_impossible_predicates<'tcx>(
 ) -> bool {
     debug!("subst_and_check_impossible_predicates(key={:?})", key);
 
-    let mut predicates = tcx.predicates_of(key.0).instantiate(tcx, key.1).predicates;
+    let mut predicates = tcx.predicates_of(key.0).instantiate_without_spans(tcx, key.1).predicates;
 
     // Specifically check trait fulfillment to avoid an error when trying to resolve
     // associated items.

--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -378,7 +378,7 @@ fn generics_require_sized_self(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
 
     // Search for a predicate like `Self : Sized` amongst the trait bounds.
     let predicates = tcx.predicates_of(def_id);
-    let predicates = predicates.instantiate_identity(tcx).predicates;
+    let predicates = predicates.instantiate_identity_without_spans(tcx).predicates;
     elaborate_predicates(tcx, predicates.into_iter()).any(|obligation| {
         match obligation.predicate.kind().skip_binder() {
             ty::PredicateKind::Clause(ty::Clause::Trait(ref trait_pred)) => {

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -469,7 +469,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // will be checked in the code below.
         for super_trait in tcx
             .super_predicates_of(trait_predicate.def_id())
-            .instantiate(tcx, trait_predicate.trait_ref.substs)
+            .instantiate_without_spans(tcx, trait_predicate.trait_ref.substs)
             .predicates
             .into_iter()
         {

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -770,7 +770,7 @@ impl<'tcx> WfPredicates<'tcx> {
 
         let predicates = predicates.instantiate(self.tcx, substs);
         trace!("{:#?}", predicates);
-        debug_assert_eq!(predicates.predicates.len(), origins.len());
+        debug_assert_eq!(predicates.predicates_alongside_spans.len(), origins.len());
 
         iter::zip(predicates, origins.into_iter().rev())
             .map(|((mut pred, span), origin_def_id)| {

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -119,8 +119,8 @@ fn adt_sized_constraint(tcx: TyCtxt<'_>, def_id: DefId) -> &[Ty<'_>] {
 /// See `ParamEnv` struct definition for details.
 fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
     // Compute the bounds on Self and the type parameters.
-    let ty::InstantiatedPredicates { mut predicates, .. } =
-        tcx.predicates_of(def_id).instantiate_identity(tcx);
+    let ty::InstantiatedPredicatesWithoutSpans { mut predicates } =
+        tcx.predicates_of(def_id).instantiate_identity_without_spans(tcx);
 
     // When computing the param_env of an RPITIT, use predicates of the containing function,
     // *except* for the additional assumption that the RPITIT normalizes to the trait method's
@@ -133,7 +133,8 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
     if let Some(ImplTraitInTraitData::Trait { fn_def_id, .. })
     | Some(ImplTraitInTraitData::Impl { fn_def_id, .. }) = tcx.opt_rpitit_info(def_id)
     {
-        predicates = tcx.predicates_of(fn_def_id).instantiate_identity(tcx).predicates;
+        predicates =
+            tcx.predicates_of(fn_def_id).instantiate_identity_without_spans(tcx).predicates;
     }
 
     // Finally, we have to normalize the bounds in the environment, in
@@ -352,8 +353,8 @@ fn well_formed_types_in_env(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::List<Predica
     }
 
     // Compute the bounds on `Self` and the type parameters.
-    let ty::InstantiatedPredicates { predicates, .. } =
-        tcx.predicates_of(def_id).instantiate_identity(tcx);
+    let ty::InstantiatedPredicatesWithoutSpans { predicates } =
+        tcx.predicates_of(def_id).instantiate_identity_without_spans(tcx);
 
     let clauses = predicates.into_iter();
 

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -63,7 +63,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                 let predicates = cx
                     .tcx
                     .predicates_of(impl_def_id)
-                    .instantiate(cx.tcx, impl_substs)
+                    .instantiate_without_spans(cx.tcx, impl_substs)
                     .predicates
                     .into_iter()
                     .chain(Some(ty::Binder::dummy(impl_trait_ref).to_predicate(infcx.tcx)));


### PR DESCRIPTION
This is a small performance tweak to a group of functions that show up throughout type-checking:

- `GenericPredicates::instantiate_identity`
- `GenericPredicates::instantiate`

These functions effectively copy the `Vec<(Predicate, Span)>` in the original `GenericPredicates` into two `Vec`s (`predicates` and `spans`) in the resulting `InstantiatedPredicates`. However, in quite a few cases, these functions are called like

```rs
some_generic
  .instantiate_identity()
  .predicates
```

which means that the `spans` vector is being built for no reason. A quick experiment suggest to me that Rustc can't compile these unused `Vec`s away, so I figured it may be possible to get a very small performance improvement by explicitly making a `_without_spans` version for each of these functions.

In order to more-carefully audit which calls needed `spans` and which didn't, I also renamed the original `predicates` field to `predicates_alongside_spans` -- this way it's clearer that you shouldn't use this version if you don't care about the `spans`.

---

It may also be possible to apply the same optimization (if this is at all effective) to `predicates_of`-- since this function also allocates a `Vec` of `Predicate` + `Span` values. However, since this is a query function whose result is presumably cached, it seems like the benefit there may be smaller.

Another possibility would be to make `InstantiatedPredicates` lazier (or at least provide a lazy version) which only references the original `GenericPredicates` instead of copying from it.