### PR TITLE
Use apple-m1 as target CPU for aarch64-apple-darwin.

### DIFF
--- a/compiler/rustc_target/src/spec/aarch64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/aarch64_apple_darwin.rs
@@ -4,7 +4,7 @@ use crate::spec::{FramePointer, SanitizerSet, Target, TargetOptions};
 pub fn target() -> Target {
     let arch = Arch::Arm64;
     let mut base = opts("macos", arch);
-    base.cpu = "apple-a14".into();
+    base.cpu = "apple-m1".into();
     base.max_atomic_width = Some(128);
 
     // FIXME: The leak sanitizer currently fails the tests, see #88132.


### PR DESCRIPTION
This updates the target CPU for the `aarch64-apple-darwin` target to `apple-m1`, which is the first generation of CPUs with this target anyway.

This wasn't able to be done before because of the minimum supported version of LLVM being 12, now that it was updated to 13 (in fact we are already at 14), this is available.

See previous update: https://github.com/rust-lang/rust/pull/90478.
See LLVM update: https://github.com/rust-lang/rust/pull/100460.