### PR TITLE
Fix wrong type in docs: i16 -> u16

### DIFF
--- a/library/core/src/num/shells/u16.rs
+++ b/library/core/src/num/shells/u16.rs
@@ -1,4 +1,4 @@
-//! Redundant constants module for the [`i16` primitive type][i16].
+//! Redundant constants module for the [`u16` primitive type][u16].
 //!
 //! New code should use the associated constants directly on the primitive type.
 


### PR DESCRIPTION
@rustbot label +A-docs

r? docs