### PR TITLE
Improve safe transmute error reporting

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -663,6 +663,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             return;
                         }
                         let trait_ref = trait_predicate.to_poly_trait_ref();
+
                         let (post_message, pre_message, type_def) = self
                             .get_parent_trait_ref(obligation.cause.code())
                             .map(|(t, s)| {
@@ -702,33 +703,45 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             (message, note, append_const_msg)
                         };
 
-                        let mut err = struct_span_err!(
-                            self.tcx.sess,
-                            span,
-                            E0277,
-                            "{}",
-                            message
-                                .and_then(|cannot_do_this| {
-                                    match (predicate_is_const, append_const_msg) {
-                                        // do nothing if predicate is not const
-                                        (false, _) => Some(cannot_do_this),
-                                        // suggested using default post message
-                                        (true, Some(None)) => {
-                                            Some(format!("{cannot_do_this} in const contexts"))
-                                        }
-                                        // overridden post message
-                                        (true, Some(Some(post_message))) => {
-                                            Some(format!("{cannot_do_this}{post_message}"))
-                                        }
-                                        // fallback to generic message
-                                        (true, None) => None,
+                        let err_msg = message
+                            .and_then(|cannot_do_this| {
+                                match (predicate_is_const, append_const_msg) {
+                                    // do nothing if predicate is not const
+                                    (false, _) => Some(cannot_do_this),
+                                    // suggested using default post message
+                                    (true, Some(None)) => {
+                                        Some(format!("{cannot_do_this} in const contexts"))
                                     }
-                                })
-                                .unwrap_or_else(|| format!(
+                                    // overridden post message
+                                    (true, Some(Some(post_message))) => {
+                                        Some(format!("{cannot_do_this}{post_message}"))
+                                    }
+                                    // fallback to generic message
+                                    (true, None) => None,
+                                }
+                            })
+                            .unwrap_or_else(|| {
+                                format!(
                                     "the trait bound `{}` is not satisfied{}",
                                     trait_predicate, post_message,
-                                ))
-                        );
+                                )
+                            });
+
+                        let (err_msg, safe_transmute_explanation) = if Some(trait_ref.def_id())
+                            == self.tcx.lang_items().transmute_trait()
+                        {
+                            // Recompute the safe transmute reason and use that for the error reporting
+                            self.get_safe_transmute_error_and_reason(
+                                trait_predicate,
+                                obligation.clone(),
+                                trait_ref,
+                                span,
+                            )
+                        } else {
+                            (err_msg, None)
+                        };
+
+                        let mut err = struct_span_err!(self.tcx.sess, span, E0277, "{}", err_msg);
 
                         if is_try_conversion && let Some(ret_span) = self.return_type_span(&obligation) {
                             err.span_label(
@@ -818,6 +831,8 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                                 // at the type param with a label to suggest constraining it.
                                 err.help(&explanation);
                             }
+                        } else if let Some(custom_explanation) = safe_transmute_explanation {
+                            err.span_label(span, custom_explanation);
                         } else {
                             err.span_label(span, explanation);
                         }
@@ -1601,6 +1616,14 @@ trait InferCtxtPrivExt<'tcx> {
         obligated_types: &mut Vec<Ty<'tcx>>,
         cause_code: &ObligationCauseCode<'tcx>,
     ) -> bool;
+
+    fn get_safe_transmute_error_and_reason(
+        &self,
+        trait_predicate: ty::Binder<'tcx, ty::TraitPredicate<'tcx>>,
+        obligation: Obligation<'tcx, ty::Predicate<'tcx>>,
+        trait_ref: ty::Binder<'tcx, ty::TraitRef<'tcx>>,
+        span: Span,
+    ) -> (String, Option<String>);
 }
 
 impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
@@ -2878,6 +2901,63 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             }
         }
         false
+    }
+
+    fn get_safe_transmute_error_and_reason(
+        &self,
+        trait_predicate: ty::Binder<'tcx, ty::TraitPredicate<'tcx>>,
+        obligation: Obligation<'tcx, ty::Predicate<'tcx>>,
+        trait_ref: ty::Binder<'tcx, ty::TraitRef<'tcx>>,
+        span: Span,
+    ) -> (String, Option<String>) {
+        let src_and_dst = trait_predicate.map_bound(|p| rustc_transmute::Types {
+            dst: p.trait_ref.substs.type_at(0),
+            src: p.trait_ref.substs.type_at(1),
+        });
+        let scope = trait_ref.skip_binder().substs.type_at(2);
+        let Some(assume) =
+            rustc_transmute::Assume::from_const(self.infcx.tcx, obligation.param_env, trait_ref.skip_binder().substs.const_at(3)) else {
+                span_bug!(span, "Unable to construct rustc_transmute::Assume where it was previously possible");
+            };
+        match rustc_transmute::TransmuteTypeEnv::new(self.infcx).is_transmutable(
+            obligation.cause,
+            src_and_dst,
+            scope,
+            assume,
+        ) {
+            rustc_transmute::Answer::No(reason) => {
+                let dst = trait_ref.skip_binder().substs.type_at(0);
+                let src = trait_ref.skip_binder().substs.type_at(1);
+                let custom_err_msg = format!("`{src}` cannot be safely transmuted into `{dst}` in the defining scope of `{scope}`").to_string();
+                let reason_msg = match reason {
+                    rustc_transmute::Reason::SrcIsUnspecified => {
+                        format!("`{src}` does not have a well-specified layout").to_string()
+                    }
+                    rustc_transmute::Reason::DstIsUnspecified => {
+                        format!("`{dst}` does not have a well-specified layout").to_string()
+                    }
+                    rustc_transmute::Reason::DstIsBitIncompatible => {
+                        format!("At least one value of `{src}` isn't a bit-valid value of `{dst}`")
+                            .to_string()
+                    }
+                    rustc_transmute::Reason::DstIsPrivate => format!(
+                        "`{dst}` is or contains a type or field that is not visible in that scope"
+                    )
+                    .to_string(),
+                    // FIXME(bryangarza): Include the number of bytes of src and dst
+                    rustc_transmute::Reason::DstIsTooBig => {
+                        format!("The size of `{src}` is smaller than the size of `{dst}`")
+                    }
+                };
+                (custom_err_msg, Some(reason_msg))
+            }
+            // Should never get a Yes at this point! We already ran it before, and did not get a Yes.
+            rustc_transmute::Answer::Yes => span_bug!(
+                span,
+                "Inconsistent rustc_transmute::is_transmutable(...) result, got Yes",
+            ),
+            _ => span_bug!(span, "Unsupported rustc_transmute::Reason variant"),
+        }
     }
 }
 

--- a/compiler/rustc_transmute/src/maybe_transmutable/tests.rs
+++ b/compiler/rustc_transmute/src/maybe_transmutable/tests.rs
@@ -1,6 +1,6 @@
 use super::query_context::test::{Def, UltraMinimal};
 use crate::maybe_transmutable::MaybeTransmutableQuery;
-use crate::{layout, Answer, Reason, Set};
+use crate::{layout, Answer, Reason};
 use itertools::Itertools;
 
 mod bool {
@@ -48,9 +48,9 @@ mod bool {
 
         let into_set = |alts: Vec<_>| {
             #[cfg(feature = "rustc")]
-            let mut set = Set::default();
+            let mut set = crate::Set::default();
             #[cfg(not(feature = "rustc"))]
-            let mut set = Set::new();
+            let mut set = std::collections::HashSet::new();
             set.extend(alts);
             set
         };

--- a/library/core/src/mem/transmutability.rs
+++ b/library/core/src/mem/transmutability.rs
@@ -5,10 +5,6 @@
 /// notwithstanding whatever safety checks you have asked the compiler to [`Assume`] are satisfied.
 #[unstable(feature = "transmutability", issue = "99571")]
 #[lang = "transmute_trait"]
-#[rustc_on_unimplemented(
-    message = "`{Src}` cannot be safely transmuted into `{Self}` in the defining scope of `{Context}`.",
-    label = "`{Src}` cannot be safely transmuted into `{Self}` in the defining scope of `{Context}`."
-)]
 pub unsafe trait BikeshedIntrinsicFrom<Src, Context, const ASSUME: Assume = { Assume::NOTHING }>
 where
     Src: ?Sized,

