### PR TITLE
Fix mismatched punctuation in Debug impl of AttrId

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2570,7 +2570,7 @@ pub enum AttrStyle {
 
 rustc_index::newtype_index! {
     #[custom_encodable]
-    #[debug_format = "AttrId({})]"]
+    #[debug_format = "AttrId({})"]
     pub struct AttrId {}
 }
 


### PR DESCRIPTION
I noticed this odd line in `ast-tree` output.

```console
$ echo '#[attr] struct S;' | rustc -Zunpretty=ast-tree -
```

```rust
...
            attrs: [
                Attribute {
                    kind: Normal(
                        NormalAttr {
                            item: AttrItem {
                                path: Path {
                                    segments: [
                                        PathSegment {
                                            ident: attr#0,
                                            args: None,
                                        },
                                    ],
                                    tokens: None,
                                },
                                args: Empty,
                            },
                        },
                    ),
                    id: AttrId(0)],      // <------
                    style: Outer,
                },
```