### PR TITLE
fluent_messages macro: don't emit the OS error in a note

### DIFF
--- a/compiler/rustc_macros/src/diagnostics/fluent.rs
+++ b/compiler/rustc_macros/src/diagnostics/fluent.rs
@@ -97,9 +97,12 @@ pub(crate) fn fluent_messages(input: proc_macro::TokenStream) -> proc_macro::Tok
     let resource_contents = match read_to_string(absolute_ftl_path) {
         Ok(resource_contents) => resource_contents,
         Err(e) => {
-            Diagnostic::spanned(resource_span, Level::Error, "could not open Fluent resource")
-                .note(e.to_string())
-                .emit();
+            Diagnostic::spanned(
+                resource_span,
+                Level::Error,
+                format!("could not open Fluent resource: {}", e.to_string()),
+            )
+            .emit();
             return failed(&crate_name);
         }
     };

--- a/tests/ui-fulldeps/fluent-messages/test.rs
+++ b/tests/ui-fulldeps/fluent-messages/test.rs
@@ -1,4 +1,4 @@
-// normalize-stderr-test "note.*" -> "note: os-specific message"
+// normalize-stderr-test "could not open Fluent resource:.*" -> "could not open Fluent resource: os-specific message"
 
 #![feature(rustc_private)]
 #![crate_type = "lib"]

--- a/tests/ui-fulldeps/fluent-messages/test.stderr
+++ b/tests/ui-fulldeps/fluent-messages/test.stderr
@@ -1,18 +1,14 @@
-error: could not open Fluent resource
+error: could not open Fluent resource: os-specific message
   --> $DIR/test.rs:24:24
    |
 LL |     fluent_messages! { "/definitely_does_not_exist.ftl" }
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: os-specific message
 
-error: could not open Fluent resource
+error: could not open Fluent resource: os-specific message
   --> $DIR/test.rs:31:24
    |
 LL |     fluent_messages! { "../definitely_does_not_exist.ftl" }
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: os-specific message
 
 error: could not parse Fluent resource
   --> $DIR/test.rs:38:24
@@ -89,7 +85,7 @@ error: invalid escape `\n` in Fluent resource
 LL |     fluent_messages! { "./invalid-escape.ftl" }
    |                        ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: os-specific message
+   = note: Fluent does not interpret these escape sequences (<https://projectfluent.org/fluent/guide/special.html>)
 
 error: invalid escape `\"` in Fluent resource
   --> $DIR/test.rs:99:24
@@ -97,7 +93,7 @@ error: invalid escape `\"` in Fluent resource
 LL |     fluent_messages! { "./invalid-escape.ftl" }
    |                        ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: os-specific message
+   = note: Fluent does not interpret these escape sequences (<https://projectfluent.org/fluent/guide/special.html>)
 
 error: invalid escape `\'` in Fluent resource
   --> $DIR/test.rs:99:24
@@ -105,7 +101,7 @@ error: invalid escape `\'` in Fluent resource
 LL |     fluent_messages! { "./invalid-escape.ftl" }
    |                        ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: os-specific message
+   = note: Fluent does not interpret these escape sequences (<https://projectfluent.org/fluent/guide/special.html>)
 
 error: aborting due to 13 previous errors
 


### PR DESCRIPTION
This makes it possible to make the normalization of the error message precise, allowing us to not normalize all notes away. See https://github.com/rust-lang/rust/pull/109700#discussion_r1152489053