### PR TITLE
add `dont_check_failure_status` option in the compiler test

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -150,6 +150,8 @@ pub struct TestProps {
     pub normalize_stdout: Vec<(String, String)>,
     pub normalize_stderr: Vec<(String, String)>,
     pub failure_status: i32,
+    // For UI tests, allows compiler to exit with arbitrary failure status
+    pub dont_check_failure_status: bool,
     // Whether or not `rustfix` should apply the `CodeSuggestion`s of this test and compile the
     // resulting Rust code.
     pub run_rustfix: bool,
@@ -192,6 +194,7 @@ mod directives {
     pub const CHECK_TEST_LINE_NUMBERS_MATCH: &'static str = "check-test-line-numbers-match";
     pub const IGNORE_PASS: &'static str = "ignore-pass";
     pub const FAILURE_STATUS: &'static str = "failure-status";
+    pub const DONT_CHECK_FAILURE_STATUS: &'static str = "dont-check-failure-status";
     pub const RUN_RUSTFIX: &'static str = "run-rustfix";
     pub const RUSTFIX_ONLY_MACHINE_APPLICABLE: &'static str = "rustfix-only-machine-applicable";
     pub const ASSEMBLY_OUTPUT: &'static str = "assembly-output";
@@ -239,6 +242,7 @@ impl TestProps {
             normalize_stdout: vec![],
             normalize_stderr: vec![],
             failure_status: -1,
+            dont_check_failure_status: false,
             run_rustfix: false,
             rustfix_only_machine_applicable: false,
             assembly_output: None,
@@ -400,6 +404,12 @@ impl TestProps {
                 {
                     self.failure_status = code;
                 }
+
+                config.set_name_directive(
+                    ln,
+                    DONT_CHECK_FAILURE_STATUS,
+                    &mut self.dont_check_failure_status,
+                );
 
                 config.set_name_directive(ln, RUN_RUSTFIX, &mut self.run_rustfix);
                 config.set_name_directive(

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -309,7 +309,9 @@ impl<'test> TestCx<'test> {
                 );
             }
 
-            self.check_correct_failure_status(proc_res);
+            if !self.props.dont_check_failure_status {
+                self.check_correct_failure_status(proc_res);
+            }
         }
     }
 

--- a/tests/ui/recursion/issue-95134.rs
+++ b/tests/ui/recursion/issue-95134.rs
@@ -1,7 +1,7 @@
 // build-fail
 // known-bug: #95134
 // compile-flags: -Copt-level=0
-// failure-status: 101
+// dont-check-failure-status
 // dont-check-compiler-stderr
 
 pub fn encode_num<Writer: ExampleWriter>(n: u32, mut writer: Writer) -> Result<(), Writer::Error> {


### PR DESCRIPTION
Sometimes the compiler triggers one ice while processing another ice. This will cause a recursive panic and go to [`sys::abort_internal()`](https://github.com/rust-lang/rust/blob/master/library/std/src/panicking.rs#L675), which generates an unfixed exit code. So I think we need an option to allow these use cases to generate different exit codes

Updates #75760
cc #95134

For example, when set `parallel_compiler = true`, issue-95134 will ice in `report_ice` since it try to print the query stack. Below is the brief error message:
```
failures:

---- [ui] tests\ui\recursion\issue-95134.rs stdout ----

error: Error: expected failure status (Some(101)) but received status Some(-1073740791).
status: exit code: 0xc0000409
command: PATH="D:\rust-backup\parallel_rust\rust-para\build\x86_64-pc-windows-msvc\stage1\bin;C:\Program Files (x86)\Windows Kits\10\bin\x64;C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\bin\HostX64\x64;C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\bin\HostX64\x64;D:\rust-backup\parallel_rust\rust-para\build\x86_64-pc-windows-msvc\stage0-bootstrap-tools\x86_64-pc-windows-msvc\release\deps;D:\rust-backup\parallel_rust\rust-para\build\x86_64-pc-windows-msvc\stage0\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4\libnvvp;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files\TortoiseGit\bin;C:\Program Files\CMake\bin;C:\Program Files (x86)\GnuWin32\bin;C:\Program Files\Git\cmd;C:\Program Files\NVIDIA Corporation\Nsight Compute 2021.2.1\;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\Users\HuaweiOpensource\anaconda3;C:\Users\HuaweiOpensource\anaconda3\Scripts;C:\Users\HuaweiOpensource\anaconda3\Library\bin;C:\Users\HuaweiOpensource\anaconda3\Library\mingw-w64;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\;C:\Program Files (x86)\GnuWin32\bin;C:\Users\HuaweiOpensource\AppData\Local\Programs\Python\Python38\Scripts\;C:\Users\HuaweiOpensource\AppData\Local\Programs\Python\Python38\;C:\Users\HuaweiOpensource\.cargo\bin;C:\Users\HuaweiOpensource\.cargo\bin;D:\Program Files\JetBrains\CLion 2022.1.3\bin;;D:\Program Files\JetBrains\PyCharm Community Edition 2020.3\bin;;D:\Program Files\OpenSSL-Win64\bin;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit;C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64;" "D:\\rust-backup\\parallel_rust\\rust-para\\build\\x86_64-pc-windows-msvc\\stage1\\bin\\rustc.exe" "D:\\rust-backup\\parallel_rust\\rust-para\\tests\\ui\\recursion\\issue-95134.rs" "-Zthreads=1" "--target=x86_64-pc-windows-msvc" "--error-format" "json" "--json" "future-incompat" "-Ccodegen-units=1" "-Zui-testing" "-Zsimulate-remapped-rust-src-base=/rustc/FAKE_PREFIX" "-Ztranslate-remapped-path-to-local-path=no" "-Zdeduplicate-diagnostics=no" "-Cstrip=debuginfo" "--remap-path-prefix=D:\\rust-backup\\parallel_rust\\rust-para\\tests\\ui=fake-test-src-base" "-C" "prefer-dynamic" "--out-dir" "D:\\rust-backup\\parallel_rust\\rust-para\\build\\x86_64-pc-windows-msvc\\test\\ui\\recursion\\issue-95134" "-A" "unused" "-Crpath" "-Cdebuginfo=0" "-Lnative=D:\\rust-backup\\parallel_rust\\rust-para\\build\\x86_64-pc-windows-msvc\\native\\rust-test-helpers" "-L" "D:\\rust-backup\\parallel_rust\\rust-para\\build\\x86_64-pc-windows-msvc\\test\\ui\\recursion\\issue-95134\\auxiliary" "-Copt-level=0"
stdout: none
--- stderr -------------------------------
thread 'rustc' panicked at 'index out of bounds: the len is 0 but the index is 0', C:\Users\HuaweiOpensource\.cargo\registry\src\github.com-1ecc6299db9ec823\ena-0.14.2\src\snapshot_vec.rs:199:10
stack backtrace:
   0:     0x7ffc3e90bc05 - std::backtrace_rs::backtrace::trace_unsynchronized::hfabb14c555fa1e54
   1:     0x7ffc3e900799 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h88786f2c1c37cad0
   2:     0x7ffc3e95143b - core::fmt::write::hef4555c5285e005b
   3:     0x7ffc3e8ef2aa - std::io::Write::write_fmt::h9ea304efc4781c26
   4:     0x7ffc3e90059b - std::sys_common::backtrace::print::h7b33cd350eefb143
......
 178:     0x7ffc27d6a3f2 - <&mut serde_json[7222a1897944c7c8]::ser::Serializer<&mut alloc[6a6f6c0f0cd9fa15]::vec::Vec<u8>, serde_json[7222a1897944c7c8]::ser::PrettyFormatter> as serde[d3e6684f4f38fcf7]::ser::Serializer>::collect_seq::<&alloc[6a6f6c0f0cd9fa15]::vec::Vec<serde_json[7222a1897944c7c8]::value::Value>>
 179:     0x7ffc3e8ed9ec - std::sys::windows::thread::Thread::new::thread_start::h5be4f069fac1a629
 180:     0x7ffcb0b37614 - BaseThreadInitThunk
 181:     0x7ffcb18c26a1 - RtlUserThreadStart

error: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.70.0-dev running on x86_64-pc-windows-msvc

note: compiler flags: -Z threads=1 -C codegen-units=1 -Z ui-testing -Z simulate-remapped-rust-src-base=/rustc/FAKE_PREFIX -Z translate-remapped-path-to-local-path=no -Z deduplicate-diagnostics=no -C strip=debuginfo -C prefer-dynamic -C rpath -C debuginfo=0 -C opt-level=0

query stack during panic:
thread 'rustc' panicked at 'type variables should not be hashed: _#0t', D:\rust-backup\parallel_rust\rust-para\compiler\rustc_type_ir\src\lib.rs:718:17
stack backtrace:
   0:     0x7ffc3e90bc05 - std::backtrace_rs::backtrace::trace_unsynchronized::hfabb14c555fa1e54
   1:     0x7ffc3e900799 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h88786f2c1c37cad0
   2:     0x7ffc3e95143b - core::fmt::write::hef4555c5285e005b
   3:     0x7ffc3e8ef2aa - std::io::Write::write_fmt::h9ea304efc4781c26
   4:     0x7ffc3e90059b - std::sys_common::backtrace::print::h7b33cd350eefb143
   5:     0x7ffc3e91c109 - std::panicking::default_hook::h12f01c5f2b8959c6
......
 197:     0x7ffc27d6a3f2 - <&mut serde_json[7222a1897944c7c8]::ser::Serializer<&mut alloc[6a6f6c0f0cd9fa15]::vec::Vec<u8>, serde_json[7222a1897944c7c8]::ser::PrettyFormatter> as serde[d3e6684f4f38fcf7]::ser::Serializer>::collect_seq::<&alloc[6a6f6c0f0cd9fa15]::vec::Vec<serde_json[7222a1897944c7c8]::value::Value>>
 198:     0x7ffc3e8ed9ec - std::sys::windows::thread::Thread::new::thread_start::h5be4f069fac1a629
 199:     0x7ffcb0b37614 - BaseThreadInitThunk
 200:     0x7ffcb18c26a1 - RtlUserThreadStart

error: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.70.0-dev running on x86_64-pc-windows-msvc

note: compiler flags: -Z threads=1 -C codegen-units=1 -Z ui-testing -Z simulate-remapped-rust-src-base=/rustc/FAKE_PREFIX -Z translate-remapped-path-to-local-path=no -Z deduplicate-diagnostics=no -C strip=debuginfo -C prefer-dynamic -C rpath -C debuginfo=0 -C opt-level=0

query stack during panic:
thread panicked while processing panic. aborting.
------------------------------------------
```




