### PR TITLE
debuginfo: Add wrapper to avoid frequent unwraps of the dbg cx

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/create_scope_map.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/create_scope_map.rs
@@ -1,9 +1,9 @@
 use super::metadata::file_metadata;
 use super::utils::DIB;
+use super::DbgCodegenCx;
 use rustc_codegen_ssa::mir::debuginfo::{DebugScope, FunctionDebugContext};
 use rustc_codegen_ssa::traits::*;
 
-use crate::common::CodegenCx;
 use crate::llvm;
 use crate::llvm::debuginfo::{DILocation, DIScope};
 use rustc_middle::mir::{Body, SourceScope};
@@ -17,7 +17,7 @@ use rustc_index::vec::Idx;
 /// Produces DIScope DIEs for each MIR Scope which has variables defined in it.
 // FIXME(eddyb) almost all of this should be in `rustc_codegen_ssa::mir::debuginfo`.
 pub fn compute_mir_scopes<'ll, 'tcx>(
-    cx: &CodegenCx<'ll, 'tcx>,
+    cx: DbgCodegenCx<'_, 'll, 'tcx>,
     instance: Instance<'tcx>,
     mir: &Body<'tcx>,
     debug_context: &mut FunctionDebugContext<&'ll DIScope, &'ll DILocation>,
@@ -47,7 +47,7 @@ pub fn compute_mir_scopes<'ll, 'tcx>(
 }
 
 fn make_mir_scope<'ll, 'tcx>(
-    cx: &CodegenCx<'ll, 'tcx>,
+    cx: DbgCodegenCx<'_, 'll, 'tcx>,
     instance: Instance<'tcx>,
     mir: &Body<'tcx>,
     variables: &Option<BitSet<SourceScope>>,
@@ -112,7 +112,7 @@ fn make_mir_scope<'ll, 'tcx>(
     let inlined_at = scope_data.inlined.map(|(_, callsite_span)| {
         // FIXME(eddyb) this doesn't account for the macro-related
         // `Span` fixups that `rustc_codegen_ssa::mir::debuginfo` does.
-        let callsite_scope = parent_scope.adjust_dbg_scope_for_span(cx, callsite_span);
+        let callsite_scope = parent_scope.adjust_dbg_scope_for_span(cx.cx, callsite_span);
         cx.dbg_loc(callsite_scope, parent_scope.inlined_at, callsite_span)
     });
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/native.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/native.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use crate::{
-    common::CodegenCx,
     debuginfo::{
         metadata::{
             enums::tag_base_type,
@@ -11,6 +10,7 @@ use crate::{
             UNKNOWN_LINE_NUMBER,
         },
         utils::{create_DIArray, get_namespace_for_item, DIB},
+        DbgCodegenCx,
     },
     llvm::{
         self,
@@ -51,7 +51,7 @@ use smallvec::smallvec;
 ///         DW_TAG_structure_type            (type of variant 3)
 /// ```
 pub(super) fn build_enum_type_di_node<'ll, 'tcx>(
-    cx: &CodegenCx<'ll, 'tcx>,
+    cx: DbgCodegenCx<'_, 'll, 'tcx>,
     unique_type_id: UniqueTypeId<'tcx>,
 ) -> DINodeCreationResult<'ll> {
     let enum_type = unique_type_id.expect_ty();
@@ -91,7 +91,7 @@ pub(super) fn build_enum_type_di_node<'ll, 'tcx>(
                         enum_type_di_node,
                         variant_index,
                         enum_adt_def.variant(variant_index),
-                        enum_type_and_layout.for_variant(cx, variant_index),
+                        enum_type_and_layout.for_variant(cx.cx, variant_index),
                     ),
                     source_info: None,
                 })
@@ -128,7 +128,7 @@ pub(super) fn build_enum_type_di_node<'ll, 'tcx>(
 ///
 /// ```
 pub(super) fn build_generator_di_node<'ll, 'tcx>(
-    cx: &CodegenCx<'ll, 'tcx>,
+    cx: DbgCodegenCx<'_, 'll, 'tcx>,
     unique_type_id: UniqueTypeId<'tcx>,
 ) -> DINodeCreationResult<'ll> {
     let generator_type = unique_type_id.expect_ty();
@@ -231,7 +231,7 @@ pub(super) fn build_generator_di_node<'ll, 'tcx>(
 ///         DW_TAG_structure_type            (type of variant 3)
 /// ```
 fn build_enum_variant_part_di_node<'ll, 'tcx>(
-    cx: &CodegenCx<'ll, 'tcx>,
+    cx: DbgCodegenCx<'_, 'll, 'tcx>,
     enum_type_and_layout: TyAndLayout<'tcx>,
     enum_type_di_node: &'ll DIType,
     variant_member_infos: &[VariantMemberInfo<'_, 'll>],
@@ -304,7 +304,7 @@ fn build_enum_variant_part_di_node<'ll, 'tcx>(
 ///
 /// ```
 fn build_discr_member_di_node<'ll, 'tcx>(
-    cx: &CodegenCx<'ll, 'tcx>,
+    cx: DbgCodegenCx<'_, 'll, 'tcx>,
     enum_or_generator_type_and_layout: TyAndLayout<'tcx>,
     enum_or_generator_type_di_node: &'ll DIType,
 ) -> Option<&'ll DIType> {
@@ -389,7 +389,7 @@ fn build_discr_member_di_node<'ll, 'tcx>(
 /// (including the DW_TAG_member) is built by a single call to
 /// `LLVMRustDIBuilderCreateVariantMemberType()`.
 fn build_enum_variant_member_di_node<'ll, 'tcx>(
-    cx: &CodegenCx<'ll, 'tcx>,
+    cx: DbgCodegenCx<'_, 'll, 'tcx>,
     enum_type_and_layout: TyAndLayout<'tcx>,
     variant_part_di_node: &'ll DIType,
     variant_member_info: &VariantMemberInfo<'_, 'll>,

--- a/compiler/rustc_codegen_llvm/src/debuginfo/namespace.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/namespace.rs
@@ -1,24 +1,15 @@
 // Namespace Handling.
 
-use super::utils::{debug_context, DIB};
+use super::utils::DIB;
+use super::DbgCodegenCx;
 use rustc_codegen_ssa::debuginfo::type_names;
-use rustc_middle::ty::{self, Instance};
 
-use crate::common::CodegenCx;
 use crate::llvm;
 use crate::llvm::debuginfo::DIScope;
 use rustc_hir::def_id::DefId;
 
-pub fn mangled_name_of_instance<'a, 'tcx>(
-    cx: &CodegenCx<'a, 'tcx>,
-    instance: Instance<'tcx>,
-) -> ty::SymbolName<'tcx> {
-    let tcx = cx.tcx;
-    tcx.symbol_name(instance)
-}
-
-pub fn item_namespace<'ll>(cx: &CodegenCx<'ll, '_>, def_id: DefId) -> &'ll DIScope {
-    if let Some(&scope) = debug_context(cx).namespace_map.borrow().get(&def_id) {
+pub fn item_namespace<'ll>(cx: DbgCodegenCx<'_, 'll, '_>, def_id: DefId) -> &'ll DIScope {
+    if let Some(&scope) = cx.dbg.namespace_map.borrow().get(&def_id) {
         return scope;
     }
 
@@ -43,6 +34,6 @@ pub fn item_namespace<'ll>(cx: &CodegenCx<'ll, '_>, def_id: DefId) -> &'ll DISco
         )
     };
 
-    debug_context(cx).namespace_map.borrow_mut().insert(def_id, scope);
+    cx.dbg.namespace_map.borrow_mut().insert(def_id, scope);
     scope
 }


### PR DESCRIPTION
I'm not sure whether these unwraps were actually perf relevant, but a profile pointed out that they may not be entirely free, as they can't be optimized away. Let's try avoiding them using some deref abuse.

I will restructure this in a way that makes it have less deref abuse and `cx.cx` uglyness if it comes back green.

r? @ghost