### PR TITLE
Handle cycles in overlap with negative impls

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -41,7 +41,9 @@ pub use self::ImplSource::*;
 pub use self::ObligationCauseCode::*;
 pub use self::SelectionError::*;
 
-pub use self::coherence::{add_placeholder_note, orphan_check, overlapping_impls};
+pub use self::coherence::{
+    add_placeholder_note, negative_impl_holds, orphan_check, overlapping_impls,
+};
 pub use self::coherence::{OrphanCheckErr, OverlapResult};
 pub use self::engine::{ObligationCtxt, TraitEngineExt};
 pub use self::fulfill::{FulfillmentContext, PendingPredicateObligation};

--- a/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
@@ -92,122 +92,141 @@ impl<'tcx> ChildrenExt<'tcx> for Children {
         simplified_self: Option<SimplifiedType>,
         overlap_mode: OverlapMode,
     ) -> Result<OverlapResult<'tcx>, OverlapError<'tcx>> {
-        let mut last_lint = None;
-        let mut replace_children = Vec::new();
-
         let possible_siblings = match simplified_self {
             Some(st) => PotentialSiblings::Filtered(filtered_children(self, st)),
             None => PotentialSiblings::Unfiltered(iter_children(self)),
         };
 
-        for possible_sibling in possible_siblings {
-            debug!(?possible_sibling);
+        let result = overlap_check_considering_specialization(
+            tcx,
+            impl_def_id,
+            possible_siblings,
+            overlap_mode,
+        );
 
-            let create_overlap_error = |overlap: traits::coherence::OverlapResult<'tcx>| {
-                let trait_ref = overlap.impl_header.trait_ref.unwrap();
-                let self_ty = trait_ref.self_ty();
+        if let Ok(OverlapResult::NoOverlap(_)) = result {
+            // No overlap with any potential siblings, so add as a new sibling.
+            debug!("placing as new sibling");
+            self.insert_blindly(tcx, impl_def_id);
+        }
 
-                OverlapError {
-                    with_impl: possible_sibling,
-                    trait_ref,
-                    // Only report the `Self` type if it has at least
-                    // some outer concrete shell; otherwise, it's
-                    // not adding much information.
-                    self_ty: self_ty.has_concrete_skeleton().then_some(self_ty),
-                    intercrate_ambiguity_causes: overlap.intercrate_ambiguity_causes,
-                    involves_placeholder: overlap.involves_placeholder,
-                }
-            };
+        result
+    }
+}
 
