### PR TITLE
add comment to `impl !Error for &str`

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2655,5 +2655,6 @@ impl_fn_for_zst! {
     };
 }
 
+// This is required to make `impl From<&str> for Box<dyn Error>` and `impl<E> From<E> for Box<dyn Error>` not overlap.
 #[stable(feature = "rust1", since = "1.0.0")]
 impl !crate::error::Error for &str {}


### PR DESCRIPTION
I saw this impl in the [standard library docs](https://doc.rust-lang.org/nightly/core/error/trait.Error.html#impl-Error-for-%26str) and wondered why it's needed. This commit adds a comment to explain its existence.