### PR TITLE
Remove Errors section from var_os docs

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -242,7 +242,6 @@ fn _var(key: &OsStr) -> Result<String, VarError> {
 ///  - the environment variable's name contains
 /// the equal sign character (`=`) or the NUL character
 ///
-///
 /// Note that the method will not check if the environment variable
 /// is valid Unicode. If you want to have an error on invalid UTF-8,
 /// use the [`var`] function instead.

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -236,11 +236,12 @@ fn _var(key: &OsStr) -> Result<String, VarError> {
 }
 
 /// Fetches the environment variable `key` from the current process, returning
-/// [`None`] if the environment variable isn't set. It may return `None` also
-/// if the environment variable's name contains
+/// [`None`] if the variable isn't set or if there is another error.
+///
+/// It may return `None` if the environment variable's name contains
 /// the equal sign character (`=`) or the NUL character.
 ///
-/// Note that the method will not check if the environment variable
+/// Note that this function will not check if the environment variable
 /// is valid Unicode. If you want to have an error on invalid UTF-8,
 /// use the [`var`] function instead.
 ///

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -236,11 +236,9 @@ fn _var(key: &OsStr) -> Result<String, VarError> {
 }
 
 /// Fetches the environment variable `key` from the current process, returning
-/// [`None`] in the following situations:
-///
-///  - the environment variable isn't set
-///  - the environment variable's name contains
-/// the equal sign character (`=`) or the NUL character
+/// [`None`] if the environment variable isn't set. It may return `None` also
+/// if the environment variable's name contains
+/// the equal sign character (`=`) or the NUL character.
 ///
 /// Note that the method will not check if the environment variable
 /// is valid Unicode. If you want to have an error on invalid UTF-8,

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -242,7 +242,6 @@ fn _var(key: &OsStr) -> Result<String, VarError> {
 ///  - the environment variable's name contains
 /// the equal sign character (`=`) or the NUL character
 ///
-/// If this is not desired, consider using [`var_os`].
 ///
 /// Note that the method will not check if the environment variable
 /// is valid Unicode. If you want to have an error on invalid UTF-8,

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -236,7 +236,13 @@ fn _var(key: &OsStr) -> Result<String, VarError> {
 }
 
 /// Fetches the environment variable `key` from the current process, returning
-/// [`None`] if the variable isn't set or there's another error.
+/// [`None`] in the following situations:
+///
+///  - the environment variable isn't set
+///  - the environment variable's name contains
+/// the equal sign character (`=`) or the NUL character
+///
+/// If this is not desired, consider using [`var_os`].
 ///
 /// Note that the method will not check if the environment variable
 /// is valid Unicode. If you want to have an error on invalid UTF-8,

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -242,16 +242,6 @@ fn _var(key: &OsStr) -> Result<String, VarError> {
 /// is valid Unicode. If you want to have an error on invalid UTF-8,
 /// use the [`var`] function instead.
 ///
-/// # Errors
-///
-/// This function returns an error if the environment variable isn't set.
-///
-/// This function may return an error if the environment variable's name contains
-/// the equal sign character (`=`) or the NUL character.
-///
-/// This function may return an error if the environment variable's value contains
-/// the NUL character.
-///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
Remove `Errors` section from `var_os` documentation, fixes #109893