### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0223.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0223.md
@@ -3,31 +3,33 @@ An attempt was made to retrieve an associated type, but the type was ambiguous.
 Erroneous code example:
 
 ```compile_fail,E0223
-trait MyTrait {type X; }
+trait Trait { type X; }
 
 fn main() {
-    let foo: MyTrait::X;
+    let foo: Trait::X;
 }
 ```
 
-The problem here is that we're attempting to take the type of X from MyTrait.
-Unfortunately, the type of X is not defined, because it's only made concrete in
-implementations of the trait. A working version of this code might look like:
+The problem here is that we're attempting to take the associated type of `X`
+from `Trait`. Unfortunately, the type of `X` is not defined, because it's only
+made concrete in implementations of the trait. A working version of this code
+might look like:
 
 ```
-trait MyTrait {type X; }
-struct MyStruct;
+trait Trait { type X; }
 
-impl MyTrait for MyStruct {
+struct Struct;
+impl Trait for Struct {
     type X = u32;
 }
 
 fn main() {
-    let foo: <MyStruct as MyTrait>::X;
+    let foo: <Struct as Trait>::X;
 }
 ```
 
-This syntax specifies that we want the X type from MyTrait, as made concrete in
-MyStruct. The reason that we cannot simply use `MyStruct::X` is that MyStruct
-might implement two different traits with identically-named associated types.
-This syntax allows disambiguation between the two.
+This syntax specifies that we want the associated type `X` from `Struct`'s
+implementation of `Trait`.
+
+Due to internal limitations of the current compiler implementation we cannot
+simply use `Struct::X`.

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -34,7 +34,7 @@ pub type MakeBackendFn = fn() -> Box<dyn CodegenBackend>;
 /// specific features (SSE, NEON etc.).
 ///
 /// This is performed by checking whether a set of permitted features
-/// is available on the target machine, by querying LLVM.
+/// is available on the target machine, by querying the codegen backend.
 pub fn add_configuration(
     cfg: &mut CrateConfig,
     sess: &mut Session,

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -331,6 +331,10 @@ mir_build_indirect_structural_match =
 mir_build_nontrivial_structural_match =
     to use a constant of type `{$non_sm_ty}` in a pattern, the constant's initializer must be trivial or `{$non_sm_ty}` must be annotated with `#[derive(PartialEq, Eq)]`
 
+mir_build_type_not_structural_tip = the traits must be derived, manual `impl`s are not sufficient
+
+mir_build_type_not_structural_more_info = see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
+
 mir_build_overlapping_range_endpoints = multiple patterns overlap on their endpoints
     .range = ... with this range
     .note = you likely meant to write mutually exclusive ranges

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -663,6 +663,8 @@ pub struct UnionPattern {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_type_not_structural)]
+#[note(mir_build_type_not_structural_tip)]
+#[note(mir_build_type_not_structural_more_info)]
 pub struct TypeNotStructural<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -695,12 +697,16 @@ pub struct PointerPattern;
 
 #[derive(LintDiagnostic)]
 #[diag(mir_build_indirect_structural_match)]
+#[note(mir_build_type_not_structural_tip)]
+#[note(mir_build_type_not_structural_more_info)]
 pub struct IndirectStructuralMatch<'tcx> {
     pub non_sm_ty: Ty<'tcx>,
 }
 
 #[derive(LintDiagnostic)]
 #[diag(mir_build_nontrivial_structural_match)]
+#[note(mir_build_type_not_structural_tip)]
+#[note(mir_build_type_not_structural_more_info)]
 pub struct NontrivialStructuralMatch<'tcx> {
     pub non_sm_ty: Ty<'tcx>,
 }

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -703,8 +703,7 @@ fn incremental_verify_ich_failed<Tcx>(
         };
 
         let dep_node = tcx.dep_graph().data().unwrap().prev_node_of(prev_index);
