### PR TITLE
Remove old `#[doc(primitive = "...")]` attribute

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1,8 +1,7 @@
 // `library/{std,core}/src/primitive_docs.rs` should have the same contents.
 // These are different files so that relative links work properly without
 // having to have `CARGO_PKG_NAME` set, but conceptually they should always be the same.
-#[cfg_attr(bootstrap, doc(primitive = "bool"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "bool")]
+#[rustc_doc_primitive = "bool"]
 #[doc(alias = "true")]
 #[doc(alias = "false")]
 /// The boolean type.
@@ -64,8 +63,7 @@
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_bool {}
 
-#[cfg_attr(bootstrap, doc(primitive = "never"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "never")]
+#[rustc_doc_primitive = "never"]
 #[doc(alias = "!")]
 //
 /// The `!` type, also called "never".
@@ -276,8 +274,7 @@ mod prim_bool {}
 #[unstable(feature = "never_type", issue = "35121")]
 mod prim_never {}
 
-#[cfg_attr(bootstrap, doc(primitive = "char"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "char")]
+#[rustc_doc_primitive = "char"]
 #[allow(rustdoc::invalid_rust_codeblocks)]
 /// A character type.
 ///
@@ -401,8 +398,7 @@ mod prim_never {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_char {}
 
-#[cfg_attr(bootstrap, doc(primitive = "unit"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "unit")]
+#[rustc_doc_primitive = "unit"]
 #[doc(alias = "(")]
 #[doc(alias = ")")]
 #[doc(alias = "()")]
@@ -464,8 +460,7 @@ impl Copy for () {
     // empty
 }
 
-#[cfg_attr(bootstrap, doc(primitive = "pointer"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "pointer")]
+#[rustc_doc_primitive = "pointer"]
 #[doc(alias = "ptr")]
 #[doc(alias = "*")]
 #[doc(alias = "*const")]
@@ -582,8 +577,7 @@ impl Copy for () {
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_pointer {}
 
-#[cfg_attr(bootstrap, doc(primitive = "array"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "array")]
+#[rustc_doc_primitive = "array"]
 #[doc(alias = "[]")]
 #[doc(alias = "[T;N]")] // unfortunately, rustdoc doesn't have fuzzy search for aliases
 #[doc(alias = "[T; N]")]
@@ -784,8 +778,7 @@ mod prim_pointer {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_array {}
 
-#[cfg_attr(bootstrap, doc(primitive = "slice"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "slice")]
+#[rustc_doc_primitive = "slice"]
 #[doc(alias = "[")]
 #[doc(alias = "]")]
 #[doc(alias = "[]")]
@@ -877,8 +870,7 @@ mod prim_array {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_slice {}
 
-#[cfg_attr(bootstrap, doc(primitive = "str"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "str")]
+#[rustc_doc_primitive = "str"]
 /// String slices.
 ///
 /// *[See also the `std::str` module](crate::str).*
@@ -945,8 +937,7 @@ mod prim_slice {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_str {}
 
-#[cfg_attr(bootstrap, doc(primitive = "tuple"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "tuple")]
+#[rustc_doc_primitive = "tuple"]
 #[doc(alias = "(")]
 #[doc(alias = ")")]
 #[doc(alias = "()")]
@@ -1090,8 +1081,7 @@ impl<T: Copy> Copy for (T,) {
     // empty
 }
 
-#[cfg_attr(bootstrap, doc(primitive = "f32"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "f32")]
+#[rustc_doc_primitive = "f32"]
 /// A 32-bit floating point type (specifically, the "binary32" type defined in IEEE 754-2008).
 ///
 /// This type can represent a wide range of decimal numbers, like `3.5`, `27`,
@@ -1157,8 +1147,7 @@ impl<T: Copy> Copy for (T,) {
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_f32 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "f64"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "f64")]
+#[rustc_doc_primitive = "f64"]
 /// A 64-bit floating point type (specifically, the "binary64" type defined in IEEE 754-2008).
 ///
 /// This type is very similar to [`f32`], but has increased
@@ -1173,78 +1162,67 @@ mod prim_f32 {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_f64 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "i8"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "i8")]
+#[rustc_doc_primitive = "i8"]
 //
 /// The 8-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i8 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "i16"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "i16")]
+#[rustc_doc_primitive = "i16"]
 //
 /// The 16-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i16 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "i32"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "i32")]
+#[rustc_doc_primitive = "i32"]
 //
 /// The 32-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i32 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "i64"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "i64")]
+#[rustc_doc_primitive = "i64"]
 //
 /// The 64-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i64 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "i128"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "i128")]
+#[rustc_doc_primitive = "i128"]
 //
 /// The 128-bit signed integer type.
 #[stable(feature = "i128", since = "1.26.0")]
 mod prim_i128 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "u8"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "u8")]
+#[rustc_doc_primitive = "u8"]
 //
 /// The 8-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_u8 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "u16"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "u16")]
+#[rustc_doc_primitive = "u16"]
 //
 /// The 16-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_u16 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "u32"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "u32")]
+#[rustc_doc_primitive = "u32"]
 //
 /// The 32-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_u32 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "u64"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "u64")]
+#[rustc_doc_primitive = "u64"]
 //
 /// The 64-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_u64 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "u128"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "u128")]
+#[rustc_doc_primitive = "u128"]
 //
 /// The 128-bit unsigned integer type.
 #[stable(feature = "i128", since = "1.26.0")]
 mod prim_u128 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "isize"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "isize")]
