### PR TITLE
Slightly micro-optimize derive of PartialOrd

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2713,6 +2713,7 @@ pub enum VariantData {
 
 impl VariantData {
     /// Return the fields of this variant.
+    #[inline]
     pub fn fields(&self) -> &[FieldDef] {
         match self {
             VariantData::Struct(fields, ..) | VariantData::Tuple(fields, _) => fields,

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
@@ -39,11 +39,7 @@ pub fn expand_deriving_partial_ord(
                 _ => {
                     let end = def.variants.len() - 1;
                     def.variants[..end].iter().enumerate().any(|(i, v)| {
-                        // `take(3)` here is for the same reason as above, short
-                        // circuiting once we know what we care about. That
-                        // said, the fact that it's also `3` is only a
-                        // coincidence.
-                        if is_dataful(v) && let Some(idx) = def.variants[i + 1..].iter().take(3).position(is_dataful) {
+                        if is_dataful(v) && let Some(idx) = def.variants[i + 1..].iter().position(is_dataful) {
                             idx >= 2
                         } else {
                             false


### PR DESCRIPTION
When I was poking around here (for #109606), I noticed this was allocating a vec for no reason.

I also noticed that the compiler doesn't seem deduce the position/count loops can short-circuit early (at least in my tweaked test code it couldn't -- I don't know how to easily inspect asm for rustc itself), so I made them manually short-circuit by adding `take(n)` to the iterator chains. This is definitely more subtle/complex code but `#[derive(PartialOrd)]` is used a lot. I think the comments help avoid it being a maintenance hazard.