### PR TITLE
check universes when instantiating infer vars with placeholders

### DIFF
--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -959,7 +959,11 @@ impl<'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for ConstInferUnifier<'_, 'tcx> {
                     Ok(t)
                 } else {
                     Err(TypeError::UniverseMismatch {
-                        variable: self.infcx.tcx.mk_const(self.target_vid, self.root_ct.ty()).into(),
+                        variable: self
+                            .infcx
+                            .tcx
+                            .mk_const(self.target_vid, self.root_ct.ty())
+                            .into(),
                         placeholder: t.into(),
                     })
                 }
@@ -1048,7 +1052,11 @@ impl<'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for ConstInferUnifier<'_, 'tcx> {
                     Ok(c)
                 } else {
                     Err(TypeError::UniverseMismatch {
-                        variable: self.infcx.tcx.mk_const(self.target_vid, self.root_ct.ty()).into(),
+                        variable: self
+                            .infcx
+                            .tcx
+                            .mk_const(self.target_vid, self.root_ct.ty())
+                            .into(),
                         placeholder: c.into(),
                     })
                 }

--- a/compiler/rustc_infer/src/infer/nll_relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/nll_relate/mod.rs
@@ -946,7 +946,10 @@ where
                          placeholder in universe {:?}",
                         self.universe, placeholder.universe
                     );
-                    Err(TypeError::Mismatch)
+                    Err(TypeError::UniverseMismatch {
+                        variable: self.tcx().mk_ty_var(self.for_vid_sub_root).into(),
+                        placeholder: a.into(),
+                    })
                 } else {
                     Ok(a)
                 }
@@ -1010,6 +1013,21 @@ where
                         });
                         Ok(self.tcx().mk_const(new_var_id, a.ty()))
                     }
+                }
+            }
+            ty::ConstKind::Placeholder(placeholder) => {
+                if self.universe.cannot_name(placeholder.universe) {
+                    debug!(
+                        "TypeGeneralizer::tys: root universe {:?} cannot name\
+                         placeholder in universe {:?}",
+                        self.universe, placeholder.universe
+                    );
+                    Err(TypeError::UniverseMismatch {
+                        variable: self.tcx().mk_ty_var(self.for_vid_sub_root).into(),
+                        placeholder: a.into(),
+                    })
+                } else {
+                    Ok(a)
                 }
             }
             ty::ConstKind::Unevaluated(..) if self.tcx().lazy_normalization() => Ok(a),

--- a/tests/ui/traits/non_lifetime_binders/missing-assoc-item.stderr
+++ b/tests/ui/traits/non_lifetime_binders/missing-assoc-item.stderr
@@ -11,7 +11,12 @@ error[E0223]: ambiguous associated type
   --> $DIR/missing-assoc-item.rs:6:12
    |
 LL |     for<B> B::Item: Send,
-   |            ^^^^^^^ help: use the fully-qualified path: `<B as IntoIterator>::Item`
+   |            ^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `Item` implemented for `B`, you could use the fully-qualified path
+   |
+LL |     for<B> <B as Example>::Item: Send,
+   |            ~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/tests/ui/traits/non_lifetime_binders/universe-error1.rs
+++ b/tests/ui/traits/non_lifetime_binders/universe-error1.rs
@@ -1,0 +1,24 @@
+// regression test for #109505
+#![feature(non_lifetime_binders)]
+#![allow(incomplete_features)]
+
+trait Other<U: ?Sized> {}
+
+impl<U: ?Sized> Other<U> for U {}
+
+//  - o: `for<T> T: Trait<?0>`
+//    - c: `for<U> U: Trait<U>`
+//      - U = ?1
+//      - T = ?1
+//      - ?0 = ?1
+
+#[rustfmt::skip]
+fn foo<U: ?Sized>()
+where
+    for<T> T: Other<U> {}
+
+fn bar() {
+    foo::<_>(); //~ ERROR the trait bound `T: Other<_>` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/traits/non_lifetime_binders/universe-error1.stderr
+++ b/tests/ui/traits/non_lifetime_binders/universe-error1.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `T: Other<_>` is not satisfied
+  --> $DIR/universe-error1.rs:21:11
+   |
+LL |     foo::<_>();
+   |           ^ the trait `Other<_>` is not implemented for `T`
+   |
+note: required by a bound in `foo`
+  --> $DIR/universe-error1.rs:18:15
+   |
+LL | fn foo<U: ?Sized>()
+   |    --- required by a bound in this function
+LL | where
+LL |     for<T> T: Other<U> {}
+   |               ^^^^^^^^ required by this bound in `foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
fixes #109505

probably not going to finish that soon and would like someone to take this over.

what needs to be done:
- add tests triggering all codepaths: at least the combine and the const generalizer
- we should merge the 3 generalizers into 1 here. Having to duplicate the same checks ~~3~~*6* times is bound to cause issues at some point

r? @compiler-errors @BoxyUwU 