### PR TITLE
simplify int/float vars into same class as int/float types

### DIFF
--- a/compiler/rustc_middle/src/ty/fast_reject.rs
+++ b/compiler/rustc_middle/src/ty/fast_reject.rs
@@ -13,9 +13,8 @@ use self::SimplifiedType::*;
 pub enum SimplifiedType {
     BoolSimplifiedType,
     CharSimplifiedType,
-    IntSimplifiedType(ty::IntTy),
-    UintSimplifiedType(ty::UintTy),
-    FloatSimplifiedType(ty::FloatTy),
+    IntSimplifiedType,
+    FloatSimplifiedType,
     AdtSimplifiedType(DefId),
     ForeignSimplifiedType(DefId),
     StrSimplifiedType,
@@ -112,9 +111,8 @@ pub fn simplify_type<'tcx>(
     match *ty.kind() {
         ty::Bool => Some(BoolSimplifiedType),
         ty::Char => Some(CharSimplifiedType),
-        ty::Int(int_type) => Some(IntSimplifiedType(int_type)),
-        ty::Uint(uint_type) => Some(UintSimplifiedType(uint_type)),
-        ty::Float(float_type) => Some(FloatSimplifiedType(float_type)),
+        ty::Int(_) | ty::Uint(_) | ty::Infer(ty::IntVar(_)) => Some(IntSimplifiedType),
+        ty::Float(_) | ty::Infer(ty::FloatVar(_)) => Some(FloatSimplifiedType),
         ty::Adt(def, _) => Some(AdtSimplifiedType(def.did())),
         ty::Str => Some(StrSimplifiedType),
         ty::Array(..) => Some(ArraySimplifiedType),

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1738,27 +1738,26 @@ impl PrimitiveType {
 
     pub(crate) fn simplified_types() -> &'static SimplifiedTypes {
         use ty::fast_reject::SimplifiedType::*;
-        use ty::{FloatTy, IntTy, UintTy};
         use PrimitiveType::*;
         static CELL: OnceCell<SimplifiedTypes> = OnceCell::new();
 
         let single = |x| iter::once(x).collect();
         CELL.get_or_init(move || {
             map! {
-                Isize => single(IntSimplifiedType(IntTy::Isize)),
-                I8 => single(IntSimplifiedType(IntTy::I8)),
-                I16 => single(IntSimplifiedType(IntTy::I16)),
-                I32 => single(IntSimplifiedType(IntTy::I32)),
-                I64 => single(IntSimplifiedType(IntTy::I64)),
-                I128 => single(IntSimplifiedType(IntTy::I128)),
-                Usize => single(UintSimplifiedType(UintTy::Usize)),
-                U8 => single(UintSimplifiedType(UintTy::U8)),
-                U16 => single(UintSimplifiedType(UintTy::U16)),
-                U32 => single(UintSimplifiedType(UintTy::U32)),
-                U64 => single(UintSimplifiedType(UintTy::U64)),
-                U128 => single(UintSimplifiedType(UintTy::U128)),
-                F32 => single(FloatSimplifiedType(FloatTy::F32)),
-                F64 => single(FloatSimplifiedType(FloatTy::F64)),
+                Isize => single(IntSimplifiedType),
+                I8 => single(IntSimplifiedType),
+                I16 => single(IntSimplifiedType),
+                I32 => single(IntSimplifiedType),
+                I64 => single(IntSimplifiedType),
+                I128 => single(IntSimplifiedType),
+                Usize => single(IntSimplifiedType),
+                U8 => single(IntSimplifiedType),
+                U16 => single(IntSimplifiedType),
+                U32 => single(IntSimplifiedType),
+                U64 => single(IntSimplifiedType),
+                U128 => single(FloatSimplifiedType),
+                F32 => single(FloatSimplifiedType),
+                F64 => single(FloatSimplifiedType),
                 Str => single(StrSimplifiedType),
                 Bool => single(BoolSimplifiedType),
                 Char => single(CharSimplifiedType),

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -101,12 +101,11 @@ use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow};
 use rustc_middle::ty::binding::BindingMode;
 use rustc_middle::ty::fast_reject::SimplifiedType::{
     ArraySimplifiedType, BoolSimplifiedType, CharSimplifiedType, FloatSimplifiedType, IntSimplifiedType,
-    PtrSimplifiedType, SliceSimplifiedType, StrSimplifiedType, UintSimplifiedType,
+    PtrSimplifiedType, SliceSimplifiedType, StrSimplifiedType,
 };
 use rustc_middle::ty::{
     layout::IntegerExt, BorrowKind, ClosureKind, Ty, TyCtxt, TypeAndMut, TypeVisitableExt, UpvarCapture,
 };
-use rustc_middle::ty::{FloatTy, IntTy, UintTy};
 use rustc_span::hygiene::{ExpnKind, MacroKind};
 use rustc_span::source_map::SourceMap;
 use rustc_span::sym;
@@ -524,20 +523,20 @@ fn find_primitive_impls<'tcx>(tcx: TyCtxt<'tcx>, name: &str) -> impl Iterator<It
         // Maybe this is something we should do here too.
         "const_ptr" => PtrSimplifiedType(Mutability::Not),
         "mut_ptr" => PtrSimplifiedType(Mutability::Mut),
-        "isize" => IntSimplifiedType(IntTy::Isize),
-        "i8" => IntSimplifiedType(IntTy::I8),
-        "i16" => IntSimplifiedType(IntTy::I16),
-        "i32" => IntSimplifiedType(IntTy::I32),
-        "i64" => IntSimplifiedType(IntTy::I64),
-        "i128" => IntSimplifiedType(IntTy::I128),
-        "usize" => UintSimplifiedType(UintTy::Usize),
-        "u8" => UintSimplifiedType(UintTy::U8),
-        "u16" => UintSimplifiedType(UintTy::U16),
-        "u32" => UintSimplifiedType(UintTy::U32),
-        "u64" => UintSimplifiedType(UintTy::U64),
-        "u128" => UintSimplifiedType(UintTy::U128),
-        "f32" => FloatSimplifiedType(FloatTy::F32),
-        "f64" => FloatSimplifiedType(FloatTy::F64),
+        "isize" => IntSimplifiedType,
+        "i8" => IntSimplifiedType,
+        "i16" => IntSimplifiedType,
+        "i32" => IntSimplifiedType,
+        "i64" => IntSimplifiedType,
+        "i128" => IntSimplifiedType,
+        "usize" => IntSimplifiedType,
+        "u8" => IntSimplifiedType,
+        "u16" => IntSimplifiedType,
+        "u32" => IntSimplifiedType,
+        "u64" => IntSimplifiedType,
+        "u128" => IntSimplifiedType,
+        "f32" => FloatSimplifiedType,
+        "f64" => FloatSimplifiedType,
         _ => return [].iter().copied(),
     };
 


### PR DESCRIPTION
This fixes compiler-errors/next-solver-hir-issues#11, but it also will very likely affect perf on the old solver.

r? @ghost