### PR TITLE
Derive `PartialOrd::{l,g}{e,t}` for fieldless enums as explicit comparisons on `discriminant_value`

### DIFF
--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -1038,6 +1038,26 @@ impl ::core::cmp::PartialOrd for Fieldless {
         let __arg1_tag = ::core::intrinsics::discriminant_value(other);
         ::core::cmp::PartialOrd::partial_cmp(&__self_tag, &__arg1_tag)
     }
+    #[inline]
+    fn lt(&self, other: &Fieldless) -> bool {
+        ::core::intrinsics::discriminant_value(self) <
+            ::core::intrinsics::discriminant_value(other)
+    }
+    #[inline]
+    fn gt(&self, other: &Fieldless) -> bool {
+        ::core::intrinsics::discriminant_value(self) >
+            ::core::intrinsics::discriminant_value(other)
+    }
+    #[inline]
+    fn le(&self, other: &Fieldless) -> bool {
+        ::core::intrinsics::discriminant_value(self) <=
+            ::core::intrinsics::discriminant_value(other)
+    }
+    #[inline]
+    fn ge(&self, other: &Fieldless) -> bool {
+        ::core::intrinsics::discriminant_value(self) >=
+            ::core::intrinsics::discriminant_value(other)
+    }
 }
 #[automatically_derived]
 impl ::core::cmp::Ord for Fieldless {


### PR DESCRIPTION
In unoptimized builds, comparisons against c-like (fieldless) enums end codegening functions like this, one for each of `lt`/`gt`/`le`/`ge` that end up codegenned:

```nasm
<MyType as core::cmp::PartialOrd>::ge:
        push    rax
        call    <MyType as core::cmp::PartialOrd>::partial_cmp
        mov     byte ptr [rsp + 7], al
        mov     eax, 1
        xor     ecx, ecx
        cmp     byte ptr [rsp + 7], 2
        cmove   rax, rcx
        cmp     rax, 1
        jne     .LBB8_2
        mov     al, byte ptr [rsp + 7]
        sub     al, 2
        jb      .LBB8_3
        jmp     .LBB8_2
.LBB8_2:
        mov     byte ptr [rsp + 6], 0
        jmp     .LBB8_4
.LBB8_3:
        mov     byte ptr [rsp + 6], 1
.LBB8_4:
        mov     al, byte ptr [rsp + 6]
        and     al, 1
        movzx   eax, al
        pop     rcx
        ret
```

This is a mess, is slow at runtime, and possibly slow at compile time too (as it's fairly heavy, and needs a bunch of optimizer work to get it cleaned up). After this patch, unoptimized code looks something like this, which is a lot cleaner:

```nasm
<MyType as core::cmp::PartialOrd>::ge:
        sub     rsp, 2
        mov     al, byte ptr [rdi]
        mov     byte ptr [rsp], al
        mov     al, byte ptr [rsp]
        mov     cl, byte ptr [rsi]
        mov     byte ptr [rsp + 1], cl
        mov     cl, byte ptr [rsp + 1]
        cmp     al, cl
        setae   al
        and     al, 1
        movzx   eax, al
        add     rsp, 2
        ret
```

Notes:
1. I don't know what I'm doing in this code, so I'm not sure this is the right way to do it (my hunch is it's not how this should be done, since I'm doing things differently than most other derives).
2. There might even be some correctness issue I'm not realizing (at the very least every test passes on stage1 and stage2, although perhaps it's subtly broken in some way still).
3. I don't know how to write codegen tests, although I'll take a stab at it if this isn't a disaster for compileperf (no idea).
4. This does nothing for empty and unit enums, or enums that have any fields at all.

CC @scottmcm who I discussed this with a bit on discord.