### PR TITLE
RELEASES: Add "Only support Android NDK 25 or newer" to 1.68.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -94,6 +94,7 @@ Misc
 Compatibility Notes
 -------------------
 
+- [Only support Android NDK 25 or newer](https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html)
 - [Add `SEMICOLON_IN_EXPRESSIONS_FROM_MACROS` to future-incompat report](https://github.com/rust-lang/rust/pull/103418/)
 - [Only specify `--target` by default for `-Zgcc-ld=lld` on wasm](https://github.com/rust-lang/rust/pull/101792/)
 - [Bump `IMPLIED_BOUNDS_ENTAILMENT` to Deny + ReportNow](https://github.com/rust-lang/rust/pull/106465/)


### PR DESCRIPTION
See https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html and https://internals.rust-lang.org/t/rust-1-68-0-pre-release-testing/18481/2