### PR TITLE
Update contributing links for rustc-dev-guide changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,6 @@ find a mentor! You can learn more about asking questions and getting help in the
 Did a compiler error message tell you to come here? If you want to create an ICE report,
 refer to [this section][contributing-bug-reports] and [open an issue][issue template].
 
-[Contributing to Rust]: https://rustc-dev-guide.rust-lang.org/contributing.html#contributing-to-rust
 [rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/
 [std-dev-guide]: https://std-dev-guide.rust-lang.org/
 [contributing-bug-reports]: https://rustc-dev-guide.rust-lang.org/contributing.html#bug-reports

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -482,7 +482,7 @@ message = "This PR changes src/bootstrap/defaults/config.codegen.toml. If approp
 
 [assign]
 warn_non_default_branch = true
-contributing_url = "https://rustc-dev-guide.rust-lang.org/contributing.html"
+contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
 
 [assign.adhoc_groups]
 compiler-team = [


### PR DESCRIPTION
Companion PR to https://github.com/rust-lang/rustc-dev-guide/pull/1653.

- Remove unused reference link in CONTRIBUTING.md
- Change the contributing_url for triagebot to the getting started page