### PR TITLE
AIX uses gmake for GNU style Makefile

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2996,6 +2996,7 @@ impl<'test> TestCx<'test> {
             || host.contains("freebsd")
             || host.contains("netbsd")
             || host.contains("openbsd")
+            || host.contains("aix")
         {
             "gmake"
         } else {


### PR DESCRIPTION
AIX's `make` is SystemV style, should use `gmake` for GNU style Makefile.