### PR TITLE
Add codegen tests for issues fixed by LLVM 16

### DIFF
--- a/tests/codegen/issues/issue-101048.rs
+++ b/tests/codegen/issues/issue-101048.rs
@@ -1,0 +1,13 @@
+// compile-flags: -O
+// min-llvm-version: 16
+
+#![crate_type = "lib"]
+
+#[no_mangle]
+pub fn all_zero(data: &[u64]) -> bool {
+    // CHECK-LABEL: @all_zero(
+    // CHECK: [[PHI:%.*]] = phi i1
+    // CHECK-NOT: phi i8
+    // CHECK-NOT: zext
+    data.iter().copied().fold(true, |acc, x| acc & (x == 0))
+}

--- a/tests/codegen/issues/issue-101082.rs
+++ b/tests/codegen/issues/issue-101082.rs
@@ -7,7 +7,7 @@
 #[no_mangle]
 pub fn test() -> usize {
     // CHECK-LABEL: @test(
-    // CHECK: ret i64 165
+    // CHECK: ret {{i64|i32}} 165
     let values = [23, 16, 54, 3, 60, 9];
     let mut acc = 0;
     for item in values {

--- a/tests/codegen/issues/issue-101082.rs
+++ b/tests/codegen/issues/issue-101082.rs
@@ -1,0 +1,16 @@
+// compile-flags: -O
+// min-llvm-version: 16
+
+#![crate_type = "lib"]
+
+#[no_mangle]
+pub fn test() -> usize {
+    // CHECK-LABEL: @test(
+    // CHECK: ret i64 165
+    let values = [23, 16, 54, 3, 60, 9];
+    let mut acc = 0;
+    for item in values {
+        acc += item;
+    }
+    acc
+}

--- a/tests/codegen/issues/issue-101082.rs
+++ b/tests/codegen/issues/issue-101082.rs
@@ -1,5 +1,6 @@
 // compile-flags: -O
 // min-llvm-version: 16
+// ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-101814.rs
+++ b/tests/codegen/issues/issue-101814.rs
@@ -1,0 +1,19 @@
+// compile-flags: -O
+// min-llvm-version: 16
+
+#![crate_type = "lib"]
+
+#[no_mangle]
+pub fn test(a: [i32; 10]) -> i32 {
+    // CHECK-LABEL: @test(
+    // CHECK: [[L1:%.+]] = load i32
+    // CHECK: [[L2:%.+]] = load i32
+    // CHECK: [[R:%.+]] = add i32 [[L1]], [[L2]]
+    // CHECK: ret i32 [[R]]
+    let mut sum = 0;
+    for v in a.iter().skip(8) {
+        sum += v;
+    }
+
+    sum
+}

--- a/tests/codegen/issues/issue-101814.rs
+++ b/tests/codegen/issues/issue-101814.rs
@@ -1,5 +1,6 @@
 // compile-flags: -O
 // min-llvm-version: 16
+// ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-103132.rs
+++ b/tests/codegen/issues/issue-103132.rs
@@ -1,0 +1,16 @@
+// compile-flags: -O -C overflow-checks
+// min-llvm-version: 16
+
+#![crate_type = "lib"]
+
+#[no_mangle]
+pub fn test(arr: &[u8], weight: u32) {
+    // CHECK-LABEL: @test(
+    // CHECK-NOT: panic
+    let weight = weight.min(256 * 256 * 256);
+
+    for x in arr {
+        assert!(weight <= 256 * 256 * 256);
+        let result = *x as u32 * weight;
+    }
+}

--- a/tests/codegen/issues/issue-103327.rs
+++ b/tests/codegen/issues/issue-103327.rs
@@ -1,0 +1,18 @@
+// compile-flags: -O
+// min-llvm-version: 16
+
+#![crate_type = "lib"]
+
+#[no_mangle]
+pub fn test(a: i32, b: i32) -> bool {
+    // CHECK-LABEL: @test(
+    // CHECK: ret i1 true
+    let c1 = (a >= 0) && (a <= 10);
+    let c2 = (b >= 0) && (b <= 20);
+
+    if c1 & c2 {
+        a + 100 != b
+    } else {
+        true
+    }
+}

--- a/tests/codegen/issues/issue-75978.rs
+++ b/tests/codegen/issues/issue-75978.rs
@@ -1,0 +1,19 @@
+// compile-flags: -O
+// min-llvm-version: 16
+
+#![crate_type = "lib"]
+
+#[no_mangle]
+pub fn test() -> u32 {
+    // CHECK-LABEL: @test(
+    // CHECK: ret i32 13
+    let s = [1, 2, 3, 4, 5, 6, 7];
+
+    let mut iter = s.iter();
+    let mut sum = 0;
+    while let Some(_) = iter.next() {
+        sum += iter.next().map_or(1, |&x| x)
+    }
+
+    sum
+}

--- a/tests/codegen/issues/issue-99960.rs
+++ b/tests/codegen/issues/issue-99960.rs
@@ -1,0 +1,15 @@
+// compile-flags: -O
+// min-llvm-version: 16
+
+#![crate_type = "lib"]
+
+#[no_mangle]
+pub fn test(dividend: i64, divisor: i64) -> Option<i64> {
+    // CHECK-LABEL: @test(
+    // CHECK-NOT: panic
+    if dividend > i64::min_value() && divisor != 0 {
+        Some(dividend / divisor)
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
Fixes #75978.
Fixes #99960.
Fixes #101048.
Fixes #101082.
Fixes #101814.
Fixes #103132.
Fixes #103327.