### PR TITLE
Do not consider elaborated projection predicates for objects in new solver

### DIFF
--- a/tests/ui/traits/new-solver/dont-elaborate-for-projections.rs
+++ b/tests/ui/traits/new-solver/dont-elaborate-for-projections.rs
@@ -1,0 +1,12 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+trait Iter<'a, I: 'a>: Iterator<Item = &'a I> {}
+
+fn needs_iter<'a, T: Iter<'a, I> + ?Sized, I: 'a>(_: &T) {}
+
+fn test(x: &dyn Iter<'_, ()>) {
+    needs_iter(x);
+}
+
+fn main() {}

--- a/tests/ui/traits/new-solver/more-object-bound.rs
+++ b/tests/ui/traits/new-solver/more-object-bound.rs
@@ -10,7 +10,7 @@ trait Trait: SuperTrait<A = <Self as SuperTrait>::B> {}
 
 fn transmute<A, B>(x: A) -> B {
     foo::<A, B, dyn Trait<A = A, B = B>>(x)
-    //~^ ERROR type annotations needed: cannot satisfy `dyn Trait<A = A, B = B>: Trait`
+    //~^ ERROR the trait bound `dyn Trait<A = A, B = B>: Trait` is not satisfied
 }
 
 fn foo<A, B, T: ?Sized>(x: T::A) -> B

--- a/tests/ui/traits/new-solver/more-object-bound.stderr
+++ b/tests/ui/traits/new-solver/more-object-bound.stderr
@@ -1,10 +1,9 @@
-error[E0283]: type annotations needed: cannot satisfy `dyn Trait<A = A, B = B>: Trait`
-  --> $DIR/more-object-bound.rs:12:5
+error[E0277]: the trait bound `dyn Trait<A = A, B = B>: Trait` is not satisfied
+  --> $DIR/more-object-bound.rs:12:17
    |
 LL |     foo::<A, B, dyn Trait<A = A, B = B>>(x)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `dyn Trait<A = A, B = B>`
    |
-   = note: cannot satisfy `dyn Trait<A = A, B = B>: Trait`
 note: required by a bound in `foo`
   --> $DIR/more-object-bound.rs:18:8
    |
@@ -13,7 +12,11 @@ LL | fn foo<A, B, T: ?Sized>(x: T::A) -> B
 LL | where
 LL |     T: Trait<B = B>,
    |        ^^^^^^^^^^^^ required by this bound in `foo`
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | fn transmute<A, B>(x: A) -> B where dyn Trait<A = A, B = B>: Trait {
+   |                               ++++++++++++++++++++++++++++++++++++
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0283`.
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Object types have projection bounds which are elaborated during astconv. There's no need to do it again for projection goals, since that'll give us duplicate projection candidatesd that are distinct up to regions due to the fact that we canonicalize every region to a separate variable. See quick example below the break for a better explanation. 

Discussed this with lcnr, and adding a stop-gap until we get something like intersection region constraints (or modify canonicalization to canonicalize identical regions to the same canonical regions) -- after which, this will hopefully not matter and may be removed.

r? @lcnr

---

See `tests/ui/traits/new-solver/more-object-bound.rs`:

Consider a goal: `<dyn Iter<'a, ()> as Iterator>::Item = &'a ()`.

After canonicalization: `<dyn Iter<'!0r, (), Item = '!1r ()> as Iterator>::Item == &!'2r ()`
* First object candidate comes from the item bound in the dyn's bounds itself, giving us `<dyn Iter<'!0r, (), Item = '?!r ()> as Iterator>::Item == &!'1r ()`. This gives us one region constraint: `!'1r == !'2r`.
* Second object candidate comes from elaborating the principal trait ref, gives us `<dyn Iter<'!0r, (), Item = '!1r ()> as Iterator>::Item == &!'0r ()`. This gives us one region constraint: `!'0r == !'2r`.
* Oops! Ambiguity!