### PR TITLE
bootstrap: create directory junction target if it does not exist

### DIFF
--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -185,6 +185,11 @@ pub fn symlink_dir(config: &Config, src: &Path, dest: &Path) -> io::Result<()> {
             Ok(s.as_ref().encode_wide().chain(Some(0)).collect())
         }
 
+        if !target.exists() {
+            // Windows requires that the target of a junction exists.
+            fs::create_dir_all(&target)?;
+        }
+
         // We're using low-level APIs to create the junction, and these are more
         // picky about paths. For example, forward slashes cannot be used as a
         // path separator, so we should try to canonicalize the path first.


### PR DESCRIPTION
#104854 added the creation of a `build/host` symlink  that points to the `build/<host_triple>` directory. However, the target directory might not exist, which causes a panic on Windows.

The directory is normally created when downloading the bootstrap tools, but if the user manually configures `build.rustc` and `build.cargo` on a clean Windows environment then the build will fail with the panic `symlink_dir(..) failed with ..` because the target directory hasn't been created yet.

This fixes the issue by creating the directory junction target if it does not exist. It's not an issue on non-Windows platforms, because they use symlinks instead of junctions which are allowed to point to non-existent entities (and it will be created later).

r? @wesleywiser 