--- a/tests/ui/transmutability/arrays/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/arrays/should_require_well_defined_layout.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `[String; 0]` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `[String; 0]` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:26:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `[String; 0]` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                    ^^ `[String; 0]` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<[String; 0], assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -20,13 +19,12 @@ LL | |                 .and(Assume::VALIDITY)
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `[String; 0]` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `[String; 0]` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:27:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `u128` cannot be safely transmuted into `[String; 0]` in the defining scope of `assert::Context`.
+   |                                               ^^^^^^^^^ `[String; 0]` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `[String; 0]`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -42,13 +40,12 @@ LL | |                 .and(Assume::VALIDITY)
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `[String; 1]` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `[String; 1]` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:32:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `[String; 1]` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                    ^^ `[String; 1]` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<[String; 1], assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -64,13 +61,12 @@ LL | |                 .and(Assume::VALIDITY)
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `[String; 1]` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `[String; 1]` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:33:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `u128` cannot be safely transmuted into `[String; 1]` in the defining scope of `assert::Context`.
+   |                                               ^^^^^^^^^ `[String; 1]` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `[String; 1]`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -86,13 +82,12 @@ LL | |                 .and(Assume::VALIDITY)
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `[String; 2]` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `[String; 2]` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:38:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `[String; 2]` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                    ^^ `[String; 2]` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<[String; 2], assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -108,13 +103,12 @@ LL | |                 .and(Assume::VALIDITY)
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `[String; 2]` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `[String; 2]` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:39:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `u128` cannot be safely transmuted into `[String; 2]` in the defining scope of `assert::Context`.
+   |                                               ^^^^^^^^^ `[String; 2]` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `[String; 2]`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |

--- a/tests/ui/transmutability/enums/repr/primitive_reprs_should_have_correct_length.stderr
+++ b/tests/ui/transmutability/enums/repr/primitive_reprs_should_have_correct_length.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `Zst` cannot be safely transmuted into `V0i8` in the defining scope of `n8::Context`.
+error[E0277]: `Zst` cannot be safely transmuted into `V0i8` in the defining scope of `n8::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:48:44
    |
 LL |         assert::is_transmutable::<Smaller, Current, Context>();
-   |                                            ^^^^^^^ `Zst` cannot be safely transmuted into `V0i8` in the defining scope of `n8::Context`.
+   |                                            ^^^^^^^ The size of `Zst` is smaller than the size of `V0i8`
    |
-   = help: the trait `BikeshedIntrinsicFrom<Zst, n8::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `V0i8`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -21,13 +20,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `V0i8` cannot be safely transmuted into `u16` in the defining scope of `n8::Context`.
+error[E0277]: `V0i8` cannot be safely transmuted into `u16` in the defining scope of `n8::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:50:44
    |
 LL |         assert::is_transmutable::<Current, Larger, Context>();
-   |                                            ^^^^^^ `V0i8` cannot be safely transmuted into `u16` in the defining scope of `n8::Context`.
+   |                                            ^^^^^^ The size of `V0i8` is smaller than the size of `u16`
    |
-   = help: the trait `BikeshedIntrinsicFrom<V0i8, n8::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `u16`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -44,13 +42,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `Zst` cannot be safely transmuted into `V0u8` in the defining scope of `n8::Context`.
+error[E0277]: `Zst` cannot be safely transmuted into `V0u8` in the defining scope of `n8::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:56:44
    |
 LL |         assert::is_transmutable::<Smaller, Current, Context>();
-   |                                            ^^^^^^^ `Zst` cannot be safely transmuted into `V0u8` in the defining scope of `n8::Context`.
+   |                                            ^^^^^^^ The size of `Zst` is smaller than the size of `V0u8`
    |
-   = help: the trait `BikeshedIntrinsicFrom<Zst, n8::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `V0u8`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -67,13 +64,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `V0u8` cannot be safely transmuted into `u16` in the defining scope of `n8::Context`.
+error[E0277]: `V0u8` cannot be safely transmuted into `u16` in the defining scope of `n8::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:58:44
    |
 LL |         assert::is_transmutable::<Current, Larger, Context>();
-   |                                            ^^^^^^ `V0u8` cannot be safely transmuted into `u16` in the defining scope of `n8::Context`.
+   |                                            ^^^^^^ The size of `V0u8` is smaller than the size of `u16`
    |
-   = help: the trait `BikeshedIntrinsicFrom<V0u8, n8::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `u16`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -90,13 +86,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `V0i16` in the defining scope of `n16::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `V0i16` in the defining scope of `n16::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:72:44
    |
 LL |         assert::is_transmutable::<Smaller, Current, Context>();
-   |                                            ^^^^^^^ `u8` cannot be safely transmuted into `V0i16` in the defining scope of `n16::Context`.
+   |                                            ^^^^^^^ At least one value of `u8` isn't a bit-valid value of `V0i16`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, n16::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `V0i16`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -113,13 +108,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `V0i16` cannot be safely transmuted into `u32` in the defining scope of `n16::Context`.
+error[E0277]: `V0i16` cannot be safely transmuted into `u32` in the defining scope of `n16::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:74:44
    |
 LL |         assert::is_transmutable::<Current, Larger, Context>();
-   |                                            ^^^^^^ `V0i16` cannot be safely transmuted into `u32` in the defining scope of `n16::Context`.
+   |                                            ^^^^^^ The size of `V0i16` is smaller than the size of `u32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<V0i16, n16::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `u32`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -136,13 +130,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `V0u16` in the defining scope of `n16::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `V0u16` in the defining scope of `n16::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:80:44
    |
 LL |         assert::is_transmutable::<Smaller, Current, Context>();
-   |                                            ^^^^^^^ `u8` cannot be safely transmuted into `V0u16` in the defining scope of `n16::Context`.
+   |                                            ^^^^^^^ At least one value of `u8` isn't a bit-valid value of `V0u16`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, n16::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `V0u16`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -159,13 +152,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `V0u16` cannot be safely transmuted into `u32` in the defining scope of `n16::Context`.
+error[E0277]: `V0u16` cannot be safely transmuted into `u32` in the defining scope of `n16::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:82:44
    |
 LL |         assert::is_transmutable::<Current, Larger, Context>();
-   |                                            ^^^^^^ `V0u16` cannot be safely transmuted into `u32` in the defining scope of `n16::Context`.
+   |                                            ^^^^^^ The size of `V0u16` is smaller than the size of `u32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<V0u16, n16::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `u32`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -182,13 +174,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `V0i32` in the defining scope of `n32::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `V0i32` in the defining scope of `n32::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:96:44
    |
 LL |         assert::is_transmutable::<Smaller, Current, Context>();