-            let report_overlap_error = |overlap: traits::coherence::OverlapResult<'tcx>,
-                                        last_lint: &mut _| {
-                // Found overlap, but no specialization; error out or report future-compat warning.
+fn overlap_check_considering_specialization<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    impl_def_id: DefId,
+    possible_siblings: PotentialSiblings<impl Iterator<Item = DefId>, impl Iterator<Item = DefId>>,
+    overlap_mode: OverlapMode,
+) -> Result<OverlapResult<'tcx>, OverlapError<'tcx>> {
+    let mut last_lint = None;
+    let mut replace_children = Vec::new();
 
-                // Do we *still* get overlap if we disable the future-incompatible modes?
-                let should_err = traits::overlapping_impls(
-                    tcx,
-                    possible_sibling,
-                    impl_def_id,
-                    traits::SkipLeakCheck::default(),
-                    overlap_mode,
-                )
-                .is_some();
+    for possible_sibling in possible_siblings {
+        debug!(?possible_sibling);
 
-                let error = create_overlap_error(overlap);
+        let create_overlap_error = |overlap: traits::coherence::OverlapResult<'tcx>| {
+            let trait_ref = overlap.impl_header.trait_ref.unwrap();
+            let self_ty = trait_ref.self_ty();
 
-                if should_err {
-                    Err(error)
-                } else {
-                    *last_lint = Some(FutureCompatOverlapError {
-                        error,
-                        kind: FutureCompatOverlapErrorKind::LeakCheck,
-                    });
+            OverlapError {
+                with_impl: possible_sibling,
+                trait_ref,
+                // Only report the `Self` type if it has at least
+                // some outer concrete shell; otherwise, it's
+                // not adding much information.
+                self_ty: self_ty.has_concrete_skeleton().then_some(self_ty),
+                intercrate_ambiguity_causes: overlap.intercrate_ambiguity_causes,
+                involves_placeholder: overlap.involves_placeholder,
+            }
+        };
 
-                    Ok((false, false))
-                }
-            };
+        let report_overlap_error = |overlap: traits::coherence::OverlapResult<'tcx>,
+                                    last_lint: &mut _| {
+            // Found overlap, but no specialization; error out or report future-compat warning.
 
-            let last_lint_mut = &mut last_lint;
-            let (le, ge) = traits::overlapping_impls(
+            // Do we *still* get overlap if we disable the future-incompatible modes?
+            let should_err = traits::overlapping_impls(
                 tcx,
                 possible_sibling,
                 impl_def_id,
-                traits::SkipLeakCheck::Yes,
+                traits::SkipLeakCheck::default(),
                 overlap_mode,
             )
-            .map_or(Ok((false, false)), |overlap| {
-                if let Some(overlap_kind) =
-                    tcx.impls_are_allowed_to_overlap(impl_def_id, possible_sibling)
-                {
-                    match overlap_kind {
-                        ty::ImplOverlapKind::Permitted { marker: _ } => {}
-                        ty::ImplOverlapKind::Issue33140 => {
-                            *last_lint_mut = Some(FutureCompatOverlapError {
-                                error: create_overlap_error(overlap),
-                                kind: FutureCompatOverlapErrorKind::Issue33140,
-                            });
-                        }
-                    }
+            .is_some();
 
-                    return Ok((false, false));
+            let error = create_overlap_error(overlap);
+
+            if should_err {
+                Err(error)
+            } else {
+                *last_lint = Some(FutureCompatOverlapError {
+                    error,
+                    kind: FutureCompatOverlapErrorKind::LeakCheck,
+                });
+
+                Ok((false, false))
+            }
+        };
+
+        let last_lint_mut = &mut last_lint;
+        let (le, ge) = traits::overlapping_impls(
+            tcx,
+            possible_sibling,
+            impl_def_id,
+            traits::SkipLeakCheck::Yes,
+            overlap_mode,
+        )
+        .map_or(Ok((false, false)), |overlap| {
+            if let Some(overlap_kind) =
+                tcx.impls_are_allowed_to_overlap(impl_def_id, possible_sibling)
+            {
+                match overlap_kind {
+                    ty::ImplOverlapKind::Permitted { marker: _ } => {}
+                    ty::ImplOverlapKind::Issue33140 => {
+                        *last_lint_mut = Some(FutureCompatOverlapError {
+                            error: create_overlap_error(overlap),
+                            kind: FutureCompatOverlapErrorKind::Issue33140,
+                        });
+                    }
                 }
 
-                let le = tcx.specializes((impl_def_id, possible_sibling));
-                let ge = tcx.specializes((possible_sibling, impl_def_id));
-
-                if le == ge { report_overlap_error(overlap, last_lint_mut) } else { Ok((le, ge)) }
-            })?;
-
-            if le && !ge {
-                debug!(
-                    "descending as child of TraitRef {:?}",
-                    tcx.impl_trait_ref(possible_sibling).unwrap().subst_identity()
-                );
-
-                // The impl specializes `possible_sibling`.
-                return Ok(OverlapResult::SpecializeOne(possible_sibling));
-            } else if ge && !le {
-                debug!(
-                    "placing as parent of TraitRef {:?}",
-                    tcx.impl_trait_ref(possible_sibling).unwrap().subst_identity()
-                );
-
-                replace_children.push(possible_sibling);
-            } else {
-                // Either there's no overlap, or the overlap was already reported by
-                // `overlap_error`.
+                return Ok((false, false));
             }
-        }
 
-        if !replace_children.is_empty() {
-            return Ok(OverlapResult::SpecializeAll(replace_children));
-        }
+            let le = tcx.specializes((impl_def_id, possible_sibling));
+            let ge = tcx.specializes((possible_sibling, impl_def_id));
 
-        // No overlap with any potential siblings, so add as a new sibling.
-        debug!("placing as new sibling");
-        self.insert_blindly(tcx, impl_def_id);
-        Ok(OverlapResult::NoOverlap(last_lint))
+            if le == ge { report_overlap_error(overlap, last_lint_mut) } else { Ok((le, ge)) }
+        })?;
+
+        if le && !ge {
+            debug!(
+                "descending as child of TraitRef {:?}",
+                tcx.impl_trait_ref(possible_sibling).unwrap().subst_identity()
+            );
+
+            // The impl specializes `possible_sibling`.
+            return Ok(OverlapResult::SpecializeOne(possible_sibling));
+        } else if ge && !le {
+            debug!(
+                "placing as parent of TraitRef {:?}",
+                tcx.impl_trait_ref(possible_sibling).unwrap().subst_identity()
+            );
+
+            replace_children.push(possible_sibling);
+        } else {
+            // Either there's no overlap, or the overlap was already reported by
+            // `overlap_error`.
+        }
     }
+
+    if !replace_children.is_empty() {
+        return Ok(OverlapResult::SpecializeAll(replace_children));
+    }
+
+    Ok(OverlapResult::NoOverlap(last_lint))
 }
 
 fn iter_children(children: &mut Children) -> impl Iterator<Item = DefId> + '_ {

