### PR TITLE
Added diagnostic/suggestion for core::pin::pin! in addition to Box::pin if Unpin isn't implemented

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -823,7 +823,7 @@ unsafe impl<T: ?Sized> Freeze for &mut T {}
 /// [`pin` module]: crate::pin
 #[stable(feature = "pin", since = "1.33.0")]
 #[rustc_on_unimplemented(
-    note = "consider using `core::pin::pin!`\nconsider using `Box::pin` if you want ownership of the pinned value",
+    note = "consider using `std::pin::pin!`\nconsider using `Box::pin` if you need to access the pinned value outside of the current scope",
     message = "`{Self}` cannot be unpinned"
 )]
 #[lang = "unpin"]

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -823,7 +823,7 @@ unsafe impl<T: ?Sized> Freeze for &mut T {}
 /// [`pin` module]: crate::pin
 #[stable(feature = "pin", since = "1.33.0")]
 #[rustc_on_unimplemented(
-    note = "consider using `Box::pin`",
+    note = "consider using `core::pin::pin!`\nconsider using `Box::pin` if you want ownership of the pinned value",
     message = "`{Self}` cannot be unpinned"
 )]
 #[lang = "unpin"]

--- a/tests/ui/async-await/pin-needed-to-poll-2.stderr
+++ b/tests/ui/async-await/pin-needed-to-poll-2.stderr
@@ -6,7 +6,8 @@ LL |         Pin::new(&mut self.sleep).poll(cx)
    |         |
    |         required by a bound introduced by this call
    |
-   = note: consider using `Box::pin`
+   = note: consider using `core::pin::pin!`
+           consider using `Box::pin` if you want ownership of the pinned value
 note: required because it appears within the type `Sleep`
   --> $DIR/pin-needed-to-poll-2.rs:8:8
    |

--- a/tests/ui/async-await/pin-needed-to-poll-2.stderr
+++ b/tests/ui/async-await/pin-needed-to-poll-2.stderr
@@ -6,8 +6,8 @@ LL |         Pin::new(&mut self.sleep).poll(cx)
    |         |
    |         required by a bound introduced by this call
    |
-   = note: consider using `core::pin::pin!`
-           consider using `Box::pin` if you want ownership of the pinned value
+   = note: consider using `std::pin::pin!`
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required because it appears within the type `Sleep`
   --> $DIR/pin-needed-to-poll-2.rs:8:8
    |

--- a/tests/ui/generator/static-not-unpin.stderr
+++ b/tests/ui/generator/static-not-unpin.stderr
@@ -6,8 +6,8 @@ LL |     assert_unpin(generator);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `core::pin::pin!`
-           consider using `Box::pin` if you want ownership of the pinned value
+   = note: consider using `std::pin::pin!`
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `assert_unpin`
   --> $DIR/static-not-unpin.rs:7:20
    |

--- a/tests/ui/generator/static-not-unpin.stderr
+++ b/tests/ui/generator/static-not-unpin.stderr
@@ -6,7 +6,8 @@ LL |     assert_unpin(generator);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `Box::pin`
+   = note: consider using `core::pin::pin!`
+           consider using `Box::pin` if you want ownership of the pinned value
 note: required by a bound in `assert_unpin`
   --> $DIR/static-not-unpin.rs:7:20
    |

--- a/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
+++ b/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
@@ -50,7 +50,8 @@ LL |     Pin::new(x)
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `Box::pin`
+   = note: consider using `core::pin::pin!`
+           consider using `Box::pin` if you want ownership of the pinned value
 note: required by a bound in `Pin::<P>::new`
   --> $SRC_DIR/core/src/pin.rs:LL:COL
 
@@ -62,7 +63,8 @@ LL |     Pin::new(Box::new(x))
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `Box::pin`
+   = note: consider using `core::pin::pin!`
+           consider using `Box::pin` if you want ownership of the pinned value
 note: required by a bound in `Pin::<P>::new`
   --> $SRC_DIR/core/src/pin.rs:LL:COL
 

--- a/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
+++ b/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
@@ -50,8 +50,8 @@ LL |     Pin::new(x)
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `core::pin::pin!`
-           consider using `Box::pin` if you want ownership of the pinned value
+   = note: consider using `std::pin::pin!`
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `Pin::<P>::new`
   --> $SRC_DIR/core/src/pin.rs:LL:COL
 
@@ -63,8 +63,8 @@ LL |     Pin::new(Box::new(x))
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `core::pin::pin!`
-           consider using `Box::pin` if you want ownership of the pinned value
+   = note: consider using `std::pin::pin!`
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `Pin::<P>::new`
   --> $SRC_DIR/core/src/pin.rs:LL:COL
 

