### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -112,8 +112,6 @@ impl<'a, 'tcx> Encoder for EncodeContext<'a, 'tcx> {
         emit_i8(i8);
 
         emit_bool(bool);
-        emit_f64(f64);
-        emit_f32(f32);
         emit_char(char);
         emit_str(&str);
         emit_raw_bytes(&[u8]);

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -511,8 +511,6 @@ macro_rules! implement_ty_decoder {
                     read_isize -> isize;
 
                     read_bool -> bool;
-                    read_f64 -> f64;
-                    read_f32 -> f32;
                     read_char -> char;
                     read_str -> &str;
                 }

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -1046,8 +1046,6 @@ impl<'a, 'tcx> Encoder for CacheEncoder<'a, 'tcx> {
         emit_i8(i8);
 
         emit_bool(bool);
-        emit_f64(f64);
-        emit_f32(f32);
         emit_char(char);
         emit_str(&str);
         emit_raw_bytes(&[u8]);

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -123,18 +123,6 @@ impl Encoder for MemEncoder {
     }
 
     #[inline]
-    fn emit_f64(&mut self, v: f64) {
-        let as_u64: u64 = v.to_bits();
-        self.emit_u64(as_u64);
-    }
-
-    #[inline]
-    fn emit_f32(&mut self, v: f32) {
-        let as_u32: u32 = v.to_bits();
-        self.emit_u32(as_u32);
-    }
-
-    #[inline]
     fn emit_char(&mut self, v: char) {
         self.emit_u32(v as u32);
     }
@@ -501,18 +489,6 @@ impl Encoder for FileEncoder {
     }
 
     #[inline]
-    fn emit_f64(&mut self, v: f64) {
-        let as_u64: u64 = v.to_bits();
-        self.emit_u64(as_u64);
-    }
-
-    #[inline]
-    fn emit_f32(&mut self, v: f32) {
-        let as_u32: u32 = v.to_bits();
-        self.emit_u32(as_u32);
-    }
-
-    #[inline]
     fn emit_char(&mut self, v: char) {
         self.emit_u32(v as u32);
     }
@@ -640,18 +616,6 @@ impl<'a> Decoder for MemDecoder<'a> {
     fn read_bool(&mut self) -> bool {
         let value = self.read_u8();
         value != 0
-    }
-
-    #[inline]
-    fn read_f64(&mut self) -> f64 {
-        let bits = self.read_u64();
-        f64::from_bits(bits)
-    }
-
-    #[inline]
-    fn read_f32(&mut self) -> f32 {
-        let bits = self.read_u32();
-        f32::from_bits(bits)
     }
 
     #[inline]

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -22,6 +22,11 @@ use std::sync::Arc;
 /// be processed or ignored, whichever is appropriate. Then they should provide
 /// a `finish` method that finishes up encoding. If the encoder is fallible,
 /// `finish` should return a `Result` that indicates success or failure.
+///
+/// This current does not support `f32` nor `f64`, as they're not needed in any
+/// serialized data structures. That could be changed, but consider whether it
+/// really makes sense to store floating-point values at all.
+/// (If you need it, revert <https://github.com/rust-lang/rust/pull/109984>.)
 pub trait Encoder {
     // Primitive types:
     fn emit_usize(&mut self, v: usize);
@@ -37,8 +42,6 @@ pub trait Encoder {
     fn emit_i16(&mut self, v: i16);
     fn emit_i8(&mut self, v: i8);
     fn emit_bool(&mut self, v: bool);
-    fn emit_f64(&mut self, v: f64);
-    fn emit_f32(&mut self, v: f32);
     fn emit_char(&mut self, v: char);
     fn emit_str(&mut self, v: &str);
     fn emit_raw_bytes(&mut self, s: &[u8]);
@@ -58,6 +61,11 @@ pub trait Encoder {
 // top-level invocation would also just panic on failure. Switching to
 // infallibility made things faster and lots of code a little simpler and more
 // concise.
+///
+/// This current does not support `f32` nor `f64`, as they're not needed in any
+/// serialized data structures. That could be changed, but consider whether it
+/// really makes sense to store floating-point values at all.
+/// (If you need it, revert <https://github.com/rust-lang/rust/pull/109984>.)
 pub trait Decoder {
     // Primitive types:
     fn read_usize(&mut self) -> usize;
@@ -73,8 +81,6 @@ pub trait Decoder {
     fn read_i16(&mut self) -> i16;
     fn read_i8(&mut self) -> i8;
     fn read_bool(&mut self) -> bool;
-    fn read_f64(&mut self) -> f64;
-    fn read_f32(&mut self) -> f32;
     fn read_char(&mut self) -> char;
     fn read_str(&mut self) -> &str;
     fn read_raw_bytes(&mut self, len: usize) -> &[u8];
@@ -143,8 +149,6 @@ direct_serialize_impls! {
     i64 emit_i64 read_i64,
     i128 emit_i128 read_i128,
 
-    f32 emit_f32 read_f32,
-    f64 emit_f64 read_f64,
     bool emit_bool read_bool,
     char emit_char read_char
 }

--- a/compiler/rustc_serialize/tests/opaque.rs
+++ b/compiler/rustc_serialize/tests/opaque.rs
@@ -22,8 +22,6 @@ struct Struct {
 
     l: char,
     m: String,
-    n: f32,
-    o: f64,
     p: bool,
     q: Option<u32>,
 }
@@ -120,24 +118,6 @@ fn test_bool() {
 }
 
 #[test]
-fn test_f32() {
-    let mut vec = vec![];
-    for i in -100..100 {
-        vec.push((i as f32) / 3.0);
-    }
-    check_round_trip(vec);
-}
-
-#[test]
-fn test_f64() {
-    let mut vec = vec![];
-    for i in -100..100 {
-        vec.push((i as f64) / 3.0);
-    }
-    check_round_trip(vec);
-}
-
-#[test]
 fn test_char() {
     let vec = vec!['a', 'b', 'c', 'd', 'A', 'X', ' ', '#', 'Ö', 'Ä', 'µ', '€'];
     check_round_trip(vec);
@@ -200,8 +180,6 @@ fn test_struct() {
 
         l: 'x',
         m: "abc".to_string(),
-        n: 20.5,
-        o: 21.5,
         p: false,
         q: None,
     }]);
@@ -222,8 +200,6 @@ fn test_struct() {
 
         l: 'y',
         m: "def".to_string(),
-        n: -20.5,
-        o: -21.5,
         p: true,
         q: Some(1234567),
     }]);
@@ -232,7 +208,7 @@ fn test_struct() {
 #[derive(PartialEq, Clone, Debug, Encodable, Decodable)]
 enum Enum {
     Variant1,
-    Variant2(usize, f32),
+    Variant2(usize, u32),
     Variant3 { a: i32, b: char, c: bool },
 }
 
@@ -240,7 +216,7 @@ enum Enum {
 fn test_enum() {
     check_round_trip(vec![
         Enum::Variant1,
-        Enum::Variant2(1, 2.5),
+        Enum::Variant2(1, 25),
         Enum::Variant3 { a: 3, b: 'b', c: false },
         Enum::Variant3 { a: -4, b: 'f', c: true },
     ]);
@@ -269,8 +245,8 @@ fn test_hash_map() {
 
 #[test]
 fn test_tuples() {
-    check_round_trip(vec![('x', (), false, 0.5f32)]);
-    check_round_trip(vec![(9i8, 10u16, 1.5f64)]);
+    check_round_trip(vec![('x', (), false, 5u32)]);
+    check_round_trip(vec![(9i8, 10u16, 15i64)]);
     check_round_trip(vec![(-12i16, 11u8, 12usize)]);
     check_round_trip(vec![(1234567isize, 100000000000000u64, 99999999999999i64)]);
     check_round_trip(vec![(String::new(), "some string".to_string())]);

--- a/compiler/rustc_span/src/edit_distance.rs
+++ b/compiler/rustc_span/src/edit_distance.rs
@@ -218,6 +218,9 @@ fn find_best_match_for_name_impl(
         }
     }
 
+    // We have a tie among several candidates, try to select the best among them ignoring substrings.
+    // For example, the candidates list `force_capture`, `capture`, and user inputed `forced_capture`,
+    // we select `force_capture` with a extra round of edit distance calculation.
     if next_candidates.len() > 1 {
         debug_assert!(use_substring_score);
         best = find_best_match_for_name_impl(

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -284,14 +284,10 @@ impl<'cx, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for QueryNormalizer<'cx, 'tcx> 
                 let result = tcx.normalize_projection_ty(c_data)?;
                 // We don't expect ambiguity.
                 if result.is_ambiguous() {
-                    // Rustdoc normalizes possibly not well-formed types, so only
-                    // treat this as a bug if we're not in rustdoc.
-                    if !tcx.sess.opts.actually_rustdoc {
-                        tcx.sess.delay_span_bug(
-                            DUMMY_SP,
-                            format!("unexpected ambiguity: {:?} {:?}", c_data, result),
-                        );
-                    }
+                    tcx.sess.delay_span_bug(
+                        DUMMY_SP,
+                        format!("unexpected ambiguity: {:?} {:?}", c_data, result),
+                    );
                     return Err(NoSolution);
                 }
                 let InferOk { value: result, obligations } =

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -359,7 +359,7 @@ use crate::vec::Vec;
 /// [Deref]: core::ops::Deref "ops::Deref"
 /// [`Deref`]: core::ops::Deref "ops::Deref"
 /// [`as_str()`]: String::as_str
-#[derive(PartialOrd, Eq, Ord)]
+#[derive(PartialEq, PartialOrd, Eq, Ord)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), lang = "String")]
 pub struct String {
@@ -2204,14 +2204,6 @@ impl<'a, 'b> Pattern<'a> for &'b String {
     #[inline]
     fn strip_suffix_of(self, haystack: &'a str) -> Option<&'a str> {
         self[..].strip_suffix_of(haystack)
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl PartialEq for String {
-    #[inline]
-    fn eq(&self, other: &String) -> bool {
-        PartialEq::eq(&self[..], &other[..])
     }
 }
 

--- a/src/bootstrap/config/tests.rs
+++ b/src/bootstrap/config/tests.rs
@@ -33,35 +33,54 @@ fn download_ci_llvm() {
     ));
 }
 
+// FIXME(ozkanonur): extend scope of the test
+// refs:
+//   - https://github.com/rust-lang/rust/issues/109120
+//   - https://github.com/rust-lang/rust/pull/109162#issuecomment-1496782487
 #[test]
 fn detect_src_and_out() {
-    let cfg = parse("");
+    fn test(cfg: Config, build_dir: Option<&str>) {
+        // This will bring absolute form of `src/bootstrap` path
+        let current_dir = std::env::current_dir().unwrap();
 
-    // This will bring absolute form of `src/bootstrap` path
-    let current_dir = std::env::current_dir().unwrap();
+        // get `src` by moving into project root path
+        let expected_src = current_dir.ancestors().nth(2).unwrap();
+        assert_eq!(&cfg.src, expected_src);
 
-    // get `src` by moving into project root path
-    let expected_src = current_dir.ancestors().nth(2).unwrap();
+        // Sanity check for `src`
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let expected_src = manifest_dir.ancestors().nth(2).unwrap();
+        assert_eq!(&cfg.src, expected_src);
 
-    assert_eq!(&cfg.src, expected_src);
+        // test if build-dir was manually given in config.toml
+        if let Some(custom_build_dir) = build_dir {
+            assert_eq!(&cfg.out, Path::new(custom_build_dir));
+        }
+        // test the native bootstrap way
+        else {
+            // This should bring output path of bootstrap in absolute form
+            let cargo_target_dir = env::var_os("CARGO_TARGET_DIR").expect(
+                "CARGO_TARGET_DIR must been provided for the test environment from bootstrap",
+            );
 
-    // This should bring output path of bootstrap in absolute form
-    let cargo_target_dir = env::var_os("CARGO_TARGET_DIR")
-        .expect("CARGO_TARGET_DIR must been provided for the test environment from bootstrap");
+            // Move to `build` from `build/bootstrap`
+            let expected_out = Path::new(&cargo_target_dir).parent().unwrap();
+            assert_eq!(&cfg.out, expected_out);
 
-    // Move to `build` from `build/bootstrap`
-    let expected_out = Path::new(&cargo_target_dir).parent().unwrap();
-    assert_eq!(&cfg.out, expected_out);
+            let args: Vec<String> = env::args().collect();
 
-    let args: Vec<String> = env::args().collect();
+            // Another test for `out` as a sanity check
+            //
+            // This will bring something similar to:
+            //     `{build-dir}/bootstrap/debug/deps/bootstrap-c7ee91d5661e2804`
+            // `{build-dir}` can be anywhere, not just in the rust project directory.
+            let dep = Path::new(args.first().unwrap());
+            let expected_out = dep.ancestors().nth(4).unwrap();
 
-    // Another test for `out` as a sanity check
-    //
-    // This will bring something similar to:
-    //     `{config_toml_place}/build/bootstrap/debug/deps/bootstrap-c7ee91d5661e2804`
-    // `{config_toml_place}` can be anywhere, not just in the rust project directory.
-    let dep = Path::new(args.first().unwrap());
-    let expected_out = dep.ancestors().nth(4).unwrap();
+            assert_eq!(&cfg.out, expected_out);
+        }
+    }
 
-    assert_eq!(&cfg.out, expected_out);
+    test(parse(""), None);
+    test(parse("build.build-dir = \"/tmp\""), Some("/tmp"));
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1666,22 +1666,46 @@ fn normalize<'tcx>(
     }
 
     use crate::rustc_trait_selection::infer::TyCtxtInferExt;
-    use crate::rustc_trait_selection::traits::query::normalize::QueryNormalizeExt;
+    use crate::rustc_trait_selection::traits::ObligationCtxt;
     use rustc_middle::traits::ObligationCause;
 
-    // Try to normalize `<X as Y>::T` to a type
+    assert!(
+        !ty.has_non_region_infer(),
+        "`ty`: {:?} has pre existing infer vars before `InferCtxt` creation",
+        ty
+    );
+
     let infcx = cx.tcx.infer_ctxt().build();
-    let normalized = infcx
-        .at(&ObligationCause::dummy(), cx.param_env)
-        .query_normalize(ty)
-        .map(|resolved| infcx.resolve_vars_if_possible(resolved.value));
-    match normalized {
-        Ok(normalized_value) => {
-            debug!("normalized {:?} to {:?}", ty, normalized_value);
-            Some(normalized_value)
+    // use an `ObligationCtxt` as it has a nice API for dealing with returned obligations from normalization
+    // and does not expect us to be inside of typeck. It also does not ICE when the projection could not be
+    // normalized like some other normalization routines (`QueryNormalizer`, `normalize_erasing_regions`, etc)
+    let ocx = ObligationCtxt::new(&infcx);
+
+    // Try to normalize `<X as Y>::T` to a type
+    let normalized = ocx.normalize(&ObligationCause::dummy(), cx.param_env, ty);
+    // We have to ensure that we deal with nested obligations from attempting to normalize as `ty`
+    // normalizing to `normalized` is only the case if the nested obligations hold.
+    let errs = ocx.select_all_or_error();
+    // Evaluating nested obligations might constrain infer vars that were created during normalization
+    // so we should resolve any infer vars in `normalized` to their new values.
+    let normalized = infcx.resolve_vars_if_possible(normalized);
+
+    match errs.as_slice() {
+        [] if normalized == ty => {
+            debug!("normalizing {:?} did not make progress", ty);
+            None
         }
-        Err(err) => {
-            debug!("failed to normalize {:?}: {:?}", ty, err);
+        [] => {
+            debug!("normalized {:?} to {:?}", ty, normalized);
+
+            assert!(
+                !normalized.has_non_region_infer(),
+                "`normalized` has infer vars which would escape the `InferCtxt` they were created in"
+            );
+            Some(normalized)
+        }
+        errs => {
+            debug!("failed to normalize {:?}: {:?}", ty, errs);
             None
         }
     }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1671,8 +1671,7 @@ fn normalize<'tcx>(
 
     assert!(
         !ty.has_non_region_infer(),
-        "`ty`: {:?} has pre existing infer vars before `InferCtxt` creation",
-        ty
+        "`ty`: {ty:?} has pre existing infer vars before `InferCtxt` creation",
     );
 
     let infcx = cx.tcx.infer_ctxt().build();

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -348,7 +348,7 @@ pre.item-decl {
 .source .content pre {
 	padding: 20px;
 }
-.rustdoc.source .example-wrap > pre.src-line-numbers  {
+.rustdoc.source .example-wrap pre.src-line-numbers  {
 	padding: 20px 0 20px 4px;
 }
 
@@ -533,17 +533,17 @@ ul.block, .block li {
 	margin-bottom: 0px;
 }
 
-.rustdoc .example-wrap > pre {
+.rustdoc .example-wrap pre {
 	margin: 0;
 	flex-grow: 1;
 }
 
-.rustdoc:not(.source) .example-wrap > pre {
+.rustdoc:not(.source) .example-wrap pre {
 	overflow: auto hidden;
 }
 
-.rustdoc .example-wrap > pre.example-line-numbers,
-.rustdoc .example-wrap > pre.src-line-numbers {
+.rustdoc .example-wrap pre.example-line-numbers,
+.rustdoc .example-wrap pre.src-line-numbers {
 	flex-grow: 0;
 	min-width: fit-content; /* prevent collapsing into nothing in truncated scraped examples */
 	overflow: initial;
@@ -554,7 +554,7 @@ ul.block, .block li {
 	color: var(--src-line-numbers-span-color);
 }
 
-.rustdoc .example-wrap > pre.src-line-numbers {
+.rustdoc .example-wrap pre.src-line-numbers {
 	padding: 14px 0;
 }
 .src-line-numbers a, .src-line-numbers span {
@@ -702,7 +702,7 @@ h2.small-section-header > .anchor {
 }
 
 .main-heading a:hover,
-.example-wrap > .rust a:hover,
+.example-wrap .rust a:hover,
 .all-items a:hover,
 .docblock a:not(.test-arrow):not(.scrape-help):not(.tooltip):hover,
 .docblock-short a:not(.test-arrow):not(.scrape-help):not(.tooltip):hover,

--- a/src/librustdoc/html/templates/source.html
+++ b/src/librustdoc/html/templates/source.html
@@ -1,5 +1,7 @@
 <div class="example-wrap"> {# #}
-    <pre class="src-line-numbers">
+    {# https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#data-nosnippet-attr
+       Do not show "1 2 3 4 5 ..." in web search results. #}
+    <div data-nosnippet><pre class="src-line-numbers">
         {% for line in lines.clone() %}
             {% if embedded %}
                 <span>{{line|safe}}</span>
@@ -7,7 +9,7 @@
                 <a href="#{{line|safe}}" id="{{line|safe}}">{{line|safe}}</a>
             {%~ endif %}
         {% endfor %}
-    </pre> {# #}
+    </pre></div> {# #}
     <pre class="rust"> {# #}
         <code>
             {% if needs_expansion %}

--- a/tests/ui/suggestions/issue-109291.rs
+++ b/tests/ui/suggestions/issue-109291.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("Custom backtrace: {}", std::backtrace::Backtrace::forced_capture());
+    //~^ ERROR no function or associated item name
+}

--- a/tests/ui/suggestions/issue-109291.stderr
+++ b/tests/ui/suggestions/issue-109291.stderr
@@ -1,0 +1,12 @@
+error[E0599]: no function or associated item named `forced_capture` found for struct `Backtrace` in the current scope
+  --> $DIR/issue-109291.rs:2:65
+   |
+LL |     println!("Custom backtrace: {}", std::backtrace::Backtrace::forced_capture());
+   |                                                                 ^^^^^^^^^^^^^^
+   |                                                                 |
+   |                                                                 function or associated item not found in `Backtrace`
+   |                                                                 help: there is an associated function with a similar name: `force_capture`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.fail.stderr
+++ b/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.fail.stderr
@@ -1,0 +1,18 @@
+error[E0277]: `impl Future<Output = ()>` cannot be sent between threads safely
+  --> $DIR/auto-with-drop_tracking_mir.rs:24:13
+   |
+LL |     is_send(foo());
+   |     ------- ^^^^^ `impl Future<Output = ()>` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Send` is not implemented for `impl Future<Output = ()>`
+note: required by a bound in `is_send`
+  --> $DIR/auto-with-drop_tracking_mir.rs:23:24
+   |
+LL |     fn is_send(_: impl Send) {}
+   |                        ^^^^ required by this bound in `is_send`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.rs
+++ b/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.rs
@@ -1,0 +1,26 @@
+// compile-flags: -Ztrait-solver=next -Zdrop-tracking-mir
+// edition: 2021
+// revisions: pass fail
+//[pass] check-pass
+
+#![feature(negative_impls)]
+
+struct NotSync;
+impl !Sync for NotSync {}
+
+async fn foo() {
+    #[cfg(pass)]
+    let x = &();
+    #[cfg(fail)]
+    let x = &NotSync;
+    bar().await;
+    drop(x);
+}
+
+async fn bar() {}
+
+fn main() {
+    fn is_send(_: impl Send) {}
+    is_send(foo());
+    //[fail]~^ ERROR `impl Future<Output = ()>` cannot be sent between threads safely
+}


### PR DESCRIPTION
Successful merges:

 - #108503 (use `ObligationCtxt` not `QueryNormalizer` in rustdoc's `normalization` )
 - #109162 (extend `detect_src_and_out` test)
 - #109395 (Fix issue when there are multiple candidates for edit_distance_with_substrings)
 - #109755 (Implement support for `GeneratorWitnessMIR` in new solver)
 - #109977 (rustdoc: avoid including line numbers in Google SERP snippets)
 - #109980 (Derive String's PartialEq implementation)
 - #109984 (Remove f32 & f64 from MemDecoder/MemEncoder)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=108503,109162,109395,109755,109977,109980,109984)
<!-- homu-ignore:end -->