### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -553,7 +553,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
             }
 
             Rvalue::Cast(CastKind::DynStar, _, _) => {
-                unimplemented!()
+                // `dyn*` coercion is implemented for CTFE.
             }
 
             Rvalue::Cast(_, _, _) => {}

--- a/compiler/rustc_log/src/lib.rs
+++ b/compiler/rustc_log/src/lib.rs
@@ -83,7 +83,7 @@ pub fn init_env_logger(env: &str) -> Result<(), Error> {
         .with_verbose_exit(verbose_entry_exit)
         .with_verbose_entry(verbose_entry_exit)
         .with_indent_amount(2);
-    #[cfg(parallel_compiler)]
+    #[cfg(all(parallel_compiler, debug_assertions))]
     let layer = layer.with_thread_ids(true).with_thread_names(true);
 
     let subscriber = tracing_subscriber::Registry::default().with(filter).with(layer);

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -207,5 +207,9 @@ resolve_expected_found =
 resolve_indeterminate =
     cannot determine resolution for the visibility
 
+resolve_tool_module_imported =
+    cannot use a tool module through an import
+    .note = the tool module imported here
+
 resolve_module_only =
     visibility must resolve to a module

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -470,5 +470,14 @@ pub(crate) struct ExpectedFound {
 pub(crate) struct Indeterminate(#[primary_span] pub(crate) Span);
 
 #[derive(Diagnostic)]
+#[diag(resolve_tool_module_imported)]
+pub(crate) struct ToolModuleImported {
+    #[primary_span]
+    pub(crate) span: Span,
+    #[note]
+    pub(crate) import: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(resolve_module_only)]
 pub(crate) struct ModuleOnly(#[primary_span] pub(crate) Span);

--- a/compiler/rustc_target/src/spec/aarch64_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_linux_ohos.rs
@@ -18,6 +18,7 @@ pub fn target() -> Target {
             features: "+reserve-x18".into(),
             mcount: "\u{1}_mcount".into(),
             force_emulated_tls: true,
+            has_thread_local: false,
             supported_sanitizers: SanitizerSet::ADDRESS
                 | SanitizerSet::CFI
                 | SanitizerSet::LEAK

--- a/compiler/rustc_target/src/spec/armv7_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/armv7_unknown_linux_ohos.rs
@@ -21,6 +21,7 @@ pub fn target() -> Target {
             crt_static_default: false,
             mcount: "\u{1}mcount".into(),
             force_emulated_tls: true,
+            has_thread_local: false,
             ..super::linux_musl_base::opts()
         },
     }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -6,6 +6,10 @@
 	3. Copy the filenames with updated suffixes from the directory.
 */
 
+:root {
+	--nav-sub-mobile-padding: 8px;
+}
+
 /* See FiraSans-LICENSE.txt for the Fira Sans license. */
 @font-face {
 	font-family: 'Fira Sans';
@@ -1726,7 +1730,7 @@ in main.js
 
 	.source nav.sub {
 		margin: 0;
-		padding: 8px;
+		padding: var(--nav-sub-mobile-padding);
 	}
 }
 
@@ -1783,6 +1787,7 @@ in main.js
 	.sub-logo-container > img {
 		height: 35px;
 		width: 35px;
+		margin-bottom: var(--nav-sub-mobile-padding);
 	}
 }
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -203,7 +203,7 @@ fn init_logging() {
         .with_verbose_exit(true)
         .with_verbose_entry(true)
         .with_indent_amount(2);
-    #[cfg(parallel_compiler)]
+    #[cfg(all(parallel_compiler, debug_assertions))]
     let layer = layer.with_thread_ids(true).with_thread_names(true);
 
     use tracing_subscriber::layer::SubscriberExt;

--- a/tests/rustdoc-gui/huge-logo.goml
+++ b/tests/rustdoc-gui/huge-logo.goml
@@ -18,4 +18,6 @@ size: (1280, 1024)
 assert-property: (".sub-logo-container", {"offsetWidth": "60", "offsetHeight": 60})
 
 size: (400, 600)
-assert-property: (".sub-logo-container", {"offsetWidth": "35", "offsetHeight": 35})
+// 43 because 35px + 8px of margin
+assert-css: (".sub-logo-container > img", {"margin-bottom": "8px"})
+assert-property: (".sub-logo-container", {"offsetWidth": "35", "offsetHeight": 43})

--- a/tests/rustdoc-gui/source-code-page.goml
+++ b/tests/rustdoc-gui/source-code-page.goml
@@ -216,3 +216,8 @@ call-function: ("check-sidebar-dir-entry", {
     "x": 0,
     "y": |source_sidebar_title_y| + |source_sidebar_title_height| + 6,
 })
+
+// Now we check that the logo has a bottom margin so it's not stuck to the search input.
+assert-css: (".sub-logo-container > img", {"margin-bottom": "8px"})
+store-property: (logo_height, ".sub-logo-container", "clientHeight")
+assert-position: (".search-form", {"y": |logo_height| + 8})

--- a/tests/ui/const_prop/issue-86351.rs
+++ b/tests/ui/const_prop/issue-86351.rs
@@ -1,0 +1,22 @@
+// compile-flags: --crate-type=lib -Zmir-opt-level=2
+// build-pass
+// ^-- Must be build-pass, because check-pass will not run const prop.
+
+pub trait TestTrait {
+    type MyType;
+    fn func() -> Option<Self>
+    where
+        Self: Sized;
+}
+
+impl<T> dyn TestTrait<MyType = T>
+where
+    Self: Sized,
+{
+    pub fn other_func() -> Option<Self> {
+        match Self::func() {
+            Some(me) => Some(me),
+            None => None,
+        }
+    }
+}

--- a/tests/ui/dyn-star/const-and-static.rs
+++ b/tests/ui/dyn-star/const-and-static.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+#![feature(dyn_star)]
+//~^ WARN the feature `dyn_star` is incomplete
+
+const C: dyn* Send + Sync = &();
+
+static S: dyn* Send + Sync = &();
+
+fn main() {}

--- a/tests/ui/dyn-star/const-and-static.stderr
+++ b/tests/ui/dyn-star/const-and-static.stderr
@@ -1,0 +1,11 @@
+warning: the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/const-and-static.rs:3:12
+   |
+LL | #![feature(dyn_star)]
+   |            ^^^^^^^^
+   |
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/inference/issue-80409.rs
+++ b/tests/ui/inference/issue-80409.rs
@@ -1,0 +1,36 @@
+// check-pass
+
+#![allow(unreachable_code, unused)]
+
+use std::marker::PhantomData;
+
+struct FsmBuilder<TFsm> {
+    _fsm: PhantomData<TFsm>,
+}
+
+impl<TFsm> FsmBuilder<TFsm> {
+    fn state(&mut self) -> FsmStateBuilder<TFsm> {
+        todo!()
+    }
+}
+
+struct FsmStateBuilder<TFsm> {
+    _state: PhantomData<TFsm>,
+}
+
+impl<TFsm> FsmStateBuilder<TFsm> {
+    fn on_entry<TAction: Fn(&mut StateContext<'_, TFsm>)>(&self, _action: TAction) {}
+}
+
+trait Fsm {
+    type Context;
+}
+
+struct StateContext<'a, TFsm: Fsm> {
+    context: &'a mut TFsm::Context,
+}
+
+fn main() {
+    let mut builder: FsmBuilder<usize> = todo!();
+    builder.state().on_entry(|_| {});
+}

--- a/tests/ui/resolve/tool-import.rs
+++ b/tests/ui/resolve/tool-import.rs
@@ -1,0 +1,8 @@
+// edition: 2018
+
+use clippy::time::Instant;
+//~^ `clippy` is a tool module
+
+fn main() {
+    Instant::now();
+}

--- a/tests/ui/resolve/tool-import.stderr
+++ b/tests/ui/resolve/tool-import.stderr
@@ -1,0 +1,9 @@
+error[E0433]: failed to resolve: `clippy` is a tool module, not a module
+  --> $DIR/tool-import.rs:3:5
+   |
+LL | use clippy::time::Instant;
+   |     ^^^^^^ `clippy` is a tool module, not a module
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Successful merges:

 - #109909 (Deny `use`ing tool paths)
 - #109921 (Don't ICE when encountering `dyn*` in statics or consts)
 - #109922 (Disable `has_thread_local` on OpenHarmony)
 - #109926 (write threads info into log only when debugging)
 - #109968 (Add regression test for #80409)
 - #109969 (Add regression test for #86351)
 - #109973 (rustdoc: Improve logo display very small screen)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=109909,109921,109922,109926,109968,109969,109973)
<!-- homu-ignore:end -->