### PR TITLE
Document const-initialization for `thread_local!` macro

### DIFF
--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -137,6 +137,28 @@ impl<T: 'static> fmt::Debug for LocalKey<T> {
 /// # fn main() {}
 /// ```
 ///
+/// This macro also supports wrapping initializing expression in `const` block
+/// if it can be evaluated in const context:
+///
+/// ```
+/// use std::cell::Cell;
+/// thread_local! {
+///     static INIT_FLAG: Cell<bool> = const { Cell::new(false) };
+/// }
+/// ```
+///
+/// Doing so does not change the behavior, but might enable more efficient implementation
+/// of [`LocalKey`][`std::thread::LocalKey`] on supported platforms.
+///
+/// If initializing expression can not be evaluated in const context, wrapping it in
+/// `const` block is a compile error.
+///
+/// ```compile_fail
+/// thread_local! {
+///     static FOO: Vec<i32> = const { vec![0] };
+/// }
+/// ```
+///
 /// See [`LocalKey` documentation][`std::thread::LocalKey`] for more
 /// information.
 ///


### PR DESCRIPTION
#83416 added const initialization for statics in `std::thread::thread_local` macro. Surprisingly, it was merged completely undocumented, so I suspect most of Rust users are not even aware of this functionality. This PR intents to close this gap.

@rustbot labels: +A-docs