### PR TITLE
Source code scrollbar

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -392,6 +392,7 @@ img {
 	overflow-x: hidden;
 	/* The sidebar is by default hidden  */
 	overflow-y: hidden;
+	z-index: 1;
 }
 
 .sidebar, .mobile-topbar, .sidebar-menu-toggle,
@@ -535,6 +536,9 @@ ul.block, .block li {
 .rustdoc .example-wrap > pre {
 	margin: 0;
 	flex-grow: 1;
+}
+
+.rustdoc:not(.source) .example-wrap > pre {
 	overflow: auto hidden;
 }
 

--- a/tests/rustdoc-gui/source-code-page-code-scroll.goml
+++ b/tests/rustdoc-gui/source-code-page-code-scroll.goml
@@ -1,0 +1,8 @@
+// Checks that the scrollbar is visible on the page rather than the code block.
+goto: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
+size: (800, 1000)
+// "scrollWidth" should be superior than "clientWidth".
+assert-property: ("body", {"scrollWidth": 1047, "clientWidth": 800})
+
+// Both properties should be equal (ie, no scroll on the code block).
+assert-property: (".example-wrap .rust", {"scrollWidth": 933, "clientWidth": 933})


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/109865.

You can test it [here](https://rustdoc.crud.net/imperio/source-code-scrollbar/src/test_docs/lib.rs.html).

It seems to introduce a few regressions (at least change of behaviour) about the scroll "saving" though.

r? @notriddle 