-   |                                            ^^^^^^^ `u16` cannot be safely transmuted into `V0i32` in the defining scope of `n32::Context`.
+   |                                            ^^^^^^^ At least one value of `u16` isn't a bit-valid value of `V0i32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, n32::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `V0i32`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -205,13 +196,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `V0i32` cannot be safely transmuted into `u64` in the defining scope of `n32::Context`.
+error[E0277]: `V0i32` cannot be safely transmuted into `u64` in the defining scope of `n32::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:98:44
    |
 LL |         assert::is_transmutable::<Current, Larger, Context>();
-   |                                            ^^^^^^ `V0i32` cannot be safely transmuted into `u64` in the defining scope of `n32::Context`.
+   |                                            ^^^^^^ The size of `V0i32` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<V0i32, n32::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -228,13 +218,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `V0u32` in the defining scope of `n32::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `V0u32` in the defining scope of `n32::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:104:44
    |
 LL |         assert::is_transmutable::<Smaller, Current, Context>();
-   |                                            ^^^^^^^ `u16` cannot be safely transmuted into `V0u32` in the defining scope of `n32::Context`.
+   |                                            ^^^^^^^ At least one value of `u16` isn't a bit-valid value of `V0u32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, n32::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `V0u32`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -251,13 +240,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `V0u32` cannot be safely transmuted into `u64` in the defining scope of `n32::Context`.
+error[E0277]: `V0u32` cannot be safely transmuted into `u64` in the defining scope of `n32::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:106:44
    |
 LL |         assert::is_transmutable::<Current, Larger, Context>();
-   |                                            ^^^^^^ `V0u32` cannot be safely transmuted into `u64` in the defining scope of `n32::Context`.
+   |                                            ^^^^^^ The size of `V0u32` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<V0u32, n32::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -274,13 +262,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `u32` cannot be safely transmuted into `V0i64` in the defining scope of `n64::Context`.
+error[E0277]: `u32` cannot be safely transmuted into `V0i64` in the defining scope of `n64::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:120:44
    |
 LL |         assert::is_transmutable::<Smaller, Current, Context>();
-   |                                            ^^^^^^^ `u32` cannot be safely transmuted into `V0i64` in the defining scope of `n64::Context`.
+   |                                            ^^^^^^^ At least one value of `u32` isn't a bit-valid value of `V0i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u32, n64::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `V0i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -297,13 +284,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `V0i64` cannot be safely transmuted into `u128` in the defining scope of `n64::Context`.
+error[E0277]: `V0i64` cannot be safely transmuted into `u128` in the defining scope of `n64::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:122:44
    |
 LL |         assert::is_transmutable::<Current, Larger, Context>();
-   |                                            ^^^^^^ `V0i64` cannot be safely transmuted into `u128` in the defining scope of `n64::Context`.
+   |                                            ^^^^^^ The size of `V0i64` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<V0i64, n64::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -320,13 +306,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `u32` cannot be safely transmuted into `V0u64` in the defining scope of `n64::Context`.
+error[E0277]: `u32` cannot be safely transmuted into `V0u64` in the defining scope of `n64::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:128:44
    |
 LL |         assert::is_transmutable::<Smaller, Current, Context>();
-   |                                            ^^^^^^^ `u32` cannot be safely transmuted into `V0u64` in the defining scope of `n64::Context`.
+   |                                            ^^^^^^^ At least one value of `u32` isn't a bit-valid value of `V0u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u32, n64::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `V0u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -343,13 +328,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `V0u64` cannot be safely transmuted into `u128` in the defining scope of `n64::Context`.
+error[E0277]: `V0u64` cannot be safely transmuted into `u128` in the defining scope of `n64::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:130:44
    |
 LL |         assert::is_transmutable::<Current, Larger, Context>();
-   |                                            ^^^^^^ `V0u64` cannot be safely transmuted into `u128` in the defining scope of `n64::Context`.
+   |                                            ^^^^^^ The size of `V0u64` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<V0u64, n64::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -366,13 +350,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `V0isize` in the defining scope of `nsize::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `V0isize` in the defining scope of `nsize::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:144:44
    |
 LL |         assert::is_transmutable::<Smaller, Current, Context>();
-   |                                            ^^^^^^^ `u8` cannot be safely transmuted into `V0isize` in the defining scope of `nsize::Context`.
+   |                                            ^^^^^^^ At least one value of `u8` isn't a bit-valid value of `V0isize`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, nsize::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `V0isize`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -389,13 +372,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `V0isize` cannot be safely transmuted into `[usize; 2]` in the defining scope of `nsize::Context`.
+error[E0277]: `V0isize` cannot be safely transmuted into `[usize; 2]` in the defining scope of `nsize::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:146:44
    |
 LL |         assert::is_transmutable::<Current, Larger, Context>();
-   |                                            ^^^^^^ `V0isize` cannot be safely transmuted into `[usize; 2]` in the defining scope of `nsize::Context`.
+   |                                            ^^^^^^ The size of `V0isize` is smaller than the size of `[usize; 2]`
    |
-   = help: the trait `BikeshedIntrinsicFrom<V0isize, nsize::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `[usize; 2]`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -412,13 +394,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `V0usize` in the defining scope of `nsize::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `V0usize` in the defining scope of `nsize::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:152:44
    |
 LL |         assert::is_transmutable::<Smaller, Current, Context>();
-   |                                            ^^^^^^^ `u8` cannot be safely transmuted into `V0usize` in the defining scope of `nsize::Context`.
+   |                                            ^^^^^^^ At least one value of `u8` isn't a bit-valid value of `V0usize`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, nsize::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `V0usize`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |
@@ -435,13 +416,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_transmutable`
 
-error[E0277]: `V0usize` cannot be safely transmuted into `[usize; 2]` in the defining scope of `nsize::Context`.
+error[E0277]: `V0usize` cannot be safely transmuted into `[usize; 2]` in the defining scope of `nsize::Context`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:154:44
    |
 LL |         assert::is_transmutable::<Current, Larger, Context>();
-   |                                            ^^^^^^ `V0usize` cannot be safely transmuted into `[usize; 2]` in the defining scope of `nsize::Context`.
+   |                                            ^^^^^^ The size of `V0usize` is smaller than the size of `[usize; 2]`
    |
-   = help: the trait `BikeshedIntrinsicFrom<V0usize, nsize::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `[usize; 2]`
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
    |

--- a/tests/ui/transmutability/enums/repr/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/enums/repr/should_require_well_defined_layout.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `void::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `void::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:28:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `void::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                    ^^ `void::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<void::repr_rust, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
@@ -21,13 +20,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `void::repr_rust` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `void::repr_rust` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:29:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `u128` cannot be safely transmuted into `void::repr_rust` in the defining scope of `assert::Context`.
+   |                                               ^^^^^^^^^ `void::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `void::repr_rust`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
@@ -44,13 +42,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `singleton::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `singleton::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:34:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `singleton::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                    ^^ `singleton::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<singleton::repr_rust, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
@@ -67,13 +64,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `singleton::repr_rust` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `singleton::repr_rust` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:35:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `u128` cannot be safely transmuted into `singleton::repr_rust` in the defining scope of `assert::Context`.
+   |                                               ^^^^^^^^^ `singleton::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `singleton::repr_rust`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
@@ -90,13 +86,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `duplex::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `duplex::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:40:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `duplex::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                    ^^ `duplex::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<duplex::repr_rust, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |
@@ -113,13 +108,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `duplex::repr_rust` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `duplex::repr_rust` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:41:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `u128` cannot be safely transmuted into `duplex::repr_rust` in the defining scope of `assert::Context`.
+   |                                               ^^^^^^^^^ `duplex::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `duplex::repr_rust`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:14:14
    |

--- a/tests/ui/transmutability/enums/should_pad_variants.stderr
+++ b/tests/ui/transmutability/enums/should_pad_variants.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `Src` cannot be safely transmuted into `Dst` in the defining scope of `should_pad_variants::Context`.
+error[E0277]: `Src` cannot be safely transmuted into `Dst` in the defining scope of `should_pad_variants::Context`
   --> $DIR/should_pad_variants.rs:44:36
    |
 LL |     assert::is_transmutable::<Src, Dst, Context>();
-   |                                    ^^^ `Src` cannot be safely transmuted into `Dst` in the defining scope of `should_pad_variants::Context`.
+   |                                    ^^^ The size of `Src` is smaller than the size of `Dst`
    |
