### PR TITLE
numeric vars can only be unified with numerical types in deep reject

### DIFF
--- a/compiler/rustc_middle/src/ty/fast_reject.rs
+++ b/compiler/rustc_middle/src/ty/fast_reject.rs
@@ -321,6 +321,10 @@ impl DeepRejectCtxt {
                 TreatParams::AsCandidateKey => true,
             },
 
+            ty::Infer(ty::IntVar(_)) => impl_ty.is_integral(),
+
+            ty::Infer(ty::FloatVar(_)) => impl_ty.is_floating_point(),
+
             ty::Infer(_) => true,
 
             // As we're walking the whole type, it may encounter projections


### PR DESCRIPTION
Don't consider numeric vars (int and float vars) to unify with non-numeric types during deep reject. This helps us reject incompatible impls sooner.