### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/tests/ui/inference/issue-80409.rs
+++ b/tests/ui/inference/issue-80409.rs
@@ -1,0 +1,36 @@
+// check-pass
+
+#![allow(unreachable_code, unused)]
+
+use std::marker::PhantomData;
+
+struct FsmBuilder<TFsm> {
+    _fsm: PhantomData<TFsm>,
+}
+
+impl<TFsm> FsmBuilder<TFsm> {
+    fn state(&mut self) -> FsmStateBuilder<TFsm> {
+        todo!()
+    }
+}
+
+struct FsmStateBuilder<TFsm> {
+    _state: PhantomData<TFsm>,
+}
+
+impl<TFsm> FsmStateBuilder<TFsm> {
+    fn on_entry<TAction: Fn(&mut StateContext<'_, TFsm>)>(&self, _action: TAction) {}
+}
+
+trait Fsm {
+    type Context;
+}
+
+struct StateContext<'a, TFsm: Fsm> {
+    context: &'a mut TFsm::Context,
+}
+
+fn main() {
+    let mut builder: FsmBuilder<usize> = todo!();
+    builder.state().on_entry(|_| {});
+}


### PR DESCRIPTION
Successful merges:

 - #107236 (Add T-bootstrap label to tools)
 - #109847 (Only create graphviz nodes for reachable MIR bb's)
 - #109848 (submodule detection for proper fix on #96188)
 - #109932 (Source code scrollbar)
 - #109952 (Move comment about python2 closer to the place it's used)
 - #109956 (Tweak debug outputs to make debugging new solver easier)
 - #109968 (Add regression test for #80409)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=107236,109847,109848,109932,109952,109956,109968)
<!-- homu-ignore:end -->