### PR TITLE
rustdoc-search: add support for nested generics

### DIFF
--- a/src/doc/rustdoc/src/how-to-read-rustdoc.md
+++ b/src/doc/rustdoc/src/how-to-read-rustdoc.md
@@ -94,6 +94,17 @@ can be matched with the following queries:
 * `trait:Iterator<primitive:u32> -> primitive:usize`
 * `Iterator -> usize`
 
+Generics and function parameters are order-agnostic, but sensitive to nesting
+and number of matches. For example, a function with the signature
+`fn read_all(&mut self: impl Read) -> Result<Vec<u8>, Error>`
+will match these queries:
+
+* `Read -> Result<Vec<u8>, Error>`
+* `Read -> Result<Error, Vec>`
+* `Read -> Result<Vec<u8>>`
+
+But it *does not* match `Result<Vec, u8>` or `Result<u8<Vec>>`.
+
 ### Changing displayed theme
 
 You can change the displayed theme by opening the settings menu (the gear

--- a/tests/rustdoc-js-std/parser-generics.js
+++ b/tests/rustdoc-js-std/parser-generics.js
@@ -1,4 +1,11 @@
-const QUERY = ['A<B<C<D>,  E>', 'p<> u8', '"p"<a>'];
+const QUERY = [
+    'A<B<C<D>,  E>',
+    'p<> u8',
+    '"p"<a>',
+    'p<u<x>>',
+    'p<u<x>, r>',
+    'p<u<x, r>>',
+];
 
 const PARSED = [
     {
@@ -7,7 +14,7 @@ const PARSED = [
         original: 'A<B<C<D>,  E>',
         returned: [],
         userQuery: 'a<b<c<d>,  e>',
-        error: 'Unexpected `<` after `<`',
+        error: 'Unclosed `<`',
     },
     {
         elems: [
@@ -57,6 +64,119 @@ const PARSED = [
         original: '"p"<a>',
         returned: [],
         userQuery: '"p"<a>',
+        error: null,
+    },
+    {
+        elems: [
+            {
+                name: "p",
+                fullPath: ["p"],
+                pathWithoutLast: [],
+                pathLast: "p",
+                generics: [
+                    {
+                        name: "u",
+                        fullPath: ["u"],
+                        pathWithoutLast: [],
+                        pathLast: "u",
+                        generics: [
+                            {
+                                name: "x",
+                                fullPath: ["x"],
+                                pathWithoutLast: [],
+                                pathLast: "x",
+                                generics: [],
+                            },
+                        ],
+                    },
+                ],
+                typeFilter: -1,
+            },
+        ],
+        foundElems: 1,
+        original: 'p<u<x>>',
+        returned: [],
+        userQuery: 'p<u<x>>',
+        error: null,
+    },
+    {
+        elems: [
+            {
+                name: "p",
+                fullPath: ["p"],
+                pathWithoutLast: [],
+                pathLast: "p",
+                generics: [
+                    {
+                        name: "u",
+                        fullPath: ["u"],
+                        pathWithoutLast: [],
+                        pathLast: "u",
+                        generics: [
+                            {
+                                name: "x",
+                                fullPath: ["x"],
+                                pathWithoutLast: [],
+                                pathLast: "x",
+                                generics: [],
+                            },
+                        ],
+                    },
+                    {
+                        name: "r",
+                        fullPath: ["r"],
+                        pathWithoutLast: [],
+                        pathLast: "r",
+                        generics: [],
+                    },
+                ],
+                typeFilter: -1,
+            },
+        ],
+        foundElems: 1,
+        original: 'p<u<x>, r>',
+        returned: [],
+        userQuery: 'p<u<x>, r>',
+        error: null,
+    },
+    {
+        elems: [
+            {
+                name: "p",
+                fullPath: ["p"],
+                pathWithoutLast: [],
+                pathLast: "p",
+                generics: [
+                    {
+                        name: "u",
+                        fullPath: ["u"],
+                        pathWithoutLast: [],
+                        pathLast: "u",
+                        generics: [
+                            {
+                                name: "x",
+                                fullPath: ["x"],
+                                pathWithoutLast: [],
+                                pathLast: "x",
+                                generics: [],
+                            },
+                            {
+                                name: "r",
+                                fullPath: ["r"],
+                                pathWithoutLast: [],
+                                pathLast: "r",
+                                generics: [],
+                            },
+                        ],
+                    },
+                ],
+                typeFilter: -1,
+            },
+        ],
+        foundElems: 1,
+        original: 'p<u<x, r>>',
+        returned: [],
+        userQuery: 'p<u<x, r>>',
         error: null,
     },
 ];

--- a/tests/rustdoc-js/generics-nested.js
+++ b/tests/rustdoc-js/generics-nested.js
@@ -1,0 +1,33 @@
+// exact-check
+
+const QUERY = [
+    '-> Out<First<Second>>',
+    '-> Out<Second<First>>',
+    '-> Out<First, Second>',
+    '-> Out<Second, First>',
+];
+
+const EXPECTED = [
+    {
+        // -> Out<First<Second>>
+        'others': [
+            { 'path': 'generics_nested', 'name': 'alef' },
+        ],
+    },
+    {
+        // -> Out<Second<First>>
+        'others': [],
+    },
+    {
+        // -> Out<First, Second>
+        'others': [
+            { 'path': 'generics_nested', 'name': 'bet' },
+        ],
+    },
+    {
+        // -> Out<Second, First>
+        'others': [
+            { 'path': 'generics_nested', 'name': 'bet' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/generics-nested.rs
+++ b/tests/rustdoc-js/generics-nested.rs
@@ -1,0 +1,19 @@
+pub struct Out<A, B = ()> {
+    a: A,
+    b: B,
+}
+
+pub struct First<In = ()> {
+    in_: In,
+}
+
+pub struct Second;
+
+// Out<First<Second>>
+pub fn alef() -> Out<First<Second>> {
+    loop {}
+}
+
+pub fn bet() -> Out<First, Second> {
+    loop {}
+}


### PR DESCRIPTION
This change allows `search.js` to parse nested generics (which look `Like<This<Example>>`) and match them. It maintains the existing "bag semantics", so that the order of type parameters is ignored but the number is required to be greater than or equal to what's in the query.

For example, a function with the signature `fn read_all(&mut self: impl Read) -> Result<Vec<u8>, Error>` will match these queries:

* `Read -> Result<Vec<u8>, Error>`
* `Read -> Result<Error, Vec>`
* `Read -> Result<Vec<u8>>`

But it *does not* match `Result<Vec, u8>` or `Result<u8<Vec>>`.