### PR TITLE
Remove Nilstrieb from review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -498,7 +498,6 @@ compiler-team-contributors = [
     "@eholk",
     "@jackh726",
     "@TaKO8Ki",
-    "@Nilstrieb",
     "@WaffleLapkin",
     "@b-naber",
 ]


### PR DESCRIPTION
I currently don't have enough time to be on rotation. You can still request a review from me and I may still steal PRs sometimes though.