--- a/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
@@ -20,17 +20,18 @@ pub struct FutureCompatOverlapError<'tcx> {
     pub kind: FutureCompatOverlapErrorKind,
 }
 
-/// The result of attempting to insert an impl into a group of children.
+/// The result of overlap_check, we would attempt to insert an impl into a group of children
+/// afterwards.
 #[derive(Debug)]
-enum Inserted<'tcx> {
-    /// The impl was inserted as a new child in this group of children.
-    BecameNewSibling(Option<FutureCompatOverlapError<'tcx>>),
+enum OverlapResult<'tcx> {
+    /// The impl is going to be inserted as a new child in this group of children.
+    NoOverlap(Option<FutureCompatOverlapError<'tcx>>),
 
     /// The impl should replace existing impls [X1, ..], because the impl specializes X1, X2, etc.
-    ReplaceChildren(Vec<DefId>),
+    SpecializeAll(Vec<DefId>),
 
     /// The impl is a specialization of an existing child.
-    ShouldRecurseOn(DefId),
+    SpecializeOne(DefId),
 }
 
 trait ChildrenExt<'tcx> {
@@ -43,7 +44,7 @@ trait ChildrenExt<'tcx> {
         impl_def_id: DefId,
         simplified_self: Option<SimplifiedType>,
         overlap_mode: OverlapMode,
-    ) -> Result<Inserted<'tcx>, OverlapError<'tcx>>;
+    ) -> Result<OverlapResult<'tcx>, OverlapError<'tcx>>;
 }
 
 impl<'tcx> ChildrenExt<'tcx> for Children {
@@ -90,7 +91,7 @@ impl<'tcx> ChildrenExt<'tcx> for Children {
         impl_def_id: DefId,
         simplified_self: Option<SimplifiedType>,
         overlap_mode: OverlapMode,
-    ) -> Result<Inserted<'tcx>, OverlapError<'tcx>> {
+    ) -> Result<OverlapResult<'tcx>, OverlapError<'tcx>> {
         let mut last_lint = None;
         let mut replace_children = Vec::new();
 
@@ -184,7 +185,7 @@ impl<'tcx> ChildrenExt<'tcx> for Children {
                 );
 
                 // The impl specializes `possible_sibling`.
-                return Ok(Inserted::ShouldRecurseOn(possible_sibling));
+                return Ok(OverlapResult::SpecializeOne(possible_sibling));
             } else if ge && !le {
                 debug!(
                     "placing as parent of TraitRef {:?}",
@@ -199,13 +200,13 @@ impl<'tcx> ChildrenExt<'tcx> for Children {
         }
 
         if !replace_children.is_empty() {
-            return Ok(Inserted::ReplaceChildren(replace_children));
+            return Ok(OverlapResult::SpecializeAll(replace_children));
         }
 
         // No overlap with any potential siblings, so add as a new sibling.
         debug!("placing as new sibling");
         self.insert_blindly(tcx, impl_def_id);
-        Ok(Inserted::BecameNewSibling(last_lint))
+        Ok(OverlapResult::NoOverlap(last_lint))
     }
 }
 
@@ -306,7 +307,7 @@ impl<'tcx> GraphExt<'tcx> for Graph {
 
         // Descend the specialization tree, where `parent` is the current parent node.
         loop {
-            use self::Inserted::*;
+            use self::OverlapResult::*;
 
             let insert_result = self.children.entry(parent).or_default().insert(
                 tcx,
@@ -316,11 +317,11 @@ impl<'tcx> GraphExt<'tcx> for Graph {
             )?;
 
             match insert_result {
-                BecameNewSibling(opt_lint) => {
+                NoOverlap(opt_lint) => {
                     last_lint = opt_lint;
                     break;
                 }
-                ReplaceChildren(grand_children_to_be) => {
+                SpecializeAll(grand_children_to_be) => {
                     // We currently have
                     //
                     //     P
@@ -359,7 +360,7 @@ impl<'tcx> GraphExt<'tcx> for Graph {
                     }
                     break;
                 }
-                ShouldRecurseOn(new_parent) => {
+                SpecializeOne(new_parent) => {
                     parent = new_parent;
                 }
             }

--- a/tests/ui/coherence/coherence-overlap-negative-cycles.rs
+++ b/tests/ui/coherence/coherence-overlap-negative-cycles.rs
@@ -1,0 +1,17 @@
+#![feature(trivial_bounds)]
+#![feature(negative_impls)]
+#![feature(rustc_attrs)]
+#![feature(with_negative_coherence)]
+#![allow(trivial_bounds)]
+
+#[rustc_strict_coherence]
+trait MyTrait {}
+
+struct Foo {}
+
+impl !MyTrait for Foo {}
+
+impl MyTrait for Foo where Foo: MyTrait {}
+//~^ ERROR: conflicting implementations of trait `MyTrait`
+
+fn main() {}

--- a/tests/ui/coherence/coherence-overlap-negative-cycles.stderr
+++ b/tests/ui/coherence/coherence-overlap-negative-cycles.stderr
@@ -1,0 +1,12 @@
+error[E0119]: conflicting implementations of trait `MyTrait` for type `Foo`
+  --> $DIR/coherence-overlap-negative-cycles.rs:14:1
+   |
+LL | impl MyTrait for Foo where Foo: MyTrait {}
+   | ^^^^^^^^^^^^^^^^^^^^
+   | |
+   | first implementation here
+   | conflicting implementation for `Foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0119`.


### PR DESCRIPTION
Fixes #102678

r? @nikomatsakis 

Opened this as a way to start reviewing it.

At the very least we have the following pending things:
1. Properly handle errors on negative impls
2. If specialize succeeds in insert loop we still want to run negative_impls_hold. I didn't bother to do that because I wanted to first see the code "doing something useful".
3. The old checks are still running and the idea is that we were going to replace them with this new logic. We still need to remove those checks.

I'd need to check a bit better to, to see if there's more to cover.