### PR TITLE
lint incorrect implied bounds in wfcheck

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -330,7 +330,7 @@ fn compare_method_predicate_entailment<'tcx>(
     // lifetime parameters.
     let outlives_env = OutlivesEnvironment::with_bounds(
         param_env,
-        infcx.implied_bounds_tys(param_env, impl_m_def_id, wf_tys.clone()),
+        infcx.implied_bounds_tys_compat(param_env, impl_m_def_id, wf_tys.clone()),
     );
     let errors = infcx.resolve_regions(&outlives_env);
     if !errors.is_empty() {
@@ -724,7 +724,7 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
     // lifetime parameters.
     let outlives_env = OutlivesEnvironment::with_bounds(
         param_env,
-        infcx.implied_bounds_tys(param_env, impl_m_def_id, wf_tys),
+        infcx.implied_bounds_tys_compat(param_env, impl_m_def_id, wf_tys),
     );
     ocx.resolve_regions_and_report_errors(impl_m_def_id, &outlives_env)?;
 
@@ -2050,7 +2050,8 @@ pub(super) fn check_type_bounds<'tcx>(
 
     // Finally, resolve all regions. This catches wily misuses of
     // lifetime parameters.
-    let implied_bounds = infcx.implied_bounds_tys(param_env, impl_ty_def_id, assumed_wf_types);
+    let implied_bounds =
+        infcx.implied_bounds_tys_compat(param_env, impl_ty_def_id, assumed_wf_types);
     let outlives_env = OutlivesEnvironment::with_bounds(param_env, implied_bounds);
     ocx.resolve_regions_and_report_errors(impl_ty_def_id, &outlives_env)
 }

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -106,7 +106,6 @@ pub(super) fn enter_wf_checking_ctxt<'tcx, F>(
     f(&mut wfcx);
 
     let assumed_wf_types = wfcx.ocx.assumed_wf_types(param_env, span, body_def_id);
-    let implied_bounds = infcx.implied_bounds_tys(param_env, body_def_id, assumed_wf_types);
 
     let errors = wfcx.select_all_or_error();
     if !errors.is_empty() {
@@ -114,6 +113,7 @@ pub(super) fn enter_wf_checking_ctxt<'tcx, F>(
         return;
     }
 
+    let implied_bounds = infcx.implied_bounds_tys_v2(param_env, body_def_id, assumed_wf_types);
     let outlives_env = OutlivesEnvironment::with_bounds(param_env, implied_bounds);
 
     let _ = wfcx.ocx.resolve_regions_and_report_errors(body_def_id, &outlives_env);

--- a/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
@@ -176,7 +176,7 @@ fn get_impl_substs(
         return None;
     }
 
