### PR TITLE
Implement `Debug` for C-like enums with an array

### DIFF
--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -989,12 +989,7 @@ impl ::core::marker::Copy for Fieldless { }
 #[automatically_derived]
 impl ::core::fmt::Debug for Fieldless {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        ::core::fmt::Formatter::write_str(f,
-            match self {
-                Fieldless::A => "A",
-                Fieldless::B => "B",
-                Fieldless::C => "C",
-            })
+        ::core::fmt::Formatter::write_str(f, ["A", "B", "C"][*self as usize])
     }
 }
 #[automatically_derived]

--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -989,7 +989,11 @@ impl ::core::marker::Copy for Fieldless { }
 #[automatically_derived]
 impl ::core::fmt::Debug for Fieldless {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        ::core::fmt::Formatter::write_str(f, ["A", "B", "C"][*self as usize])
+        ::core::fmt::Formatter::write_str(f,
+            {
+                const __NAMES: [&str; 3] = ["A", "B", "C"];
+                __NAMES[::core::intrinsics::discriminant_value(self) as usize]
+            })
     }
 }
 #[automatically_derived]


### PR DESCRIPTION
Implement `Debug` for C-like, automatic discriminant, `Copy` enums with `["A", "B", "C"][*self as usize]`
Points to improve:

- Possibly using `unsafe` to avoid a needless bounds check in MIR (should be eliminated, but seems a shame to add a redundant branch)
- ~~Handling enums with an explicit `repr` (currently, only `Copy` enums work~~
- Handle enums with discriminants like `Enum Foo { A = 0, B = 1, C = 2 }` (might not be worth it for the extra complexity)

cc @nnethercote 