### PR TITLE
Use llvm 16.0.0 instead of 16.0.0-rc4 for build-clang.sh

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-16.0.0-rc4
+LLVM=llvmorg-16.0.0
 
 mkdir llvm-project
 cd llvm-project


### PR DESCRIPTION
Ref: https://github.com/rust-lang/rust/pull/107224

This PR doesn't make any update on LLVM submodule used by Rust repo, but would be super keen to update it, if necessary (https://rustc-dev-guide.rust-lang.org/backend/updating-llvm.html). LLVM 16.0.0 has been [released](https://discourse.llvm.org/t/llvm-16-0-0-release/69326) on March 18, while Rust 1.70 will become stable on June 1.

- https://releases.llvm.org/16.0.0/docs/ReleaseNotes.html