### PR TITLE
Switch to LLD as default linker for {arm,thumb}v4t-none-eabi

### DIFF
--- a/compiler/rustc_target/src/spec/armv4t_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv4t_none_eabi.rs
@@ -4,13 +4,6 @@
 //!
 //! Please ping @Lokathor if changes are needed.
 //!
-//! This target profile assumes that you have the ARM binutils in your path
-//! (specifically the linker, `arm-none-eabi-ld`). They can be obtained for free
-//! for all major OSes from the ARM developer's website, and they may also be
-//! available in your system's package manager. Unfortunately, the standard
-//! linker that Rust uses (`lld`) only supports as far back as `ARMv5TE`, so we
-//! must use the GNU `ld` linker.
-//!
 //! **Important:** This target profile **does not** specify a linker script. You
 //! just get the default link script when you build a binary for this target.
 //! The default link script is very likely wrong, so you should use
@@ -35,8 +28,8 @@ pub fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         options: TargetOptions {
             abi: "eabi".into(),
-            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::No),
-            linker: Some("arm-none-eabi-ld".into()),
+            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
+            linker: Some("rust-lld".into()),
             asm_args: cvs!["-mthumb-interwork", "-march=armv4t", "-mlittle-endian",],
             // Force-enable 32-bit atomics, which allows the use of atomic load/store only.
             // The resulting atomics are ABI incompatible with atomics backed by libatomic.

--- a/compiler/rustc_target/src/spec/thumbv4t_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/thumbv4t_none_eabi.rs
@@ -4,19 +4,12 @@
 //!
 //! Please ping @Lokathor if changes are needed.
 //!
-//! This target profile assumes that you have the ARM binutils in your path
-//! (specifically the linker, `arm-none-eabi-ld`). They can be obtained for free
-//! for all major OSes from the ARM developer's website, and they may also be
-//! available in your system's package manager. Unfortunately, the standard
-//! linker that Rust uses (`lld`) only supports as far back as `ARMv5TE`, so we
-//! must use the GNU `ld` linker.
-//!
 //! **Important:** This target profile **does not** specify a linker script. You
 //! just get the default link script when you build a binary for this target.
 //! The default link script is very likely wrong, so you should use
 //! `-Clink-arg=-Tmy_script.ld` to override that with a correct linker script.
 
-use crate::spec::{cvs, Cc, FramePointer, LinkerFlavor, Lld};
+use crate::spec::{cvs, FramePointer};
 use crate::spec::{PanicStrategy, RelocModel, Target, TargetOptions};
 
 pub fn target() -> Target {
@@ -36,8 +29,6 @@ pub fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         options: TargetOptions {
             abi: "eabi".into(),
-            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::No),
-            linker: Some("arm-none-eabi-ld".into()),
 
             // extra args passed to the external assembler (assuming `arm-none-eabi-as`):
             // * activate t32/a32 interworking

--- a/src/doc/rustc/src/platform-support/armv4t-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv4t-none-eabi.md
@@ -17,13 +17,6 @@ specific with this target, so any ARMv4T device should work fine.
 
 The target is cross-compiled, and uses static linking.
 
-The linker that comes with rustc cannot link for this platform (the platform is
-too old). You will need the `arm-none-eabi-ld` linker from a GNU Binutils
-targeting ARM. This can be obtained for Windows/Mac/Linux from the [ARM
-Developer Website][arm-dev], or possibly from your OS's package manager.
-
-[arm-dev]: https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain
-
 This target doesn't provide a linker script, you'll need to bring your own
 according to the specific device you want to target. Pass
 `-Clink-arg=-Tyour_script.ld` as a rustc argument to make the linker use


### PR DESCRIPTION
The LLVM 16 update brought ARMv4t support to LLD. We should use it by default so users don't need to install an external linker.

cc @Lokathor 