### PR TITLE
Add Nilstrieb to mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -415,6 +415,7 @@ Nick Platt <platt.nicholas@gmail.com>
 Niclas Schwarzlose <15schnic@gmail.com>
 Nicolas Abram <abramlujan@gmail.com>
 Nicole Mazzuca <npmazzuca@gmail.com>
+Nilstrieb <48135649+Nilstrieb@users.noreply.github.com> nils <48135649+Nilstrieb@users.noreply.github.com>
 Nif Ward <nif.ward@gmail.com>
 Nika Layzell <nika@thelayzells.com> <michael@thelayzells.com>
 NODA Kai <nodakai@gmail.com>


### PR DESCRIPTION
I saw that I'm on https://thanks.rust-lang.org/ twice (once as `Nilstrieb` and once as `nils`).

This is because I've contributed as both `Nilstrieb` (locally) and `nils` (on github). So I've mailmapped them both to `Nilstrieb` (the less ambiguous of the two).

I am not entirely sure whether I've done this correctly.