-   = help: the trait `BikeshedIntrinsicFrom<Src, should_pad_variants::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `Dst`
 note: required by a bound in `is_transmutable`
   --> $DIR/should_pad_variants.rs:13:14
    |

--- a/tests/ui/transmutability/enums/should_respect_endianness.stderr
+++ b/tests/ui/transmutability/enums/should_respect_endianness.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `Src` cannot be safely transmuted into `Unexpected` in the defining scope of `assert::Context`.
+error[E0277]: `Src` cannot be safely transmuted into `Unexpected` in the defining scope of `assert::Context`
   --> $DIR/should_respect_endianness.rs:36:36
    |
 LL |     assert::is_transmutable::<Src, Unexpected>();
-   |                                    ^^^^^^^^^^ `Src` cannot be safely transmuted into `Unexpected` in the defining scope of `assert::Context`.
+   |                                    ^^^^^^^^^^ At least one value of `Src` isn't a bit-valid value of `Unexpected`
    |
-   = help: the trait `BikeshedIntrinsicFrom<Src, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `Unexpected`
 note: required by a bound in `is_transmutable`
   --> $DIR/should_respect_endianness.rs:14:14
    |

--- a/tests/ui/transmutability/primitives/bool.current.stderr
+++ b/tests/ui/transmutability/primitives/bool.current.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `u8` cannot be safely transmuted into `bool` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `bool` in the defining scope of `assert::Context`
   --> $DIR/bool.rs:24:35
    |
 LL |     assert::is_transmutable::<u8, bool>();
-   |                                   ^^^^ `u8` cannot be safely transmuted into `bool` in the defining scope of `assert::Context`.
+   |                                   ^^^^ At least one value of `u8` isn't a bit-valid value of `bool`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: true, validity: false }>` is not implemented for `bool`
 note: required by a bound in `is_transmutable`
   --> $DIR/bool.rs:14:14
    |

--- a/tests/ui/transmutability/primitives/bool.next.stderr
+++ b/tests/ui/transmutability/primitives/bool.next.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `u8` cannot be safely transmuted into `bool` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `bool` in the defining scope of `assert::Context`
   --> $DIR/bool.rs:24:35
    |
 LL |     assert::is_transmutable::<u8, bool>();
-   |                                   ^^^^ `u8` cannot be safely transmuted into `bool` in the defining scope of `assert::Context`.
+   |                                   ^^^^ At least one value of `u8` isn't a bit-valid value of `bool`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: true, validity: false }>` is not implemented for `bool`
 note: required by a bound in `is_transmutable`
   --> $DIR/bool.rs:14:14
    |

--- a/tests/ui/transmutability/primitives/numbers.current.stderr
+++ b/tests/ui/transmutability/primitives/numbers.current.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `i8` cannot be safely transmuted into `i16` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `i16` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:65:40
    |
 LL |     assert::is_transmutable::<   i8,   i16>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `i16` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `i16`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i16`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -14,13 +13,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `u16` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `u16` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:66:40
    |
 LL |     assert::is_transmutable::<   i8,   u16>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `u16` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `u16`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u16`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -30,13 +28,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:67:40
    |
 LL |     assert::is_transmutable::<   i8,   i32>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `i32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -46,13 +43,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:68:40
    |
 LL |     assert::is_transmutable::<   i8,   f32>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `f32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -62,13 +58,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:69:40
    |
 LL |     assert::is_transmutable::<   i8,   u32>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `u32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -78,13 +73,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:70:40
    |
 LL |     assert::is_transmutable::<   i8,   u64>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -94,13 +88,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:71:40
    |
 LL |     assert::is_transmutable::<   i8,   i64>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -110,13 +103,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:72:40
    |
 LL |     assert::is_transmutable::<   i8,   f64>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -126,13 +118,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:73:39
    |
 LL |     assert::is_transmutable::<   i8,  u128>();
-   |                                       ^^^^ `i8` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i8` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -142,13 +133,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:74:39
    |
 LL |     assert::is_transmutable::<   i8,  i128>();
-   |                                       ^^^^ `i8` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i8` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -158,13 +148,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `i16` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `i16` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:76:40
    |
 LL |     assert::is_transmutable::<   u8,   i16>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `i16` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `i16`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i16`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -174,13 +163,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `u16` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `u16` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:77:40
    |
 LL |     assert::is_transmutable::<   u8,   u16>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `u16` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `u16`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u16`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -190,13 +178,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:78:40
    |
 LL |     assert::is_transmutable::<   u8,   i32>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `i32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -206,13 +193,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:79:40
    |
 LL |     assert::is_transmutable::<   u8,   f32>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `f32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -222,13 +208,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:80:40
    |
 LL |     assert::is_transmutable::<   u8,   u32>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `u32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -238,13 +223,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:81:40
    |
 LL |     assert::is_transmutable::<   u8,   u64>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -254,13 +238,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:82:40
    |
 LL |     assert::is_transmutable::<   u8,   i64>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -270,13 +253,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:83:40
    |
 LL |     assert::is_transmutable::<   u8,   f64>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -286,13 +268,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:84:39
    |
 LL |     assert::is_transmutable::<   u8,  u128>();
-   |                                       ^^^^ `u8` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u8` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -302,13 +283,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:85:39
    |
 LL |     assert::is_transmutable::<   u8,  i128>();
-   |                                       ^^^^ `u8` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u8` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -318,13 +298,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:87:40
    |
 LL |     assert::is_transmutable::<  i16,   i32>();
-   |                                        ^^^ `i16` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i16` is smaller than the size of `i32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -334,13 +313,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:88:40
    |
 LL |     assert::is_transmutable::<  i16,   f32>();
-   |                                        ^^^ `i16` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i16` is smaller than the size of `f32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -350,13 +328,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:89:40
    |
 LL |     assert::is_transmutable::<  i16,   u32>();
-   |                                        ^^^ `i16` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i16` is smaller than the size of `u32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -366,13 +343,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:90:40
    |
 LL |     assert::is_transmutable::<  i16,   u64>();
-   |                                        ^^^ `i16` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i16` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -382,13 +358,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:91:40
    |
 LL |     assert::is_transmutable::<  i16,   i64>();
-   |                                        ^^^ `i16` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i16` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -398,13 +373,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:92:40
    |
 LL |     assert::is_transmutable::<  i16,   f64>();
-   |                                        ^^^ `i16` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i16` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -414,13 +388,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:93:39
    |
 LL |     assert::is_transmutable::<  i16,  u128>();
-   |                                       ^^^^ `i16` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i16` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -430,13 +403,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:94:39
    |
 LL |     assert::is_transmutable::<  i16,  i128>();
-   |                                       ^^^^ `i16` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i16` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -446,13 +418,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:96:40
    |
 LL |     assert::is_transmutable::<  u16,   i32>();
-   |                                        ^^^ `u16` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u16` is smaller than the size of `i32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -462,13 +433,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:97:40
    |
 LL |     assert::is_transmutable::<  u16,   f32>();
-   |                                        ^^^ `u16` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u16` is smaller than the size of `f32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -478,13 +448,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:98:40
    |
 LL |     assert::is_transmutable::<  u16,   u32>();
-   |                                        ^^^ `u16` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u16` is smaller than the size of `u32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -494,13 +463,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:99:40
    |
 LL |     assert::is_transmutable::<  u16,   u64>();
-   |                                        ^^^ `u16` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u16` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -510,13 +478,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:100:40
    |
 LL |     assert::is_transmutable::<  u16,   i64>();
-   |                                        ^^^ `u16` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u16` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -526,13 +493,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:101:40
    |
 LL |     assert::is_transmutable::<  u16,   f64>();
-   |                                        ^^^ `u16` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u16` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -542,13 +508,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:102:39
    |
 LL |     assert::is_transmutable::<  u16,  u128>();
-   |                                       ^^^^ `u16` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u16` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -558,13 +523,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:103:39
    |
 LL |     assert::is_transmutable::<  u16,  i128>();
-   |                                       ^^^^ `u16` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u16` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -574,13 +538,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `i32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:105:40
    |
 LL |     assert::is_transmutable::<  i32,   u64>();
-   |                                        ^^^ `i32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i32` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -590,13 +553,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `i32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:106:40
    |
 LL |     assert::is_transmutable::<  i32,   i64>();
