### PR TITLE
Remove the use of `-use-gnu-stack` when BOLTing LLVM

### DIFF
--- a/src/bootstrap/bolt.rs
+++ b/src/bootstrap/bolt.rs
@@ -45,8 +45,6 @@ pub fn optimize_with_bolt(path: &Path, profile_path: &Path, output_path: &Path) 
         .arg("-split-all-cold")
         // Move jump tables to a separate section
         .arg("-jump-tables=move")
-        // Use GNU_STACK program header for new segment (workaround for issues with strip/objcopy)
-        .arg("-use-gnu-stack")
         // Fold functions with identical code
         .arg("-icf=1")
         // Update DWARF debug info in the final binary


### PR DESCRIPTION
This flag was (counterintuitively) removing the `GNU_STACK` ELF attribute, which caused the optimized `libLLVM.so` file to be flagged as having an executable stack on SELinux.

Removing the flag might cause issues with `strip`. I'm not aware that we're stripping `libLLVM.so` though. Does it happen anywhere?

Fixes: https://github.com/rust-lang/rust/issues/105783