### PR TITLE
Canonicalize float var as float in new solver

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/canonicalize.rs
+++ b/compiler/rustc_trait_selection/src/solve/canonicalize.rs
@@ -291,7 +291,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'_, 'tcx> {
                 if nt != t {
                     return self.fold_ty(nt);
                 } else {
-                    CanonicalVarKind::Ty(CanonicalTyVarKind::Int)
+                    CanonicalVarKind::Ty(CanonicalTyVarKind::Float)
                 }
             }
             ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {

--- a/tests/ui/traits/new-solver/float-canonical.rs
+++ b/tests/ui/traits/new-solver/float-canonical.rs
@@ -1,0 +1,8 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+fn foo(x: f64) {
+    let y = x + 1.0;
+}
+
+fn main() {}


### PR DESCRIPTION
Typo in new canonicalizer -- we should be canonicalizing float vars as `CanonicalTyVarKind::Float`, not `CanonicalTyVarKind::Int`.

Fixes compiler-errors/next-solver-hir-issues#9