-   |                                        ^^^ `i32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i32` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -606,13 +568,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `i32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:107:40
    |
 LL |     assert::is_transmutable::<  i32,   f64>();
-   |                                        ^^^ `i32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i32` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -622,13 +583,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `i32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:108:39
    |
 LL |     assert::is_transmutable::<  i32,  u128>();
-   |                                       ^^^^ `i32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i32` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -638,13 +598,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `i32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:109:39
    |
 LL |     assert::is_transmutable::<  i32,  i128>();
-   |                                       ^^^^ `i32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i32` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -654,13 +613,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `f32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:111:40
    |
 LL |     assert::is_transmutable::<  f32,   u64>();
-   |                                        ^^^ `f32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `f32` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -670,13 +628,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `f32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:112:40
    |
 LL |     assert::is_transmutable::<  f32,   i64>();
-   |                                        ^^^ `f32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `f32` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -686,13 +643,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `f32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:113:40
    |
 LL |     assert::is_transmutable::<  f32,   f64>();
-   |                                        ^^^ `f32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `f32` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -702,13 +658,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `f32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:114:39
    |
 LL |     assert::is_transmutable::<  f32,  u128>();
-   |                                       ^^^^ `f32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `f32` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -718,13 +673,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `f32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:115:39
    |
 LL |     assert::is_transmutable::<  f32,  i128>();
-   |                                       ^^^^ `f32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `f32` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -734,13 +688,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `u32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:117:40
    |
 LL |     assert::is_transmutable::<  u32,   u64>();
-   |                                        ^^^ `u32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u32` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -750,13 +703,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `u32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:118:40
    |
 LL |     assert::is_transmutable::<  u32,   i64>();
-   |                                        ^^^ `u32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u32` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -766,13 +718,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `u32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:119:40
    |
 LL |     assert::is_transmutable::<  u32,   f64>();
-   |                                        ^^^ `u32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u32` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -782,13 +733,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `u32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:120:39
    |
 LL |     assert::is_transmutable::<  u32,  u128>();
-   |                                       ^^^^ `u32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u32` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -798,13 +748,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `u32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:121:39
    |
 LL |     assert::is_transmutable::<  u32,  i128>();
-   |                                       ^^^^ `u32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u32` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -814,13 +763,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `u64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:123:39
    |
 LL |     assert::is_transmutable::<  u64,  u128>();
-   |                                       ^^^^ `u64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u64` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u64, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -830,13 +778,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `u64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:124:39
    |
 LL |     assert::is_transmutable::<  u64,  i128>();
-   |                                       ^^^^ `u64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u64` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u64, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -846,13 +793,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `i64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:126:39
    |
 LL |     assert::is_transmutable::<  i64,  u128>();
-   |                                       ^^^^ `i64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i64` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i64, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -862,13 +808,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `i64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:127:39
    |
 LL |     assert::is_transmutable::<  i64,  i128>();
-   |                                       ^^^^ `i64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i64` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i64, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -878,13 +823,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `f64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:129:39
    |
 LL |     assert::is_transmutable::<  f64,  u128>();
-   |                                       ^^^^ `f64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `f64` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f64, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -894,13 +838,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `f64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:130:39
    |
 LL |     assert::is_transmutable::<  f64,  i128>();
-   |                                       ^^^^ `f64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `f64` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f64, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |

--- a/tests/ui/transmutability/primitives/numbers.next.stderr
+++ b/tests/ui/transmutability/primitives/numbers.next.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `i8` cannot be safely transmuted into `i16` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `i16` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:65:40
    |
 LL |     assert::is_transmutable::<   i8,   i16>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `i16` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `i16`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i16`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -14,13 +13,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `u16` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `u16` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:66:40
    |
 LL |     assert::is_transmutable::<   i8,   u16>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `u16` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `u16`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u16`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -30,13 +28,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:67:40
    |
 LL |     assert::is_transmutable::<   i8,   i32>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `i32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -46,13 +43,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:68:40
    |
 LL |     assert::is_transmutable::<   i8,   f32>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `f32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -62,13 +58,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:69:40
    |
 LL |     assert::is_transmutable::<   i8,   u32>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `u32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -78,13 +73,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:70:40
    |
 LL |     assert::is_transmutable::<   i8,   u64>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -94,13 +88,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:71:40
    |
 LL |     assert::is_transmutable::<   i8,   i64>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -110,13 +103,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:72:40
    |
 LL |     assert::is_transmutable::<   i8,   f64>();
-   |                                        ^^^ `i8` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i8` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -126,13 +118,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:73:39
    |
 LL |     assert::is_transmutable::<   i8,  u128>();
-   |                                       ^^^^ `i8` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i8` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -142,13 +133,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i8` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `i8` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:74:39
    |
 LL |     assert::is_transmutable::<   i8,  i128>();
-   |                                       ^^^^ `i8` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i8` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -158,13 +148,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `i16` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `i16` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:76:40
    |
 LL |     assert::is_transmutable::<   u8,   i16>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `i16` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `i16`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i16`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -174,13 +163,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `u16` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `u16` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:77:40
    |
 LL |     assert::is_transmutable::<   u8,   u16>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `u16` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `u16`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u16`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -190,13 +178,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:78:40
    |
 LL |     assert::is_transmutable::<   u8,   i32>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `i32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -206,13 +193,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:79:40
    |
 LL |     assert::is_transmutable::<   u8,   f32>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `f32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -222,13 +208,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:80:40
    |
 LL |     assert::is_transmutable::<   u8,   u32>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `u32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -238,13 +223,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:81:40
    |
 LL |     assert::is_transmutable::<   u8,   u64>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -254,13 +238,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:82:40
    |
 LL |     assert::is_transmutable::<   u8,   i64>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -270,13 +253,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:83:40
    |
 LL |     assert::is_transmutable::<   u8,   f64>();
-   |                                        ^^^ `u8` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u8` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -286,13 +268,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:84:39
    |
 LL |     assert::is_transmutable::<   u8,  u128>();
-   |                                       ^^^^ `u8` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u8` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -302,13 +283,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u8` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `u8` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:85:39
    |
 LL |     assert::is_transmutable::<   u8,  i128>();
-   |                                       ^^^^ `u8` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u8` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u8, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -318,13 +298,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:87:40
    |
 LL |     assert::is_transmutable::<  i16,   i32>();
-   |                                        ^^^ `i16` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i16` is smaller than the size of `i32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -334,13 +313,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:88:40
    |
 LL |     assert::is_transmutable::<  i16,   f32>();
-   |                                        ^^^ `i16` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i16` is smaller than the size of `f32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -350,13 +328,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:89:40
    |
 LL |     assert::is_transmutable::<  i16,   u32>();
-   |                                        ^^^ `i16` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i16` is smaller than the size of `u32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -366,13 +343,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:90:40
    |
 LL |     assert::is_transmutable::<  i16,   u64>();
-   |                                        ^^^ `i16` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i16` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -382,13 +358,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:91:40
    |
 LL |     assert::is_transmutable::<  i16,   i64>();
-   |                                        ^^^ `i16` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i16` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -398,13 +373,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:92:40
    |
 LL |     assert::is_transmutable::<  i16,   f64>();
-   |                                        ^^^ `i16` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i16` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -414,13 +388,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:93:39
    |
 LL |     assert::is_transmutable::<  i16,  u128>();
-   |                                       ^^^^ `i16` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i16` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -430,13 +403,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i16` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `i16` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:94:39
    |
 LL |     assert::is_transmutable::<  i16,  i128>();
-   |                                       ^^^^ `i16` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i16` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -446,13 +418,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:96:40
    |
 LL |     assert::is_transmutable::<  u16,   i32>();
