### PR TITLE
Label `non_exhaustive` attribute on privacy errors from non-local items

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1608,11 +1608,15 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             struct_span_err!(self.tcx.sess, ident.span, E0603, "{} `{}` is private", descr, ident);
         err.span_label(ident.span, &format!("private {}", descr));
 
+        let mut non_exhaustive = None;
+        // If an ADT is foreign and marked as `non_exhaustive`, then that's
+        // probably why we have the privacy error.
+        // Otherwise, point out if the struct has any private fields.
         if let Some(def_id) = res.opt_def_id()
             && !def_id.is_local()
             && let Some(attr) = self.tcx.get_attr(def_id, sym::non_exhaustive)
         {
-            err.span_label(attr.span, format!("the {nonimport_descr} is `#[non_exhaustive]`"));
+            non_exhaustive = Some(attr.span);
         } else if let Some(span) = ctor_fields_span {
             err.span_label(span, "a constructor is private if any of the fields is private");
             if let Res::Def(_, d) = res && let Some(fields) = self.field_visibility_spans.get(&d) {
@@ -1661,6 +1665,14 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             let mut note_span = MultiSpan::from_span(def_span);
             if !first && binding.vis.is_public() {
                 note_span.push_span_label(def_span, "consider importing it directly");
+            }
+            // Final step in the import chain, point out if the ADT is `non_exhaustive`
+            // which is probably why this privacy violation occurred.
+            if next_binding.is_none() && let Some(span) = non_exhaustive {
+                note_span.push_span_label(
+                    span,
+                    format!("cannot be constructed because it is `#[non_exhaustive]`"),
+                );
             }
             err.span_note(note_span, &msg);
         }

--- a/tests/ui/rfc-2008-non-exhaustive/struct.stderr
+++ b/tests/ui/rfc-2008-non-exhaustive/struct.stderr
@@ -10,14 +10,11 @@ error[E0603]: tuple struct constructor `TupleStruct` is private
 LL |     let ts_explicit = structs::TupleStruct(640, 480);
    |                                ^^^^^^^^^^^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/structs.rs:11:1
-   |
-LL | #[non_exhaustive]
-   | ----------------- the tuple struct constructor is `#[non_exhaustive]`
-   |
 note: the tuple struct constructor `TupleStruct` is defined here
   --> $DIR/auxiliary/structs.rs:12:1
    |
+LL | #[non_exhaustive]
+   | ----------------- cannot be constructed because it is `#[non_exhaustive]`
 LL | pub struct TupleStruct(pub u16, pub u16);
    | ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -27,14 +24,11 @@ error[E0603]: unit struct `UnitStruct` is private
 LL |     let us_explicit = structs::UnitStruct;
    |                                ^^^^^^^^^^ private unit struct
    |
-  ::: $DIR/auxiliary/structs.rs:8:1
-   |
-LL | #[non_exhaustive]
-   | ----------------- the unit struct is `#[non_exhaustive]`
-   |
 note: the unit struct `UnitStruct` is defined here
   --> $DIR/auxiliary/structs.rs:9:1
    |
+LL | #[non_exhaustive]
+   | ----------------- cannot be constructed because it is `#[non_exhaustive]`
 LL | pub struct UnitStruct;
    | ^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/rfc-2008-non-exhaustive/struct.stderr
+++ b/tests/ui/rfc-2008-non-exhaustive/struct.stderr
@@ -10,10 +10,10 @@ error[E0603]: tuple struct constructor `TupleStruct` is private
 LL |     let ts_explicit = structs::TupleStruct(640, 480);
    |                                ^^^^^^^^^^^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/structs.rs:12:24
+  ::: $DIR/auxiliary/structs.rs:11:1
    |
-LL | pub struct TupleStruct(pub u16, pub u16);
-   |                        ---------------- a constructor is private if any of the fields is private
+LL | #[non_exhaustive]
+   | ----------------- the tuple struct constructor is `#[non_exhaustive]`
    |
 note: the tuple struct constructor `TupleStruct` is defined here
   --> $DIR/auxiliary/structs.rs:12:1
@@ -26,6 +26,11 @@ error[E0603]: unit struct `UnitStruct` is private
    |
 LL |     let us_explicit = structs::UnitStruct;
    |                                ^^^^^^^^^^ private unit struct
+   |
+  ::: $DIR/auxiliary/structs.rs:8:1
+   |
+LL | #[non_exhaustive]
+   | ----------------- the unit struct is `#[non_exhaustive]`
    |
 note: the unit struct `UnitStruct` is defined here
   --> $DIR/auxiliary/structs.rs:9:1

--- a/tests/ui/rfc-2008-non-exhaustive/variant.stderr
+++ b/tests/ui/rfc-2008-non-exhaustive/variant.stderr
@@ -4,6 +4,11 @@ error[E0603]: tuple variant `Tuple` is private
 LL |     let variant_tuple = NonExhaustiveVariants::Tuple(640);
    |                                                ^^^^^ private tuple variant
    |
+  ::: $DIR/auxiliary/variants.rs:5:5
+   |
+LL |     #[non_exhaustive] Tuple(u32),
+   |     ----------------- the tuple variant is `#[non_exhaustive]`
+   |
 note: the tuple variant `Tuple` is defined here
   --> $DIR/auxiliary/variants.rs:5:23
    |
@@ -15,6 +20,11 @@ error[E0603]: unit variant `Unit` is private
    |
 LL |     let variant_unit = NonExhaustiveVariants::Unit;
    |                                               ^^^^ private unit variant
+   |
+  ::: $DIR/auxiliary/variants.rs:4:5
+   |
+LL |     #[non_exhaustive] Unit,
+   |     ----------------- the unit variant is `#[non_exhaustive]`
    |
 note: the unit variant `Unit` is defined here
   --> $DIR/auxiliary/variants.rs:4:23
@@ -28,6 +38,11 @@ error[E0603]: unit variant `Unit` is private
 LL |         NonExhaustiveVariants::Unit => "",
    |                                ^^^^ private unit variant
    |
+  ::: $DIR/auxiliary/variants.rs:4:5
+   |
+LL |     #[non_exhaustive] Unit,
+   |     ----------------- the unit variant is `#[non_exhaustive]`
+   |
 note: the unit variant `Unit` is defined here
   --> $DIR/auxiliary/variants.rs:4:23
    |
@@ -40,6 +55,11 @@ error[E0603]: tuple variant `Tuple` is private
 LL |         NonExhaustiveVariants::Tuple(fe_tpl) => "",
    |                                ^^^^^ private tuple variant
    |
+  ::: $DIR/auxiliary/variants.rs:5:5
+   |
+LL |     #[non_exhaustive] Tuple(u32),
+   |     ----------------- the tuple variant is `#[non_exhaustive]`
+   |
 note: the tuple variant `Tuple` is defined here
   --> $DIR/auxiliary/variants.rs:5:23
    |
@@ -51,6 +71,11 @@ error[E0603]: tuple variant `Tuple` is private
    |
 LL |     if let NonExhaustiveVariants::Tuple(fe_tpl) = variant_struct {
    |                                   ^^^^^ private tuple variant
+   |
+  ::: $DIR/auxiliary/variants.rs:5:5
+   |
+LL |     #[non_exhaustive] Tuple(u32),
+   |     ----------------- the tuple variant is `#[non_exhaustive]`
    |
 note: the tuple variant `Tuple` is defined here
   --> $DIR/auxiliary/variants.rs:5:23

--- a/tests/ui/rfc-2008-non-exhaustive/variant.stderr
+++ b/tests/ui/rfc-2008-non-exhaustive/variant.stderr
@@ -4,16 +4,13 @@ error[E0603]: tuple variant `Tuple` is private
 LL |     let variant_tuple = NonExhaustiveVariants::Tuple(640);
    |                                                ^^^^^ private tuple variant
    |
-  ::: $DIR/auxiliary/variants.rs:5:5
-   |
-LL |     #[non_exhaustive] Tuple(u32),
-   |     ----------------- the tuple variant is `#[non_exhaustive]`
-   |
 note: the tuple variant `Tuple` is defined here
   --> $DIR/auxiliary/variants.rs:5:23
    |
 LL |     #[non_exhaustive] Tuple(u32),
-   |                       ^^^^^
+   |     ----------------- ^^^^^
+   |     |
+   |     cannot be constructed because it is `#[non_exhaustive]`
 
 error[E0603]: unit variant `Unit` is private
   --> $DIR/variant.rs:14:47
@@ -21,16 +18,13 @@ error[E0603]: unit variant `Unit` is private
 LL |     let variant_unit = NonExhaustiveVariants::Unit;
    |                                               ^^^^ private unit variant
    |
-  ::: $DIR/auxiliary/variants.rs:4:5
-   |
-LL |     #[non_exhaustive] Unit,
-   |     ----------------- the unit variant is `#[non_exhaustive]`
-   |
 note: the unit variant `Unit` is defined here
   --> $DIR/auxiliary/variants.rs:4:23
    |
 LL |     #[non_exhaustive] Unit,
-   |                       ^^^^
+   |     ----------------- ^^^^
+   |     |
+   |     cannot be constructed because it is `#[non_exhaustive]`
 
 error[E0603]: unit variant `Unit` is private
   --> $DIR/variant.rs:18:32
@@ -38,16 +32,13 @@ error[E0603]: unit variant `Unit` is private
 LL |         NonExhaustiveVariants::Unit => "",
    |                                ^^^^ private unit variant
    |
-  ::: $DIR/auxiliary/variants.rs:4:5
-   |
-LL |     #[non_exhaustive] Unit,
-   |     ----------------- the unit variant is `#[non_exhaustive]`
-   |
 note: the unit variant `Unit` is defined here
   --> $DIR/auxiliary/variants.rs:4:23
    |
 LL |     #[non_exhaustive] Unit,
-   |                       ^^^^
+   |     ----------------- ^^^^
+   |     |
+   |     cannot be constructed because it is `#[non_exhaustive]`
 
 error[E0603]: tuple variant `Tuple` is private
   --> $DIR/variant.rs:20:32
@@ -55,16 +46,13 @@ error[E0603]: tuple variant `Tuple` is private
 LL |         NonExhaustiveVariants::Tuple(fe_tpl) => "",
    |                                ^^^^^ private tuple variant
    |
-  ::: $DIR/auxiliary/variants.rs:5:5
-   |
-LL |     #[non_exhaustive] Tuple(u32),
-   |     ----------------- the tuple variant is `#[non_exhaustive]`
-   |
 note: the tuple variant `Tuple` is defined here
   --> $DIR/auxiliary/variants.rs:5:23
    |
 LL |     #[non_exhaustive] Tuple(u32),
-   |                       ^^^^^
+   |     ----------------- ^^^^^
+   |     |
+   |     cannot be constructed because it is `#[non_exhaustive]`
 
 error[E0603]: tuple variant `Tuple` is private
   --> $DIR/variant.rs:26:35
@@ -72,16 +60,13 @@ error[E0603]: tuple variant `Tuple` is private
 LL |     if let NonExhaustiveVariants::Tuple(fe_tpl) = variant_struct {
    |                                   ^^^^^ private tuple variant
    |
-  ::: $DIR/auxiliary/variants.rs:5:5
-   |
-LL |     #[non_exhaustive] Tuple(u32),
-   |     ----------------- the tuple variant is `#[non_exhaustive]`
-   |
 note: the tuple variant `Tuple` is defined here
   --> $DIR/auxiliary/variants.rs:5:23
    |
 LL |     #[non_exhaustive] Tuple(u32),
-   |                       ^^^^^
+   |     ----------------- ^^^^^
+   |     |
+   |     cannot be constructed because it is `#[non_exhaustive]`
 
 error[E0639]: cannot create non-exhaustive variant using struct expression
   --> $DIR/variant.rs:8:26


### PR DESCRIPTION
Label when an ADT is `non_exhaustive` and we get a privacy error, help with confusion in a case like this:

```rust
#[non_exhaustive]
pub struct Foo;

// other crate
let x = Foo;
//~^ ERROR unit struct `Foo` is private
```