-
-        let dep_node = tcx.sess().emit_err(crate::error::IncrementCompilation {
+        tcx.sess().emit_err(crate::error::IncrementCompilation {
             run_cmd,
             dep_node: format!("{dep_node:?}"),
         });

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -172,6 +172,7 @@ impl fmt::Debug for CStr {
 
 #[stable(feature = "cstr_default", since = "1.10.0")]
 impl Default for &CStr {
+    #[inline]
     fn default() -> Self {
         const SLICE: &[c_char] = &[0];
         // SAFETY: `SLICE` is indeed pointing to a valid nul-terminated string.
@@ -623,6 +624,7 @@ impl CStr {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl PartialEq for CStr {
+    #[inline]
     fn eq(&self, other: &CStr) -> bool {
         self.to_bytes().eq(other.to_bytes())
     }
@@ -631,12 +633,14 @@ impl PartialEq for CStr {
 impl Eq for CStr {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl PartialOrd for CStr {
+    #[inline]
     fn partial_cmp(&self, other: &CStr) -> Option<Ordering> {
         self.to_bytes().partial_cmp(&other.to_bytes())
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Ord for CStr {
+    #[inline]
     fn cmp(&self, other: &CStr) -> Ordering {
         self.to_bytes().cmp(&other.to_bytes())
     }
@@ -646,6 +650,7 @@ impl Ord for CStr {
 impl ops::Index<ops::RangeFrom<usize>> for CStr {
     type Output = CStr;
 
+    #[inline]
     fn index(&self, index: ops::RangeFrom<usize>) -> &CStr {
         let bytes = self.to_bytes_with_nul();
         // we need to manually check the starting index to account for the null

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -1055,9 +1055,14 @@ pub trait IsTerminal: crate::sealed::Sealed {
     /// `false`. This will also return `false` if an unexpected error occurred, such as from
     /// passing an invalid file descriptor.
     ///
+    /// # Platform-specific behavior
+    ///
     /// On Windows, in addition to detecting consoles, this currently uses some heuristics to
     /// detect older msys/cygwin/mingw pseudo-terminals based on device name: devices with names
     /// starting with `msys-` or `cygwin-` and ending in `-pty` will be considered terminals.
+    /// Note that this [may change in the future][changes].
+    ///
+    /// [changes]: io#platform-specific-behavior
     fn is_terminal(&self) -> bool;
 }
 

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -1054,6 +1054,10 @@ pub trait IsTerminal: crate::sealed::Sealed {
     /// On platforms where Rust does not know how to detect a terminal yet, this will return
     /// `false`. This will also return `false` if an unexpected error occurred, such as from
     /// passing an invalid file descriptor.
+    ///
+    /// On Windows, in addition to detecting consoles, this currently uses some heuristics to
+    /// detect older msys/cygwin/mingw pseudo-terminals based on device name: devices with names
+    /// starting with `msys-` or `cygwin-` and ending in `-pty` will be considered terminals.
     fn is_terminal(&self) -> bool;
 }
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -1027,10 +1027,11 @@ impl Step for RustcBook {
         if self.validate {
             cmd.arg("--validate");
         }
-        if !builder.unstable_features() {
-            // We need to validate nightly features, even on the stable channel.
-            cmd.env("RUSTC_BOOTSTRAP", "1");
-        }
+        // We need to validate nightly features, even on the stable channel.
+        // Set this unconditionally as the stage0 compiler may be being used to
+        // document.
+        cmd.env("RUSTC_BOOTSTRAP", "1");
+
         // If the lib directories are in an unusual location (changed in
         // config.toml), then this needs to explicitly update the dylib search
         // path.

--- a/src/tools/clippy/tests/ui/crashes/ice-6254.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6254.stderr
@@ -6,6 +6,8 @@ LL |         FOO_REF_REF => {},
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
    = note: `-D indirect-structural-match` implied by `-D warnings`
 
 error: aborting due to previous error

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_asm.checks
@@ -2,6 +2,6 @@ CHECK: cc_plus_one_asm
 CHECK-NEXT: movl
 CHECK-NEXT: lfence
 CHECK-NEXT: incl
-CHECK-NEXT: shlq $0, (%rsp)
+CHECK-NEXT: shlq $0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_c_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_c_asm.checks
@@ -6,7 +6,7 @@ CHECK:      lfence
 CHECK:      lfence
 CHECK-NEXT: incl
 CHECK-NEXT: jmp
-CHECK-NEXT: shlq    $0, (%rsp)
+CHECK-NEXT: shlq	$0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq
 CHECK:      popq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_cxx_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cc_plus_one_cxx_asm.checks
@@ -7,7 +7,7 @@ CHECK:      lfence
 CHECK:      lfence
 CHECK-NEXT: incl
 CHECK-NEXT: jmp     0x{{[[:xdigit:]]+}} <cc_plus_one_cxx_asm+0x{{[[:xdigit:]]+}}>
-CHECK-NEXT: shlq    $0, (%rsp)
+CHECK-NEXT: shlq    $0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq
 CHECK:      popq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cmake_plus_one_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cmake_plus_one_asm.checks
@@ -2,6 +2,6 @@ CHECK: cmake_plus_one_asm
 CHECK-NEXT: movl
 CHECK-NEXT: lfence
 CHECK-NEXT: incl
-CHECK-NEXT: shlq    $0, (%rsp)
+CHECK-NEXT: shlq    $0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cmake_plus_one_c_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cmake_plus_one_c_asm.checks
@@ -7,7 +7,7 @@ CHECK:      movl
 CHECK:      lfence
 CHECK-NEXT: incl
 CHECK-NEXT: jmp     0x{{[[:xdigit:]]+}} <cmake_plus_one_c_asm+0x{{[[:xdigit:]]+}}>
-CHECK-NEXT: shlq    $0, (%rsp)
+CHECK-NEXT: shlq    $0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq
 CHECK:      popq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cmake_plus_one_cxx_asm.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/cmake_plus_one_cxx_asm.checks
@@ -7,7 +7,7 @@ CHECK:      movl
 CHECK:      lfence
 CHECK-NEXT: incl
 CHECK-NEXT: jmp     0x{{[[:xdigit:]]+}} <cmake_plus_one_cxx_asm+0x{{[[:xdigit:]]+}}>
-CHECK-NEXT: shlq    $0, (%rsp)
+CHECK-NEXT: shlq    $0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq
 CHECK:      popq

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/unw_getcontext.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/unw_getcontext.checks
@@ -1,6 +1,6 @@
 CHECK: unw_getcontext
 CHECK:      lfence
 CHECK:      lfence
-CHECK:      shlq    $0, (%rsp)
+CHECK:      shlq    $0x0, (%rsp)
 CHECK-NEXT: lfence
 CHECK-NEXT: retq

--- a/tests/ui/consts/const_in_pattern/cross-crate-fail.stderr
+++ b/tests/ui/consts/const_in_pattern/cross-crate-fail.stderr
@@ -3,12 +3,18 @@ error: to use a constant of type `CustomEq` in a pattern, `CustomEq` must be ann
    |
 LL |         consts::SOME => panic!(),
    |         ^^^^^^^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `CustomEq` in a pattern, `CustomEq` must be annotated with `#[derive(PartialEq, Eq)]`
   --> $DIR/cross-crate-fail.rs:20:9
    |
 LL |         <Defaulted as consts::AssocConst>::SOME  => panic!(),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const_in_pattern/custom-eq-branch-warn.rs
+++ b/tests/ui/consts/const_in_pattern/custom-eq-branch-warn.rs
@@ -28,6 +28,8 @@ fn main() {
     match Foo::Qux(CustomEq) {
         BAR_BAZ => panic!(),
         //~^ WARN must be annotated with `#[derive(PartialEq, Eq)]`
+        //~| NOTE the traits must be derived
+        //~| NOTE StructuralEq.html for details
         //~| WARN this was previously accepted
         //~| NOTE see issue #73448
         //~| NOTE `#[warn(nontrivial_structural_match)]` on by default

--- a/tests/ui/consts/const_in_pattern/custom-eq-branch-warn.stderr
+++ b/tests/ui/consts/const_in_pattern/custom-eq-branch-warn.stderr
@@ -6,6 +6,8 @@ LL |         BAR_BAZ => panic!(),
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #73448 <https://github.com/rust-lang/rust/issues/73448>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
    = note: `#[warn(nontrivial_structural_match)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/consts/const_in_pattern/incomplete-slice.stderr
+++ b/tests/ui/consts/const_in_pattern/incomplete-slice.stderr
@@ -6,6 +6,8 @@ LL |         E_SL => {}
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
    = note: `#[warn(indirect_structural_match)]` on by default
 
 error[E0004]: non-exhaustive patterns: `&_` not covered

--- a/tests/ui/consts/const_in_pattern/issue-78057.stderr
+++ b/tests/ui/consts/const_in_pattern/issue-78057.stderr
@@ -3,6 +3,9 @@ error: to use a constant of type `Opaque` in a pattern, `Opaque` must be annotat
    |
 LL |         FOO => {},
    |         ^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: unreachable pattern
   --> $DIR/issue-78057.rs:14:9

--- a/tests/ui/consts/const_in_pattern/no-eq-branch-fail.stderr
+++ b/tests/ui/consts/const_in_pattern/no-eq-branch-fail.stderr
@@ -3,6 +3,9 @@ error: to use a constant of type `Foo` in a pattern, `Foo` must be annotated wit
    |
 LL |         BAR_BAZ => panic!(),
    |         ^^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: aborting due to previous error
 

--- a/tests/ui/consts/const_in_pattern/reject_non_partial_eq.stderr
+++ b/tests/ui/consts/const_in_pattern/reject_non_partial_eq.stderr
@@ -3,6 +3,9 @@ error: to use a constant of type `NoPartialEq` in a pattern, `NoPartialEq` must 
    |
 LL |         NO_PARTIAL_EQ_NONE => println!("NO_PARTIAL_EQ_NONE"),
    |         ^^^^^^^^^^^^^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: aborting due to previous error
 

--- a/tests/ui/consts/const_in_pattern/reject_non_structural.rs
+++ b/tests/ui/consts/const_in_pattern/reject_non_structural.rs
@@ -39,45 +39,67 @@ fn main() {
     const ENUM: Derive<NoDerive> = Derive::Some(NoDerive);
     match Derive::Some(NoDerive) { ENUM => dbg!(ENUM), _ => panic!("whoops"), };
     //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| NOTE the traits must be derived
+    //~| NOTE StructuralEq.html for details
 
     const FIELD: OND = TrivialEq(Some(NoDerive)).0;
     match Some(NoDerive) { FIELD => dbg!(FIELD), _ => panic!("whoops"), };
     //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| NOTE the traits must be derived
+    //~| NOTE StructuralEq.html for details
 
     const NO_DERIVE_SOME: OND = Some(NoDerive);
     const INDIRECT: OND = NO_DERIVE_SOME;
     match Some(NoDerive) {INDIRECT => dbg!(INDIRECT), _ => panic!("whoops"), };
     //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| NOTE the traits must be derived
+    //~| NOTE StructuralEq.html for details
 
     const TUPLE: (OND, OND) = (None, Some(NoDerive));
     match (None, Some(NoDerive)) { TUPLE => dbg!(TUPLE), _ => panic!("whoops"), };
     //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| NOTE the traits must be derived
+    //~| NOTE StructuralEq.html for details
 
     const TYPE_ASCRIPTION: OND = type_ascribe!(Some(NoDerive), OND);
     match Some(NoDerive) { TYPE_ASCRIPTION => dbg!(TYPE_ASCRIPTION), _ => panic!("whoops"), };
     //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| NOTE the traits must be derived
+    //~| NOTE StructuralEq.html for details
 
     const ARRAY: [OND; 2] = [None, Some(NoDerive)];
     match [None, Some(NoDerive)] { ARRAY => dbg!(ARRAY), _ => panic!("whoops"), };
     //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| NOTE the traits must be derived
+    //~| NOTE StructuralEq.html for details
 
     const REPEAT: [OND; 2] = [Some(NoDerive); 2];
     match [Some(NoDerive); 2] { REPEAT => dbg!(REPEAT), _ => panic!("whoops"), };
     //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| NOTE the traits must be derived
+    //~| NOTE StructuralEq.html for details
     //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| NOTE the traits must be derived
+    //~| NOTE StructuralEq.html for details
 
     trait Trait: Sized { const ASSOC: Option<Self>; }
     impl Trait for NoDerive { const ASSOC: Option<NoDerive> = Some(NoDerive); }
     match Some(NoDerive) { NoDerive::ASSOC => dbg!(NoDerive::ASSOC), _ => panic!("whoops"), };
     //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| NOTE the traits must be derived
+    //~| NOTE StructuralEq.html for details
 
     const BLOCK: OND = { NoDerive; Some(NoDerive) };
     match Some(NoDerive) { BLOCK => dbg!(BLOCK), _ => panic!("whoops"), };
     //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| NOTE the traits must be derived
+    //~| NOTE StructuralEq.html for details
 
     const ADDR_OF: &OND = &Some(NoDerive);
     match &Some(NoDerive) { ADDR_OF => dbg!(ADDR_OF), _ => panic!("whoops"), };
     //~^ WARN must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| NOTE the traits must be derived
+    //~| NOTE StructuralEq.html for details
     //~| WARN previously accepted by the compiler but is being phased out
     //~| NOTE for more information, see issue #62411
 }

--- a/tests/ui/consts/const_in_pattern/reject_non_structural.stderr
+++ b/tests/ui/consts/const_in_pattern/reject_non_structural.stderr
@@ -3,69 +3,101 @@ error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be ann
    |
 LL |     match Derive::Some(NoDerive) { ENUM => dbg!(ENUM), _ => panic!("whoops"), };
    |                                    ^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:44:28
+  --> $DIR/reject_non_structural.rs:46:28
    |
 LL |     match Some(NoDerive) { FIELD => dbg!(FIELD), _ => panic!("whoops"), };
    |                            ^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:49:27
+  --> $DIR/reject_non_structural.rs:53:27
    |
 LL |     match Some(NoDerive) {INDIRECT => dbg!(INDIRECT), _ => panic!("whoops"), };
    |                           ^^^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:53:36
+  --> $DIR/reject_non_structural.rs:59:36
    |
 LL |     match (None, Some(NoDerive)) { TUPLE => dbg!(TUPLE), _ => panic!("whoops"), };
    |                                    ^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:57:28
+  --> $DIR/reject_non_structural.rs:65:28
    |
 LL |     match Some(NoDerive) { TYPE_ASCRIPTION => dbg!(TYPE_ASCRIPTION), _ => panic!("whoops"), };
    |                            ^^^^^^^^^^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:61:36
+  --> $DIR/reject_non_structural.rs:71:36
    |
 LL |     match [None, Some(NoDerive)] { ARRAY => dbg!(ARRAY), _ => panic!("whoops"), };
    |                                    ^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:65:33
+  --> $DIR/reject_non_structural.rs:77:33
    |
 LL |     match [Some(NoDerive); 2] { REPEAT => dbg!(REPEAT), _ => panic!("whoops"), };
    |                                 ^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:65:33
+  --> $DIR/reject_non_structural.rs:77:33
    |
 LL |     match [Some(NoDerive); 2] { REPEAT => dbg!(REPEAT), _ => panic!("whoops"), };
    |                                 ^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:71:28
+  --> $DIR/reject_non_structural.rs:87:28
    |
 LL |     match Some(NoDerive) { NoDerive::ASSOC => dbg!(NoDerive::ASSOC), _ => panic!("whoops"), };
    |                            ^^^^^^^^^^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:75:28
+  --> $DIR/reject_non_structural.rs:93:28
    |
 LL |     match Some(NoDerive) { BLOCK => dbg!(BLOCK), _ => panic!("whoops"), };
    |                            ^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:79:29
+  --> $DIR/reject_non_structural.rs:99:29
    |
 LL |     match &Some(NoDerive) { ADDR_OF => dbg!(ADDR_OF), _ => panic!("whoops"), };
    |                             ^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 note: the lint level is defined here
   --> $DIR/reject_non_structural.rs:12:9
    |

--- a/tests/ui/consts/const_in_pattern/warn_corner_cases.stderr
+++ b/tests/ui/consts/const_in_pattern/warn_corner_cases.stderr
@@ -6,6 +6,8 @@ LL |     match None { Some(_) => panic!("whoops"), INDEX => dbg!(INDEX), };
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #73448 <https://github.com/rust-lang/rust/issues/73448>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
    = note: `#[warn(nontrivial_structural_match)]` on by default
 
 warning: to use a constant of type `NoDerive` in a pattern, the constant's initializer must be trivial or `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
@@ -16,6 +18,8 @@ LL |     match None { Some(_) => panic!("whoops"), CALL => dbg!(CALL), };
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #73448 <https://github.com/rust-lang/rust/issues/73448>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 warning: to use a constant of type `NoDerive` in a pattern, the constant's initializer must be trivial or `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
   --> $DIR/warn_corner_cases.rs:38:47
@@ -25,6 +29,8 @@ LL |     match None { Some(_) => panic!("whoops"), METHOD_CALL => dbg!(METHOD_CA
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #73448 <https://github.com/rust-lang/rust/issues/73448>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 warning: 3 warnings emitted
 

--- a/tests/ui/consts/match_ice.stderr
+++ b/tests/ui/consts/match_ice.stderr
@@ -3,6 +3,9 @@ error: to use a constant of type `S` in a pattern, `S` must be annotated with `#
    |
 LL |         C => {}
    |         ^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: aborting due to previous error
 

--- a/tests/ui/pattern/usefulness/const-partial_eq-fallback-ice.stderr
+++ b/tests/ui/pattern/usefulness/const-partial_eq-fallback-ice.stderr
@@ -3,6 +3,9 @@ error: to use a constant of type `MyType` in a pattern, `MyType` must be annotat
    |
 LL |     if let CONSTANT = &&MyType {
    |            ^^^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: aborting due to previous error
 

--- a/tests/ui/pattern/usefulness/consts-opaque.stderr
+++ b/tests/ui/pattern/usefulness/consts-opaque.stderr
@@ -3,6 +3,9 @@ error: to use a constant of type `Foo` in a pattern, `Foo` must be annotated wit
    |
 LL |         FOO => {}
    |         ^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:32:9
@@ -24,6 +27,9 @@ error: to use a constant of type `Foo` in a pattern, `Foo` must be annotated wit
    |
 LL |         FOO_REF => {}
    |         ^^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:39:9
@@ -42,6 +48,8 @@ LL |         FOO_REF_REF => {}
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
    = note: `#[warn(indirect_structural_match)]` on by default
 
 error: to use a constant of type `Bar` in a pattern, `Bar` must be annotated with `#[derive(PartialEq, Eq)]`
@@ -49,6 +57,9 @@ error: to use a constant of type `Bar` in a pattern, `Bar` must be annotated wit
    |
 LL |         BAR => {} // should not be emitting unreachable warning
    |         ^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:53:9
@@ -72,6 +83,9 @@ error: to use a constant of type `Bar` in a pattern, `Bar` must be annotated wit
    |
 LL |         BAR => {}
    |         ^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:63:9
@@ -96,12 +110,18 @@ error: to use a constant of type `Bar` in a pattern, `Bar` must be annotated wit
    |
 LL |         BAR => {}
    |         ^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `Bar` in a pattern, `Bar` must be annotated with `#[derive(PartialEq, Eq)]`
   --> $DIR/consts-opaque.rs:72:9
    |
 LL |         BAR => {} // should not be emitting unreachable warning
    |         ^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:72:9
@@ -126,6 +146,9 @@ error: to use a constant of type `Baz` in a pattern, `Baz` must be annotated wit
    |
 LL |         BAZ => {}
    |         ^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:82:9
@@ -150,6 +173,9 @@ error: to use a constant of type `Baz` in a pattern, `Baz` must be annotated wit
    |
 LL |         BAZ => {}
    |         ^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:92:9
@@ -165,6 +191,9 @@ error: to use a constant of type `Baz` in a pattern, `Baz` must be annotated wit
    |
 LL |         BAZ => {}
    |         ^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:99:9

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-direct-struct-embedded.stderr
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-direct-struct-embedded.stderr
@@ -3,6 +3,9 @@ error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be ann
    |
 LL |         WRAP_DIRECT_INLINE => { panic!("WRAP_DIRECT_INLINE matched itself"); }
    |         ^^^^^^^^^^^^^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: aborting due to previous error
 

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-direct-struct-param.stderr
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-direct-struct-param.stderr
@@ -3,6 +3,9 @@ error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be ann
    |
 LL |         WRAP_DIRECT_PARAM => { panic!("WRAP_DIRECT_PARAM matched itself"); }
    |         ^^^^^^^^^^^^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: aborting due to previous error
 

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-doubly-indirect-embedded.stderr
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-doubly-indirect-embedded.stderr
@@ -6,6 +6,8 @@ LL |         WRAP_DOUBLY_INDIRECT_INLINE => { panic!("WRAP_DOUBLY_INDIRECT_INLIN
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 note: the lint level is defined here
   --> $DIR/cant-hide-behind-doubly-indirect-embedded.rs:7:9
    |

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-doubly-indirect-param.stderr
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-doubly-indirect-param.stderr
@@ -6,6 +6,8 @@ LL |         WRAP_DOUBLY_INDIRECT_PARAM => { panic!("WRAP_DOUBLY_INDIRECT_PARAM 
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 note: the lint level is defined here
   --> $DIR/cant-hide-behind-doubly-indirect-param.rs:7:9
    |

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-indirect-struct-embedded.stderr
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-indirect-struct-embedded.stderr
@@ -6,6 +6,8 @@ LL |         WRAP_INDIRECT_INLINE => { panic!("WRAP_INDIRECT_INLINE matched itse
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 note: the lint level is defined here
   --> $DIR/cant-hide-behind-indirect-struct-embedded.rs:7:9
    |

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-indirect-struct-param.stderr
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-indirect-struct-param.stderr
@@ -6,6 +6,8 @@ LL |         WRAP_INDIRECT_PARAM => { panic!("WRAP_INDIRECT_PARAM matched itself
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 note: the lint level is defined here
   --> $DIR/cant-hide-behind-indirect-struct-param.rs:7:9
    |

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/issue-61188-match-slice-forbidden-without-eq.stderr
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/issue-61188-match-slice-forbidden-without-eq.stderr
@@ -3,6 +3,9 @@ error: to use a constant of type `B` in a pattern, `B` must be annotated with `#
    |
 LL |         A => (),
    |         ^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: aborting due to previous error
 

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/issue-62307-match-ref-ref-forbidden-without-eq.stderr
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/issue-62307-match-ref-ref-forbidden-without-eq.stderr
@@ -6,6 +6,8 @@ LL |         RR_B1 => { println!("CLAIM RR0: {:?} matches {:?}", RR_B1, RR_B0); 
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 note: the lint level is defined here
   --> $DIR/issue-62307-match-ref-ref-forbidden-without-eq.rs:13:9
    |
@@ -20,6 +22,8 @@ LL |         RR_B1 => { println!("CLAIM RR1: {:?} matches {:?}", RR_B1, RR_B1); 
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 warning: 2 warnings emitted
 

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/match-forbidden-without-eq.stderr
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/match-forbidden-without-eq.stderr
@@ -3,6 +3,9 @@ error: to use a constant of type `Foo` in a pattern, `Foo` must be annotated wit
    |
 LL |         FOO => { }
    |         ^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 warning: floating-point types cannot be used in patterns
   --> $DIR/match-forbidden-without-eq.rs:18:9

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/match-nonempty-array-forbidden-without-eq.stderr
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/match-nonempty-array-forbidden-without-eq.stderr
@@ -3,6 +3,9 @@ error: to use a constant of type `B` in a pattern, `B` must be annotated with `#
    |
 LL |         FOO => { }
    |         ^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: aborting due to previous error
 

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/match-requires-both-partialeq-and-eq.stderr
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/match-requires-both-partialeq-and-eq.stderr
@@ -3,6 +3,9 @@ error: to use a constant of type `Foo` in a pattern, `Foo` must be annotated wit
    |
 LL |         FOO => { }
    |         ^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #108548 (Clarify the 'use a constant in a pattern' error message)
 - #109565 (Improve documentation for E0223)
 - #109661 (Fix LVI test post LLVM 16 update)
 - #109667 (Always set `RUSTC_BOOTSTRAP` with `x doc`)
 - #109669 (Update books)
 - #109678 (Don't shadow the `dep_node` var in `incremental_verify_ich_failed`)
 - #109682 (Add `#[inline]` to CStr trait implementations)
 - #109685 (Make doc comment a little bit more accurate)
 - #109687 (Document the heuristics IsTerminal uses on Windows)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=108548,109565,109661,109667,109669,109678,109682,109685,109687)
<!-- homu-ignore:end -->