### PR TITLE
Don't leave a comma at the start of argument list when removing arguments

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -21,7 +21,7 @@ use rustc_hir_analysis::astconv::AstConv;
 use rustc_hir_analysis::check::intrinsicck::InlineAsmCtxt;
 use rustc_hir_analysis::check::potentially_plural_count;
 use rustc_hir_analysis::structured_errors::StructuredDiagnostic;
-use rustc_index::vec::{Idx, IndexVec};
+use rustc_index::vec::IndexVec;
 use rustc_infer::infer::error_reporting::{FailureCode, ObligationCauseExt};
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::infer::TypeTrace;
@@ -963,14 +963,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 .map_or(true, |next_error| !matches!(next_error, Error::Extra(_)))
                         {
                             let next = provided_arg_tys
-                                .get(arg_idx.plus(1))
+                                .get(arg_idx + 1)
                                 .map(|&(_, sp)| sp)
                                 .unwrap_or_else(|| {
                                     // Subtract one to move before `)`
-                                    call_expr
-                                        .span
-                                        .shrink_to_hi()
-                                        .with_lo(call_expr.span.hi() - BytePos(1))
+                                    call_expr.span.with_lo(call_expr.span.hi() - BytePos(1))
                                 });
 
                             // Include next comma

--- a/tests/ui/argument-suggestions/issue-109425.fixed
+++ b/tests/ui/argument-suggestions/issue-109425.fixed
@@ -7,14 +7,14 @@ fn s(_: &str) {}
 
 fn main() {
     // code             expected suggestion
-    f(0, 1,);        // f()
+    f();        // f()
     //~^ error: this function takes 0 arguments but 2 arguments were supplied
-    i(0, 1, 2,);     // i(0,)
+    i(0,);     // i(0,)
     //~^ error: this function takes 1 argument but 3 arguments were supplied
-    i(0, 1, 2);      // i(0)
+    i(0);      // i(0)
     //~^ error: this function takes 1 argument but 3 arguments were supplied
-    is(0, 1, 2, ""); // is(0, "")
+    is(0, ""); // is(0, "")
     //~^ error: this function takes 2 arguments but 4 arguments were supplied
-    s(0, 1, "");     // s("")
+    s("");     // s("")
     //~^ error: this function takes 1 argument but 3 arguments were supplied
 }

--- a/tests/ui/argument-suggestions/issue-109425.rs
+++ b/tests/ui/argument-suggestions/issue-109425.rs
@@ -1,0 +1,18 @@
+fn f() {}
+fn i(_: u32) {}
+fn is(_: u32, _: &str) {}
+fn s(_: &str) {}
+
+fn main() {
+    // code             expected suggestion
+    f(0, 1,);        // f()
+    //~^ error: this function takes 0 arguments but 2 arguments were supplied
+    i(0, 1, 2,);     // i(0,)
+    //~^ error: this function takes 1 argument but 3 arguments were supplied
+    i(0, 1, 2);      // i(0)
+    //~^ error: this function takes 1 argument but 3 arguments were supplied
+    is(0, 1, 2, ""); // is(0, "")
+    //~^ error: this function takes 2 arguments but 4 arguments were supplied
+    s(0, 1, "");     // s("")
+    //~^ error: this function takes 1 argument but 3 arguments were supplied
+}

--- a/tests/ui/argument-suggestions/issue-109425.stderr
+++ b/tests/ui/argument-suggestions/issue-109425.stderr
@@ -1,5 +1,5 @@
 error[E0061]: this function takes 0 arguments but 2 arguments were supplied
-  --> $DIR/issue-109425.rs:8:5
+  --> $DIR/issue-109425.rs:10:5
    |
 LL |     f(0, 1,);        // f()
    |     ^ -  - unexpected argument of type `{integer}`
@@ -7,18 +7,18 @@ LL |     f(0, 1,);        // f()
    |       unexpected argument of type `{integer}`
    |
 note: function defined here
-  --> $DIR/issue-109425.rs:1:4
+  --> $DIR/issue-109425.rs:3:4
    |
 LL | fn f() {}
    |    ^
 help: remove the extra arguments
    |
 LL -     f(0, 1,);        // f()
-LL +     f(,);        // f()
+LL +     f();        // f()
    |
 
 error[E0061]: this function takes 1 argument but 3 arguments were supplied
-  --> $DIR/issue-109425.rs:10:5
+  --> $DIR/issue-109425.rs:12:5
    |
 LL |     i(0, 1, 2,);     // i(0,)
    |     ^    -  - unexpected argument of type `{integer}`
@@ -26,7 +26,7 @@ LL |     i(0, 1, 2,);     // i(0,)
    |          unexpected argument of type `{integer}`
    |
 note: function defined here
-  --> $DIR/issue-109425.rs:2:4
+  --> $DIR/issue-109425.rs:4:4
    |
 LL | fn i(_: u32) {}
    |    ^ ------
@@ -37,7 +37,7 @@ LL +     i(0,);     // i(0,)
    |
 
 error[E0061]: this function takes 1 argument but 3 arguments were supplied
-  --> $DIR/issue-109425.rs:12:5
+  --> $DIR/issue-109425.rs:14:5
    |
 LL |     i(0, 1, 2);      // i(0)
    |     ^    -  - unexpected argument of type `{integer}`
@@ -45,7 +45,7 @@ LL |     i(0, 1, 2);      // i(0)
    |          unexpected argument of type `{integer}`
    |
 note: function defined here
-  --> $DIR/issue-109425.rs:2:4
+  --> $DIR/issue-109425.rs:4:4
    |
 LL | fn i(_: u32) {}
    |    ^ ------
@@ -56,7 +56,7 @@ LL +     i(0);      // i(0)
    |
 
 error[E0061]: this function takes 2 arguments but 4 arguments were supplied
-  --> $DIR/issue-109425.rs:14:5
+  --> $DIR/issue-109425.rs:16:5
    |
 LL |     is(0, 1, 2, ""); // is(0, "")
    |     ^^    -  - unexpected argument of type `{integer}`
@@ -64,7 +64,7 @@ LL |     is(0, 1, 2, ""); // is(0, "")
    |           unexpected argument of type `{integer}`
    |
 note: function defined here
-  --> $DIR/issue-109425.rs:3:4
+  --> $DIR/issue-109425.rs:5:4
    |
 LL | fn is(_: u32, _: &str) {}
    |    ^^ ------  -------
@@ -75,7 +75,7 @@ LL +     is(0, ""); // is(0, "")
    |
 
 error[E0061]: this function takes 1 argument but 3 arguments were supplied
-  --> $DIR/issue-109425.rs:16:5
+  --> $DIR/issue-109425.rs:18:5
    |
 LL |     s(0, 1, "");     // s("")
    |     ^ -  - unexpected argument of type `{integer}`
@@ -83,14 +83,14 @@ LL |     s(0, 1, "");     // s("")
    |       unexpected argument of type `{integer}`
    |
 note: function defined here
-  --> $DIR/issue-109425.rs:4:4
+  --> $DIR/issue-109425.rs:6:4
    |
 LL | fn s(_: &str) {}
    |    ^ -------
 help: remove the extra arguments
    |
 LL -     s(0, 1, "");     // s("")
-LL +     s(, "");     // s("")
+LL +     s("");     // s("")
    |
 
 error: aborting due to 5 previous errors

--- a/tests/ui/argument-suggestions/issue-109425.stderr
+++ b/tests/ui/argument-suggestions/issue-109425.stderr
@@ -1,0 +1,98 @@
+error[E0061]: this function takes 0 arguments but 2 arguments were supplied
+  --> $DIR/issue-109425.rs:8:5
+   |
+LL |     f(0, 1,);        // f()
+   |     ^ -  - unexpected argument of type `{integer}`
+   |       |
+   |       unexpected argument of type `{integer}`
+   |
+note: function defined here
+  --> $DIR/issue-109425.rs:1:4
+   |
+LL | fn f() {}
+   |    ^
+help: remove the extra arguments
+   |
+LL -     f(0, 1,);        // f()
+LL +     f(,);        // f()
+   |
+
+error[E0061]: this function takes 1 argument but 3 arguments were supplied
+  --> $DIR/issue-109425.rs:10:5
+   |
+LL |     i(0, 1, 2,);     // i(0,)
+   |     ^    -  - unexpected argument of type `{integer}`
+   |          |
+   |          unexpected argument of type `{integer}`
+   |
+note: function defined here
+  --> $DIR/issue-109425.rs:2:4
+   |
+LL | fn i(_: u32) {}
+   |    ^ ------
+help: remove the extra arguments
+   |
+LL -     i(0, 1, 2,);     // i(0,)
+LL +     i(0,);     // i(0,)
+   |
+
+error[E0061]: this function takes 1 argument but 3 arguments were supplied
+  --> $DIR/issue-109425.rs:12:5
+   |
+LL |     i(0, 1, 2);      // i(0)
+   |     ^    -  - unexpected argument of type `{integer}`
+   |          |
+   |          unexpected argument of type `{integer}`
+   |
+note: function defined here
+  --> $DIR/issue-109425.rs:2:4
+   |
+LL | fn i(_: u32) {}
+   |    ^ ------
+help: remove the extra arguments
+   |
+LL -     i(0, 1, 2);      // i(0)
+LL +     i(0);      // i(0)
+   |
+
+error[E0061]: this function takes 2 arguments but 4 arguments were supplied
+  --> $DIR/issue-109425.rs:14:5
+   |
+LL |     is(0, 1, 2, ""); // is(0, "")
+   |     ^^    -  - unexpected argument of type `{integer}`
+   |           |
+   |           unexpected argument of type `{integer}`
+   |
+note: function defined here
+  --> $DIR/issue-109425.rs:3:4
+   |
+LL | fn is(_: u32, _: &str) {}
+   |    ^^ ------  -------
+help: remove the extra arguments
+   |
+LL -     is(0, 1, 2, ""); // is(0, "")
+LL +     is(0, ""); // is(0, "")
+   |
+
+error[E0061]: this function takes 1 argument but 3 arguments were supplied
+  --> $DIR/issue-109425.rs:16:5
+   |
+LL |     s(0, 1, "");     // s("")
+   |     ^ -  - unexpected argument of type `{integer}`
+   |       |
+   |       unexpected argument of type `{integer}`
+   |
+note: function defined here
+  --> $DIR/issue-109425.rs:4:4
+   |
+LL | fn s(_: &str) {}
+   |    ^ -------
+help: remove the extra arguments
+   |
+LL -     s(0, 1, "");     // s("")
+LL +     s(, "");     // s("")
+   |
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0061`.

--- a/tests/ui/suggestions/issue-109396.stderr
+++ b/tests/ui/suggestions/issue-109396.stderr
@@ -25,7 +25,7 @@ note: function defined here
 help: remove the extra arguments
    |
 LL -             file.as_raw_fd(),
-LL +             ,
+LL +             );
    |
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
Fixes #109425

Quite a dirty hack, but at least it works ig.