+#[rustc_doc_primitive = "isize"]
 //
 /// The pointer-sized signed integer type.
 ///
@@ -1254,8 +1232,7 @@ mod prim_u128 {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_isize {}
 
-#[cfg_attr(bootstrap, doc(primitive = "usize"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "usize")]
+#[rustc_doc_primitive = "usize"]
 //
 /// The pointer-sized unsigned integer type.
 ///
@@ -1265,8 +1242,7 @@ mod prim_isize {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_usize {}
 
-#[cfg_attr(bootstrap, doc(primitive = "reference"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "reference")]
+#[rustc_doc_primitive = "reference"]
 #[doc(alias = "&")]
 #[doc(alias = "&mut")]
 //
@@ -1397,8 +1373,7 @@ mod prim_usize {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_ref {}
 
-#[cfg_attr(bootstrap, doc(primitive = "fn"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "fn")]
+#[rustc_doc_primitive = "fn"]
 //
 /// Function pointers, like `fn(usize) -> bool`.
 ///

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -1,8 +1,7 @@
 // `library/{std,core}/src/primitive_docs.rs` should have the same contents.
 // These are different files so that relative links work properly without
 // having to have `CARGO_PKG_NAME` set, but conceptually they should always be the same.
-#[cfg_attr(bootstrap, doc(primitive = "bool"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "bool")]
+#[rustc_doc_primitive = "bool"]
 #[doc(alias = "true")]
 #[doc(alias = "false")]
 /// The boolean type.
@@ -64,8 +63,7 @@
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_bool {}
 
-#[cfg_attr(bootstrap, doc(primitive = "never"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "never")]
+#[rustc_doc_primitive = "never"]
 #[doc(alias = "!")]
 //
 /// The `!` type, also called "never".
@@ -276,8 +274,7 @@ mod prim_bool {}
 #[unstable(feature = "never_type", issue = "35121")]
 mod prim_never {}
 
-#[cfg_attr(bootstrap, doc(primitive = "char"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "char")]
+#[rustc_doc_primitive = "char"]
 #[allow(rustdoc::invalid_rust_codeblocks)]
 /// A character type.
 ///
@@ -401,8 +398,7 @@ mod prim_never {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_char {}
 
-#[cfg_attr(bootstrap, doc(primitive = "unit"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "unit")]
+#[rustc_doc_primitive = "unit"]
 #[doc(alias = "(")]
 #[doc(alias = ")")]
 #[doc(alias = "()")]
@@ -464,8 +460,7 @@ impl Copy for () {
     // empty
 }
 
-#[cfg_attr(bootstrap, doc(primitive = "pointer"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "pointer")]
+#[rustc_doc_primitive = "pointer"]
 #[doc(alias = "ptr")]
 #[doc(alias = "*")]
 #[doc(alias = "*const")]
@@ -582,8 +577,7 @@ impl Copy for () {
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_pointer {}
 
-#[cfg_attr(bootstrap, doc(primitive = "array"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "array")]
+#[rustc_doc_primitive = "array"]
 #[doc(alias = "[]")]
 #[doc(alias = "[T;N]")] // unfortunately, rustdoc doesn't have fuzzy search for aliases
 #[doc(alias = "[T; N]")]
@@ -784,8 +778,7 @@ mod prim_pointer {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_array {}
 
-#[cfg_attr(bootstrap, doc(primitive = "slice"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "slice")]
+#[rustc_doc_primitive = "slice"]
 #[doc(alias = "[")]
 #[doc(alias = "]")]
 #[doc(alias = "[]")]
@@ -877,8 +870,7 @@ mod prim_array {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_slice {}
 
-#[cfg_attr(bootstrap, doc(primitive = "str"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "str")]
+#[rustc_doc_primitive = "str"]
 /// String slices.
 ///
 /// *[See also the `std::str` module](crate::str).*
@@ -945,8 +937,7 @@ mod prim_slice {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_str {}
 
-#[cfg_attr(bootstrap, doc(primitive = "tuple"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "tuple")]
+#[rustc_doc_primitive = "tuple"]
 #[doc(alias = "(")]
 #[doc(alias = ")")]
 #[doc(alias = "()")]
@@ -1090,8 +1081,7 @@ impl<T: Copy> Copy for (T,) {
     // empty
 }
 
-#[cfg_attr(bootstrap, doc(primitive = "f32"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "f32")]
+#[rustc_doc_primitive = "f32"]
 /// A 32-bit floating point type (specifically, the "binary32" type defined in IEEE 754-2008).
 ///
 /// This type can represent a wide range of decimal numbers, like `3.5`, `27`,
@@ -1157,8 +1147,7 @@ impl<T: Copy> Copy for (T,) {
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_f32 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "f64"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "f64")]
+#[rustc_doc_primitive = "f64"]
 /// A 64-bit floating point type (specifically, the "binary64" type defined in IEEE 754-2008).
 ///
 /// This type is very similar to [`f32`], but has increased
@@ -1173,78 +1162,67 @@ mod prim_f32 {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_f64 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "i8"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "i8")]
+#[rustc_doc_primitive = "i8"]
 //
 /// The 8-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i8 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "i16"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "i16")]
+#[rustc_doc_primitive = "i16"]
 //
 /// The 16-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i16 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "i32"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "i32")]
+#[rustc_doc_primitive = "i32"]
 //
 /// The 32-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i32 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "i64"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "i64")]
+#[rustc_doc_primitive = "i64"]
 //
 /// The 64-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i64 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "i128"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "i128")]
+#[rustc_doc_primitive = "i128"]
 //
 /// The 128-bit signed integer type.
 #[stable(feature = "i128", since = "1.26.0")]
 mod prim_i128 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "u8"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "u8")]
+#[rustc_doc_primitive = "u8"]
 //
 /// The 8-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_u8 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "u16"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "u16")]
+#[rustc_doc_primitive = "u16"]
 //
 /// The 16-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_u16 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "u32"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "u32")]
+#[rustc_doc_primitive = "u32"]
 //
 /// The 32-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_u32 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "u64"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "u64")]
+#[rustc_doc_primitive = "u64"]
 //
 /// The 64-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_u64 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "u128"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "u128")]
+#[rustc_doc_primitive = "u128"]
 //
 /// The 128-bit unsigned integer type.
 #[stable(feature = "i128", since = "1.26.0")]
 mod prim_u128 {}
 
-#[cfg_attr(bootstrap, doc(primitive = "isize"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "isize")]
+#[rustc_doc_primitive = "isize"]
 //
 /// The pointer-sized signed integer type.
 ///
@@ -1254,8 +1232,7 @@ mod prim_u128 {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_isize {}
 
-#[cfg_attr(bootstrap, doc(primitive = "usize"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "usize")]
+#[rustc_doc_primitive = "usize"]
 //
 /// The pointer-sized unsigned integer type.
 ///
@@ -1265,8 +1242,7 @@ mod prim_isize {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_usize {}
 
-#[cfg_attr(bootstrap, doc(primitive = "reference"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "reference")]
+#[rustc_doc_primitive = "reference"]
 #[doc(alias = "&")]
 #[doc(alias = "&mut")]
 //
@@ -1397,8 +1373,7 @@ mod prim_usize {}
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_ref {}
 
-#[cfg_attr(bootstrap, doc(primitive = "fn"))]
-#[cfg_attr(not(bootstrap), rustc_doc_primitive = "fn")]
+#[rustc_doc_primitive = "fn"]
 //
 /// Function pointers, like `fn(usize) -> bool`.
 ///


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/109443.

Since it was merged, we can now completely get rid of the old attribute.

r? @notriddle 