### PR TITLE
Implement `Future` for `Option<F>`

### DIFF
--- a/tests/ui/async-await/drop-track-bad-field-in-fru.rs
+++ b/tests/ui/async-await/drop-track-bad-field-in-fru.rs
@@ -5,6 +5,5 @@ fn main() {}
 
 async fn foo() {
     None { value: (), ..Default::default() }.await;
-    //~^ ERROR `Option<_>` is not a future
-    //~| ERROR variant `Option<_>::None` has no field named `value`
+    //~^ ERROR variant `Option<_>::None` has no field named `value`
 }

--- a/tests/ui/async-await/drop-track-bad-field-in-fru.stderr
+++ b/tests/ui/async-await/drop-track-bad-field-in-fru.stderr
@@ -4,20 +4,6 @@ error[E0559]: variant `Option<_>::None` has no field named `value`
 LL |     None { value: (), ..Default::default() }.await;
    |            ^^^^^ `Option<_>::None` does not have this field
 
-error[E0277]: `Option<_>` is not a future
-  --> $DIR/drop-track-bad-field-in-fru.rs:7:45
-   |
-LL |     None { value: (), ..Default::default() }.await;
-   |                                             ^^^^^^
-   |                                             |
-   |                                             `Option<_>` is not a future
-   |                                             help: remove the `.await`
-   |
-   = help: the trait `Future` is not implemented for `Option<_>`
-   = note: Option<_> must be a future or must implement `IntoFuture` to be awaited
-   = note: required for `Option<_>` to implement `IntoFuture`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0277, E0559.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0559`.


### PR DESCRIPTION
When working with an `Option<F: Future>` in an `async` context, one may want to defer the handling of `None`. This is currently cumbersome/verbose to do.

ACP: https://github.com/rust-lang/libs-team/issues/197