### PR TITLE
Drop binutils on powerpc-unknown-freebsd

### DIFF
--- a/src/bootstrap/llvm.rs
+++ b/src/bootstrap/llvm.rs
@@ -434,11 +434,6 @@ impl Step for Llvm {
             }
         }
 
-        // Workaround for ppc32 lld limitation
-        if target == "powerpc-unknown-freebsd" {
-            ldflags.exe.push(" -fuse-ld=bfd");
-        }
-
         // https://llvm.org/docs/HowToCrossCompileLLVM.html
         if target != builder.config.build {
             let LlvmResult { llvm_config, .. } =


### PR DESCRIPTION
FreeBSD 13.1 and 13.2 can build Rust with LLD just fine on powerpc.