### PR TITLE
Make the "codegen" profile of `config.toml` download and build llvm from source.

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -16,7 +16,7 @@
 # Use different pre-set defaults than the global defaults.
 #
 # See `src/bootstrap/defaults` for more information.
-# Note that this has no default value (x.py uses the defaults in `config.toml.example`).
+# Note that this has no default value (x.py uses the defaults in `config.example.toml`).
 #profile = <none>
 
 # Keeps track of the last version of `x.py` used.

--- a/src/bootstrap/defaults/config.codegen.toml
+++ b/src/bootstrap/defaults/config.codegen.toml
@@ -9,6 +9,8 @@ compiler-docs = true
 assertions = true
 # enable warnings during the llvm compilation
 enable-warnings = true
+# build llvm from source
+download-ci-llvm = false
 
 [rust]
 # This enables `RUSTC_LOG=debug`, avoiding confusing situations


### PR DESCRIPTION
The stated purpose of the codegen profile in config.toml is:

> `# These defaults are meant for contributors to the compiler who modify codegen or LLVM`

but `download-ci-llvm` must be set to be false for the llvm source to even be downloaded. This patch adds that in.

Also included: a small docs fix in `config.example.toml`