### PR TITLE
Run "Auto-hide item contents for large items" setting test in mobile mode as well

### DIFF
--- a/tests/rustdoc-gui/setting-auto-hide-content-large-items.goml
+++ b/tests/rustdoc-gui/setting-auto-hide-content-large-items.goml
@@ -16,36 +16,51 @@ define-function: (
     }
 )
 
-goto: "file://" + |DOC_PATH| + "/lib2/scroll_traits/trait.Iterator.html"
+define-function: (
+    "check-full",
+    (size),
+    block {
+        goto: "file://" + |DOC_PATH| + "/lib2/scroll_traits/trait.Iterator.html"
+        size: |size|
 
-// We check that the setting is enabled by default and is working.
-call-function: ("check-setting", {
-    "storage_value": null,
-    "setting_attribute_value": "true",
-    "toggle_attribute_value": null,
-})
+        // We check that the setting is enabled by default and is working.
+        call-function: ("check-setting", {
+            "storage_value": null,
+            "setting_attribute_value": "true",
+            "toggle_attribute_value": null,
+        })
 
-// Now we change its value.
-click: "#auto-hide-large-items"
-assert-local-storage: {"rustdoc-auto-hide-large-items": "false"}
+        // Now we change its value.
+        click: "#auto-hide-large-items"
+        assert-local-storage: {"rustdoc-auto-hide-large-items": "false"}
 
-// We check that the changes were applied as expected.
-reload:
+        // We check that the changes were applied as expected.
+        reload:
 
-call-function: ("check-setting", {
-    "storage_value": "false",
-    "setting_attribute_value": "false",
-    "toggle_attribute_value": "",
-})
+        call-function: ("check-setting", {
+            "storage_value": "false",
+            "setting_attribute_value": "false",
+            "toggle_attribute_value": "",
+        })
 
-// And now we re-enable the setting.
-click: "#auto-hide-large-items"
-assert-local-storage: {"rustdoc-auto-hide-large-items": "true"}
+        // And now we re-enable the setting.
+        click: "#auto-hide-large-items"
+        assert-local-storage: {"rustdoc-auto-hide-large-items": "true"}
 
-// And we check everything is back the way it was before.
-reload:
-call-function: ("check-setting", {
-    "storage_value": "true",
-    "setting_attribute_value": "true",
-    "toggle_attribute_value": null,
-})
+        // And we check everything is back the way it was before.
+        reload:
+        call-function: ("check-setting", {
+            "storage_value": "true",
+            "setting_attribute_value": "true",
+            "toggle_attribute_value": null,
+        })
+        // Removing the value for next test pass.
+        local-storage: {"rustdoc-auto-hide-large-items": null}
+    }
+)
+
+// First we test on desktop.
+call-function: ("check-full", {"size": (900, 900)})
+
+// Then on mobile.
+call-function: ("check-full", {"size": (600, 600)})


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/66181.

It extends the test so it's also run in mobile mode.

r? @notriddle 