### PR TITLE
rustdoc: Don't strip crate module

### DIFF
--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -121,9 +121,14 @@ impl<'a, 'tcx> DocFolder for Stripper<'a, 'tcx> {
                 // strip things like impl methods but when doing so
                 // we must not add any items to the `retained` set.
                 let old = mem::replace(&mut self.update_retained, false);
-                let ret = strip_item(self.set_is_in_hidden_item_and_fold(true, i));
+                let ret = self.set_is_in_hidden_item_and_fold(true, i);
                 self.update_retained = old;
-                Some(ret)
+                if ret.is_crate() {
+                    // We don't strip the crate, even if it has `#[doc(hidden)]`.
+                    Some(ret)
+                } else {
+                    Some(strip_item(ret))
+                }
             }
             _ => {
                 let ret = self.set_is_in_hidden_item_and_fold(true, i);

--- a/tests/rustdoc/issue-109695-crate-doc-hidden.rs
+++ b/tests/rustdoc/issue-109695-crate-doc-hidden.rs
@@ -1,0 +1,8 @@
+// This test ensures that even if the crate module is `#[doc(hidden)]`, the file
+// is generated.
+
+// @has 'foo/index.html'
+// @has 'foo/all.html'
+
+#![crate_name = "foo"]
+#![doc(hidden)]


### PR DESCRIPTION
Until we decide something for https://github.com/rust-lang/rust/issues/109695, rustdoc won't crash anymore because the crate folder doesn't exist.

r? @notriddle 