-   |                                        ^^^ `u16` cannot be safely transmuted into `i32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u16` is smaller than the size of `i32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -462,13 +433,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:97:40
    |
 LL |     assert::is_transmutable::<  u16,   f32>();
-   |                                        ^^^ `u16` cannot be safely transmuted into `f32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u16` is smaller than the size of `f32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -478,13 +448,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:98:40
    |
 LL |     assert::is_transmutable::<  u16,   u32>();
-   |                                        ^^^ `u16` cannot be safely transmuted into `u32` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u16` is smaller than the size of `u32`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u32`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -494,13 +463,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:99:40
    |
 LL |     assert::is_transmutable::<  u16,   u64>();
-   |                                        ^^^ `u16` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u16` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -510,13 +478,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:100:40
    |
 LL |     assert::is_transmutable::<  u16,   i64>();
-   |                                        ^^^ `u16` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u16` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -526,13 +493,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:101:40
    |
 LL |     assert::is_transmutable::<  u16,   f64>();
-   |                                        ^^^ `u16` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u16` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -542,13 +508,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:102:39
    |
 LL |     assert::is_transmutable::<  u16,  u128>();
-   |                                       ^^^^ `u16` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u16` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -558,13 +523,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u16` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `u16` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:103:39
    |
 LL |     assert::is_transmutable::<  u16,  i128>();
-   |                                       ^^^^ `u16` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u16` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u16, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -574,13 +538,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `i32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:105:40
    |
 LL |     assert::is_transmutable::<  i32,   u64>();
-   |                                        ^^^ `i32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i32` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -590,13 +553,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `i32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:106:40
    |
 LL |     assert::is_transmutable::<  i32,   i64>();
-   |                                        ^^^ `i32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i32` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -606,13 +568,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `i32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:107:40
    |
 LL |     assert::is_transmutable::<  i32,   f64>();
-   |                                        ^^^ `i32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `i32` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -622,13 +583,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `i32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:108:39
    |
 LL |     assert::is_transmutable::<  i32,  u128>();
-   |                                       ^^^^ `i32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i32` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -638,13 +598,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `i32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:109:39
    |
 LL |     assert::is_transmutable::<  i32,  i128>();
-   |                                       ^^^^ `i32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i32` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -654,13 +613,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `f32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:111:40
    |
 LL |     assert::is_transmutable::<  f32,   u64>();
-   |                                        ^^^ `f32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `f32` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -670,13 +628,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `f32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:112:40
    |
 LL |     assert::is_transmutable::<  f32,   i64>();
-   |                                        ^^^ `f32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `f32` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -686,13 +643,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `f32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:113:40
    |
 LL |     assert::is_transmutable::<  f32,   f64>();
-   |                                        ^^^ `f32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `f32` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -702,13 +658,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `f32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:114:39
    |
 LL |     assert::is_transmutable::<  f32,  u128>();
-   |                                       ^^^^ `f32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `f32` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -718,13 +673,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `f32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:115:39
    |
 LL |     assert::is_transmutable::<  f32,  i128>();
-   |                                       ^^^^ `f32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `f32` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -734,13 +688,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+error[E0277]: `u32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:117:40
    |
 LL |     assert::is_transmutable::<  u32,   u64>();
-   |                                        ^^^ `u32` cannot be safely transmuted into `u64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u32` is smaller than the size of `u64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -750,13 +703,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+error[E0277]: `u32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:118:40
    |
 LL |     assert::is_transmutable::<  u32,   i64>();
-   |                                        ^^^ `u32` cannot be safely transmuted into `i64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u32` is smaller than the size of `i64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -766,13 +718,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+error[E0277]: `u32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:119:40
    |
 LL |     assert::is_transmutable::<  u32,   f64>();
-   |                                        ^^^ `u32` cannot be safely transmuted into `f64` in the defining scope of `assert::Context`.
+   |                                        ^^^ The size of `u32` is smaller than the size of `f64`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `f64`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -782,13 +733,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `u32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:120:39
    |
 LL |     assert::is_transmutable::<  u32,  u128>();
-   |                                       ^^^^ `u32` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u32` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -798,13 +748,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `u32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:121:39
    |
 LL |     assert::is_transmutable::<  u32,  i128>();
-   |                                       ^^^^ `u32` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u32` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u32, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -814,13 +763,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `u64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:123:39
    |
 LL |     assert::is_transmutable::<  u64,  u128>();
-   |                                       ^^^^ `u64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u64` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u64, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -830,13 +778,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `u64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `u64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:124:39
    |
 LL |     assert::is_transmutable::<  u64,  i128>();
-   |                                       ^^^^ `u64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `u64` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<u64, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -846,13 +793,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `i64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:126:39
    |
 LL |     assert::is_transmutable::<  i64,  u128>();
-   |                                       ^^^^ `i64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i64` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i64, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -862,13 +808,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `i64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `i64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:127:39
    |
 LL |     assert::is_transmutable::<  i64,  i128>();
-   |                                       ^^^^ `i64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `i64` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<i64, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -878,13 +823,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+error[E0277]: `f64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:129:39
    |
 LL |     assert::is_transmutable::<  f64,  u128>();
-   |                                       ^^^^ `f64` cannot be safely transmuted into `u128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `f64` is smaller than the size of `u128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f64, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `u128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |
@@ -894,13 +838,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `f64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+error[E0277]: `f64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`
   --> $DIR/numbers.rs:130:39
    |
 LL |     assert::is_transmutable::<  f64,  i128>();
-   |                                       ^^^^ `f64` cannot be safely transmuted into `i128` in the defining scope of `assert::Context`.
+   |                                       ^^^^ The size of `f64` is smaller than the size of `i128`
    |
-   = help: the trait `BikeshedIntrinsicFrom<f64, assert::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `i128`
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:15:14
    |

--- a/tests/ui/transmutability/primitives/unit.current.stderr
+++ b/tests/ui/transmutability/primitives/unit.current.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `()` cannot be safely transmuted into `u8` in the defining scope of `should_have_correct_size::Context`.
+error[E0277]: `()` cannot be safely transmuted into `u8` in the defining scope of `should_have_correct_size::Context`
   --> $DIR/unit.rs:31:35
    |
 LL |     assert::is_transmutable::<(), u8, Context>();
-   |                                   ^^ `()` cannot be safely transmuted into `u8` in the defining scope of `should_have_correct_size::Context`.
+   |                                   ^^ The size of `()` is smaller than the size of `u8`
    |
-   = help: the trait `BikeshedIntrinsicFrom<(), should_have_correct_size::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `u8`
 note: required by a bound in `is_transmutable`
   --> $DIR/unit.rs:15:14
    |

--- a/tests/ui/transmutability/primitives/unit.next.stderr
+++ b/tests/ui/transmutability/primitives/unit.next.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `()` cannot be safely transmuted into `u8` in the defining scope of `should_have_correct_size::Context`.
+error[E0277]: `()` cannot be safely transmuted into `u8` in the defining scope of `should_have_correct_size::Context`
   --> $DIR/unit.rs:31:35
    |
 LL |     assert::is_transmutable::<(), u8, Context>();
-   |                                   ^^ `()` cannot be safely transmuted into `u8` in the defining scope of `should_have_correct_size::Context`.
+   |                                   ^^ The size of `()` is smaller than the size of `u8`
    |
-   = help: the trait `BikeshedIntrinsicFrom<(), should_have_correct_size::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `u8`
 note: required by a bound in `is_transmutable`
   --> $DIR/unit.rs:15:14
    |

--- a/tests/ui/transmutability/references.current.stderr
+++ b/tests/ui/transmutability/references.current.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`.
+error[E0277]: `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`
   --> $DIR/references.rs:29:52
    |
 LL |     assert::is_maybe_transmutable::<&'static Unit, &'static Unit>();