--- a/tests/ui/suggestions/issue-84973-blacklist.stderr
+++ b/tests/ui/suggestions/issue-84973-blacklist.stderr
@@ -38,7 +38,8 @@ LL |     f_unpin(static || { yield; });
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `Box::pin`
+   = note: consider using `core::pin::pin!`
+           consider using `Box::pin` if you want ownership of the pinned value
 note: required by a bound in `f_unpin`
   --> $DIR/issue-84973-blacklist.rs:8:15
    |

--- a/tests/ui/suggestions/issue-84973-blacklist.stderr
+++ b/tests/ui/suggestions/issue-84973-blacklist.stderr
@@ -38,8 +38,8 @@ LL |     f_unpin(static || { yield; });
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `core::pin::pin!`
-           consider using `Box::pin` if you want ownership of the pinned value
+   = note: consider using `std::pin::pin!`
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `f_unpin`
   --> $DIR/issue-84973-blacklist.rs:8:15
    |

--- a/tests/ui/suggestions/suggest-pin-macro.rs
+++ b/tests/ui/suggestions/suggest-pin-macro.rs
@@ -1,0 +1,24 @@
+use std::pin::Pin;
+use std::marker::PhantomPinned;
+
+#[derive(Debug)]
+struct Test {
+    _marker: PhantomPinned,
+}
+impl Test {
+    fn new() -> Self {
+        Test {
+            _marker: PhantomPinned, // This makes our type `!Unpin`
+        }
+    }
+}
+
+fn dummy(_: &mut Test) {}
+
+pub fn main() {
+    let mut test1 = Test::new();
+    let mut test1 = unsafe { Pin::new_unchecked(&mut test1) };
+
+    dummy(test1.get_mut()); //~ ERROR E0277
+}
+

--- a/tests/ui/suggestions/suggest-pin-macro.rs
+++ b/tests/ui/suggestions/suggest-pin-macro.rs
@@ -21,4 +21,3 @@ pub fn main() {
 
     dummy(test1.get_mut()); //~ ERROR E0277
 }
-

--- a/tests/ui/suggestions/suggest-pin-macro.stderr
+++ b/tests/ui/suggestions/suggest-pin-macro.stderr
@@ -1,0 +1,19 @@
+error[E0277]: `PhantomPinned` cannot be unpinned
+  --> $DIR/suggest-pin-macro.rs:22:17
+   |
+LL |     dummy(test1.get_mut());
+   |                 ^^^^^^^ within `Test`, the trait `Unpin` is not implemented for `PhantomPinned`
+   |
+   = note: consider using `core::pin::pin!`
+           consider using `Box::pin` if you want ownership of the pinned value
+note: required because it appears within the type `Test`
+  --> $DIR/suggest-pin-macro.rs:5:8
+   |
+LL | struct Test {
+   |        ^^^^
+note: required by a bound in `Pin::<&'a mut T>::get_mut`
+  --> $SRC_DIR/core/src/pin.rs:LL:COL
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/suggest-pin-macro.stderr
+++ b/tests/ui/suggestions/suggest-pin-macro.stderr
@@ -4,8 +4,8 @@ error[E0277]: `PhantomPinned` cannot be unpinned
 LL |     dummy(test1.get_mut());
    |                 ^^^^^^^ within `Test`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-   = note: consider using `core::pin::pin!`
-           consider using `Box::pin` if you want ownership of the pinned value
+   = note: consider using `std::pin::pin!`
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required because it appears within the type `Test`
   --> $DIR/suggest-pin-macro.rs:5:8
    |

--- a/tests/ui/typeck/issue-90164.stderr
+++ b/tests/ui/typeck/issue-90164.stderr
@@ -6,8 +6,8 @@ LL |     copy(r, w);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `core::pin::pin!`
-           consider using `Box::pin` if you want ownership of the pinned value
+   = note: consider using `std::pin::pin!`
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `copy`
   --> $DIR/issue-90164.rs:1:12
    |

--- a/tests/ui/typeck/issue-90164.stderr
+++ b/tests/ui/typeck/issue-90164.stderr
@@ -6,7 +6,8 @@ LL |     copy(r, w);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `Box::pin`
+   = note: consider using `core::pin::pin!`
+           consider using `Box::pin` if you want ownership of the pinned value
 note: required by a bound in `copy`
   --> $DIR/issue-90164.rs:1:12
    |


### PR DESCRIPTION
Currently, if an operation on `Pin<T>` is performed that requires `T` to implement `Unpin`, the diagnostic suggestion is to use `Box::pin` ("note: consider using `Box::pin`").

As others have noted, using `pin!` avoids a heap allocation, so it should be suggested as well (and probably over `Box::pin` whenever possible).

This PR adds the diagnostic "consider using `Box::pin` if you want ownership of the pinned value", and updates tests to match.

Addresses/attempts to address #109964 