### PR TITLE
rustdoc: Improve logo display very small screen

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -6,6 +6,10 @@
 	3. Copy the filenames with updated suffixes from the directory.
 */
 
+:root {
+	--nav-sub-mobile-padding: 8px;
+}
+
 /* See FiraSans-LICENSE.txt for the Fira Sans license. */
 @font-face {
 	font-family: 'Fira Sans';
@@ -1726,7 +1730,7 @@ in main.js
 
 	.source nav.sub {
 		margin: 0;
-		padding: 8px;
+		padding: var(--nav-sub-mobile-padding);
 	}
 }
 
@@ -1783,6 +1787,7 @@ in main.js
 	.sub-logo-container > img {
 		height: 35px;
 		width: 35px;
+		margin-bottom: var(--nav-sub-mobile-padding);
 	}
 }
 

--- a/tests/rustdoc-gui/huge-logo.goml
+++ b/tests/rustdoc-gui/huge-logo.goml
@@ -18,4 +18,6 @@ size: (1280, 1024)
 assert-property: (".sub-logo-container", {"offsetWidth": "60", "offsetHeight": 60})
 
 size: (400, 600)
-assert-property: (".sub-logo-container", {"offsetWidth": "35", "offsetHeight": 35})
+// 43 because 35px + 8px of margin
+assert-css: (".sub-logo-container > img", {"margin-bottom": "8px"})
+assert-property: (".sub-logo-container", {"offsetWidth": "35", "offsetHeight": 43})

--- a/tests/rustdoc-gui/source-code-page.goml
+++ b/tests/rustdoc-gui/source-code-page.goml
@@ -216,3 +216,8 @@ call-function: ("check-sidebar-dir-entry", {
     "x": 0,
     "y": |source_sidebar_title_y| + |source_sidebar_title_height| + 6,
 })
+
+// Now we check that the logo has a bottom margin so it's not stuck to the search input.
+assert-css: (".sub-logo-container > img", {"margin-bottom": "8px"})
+store-property: (logo_height, ".sub-logo-container", "clientHeight")
+assert-position: (".search-form", {"y": |logo_height| + 8})


### PR DESCRIPTION
Before:


![Screenshot from 2023-04-05 16-56-33](https://user-images.githubusercontent.com/3050060/230125438-c63c8de1-923c-4534-adf1-bdef02e402a9.png)

After:


![Screenshot from 2023-04-05 16-57-17](https://user-images.githubusercontent.com/3050060/230125467-d3d46878-373a-4f8a-8554-1bb8c4baf46d.png)

r? @notriddle 