### PR TITLE
rustc_session: default to -Z plt=yes on non-x86_64

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1613,7 +1613,7 @@ options! {
     plt: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "whether to use the PLT when calling into shared libraries;
         only has effect for PIC code on systems with ELF binaries
-        (default: PLT is disabled if full relro is enabled)"),
+        (default: PLT is disabled if full relro is enabled on x86_64)"),
     polonius: bool = (false, parse_bool, [TRACKED],
         "enable polonius-based borrow-checker (default: no)"),
     polymorphize: bool = (false, parse_bool, [TRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1013,7 +1013,7 @@ impl Session {
     pub fn needs_plt(&self) -> bool {
         // Check if the current target usually needs PLT to be enabled.
         // The user can use the command line flag to override it.
-        let needs_plt = self.target.needs_plt;
+        let needs_plt = self.target.arch != "x86_64";
 
         let dbg_opts = &self.opts.unstable_opts;
 

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1009,11 +1009,11 @@ impl Session {
         self.edition().rust_2024()
     }
 
-    /// Returns `true` if we cannot skip the PLT for shared library calls.
+    /// Returns `true` if we should use the PLT for shared library calls.
     pub fn needs_plt(&self) -> bool {
-        // Check if the current target usually needs PLT to be enabled.
+        // Check if the current target usually wants PLT to be enabled.
         // The user can use the command line flag to override it.
-        let needs_plt = self.target.arch != "x86_64";
+        let want_plt = self.target.plt_by_default;
 
         let dbg_opts = &self.opts.unstable_opts;
 
@@ -1025,8 +1025,8 @@ impl Session {
         let full_relro = RelroLevel::Full == relro_level;
 
         // If user didn't explicitly forced us to use / skip the PLT,
-        // then try to skip it where possible.
-        dbg_opts.plt.unwrap_or(needs_plt || !full_relro)
+        // then use it unless the target doesn't want it by default or the full relro forces it on.
+        dbg_opts.plt.unwrap_or(want_plt || !full_relro)
     }
 
     /// Checks if LLVM lifetime markers should be emitted.

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1670,7 +1670,7 @@ pub struct TargetOptions {
     pub static_position_independent_executables: bool,
     /// Determines if the target always requires using the PLT for indirect
     /// library calls or not. This controls the default value of the `-Z plt` flag.
-    pub needs_plt: bool,
+    pub plt_by_default: bool,
     /// Either partial, full, or off. Full RELRO makes the dynamic linker
     /// resolve all symbols at startup and marks the GOT read-only before
     /// starting the program, preventing overwriting the GOT.
@@ -1992,7 +1992,7 @@ impl Default for TargetOptions {
             no_default_libraries: true,
             position_independent_executables: false,
             static_position_independent_executables: false,
-            needs_plt: false,
+            plt_by_default: true,
             relro_level: RelroLevel::None,
             pre_link_objects: Default::default(),
             post_link_objects: Default::default(),
@@ -2665,7 +2665,7 @@ impl Target {
         key!(no_default_libraries, bool);
         key!(position_independent_executables, bool);
         key!(static_position_independent_executables, bool);
-        key!(needs_plt, bool);
+        key!(plt_by_default, bool);
         key!(relro_level, RelroLevel)?;
         key!(archive_format);
         key!(allow_asm, bool);
@@ -2921,7 +2921,7 @@ impl ToJson for Target {
         target_option_val!(no_default_libraries);
         target_option_val!(position_independent_executables);
         target_option_val!(static_position_independent_executables);
-        target_option_val!(needs_plt);
+        target_option_val!(plt_by_default);
         target_option_val!(relro_level);
         target_option_val!(archive_format);
         target_option_val!(allow_asm);

--- a/compiler/rustc_target/src/spec/x86_64_fortanix_unknown_sgx.rs
+++ b/compiler/rustc_target/src/spec/x86_64_fortanix_unknown_sgx.rs
@@ -63,6 +63,7 @@ pub fn target() -> Target {
         linker: Some("rust-lld".into()),
         max_atomic_width: Some(64),
         cpu: "x86-64".into(),
+        plt_by_default: false,
         features: "+rdrnd,+rdseed,+lvi-cfi,+lvi-load-hardening".into(),
         llvm_args: cvs!["--x86-experimental-lvi-inline-asm-hardening"],
         position_independent_executables: true,

--- a/compiler/rustc_target/src/spec/x86_64_linux_android.rs
+++ b/compiler/rustc_target/src/spec/x86_64_linux_android.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target, T
 pub fn target() -> Target {
     let mut base = super::android_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     // https://developer.android.com/ndk/guides/abis.html#86-64
     base.features = "+mmx,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt".into();
     base.max_atomic_width = Some(64);

--- a/compiler/rustc_target/src/spec/x86_64_pc_nto_qnx710.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pc_nto_qnx710.rs
@@ -10,6 +10,7 @@ pub fn target() -> Target {
         arch: "x86_64".into(),
         options: TargetOptions {
             cpu: "x86-64".into(),
+            plt_by_default: false,
             max_atomic_width: Some(64),
             pre_link_args: TargetOptions::link_args(
                 LinkerFlavor::Gnu(Cc::Yes, Lld::No),

--- a/compiler/rustc_target/src/spec/x86_64_pc_solaris.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pc_solaris.rs
@@ -4,6 +4,7 @@ pub fn target() -> Target {
     let mut base = super::solaris_base::opts();
     base.add_pre_link_args(LinkerFlavor::Unix(Cc::Yes), &["-m64"]);
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.vendor = "pc".into();
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/x86_64_pc_windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pc_windows_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, Target};
 pub fn target() -> Target {
     let mut base = super::windows_gnu_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     // Use high-entropy 64 bit address space for ASLR
     base.add_pre_link_args(
         LinkerFlavor::Gnu(Cc::No, Lld::No),

--- a/compiler/rustc_target/src/spec/x86_64_pc_windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pc_windows_gnullvm.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, Target};
 pub fn target() -> Target {
     let mut base = super::windows_gnullvm_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.linker = Some("x86_64-w64-mingw32-clang".into());

--- a/compiler/rustc_target/src/spec/x86_64_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pc_windows_msvc.rs
@@ -3,6 +3,7 @@ use crate::spec::Target;
 pub fn target() -> Target {
     let mut base = super::windows_msvc_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
 
     Target {

--- a/compiler/rustc_target/src/spec/x86_64_sun_solaris.rs
+++ b/compiler/rustc_target/src/spec/x86_64_sun_solaris.rs
@@ -4,6 +4,7 @@ pub fn target() -> Target {
     let mut base = super::solaris_base::opts();
     base.add_pre_link_args(LinkerFlavor::Unix(Cc::Yes), &["-m64"]);
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.vendor = "sun".into();
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/x86_64_unknown_dragonfly.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_dragonfly.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::dragonfly_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/x86_64_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_freebsd.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::freebsd_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/x86_64_unknown_fuchsia.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_fuchsia.rs
@@ -3,6 +3,7 @@ use crate::spec::{SanitizerSet, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::fuchsia_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::X86;
     base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI;

--- a/compiler/rustc_target/src/spec/x86_64_unknown_haiku.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_haiku.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::haiku_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/x86_64_unknown_hermit.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_hermit.rs
@@ -3,6 +3,7 @@ use crate::spec::{StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::hermit_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.features = "+rdrnd,+rdseed".into();
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/x86_64_unknown_illumos.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_illumos.rs
@@ -4,6 +4,7 @@ pub fn target() -> Target {
     let mut base = super::illumos_base::opts();
     base.add_pre_link_args(LinkerFlavor::Unix(Cc::Yes), &["-m64", "-std=c99"]);
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::THREAD;
 

--- a/compiler/rustc_target/src/spec/x86_64_unknown_l4re_uclibc.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_l4re_uclibc.rs
@@ -3,6 +3,7 @@ use crate::spec::{PanicStrategy, Target};
 pub fn target() -> Target {
     let mut base = super::l4re_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.panic_strategy = PanicStrategy::Abort;
 

--- a/compiler/rustc_target/src/spec/x86_64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_linux_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::linux_gnu_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/x86_64_unknown_linux_gnux32.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_linux_gnux32.rs
@@ -10,7 +10,7 @@ pub fn target() -> Target {
     base.has_thread_local = false;
     // BUG(GabrielMajeri): disabling the PLT on x86_64 Linux with x32 ABI
     // breaks code gen. See LLVM bug 36743
-    base.needs_plt = true;
+    base.plt_by_default = true;
 
     Target {
         llvm_target: "x86_64-unknown-linux-gnux32".into(),

--- a/compiler/rustc_target/src/spec/x86_64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_linux_musl.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::linux_musl_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/x86_64_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_netbsd.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target, T
 pub fn target() -> Target {
     let mut base = super::netbsd_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/x86_64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_none.rs
@@ -10,6 +10,7 @@ use super::{RelroLevel, SanitizerSet, StackProbeType, Target, TargetOptions};
 pub fn target() -> Target {
     let opts = TargetOptions {
         cpu: "x86-64".into(),
+        plt_by_default: false,
         max_atomic_width: Some(64),
         stack_probes: StackProbeType::X86,
         position_independent_executables: true,

--- a/compiler/rustc_target/src/spec/x86_64_unknown_openbsd.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_openbsd.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::openbsd_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/x86_64_unknown_redox.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_redox.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::redox_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/x86_64_unknown_uefi.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_uefi.rs
@@ -10,6 +10,7 @@ use crate::spec::Target;
 pub fn target() -> Target {
     let mut base = super::uefi_msvc_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
 
     // We disable MMX and SSE for now, even though UEFI allows using them. Problem is, you have to

--- a/compiler/rustc_target/src/spec/x86_64_uwp_windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/x86_64_uwp_windows_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, Target};
 pub fn target() -> Target {
     let mut base = super::windows_uwp_gnu_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     // Use high-entropy 64 bit address space for ASLR
     base.add_pre_link_args(
         LinkerFlavor::Gnu(Cc::No, Lld::No),

--- a/compiler/rustc_target/src/spec/x86_64_uwp_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/x86_64_uwp_windows_msvc.rs
@@ -3,6 +3,7 @@ use crate::spec::Target;
 pub fn target() -> Target {
     let mut base = super::windows_uwp_msvc_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
 
     Target {

--- a/compiler/rustc_target/src/spec/x86_64_wrs_vxworks.rs
+++ b/compiler/rustc_target/src/spec/x86_64_wrs_vxworks.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::vxworks_base::opts();
     base.cpu = "x86-64".into();
+    base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::X86;

--- a/tests/codegen/stack-protector.rs
+++ b/tests/codegen/stack-protector.rs
@@ -10,25 +10,25 @@
 pub fn foo() {
     // CHECK: @foo() unnamed_addr #0
 
-    // all-NOT: attributes #0 = { {{.*}} sspstrong {{.*}} }
-    // all-NOT: attributes #0 = { {{.*}} ssp {{.*}} }
-    // all: attributes #0 = { {{.*}} sspreq {{.*}} }
-    // all-NOT: attributes #0 = { {{.*}} sspstrong {{.*}} }
-    // all-NOT: attributes #0 = { {{.*}} ssp {{.*}} }
+    // all-NOT: attributes #0 = { {{.*}}sspstrong {{.*}} }
+    // all-NOT: attributes #0 = { {{.*}}ssp {{.*}} }
+    // all: attributes #0 = { {{.*}}sspreq {{.*}} }
+    // all-NOT: attributes #0 = { {{.*}}sspstrong {{.*}} }
+    // all-NOT: attributes #0 = { {{.*}}ssp {{.*}} }
 
-    // strong-NOT: attributes #0 = { {{.*}} sspreq {{.*}} }
-    // strong-NOT: attributes #0 = { {{.*}} ssp {{.*}} }
-    // strong: attributes #0 = { {{.*}} sspstrong {{.*}} }
-    // strong-NOT: attributes #0 = { {{.*}} sspreq {{.*}} }
-    // strong-NOT: attributes #0 = { {{.*}} ssp {{.*}} }
+    // strong-NOT: attributes #0 = { {{.*}}sspreq {{.*}} }
+    // strong-NOT: attributes #0 = { {{.*}}ssp {{.*}} }
+    // strong: attributes #0 = { {{.*}}sspstrong {{.*}} }
+    // strong-NOT: attributes #0 = { {{.*}}sspreq {{.*}} }
+    // strong-NOT: attributes #0 = { {{.*}}ssp {{.*}} }
 
-    // basic-NOT: attributes #0 = { {{.*}} sspreq {{.*}} }
-    // basic-NOT: attributes #0 = { {{.*}} sspstrong {{.*}} }
+    // basic-NOT: attributes #0 = { {{.*}}sspreq {{.*}} }
+    // basic-NOT: attributes #0 = { {{.*}}sspstrong {{.*}} }
     // basic: attributes #0 = { {{.*}}ssp {{.*}} }
-    // basic-NOT: attributes #0 = { {{.*}} sspreq {{.*}} }
-    // basic-NOT: attributes #0 = { {{.*}} sspstrong {{.*}} }
+    // basic-NOT: attributes #0 = { {{.*}}sspreq {{.*}} }
+    // basic-NOT: attributes #0 = { {{.*}}sspstrong {{.*}} }
 
-    // none-NOT: attributes #0 = { {{.*}} sspreq {{.*}} }
-    // none-NOT: attributes #0 = { {{.*}} sspstrong {{.*}} }
-    // none-NOT: attributes #0 = { {{.*}} ssp {{.*}} }
+    // none-NOT: attributes #0 = { {{.*}}sspreq {{.*}} }
+    // none-NOT: attributes #0 = { {{.*}}sspstrong {{.*}} }
+    // none-NOT: attributes #0 = { {{.*}}ssp {{.*}} }
 }

--- a/tests/codegen/stack-protector.rs
+++ b/tests/codegen/stack-protector.rs
@@ -24,7 +24,7 @@ pub fn foo() {
 
     // basic-NOT: attributes #0 = { {{.*}} sspreq {{.*}} }
     // basic-NOT: attributes #0 = { {{.*}} sspstrong {{.*}} }
-    // basic: attributes #0 = { {{.*}} ssp {{.*}} }
+    // basic: attributes #0 = { {{.*}}ssp {{.*}} }
     // basic-NOT: attributes #0 = { {{.*}} sspreq {{.*}} }
     // basic-NOT: attributes #0 = { {{.*}} sspstrong {{.*}} }
 


### PR DESCRIPTION
Per the discussion in #106380 plt=no isn't a great default, and rust-lang/compiler-team#581 decided that the default should be PLT=yes for everything except x86_64. Not everyone agrees about the x86_64 part of this change, but this at least is an improvement in the state of things without changing the x86_64 situation, so I've attempted making this change in the name of not letting the perfect be the enemy of the good.

Please let me know if I've messed this up somehow - I'm not wholly confident I got this right.

r? @nikic 