### PR TITLE
rustdoc: use a template to generate Hrefs

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -461,7 +461,8 @@ impl Item {
             .iter()
             .filter_map(|ItemLink { link: s, link_text, page_id: id, ref fragment }| {
                 debug!(?id);
-                if let Ok((mut href, ..)) = href(*id, cx) {
+                if let Ok((href, ..)) = href(*id, cx) {
+                    let mut href = href.render_string();
                     debug!(?href);
                     if let Some(ref fragment) = *fragment {
                         fragment.render(&mut href, cx.tcx())

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -977,7 +977,7 @@ fn string_without_closing_tag<T: Display>(
                     LinkFromSrc::External(def_id) => {
                         format::href_with_root_path(*def_id, context, Some(href_context.root_path))
                             .ok()
-                            .map(|(url, _, _)| url)
+                            .map(|(url, _)| url.render_string())
                     }
                     LinkFromSrc::Primitive(prim) => format::href_with_root_path(
                         PrimitiveType::primitive_locations(context.tcx())[prim],
@@ -985,7 +985,7 @@ fn string_without_closing_tag<T: Display>(
                         Some(href_context.root_path),
                     )
                     .ok()
-                    .map(|(url, _, _)| url),
+                    .map(|(url, _)| url.render_string()),
                 }
             })
         {

--- a/src/librustdoc/html/templates/href.html
+++ b/src/librustdoc/html/templates/href.html
@@ -1,0 +1,11 @@
+{%- if !root.is_empty() -%}
+{{root|safe}}/
+{%- endif -%}
+{{parent_directories|safe}}
+{{path_components|safe}}
+{%- if !filename_prefix.is_empty() -%}
+    {{filename_prefix|safe}}.
+{%- endif -%}
+{{filename_base|safe}}
+.html
+{{fragment|safe}}

--- a/src/librustdoc/html/tests.rs
+++ b/src/librustdoc/html/tests.rs
@@ -1,50 +1,50 @@
 use crate::html::format::href_relative_parts;
 use rustc_span::{sym, Symbol};
 
-fn assert_relative_path(expected: &[Symbol], relative_to_fqp: &[Symbol], fqp: &[Symbol]) {
+fn assert_relative_path(expected: (usize, &[Symbol]), relative_to_fqp: &[Symbol], fqp: &[Symbol]) {
     // No `create_default_session_globals_then` call is needed here because all
     // the symbols used are static, and no `Symbol::intern` calls occur.
-    assert_eq!(expected, href_relative_parts(&fqp, &relative_to_fqp).collect::<Vec<_>>());
+    assert_eq!(expected, href_relative_parts(&fqp, &relative_to_fqp));
 }
 
 #[test]
 fn href_relative_parts_basic() {
     let relative_to_fqp = &[sym::std, sym::vec];
     let fqp = &[sym::std, sym::iter];
-    assert_relative_path(&[sym::dotdot, sym::iter], relative_to_fqp, fqp);
+    assert_relative_path((1, &[sym::iter]), relative_to_fqp, fqp);
 }
 
 #[test]
 fn href_relative_parts_parent_module() {
     let relative_to_fqp = &[sym::std, sym::vec];
     let fqp = &[sym::std];
-    assert_relative_path(&[sym::dotdot], relative_to_fqp, fqp);
+    assert_relative_path((1, &[]), relative_to_fqp, fqp);
 }
 
 #[test]
 fn href_relative_parts_different_crate() {
     let relative_to_fqp = &[sym::std, sym::vec];
     let fqp = &[sym::core, sym::iter];
-    assert_relative_path(&[sym::dotdot, sym::dotdot, sym::core, sym::iter], relative_to_fqp, fqp);
+    assert_relative_path((2, &[sym::core, sym::iter]), relative_to_fqp, fqp);
 }
 
 #[test]
 fn href_relative_parts_same_module() {
     let relative_to_fqp = &[sym::std, sym::vec];
     let fqp = &[sym::std, sym::vec];
-    assert_relative_path(&[], relative_to_fqp, fqp);
+    assert_relative_path((0, &[]), relative_to_fqp, fqp);
 }
 
 #[test]
 fn href_relative_parts_child_module() {
     let relative_to_fqp = &[sym::std];
     let fqp = &[sym::std, sym::vec];
-    assert_relative_path(&[sym::vec], relative_to_fqp, fqp);
+    assert_relative_path((0, &[sym::vec]), relative_to_fqp, fqp);
 }
 
 #[test]
 fn href_relative_parts_root() {
     let relative_to_fqp = &[];
     let fqp = &[sym::std];
-    assert_relative_path(&[sym::std], relative_to_fqp, fqp);
+    assert_relative_path((0, &[sym::std]), relative_to_fqp, fqp);
 }

--- a/src/librustdoc/html/url_parts_builder.rs
+++ b/src/librustdoc/html/url_parts_builder.rs
@@ -24,29 +24,6 @@ impl UrlPartsBuilder {
         Self { buf: String::with_capacity(count) }
     }
 
-    /// Create a buffer with one URL component.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```ignore (private-type)
-    /// let builder = UrlPartsBuilder::singleton("core");
-    /// assert_eq!(builder.finish(), "core");
-    /// ```
-    ///
-    /// Adding more components afterward.
-    ///
-    /// ```ignore (private-type)
-    /// let mut builder = UrlPartsBuilder::singleton("core");
-    /// builder.push("str");
-    /// builder.push_front("nightly");
-    /// assert_eq!(builder.finish(), "nightly/core/str");
-    /// ```
-    pub(crate) fn singleton(part: &str) -> Self {
-        Self { buf: part.to_owned() }
-    }
-
     /// Push a component onto the buffer.
     ///
     /// # Examples
@@ -85,29 +62,6 @@ impl UrlPartsBuilder {
             self.buf.push('/');
         }
         self.buf.write_fmt(args).unwrap()
-    }
-
-    /// Push a component onto the front of the buffer.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```ignore (private-type)
-    /// let mut builder = UrlPartsBuilder::new();
-    /// builder.push("core");
-    /// builder.push("str");
-    /// builder.push_front("nightly");
-    /// builder.push("struct.Bytes.html");
-    /// assert_eq!(builder.finish(), "nightly/core/str/struct.Bytes.html");
-    /// ```
-    pub(crate) fn push_front(&mut self, part: &str) {
-        let is_empty = self.buf.is_empty();
-        self.buf.reserve(part.len() + if !is_empty { 1 } else { 0 });
-        self.buf.insert_str(0, part);
-        if !is_empty {
-            self.buf.insert(part.len(), '/');
-        }
     }
 
     /// Get the final `String` buffer.

--- a/src/librustdoc/html/url_parts_builder/tests.rs
+++ b/src/librustdoc/html/url_parts_builder/tests.rs
@@ -10,11 +10,6 @@ fn empty() {
 }
 
 #[test]
-fn singleton() {
-    t(UrlPartsBuilder::singleton("index.html"), "index.html");
-}
-
-#[test]
 fn push_several() {
     let mut builder = UrlPartsBuilder::new();
     builder.push("core");
@@ -24,28 +19,11 @@ fn push_several() {
 }
 
 #[test]
-fn push_front_empty() {
-    let mut builder = UrlPartsBuilder::new();
-    builder.push_front("page.html");
-    t(builder, "page.html");
-}
-
-#[test]
-fn push_front_non_empty() {
-    let mut builder = UrlPartsBuilder::new();
-    builder.push("core");
-    builder.push("str");
-    builder.push("struct.Bytes.html");
-    builder.push_front("nightly");
-    t(builder, "nightly/core/str/struct.Bytes.html");
-}
-
-#[test]
 fn push_fmt() {
     let mut builder = UrlPartsBuilder::new();
+    builder.push("nightly");
     builder.push_fmt(format_args!("{}", "core"));
     builder.push("str");
-    builder.push_front("nightly");
     builder.push_fmt(format_args!("{}.{}.html", "struct", "Bytes"));
     t(builder, "nightly/core/str/struct.Bytes.html");
 }
@@ -58,7 +36,8 @@ fn collect() {
 
 #[test]
 fn extend() {
-    let mut builder = UrlPartsBuilder::singleton("core");
+    let mut builder = UrlPartsBuilder::new();
+    builder.push("core");
     builder.extend(["str", "struct.Bytes.html"]);
     t(builder, "core/str/struct.Bytes.html");
 }


### PR DESCRIPTION
Previously, href always returned a string, so each link incurred at least one allocation. We were also using `"../".repeat()`, and `.collect()` into strings to generate part of the paths. This abstracts away those repetitions into a couple of helper structs, ParentDirectories and PathComponents, and puts them together into an `Href` template, which should save some allocations. As a side benefit, I think it makes the logic of constructing links a little clearer.

This removes the only call sites for certain methods of UrlPartsBuilder, so it also removes those methods.

Also, remove the ItemType return value from `href` and friends; it was basically unused.

Part of #108868