-    let implied_bounds = infcx.implied_bounds_tys(param_env, impl1_def_id, assumed_wf_types);
+    let implied_bounds = infcx.implied_bounds_tys_compat(param_env, impl1_def_id, assumed_wf_types);
     let outlives_env = OutlivesEnvironment::with_bounds(param_env, implied_bounds);
     let _ = ocx.resolve_regions_and_report_errors(impl1_def_id, &outlives_env);
     let Ok(impl2_substs) = infcx.fully_resolve(impl2_substs) else {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3304,6 +3304,7 @@ declare_lint_pass! {
         ILL_FORMED_ATTRIBUTE_INPUT,
         ILLEGAL_FLOATING_POINT_LITERAL_PATTERN,
         IMPLIED_BOUNDS_ENTAILMENT,
+        IMPLIED_BOUNDS_FROM_TRAIT_IMPL,
         INCOMPLETE_INCLUDE,
         INDIRECT_STRUCTURAL_MATCH,
         INEFFECTIVE_UNSTABLE_TRAIT_IMPL,
@@ -4171,4 +4172,45 @@ declare_lint! {
     pub INVALID_MACRO_EXPORT_ARGUMENTS,
     Warn,
     "\"invalid_parameter\" isn't a valid argument for `#[macro_export]`",
+}
+
+declare_lint! {
+    /// The `implied_bounds_from_trait_impl` lint detects
+    /// a compiler bug allowed some code to assume invalid implied lifetime bounds.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(implied_bounds_from_trait_impl)]
+    ///
+    /// trait Trait {
+    ///     type Assoc;
+    /// }
+    ///
+    /// impl<X: 'static> Trait for (X,) {
+    ///     type Assoc = ();
+    /// }
+    ///
+    /// struct Foo<T: Trait>(T)
+    /// where
+    ///     T::Assoc: Clone; // any bound using `T::Assoc`
+    ///
+    /// fn func(foo: Foo<(&str,)>) {
+    ///     let _: &'static str = foo.0.0;
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// FIXME: explanataion
+    ///
+    pub IMPLIED_BOUNDS_FROM_TRAIT_IMPL,
+    Warn,
+    "item uses illegal implied bounds derived from a trait impl",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #109628 <https://github.com/rust-lang/rust/issues/109628>",
+        reason: FutureIncompatibilityReason::FutureReleaseError,
+    };
 }

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -56,7 +56,7 @@ macro_rules! arena_types {
                         rustc_middle::traits::query::NormalizationResult<'tcx>
                     >
                 >,
-            [] implied_outlives_bounds:
+            [] implied_outlives_bounds_compat:
                 rustc_middle::infer::canonical::Canonical<'tcx,
                     rustc_middle::infer::canonical::QueryResponse<'tcx,
                         Vec<rustc_middle::traits::query::OutlivesBound<'tcx>>

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -59,6 +59,10 @@ impl<T> EraseType for Result<&'_ T, traits::query::NoSolution> {
     type Result = [u8; size_of::<Result<&'static (), traits::query::NoSolution>>()];
 }
 
+impl<T> EraseType for Result<&'_ [T], traits::query::NoSolution> {
+    type Result = [u8; size_of::<Result<&'static [()], traits::query::NoSolution>>()];
+}
+
 impl<T> EraseType for Result<&'_ T, rustc_errors::ErrorGuaranteed> {
     type Result = [u8; size_of::<Result<&'static (), rustc_errors::ErrorGuaranteed>>()];
 }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1837,6 +1837,12 @@ rustc_queries! {
         desc { "computing implied outlives bounds for `{}`", goal.value.value }
     }
 
+    query implied_outlives_bounds_v2(
+        goal: ParamEnvAnd<'tcx, Ty<'tcx>>
+    ) -> Result<&'tcx [OutlivesBound<'tcx>], NoSolution> {
+        desc { "computing implied outlives bounds v2 for `{}`", goal.value }
+    }
+
     /// Do not call this query directly:
     /// invoke `DropckOutlives::new(dropped_ty)).fully_perform(typeck.infcx)` instead.
     query dropck_outlives(

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1828,7 +1828,7 @@ rustc_queries! {
         desc { "normalizing `{}`", goal.value }
     }
 
-    query implied_outlives_bounds(
+    query implied_outlives_bounds_compat(
         goal: CanonicalTyGoal<'tcx>
     ) -> Result<
         &'tcx Canonical<'tcx, canonical::QueryResponse<'tcx, Vec<OutlivesBound<'tcx>>>>,
@@ -1837,7 +1837,7 @@ rustc_queries! {
         desc { "computing implied outlives bounds for `{}`", goal.value.value }
     }
 
-    query implied_outlives_bounds_v2(
+    query implied_outlives_bounds(
         goal: ParamEnvAnd<'tcx, Ty<'tcx>>
     ) -> Result<&'tcx [OutlivesBound<'tcx>], NoSolution> {
         desc { "computing implied outlives bounds v2 for `{}`", goal.value }

--- a/compiler/rustc_middle/src/traits/query.rs
+++ b/compiler/rustc_middle/src/traits/query.rs
@@ -209,7 +209,7 @@ pub struct NormalizationResult<'tcx> {
 /// case they are called implied bounds). They are fed to the
 /// `OutlivesEnv` which in turn is supplied to the region checker and
 /// other parts of the inference system.
-#[derive(Clone, Debug, TypeFoldable, TypeVisitable, Lift, HashStable)]
+#[derive(Copy, Clone, Debug, TypeFoldable, TypeVisitable, Lift, HashStable)]
 pub enum OutlivesBound<'tcx> {
     RegionSubRegion(ty::Region<'tcx>, ty::Region<'tcx>),
     RegionSubParam(ty::Region<'tcx>, ty::ParamTy),

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -658,8 +658,13 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         arg: ty::GenericArg<'tcx>,
     ) -> Option<impl Iterator<Item = Goal<'tcx, ty::Predicate<'tcx>>>> {
-        crate::traits::wf::unnormalized_obligations(self.infcx, param_env, arg)
-            .map(|obligations| obligations.into_iter().map(|obligation| obligation.into()))
+        debug_assert_eq!(arg, self.infcx.resolve_vars_if_possible(arg));
+        // FIXME: useless `Option` in return type?
+        Some(
+            crate::traits::wf::unnormalized_obligations(self.tcx(), param_env, arg)
+                .into_iter()
+                .map(|obligation| obligation.into()),
+        )
     }
 
     pub(super) fn is_transmutable(

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -403,7 +403,7 @@ fn resolve_negative_obligation<'tcx>(
     let wf_tys = ocx.assumed_wf_types(param_env, DUMMY_SP, body_def_id);
     let outlives_env = OutlivesEnvironment::with_bounds(
         param_env,
-        infcx.implied_bounds_tys(param_env, body_def_id, wf_tys),
+        infcx.implied_bounds_tys_compat(param_env, body_def_id, wf_tys),
     );
     infcx.resolve_regions(&outlives_env).is_empty()
 }

--- a/compiler/rustc_trait_selection/src/traits/misc.rs
+++ b/compiler/rustc_trait_selection/src/traits/misc.rs
@@ -190,7 +190,7 @@ pub fn all_fields_implement_trait<'tcx>(
             // Check regions assuming the self type of the impl is WF
             let outlives_env = OutlivesEnvironment::with_bounds(
                 param_env,
-                infcx.implied_bounds_tys(
+                infcx.implied_bounds_tys_compat(
                     param_env,
                     parent_cause.body_id,
                     FxIndexSet::from_iter([self_type]),

--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -30,8 +30,7 @@ pub trait InferCtxtExt<'a, 'tcx> {
     fn implied_bounds_tys_v2(
         &'a self,
         param_env: ty::ParamEnv<'tcx>,
-        _body_id: LocalDefId,
-        tys: FxIndexSet<Ty<'tcx>>,
+        tys: &'a FxIndexSet<Ty<'tcx>>,
     ) -> BoundsV2<'a, 'tcx>;
 }
 
@@ -136,11 +135,10 @@ impl<'a, 'tcx: 'a> InferCtxtExt<'a, 'tcx> for InferCtxt<'tcx> {
     fn implied_bounds_tys_v2(
         &'a self,
         param_env: ParamEnv<'tcx>,
-        _body_id: LocalDefId,
-        tys: FxIndexSet<Ty<'tcx>>,
+        tys: &'a FxIndexSet<Ty<'tcx>>,
     ) -> BoundsV2<'a, 'tcx> {
-        tys.into_iter()
-            .flat_map(move |ty| {
+        tys.iter()
+            .flat_map(move |&ty| {
                 let ty = self.resolve_vars_if_possible(ty);
                 let ty = OpportunisticRegionResolver::new(self).fold_ty(ty);
                 if ty.has_infer() {

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
@@ -37,6 +37,6 @@ impl<'tcx> super::QueryTypeOp<'tcx> for ImpliedOutlivesBounds<'tcx> {
             param_env.and(ty)
         });
 
-        tcx.implied_outlives_bounds(canonicalized)
+        tcx.implied_outlives_bounds_compat(canonicalized)
     }
 }

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -77,21 +77,20 @@ pub fn obligations<'tcx>(
 
 /// Compute the predicates that are required for a type to be well-formed.
 ///
-/// This is only intended to be used in the new solver, since it does not
-/// take into account recursion depth or proper error-reporting spans.
+/// This is only intended to be used in implied bounds computation and in
+/// the new solver, since it does not take into account recursion depth or
+/// proper error-reporting spans.
 pub fn unnormalized_obligations<'tcx>(
-    infcx: &InferCtxt<'tcx>,
+    tcx: TyCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     arg: GenericArg<'tcx>,
-) -> Option<Vec<traits::PredicateObligation<'tcx>>> {
+) -> Vec<traits::PredicateObligation<'tcx>> {
     if let ty::GenericArgKind::Lifetime(..) = arg.unpack() {
-        return Some(vec![]);
+        return vec![];
     }
 
-    debug_assert_eq!(arg, infcx.resolve_vars_if_possible(arg));
-
     let mut wf = WfPredicates {
-        tcx: infcx.tcx,
+        tcx,
         param_env,
         body_id: CRATE_DEF_ID,
         span: DUMMY_SP,
@@ -100,7 +99,7 @@ pub fn unnormalized_obligations<'tcx>(
         item: None,
     };
     wf.compute(arg);
-    Some(wf.out)
+    wf.out
 }
 
 /// Returns the obligations that make this trait reference

--- a/compiler/rustc_traits/src/implied_outlives_bounds.rs
+++ b/compiler/rustc_traits/src/implied_outlives_bounds.rs
@@ -2,31 +2,121 @@
 //! Do not call this query directory. See
 //! [`rustc_trait_selection::traits::query::type_op::implied_outlives_bounds`].
 
-use rustc_infer::infer::canonical::{self, Canonical};
+use rustc_infer::infer::canonical;
 use rustc_infer::infer::outlives::components::{push_outlives_components, Component};
+use rustc_infer::infer::resolve::OpportunisticRegionResolver;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::query::OutlivesBound;
 use rustc_middle::ty::query::Providers;
-use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt};
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeFolder, TypeVisitableExt};
 use rustc_span::def_id::CRATE_DEF_ID;
 use rustc_span::source_map::DUMMY_SP;
 use rustc_trait_selection::infer::InferCtxtBuilderExt;
 use rustc_trait_selection::traits::query::{CanonicalTyGoal, Fallible, NoSolution};
 use rustc_trait_selection::traits::wf;
-use rustc_trait_selection::traits::ObligationCtxt;
+use rustc_trait_selection::traits::{ObligationCause, ObligationCtxt};
 use smallvec::{smallvec, SmallVec};
 
 pub(crate) fn provide(p: &mut Providers) {
     *p = Providers { implied_outlives_bounds, ..*p };
+    *p = Providers { implied_outlives_bounds_v2, ..*p };
+}
+
+fn implied_outlives_bounds_v2<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    goal: ty::ParamEnvAnd<'tcx, Ty<'tcx>>,
+) -> Fallible<&'tcx [OutlivesBound<'tcx>]> {
+    let (param_env, goal_ty) = goal.into_parts();
+    let infcx = tcx.infer_ctxt().build();
+    let ocx = ObligationCtxt::new(&infcx);
+    let normalize_op = |ty| {
+        let ty = ocx.normalize(&ObligationCause::dummy(), param_env, ty);
+        if !ocx.select_all_or_error().is_empty() {
+            return Err(NoSolution);
+        }
+        let ty = ocx.infcx.resolve_vars_if_possible(ty);
+        let ty = OpportunisticRegionResolver::new(&infcx).fold_ty(ty);
+        assert!(!ty.has_infer());
+        Ok(ty)
+    };
+
+    compute_implied_outlives_bounds_v2(tcx, goal_ty, normalize_op)
+}
+
+/// For the sake of completeness, we should be careful when dealing with inference artifacts:
+/// - This function shouldn't access an InferCtxt.
+/// - `ty` must be fully resolved.
+/// - `normalize_op` must return a fully resolved type.
+fn compute_implied_outlives_bounds_v2<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    ty: Ty<'tcx>,
+    normalize_op: impl Fn(Ty<'tcx>) -> Fallible<Ty<'tcx>>,
+) -> Fallible<&'tcx [OutlivesBound<'tcx>]> {
+    // Sometimes when we ask what it takes for T: WF, we get back that
+    // U: WF is required; in that case, we push U onto this stack and
+    // process it next. Because the resulting predicates aren't always
+    // guaranteed to be a subset of the original type, so we need to store the
+    // WF args we've computed in a set.
+    let mut checked_wf_args = rustc_data_structures::fx::FxHashSet::default();
+    let mut wf_args = vec![ty.into(), normalize_op(ty)?.into()];
+
+    let mut outlives_bounds: Vec<OutlivesBound<'tcx>> = vec![];
+
+    while let Some(arg) = wf_args.pop() {
+        if !checked_wf_args.insert(arg) {
+            continue;
+        }
+
+        // From the full set of obligations, just filter down to the region relationships.
+        for obligation in wf::unnormalized_obligations(tcx, ty::ParamEnv::empty(), arg) {
+            assert!(!obligation.has_escaping_bound_vars());
+            let Some(pred) = obligation.predicate.kind().no_bound_vars() else {
+                continue;
+            };
+            match pred {
+                ty::PredicateKind::Clause(ty::Clause::Trait(..))
+                // FIXME(const_generics): Make sure that `<'a, 'b, const N: &'a &'b u32>` is sound
+                // if we ever support that
+                | ty::PredicateKind::Clause(ty::Clause::ConstArgHasType(..))
+                | ty::PredicateKind::Subtype(..)
+                | ty::PredicateKind::Coerce(..)
+                | ty::PredicateKind::Clause(ty::Clause::Projection(..))
+                | ty::PredicateKind::ClosureKind(..)
+                | ty::PredicateKind::ObjectSafe(..)
+                | ty::PredicateKind::ConstEvaluatable(..)
+                | ty::PredicateKind::ConstEquate(..)
+                | ty::PredicateKind::Ambiguous
+                | ty::PredicateKind::AliasRelate(..)
+                | ty::PredicateKind::TypeWellFormedFromEnv(..) => {}
+
+                // We need to search through *all* WellFormed predicates
+                ty::PredicateKind::WellFormed(arg) => wf_args.push(arg),
+
+                // We need to register region relationships
+                ty::PredicateKind::Clause(ty::Clause::RegionOutlives(
+                    ty::OutlivesPredicate(r_a, r_b),
+                )) => outlives_bounds.push(OutlivesBound::RegionSubRegion(r_b, r_a)),
+
+                ty::PredicateKind::Clause(ty::Clause::TypeOutlives(ty::OutlivesPredicate(
+                    ty_a,
+                    r_b,
+                ))) => {
+                    let ty_a = normalize_op(ty_a)?;
+                    let mut components = smallvec![];
+                    push_outlives_components(tcx, ty_a, &mut components);
+                    outlives_bounds.extend(implied_bounds_from_components(r_b, components))
+                }
+            }
+        }
+    }
+
+    Ok(tcx.arena.alloc_slice(&outlives_bounds))
 }
 
 fn implied_outlives_bounds<'tcx>(
     tcx: TyCtxt<'tcx>,
     goal: CanonicalTyGoal<'tcx>,
-) -> Result<
-    &'tcx Canonical<'tcx, canonical::QueryResponse<'tcx, Vec<OutlivesBound<'tcx>>>>,
-    NoSolution,
-> {
+) -> Fallible<canonical::CanonicalQueryResponse<'tcx, Vec<OutlivesBound<'tcx>>>> {
     tcx.infer_ctxt().enter_canonical_trait_query(&goal, |ocx, key| {
         let (param_env, ty) = key.into_parts();
         compute_implied_outlives_bounds(ocx, param_env, ty)
@@ -149,7 +239,7 @@ fn compute_implied_outlives_bounds<'tcx>(
                 let ty_a = ocx.infcx.resolve_vars_if_possible(ty_a);
                 let mut components = smallvec![];
                 push_outlives_components(tcx, ty_a, &mut components);
-                implied_bounds_from_components(r_b, components)
+                implied_bounds_from_components(r_b, components).collect()
             }
             ty::GenericArgKind::Const(_) => unreachable!(),
         })
@@ -165,28 +255,24 @@ fn compute_implied_outlives_bounds<'tcx>(
 fn implied_bounds_from_components<'tcx>(
     sub_region: ty::Region<'tcx>,
     sup_components: SmallVec<[Component<'tcx>; 4]>,
-) -> Vec<OutlivesBound<'tcx>> {
-    sup_components
-        .into_iter()
-        .filter_map(|component| {
-            match component {
-                Component::Region(r) => Some(OutlivesBound::RegionSubRegion(sub_region, r)),
-                Component::Param(p) => Some(OutlivesBound::RegionSubParam(sub_region, p)),
-                Component::Alias(p) => Some(OutlivesBound::RegionSubAlias(sub_region, p)),
-                Component::EscapingAlias(_) =>
-                // If the projection has escaping regions, don't
-                // try to infer any implied bounds even for its
-                // free components. This is conservative, because
-                // the caller will still have to prove that those
-                // free components outlive `sub_region`. But the
-                // idea is that the WAY that the caller proves
-                // that may change in the future and we want to
-                // give ourselves room to get smarter here.
-                {
-                    None
-                }
-                Component::UnresolvedInferenceVariable(..) => None,
-            }
-        })
-        .collect()
+) -> impl Iterator<Item = OutlivesBound<'tcx>> {
+    sup_components.into_iter().filter_map(move |component| {
+        match component {
+            Component::Region(r) => Some(OutlivesBound::RegionSubRegion(sub_region, r)),
+            Component::Param(p) => Some(OutlivesBound::RegionSubParam(sub_region, p)),
+            Component::Alias(p) => Some(OutlivesBound::RegionSubAlias(sub_region, p)),
+            // If the projection has escaping regions, don't
+            // try to infer any implied bounds even for its
+            // free components. This is conservative, because
+            // the caller will still have to prove that those
+            // free components outlive `sub_region`. But the
+            // idea is that the WAY that the caller proves
+            // that may change in the future and we want to
+            // give ourselves room to get smarter here.
+            Component::EscapingAlias(_) => None,
+            // FIXME: We shouldn't have inference vars in implied bounds computation.
+            // Panic here once we remove the legacy implied bounds.
+            Component::UnresolvedInferenceVariable(..) => None,
+        }
+    })
 }

