### PR TITLE
Workaround #109797 on windows-gnu

### DIFF
--- a/library/std/src/sys/common/thread_local/os_local.rs
+++ b/library/std/src/sys/common/thread_local/os_local.rs
@@ -49,7 +49,9 @@ macro_rules! __thread_local_inner {
             #[inline]
             fn __init() -> $t { $init }
 
-            #[cfg_attr(not(bootstrap), inline)]
+            // `#[inline] does not work on windows-gnu due to linking errors around dllimports.
+            // See https://github.com/rust-lang/rust/issues/109797.
+            #[cfg_attr(not(windows), inline)]
             unsafe fn __getit(
                 init: $crate::option::Option<&mut $crate::option::Option<$t>>,
             ) -> $crate::option::Option<&'static $t> {


### PR DESCRIPTION
The addition of `#[inline]` here in https://github.com/rust-lang/rust/pull/108089 caused an unrelated linking issue (https://github.com/rust-lang/rust/issues/109797). This PR removes this attribute again on Windows to avoid regressions.