### PR TITLE
Implement support for `GeneratorWitnessMIR` in new solver

### DIFF
--- a/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.fail.stderr
+++ b/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.fail.stderr
@@ -1,0 +1,18 @@
+error[E0277]: `impl Future<Output = ()>` cannot be sent between threads safely
+  --> $DIR/auto-with-drop_tracking_mir.rs:24:13
+   |
+LL |     is_send(foo());
+   |     ------- ^^^^^ `impl Future<Output = ()>` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Send` is not implemented for `impl Future<Output = ()>`
+note: required by a bound in `is_send`
+  --> $DIR/auto-with-drop_tracking_mir.rs:23:24
+   |
+LL |     fn is_send(_: impl Send) {}
+   |                        ^^^^ required by this bound in `is_send`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.rs
+++ b/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.rs
@@ -1,0 +1,26 @@
+// compile-flags: -Ztrait-solver=next -Zdrop-tracking-mir
+// edition: 2021
+// revisions: pass fail
+//[pass] check-pass
+
+#![feature(negative_impls)]
+
+struct NotSync;
+impl !Sync for NotSync {}
+
+async fn foo() {
+    #[cfg(pass)]
+    let x = &();
+    #[cfg(fail)]
+    let x = &NotSync;
+    bar().await;
+    drop(x);
+}
+
+async fn bar() {}
+
+fn main() {
+    fn is_send(_: impl Send) {}
+    is_send(foo());
+    //[fail]~^ ERROR `impl Future<Output = ()>` cannot be sent between threads safely
+}


### PR DESCRIPTION
r? @cjgillot 

I mostly want this to cut down the number of failing UI tests when running the UI test suite with `--compare-mode=next-solver`, but there doesn't seem like much reason to block implementing this since it adds minimal complexity to the existing structural traits impl in the new solver.

If others are against adding this for some reason, then maybe we should just make `GeneratorWitnessMIR` return `NoSolution` for these traits. Anything but an ICE please :smile_cat: :ice_cube: 