--- a/tests/ui/implied-bounds/from-trait-impl.rs
+++ b/tests/ui/implied-bounds/from-trait-impl.rs
@@ -1,0 +1,39 @@
+trait Trait {
+    type Assoc;
+}
+
+impl<X: 'static> Trait for (X,) {
+    type Assoc = ();
+}
+
+struct Foo<T: Trait>(T)
+where
+    T::Assoc: Clone; // any predicate using `T::Assoc` works here
+
+fn func1(foo: Foo<(&str,)>) {
+//~^ WARN function is missing necessary lifetime bounds
+//~| WARN this was previously accepted
+    let _: &'static str = foo.0.0;
+}
+
+#[deny(implied_bounds_from_trait_impl)]
+fn func2(foo: Foo<(&str,)>) {
+//~^ ERROR function is missing necessary lifetime bounds
+//~| WARN this was previously accepted
+//~| ERROR `&str` does not fulfill the required lifetime
+    let _: &'static str = foo.0.0;
+}
+
+trait TestTrait {}
+
+impl<X> TestTrait for [Foo<(X,)>; 1] {}
+//~^ WARN implementation is missing necessary lifetime bounds
+//~| WARN this was previously accepted
+
+#[deny(implied_bounds_from_trait_impl)]
+impl<X> TestTrait for [Foo<(X,)>; 2] {}
+//~^ ERROR implementation is missing necessary lifetime bounds
+//~| WARN this was previously accepted
+//~| ERROR `X` may not live long enough
+
+fn main() {}

