### PR TITLE
Fix "Directly go to item in search if there is only one result" setting

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1888,11 +1888,7 @@ function initSearch(rawSearchIndex) {
     function showResults(results, go_to_first, filterCrates) {
         const search = searchState.outputElement();
         if (go_to_first || (results.others.length === 1
-            && getSettingValue("go-to-only-result") === "true"
-            // By default, the search DOM element is "empty" (meaning it has no children not
-            // text content). Once a search has been run, it won't be empty, even if you press
-            // ESC or empty the search input (which also "cancels" the search).
-            && (!search.firstChild || search.firstChild.innerText !== searchState.loadingText))
+            && getSettingValue("go-to-only-result") === "true")
         ) {
             const elem = document.createElement("a");
             elem.href = results.others[0].href;

--- a/tests/rustdoc-gui/setting-go-to-only-result.goml
+++ b/tests/rustdoc-gui/setting-go-to-only-result.goml
@@ -1,0 +1,63 @@
+// Checks that the setting "Directly go to item in search if there is only one result " is working as expected.
+
+define-function: (
+    "check-setting",
+    (storage_value, setting_attribute_value),
+    block {
+        assert-local-storage: {"rustdoc-go-to-only-result": |storage_value|}
+        click: "#settings-menu"
+        wait-for: "#settings"
+        assert-property: ("#go-to-only-result", {"checked": |setting_attribute_value|})
+    }
+)
+
+goto: "file://" + |DOC_PATH| + "/lib2/index.html"
+
+call-function: ("check-setting", {
+    "storage_value": null,
+    "setting_attribute_value": "false",
+})
+
+// By default, the search doesn't automatically go to the page if there is only one result.
+goto: "file://" + |DOC_PATH| + "/lib2/index.html?search=HasALongTraitWithParams"
+// It will timeout if the setting isn't working.
+wait-for: "#search"
+assert-document-property: ({"URL": "/lib2/index.html"}, CONTAINS)
+
+// Now we change its value.
+click: "#settings-menu"
+wait-for: "#settings"
+click: "#go-to-only-result"
+assert-local-storage: {"rustdoc-go-to-only-result": "true"}
+
+goto: "file://" + |DOC_PATH| + "/lib2/index.html"
+// We enter it into the search.
+write: (".search-input", "HasALongTraitWithParams")
+wait-for-document-property: {"title": "HasALongTraitWithParams in lib2 - Rust"}
+assert-document-property: ({"URL": "/lib2/struct.HasALongTraitWithParams.html"}, ENDS_WITH)
+
+// We try again to see if it goes to the only result
+goto: "file://" + |DOC_PATH| + "/lib2/index.html?search=HasALongTraitWithParams"
+wait-for-document-property: {"title": "HasALongTraitWithParams in lib2 - Rust"}
+assert-document-property: ({"URL": "/lib2/struct.HasALongTraitWithParams.html"}, ENDS_WITH)
+
+// We check the settings
+call-function: ("check-setting", {
+    "storage_value": "true",
+    "setting_attribute_value": "true",
+})
+
+// And now we re-disable the setting.
+click: "#go-to-only-result"
+assert-local-storage: {"rustdoc-go-to-only-result": "false"}
+
+goto: "file://" + |DOC_PATH| + "/lib2/index.html?search=HasALongTraitWithParams"
+// It will timeout if the setting isn't working.
+wait-for: "#search"
+assert-document-property: ({"URL": "/lib2/index.html"}, CONTAINS)
+
+// And we check everything is back the way it was before.
+call-function: ("check-setting", {
+    "storage_value": "false",
+    "setting_attribute_value": "false",
+})


### PR DESCRIPTION
Part of #66181.

The setting was actually broken, so I fixed it when I added the GUI test.

r? @notriddle 