### PR TITLE
Erase regions when confirming transmutability candidate

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -649,7 +649,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         // FIXME(transmutability): This really should be returning nested goals for `Answer::If*`
         match rustc_transmute::TransmuteTypeEnv::new(self.infcx).is_transmutable(
             ObligationCause::dummy(),
-            ty::Binder::dummy(src_and_dst),
+            src_and_dst,
             scope,
             assume,
         ) {

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -64,7 +64,6 @@ mod rustc {
     use rustc_infer::infer::InferCtxt;
     use rustc_macros::{TypeFoldable, TypeVisitable};
     use rustc_middle::traits::ObligationCause;
-    use rustc_middle::ty::Binder;
     use rustc_middle::ty::Const;
     use rustc_middle::ty::ParamEnv;
     use rustc_middle::ty::Ty;
@@ -92,15 +91,13 @@ mod rustc {
         pub fn is_transmutable(
             &mut self,
             cause: ObligationCause<'tcx>,
-            src_and_dst: Binder<'tcx, Types<'tcx>>,
+            types: Types<'tcx>,
             scope: Ty<'tcx>,
             assume: crate::Assume,
         ) -> crate::Answer<crate::layout::rustc::Ref<'tcx>> {
-            let src = src_and_dst.map_bound(|types| types.src).skip_binder();
-            let dst = src_and_dst.map_bound(|types| types.dst).skip_binder();
             crate::maybe_transmutable::MaybeTransmutableQuery::new(
-                src,
-                dst,
+                types.src,
+                types.dst,
                 scope,
                 assume,
                 self.infcx.tcx,

--- a/tests/ui/transmutability/references.current.stderr
+++ b/tests/ui/transmutability/references.current.stderr
@@ -1,8 +1,8 @@
-error[E0277]: `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`
+error[E0277]: `&Unit` cannot be safely transmuted into `&Unit` in the defining scope of `assert::Context`
   --> $DIR/references.rs:29:52
    |
 LL |     assert::is_maybe_transmutable::<&'static Unit, &'static Unit>();
-   |                                                    ^^^^^^^^^^^^^ `&'static Unit` does not have a well-specified layout
+   |                                                    ^^^^^^^^^^^^^ `&Unit` does not have a well-specified layout
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/references.rs:16:14

--- a/tests/ui/transmutability/references.next.stderr
+++ b/tests/ui/transmutability/references.next.stderr
@@ -1,8 +1,8 @@
-error[E0277]: `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`
+error[E0277]: `&Unit` cannot be safely transmuted into `&Unit` in the defining scope of `assert::Context`
   --> $DIR/references.rs:29:52
    |
 LL |     assert::is_maybe_transmutable::<&'static Unit, &'static Unit>();
-   |                                                    ^^^^^^^^^^^^^ `&'static Unit` does not have a well-specified layout
+   |                                                    ^^^^^^^^^^^^^ `&Unit` does not have a well-specified layout
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/references.rs:16:14

--- a/tests/ui/transmutability/region-infer.rs
+++ b/tests/ui/transmutability/region-infer.rs
@@ -1,0 +1,22 @@
+#![feature(transmutability)]
+
+use std::mem::{Assume, BikeshedIntrinsicFrom};
+pub struct Context;
+
+#[repr(C)]
+struct W<'a>(&'a ());
+
+fn test<'a>()
+where
+    W<'a>: BikeshedIntrinsicFrom<
+            (),
+            Context,
+            { Assume { alignment: true, lifetimes: true, safety: true, validity: true } },
+        >,
+{
+}
+
+fn main() {
+    test();
+    //~^ ERROR `()` cannot be safely transmuted into `W<'_>`
+}

--- a/tests/ui/transmutability/region-infer.stderr
+++ b/tests/ui/transmutability/region-infer.stderr
@@ -1,0 +1,23 @@
+error[E0277]: `()` cannot be safely transmuted into `W<'_>` in the defining scope of `Context`
+  --> $DIR/region-infer.rs:20:5
+   |
+LL |     test();
+   |     ^^^^ `W<'_>` does not have a well-specified layout
+   |
+note: required by a bound in `test`
+  --> $DIR/region-infer.rs:11:12
+   |
+LL |   fn test<'a>()
+   |      ---- required by a bound in this function
+LL |   where
+LL |       W<'a>: BikeshedIntrinsicFrom<
+   |  ____________^
+LL | |             (),
+LL | |             Context,
+LL | |             { Assume { alignment: true, lifetimes: true, safety: true, validity: true } },
+LL | |         >,
+   | |_________^ required by this bound in `test`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes an ICE where we call `layout_of` on a type with infer regions.