--- a/tests/ui/implied-bounds/from-trait-impl.stderr
+++ b/tests/ui/implied-bounds/from-trait-impl.stderr
@@ -1,0 +1,74 @@
+warning: function is missing necessary lifetime bounds
+  --> $DIR/from-trait-impl.rs:13:1
+   |
+LL | fn func1(foo: Foo<(&str,)>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #109628 <https://github.com/rust-lang/rust/issues/109628>
+   = note: to get more detailed errors, use `#[deny(implied_bounds_from_trait_impl)]`
+   = note: `#[warn(implied_bounds_from_trait_impl)]` on by default
+
+error: function is missing necessary lifetime bounds
+  --> $DIR/from-trait-impl.rs:20:1
+   |
+LL | fn func2(foo: Foo<(&str,)>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #109628 <https://github.com/rust-lang/rust/issues/109628>
+   = note: more concrete lifetime errors are emitted below
+note: the lint level is defined here
+  --> $DIR/from-trait-impl.rs:19:8
+   |
+LL | #[deny(implied_bounds_from_trait_impl)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0477]: the type `&str` does not fulfill the required lifetime
+  --> $DIR/from-trait-impl.rs:20:15
+   |
+LL | fn func2(foo: Foo<(&str,)>) {
+   |               ^^^^^^^^^^^^
+   |
+   = note: type must satisfy the static lifetime
+
+warning: implementation is missing necessary lifetime bounds
+  --> $DIR/from-trait-impl.rs:29:1
+   |
+LL | impl<X> TestTrait for [Foo<(X,)>; 1] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #109628 <https://github.com/rust-lang/rust/issues/109628>
+   = note: to get more detailed errors, use `#[deny(implied_bounds_from_trait_impl)]`
+
+error: implementation is missing necessary lifetime bounds
+  --> $DIR/from-trait-impl.rs:34:1
+   |
+LL | impl<X> TestTrait for [Foo<(X,)>; 2] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #109628 <https://github.com/rust-lang/rust/issues/109628>
+   = note: more concrete lifetime errors are emitted below
+note: the lint level is defined here
+  --> $DIR/from-trait-impl.rs:33:8
+   |
+LL | #[deny(implied_bounds_from_trait_impl)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0310]: the parameter type `X` may not live long enough
+  --> $DIR/from-trait-impl.rs:34:23
+   |
+LL | impl<X> TestTrait for [Foo<(X,)>; 2] {}
+   |                       ^^^^^^^^^^^^^^ ...so that the type `X` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL | impl<X: 'static> TestTrait for [Foo<(X,)>; 2] {}
+   |       +++++++++
+
+error: aborting due to 4 previous errors; 2 warnings emitted
+
+Some errors have detailed explanations: E0310, E0477.
+For more information about an error, try `rustc --explain E0310`.

--- a/tests/ui/implied-bounds/normalization-nested.lifetime.stderr
+++ b/tests/ui/implied-bounds/normalization-nested.lifetime.stderr
@@ -1,18 +1,10 @@
-error[E0759]: `fn` parameter has lifetime `'x` but it needs to satisfy a `'static` lifetime requirement
-  --> $DIR/normalization-nested.rs:35:20
+error: lifetime may not live long enough
+  --> $DIR/normalization-nested.rs:39:5
    |
-LL | pub fn test<'x>(_: Map<Vec<&'x ()>>, s: &'x str) -> &'static str {
-   |                    ^^^^^^^^^^^^^^^^
-   |                    |
-   |                    this data with lifetime `'x`...
-   |                    ...is used and required to live as long as `'static` here
-   |
-note: `'static` lifetime requirement introduced by this bound
-  --> $DIR/normalization-nested.rs:33:14
-   |
-LL |     I::Item: 'static;
-   |              ^^^^^^^
+LL | pub fn test_borrowck<'x>(_: Map<Vec<&'x ()>>, s: &'x str) -> &'static str {
+   |                      -- lifetime `'x` defined here
+LL |     s
+   |     ^ returning this value requires that `'x` must outlive `'static`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0759`.

--- a/tests/ui/implied-bounds/normalization-nested.rs
+++ b/tests/ui/implied-bounds/normalization-nested.rs
@@ -5,7 +5,7 @@
 // revisions: param_ty lifetime
 // [param_ty] check-pass
 // [lifetime] check-fail
-// [lifetime] known-bug: #109799
+// [lifetime] issue: #109799
 
 pub trait Iter {
     type Item;
@@ -32,8 +32,12 @@ where
     I: Iter,
     I::Item: 'static;
 
-pub fn test<'x>(_: Map<Vec<&'x ()>>, s: &'x str) -> &'static str {
+// passes for lifetime and type paramters.
+pub fn test_wfcheck<'x>(_: Map<Vec<&'x ()>>) {}
+
+pub fn test_borrowck<'x>(_: Map<Vec<&'x ()>>, s: &'x str) -> &'static str {
     s
+    //[lifetime]~^ ERROR lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/implied-bounds/normalization-preserve-equality.borrowck.stderr
+++ b/tests/ui/implied-bounds/normalization-preserve-equality.borrowck.stderr
@@ -1,0 +1,28 @@
+error: lifetime may not live long enough
+  --> $DIR/normalization-preserve-equality.rs:20:1
+   |
+LL | fn test_borrowck<'a, 'b>(_: (<Equal<'a, 'b> as Trait>::Ty, Equal<'a, 'b>)) {
+   | ^^^^^^^^^^^^^^^^^--^^--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |                |   |
+   | |                |   lifetime `'b` defined here
+   | |                lifetime `'a` defined here
+   | requires that `'a` must outlive `'b`
+   |
+   = help: consider adding the following bound: `'a: 'b`
+
+error: lifetime may not live long enough
+  --> $DIR/normalization-preserve-equality.rs:20:1
+   |
+LL | fn test_borrowck<'a, 'b>(_: (<Equal<'a, 'b> as Trait>::Ty, Equal<'a, 'b>)) {
+   | ^^^^^^^^^^^^^^^^^--^^--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |                |   |
+   | |                |   lifetime `'b` defined here
+   | |                lifetime `'a` defined here
+   | requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+
+help: `'a` and `'b` must be the same: replace one with the other
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/implied-bounds/normalization-preserve-equality.rs
+++ b/tests/ui/implied-bounds/normalization-preserve-equality.rs
@@ -1,0 +1,26 @@
+// Both revisions should pass. `borrowck` revision is a bug!
+//
+// revisions: wfcheck borrowck
+// [wfcheck] check-pass
+// [borrowck] check-fail
+// [borrowck] issue: #106569
+
+struct Equal<'a, 'b>(&'a &'b (), &'b &'a ()); // implies 'a == 'b
+
+trait Trait { type Ty; }
+
+impl<'x> Trait for Equal<'x, 'x> { type Ty = (); }
+
+trait WfCheckTrait {}
+
+#[cfg(wfcheck)]
+impl<'a, 'b> WfCheckTrait for (<Equal<'a, 'b> as Trait>::Ty, Equal<'a, 'b>) {}
+
+#[cfg(borrowck)]
+fn test_borrowck<'a, 'b>(_: (<Equal<'a, 'b> as Trait>::Ty, Equal<'a, 'b>)) {
+    //[borrowck]~^ ERROR lifetime may not live long enough
+    //[borrowck]~| ERROR lifetime may not live long enough
+    let _ = None::<Equal<'a, 'b>>;
+}
+
+fn main() {}


### PR DESCRIPTION
Lint version of #109482.

This implements a new implied bounds query that fixes the normalization problems with the previous query, including #106569, #109628 and #109799. While the new implementation allows more code to compile, it also breaks code that relies on #109628 (see the crater run in #109482 for details.) For this reason we keep the legacy implementation and emit a lint when they disagree.

Fixes #109628.

~This doesn't implement the lint yet. I want to have a perf baseline first.~
r? @ghost 


