### PR TITLE
Add suggestion to remove `derive()` if invoked macro is non-derive

### DIFF
--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -209,3 +209,13 @@ resolve_indeterminate =
 
 resolve_module_only =
     visibility must resolve to a module
+
+resolve_macro_expected_found =
+    expected {$expected}, found {$found} `{$macro_path}`
+
+resolve_remove_surrounding_derive =
+    remove from the surrounding `derive()`
+
+resolve_add_as_non_derive =
+    add as non-Derive macro
+    `#[{$macro_path}]`

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -484,7 +484,7 @@ pub(crate) struct MacroExpectedFound<'a> {
     #[subdiagnostic]
     pub(crate) remove_surrounding_derive: Option<RemoveSurroundingDerive>,
     #[subdiagnostic]
-    pub(crate) remove_surrounding_derive_help: Option<RemoveAddAsNonDerive<'a>>,
+    pub(crate) add_as_non_derive: Option<AddAsNonDerive<'a>>,
 }
 
 #[derive(Subdiagnostic)]
@@ -496,6 +496,6 @@ pub(crate) struct RemoveSurroundingDerive {
 
 #[derive(Subdiagnostic)]
 #[help(resolve_add_as_non_derive)]
-pub(crate) struct RemoveAddAsNonDerive<'a> {
+pub(crate) struct AddAsNonDerive<'a> {
     pub(crate) macro_path: &'a str,
 }

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -472,3 +472,30 @@ pub(crate) struct Indeterminate(#[primary_span] pub(crate) Span);
 #[derive(Diagnostic)]
 #[diag(resolve_module_only)]
 pub(crate) struct ModuleOnly(#[primary_span] pub(crate) Span);
+
+#[derive(Diagnostic, Default)]
+#[diag(resolve_macro_expected_found)]
+pub(crate) struct MacroExpectedFound<'a> {
+    #[primary_span]
+    pub(crate) span: Span,
+    pub(crate) found: &'a str,
+    pub(crate) expected: &'a str,
+    pub(crate) macro_path: &'a str,
+    #[subdiagnostic]
+    pub(crate) remove_surrounding_derive: Option<RemoveSurroundingDerive>,
+    #[subdiagnostic]
+    pub(crate) remove_surrounding_derive_help: Option<RemoveAddAsNonDerive<'a>>,
+}
+
+#[derive(Subdiagnostic)]
+#[help(resolve_remove_surrounding_derive)]
+pub(crate) struct RemoveSurroundingDerive {
+    #[primary_span]
+    pub(crate) span: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[help(resolve_add_as_non_derive)]
+pub(crate) struct RemoveAddAsNonDerive<'a> {
+    pub(crate) macro_path: &'a str,
+}

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -1,7 +1,7 @@
 //! A bunch of methods and structures more or less related to resolving macros and
 //! interface provided by `Resolver` to macro expander.
 
-use crate::errors::{MacroExpectedFound, RemoveAddAsNonDerive, RemoveSurroundingDerive};
+use crate::errors::{AddAsNonDerive, MacroExpectedFound, RemoveSurroundingDerive};
 use crate::Namespace::*;
 use crate::{BuiltinMacroState, Determinacy};
 use crate::{DeriveData, Finalize, ParentScope, ResolutionError, Resolver, ScopeSet};
@@ -559,8 +559,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 && ext.macro_kind() != MacroKind::Derive
             {
                 err.remove_surrounding_derive = Some(RemoveSurroundingDerive { span: path.span });
-                err.remove_surrounding_derive_help =
-                    Some(RemoveAddAsNonDerive { macro_path: &path_str });
+                err.add_as_non_derive = Some(AddAsNonDerive { macro_path: &path_str });
             }
 
             let mut err = self.tcx.sess.create_err(err);

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -549,15 +549,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             err.span_label(path.span, format!("not {} {}", article, expected));
 
             if kind == MacroKind::Derive && ext.macro_kind() != MacroKind::Derive {
-                // Suggest removing the derive() as the macro isn't Derive
-                let opening_span =
-                    path.span.shrink_to_lo().with_lo(path.span.lo() - rustc_span::BytePos(7));
-                let closing_span =
-                    path.span.shrink_to_hi().with_hi(path.span.hi() + rustc_span::BytePos(1));
-                err.span_help(
-                    vec![opening_span, closing_span],
-                    "remove the surrounding \"derive()\":",
-                );
+                // Suggest moving the macro our of the derive() as the macro isn't Derive
+                err.span_help(path.span, "Remove from the surrounding `derive()`");
+                err.help(format!("Add as non-Derive macro\n`#[{}]`", path_str));
             }
 
             err.emit();

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -548,10 +548,12 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
             err.span_label(path.span, format!("not {} {}", article, expected));
 
-            if kind == MacroKind::Derive && ext.macro_kind() != MacroKind::Derive {
+            if !path.span.from_expansion() {
                 // Suggest moving the macro out of the derive() as the macro isn't Derive
-                err.span_help(path.span, "Remove from the surrounding `derive()`");
-                err.help(format!("Add as non-Derive macro\n`#[{}]`", path_str));
+                if kind == MacroKind::Derive && ext.macro_kind() != MacroKind::Derive {
+                    err.span_help(path.span, "Remove from the surrounding `derive()`");
+                    err.help(format!("Add as non-Derive macro\n`#[{}]`", path_str));
+                }
             }
 
             err.emit();

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -549,7 +549,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             err.span_label(path.span, format!("not {} {}", article, expected));
 
             if kind == MacroKind::Derive && ext.macro_kind() != MacroKind::Derive {
-                // Suggest moving the macro our of the derive() as the macro isn't Derive
+                // Suggest moving the macro out of the derive() as the macro isn't Derive
                 err.span_help(path.span, "Remove from the surrounding `derive()`");
                 err.help(format!("Add as non-Derive macro\n`#[{}]`", path_str));
             }

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -548,12 +548,13 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
             err.span_label(path.span, format!("not {} {}", article, expected));
 
-            if !path.span.from_expansion() {
-                // Suggest moving the macro out of the derive() as the macro isn't Derive
-                if kind == MacroKind::Derive && ext.macro_kind() != MacroKind::Derive {
-                    err.span_help(path.span, "Remove from the surrounding `derive()`");
-                    err.help(format!("Add as non-Derive macro\n`#[{}]`", path_str));
-                }
+            // Suggest moving the macro out of the derive() as the macro isn't Derive
+            if !path.span.from_expansion()
+                && kind == MacroKind::Derive
+                && ext.macro_kind() != MacroKind::Derive
+            {
+                err.span_help(path.span, "remove from the surrounding `derive()`");
+                err.help(format!("add as non-Derive macro\n`#[{}]`", path_str));
             }
 
             err.emit();

--- a/tests/ui/macros/macro-path-prelude-fail-4.stderr
+++ b/tests/ui/macros/macro-path-prelude-fail-4.stderr
@@ -2,11 +2,13 @@ error: expected derive macro, found built-in attribute `inline`
   --> $DIR/macro-path-prelude-fail-4.rs:1:10
    |
 LL | #[derive(inline)]
-   |          ^^^^^^
-   |          |
-   |          not a derive macro
-   |          help: Remove from the surrounding `derive()`
+   |          ^^^^^^ not a derive macro
    |
+help: Remove from the surrounding `derive()`
+  --> $DIR/macro-path-prelude-fail-4.rs:1:10
+   |
+LL | #[derive(inline)]
+   |          ^^^^^^
    = help: Add as non-Derive macro
            `#[inline]`
 

--- a/tests/ui/macros/macro-path-prelude-fail-4.stderr
+++ b/tests/ui/macros/macro-path-prelude-fail-4.stderr
@@ -2,13 +2,13 @@ error: expected derive macro, found built-in attribute `inline`
   --> $DIR/macro-path-prelude-fail-4.rs:1:10
    |
 LL | #[derive(inline)]
-   |          ^^^^^^ not a derive macro
+   |          ^^^^^^
+   |          |
+   |          not a derive macro
+   |          help: Remove from the surrounding `derive()`
    |
-help: remove the surrounding "derive()":
-  --> $DIR/macro-path-prelude-fail-4.rs:1:3
-   |
-LL | #[derive(inline)]
-   |   ^^^^^^^      ^
+   = help: Add as non-Derive macro
+           `#[inline]`
 
 error: aborting due to previous error
 

--- a/tests/ui/macros/macro-path-prelude-fail-4.stderr
+++ b/tests/ui/macros/macro-path-prelude-fail-4.stderr
@@ -4,12 +4,12 @@ error: expected derive macro, found built-in attribute `inline`
 LL | #[derive(inline)]
    |          ^^^^^^ not a derive macro
    |
-help: Remove from the surrounding `derive()`
+help: remove from the surrounding `derive()`
   --> $DIR/macro-path-prelude-fail-4.rs:1:10
    |
 LL | #[derive(inline)]
    |          ^^^^^^
-   = help: Add as non-Derive macro
+   = help: add as non-Derive macro
            `#[inline]`
 
 error: aborting due to previous error

--- a/tests/ui/macros/macro-path-prelude-fail-4.stderr
+++ b/tests/ui/macros/macro-path-prelude-fail-4.stderr
@@ -3,6 +3,12 @@ error: expected derive macro, found built-in attribute `inline`
    |
 LL | #[derive(inline)]
    |          ^^^^^^ not a derive macro
+   |
+help: remove the surrounding "derive()":
+  --> $DIR/macro-path-prelude-fail-4.rs:1:3
+   |
+LL | #[derive(inline)]
+   |   ^^^^^^^      ^
 
 error: aborting due to previous error
 

--- a/tests/ui/macros/macro-path-prelude-fail-5.rs
+++ b/tests/ui/macros/macro-path-prelude-fail-5.rs
@@ -1,0 +1,10 @@
+#[derive(Clone, Debug)] // OK
+struct S;
+
+#[derive(Debug, inline)] //~ ERROR expected derive macro, found built-in attribute `inline`
+struct T;
+
+#[derive(inline, Debug)] //~ ERROR expected derive macro, found built-in attribute `inline`
+struct U;
+
+fn main() {}

--- a/tests/ui/macros/macro-path-prelude-fail-5.stderr
+++ b/tests/ui/macros/macro-path-prelude-fail-5.stderr
@@ -1,0 +1,30 @@
+error: expected derive macro, found built-in attribute `inline`
+  --> $DIR/macro-path-prelude-fail-5.rs:4:17
+   |
+LL | #[derive(Debug, inline)]
+   |                 ^^^^^^ not a derive macro
+   |
+help: remove from the surrounding `derive()`
+  --> $DIR/macro-path-prelude-fail-5.rs:4:17
+   |
+LL | #[derive(Debug, inline)]
+   |                 ^^^^^^
+   = help: add as non-Derive macro
+           `#[inline]`
+
+error: expected derive macro, found built-in attribute `inline`
+  --> $DIR/macro-path-prelude-fail-5.rs:7:10
+   |
+LL | #[derive(inline, Debug)]
+   |          ^^^^^^ not a derive macro
+   |
+help: remove from the surrounding `derive()`
+  --> $DIR/macro-path-prelude-fail-5.rs:7:10
+   |
+LL | #[derive(inline, Debug)]
+   |          ^^^^^^
+   = help: add as non-Derive macro
+           `#[inline]`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/proc-macro/macro-namespace-reserved-2.stderr
+++ b/tests/ui/proc-macro/macro-namespace-reserved-2.stderr
@@ -56,13 +56,13 @@ error: expected derive macro, found attribute macro `my_macro_attr`
   --> $DIR/macro-namespace-reserved-2.rs:53:10
    |
 LL | #[derive(my_macro_attr)]
-   |          ^^^^^^^^^^^^^ not a derive macro
+   |          ^^^^^^^^^^^^^
+   |          |
+   |          not a derive macro
+   |          help: Remove from the surrounding `derive()`
    |
-help: remove the surrounding "derive()":
-  --> $DIR/macro-namespace-reserved-2.rs:53:3
-   |
-LL | #[derive(my_macro_attr)]
-   |   ^^^^^^^             ^
+   = help: Add as non-Derive macro
+           `#[my_macro_attr]`
 
 error: can't use a procedural macro from the same crate that defines it
   --> $DIR/macro-namespace-reserved-2.rs:56:10
@@ -92,13 +92,13 @@ error: expected derive macro, found macro `crate::my_macro`
   --> $DIR/macro-namespace-reserved-2.rs:50:10
    |
 LL | #[derive(crate::my_macro)]
-   |          ^^^^^^^^^^^^^^^ not a derive macro
+   |          ^^^^^^^^^^^^^^^
+   |          |
+   |          not a derive macro
+   |          help: Remove from the surrounding `derive()`
    |
-help: remove the surrounding "derive()":
-  --> $DIR/macro-namespace-reserved-2.rs:50:3
-   |
-LL | #[derive(crate::my_macro)]
-   |   ^^^^^^^               ^
+   = help: Add as non-Derive macro
+           `#[crate::my_macro]`
 
 error: cannot find macro `my_macro_attr` in this scope
   --> $DIR/macro-namespace-reserved-2.rs:28:5

--- a/tests/ui/proc-macro/macro-namespace-reserved-2.stderr
+++ b/tests/ui/proc-macro/macro-namespace-reserved-2.stderr
@@ -58,12 +58,12 @@ error: expected derive macro, found attribute macro `my_macro_attr`
 LL | #[derive(my_macro_attr)]
    |          ^^^^^^^^^^^^^ not a derive macro
    |
-help: Remove from the surrounding `derive()`
+help: remove from the surrounding `derive()`
   --> $DIR/macro-namespace-reserved-2.rs:53:10
    |
 LL | #[derive(my_macro_attr)]
    |          ^^^^^^^^^^^^^
-   = help: Add as non-Derive macro
+   = help: add as non-Derive macro
            `#[my_macro_attr]`
 
 error: can't use a procedural macro from the same crate that defines it
@@ -96,12 +96,12 @@ error: expected derive macro, found macro `crate::my_macro`
 LL | #[derive(crate::my_macro)]
    |          ^^^^^^^^^^^^^^^ not a derive macro
    |
-help: Remove from the surrounding `derive()`
+help: remove from the surrounding `derive()`
   --> $DIR/macro-namespace-reserved-2.rs:50:10
    |
 LL | #[derive(crate::my_macro)]
    |          ^^^^^^^^^^^^^^^
-   = help: Add as non-Derive macro
+   = help: add as non-Derive macro
            `#[crate::my_macro]`
 
 error: cannot find macro `my_macro_attr` in this scope

--- a/tests/ui/proc-macro/macro-namespace-reserved-2.stderr
+++ b/tests/ui/proc-macro/macro-namespace-reserved-2.stderr
@@ -56,11 +56,13 @@ error: expected derive macro, found attribute macro `my_macro_attr`
   --> $DIR/macro-namespace-reserved-2.rs:53:10
    |
 LL | #[derive(my_macro_attr)]
-   |          ^^^^^^^^^^^^^
-   |          |
-   |          not a derive macro
-   |          help: Remove from the surrounding `derive()`
+   |          ^^^^^^^^^^^^^ not a derive macro
    |
+help: Remove from the surrounding `derive()`
+  --> $DIR/macro-namespace-reserved-2.rs:53:10
+   |
+LL | #[derive(my_macro_attr)]
+   |          ^^^^^^^^^^^^^
    = help: Add as non-Derive macro
            `#[my_macro_attr]`
 
@@ -92,11 +94,13 @@ error: expected derive macro, found macro `crate::my_macro`
   --> $DIR/macro-namespace-reserved-2.rs:50:10
    |
 LL | #[derive(crate::my_macro)]
-   |          ^^^^^^^^^^^^^^^
-   |          |
-   |          not a derive macro
-   |          help: Remove from the surrounding `derive()`
+   |          ^^^^^^^^^^^^^^^ not a derive macro
    |
+help: Remove from the surrounding `derive()`
+  --> $DIR/macro-namespace-reserved-2.rs:50:10
+   |
+LL | #[derive(crate::my_macro)]
+   |          ^^^^^^^^^^^^^^^
    = help: Add as non-Derive macro
            `#[crate::my_macro]`
 

--- a/tests/ui/proc-macro/macro-namespace-reserved-2.stderr
+++ b/tests/ui/proc-macro/macro-namespace-reserved-2.stderr
@@ -57,6 +57,12 @@ error: expected derive macro, found attribute macro `my_macro_attr`
    |
 LL | #[derive(my_macro_attr)]
    |          ^^^^^^^^^^^^^ not a derive macro
+   |
+help: remove the surrounding "derive()":
+  --> $DIR/macro-namespace-reserved-2.rs:53:3
+   |
+LL | #[derive(my_macro_attr)]
+   |   ^^^^^^^             ^
 
 error: can't use a procedural macro from the same crate that defines it
   --> $DIR/macro-namespace-reserved-2.rs:56:10
@@ -87,6 +93,12 @@ error: expected derive macro, found macro `crate::my_macro`
    |
 LL | #[derive(crate::my_macro)]
    |          ^^^^^^^^^^^^^^^ not a derive macro
+   |
+help: remove the surrounding "derive()":
+  --> $DIR/macro-namespace-reserved-2.rs:50:3
+   |
+LL | #[derive(crate::my_macro)]
+   |   ^^^^^^^               ^
 
 error: cannot find macro `my_macro_attr` in this scope
   --> $DIR/macro-namespace-reserved-2.rs:28:5

--- a/tests/ui/tool-attributes/tool-attributes-misplaced-2.stderr
+++ b/tests/ui/tool-attributes/tool-attributes-misplaced-2.stderr
@@ -4,12 +4,12 @@ error: expected derive macro, found tool attribute `rustfmt::skip`
 LL | #[derive(rustfmt::skip)]
    |          ^^^^^^^^^^^^^ not a derive macro
    |
-help: Remove from the surrounding `derive()`
+help: remove from the surrounding `derive()`
   --> $DIR/tool-attributes-misplaced-2.rs:1:10
    |
 LL | #[derive(rustfmt::skip)]
    |          ^^^^^^^^^^^^^
-   = help: Add as non-Derive macro
+   = help: add as non-Derive macro
            `#[rustfmt::skip]`
 
 error: expected macro, found tool attribute `rustfmt::skip`

--- a/tests/ui/tool-attributes/tool-attributes-misplaced-2.stderr
+++ b/tests/ui/tool-attributes/tool-attributes-misplaced-2.stderr
@@ -2,11 +2,13 @@ error: expected derive macro, found tool attribute `rustfmt::skip`
   --> $DIR/tool-attributes-misplaced-2.rs:1:10
    |
 LL | #[derive(rustfmt::skip)]
-   |          ^^^^^^^^^^^^^
-   |          |
-   |          not a derive macro
-   |          help: Remove from the surrounding `derive()`
+   |          ^^^^^^^^^^^^^ not a derive macro
    |
+help: Remove from the surrounding `derive()`
+  --> $DIR/tool-attributes-misplaced-2.rs:1:10
+   |
+LL | #[derive(rustfmt::skip)]
+   |          ^^^^^^^^^^^^^
    = help: Add as non-Derive macro
            `#[rustfmt::skip]`
 

--- a/tests/ui/tool-attributes/tool-attributes-misplaced-2.stderr
+++ b/tests/ui/tool-attributes/tool-attributes-misplaced-2.stderr
@@ -2,13 +2,13 @@ error: expected derive macro, found tool attribute `rustfmt::skip`
   --> $DIR/tool-attributes-misplaced-2.rs:1:10
    |
 LL | #[derive(rustfmt::skip)]
-   |          ^^^^^^^^^^^^^ not a derive macro
+   |          ^^^^^^^^^^^^^
+   |          |
+   |          not a derive macro
+   |          help: Remove from the surrounding `derive()`
    |
-help: remove the surrounding "derive()":
-  --> $DIR/tool-attributes-misplaced-2.rs:1:3
-   |
-LL | #[derive(rustfmt::skip)]
-   |   ^^^^^^^             ^
+   = help: Add as non-Derive macro
+           `#[rustfmt::skip]`
 
 error: expected macro, found tool attribute `rustfmt::skip`
   --> $DIR/tool-attributes-misplaced-2.rs:5:5

--- a/tests/ui/tool-attributes/tool-attributes-misplaced-2.stderr
+++ b/tests/ui/tool-attributes/tool-attributes-misplaced-2.stderr
@@ -3,6 +3,12 @@ error: expected derive macro, found tool attribute `rustfmt::skip`
    |
 LL | #[derive(rustfmt::skip)]
    |          ^^^^^^^^^^^^^ not a derive macro
+   |
+help: remove the surrounding "derive()":
+  --> $DIR/tool-attributes-misplaced-2.rs:1:3
+   |
+LL | #[derive(rustfmt::skip)]
+   |   ^^^^^^^             ^
 
 error: expected macro, found tool attribute `rustfmt::skip`
   --> $DIR/tool-attributes-misplaced-2.rs:5:5


### PR DESCRIPTION
Adds to the existing `expected derive macro, found {}` error message:
```
help: remove the surrounding "derive()":
  --> $DIR/macro-path-prelude-fail-4.rs:1:3
   |
LL | #[derive(inline)]
   |   ^^^^^^^      ^
```

This suggestion will either fix the issue, in the case that the macro was valid, or provide a better error message if not

Not ready for merge yet, as the highlighted span is only valid for trivial formatting. Is there a nice way to get the parent span of the macro path within `smart_resolve_macro_path`?

Closes #109589