### PR TITLE
Reduce the default max number of files in a UI test directory

### DIFF
--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-const ENTRY_LIMIT: usize = 1000;
 // FIXME: The following limits should be reduced eventually.
+const ENTRY_LIMIT: usize = 885;
 const ROOT_ENTRY_LIMIT: usize = 881;
 const ISSUES_ENTRY_LIMIT: usize = 1978;
 


### PR DESCRIPTION
It doesn't make sense for the root directory to have a lower limit than subdirectories.