### PR TITLE
Stall auto trait assembly in new solver for int/float vars

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/structural_traits.rs
@@ -24,21 +24,19 @@ pub(in crate::solve) fn instantiate_constituent_tys_for_auto_trait<'tcx>(
         | ty::FnDef(..)
         | ty::FnPtr(_)
         | ty::Error(_)
-        | ty::Infer(ty::IntVar(_) | ty::FloatVar(_))
         | ty::Never
         | ty::Char => Ok(vec![]),
 
-        // Treat this like `struct str([u8]);`
+        // Treat `str` like it's defined as `struct str([u8]);`
         ty::Str => Ok(vec![tcx.mk_slice(tcx.types.u8)]),
 
         ty::Dynamic(..)
         | ty::Param(..)
         | ty::Foreign(..)
         | ty::Alias(ty::Projection, ..)
-        | ty::Placeholder(..) => Err(NoSolution),
-
-        ty::Bound(..)
-        | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+        | ty::Placeholder(..)
+        | ty::Bound(..)
+        | ty::Infer(_) => {
             bug!("unexpected type `{ty}`")
         }
 

--- a/tests/ui/traits/new-solver/int-var-is-send.rs
+++ b/tests/ui/traits/new-solver/int-var-is-send.rs
@@ -1,0 +1,8 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+fn needs_send(_: impl Send) {}
+
+fn main() {
+    needs_send(1);
+}

--- a/tests/ui/traits/new-solver/stall-num-var-auto-trait.fallback.stderr
+++ b/tests/ui/traits/new-solver/stall-num-var-auto-trait.fallback.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `i32: Foo` is not satisfied
+  --> $DIR/stall-num-var-auto-trait.rs:18:15
+   |
+LL |     needs_foo(x);
+   |     --------- ^ the trait `Foo` is not implemented for `i32`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `needs_foo`
+  --> $DIR/stall-num-var-auto-trait.rs:14:22
+   |
+LL | fn needs_foo(x: impl Foo) {}
+   |                      ^^^ required by this bound in `needs_foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/new-solver/stall-num-var-auto-trait.rs
+++ b/tests/ui/traits/new-solver/stall-num-var-auto-trait.rs
@@ -1,0 +1,25 @@
+// compile-flags: -Ztrait-solver=next
+// revisions: fallback constrain
+//[constrain] check-pass
+
+// Tests that we stall the `{integer}: Foo` obligation until after we
+// constrain the int type (or fallback occurs).
+
+#![feature(negative_impls, auto_traits)]
+
+auto trait Foo {}
+
+impl !Foo for i32 {}
+
+fn needs_foo(x: impl Foo) {}
+
+fn main() {
+    let mut x = 0;
+    needs_foo(x);
+    //[fallback]~^ ERROR the trait bound `i32: Foo` is not satisfied
+
+    #[cfg(constrain)]
+    {
+        x = 1u64;
+    }
+}


### PR DESCRIPTION
Make sure that we don't match int/float vars against *all* manual auto trait impls due to this check:

https://github.com/rust-lang/rust/blob/2fb0e8d162a021f8a795fb603f5d8c0017855160/compiler/rustc_trait_selection/src/solve/trait_goals.rs#L151-L169

Since `find_map_relevant_impl` treats all impls as candidates for int/float vars, due to the way that `fast_reject::simplify_type` works.

This fixes compiler-errors/next-solver-hir-issues#11.

r? @lcnr