### PR TITLE
write threads info into log only when debugging

### DIFF
--- a/compiler/rustc_log/src/lib.rs
+++ b/compiler/rustc_log/src/lib.rs
@@ -83,7 +83,7 @@ pub fn init_env_logger(env: &str) -> Result<(), Error> {
         .with_verbose_exit(verbose_entry_exit)
         .with_verbose_entry(verbose_entry_exit)
         .with_indent_amount(2);
-    #[cfg(parallel_compiler)]
+    #[cfg(all(parallel_compiler, debug_assertions))]
     let layer = layer.with_thread_ids(true).with_thread_names(true);
 
     let subscriber = tracing_subscriber::Registry::default().with(filter).with(layer);

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -203,7 +203,7 @@ fn init_logging() {
         .with_verbose_exit(true)
         .with_verbose_entry(true)
         .with_indent_amount(2);
-    #[cfg(parallel_compiler)]
+    #[cfg(all(parallel_compiler, debug_assertions))]
     let layer = layer.with_thread_ids(true).with_thread_names(true);
 
     use tracing_subscriber::layer::SubscriberExt;


### PR DESCRIPTION
The current tracing log will unconditionally write thread information during parallel compilation, which sometimes confuses some normal output log information

This fixes the UI test failure of:
```
[ui] tests/ui/consts/const_in_pattern/issue-73431.rs
```
Updates #75760