### PR TITLE
Increase instances of `try_get_cached`

### DIFF
--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -355,7 +355,7 @@ macro_rules! define_callbacks {
                 let key = key.into_query_param();
                 opt_remap_env_constness!([$($modifiers)*][key]);
 
-                match try_get_cached(self.tcx, &self.tcx.query_system.caches.$name, &key) {
+                match try_get_cached::<_, _, $V>(self.tcx, &self.tcx.query_system.caches.$name, &key) {
                     Some(_) => return,
                     None => self.tcx.queries.$name(
                         self.tcx,
@@ -374,7 +374,7 @@ macro_rules! define_callbacks {
                 let key = key.into_query_param();
                 opt_remap_env_constness!([$($modifiers)*][key]);
 
-                match try_get_cached(self.tcx, &self.tcx.query_system.caches.$name, &key) {
+                match try_get_cached::<_, _, $V>(self.tcx, &self.tcx.query_system.caches.$name, &key) {
                     Some(_) => return,
                     None => self.tcx.queries.$name(
                         self.tcx,
@@ -404,7 +404,7 @@ macro_rules! define_callbacks {
                 let key = key.into_query_param();
                 opt_remap_env_constness!([$($modifiers)*][key]);
 
-                restore::<$V>(match try_get_cached(self.tcx, &self.tcx.query_system.caches.$name, &key) {
+                restore::<$V>(match try_get_cached::<_, _, $V>(self.tcx, &self.tcx.query_system.caches.$name, &key) {
                     Some(value) => value,
                     None => self.tcx.queries.$name(self.tcx, self.span, key, QueryMode::Get).unwrap(),
                 })
@@ -499,7 +499,7 @@ macro_rules! define_feedable {
                 let value = restore::<$V>(erased);
                 let cache = &tcx.query_system.caches.$name;
 
-                match try_get_cached(tcx, cache, &key) {
+                match try_get_cached::<_, _, $V>(tcx, cache, &key) {
                     Some(old) => {
                         let old = restore::<$V>(old);
                         bug!(

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -237,7 +237,7 @@ pub(crate) struct CycleError<D: DepKind> {
 /// which will be used if the query is not in the cache and we need
 /// to compute it.
 #[inline]
-pub fn try_get_cached<Tcx, C>(tcx: Tcx, cache: &C, key: &C::Key) -> Option<C::Value>
+pub fn try_get_cached<Tcx, C, V>(tcx: Tcx, cache: &C, key: &C::Key) -> Option<C::Value>
 where
     C: QueryCache,
     Tcx: DepContext,


### PR DESCRIPTION
This increases the instances of `try_get_cached` in order to try to reduce the regressions in https://github.com/rust-lang/rust/pull/109333. Using `#[inline(always)]` seems to be too aggressive so this is a way to keep inlining behavior more similar to the previous state.

r? @cjgillot 