### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -485,17 +485,10 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             if let Some(args) = constraint.gen_args.as_ref()
                 && matches!(
                     args,
-                    ast::GenericArgs::ReturnTypeNotation(..) | ast::GenericArgs::Parenthesized(..)
+                    ast::GenericArgs::ReturnTypeNotation(..)
                 )
             {
-                // RTN is gated elsewhere, and parenthesized args will turn into
-                // another error.
-                if matches!(args, ast::GenericArgs::Parenthesized(..)) {
-                    self.sess.delay_span_bug(
-                        constraint.span,
-                        "should have emitted a parenthesized generics error",
-                    );
-                }
+                // RTN is gated below with a `gate_all`.
             } else {
                 gate_feature_post!(
                     &self,

--- a/compiler/rustc_borrowck/src/type_check/liveness/local_use_map.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/local_use_map.rs
@@ -63,7 +63,7 @@ impl LocalUseMap {
         elements: &RegionValueElements,
         body: &Body<'_>,
     ) -> Self {
-        let nones = IndexVec::from_elem_n(None, body.local_decls.len());
+        let nones = IndexVec::from_elem(None, &body.local_decls);
         let mut local_use_map = LocalUseMap {
             first_def_at: nones.clone(),
             first_use_at: nones.clone(),
@@ -76,7 +76,7 @@ impl LocalUseMap {
         }
 
         let mut locals_with_use_data: IndexVec<Local, bool> =
-            IndexVec::from_elem_n(false, body.local_decls.len());
+            IndexVec::from_elem(false, &body.local_decls);
         live_locals.iter().for_each(|&local| locals_with_use_data[local] = true);
 
         LocalUseMapBuild { local_use_map: &mut local_use_map, elements, locals_with_use_data }

--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -129,6 +129,17 @@ impl<I: Idx, T> IndexVec<I, T> {
         IndexVec { raw: Vec::with_capacity(capacity), _marker: PhantomData }
     }
 
+    /// Creates a new vector with a copy of `elem` for each index in `universe`.
+    ///
+    /// Thus `IndexVec::from_elem(elem, &universe)` is equivalent to
+    /// `IndexVec::<I, _>::from_elem_n(elem, universe.len())`. That can help
+    /// type inference as it ensures that the resulting vector uses the same
+    /// index type as `universe`, rather than something potentially surprising.
+    ///
+    /// For example, if you want to store data for each local in a MIR body,
+    /// using `let mut uses = IndexVec::from_elem(vec![], &body.local_decls);`
+    /// ensures that `uses` is an `IndexVec<Local, _>`, and thus can give
+    /// better error messages later if one accidentally mismatches indices.
     #[inline]
     pub fn from_elem<S>(elem: T, universe: &IndexSlice<I, S>) -> Self
     where

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -203,7 +203,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
 
         // Tracks the `VarSubVar` constraints generated for each region vid. We
         // later use this to expand across vids.
-        let mut constraints = IndexVec::from_elem_n(Vec::new(), var_values.values.len());
+        let mut constraints = IndexVec::from_elem(Vec::new(), &var_values.values);
         // Tracks the changed region vids.
         let mut changes = Vec::new();
         for constraint in self.data.constraints.keys() {

--- a/compiler/rustc_mir_transform/src/coverage/graph.rs
+++ b/compiler/rustc_mir_transform/src/coverage/graph.rs
@@ -37,8 +37,7 @@ impl CoverageGraph {
         // `SwitchInt` to have multiple targets to the same destination `BasicBlock`, so
         // de-duplication is required. This is done without reordering the successors.
 
-        let bcbs_len = bcbs.len();
-        let mut seen = IndexVec::from_elem_n(false, bcbs_len);
+        let mut seen = IndexVec::from_elem(false, &bcbs);
         let successors = IndexVec::from_fn_n(
             |bcb| {
                 for b in seen.iter_mut() {
@@ -60,7 +59,7 @@ impl CoverageGraph {
             bcbs.len(),
         );
 
-        let mut predecessors = IndexVec::from_elem_n(Vec::new(), bcbs.len());
+        let mut predecessors = IndexVec::from_elem(Vec::new(), &bcbs);
         for (bcb, bcb_successors) in successors.iter_enumerated() {
             for &successor in bcb_successors {
                 predecessors[successor].push(bcb);

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -522,7 +522,7 @@ fn generator_saved_local_eligibility(
     use SavedLocalEligibility::*;
 
     let mut assignments: IndexVec<GeneratorSavedLocal, SavedLocalEligibility> =
-        IndexVec::from_elem_n(Unassigned, info.field_tys.len());
+        IndexVec::from_elem(Unassigned, &info.field_tys);
 
     // The saved locals not eligible for overlap. These will get
     // "promoted" to the prefix of our generator.

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1142,22 +1142,21 @@ fn fmt_type<'cx>(
             //        the ugliness comes from inlining across crates where
             //        everything comes in as a fully resolved QPath (hard to
             //        look at).
-            match href(trait_.def_id(), cx) {
-                Ok((ref url, _, ref path)) if !f.alternate() => {
-                    write!(
-                        f,
-                        "<a class=\"associatedtype\" href=\"{url}#{shortty}.{name}\" \
-                                    title=\"type {path}::{name}\">{name}</a>{args}",
-                        url = url,
-                        shortty = ItemType::AssocType,
-                        name = assoc.name,
-                        path = join_with_double_colon(path),
-                        args = assoc.args.print(cx),
-                    )?;
-                }
-                _ => write!(f, "{}{:#}", assoc.name, assoc.args.print(cx))?,
-            }
-            Ok(())
+            if !f.alternate() && let Ok((url, _, path)) = href(trait_.def_id(), cx) {
+                write!(
+                    f,
+                    "<a class=\"associatedtype\" href=\"{url}#{shortty}.{name}\" \
+                                title=\"type {path}::{name}\">{name}</a>",
+                    shortty = ItemType::AssocType,
+                    name = assoc.name,
+                    path = join_with_double_colon(&path),
+                )
+            } else {
+                write!(f, "{}", assoc.name)
+            }?;
+
+            // Carry `f.alternate()` into this display w/o branching manually.
+            fmt::Display::fmt(&assoc.args.print(cx), f)
         }
     }
 }

--- a/tests/rustdoc/generic-associated-types/issue-109488.rs
+++ b/tests/rustdoc/generic-associated-types/issue-109488.rs
@@ -1,0 +1,18 @@
+// Make sure that we escape the arguments of the GAT projection even if we fail to compute
+// the href of the corresponding trait (in this case it is private).
+// Further, test that we also linkify the GAT arguments.
+
+// @has 'issue_109488/type.A.html'
+// @has - '//pre[@class="rust item-decl"]' '<S as Tr>::P<Option<i32>>'
+// @has - '//pre[@class="rust item-decl"]//a[@class="enum"]/@href' '{{channel}}/core/option/enum.Option.html'
+pub type A = <S as Tr>::P<Option<i32>>;
+
+/*private*/ trait Tr {
+    type P<T>;
+}
+
+pub struct S;
+
+impl Tr for S {
+    type P<T> = ();
+}

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
@@ -10,11 +10,13 @@ trait Trait {
 
 fn foo<T: Trait<method(i32): Send>>() {}
 //~^ ERROR argument types not allowed with return type notation
+//~| ERROR associated type bounds are unstable
 
 fn bar<T: Trait<method(..) -> (): Send>>() {}
 //~^ ERROR return type not allowed with return type notation
 
 fn baz<T: Trait<method(): Send>>() {}
 //~^ ERROR return type notation arguments must be elided with `..`
+//~| ERROR associated type bounds are unstable
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
@@ -1,8 +1,26 @@
 error: return type not allowed with return type notation
-  --> $DIR/bad-inputs-and-output.rs:14:28
+  --> $DIR/bad-inputs-and-output.rs:15:28
    |
 LL | fn bar<T: Trait<method(..) -> (): Send>>() {}
    |                            ^^^^^ help: remove the return type
+
+error[E0658]: associated type bounds are unstable
+  --> $DIR/bad-inputs-and-output.rs:11:17
+   |
+LL | fn foo<T: Trait<method(i32): Send>>() {}
+   |                 ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+
+error[E0658]: associated type bounds are unstable
+  --> $DIR/bad-inputs-and-output.rs:18:17
+   |
+LL | fn baz<T: Trait<method(): Send>>() {}
+   |                 ^^^^^^^^^^^^^^
+   |
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/bad-inputs-and-output.rs:3:12
@@ -28,10 +46,11 @@ LL | fn foo<T: Trait<method(i32): Send>>() {}
    |                       ^^^^^ help: remove the input types: `(..)`
 
 error: return type notation arguments must be elided with `..`
-  --> $DIR/bad-inputs-and-output.rs:17:23
+  --> $DIR/bad-inputs-and-output.rs:18:23
    |
 LL | fn baz<T: Trait<method(): Send>>() {}
    |                       ^^ help: add `..`: `(..)`
 
-error: aborting due to 3 previous errors; 2 warnings emitted
+error: aborting due to 5 previous errors; 2 warnings emitted
 
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.rs
@@ -1,0 +1,11 @@
+// edition: 2021
+// compile-flags: -Zunpretty=expanded
+
+trait Trait {
+    async fn method() {}
+}
+
+fn foo<T: Trait<method(i32): Send>>() {}
+//~^ ERROR associated type bounds are unstable
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.stderr
@@ -1,0 +1,12 @@
+error[E0658]: associated type bounds are unstable
+  --> $DIR/unpretty-parenthesized.rs:8:17
+   |
+LL | fn foo<T: Trait<method(i32): Send>>() {}
+   |                 ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.stdout
+++ b/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.stdout
@@ -1,0 +1,15 @@
+#![feature(prelude_import)]
+#[prelude_import]
+use std::prelude::rust_2021::*;
+#[macro_use]
+extern crate std;
+// edition: 2021
+// compile-flags: -Zunpretty=expanded
+
+trait Trait {
+    async fn method() {}
+}
+
+fn foo<T: Trait<method(i32) : Send>>() {}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #109913 (Doc-comment  `IndexVec::from_elem` and use it in a few more places)
 - #109914 (Emit feature error for parenthesized generics in associated type bounds)
 - #109919 (rustdoc: escape GAT args in more cases)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=109913,109914,109919)
<!-- homu-ignore:end -->