### PR TITLE
`format_args`: insert implicit named arguments by format trait also

### DIFF
--- a/tests/ui/fmt/format-args-point-to-correct-arg-expansion.rs
+++ b/tests/ui/fmt/format-args-point-to-correct-arg-expansion.rs
@@ -1,0 +1,8 @@
+// compile-flags: -Z unpretty=expanded
+// check-pass
+struct X;
+
+fn main() {
+    let x = X;
+    println!("test: {x} {x:?}");
+}

--- a/tests/ui/fmt/format-args-point-to-correct-arg-expansion.stdout
+++ b/tests/ui/fmt/format-args-point-to-correct-arg-expansion.stdout
@@ -1,0 +1,14 @@
+#![feature(prelude_import)]
+#![no_std]
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// compile-flags: -Z unpretty=expanded
+// check-pass
+struct X;
+
+fn main() {
+    let x = X;
+    { ::std::io::_print(format_args!("test: {0} {1:?}\n", x, x)); };
+}

--- a/tests/ui/fmt/format-args-point-to-correct-arg.rs
+++ b/tests/ui/fmt/format-args-point-to-correct-arg.rs
@@ -1,0 +1,13 @@
+struct X;
+
+impl std::fmt::Display for X {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "x")
+    }
+}
+
+fn main() {
+    let x = X;
+    println!("test: {x} {x:?}");
+    //~^ ERROR: `X` doesn't implement `Debug`
+}

--- a/tests/ui/fmt/format-args-point-to-correct-arg.stderr
+++ b/tests/ui/fmt/format-args-point-to-correct-arg.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `X` doesn't implement `Debug`
+  --> $DIR/format-args-point-to-correct-arg.rs:11:26
+   |
+LL |     println!("test: {x} {x:?}");
+   |                          ^ `X` cannot be formatted using `{:?}`
+   |
+   = help: the trait `Debug` is not implemented for `X`
+   = note: add `#[derive(Debug)]` to `X` or manually `impl Debug for X`
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `X` with `#[derive(Debug)]`
+   |
+LL | #[derive(Debug)]
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This fixes #109576 by not using the same argument for implicit named arguments that have the same name but different traits.