### PR TITLE
Fix transmute intrinsic mir validation ICE

### DIFF
--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -679,13 +679,21 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             // Unlike `mem::transmute`, a MIR `Transmute` is well-formed
                             // for any two `Sized` types, just potentially UB to run.
 
-                            if !op_ty.is_sized(self.tcx, self.param_env) {
+                            if !self
+                                .tcx
+                                .normalize_erasing_regions(self.param_env, op_ty)
+                                .is_sized(self.tcx, self.param_env)
+                            {
                                 self.fail(
                                     location,
                                     format!("Cannot transmute from non-`Sized` type {op_ty:?}"),
                                 );
                             }
-                            if !target_type.is_sized(self.tcx, self.param_env) {
+                            if !self
+                                .tcx
+                                .normalize_erasing_regions(self.param_env, *target_type)
+                                .is_sized(self.tcx, self.param_env)
+                            {
                                 self.fail(
                                     location,
                                     format!("Cannot transmute to non-`Sized` type {target_type:?}"),

--- a/tests/ui/mir/validate/transmute_cast_sized.rs
+++ b/tests/ui/mir/validate/transmute_cast_sized.rs
@@ -1,0 +1,17 @@
+// build-pass
+// compile-flags: -Zvalidate-mir
+// edition: 2021
+
+#![crate_type = "lib"]
+
+// Use `PhantomData` to get target-independent size
+async fn get(_r: std::marker::PhantomData<&i32>) {
+    loop {}
+}
+
+pub fn check() {
+    let mut v = get(loop {});
+    let _ = || unsafe {
+        v = std::mem::transmute([0_u8; 1]);
+    };
+}


### PR DESCRIPTION
I stumbled across this at work, the minimal reproducer is included as a test which ICEs before this change.

I'm not 100% sure this is the right fix, but it matches what we do in `mir_assign_valid_types` so seems reasonable at least.

fixes #110151

r? @lcnr since they've been keeping the relevant logic correct, cc @scottmcm 