### PR TITLE
use SmallVec for InstantiatedPredicates lists

### DIFF
--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -376,7 +376,7 @@ impl<'tcx> GenericPredicates<'tcx> {
         if let Some(def_id) = self.parent {
             tcx.predicates_of(def_id).instantiate_identity_into(tcx, instantiated);
         }
-        instantiated.predicates.extend(self.predicates.iter().map(|(p, _)| p));
-        instantiated.spans.extend(self.predicates.iter().map(|(_, s)| s));
+        instantiated.predicates.extend(self.predicates.iter().map(|(p, _)| *p));
+        instantiated.spans.extend(self.predicates.iter().map(|(_, s)| *s));
     }
 }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1301,8 +1301,8 @@ impl<'tcx> Predicate<'tcx> {
 /// [usize:Bar<isize>]]`.
 #[derive(Clone, Debug, TypeFoldable, TypeVisitable)]
 pub struct InstantiatedPredicates<'tcx> {
-    pub predicates: smallvec::SmallVec<[Predicate<'tcx>; 4]>,
-    pub spans: smallvec::SmallVec<[Span; 4]>,
+    pub predicates: smallvec::SmallVec<[Predicate<'tcx>; 3]>,
+    pub spans: smallvec::SmallVec<[Span; 3]>,
 }
 
 impl<'tcx> InstantiatedPredicates<'tcx> {
@@ -1326,7 +1326,7 @@ impl<'tcx> IntoIterator for InstantiatedPredicates<'tcx> {
     type Item = (Predicate<'tcx>, Span);
 
     type IntoIter =
-        std::iter::Zip<smallvec::IntoIter<[Predicate<'tcx>; 4]>, smallvec::IntoIter<[Span; 4]>>;
+        std::iter::Zip<smallvec::IntoIter<[Predicate<'tcx>; 3]>, smallvec::IntoIter<[Span; 3]>>;
 
     fn into_iter(self) -> Self::IntoIter {
         debug_assert_eq!(self.predicates.len(), self.spans.len());

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1325,7 +1325,8 @@ impl<'tcx> InstantiatedPredicates<'tcx> {
 impl<'tcx> IntoIterator for InstantiatedPredicates<'tcx> {
     type Item = (Predicate<'tcx>, Span);
 
-    type IntoIter = std::iter::Zip<smallvec::IntoIter<[Predicate<'tcx>; 4]>, smallvec::IntoIter<[Span; 4]>>;
+    type IntoIter =
+        std::iter::Zip<smallvec::IntoIter<[Predicate<'tcx>; 4]>, smallvec::IntoIter<[Span; 4]>>;
 
     fn into_iter(self) -> Self::IntoIter {
         debug_assert_eq!(self.predicates.len(), self.spans.len());

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1301,13 +1301,16 @@ impl<'tcx> Predicate<'tcx> {
 /// [usize:Bar<isize>]]`.
 #[derive(Clone, Debug, TypeFoldable, TypeVisitable)]
 pub struct InstantiatedPredicates<'tcx> {
-    pub predicates: Vec<Predicate<'tcx>>,
-    pub spans: Vec<Span>,
+    pub predicates: smallvec::SmallVec<[Predicate<'tcx>; 4]>,
+    pub spans: smallvec::SmallVec<[Span; 4]>,
 }
 
 impl<'tcx> InstantiatedPredicates<'tcx> {
     pub fn empty() -> InstantiatedPredicates<'tcx> {
-        InstantiatedPredicates { predicates: vec![], spans: vec![] }
+        InstantiatedPredicates {
+            predicates: smallvec::SmallVec::new(),
+            spans: smallvec::SmallVec::new(),
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -1322,7 +1325,7 @@ impl<'tcx> InstantiatedPredicates<'tcx> {
 impl<'tcx> IntoIterator for InstantiatedPredicates<'tcx> {
     type Item = (Predicate<'tcx>, Span);
 
-    type IntoIter = std::iter::Zip<std::vec::IntoIter<Predicate<'tcx>>, std::vec::IntoIter<Span>>;
+    type IntoIter = std::iter::Zip<smallvec::IntoIter<[Predicate<'tcx>; 4]>, smallvec::IntoIter<[Span; 4]>>;
 
     fn into_iter(self) -> Self::IntoIter {
         debug_assert_eq!(self.predicates.len(), self.spans.len());

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -132,7 +132,7 @@ fn with_fresh_ty_vars<'cx, 'tcx>(
         impl_def_id,
         self_ty: tcx.type_of(impl_def_id).subst(tcx, impl_substs),
         trait_ref: tcx.impl_trait_ref(impl_def_id).map(|i| i.subst(tcx, impl_substs)),
-        predicates: tcx.predicates_of(impl_def_id).instantiate(tcx, impl_substs).predicates,
+        predicates: tcx.predicates_of(impl_def_id).instantiate(tcx, impl_substs).predicates.to_vec(),
     };
 
     let InferOk { value: mut header, obligations } =

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -136,7 +136,7 @@ fn with_fresh_ty_vars<'cx, 'tcx>(
             .predicates_of(impl_def_id)
             .instantiate(tcx, impl_substs)
             .predicates
-            .to_vec(),
+            .into_vec(),
     };
 
     let InferOk { value: mut header, obligations } =

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -132,7 +132,11 @@ fn with_fresh_ty_vars<'cx, 'tcx>(
         impl_def_id,
         self_ty: tcx.type_of(impl_def_id).subst(tcx, impl_substs),
         trait_ref: tcx.impl_trait_ref(impl_def_id).map(|i| i.subst(tcx, impl_substs)),
-        predicates: tcx.predicates_of(impl_def_id).instantiate(tcx, impl_substs).predicates.to_vec(),
+        predicates: tcx
+            .predicates_of(impl_def_id)
+            .instantiate(tcx, impl_substs)
+            .predicates
+            .to_vec(),
     };
 
     let InferOk { value: mut header, obligations } =

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -410,7 +410,7 @@ fn subst_and_check_impossible_predicates<'tcx>(
 ) -> bool {
     debug!("subst_and_check_impossible_predicates(key={:?})", key);
 
-    let mut predicates = tcx.predicates_of(key.0).instantiate(tcx, key.1).predicates;
+    let mut predicates = tcx.predicates_of(key.0).instantiate(tcx, key.1).predicates.to_vec();
 
     // Specifically check trait fulfillment to avoid an error when trying to resolve
     // associated items.

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -410,7 +410,7 @@ fn subst_and_check_impossible_predicates<'tcx>(
 ) -> bool {
     debug!("subst_and_check_impossible_predicates(key={:?})", key);
 
-    let mut predicates = tcx.predicates_of(key.0).instantiate(tcx, key.1).predicates.to_vec();
+    let mut predicates = tcx.predicates_of(key.0).instantiate(tcx, key.1).predicates.into_vec();
 
     // Specifically check trait fulfillment to avoid an error when trying to resolve
     // associated items.

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -136,6 +136,9 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
         predicates = tcx.predicates_of(fn_def_id).instantiate_identity(tcx).predicates;
     }
 
+    // Convert from a smallvec::SmallVec to a Vec.
+    let mut predicates = predicates.to_vec();
+
     // Finally, we have to normalize the bounds in the environment, in
     // case they contain any associated type projections. This process
     // can yield errors if the put in illegal associated types, like

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -137,7 +137,7 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
     }
 
     // Convert from a smallvec::SmallVec to a Vec.
-    let mut predicates = predicates.to_vec();
+    let mut predicates = predicates.into_vec();
 
     // Finally, we have to normalize the bounds in the environment, in
     // case they contain any associated type projections. This process

--- a/compiler/rustc_type_ir/src/structural_impls.rs
+++ b/compiler/rustc_type_ir/src/structural_impls.rs
@@ -144,6 +144,18 @@ impl<I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for Vec<T> {
     }
 }
 
+impl<const N: usize, I: Interner, T: TypeFoldable<I>> TypeFoldable<I> for smallvec::SmallVec<[T; N]> {
+    fn try_fold_with<F: FallibleTypeFolder<I>>(self, folder: &mut F) -> Result<Self, F::Error> {
+        self.into_iter().map(|t| t.try_fold_with(folder)).collect()
+    }
+}
+
+impl<const N: usize, I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for smallvec::SmallVec<[T; N]> {
+    fn visit_with<V: TypeVisitor<I>>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
+        self.iter().try_for_each(|t| t.visit_with(visitor))
+    }
+}
+
 impl<I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for &[T] {
     fn visit_with<V: TypeVisitor<I>>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
         self.iter().try_for_each(|t| t.visit_with(visitor))

--- a/compiler/rustc_type_ir/src/structural_impls.rs
+++ b/compiler/rustc_type_ir/src/structural_impls.rs
@@ -144,13 +144,17 @@ impl<I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for Vec<T> {
     }
 }
 
-impl<const N: usize, I: Interner, T: TypeFoldable<I>> TypeFoldable<I> for smallvec::SmallVec<[T; N]> {
+impl<const N: usize, I: Interner, T: TypeFoldable<I>> TypeFoldable<I>
+    for smallvec::SmallVec<[T; N]>
+{
     fn try_fold_with<F: FallibleTypeFolder<I>>(self, folder: &mut F) -> Result<Self, F::Error> {
         self.into_iter().map(|t| t.try_fold_with(folder)).collect()
     }
 }
 
-impl<const N: usize, I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for smallvec::SmallVec<[T; N]> {
+impl<const N: usize, I: Interner, T: TypeVisitable<I>> TypeVisitable<I>
+    for smallvec::SmallVec<[T; N]>
+{
     fn visit_with<V: TypeVisitor<I>>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
         self.iter().try_for_each(|t| t.visit_with(visitor))
     }


### PR DESCRIPTION
I ran some basic counts for how many times `.instantiate_into()` or `.instantiate_into_identity()` were called to produce a `InstantiatedPredicates` struct during the `python x.py build` process (starting from a `clean` build).

I got these numbers:



```
total calls:     2_773_010
--------------------------
    identity:      525_181
    subst:       2_247_829
```

So this function is "reasonably" hot, with about 18% of calls being to the `identity` version.

I also counted how large each result was, summarized in the following table:

| Size | Percentage |
|:-:|:-:|
|<= 0|41.4%|
|<= 1|64.2%|
|<= 2|87.2%|
|<= 3|93.6%|
|<= 4|96.2%|
|<= 5|97.2%|
|<= 6|98.2%|
|<= 7|98.5%|
|<= 8|98.9%|
|<= 9|99.1%|



So, I figured that a `smallvec::SmallVec<[Predicate<'tcx>; 3]>` may be better suited to storing this value instead of a plain `Vec<Predicate<'tcx>>`. The value of ~~4~~ 3 was chosen mostly arbitrarily - although it makes the `InstantiatedPredicates` struct larger, my cursory inspection of how this type is used suggest it mostly lives as a temporary on the stack, where I expect that this will cause fewer problems.

---

An attempt at size 4 [only slightly improved some secondary metrics](https://github.com/rust-lang/rust/pull/109866#issuecomment-1493491618) some benchmarks while causing some regressions. 

---

Separately, to minimize the overall diff, I added new impls that make `SmallVec<[T; N]>` `TypeFoldable` and `TypeVisitable` just like `Vec<T>`; this makes it possible to `#[derive(TypeFoldable, TypeVisitable)]` in the new definition of `InstantiatedPredicates`.

```rs
impl<const N: usize, I: Interner, T: TypeFoldable<I>> TypeFoldable<I> for smallvec::SmallVec<[T; N]> {
    fn try_fold_with<F: FallibleTypeFolder<I>>(self, folder: &mut F) -> Result<Self, F::Error> {
        self.into_iter().map(|t| t.try_fold_with(folder)).collect()
    }
}

impl<const N: usize, I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for smallvec::SmallVec<[T; N]> {
    fn visit_with<V: TypeVisitor<I>>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
        self.iter().try_for_each(|t| t.visit_with(visitor))
    }
}
```

In a few places, types specifically ask for `Vec` after pulling fields out the `InstantiatedPredicates` - in these cases, I just used `.to_vec()` to paper over the difference.

---

This will very likely be perf neutral for compile times (or even negative), but might be a small win with a relatively small change, so I figure it's worth submitting to benchmarking.