### PR TITLE
Prefer param-env candidates that do no inference in new solver

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/assembly.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly.rs
@@ -565,6 +565,8 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
     ) -> bool {
         // FIXME: implement this
         match (candidate.source, other.source) {
+            (CandidateSource::ParamEnv(_), CandidateSource::ParamEnv(_)) => false,
+            (_, CandidateSource::ParamEnv(_)) if other.result.has_only_region_constraints() => true,
             (CandidateSource::Impl(_), _)
             | (CandidateSource::ParamEnv(_), _)
             | (CandidateSource::AliasBound, _)

--- a/compiler/rustc_trait_selection/src/solve/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/mod.rs
@@ -52,12 +52,19 @@ enum SolverMode {
 
 trait CanonicalResponseExt {
     fn has_no_inference_or_external_constraints(&self) -> bool;
+
+    fn has_only_region_constraints(&self) -> bool;
 }
 
 impl<'tcx> CanonicalResponseExt for Canonical<'tcx, Response<'tcx>> {
     fn has_no_inference_or_external_constraints(&self) -> bool {
         self.value.external_constraints.region_constraints.is_empty()
             && self.value.var_values.is_identity()
+            && self.value.external_constraints.opaque_types.is_empty()
+    }
+
+    fn has_only_region_constraints(&self) -> bool {
+        self.value.var_values.is_identity()
             && self.value.external_constraints.opaque_types.is_empty()
     }
 }

--- a/compiler/rustc_trait_selection/src/solve/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/mod.rs
@@ -11,6 +11,7 @@
 
 // FIXME: uses of `infcx.at` need to enable deferred projection equality once that's implemented.
 
+use itertools::Itertools;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::canonical::{Canonical, CanonicalVarValues};
 use rustc_infer::traits::query::NoSolution;
@@ -300,9 +301,8 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
 
         // FIXME(-Ztrait-solver=next): We should instead try to find a `Certainty::Yes` response with
         // a subset of the constraints that all the other responses have.
-        let one = candidates[0];
-        if candidates[1..].iter().all(|resp| resp == &one) {
-            return Ok(one);
+        if candidates.iter().all_equal() {
+            return Ok(candidates[0]);
         }
 
         if let Some(response) = candidates.iter().find(|response| {

--- a/tests/ui/traits/new-solver/prefer-candidate-no-constraints.rs
+++ b/tests/ui/traits/new-solver/prefer-candidate-no-constraints.rs
@@ -1,0 +1,22 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+trait Foo {}
+
+impl<T> Foo for T {}
+
+trait Bar {}
+
+struct Wrapper<'a, T>(&'a T);
+
+impl<'a, T> Bar for Wrapper<'a, T> where &'a T: Foo {}
+// We need to satisfy `&'a T: Foo` when checking that this impl is WF
+// that can either be satisfied via the param-env, or via an impl.
+//
+// When satisfied via the param-env, since each lifetime is canonicalized
+// separately, we end up getting extra region constraints.
+//
+// However, when satisfied via the impl, there are no region constraints,
+// and we can short-circuit a response with no external constraints.
+
+fn main() {}

--- a/tests/ui/traits/new-solver/prefer-param-env-on-ambiguity.rs
+++ b/tests/ui/traits/new-solver/prefer-param-env-on-ambiguity.rs
@@ -1,0 +1,10 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+trait Foo<'a> {}
+trait Bar<'a> {}
+
+impl<'a, T: Bar<'a>> Foo<'a> for T {}
+impl<T> Bar<'static> for T {}
+
+fn main() {}


### PR DESCRIPTION
r? @lcnr since we discussed that:
* in the short term, prefer param-env candidates so we can actually wf-check impls that return non-trivial region constraints (see ui tests) -- this *shouldn't* affect coherence where we don't see param-env candidates during coherence, since this is pretty badly affecting any testing of hir typeck with the new solver.
* in the long term, we'd like to take intersections of region responses instead of having to prefer param-env over other candidates.