### PR TITLE
Fixes LTO + build-std + Oz failed to resolve undefined symbols

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -53,8 +53,17 @@ fn prepare_lto(
         Lto::No => panic!("didn't request LTO but we're doing LTO"),
     };
 
+    let export_for_undefined_symbols =
+        &|name: &str| match &cgcx.undefined_symbols_from_ignored_for_lto {
+            Some(undefined_symbols) => undefined_symbols.contains(name),
+            None => false,
+        };
+
     let symbol_filter = &|&(ref name, info): &(String, SymbolExportInfo)| {
-        if info.level.is_below_threshold(export_threshold) || info.used {
+        if info.level.is_below_threshold(export_threshold)
+            || info.used
+            || export_for_undefined_symbols(name)
+        {
             Some(CString::new(name.as_str()).unwrap())
         } else {
             None


### PR DESCRIPTION
Fixes #108853. Fixes #72140. Fixes #110606.

The problem is that `compiler_builtins` is not involved in LTO. When `share-generics` + `Oz/s/1` is turned on, the symbols needed for `compiler_builtins` are defined in `core` or other target files are involved in LTO.
In this case, we should export the relevant symbols at LTO. And we can write similar code to reproduce it in the stable version. Please see https://github.com/DianQK/rust-109821-reproducible.

Before LTO:
```
$ nm libcompiler_builtins-xx.rlib
U <u32 as core::convert::TryInto<u8>>::try_into
U <u32 as core::convert::TryInto<u32>>::try_into
U <u32 as core::convert::TryInto<u16>>::try_into
$ nm 
nm foo-cgu.0.rcgu.lto.input.bc
T <u32 as core::convert::TryInto<u8>>::try_into
U <u32 as core::convert::TryInto<usize>>::try_into
T <u32 as core::convert::TryInto<u32>>::try_into
T <u32 as core::convert::TryInto<u16>>::try_into
```

After LTO (Before the PR):
```
$ nm 
nm foo-cgu.0.rcgu.lto.after-restriction.bc
t <u32 as core::convert::TryInto<u8>>::try_into
U <u32 as core::convert::TryInto<usize>>::try_into
t <u32 as core::convert::TryInto<u32>>::try_into
t <u32 as core::convert::TryInto<u16>>::try_into
```

After LTO (After the PR):
```
$ nm 
nm foo-cgu.0.rcgu.lto.after-restriction.bc
T <u32 as core::convert::TryInto<u8>>::try_into
U <u32 as core::convert::TryInto<usize>>::try_into
T <u32 as core::convert::TryInto<u32>>::try_into
T <u32 as core::convert::TryInto<u16>>::try_into
```

Why does the problem only occur in Windows?
The rustc adds the `-gc-sections` on Linux and `-Wl,-dead_strip` on macOS. This problem can also be reproduced if these parameters are removed.

Another candidate patch that allows compiler_builtins to generate LLVM IR to be involved in LTO. Let `ignored_for_lto` always return false.

TODO:
- [ ] Add a test?
- [ ] wasm support?
- [x] Provide a small reproducible. https://github.com/DianQK/rust-109821-reproducible
- [ ] Update the code of `rustc_codegen_gcc`.
- [x] Test RustScan and Helix.