-   |                                                    ^^^^^^^^^^^^^ `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`.
+   |                                                    ^^^^^^^^^^^^^ `&'static Unit` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<&'static Unit, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `&'static Unit`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/references.rs:16:14
    |

--- a/tests/ui/transmutability/references.next.stderr
+++ b/tests/ui/transmutability/references.next.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`.
+error[E0277]: `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`
   --> $DIR/references.rs:29:52
    |
 LL |     assert::is_maybe_transmutable::<&'static Unit, &'static Unit>();
-   |                                                    ^^^^^^^^^^^^^ `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`.
+   |                                                    ^^^^^^^^^^^^^ `&'static Unit` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<&'static Unit, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `&'static Unit`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/references.rs:16:14
    |

--- a/tests/ui/transmutability/structs/repr/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/structs/repr/should_require_well_defined_layout.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `should_reject_repr_rust::unit::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `should_reject_repr_rust::unit::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:28:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `should_reject_repr_rust::unit::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                    ^^ `should_reject_repr_rust::unit::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<should_reject_repr_rust::unit::repr_rust, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -21,13 +20,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `should_reject_repr_rust::unit::repr_rust` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `should_reject_repr_rust::unit::repr_rust` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:29:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `u128` cannot be safely transmuted into `should_reject_repr_rust::unit::repr_rust` in the defining scope of `assert::Context`.
+   |                                               ^^^^^^^^^ `should_reject_repr_rust::unit::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `should_reject_repr_rust::unit::repr_rust`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -44,13 +42,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `should_reject_repr_rust::tuple::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `should_reject_repr_rust::tuple::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:34:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `should_reject_repr_rust::tuple::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                    ^^ `should_reject_repr_rust::tuple::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<should_reject_repr_rust::tuple::repr_rust, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -67,13 +64,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `should_reject_repr_rust::tuple::repr_rust` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `should_reject_repr_rust::tuple::repr_rust` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:35:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `u128` cannot be safely transmuted into `should_reject_repr_rust::tuple::repr_rust` in the defining scope of `assert::Context`.
+   |                                               ^^^^^^^^^ `should_reject_repr_rust::tuple::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `should_reject_repr_rust::tuple::repr_rust`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -90,13 +86,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `should_reject_repr_rust::braces::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `should_reject_repr_rust::braces::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:40:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `should_reject_repr_rust::braces::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                    ^^ `should_reject_repr_rust::braces::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<should_reject_repr_rust::braces::repr_rust, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -113,13 +108,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `should_reject_repr_rust::braces::repr_rust` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `should_reject_repr_rust::braces::repr_rust` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:41:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `u128` cannot be safely transmuted into `should_reject_repr_rust::braces::repr_rust` in the defining scope of `assert::Context`.
+   |                                               ^^^^^^^^^ `should_reject_repr_rust::braces::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `should_reject_repr_rust::braces::repr_rust`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -136,13 +130,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `aligned::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `aligned::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:46:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `aligned::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                    ^^ `aligned::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<aligned::repr_rust, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -159,13 +152,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `aligned::repr_rust` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `aligned::repr_rust` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:47:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `u128` cannot be safely transmuted into `aligned::repr_rust` in the defining scope of `assert::Context`.
+   |                                               ^^^^^^^^^ `aligned::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `aligned::repr_rust`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -182,13 +174,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `packed::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `packed::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:52:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `packed::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                    ^^ `packed::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<packed::repr_rust, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -205,13 +196,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `packed::repr_rust` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `packed::repr_rust` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:53:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `u128` cannot be safely transmuted into `packed::repr_rust` in the defining scope of `assert::Context`.
+   |                                               ^^^^^^^^^ `packed::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `packed::repr_rust`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -228,13 +218,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `nested::repr_c` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `nested::repr_c` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:59:49
    |
 LL |         assert::is_maybe_transmutable::<repr_c, ()>();
-   |                                                 ^^ `nested::repr_c` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                 ^^ `nested::repr_c` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<nested::repr_c, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -251,13 +240,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `nested::repr_c` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `nested::repr_c` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:60:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_c>();
-   |                                               ^^^^^^ `u128` cannot be safely transmuted into `nested::repr_c` in the defining scope of `assert::Context`.
+   |                                               ^^^^^^ `nested::repr_c` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `nested::repr_c`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |

--- a/tests/ui/transmutability/unions/repr/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/unions/repr/should_require_well_defined_layout.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `should_reject_repr_rust::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+error[E0277]: `should_reject_repr_rust::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:30:48
    |
 LL |     assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                ^^ `should_reject_repr_rust::repr_rust` cannot be safely transmuted into `()` in the defining scope of `assert::Context`.
+   |                                                ^^ `should_reject_repr_rust::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<should_reject_repr_rust::repr_rust, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `()`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |
@@ -21,13 +20,12 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `u128` cannot be safely transmuted into `should_reject_repr_rust::repr_rust` in the defining scope of `assert::Context`.
+error[E0277]: `u128` cannot be safely transmuted into `should_reject_repr_rust::repr_rust` in the defining scope of `assert::Context`
   --> $DIR/should_require_well_defined_layout.rs:31:43
    |
 LL |     assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                           ^^^^^^^^^ `u128` cannot be safely transmuted into `should_reject_repr_rust::repr_rust` in the defining scope of `assert::Context`.
+   |                                           ^^^^^^^^^ `should_reject_repr_rust::repr_rust` does not have a well-specified layout
    |
-   = help: the trait `BikeshedIntrinsicFrom<u128, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `should_reject_repr_rust::repr_rust`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
    |

--- a/tests/ui/transmutability/unions/should_pad_variants.stderr
+++ b/tests/ui/transmutability/unions/should_pad_variants.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `Src` cannot be safely transmuted into `Dst` in the defining scope of `should_pad_variants::Context`.
+error[E0277]: `Src` cannot be safely transmuted into `Dst` in the defining scope of `should_pad_variants::Context`
   --> $DIR/should_pad_variants.rs:44:36
    |
 LL |     assert::is_transmutable::<Src, Dst, Context>();
-   |                                    ^^^ `Src` cannot be safely transmuted into `Dst` in the defining scope of `should_pad_variants::Context`.
+   |                                    ^^^ The size of `Src` is smaller than the size of `Dst`
    |
