### PR TITLE
Don't ICE when encountering `dyn*` in statics or consts

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -553,7 +553,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
             }
 
             Rvalue::Cast(CastKind::DynStar, _, _) => {
-                unimplemented!()
+                // `dyn*` coercion is implemented for CTFE.
             }
 
             Rvalue::Cast(_, _, _) => {}

--- a/tests/ui/dyn-star/const-and-static.rs
+++ b/tests/ui/dyn-star/const-and-static.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+#![feature(dyn_star)]
+//~^ WARN the feature `dyn_star` is incomplete
+
+const C: dyn* Send + Sync = &();
+
+static S: dyn* Send + Sync = &();
+
+fn main() {}

--- a/tests/ui/dyn-star/const-and-static.stderr
+++ b/tests/ui/dyn-star/const-and-static.stderr
@@ -1,0 +1,11 @@
+warning: the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/const-and-static.rs:3:12
+   |
+LL | #![feature(dyn_star)]
+   |            ^^^^^^^^
+   |
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Since we have properly implemented `dyn*` support in CTFE (#107728), let's not ICE here anymore.

Fixes #105777

r? @eholk