### PR TITLE
More descriptive error when qself path doesnt have a trait on the RHS of `as`

### DIFF
--- a/tests/ui/parser/dyn-trait-compatibility.rs
+++ b/tests/ui/parser/dyn-trait-compatibility.rs
@@ -9,6 +9,6 @@ type A2 = dyn<dyn, dyn>;
 type A3 = dyn<<dyn as dyn>::dyn>;
 //~^ ERROR cannot find type `dyn` in this scope
 //~| ERROR cannot find type `dyn` in this scope
-//~| ERROR use of undeclared crate or module `dyn`
+//~| ERROR cannot find trait `dyn` in this scope
 
 fn main() {}

--- a/tests/ui/parser/dyn-trait-compatibility.stderr
+++ b/tests/ui/parser/dyn-trait-compatibility.stderr
@@ -4,12 +4,6 @@ error[E0433]: failed to resolve: use of undeclared crate or module `dyn`
 LL | type A1 = dyn::dyn;
    |           ^^^ use of undeclared crate or module `dyn`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `dyn`
-  --> $DIR/dyn-trait-compatibility.rs:9:23
-   |
-LL | type A3 = dyn<<dyn as dyn>::dyn>;
-   |                       ^^^ use of undeclared crate or module `dyn`
-
 error[E0412]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:1:11
    |
@@ -40,6 +34,12 @@ error[E0412]: cannot find type `dyn` in this scope
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |           ^^^ not found in this scope
 
+error[E0405]: cannot find trait `dyn` in this scope
+  --> $DIR/dyn-trait-compatibility.rs:9:23
+   |
+LL | type A3 = dyn<<dyn as dyn>::dyn>;
+   |                       ^^^ not found in this scope
+
 error[E0412]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:9:16
    |
@@ -48,5 +48,5 @@ LL | type A3 = dyn<<dyn as dyn>::dyn>;
 
 error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0412, E0433.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0405, E0412, E0433.
+For more information about an error, try `rustc --explain E0405`.

--- a/tests/ui/rust-2018/edition-lint-fully-qualified-paths.fixed
+++ b/tests/ui/rust-2018/edition-lint-fully-qualified-paths.fixed
@@ -18,9 +18,11 @@ mod foo {
 fn main() {
     let _: <foo::Baz as crate::foo::Foo>::Bar = ();
     //~^ ERROR absolute paths must start with
-    //~| this is accepted in the current edition
+    //~| WARN this is accepted in the current edition
+    //~| ERROR absolute paths must start with
+    //~| WARN this is accepted in the current edition
 
     let _: <crate::foo::Baz as foo::Foo>::Bar = ();
     //~^ ERROR absolute paths must start with
-    //~| this is accepted in the current edition
+    //~| WARN this is accepted in the current edition
 }

--- a/tests/ui/rust-2018/edition-lint-fully-qualified-paths.rs
+++ b/tests/ui/rust-2018/edition-lint-fully-qualified-paths.rs
@@ -18,9 +18,11 @@ mod foo {
 fn main() {
     let _: <foo::Baz as ::foo::Foo>::Bar = ();
     //~^ ERROR absolute paths must start with
-    //~| this is accepted in the current edition
+    //~| WARN this is accepted in the current edition
+    //~| ERROR absolute paths must start with
+    //~| WARN this is accepted in the current edition
 
     let _: <::foo::Baz as foo::Foo>::Bar = ();
     //~^ ERROR absolute paths must start with
-    //~| this is accepted in the current edition
+    //~| WARN this is accepted in the current edition
 }

--- a/tests/ui/rust-2018/edition-lint-fully-qualified-paths.stderr
+++ b/tests/ui/rust-2018/edition-lint-fully-qualified-paths.stderr
@@ -13,7 +13,16 @@ LL | #![deny(absolute_paths_not_starting_with_crate)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-fully-qualified-paths.rs:23:13
+  --> $DIR/edition-lint-fully-qualified-paths.rs:19:25
+   |
+LL |     let _: <foo::Baz as ::foo::Foo>::Bar = ();
+   |                         ^^^^^^^^^^ help: use `crate`: `crate::foo::Foo`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-fully-qualified-paths.rs:25:13
    |
 LL |     let _: <::foo::Baz as foo::Foo>::Bar = ();
    |             ^^^^^^^^^^ help: use `crate`: `crate::foo::Baz`
@@ -21,5 +30,5 @@ LL |     let _: <::foo::Baz as foo::Foo>::Bar = ();
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/traits/associated_type_bound/assoc_type_bound_with_struct.rs
+++ b/tests/ui/traits/associated_type_bound/assoc_type_bound_with_struct.rs
@@ -18,6 +18,6 @@ fn qux<'a, T: Bar>(_: &'a T) where <&'a T as Bar>::Baz: String { //~ ERROR expec
 
 fn issue_95327() where <u8 as Unresolved>::Assoc: String {}
 //~^ ERROR expected trait, found struct
-//~| ERROR use of undeclared type `Unresolved`
+//~| ERROR cannot find trait `Unresolved` in this scope
 
 fn main() {}

--- a/tests/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
+++ b/tests/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
@@ -1,9 +1,3 @@
-error[E0433]: failed to resolve: use of undeclared type `Unresolved`
-  --> $DIR/assoc_type_bound_with_struct.rs:19:31
-   |
-LL | fn issue_95327() where <u8 as Unresolved>::Assoc: String {}
-   |                               ^^^^^^^^^^ use of undeclared type `Unresolved`
-
 error[E0404]: expected trait, found struct `String`
   --> $DIR/assoc_type_bound_with_struct.rs:5:46
    |
@@ -76,6 +70,12 @@ help: a trait with a similar name exists
 LL | fn qux<'a, T: Bar>(_: &'a T) where <&'a T as Bar>::Baz: ToString {
    |                                                         ~~~~~~~~
 
