### PR TITLE
Increase libffi version to 3.2 to support s390x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "libffi"
-version = "3.0.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e454b3efb16fba3b17810ae5e41df02b649e564ab3c5a34b3b93ed07ad287e6"
+checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
 dependencies = [
  "libc",
  "libffi-sys",
@@ -2898,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "libffi-sys"
-version = "2.0.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4106b7f09d7b87d021334d5618fac1dfcfb824d4c5fe111ff0074dfd242e15"
+checksum = "dc65067b78c0fc069771e8b9a9e02df71e08858bec92c1f101377c67b9dca7c7"
 dependencies = [
  "cc",
 ]

--- a/src/tools/miri/Cargo.toml
+++ b/src/tools/miri/Cargo.toml
@@ -34,7 +34,7 @@ measureme = "10.0.0"
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libffi = "3.0.0"
+libffi = "3.2.0"
 libloading = "0.7"
 
 [dev-dependencies]


### PR DESCRIPTION
libffi versions prior to 3.2 have no support for s390x, causing the Miri build to fail on our platform.