### PR TITLE
Add `#[inline]` to functions that are never called

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1412,6 +1412,7 @@ mod impls {
 
     #[unstable(feature = "never_type", issue = "35121")]
     impl PartialEq for ! {
+        #[inline]
         fn eq(&self, _: &!) -> bool {
             *self
         }
@@ -1422,6 +1423,7 @@ mod impls {
 
     #[unstable(feature = "never_type", issue = "35121")]
     impl PartialOrd for ! {
+        #[inline]
         fn partial_cmp(&self, _: &!) -> Option<Ordering> {
             *self
         }
@@ -1429,6 +1431,7 @@ mod impls {
 
     #[unstable(feature = "never_type", issue = "35121")]
     impl Ord for ! {
+        #[inline]
         fn cmp(&self, _: &!) -> Ordering {
             *self
         }

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -915,6 +915,7 @@ impl Ord for Infallible {
 
 #[stable(feature = "convert_infallible", since = "1.34.0")]
 impl From<!> for Infallible {
+    #[inline]
     fn from(x: !) -> Self {
         x
     }

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2269,6 +2269,7 @@ fmt_refs! { Debug, Display, Octal, Binary, LowerHex, UpperHex, LowerExp, UpperEx
 
 #[unstable(feature = "never_type", issue = "35121")]
 impl Debug for ! {
+    #[inline]
     fn fmt(&self, _: &mut Formatter<'_>) -> Result {
         *self
     }
@@ -2276,6 +2277,7 @@ impl Debug for ! {
 
 #[unstable(feature = "never_type", issue = "35121")]
 impl Display for ! {
+    #[inline]
     fn fmt(&self, _: &mut Formatter<'_>) -> Result {
         *self
     }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2523,6 +2523,7 @@ macro_rules! assert_unsafe_precondition {
                 }
             }
             #[allow(non_snake_case)]
+            #[inline]
             const fn comptime$(<$($tt)*>)?($(_:$ty),*) {}
 
             ::core::intrinsics::const_eval_select(($($i,)*), comptime, runtime);

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -265,6 +265,7 @@ pub struct BasicBlock;
 macro_rules! define {
     ($name:literal, $( #[ $meta:meta ] )* fn $($sig:tt)*) => {
         #[rustc_diagnostic_item = $name]
+        #[inline]
         $( #[ $meta ] )*
         pub fn $($sig)* { panic!() }
     }

--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -34,6 +34,7 @@ impl From<Infallible> for TryFromIntError {
 
 #[unstable(feature = "never_type", issue = "35121")]
 impl From<!> for TryFromIntError {
+    #[inline]
     fn from(never: !) -> TryFromIntError {
         // Match rather than coerce to make sure that code like
         // `From<Infallible> for TryFromIntError` above will keep working


### PR DESCRIPTION
This makes libcore binary size reduce by ~300 bytes. Not much, but these functions are never called so it doesn't make sense for them to get into the binary anyway.