### PR TITLE
Fix LVI test post LLVM 16 update

### DIFF
--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_asm.checks
@@ -2,6 +2,6 @@ CHECK: cc_plus_one_asm
 CHECK-NEXT: movl
 CHECK-NEXT: lfence
 CHECK-NEXT: incl
-CHECK-NEXT: shlq $0, (%rsp)
+CHECK-NEXT: shlq $0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_c_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_c_asm.checks
@@ -6,7 +6,7 @@ CHECK:      lfence
 CHECK:      lfence
 CHECK-NEXT: incl
 CHECK-NEXT: jmp
-CHECK-NEXT: shlq    $0, (%rsp)
+CHECK-NEXT: shlq	$0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq
 CHECK:      popq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_cxx_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_cxx_asm.checks
@@ -7,7 +7,7 @@ CHECK:      lfence
 CHECK:      lfence
 CHECK-NEXT: incl
 CHECK-NEXT: jmp     0x{{[[:xdigit:]]+}} <cc_plus_one_cxx_asm+0x{{[[:xdigit:]]+}}>
-CHECK-NEXT: shlq    $0, (%rsp)
+CHECK-NEXT: shlq    $0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq
 CHECK:      popq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cmake_plus_one_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cmake_plus_one_asm.checks
@@ -2,6 +2,6 @@ CHECK: cmake_plus_one_asm
 CHECK-NEXT: movl
 CHECK-NEXT: lfence
 CHECK-NEXT: incl
-CHECK-NEXT: shlq    $0, (%rsp)
+CHECK-NEXT: shlq    $0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cmake_plus_one_c_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cmake_plus_one_c_asm.checks
@@ -7,7 +7,7 @@ CHECK:      movl
 CHECK:      lfence
 CHECK-NEXT: incl
 CHECK-NEXT: jmp     0x{{[[:xdigit:]]+}} <cmake_plus_one_c_asm+0x{{[[:xdigit:]]+}}>
-CHECK-NEXT: shlq    $0, (%rsp)
+CHECK-NEXT: shlq    $0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq
 CHECK:      popq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cmake_plus_one_cxx_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cmake_plus_one_cxx_asm.checks
@@ -7,7 +7,7 @@ CHECK:      movl
 CHECK:      lfence
 CHECK-NEXT: incl
 CHECK-NEXT: jmp     0x{{[[:xdigit:]]+}} <cmake_plus_one_cxx_asm+0x{{[[:xdigit:]]+}}>
-CHECK-NEXT: shlq    $0, (%rsp)
+CHECK-NEXT: shlq    $0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq
 CHECK:      popq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/unw_getcontext.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/unw_getcontext.checks
@@ -1,6 +1,6 @@
 CHECK: unw_getcontext
 CHECK:      lfence
 CHECK:      lfence
-CHECK:      shlq    $0, (%rsp)
+CHECK:      shlq    $0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq


### PR DESCRIPTION
#109474 updated LLVM to 16. This causes the LVI mitigation tests for the `x86_64-fortanix-unknown-sgx` platform to fail. This PR fixes those tests again.

cc: @jethrogb 