### PR TITLE
do not panic on failure to acquire jobserver token

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1452,8 +1452,8 @@ fn start_executing_work<B: ExtraBackendMethods>(
                         Err(e) => {
                             let msg = &format!("failed to acquire jobserver token: {}", e);
                             shared_emitter.fatal(msg);
-                            // Exit the coordinator thread
-                            panic!("{}", msg)
+                            codegen_done = true;
+                            codegen_aborted = true;
                         }
                     }
                 }

--- a/tests/run-make/jobserver-error/Makefile
+++ b/tests/run-make/jobserver-error/Makefile
@@ -1,0 +1,8 @@
+include ../../run-make-fulldeps/tools.mk
+
+# only-linux
+
+# Test compiler behavior in case: `jobserver-auth` points to correct pipe which is not jobserver.
+
+all:
+	bash -c 'echo "fn main() {}" | MAKEFLAGS="--jobserver-auth=3,3" $(RUSTC) - 3</dev/null' 2>&1 | diff jobserver.stderr -

--- a/tests/run-make/jobserver-error/jobserver.stderr
+++ b/tests/run-make/jobserver-error/jobserver.stderr
@@ -1,0 +1,4 @@
+error: failed to acquire jobserver token: early EOF on jobserver pipe
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Purpose: remove `panic`.

Rust fails to acquire token if an error in build system occurs - environment variable contains incorrect `jobserver-auth`. It isn't ice so compiler shouldn't panic on such error.

Related issue: #46981

