### PR TITLE
warning on panic while panic-in-drop=abort

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -508,3 +508,5 @@ lint_opaque_hidden_inferred_bound = opaque type `{$ty}` does not satisfy its ass
     .specifically = this associated type bound is unsatisfied for `{$proj_ty}`
 
 lint_opaque_hidden_inferred_bound_sugg = add this bound
+
+lint_panic_in_drop = found panic in Drop::drop call stack

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -71,6 +71,7 @@ mod non_fmt_panic;
 mod nonstandard_style;
 mod noop_method_call;
 mod opaque_hidden_inferred_bound;
+mod panic_in_drop;
 mod pass_by_value;
 mod passes;
 mod redundant_semicolon;
@@ -109,6 +110,7 @@ use non_fmt_panic::NonPanicFmt;
 use nonstandard_style::*;
 use noop_method_call::*;
 use opaque_hidden_inferred_bound::*;
+use panic_in_drop::*;
 use pass_by_value::*;
 use redundant_semicolon::*;
 use traits::*;
@@ -242,6 +244,7 @@ late_lint_methods!(
             OpaqueHiddenInferredBound: OpaqueHiddenInferredBound,
             MultipleSupertraitUpcastable: MultipleSupertraitUpcastable,
             MapUnitFn: MapUnitFn,
+            PanicInDrop: PanicInDrop,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1171,6 +1171,11 @@ pub struct DropTraitConstraintsDiag<'a> {
     pub def_id: DefId,
 }
 
+// panic_in_drop.rs
+#[derive(LintDiagnostic)]
+#[diag(lint_panic_in_drop)]
+pub struct PanicInDropAbortDiag {}
+
 // Needed for def_path_str
 impl<'a> DecorateLint<'a, ()> for DropTraitConstraintsDiag<'_> {
     fn decorate_lint<'b>(

--- a/compiler/rustc_lint/src/panic_in_drop.rs
+++ b/compiler/rustc_lint/src/panic_in_drop.rs
@@ -1,0 +1,81 @@
+use crate::context::LintContext;
+use crate::lints::PanicInDropAbortDiag;
+use crate::{LateContext, LateLintPass};
+use rustc_data_structures::fx::FxHashSet;
+use rustc_hir::Node::Item;
+use rustc_hir::{ImplItemKind, ItemKind, LangItem};
+use rustc_middle::mir::{self, visit::Visitor};
+use rustc_middle::ty;
+use rustc_session::config::OptLevel;
+use rustc_span::def_id::DefId;
+use rustc_span::sym;
+use rustc_target::spec::PanicStrategy;
+
+declare_lint! {
+    pub PANIC_IN_DROP,
+    Warn,
+    "detected panic inside Drop::drop call stack"
+}
+
+declare_lint_pass!(PanicInDrop => [PANIC_IN_DROP]);
+
+impl<'tcx> LateLintPass<'tcx> for PanicInDrop {
+    fn check_impl_item(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        impl_item: &'tcx rustc_hir::ImplItem<'tcx>,
+    ) {
+        if cx.tcx.sess.opts.unstable_opts.panic_in_drop != PanicStrategy::Abort
+            || cx.tcx.sess.opts.optimize == OptLevel::No
+            || cx.tcx.sess.opts.debug_assertions
+        {
+            return;
+        }
+        let hir_id = cx.tcx.hir().local_def_id_to_hir_id(impl_item.owner_id.def_id);
+        let parent_impl = cx.tcx.hir().get_parent_item(hir_id);
+        let trait_ref = if let Item(item) = cx.tcx.hir().get_by_def_id(parent_impl.def_id)
+            && parent_impl != rustc_hir::CRATE_OWNER_ID
+            && let ItemKind::Impl(impl_) = &item.kind
+        {
+            impl_.of_trait.as_ref().and_then(|t| t.trait_def_id())
+        } else {
+            None
+        };
+
+        if let ImplItemKind::Fn(..) = impl_item.kind
+            &&  cx.tcx.lang_items().drop_trait() == trait_ref
+            && impl_item.ident.name == sym::drop
+        {
+            let mir = cx.tcx.optimized_mir(impl_item.owner_id.def_id);
+            let mut visitor = PanicFnVisitor::new(&cx);
+            visitor.visit_body(mir);
+        }
+    }
+}
+
+struct PanicFnVisitor<'tcx, 'a> {
+    cx: &'a LateContext<'tcx>,
+}
+
+impl<'a, 'tcx> PanicFnVisitor<'tcx, 'a> {
+    fn new(cx: &'a LateContext<'tcx>) -> Self {
+        PanicFnVisitor { cx }
+    }
+}
+
+impl<'tcx, 'a> Visitor<'tcx> for PanicFnVisitor<'tcx, 'a> {
+    fn visit_operand(&mut self, operand: &mir::Operand<'tcx>, location: mir::Location) {
+        use mir::Operand::*;
+        match operand {
+            Constant(cst) => {
+                if let ty::FnDef(def_id, _) = cst.literal.ty().kind() {
+                    if self.cx.tcx.lang_items().get(LangItem::Panic) == Some(*def_id) {
+                        self.cx.emit_spanned_lint(PANIC_IN_DROP, cst.span, PanicInDropAbortDiag {});
+                    }
+                }
+            }
+            _ => {}
+        };
+        self.super_operand(operand, location);
+    }
+}

--- a/tests/ui/panics/panic_in_drop.rs
+++ b/tests/ui/panics/panic_in_drop.rs
@@ -1,0 +1,15 @@
+// compile-flags: -Zpanic-in-drop=abort -Copt-level=1 --crate-type lib
+// check-pass
+#![warn(panic_in_drop)]
+
+pub struct A;
+
+impl Drop for A {
+    fn drop(&mut self) {
+        (|| bar())();
+    }
+}
+
+fn bar() {
+    todo!();
+}


### PR DESCRIPTION
This lint checks whether the call stack of Drop::drop contains a `panic_fmt` function on `panic-in-drop=abort` mode.

https://github.com/rust-lang/rfcs/pull/3288

cc @danielhenrymantilla 