### PR TITLE
Don't print extra space for `debug_struct` with empty name

### DIFF
--- a/library/core/tests/fmt/builders.rs
+++ b/library/core/tests/fmt/builders.rs
@@ -16,6 +16,25 @@ mod debug_struct {
     }
 
     #[test]
+    fn test_empty_name() {
+        struct Foo {
+            field: ()
+        }
+
+        impl fmt::Debug for Foo {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt.debug_struct("").field("field", &self.field).finish()
+            }
+        }
+
+        assert_eq!("{ field: () }", format!("{:?}", Foo { field: () }));
+        assert_eq!(
+            "{
+    field: (),
+}", format!("{:#?}", Foo { field: () }));
+    }
+
+    #[test]
     fn test_single() {
         struct Foo;
 


### PR DESCRIPTION
Fixes #88261

I'm not sure if we necessarily want to support what is likely a niche use case, but as it's a quick fix I thought it might be worth having this up and ready for discussion.

@rustbot label +T-libs-api -T-libs