+error[E0405]: cannot find trait `Unresolved` in this scope
+  --> $DIR/assoc_type_bound_with_struct.rs:19:31
+   |
+LL | fn issue_95327() where <u8 as Unresolved>::Assoc: String {}
+   |                               ^^^^^^^^^^ not found in this scope
+
 error[E0404]: expected trait, found struct `String`
   --> $DIR/assoc_type_bound_with_struct.rs:19:51
    |
@@ -87,5 +87,5 @@ LL | fn issue_95327() where <u8 as Unresolved>::Assoc: String {}
 
 error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0404, E0433.
+Some errors have detailed explanations: E0404, E0405.
 For more information about an error, try `rustc --explain E0404`.

--- a/tests/ui/ufcs/ufcs-partially-resolved.rs
+++ b/tests/ui/ufcs/ufcs-partially-resolved.rs
@@ -17,37 +17,37 @@ type A = u32;
 
 fn main() {
     let _: <u8 as Tr>::N; //~ ERROR cannot find associated type `N` in trait `Tr`
-    let _: <u8 as E>::N; //~ ERROR cannot find associated type `N` in enum `E`
-    let _: <u8 as A>::N; //~ ERROR cannot find associated type `N` in `A`
+    let _: <u8 as E>::N; //~ ERROR expected trait, found enum `E`
+    let _: <u8 as A>::N; //~ ERROR expected trait, found type alias `A`
     <u8 as Tr>::N; //~ ERROR cannot find method or associated constant `N` in trait `Tr`
-    <u8 as E>::N; //~ ERROR cannot find method or associated constant `N` in enum `E`
-    <u8 as A>::N; //~ ERROR cannot find method or associated constant `N` in `A`
+    <u8 as E>::N; //~ ERROR expected trait, found enum `E`
+    <u8 as A>::N; //~ ERROR expected trait, found type alias `A`
     let _: <u8 as Tr>::Y; // OK
-    let _: <u8 as E>::Y; //~ ERROR expected associated type, found variant `E::Y`
+    let _: <u8 as E>::Y; //~ ERROR expected trait, found enum `E`
     <u8 as Tr>::Y; // OK
-    <u8 as E>::Y; //~ ERROR expected method or associated constant, found unit variant `E::Y`
+    <u8 as E>::Y; //~ ERROR expected trait, found enum `E`
 
     let _: <u8 as Tr>::N::NN; //~ ERROR cannot find associated type `N` in trait `Tr`
-    let _: <u8 as E>::N::NN; //~ ERROR cannot find associated type `N` in enum `E`
-    let _: <u8 as A>::N::NN; //~ ERROR cannot find associated type `N` in `A`
+    let _: <u8 as E>::N::NN; //~ ERROR expected trait, found enum `E`
+    let _: <u8 as A>::N::NN; //~ ERROR expected trait, found type alias `A`
     <u8 as Tr>::N::NN; //~ ERROR cannot find associated type `N` in trait `Tr`
-    <u8 as E>::N::NN; //~ ERROR cannot find associated type `N` in enum `E`
-    <u8 as A>::N::NN; //~ ERROR cannot find associated type `N` in `A`
+    <u8 as E>::N::NN; //~ ERROR expected trait, found enum `E`
+    <u8 as A>::N::NN; //~ ERROR expected trait, found type alias `A`
     let _: <u8 as Tr>::Y::NN; //~ ERROR ambiguous associated type
-    let _: <u8 as E>::Y::NN; //~ ERROR expected associated type, found variant `E::Y`
+    let _: <u8 as E>::Y::NN; //~ ERROR expected trait, found enum `E`
     <u8 as Tr>::Y::NN; //~ ERROR no associated item named `NN` found for type `u16`
-    <u8 as E>::Y::NN; //~ ERROR expected associated type, found variant `E::Y`
+    <u8 as E>::Y::NN; //~ ERROR expected trait, found enum `E`
 
-    let _: <u8 as Tr::N>::NN; //~ ERROR cannot find associated type `NN` in `Tr::N`
-    let _: <u8 as E::N>::NN; //~ ERROR cannot find associated type `NN` in `E::N`
-    let _: <u8 as A::N>::NN; //~ ERROR cannot find associated type `NN` in `A::N`
-    <u8 as Tr::N>::NN; //~ ERROR cannot find method or associated constant `NN` in `Tr::N`
-    <u8 as E::N>::NN; //~ ERROR cannot find method or associated constant `NN` in `E::N`
-    <u8 as A::N>::NN; //~ ERROR cannot find method or associated constant `NN` in `A::N`
-    let _: <u8 as Tr::Y>::NN; //~ ERROR cannot find associated type `NN` in `Tr::Y`
-    let _: <u8 as E::Y>::NN; //~ ERROR failed to resolve: `Y` is a variant, not a module
-    <u8 as Tr::Y>::NN; //~ ERROR cannot find method or associated constant `NN` in `Tr::Y`
-    <u8 as E::Y>::NN; //~ ERROR failed to resolve: `Y` is a variant, not a module
+    let _: <u8 as Tr::N>::NN; //~ ERROR cannot find trait `N` in trait `Tr`
+    let _: <u8 as E::N>::NN; //~ ERROR cannot find trait `N` in enum `E`
+    let _: <u8 as A::N>::NN; //~ ERROR cannot find trait `N` in `A`
+    <u8 as Tr::N>::NN; //~ ERROR cannot find trait `N` in trait `Tr`
+    <u8 as E::N>::NN; //~ ERROR cannot find trait `N` in enum `E`
+    <u8 as A::N>::NN; //~ ERROR cannot find trait `N` in `A`
+    let _: <u8 as Tr::Y>::NN; //~ ERROR expected trait, found associated type `Tr::Y
+    let _: <u8 as E::Y>::NN; //~ ERROR expected trait, found variant `E::Y`
+    <u8 as Tr::Y>::NN; //~ ERROR expected trait, found associated type `Tr::Y`
+    <u8 as E::Y>::NN; //~ ERROR expected trait, found variant `E::Y`
 
     let _: <u8 as Dr>::Z; //~ ERROR expected associated type, found associated function `Dr::Z`
     <u8 as Dr>::X; //~ ERROR expected method or associated constant, found associated type `Dr::X`

--- a/tests/ui/ufcs/ufcs-partially-resolved.stderr
+++ b/tests/ui/ufcs/ufcs-partially-resolved.stderr
@@ -1,15 +1,3 @@
-error[E0433]: failed to resolve: `Y` is a variant, not a module
-  --> $DIR/ufcs-partially-resolved.rs:48:22
-   |
-LL |     let _: <u8 as E::Y>::NN;
-   |                      ^ `Y` is a variant, not a module
-
-error[E0433]: failed to resolve: `Y` is a variant, not a module
-  --> $DIR/ufcs-partially-resolved.rs:50:15
-   |
-LL |     <u8 as E::Y>::NN;
-   |               ^ `Y` is a variant, not a module
-
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:19:24
    |
@@ -19,17 +7,25 @@ LL |     type Y = u16;
 LL |     let _: <u8 as Tr>::N;
    |                        ^ help: an associated type with a similar name exists: `Y`
 
-error[E0576]: cannot find associated type `N` in enum `E`
-  --> $DIR/ufcs-partially-resolved.rs:20:23
+error[E0404]: expected trait, found enum `E`
+  --> $DIR/ufcs-partially-resolved.rs:20:19
    |
 LL |     let _: <u8 as E>::N;
-   |                       ^ not found in `E`
+   |                   ^ help: a trait with a similar name exists: `Eq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: similarly named trait `Eq` defined here
 
-error[E0576]: cannot find associated type `N` in `A`
-  --> $DIR/ufcs-partially-resolved.rs:21:23
+error[E0404]: expected trait, found type alias `A`
+  --> $DIR/ufcs-partially-resolved.rs:21:19
    |
 LL |     let _: <u8 as A>::N;
-   |                       ^ not found in `A`
+   |                   ^ type aliases cannot be used as traits
+   |
+help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
+   |
+LL | trait A = u32;
+   |
 
 error[E0576]: cannot find method or associated constant `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:22:17
@@ -40,29 +36,43 @@ LL |     fn Y() {}
 LL |     <u8 as Tr>::N;
    |                 ^ help: an associated function with a similar name exists: `Y`
 
-error[E0576]: cannot find method or associated constant `N` in enum `E`
-  --> $DIR/ufcs-partially-resolved.rs:23:16
+error[E0404]: expected trait, found enum `E`
+  --> $DIR/ufcs-partially-resolved.rs:23:12
    |
 LL |     <u8 as E>::N;
-   |                ^ not found in `E`
+   |            ^ help: a trait with a similar name exists: `Eq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: similarly named trait `Eq` defined here
 
-error[E0576]: cannot find method or associated constant `N` in `A`
-  --> $DIR/ufcs-partially-resolved.rs:24:16
+error[E0404]: expected trait, found type alias `A`
+  --> $DIR/ufcs-partially-resolved.rs:24:12
    |
 LL |     <u8 as A>::N;
-   |                ^ not found in `A`
+   |            ^ type aliases cannot be used as traits
+   |
+help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
+   |
+LL | trait A = u32;
+   |
 
-error[E0575]: expected associated type, found variant `E::Y`
-  --> $DIR/ufcs-partially-resolved.rs:26:12
+error[E0404]: expected trait, found enum `E`
+  --> $DIR/ufcs-partially-resolved.rs:26:19
    |
 LL |     let _: <u8 as E>::Y;
-   |            ^^^^^^^^^^^^ not a associated type
+   |                   ^ help: a trait with a similar name exists: `Eq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: similarly named trait `Eq` defined here
 
-error[E0575]: expected method or associated constant, found unit variant `E::Y`
-  --> $DIR/ufcs-partially-resolved.rs:28:5
+error[E0404]: expected trait, found enum `E`
+  --> $DIR/ufcs-partially-resolved.rs:28:12
    |
 LL |     <u8 as E>::Y;
-   |     ^^^^^^^^^^^^ not a method or associated constant
+   |            ^ help: a trait with a similar name exists: `Eq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: similarly named trait `Eq` defined here
 
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:30:24
@@ -73,17 +83,25 @@ LL |     type Y = u16;
 LL |     let _: <u8 as Tr>::N::NN;
    |                        ^ help: an associated type with a similar name exists: `Y`
 
-error[E0576]: cannot find associated type `N` in enum `E`
-  --> $DIR/ufcs-partially-resolved.rs:31:23
+error[E0404]: expected trait, found enum `E`
+  --> $DIR/ufcs-partially-resolved.rs:31:19
    |
 LL |     let _: <u8 as E>::N::NN;
-   |                       ^ not found in `E`
+   |                   ^ help: a trait with a similar name exists: `Eq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: similarly named trait `Eq` defined here
 
-error[E0576]: cannot find associated type `N` in `A`
-  --> $DIR/ufcs-partially-resolved.rs:32:23
+error[E0404]: expected trait, found type alias `A`
+  --> $DIR/ufcs-partially-resolved.rs:32:19
    |
 LL |     let _: <u8 as A>::N::NN;
-   |                       ^ not found in `A`
+   |                   ^ type aliases cannot be used as traits
+   |
+help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
+   |
+LL | trait A = u32;
+   |
 
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:33:17
@@ -94,77 +112,103 @@ LL |     type Y = u16;
 LL |     <u8 as Tr>::N::NN;
    |                 ^ help: an associated type with a similar name exists: `Y`
 
-error[E0576]: cannot find associated type `N` in enum `E`
-  --> $DIR/ufcs-partially-resolved.rs:34:16
+error[E0404]: expected trait, found enum `E`
+  --> $DIR/ufcs-partially-resolved.rs:34:12
    |
 LL |     <u8 as E>::N::NN;
-   |                ^ not found in `E`
+   |            ^ help: a trait with a similar name exists: `Eq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: similarly named trait `Eq` defined here
 
-error[E0576]: cannot find associated type `N` in `A`
-  --> $DIR/ufcs-partially-resolved.rs:35:16
+error[E0404]: expected trait, found type alias `A`
+  --> $DIR/ufcs-partially-resolved.rs:35:12
    |
 LL |     <u8 as A>::N::NN;
-   |                ^ not found in `A`
+   |            ^ type aliases cannot be used as traits
+   |
+help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
+   |
+LL | trait A = u32;
+   |
 
-error[E0575]: expected associated type, found variant `E::Y`
-  --> $DIR/ufcs-partially-resolved.rs:37:12
+error[E0404]: expected trait, found enum `E`
+  --> $DIR/ufcs-partially-resolved.rs:37:19
    |
 LL |     let _: <u8 as E>::Y::NN;
-   |            ^^^^^^^^^^^^^^^^ not a associated type
+   |                   ^ help: a trait with a similar name exists: `Eq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: similarly named trait `Eq` defined here
 
-error[E0575]: expected associated type, found variant `E::Y`
-  --> $DIR/ufcs-partially-resolved.rs:39:5
+error[E0404]: expected trait, found enum `E`
+  --> $DIR/ufcs-partially-resolved.rs:39:12
    |
 LL |     <u8 as E>::Y::NN;
-   |     ^^^^^^^^^^^^^^^^ not a associated type
+   |            ^ help: a trait with a similar name exists: `Eq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: similarly named trait `Eq` defined here
 
-error[E0576]: cannot find associated type `NN` in `Tr::N`
-  --> $DIR/ufcs-partially-resolved.rs:41:27
+error[E0405]: cannot find trait `N` in trait `Tr`
+  --> $DIR/ufcs-partially-resolved.rs:41:23
    |
 LL |     let _: <u8 as Tr::N>::NN;
-   |                           ^^ not found in `Tr::N`
+   |                       ^ not found in `Tr`
 
-error[E0576]: cannot find associated type `NN` in `E::N`
-  --> $DIR/ufcs-partially-resolved.rs:42:26
+error[E0405]: cannot find trait `N` in enum `E`
+  --> $DIR/ufcs-partially-resolved.rs:42:22
    |
 LL |     let _: <u8 as E::N>::NN;
-   |                          ^^ not found in `E::N`
+   |                      ^ not found in `E`
 
-error[E0576]: cannot find associated type `NN` in `A::N`
-  --> $DIR/ufcs-partially-resolved.rs:43:26
+error[E0405]: cannot find trait `N` in `A`
+  --> $DIR/ufcs-partially-resolved.rs:43:22
    |
 LL |     let _: <u8 as A::N>::NN;
-   |                          ^^ not found in `A::N`
+   |                      ^ not found in `A`
 
-error[E0576]: cannot find method or associated constant `NN` in `Tr::N`
-  --> $DIR/ufcs-partially-resolved.rs:44:20
+error[E0405]: cannot find trait `N` in trait `Tr`
+  --> $DIR/ufcs-partially-resolved.rs:44:16
    |
 LL |     <u8 as Tr::N>::NN;
-   |                    ^^ not found in `Tr::N`
+   |                ^ not found in `Tr`
 
-error[E0576]: cannot find method or associated constant `NN` in `E::N`
-  --> $DIR/ufcs-partially-resolved.rs:45:19
+error[E0405]: cannot find trait `N` in enum `E`
+  --> $DIR/ufcs-partially-resolved.rs:45:15
    |
 LL |     <u8 as E::N>::NN;
-   |                   ^^ not found in `E::N`
+   |               ^ not found in `E`
 
-error[E0576]: cannot find method or associated constant `NN` in `A::N`
-  --> $DIR/ufcs-partially-resolved.rs:46:19
+error[E0405]: cannot find trait `N` in `A`
+  --> $DIR/ufcs-partially-resolved.rs:46:15
    |
 LL |     <u8 as A::N>::NN;
-   |                   ^^ not found in `A::N`
+   |               ^ not found in `A`
 
-error[E0576]: cannot find associated type `NN` in `Tr::Y`
-  --> $DIR/ufcs-partially-resolved.rs:47:27
+error[E0404]: expected trait, found associated type `Tr::Y`
+  --> $DIR/ufcs-partially-resolved.rs:47:19
    |
 LL |     let _: <u8 as Tr::Y>::NN;
-   |                           ^^ not found in `Tr::Y`
+   |                   ^^^^^ not a trait
 
-error[E0576]: cannot find method or associated constant `NN` in `Tr::Y`
-  --> $DIR/ufcs-partially-resolved.rs:49:20
+error[E0404]: expected trait, found variant `E::Y`
+  --> $DIR/ufcs-partially-resolved.rs:48:19
+   |
+LL |     let _: <u8 as E::Y>::NN;
+   |                   ^^^^ not a trait
+
+error[E0404]: expected trait, found associated type `Tr::Y`
+  --> $DIR/ufcs-partially-resolved.rs:49:12
    |
 LL |     <u8 as Tr::Y>::NN;
-   |                    ^^ not found in `Tr::Y`
+   |            ^^^^^ not a trait
+
+error[E0404]: expected trait, found variant `E::Y`
+  --> $DIR/ufcs-partially-resolved.rs:50:12
+   |
+LL |     <u8 as E::Y>::NN;
+   |            ^^^^ not a trait
 
 error[E0575]: expected associated type, found associated function `Dr::Z`
   --> $DIR/ufcs-partially-resolved.rs:52:12
@@ -226,5 +270,5 @@ LL |     <u8 as Dr>::X::N;
 
 error: aborting due to 32 previous errors
 
-Some errors have detailed explanations: E0223, E0433, E0575, E0576, E0599.
+Some errors have detailed explanations: E0223, E0404, E0405, E0575, E0576, E0599.
 For more information about an error, try `rustc --explain E0223`.


### PR DESCRIPTION
`<Ty as Enum>::Assoc` should report that `Enum` is a trait. Main question is whether to eagerly report the error, or raise it with `return Err(..)` -- i'll note that in an inline comment though.

cc @GuillaumeGomez who said this came up at a Paris Rust meetup.

r? @petrochenkov 