### PR TITLE
Closures always implement `FnOnce` in new solver

### DIFF
--- a/tests/ui/traits/new-solver/closure-inference-guidance.rs
+++ b/tests/ui/traits/new-solver/closure-inference-guidance.rs
@@ -1,0 +1,11 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+fn foo(i: isize) -> isize { i + 1 }
+
+fn apply<A, F>(f: F, v: A) -> A where F: FnOnce(A) -> A { f(v) }
+
+pub fn main() {
+    let f = |i| foo(i);
+    assert_eq!(apply(f, 2), 3);
+}


### PR DESCRIPTION
We should process `[closure]: FnOnce(Tys...) -> Ty` obligations *before* fallback and closure analysis. We can do this by taking advantage of the fact that `FnOnce` is always implemented by closures, even before we definitely know the closure kind.

Fixes compiler-errors/next-solver-hir-issues#15

r? @oli-obk (trying to spread the reviewer load for new trait solver prs, and this one is pretty self-contained, though feel free to reassign 😸)