### PR TITLE
Make doc comment a little bit more accurate

### DIFF
--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -34,7 +34,7 @@ pub type MakeBackendFn = fn() -> Box<dyn CodegenBackend>;
 /// specific features (SSE, NEON etc.).
 ///
 /// This is performed by checking whether a set of permitted features
-/// is available on the target machine, by querying LLVM.
+/// is available on the target machine, by querying the codegen backend.
 pub fn add_configuration(
     cfg: &mut CrateConfig,
     sess: &mut Session,


### PR DESCRIPTION
It queries not LLVM in particular but the codegen backend *in general*. While cranelift does not provide target features, other codegen backends do.

Found while looking for [this answer](https://github.com/rust-lang/rust/issues/108680#issuecomment-1484324690).