### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1452,8 +1452,8 @@ fn start_executing_work<B: ExtraBackendMethods>(
                         Err(e) => {
                             let msg = &format!("failed to acquire jobserver token: {}", e);
                             shared_emitter.fatal(msg);
-                            // Exit the coordinator thread
-                            panic!("{}", msg)
+                            codegen_done = true;
+                            codegen_aborted = true;
                         }
                     }
                 }

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -202,7 +202,10 @@ impl AnnotateSnippetEmitterWriter {
                             annotations: annotations
                                 .iter()
                                 .map(|annotation| SourceAnnotation {
-                                    range: (annotation.start_col, annotation.end_col),
+                                    range: (
+                                        annotation.start_col.display,
+                                        annotation.end_col.display,
+                                    ),
                                     label: annotation.label.as_deref().unwrap_or_default(),
                                     annotation_type: annotation_type_for_level(*level),
                                 })

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -17,7 +17,6 @@ use rustc_middle::ty::ProjectionPredicate;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_middle::ty::{ToPredicate, TypeVisitableExt};
 use rustc_span::{sym, DUMMY_SP};
-use std::iter;
 
 impl<'tcx> EvalCtxt<'_, 'tcx> {
     #[instrument(level = "debug", skip(self), ret)]
@@ -144,9 +143,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
         let goal_trait_ref = goal.predicate.projection_ty.trait_ref(tcx);
         let impl_trait_ref = tcx.impl_trait_ref(impl_def_id).unwrap();
         let drcx = DeepRejectCtxt { treat_obligation_params: TreatParams::ForLookup };
-        if iter::zip(goal_trait_ref.substs, impl_trait_ref.skip_binder().substs)
-            .any(|(goal, imp)| !drcx.generic_args_may_unify(goal, imp))
-        {
+        if !drcx.substs_refs_may_unify(goal_trait_ref.substs, impl_trait_ref.skip_binder().substs) {
             return Err(NoSolution);
         }
 

--- a/compiler/rustc_trait_selection/src/solve/trait_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals.rs
@@ -1,7 +1,5 @@
 //! Dealing with trait goals, i.e. `T: Trait<'a, U>`.
 
-use std::iter;
-
 use super::{assembly, EvalCtxt, SolverMode};
 use rustc_hir::def_id::DefId;
 use rustc_hir::LangItem;
@@ -41,9 +39,10 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
 
         let impl_trait_ref = tcx.impl_trait_ref(impl_def_id).unwrap();
         let drcx = DeepRejectCtxt { treat_obligation_params: TreatParams::ForLookup };
-        if iter::zip(goal.predicate.trait_ref.substs, impl_trait_ref.skip_binder().substs)
-            .any(|(goal, imp)| !drcx.generic_args_may_unify(goal, imp))
-        {
+        if !drcx.substs_refs_may_unify(
+            goal.predicate.trait_ref.substs,
+            impl_trait_ref.skip_binder().substs,
+        ) {
             return Err(NoSolution);
         }
 

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -79,8 +79,9 @@ pub fn overlapping_impls(
     let impl1_ref = tcx.impl_trait_ref(impl1_def_id);
     let impl2_ref = tcx.impl_trait_ref(impl2_def_id);
     let may_overlap = match (impl1_ref, impl2_ref) {
-        (Some(a), Some(b)) => iter::zip(a.skip_binder().substs, b.skip_binder().substs)
-            .all(|(arg1, arg2)| drcx.generic_args_may_unify(arg1, arg2)),
+        (Some(a), Some(b)) => {
+            drcx.substs_refs_may_unify(a.skip_binder().substs, b.skip_binder().substs)
+        }
         (None, None) => {
             let self_ty1 = tcx.type_of(impl1_def_id).skip_binder();
             let self_ty2 = tcx.type_of(impl2_def_id).skip_binder();

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2542,8 +2542,10 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
         // substitution if we find that any of the input types, when
         // simplified, do not match.
         let drcx = DeepRejectCtxt { treat_obligation_params: TreatParams::ForLookup };
-        iter::zip(obligation.predicate.skip_binder().trait_ref.substs, impl_trait_ref.substs)
-            .any(|(obl, imp)| !drcx.generic_args_may_unify(obl, imp))
+        !drcx.substs_refs_may_unify(
+            obligation.predicate.skip_binder().trait_ref.substs,
+            impl_trait_ref.substs,
+        )
     }
 
     /// Normalize `where_clause_trait_ref` and try to match it against

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -45,7 +45,6 @@ use rustc_infer::traits::TraitEngineExt;
 use rustc_middle::dep_graph::{DepKind, DepNodeIndex};
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::ty::abstract_const::NotConstEvaluatable;
-use rustc_middle::ty::fast_reject::{DeepRejectCtxt, TreatParams};
 use rustc_middle::ty::fold::BottomUpFolder;
 use rustc_middle::ty::relate::TypeRelation;
 use rustc_middle::ty::SubstsRef;
@@ -2531,21 +2530,6 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
         }
 
         Ok(Normalized { value: impl_substs, obligations: nested_obligations })
-    }
-
-    fn fast_reject_trait_refs(
-        &mut self,
-        obligation: &TraitObligation<'tcx>,
-        impl_trait_ref: &ty::TraitRef<'tcx>,
-    ) -> bool {
-        // We can avoid creating type variables and doing the full
-        // substitution if we find that any of the input types, when
-        // simplified, do not match.
-        let drcx = DeepRejectCtxt { treat_obligation_params: TreatParams::ForLookup };
-        !drcx.substs_refs_may_unify(
-            obligation.predicate.skip_binder().trait_ref.substs,
-            impl_trait_ref.substs,
-        )
     }
 
     /// Normalize `where_clause_trait_ref` and try to match it against

--- a/tests/run-make/jobserver-error/Makefile
+++ b/tests/run-make/jobserver-error/Makefile
@@ -1,0 +1,8 @@
+include ../../run-make-fulldeps/tools.mk
+
+# only-linux
+
+# Test compiler behavior in case: `jobserver-auth` points to correct pipe which is not jobserver.
+
+all:
+	bash -c 'echo "fn main() {}" | MAKEFLAGS="--jobserver-auth=3,3" $(RUSTC) - 3</dev/null' 2>&1 | diff jobserver.stderr -

--- a/tests/run-make/jobserver-error/jobserver.stderr
+++ b/tests/run-make/jobserver-error/jobserver.stderr
@@ -1,0 +1,4 @@
+error: failed to acquire jobserver token: early EOF on jobserver pipe
+
+error: aborting due to previous error
+

--- a/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.current.stderr
+++ b/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/dont-project-to-specializable-projection.rs:4:12
+  --> $DIR/dont-project-to-specializable-projection.rs:6:12
    |
 LL | #![feature(async_fn_in_trait)]
    |            ^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | #![feature(async_fn_in_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: async associated function in trait cannot be specialized
-  --> $DIR/dont-project-to-specializable-projection.rs:14:5
+  --> $DIR/dont-project-to-specializable-projection.rs:16:5
    |
 LL |     default async fn foo(_: T) -> &'static str {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.next.stderr
+++ b/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.next.stderr
@@ -1,0 +1,34 @@
+warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/dont-project-to-specializable-projection.rs:6:12
+   |
+LL | #![feature(async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0053]: method `foo` has an incompatible type for trait
+  --> $DIR/dont-project-to-specializable-projection.rs:16:35
+   |
+LL |     default async fn foo(_: T) -> &'static str {
+   |                                   ^^^^^^^^^^^^ expected associated type, found future
+   |
+note: type in trait
+  --> $DIR/dont-project-to-specializable-projection.rs:12:27
+   |
+LL |     async fn foo(_: T) -> &'static str;
+   |                           ^^^^^^^^^^^^
+   = note: expected signature `fn(_) -> impl Future<Output = &'static str>`
+              found signature `fn(_) -> impl Future<Output = &'static str>`
+
+error: async associated function in trait cannot be specialized
+  --> $DIR/dont-project-to-specializable-projection.rs:16:5
+   |
+LL |     default async fn foo(_: T) -> &'static str {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: specialization behaves in inconsistent and surprising ways with `#![feature(async_fn_in_trait)]`, and for now is disallowed
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0053`.

--- a/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.rs
+++ b/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.rs
@@ -1,5 +1,7 @@
 // edition: 2021
 // known-bug: #108309
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(async_fn_in_trait)]
 #![feature(min_specialization)]

--- a/tests/ui/diagnostic-width/auxiliary/tab_column_numbers.rs
+++ b/tests/ui/diagnostic-width/auxiliary/tab_column_numbers.rs
@@ -1,0 +1,6 @@
+// ignore-tidy-tab
+
+pub struct S;
+impl S {
+		fn method(&self) {}
+}

--- a/tests/ui/diagnostic-width/tab-column-numbers.rs
+++ b/tests/ui/diagnostic-width/tab-column-numbers.rs
@@ -1,0 +1,12 @@
+// Test for #109537: ensure that column numbers are correctly generated when using hard tabs.
+// aux-build:tab_column_numbers.rs
+
+// ignore-tidy-tab
+
+extern crate tab_column_numbers;
+
+fn main() {
+	let s = tab_column_numbers::S;
+	s.method();
+	//~^ ERROR method `method` is private
+}

--- a/tests/ui/diagnostic-width/tab-column-numbers.stderr
+++ b/tests/ui/diagnostic-width/tab-column-numbers.stderr
@@ -1,0 +1,14 @@
+error[E0624]: method `method` is private
+  --> $DIR/tab-column-numbers.rs:10:4
+   |
+LL |     s.method();
+   |       ^^^^^^ private method
+   |
+  ::: $DIR/auxiliary/tab_column_numbers.rs:5:3
+   |
+LL |         fn method(&self) {}
+   |         ---------------- private method defined here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0624`.

--- a/tests/ui/macros/missing-writer.rs
+++ b/tests/ui/macros/missing-writer.rs
@@ -1,0 +1,17 @@
+// Check error for missing writer in writeln! and write! macro
+fn main() {
+    let x = 1;
+    let y = 2;
+    write!("{}_{}", x, y);
+    //~^ ERROR format argument must be a string literal
+    //~| HELP you might be missing a string literal to format with
+    //~| ERROR cannot write into `&'static str`
+    //~| NOTE must implement `io::Write`, `fmt::Write`, or have a `write_fmt` method
+    //~| HELP a writer is needed before this format string
+    writeln!("{}_{}", x, y);
+    //~^ ERROR format argument must be a string literal
+    //~| HELP you might be missing a string literal to format with
+    //~| ERROR cannot write into `&'static str`
+    //~| NOTE must implement `io::Write`, `fmt::Write`, or have a `write_fmt` method
+    //~| HELP a writer is needed before this format string
+}

--- a/tests/ui/macros/missing-writer.stderr
+++ b/tests/ui/macros/missing-writer.stderr
@@ -1,0 +1,59 @@
+error: format argument must be a string literal
+  --> $DIR/missing-writer.rs:5:21
+   |
+LL |     write!("{}_{}", x, y);
+   |                     ^
+   |
+help: you might be missing a string literal to format with
+   |
+LL |     write!("{}_{}", "{} {}", x, y);
+   |                     ++++++++
+
+error: format argument must be a string literal
+  --> $DIR/missing-writer.rs:11:23
+   |
+LL |     writeln!("{}_{}", x, y);
+   |                       ^
+   |
+help: you might be missing a string literal to format with
+   |
+LL |     writeln!("{}_{}", "{} {}", x, y);
+   |                       ++++++++
+
+error[E0599]: cannot write into `&'static str`
+  --> $DIR/missing-writer.rs:5:12
+   |
+LL |     write!("{}_{}", x, y);
+   |     -------^^^^^^^------- method not found in `&str`
+   |
+note: must implement `io::Write`, `fmt::Write`, or have a `write_fmt` method
+  --> $DIR/missing-writer.rs:5:12
+   |
+LL |     write!("{}_{}", x, y);
+   |            ^^^^^^^
+help: a writer is needed before this format string
+  --> $DIR/missing-writer.rs:5:12
+   |
+LL |     write!("{}_{}", x, y);
+   |            ^
+
+error[E0599]: cannot write into `&'static str`
+  --> $DIR/missing-writer.rs:11:14
+   |
+LL |     writeln!("{}_{}", x, y);
+   |     ---------^^^^^^^------- method not found in `&str`
+   |
+note: must implement `io::Write`, `fmt::Write`, or have a `write_fmt` method
+  --> $DIR/missing-writer.rs:11:14
+   |
+LL |     writeln!("{}_{}", x, y);
+   |              ^^^^^^^
+help: a writer is needed before this format string
+  --> $DIR/missing-writer.rs:11:14
+   |
+LL |     writeln!("{}_{}", x, y);
+   |              ^
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/tests/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -21,18 +21,22 @@ note: required by a bound in `BufWriter`
   --> $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
 
 error[E0599]: the method `write_fmt` exists for struct `BufWriter<&dyn Write>`, but its trait bounds were not satisfied
-  --> $DIR/mut-borrow-needed-by-trait.rs:21:5
+  --> $DIR/mut-borrow-needed-by-trait.rs:21:14
    |
 LL |     writeln!(fp, "hello world").unwrap();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `BufWriter<&dyn Write>` due to unsatisfied trait bounds
+   |     ---------^^---------------- method cannot be called on `BufWriter<&dyn Write>` due to unsatisfied trait bounds
   --> $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
    |
    = note: doesn't satisfy `BufWriter<&dyn std::io::Write>: std::io::Write`
    |
+note: must implement `io::Write`, `fmt::Write`, or have a `write_fmt` method
+  --> $DIR/mut-borrow-needed-by-trait.rs:21:14
+   |
+LL |     writeln!(fp, "hello world").unwrap();
+   |              ^^
    = note: the following trait bounds were not satisfied:
            `&dyn std::io::Write: std::io::Write`
            which is required by `BufWriter<&dyn std::io::Write>: std::io::Write`
-   = note: this error originates in the macro `writeln` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #109149 (Improve error message when writer is forgotten in write and writeln macro)
 - #109367 (Streamline fast rejection)
 - #109548 (AnnotationColumn struct to fix hard tab column numbers in errors)
 - #109694 (do not panic on failure to acquire jobserver token)
 - #109705 (new solver: check for intercrate mode when accessing the cache)
 - #109708 (Specialization involving RPITITs is broken so ignore the diagnostic differences)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=109149,109367,109548,109694,109705,109708)
<!-- homu-ignore:end -->