### PR TITLE
Disable `has_thread_local` on OpenHarmony

### DIFF
--- a/compiler/rustc_target/src/spec/aarch64_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_linux_ohos.rs
@@ -18,6 +18,7 @@ pub fn target() -> Target {
             features: "+reserve-x18".into(),
             mcount: "\u{1}_mcount".into(),
             force_emulated_tls: true,
+            has_thread_local: false,
             supported_sanitizers: SanitizerSet::ADDRESS
                 | SanitizerSet::CFI
                 | SanitizerSet::LEAK

--- a/compiler/rustc_target/src/spec/armv7_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/armv7_unknown_linux_ohos.rs
@@ -21,6 +21,7 @@ pub fn target() -> Target {
             crt_static_default: false,
             mcount: "\u{1}mcount".into(),
             force_emulated_tls: true,
+            has_thread_local: false,
             ..super::linux_musl_base::opts()
         },
     }


### PR DESCRIPTION
OpenHarmony uses emulated TLS, which doesn't link properly when using thread-local variables across crate boundaries with `-C prefer-dynamic`. This PR makes thread_local! use pthreads directly instead.