-   = help: the trait `BikeshedIntrinsicFrom<Src, should_pad_variants::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `Dst`
 note: required by a bound in `is_transmutable`
   --> $DIR/should_pad_variants.rs:13:14
    |

--- a/tests/ui/transmutability/unions/should_reject_contraction.stderr
+++ b/tests/ui/transmutability/unions/should_reject_contraction.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `Superset` cannot be safely transmuted into `Subset` in the defining scope of `assert::Context`.
+error[E0277]: `Superset` cannot be safely transmuted into `Subset` in the defining scope of `assert::Context`
   --> $DIR/should_reject_contraction.rs:35:41
    |
 LL |     assert::is_transmutable::<Superset, Subset>();
-   |                                         ^^^^^^ `Superset` cannot be safely transmuted into `Subset` in the defining scope of `assert::Context`.
+   |                                         ^^^^^^ At least one value of `Superset` isn't a bit-valid value of `Subset`
    |
-   = help: the trait `BikeshedIntrinsicFrom<Superset, assert::Context, Assume { alignment: false, lifetimes: false, safety: true, validity: false }>` is not implemented for `Subset`
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_contraction.rs:13:14
    |

--- a/tests/ui/transmutability/unions/should_reject_disjoint.stderr
+++ b/tests/ui/transmutability/unions/should_reject_disjoint.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `A` cannot be safely transmuted into `B` in the defining scope of `assert::Context`.
+error[E0277]: `A` cannot be safely transmuted into `B` in the defining scope of `assert::Context`
   --> $DIR/should_reject_disjoint.rs:33:40
    |
 LL |     assert::is_maybe_transmutable::<A, B>();
-   |                                        ^ `A` cannot be safely transmuted into `B` in the defining scope of `assert::Context`.
+   |                                        ^ At least one value of `A` isn't a bit-valid value of `B`
    |
-   = help: the trait `BikeshedIntrinsicFrom<A, assert::Context, Assume { alignment: false, lifetimes: false, safety: true, validity: true }>` is not implemented for `B`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_reject_disjoint.rs:13:14
    |
@@ -14,13 +13,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY.and(Assume::VALIDITY) }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `B` cannot be safely transmuted into `A` in the defining scope of `assert::Context`.
+error[E0277]: `B` cannot be safely transmuted into `A` in the defining scope of `assert::Context`
   --> $DIR/should_reject_disjoint.rs:34:40
    |
 LL |     assert::is_maybe_transmutable::<B, A>();
-   |                                        ^ `B` cannot be safely transmuted into `A` in the defining scope of `assert::Context`.
+   |                                        ^ At least one value of `B` isn't a bit-valid value of `A`
    |
-   = help: the trait `BikeshedIntrinsicFrom<B, assert::Context, Assume { alignment: false, lifetimes: false, safety: true, validity: true }>` is not implemented for `A`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_reject_disjoint.rs:13:14
    |

--- a/tests/ui/transmutability/unions/should_reject_intersecting.stderr
+++ b/tests/ui/transmutability/unions/should_reject_intersecting.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `A` cannot be safely transmuted into `B` in the defining scope of `assert::Context`.
+error[E0277]: `A` cannot be safely transmuted into `B` in the defining scope of `assert::Context`
   --> $DIR/should_reject_intersecting.rs:36:34
    |
 LL |     assert::is_transmutable::<A, B>();
-   |                                  ^ `A` cannot be safely transmuted into `B` in the defining scope of `assert::Context`.
+   |                                  ^ At least one value of `A` isn't a bit-valid value of `B`
    |
-   = help: the trait `BikeshedIntrinsicFrom<A, assert::Context, Assume { alignment: false, lifetimes: false, safety: true, validity: false }>` is not implemented for `B`
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_intersecting.rs:14:14
    |
@@ -14,13 +13,12 @@ LL |     where
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, { Assume::SAFETY }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
-error[E0277]: `B` cannot be safely transmuted into `A` in the defining scope of `assert::Context`.
+error[E0277]: `B` cannot be safely transmuted into `A` in the defining scope of `assert::Context`
   --> $DIR/should_reject_intersecting.rs:37:34
    |
 LL |     assert::is_transmutable::<B, A>();
-   |                                  ^ `B` cannot be safely transmuted into `A` in the defining scope of `assert::Context`.
+   |                                  ^ At least one value of `B` isn't a bit-valid value of `A`
    |
-   = help: the trait `BikeshedIntrinsicFrom<B, assert::Context, Assume { alignment: false, lifetimes: false, safety: true, validity: false }>` is not implemented for `A`
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_intersecting.rs:14:14
    |

--- a/tests/ui/transmutability/visibility/should_reject_if_dst_has_private_field.stderr
+++ b/tests/ui/transmutability/visibility/should_reject_if_dst_has_private_field.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `Src` cannot be safely transmuted into `Dst` in the defining scope of `test::Context`.
+error[E0277]: `Src` cannot be safely transmuted into `Dst` in the defining scope of `test::Context`
   --> $DIR/should_reject_if_dst_has_private_field.rs:35:41
    |
 LL |     assert::is_transmutable::<src::Src, dst::Dst, Context>();
-   |                                         ^^^^^^^^ `Src` cannot be safely transmuted into `Dst` in the defining scope of `test::Context`.
+   |                                         ^^^^^^^^ `Dst` is or contains a type or field that is not visible in that scope
    |
-   = help: the trait `BikeshedIntrinsicFrom<Src, test::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `Dst`
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_if_dst_has_private_field.rs:13:14
    |

--- a/tests/ui/transmutability/visibility/should_reject_if_dst_has_private_variant.stderr
+++ b/tests/ui/transmutability/visibility/should_reject_if_dst_has_private_variant.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `Src` cannot be safely transmuted into `Dst` in the defining scope of `test::Context`.
+error[E0277]: `Src` cannot be safely transmuted into `Dst` in the defining scope of `test::Context`
   --> $DIR/should_reject_if_dst_has_private_variant.rs:36:41
    |
 LL |     assert::is_transmutable::<src::Src, dst::Dst, Context>();
-   |                                         ^^^^^^^^ `Src` cannot be safely transmuted into `Dst` in the defining scope of `test::Context`.
+   |                                         ^^^^^^^^ `Dst` is or contains a type or field that is not visible in that scope
    |
-   = help: the trait `BikeshedIntrinsicFrom<Src, test::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `Dst`
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_if_dst_has_private_variant.rs:13:14
    |

--- a/tests/ui/transmutability/visibility/should_reject_if_dst_has_unreachable_field.stderr
+++ b/tests/ui/transmutability/visibility/should_reject_if_dst_has_unreachable_field.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `Src` cannot be safely transmuted into `Dst` in the defining scope of `test::Context`.
+error[E0277]: `Src` cannot be safely transmuted into `Dst` in the defining scope of `test::Context`
   --> $DIR/should_reject_if_dst_has_unreachable_field.rs:37:41
    |
 LL |     assert::is_transmutable::<src::Src, dst::Dst, Context>();
-   |                                         ^^^^^^^^ `Src` cannot be safely transmuted into `Dst` in the defining scope of `test::Context`.
+   |                                         ^^^^^^^^ `Dst` is or contains a type or field that is not visible in that scope
    |
-   = help: the trait `BikeshedIntrinsicFrom<Src, test::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `Dst`
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_if_dst_has_unreachable_field.rs:15:14
    |

--- a/tests/ui/transmutability/visibility/should_reject_if_dst_has_unreachable_ty.stderr
+++ b/tests/ui/transmutability/visibility/should_reject_if_dst_has_unreachable_ty.stderr
@@ -10,13 +10,12 @@ note: the struct `Dst` is defined here
 LL |     #[repr(C)] pub(self) struct Dst {
    |                ^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: `Src` cannot be safely transmuted into `Dst` in the defining scope of `test::Context`.
+error[E0277]: `Src` cannot be safely transmuted into `Dst` in the defining scope of `test::Context`
   --> $DIR/should_reject_if_dst_has_unreachable_ty.rs:38:41
    |
 LL |     assert::is_transmutable::<src::Src, dst::Dst, Context>();
-   |                                         ^^^^^^^^ `Src` cannot be safely transmuted into `Dst` in the defining scope of `test::Context`.
+   |                                         ^^^^^^^^ `Dst` is or contains a type or field that is not visible in that scope
    |
-   = help: the trait `BikeshedIntrinsicFrom<Src, test::Context, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `Dst`
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_if_dst_has_unreachable_ty.rs:15:14
    |

--- a/tests/ui/transmute/transmute-padding-ice.stderr
+++ b/tests/ui/transmute/transmute-padding-ice.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `B` cannot be safely transmuted into `A` in the defining scope of `assert::Context`.
+error[E0277]: `B` cannot be safely transmuted into `A` in the defining scope of `assert::Context`
   --> $DIR/transmute-padding-ice.rs:27:40
    |
 LL |     assert::is_maybe_transmutable::<B, A>();
-   |                                        ^ `B` cannot be safely transmuted into `A` in the defining scope of `assert::Context`.
+   |                                        ^ The size of `B` is smaller than the size of `A`
    |
-   = help: the trait `BikeshedIntrinsicFrom<B, assert::Context, Assume { alignment: true, lifetimes: true, safety: true, validity: true }>` is not implemented for `A`
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/transmute-padding-ice.rs:11:14
    |


### PR DESCRIPTION
This patch updates the error reporting when Safe Transmute is not possible between 2 types by including the reason.

Also, fix some small bugs that occur when computing the `Answer` for transmutability.