### PR TITLE
Changed std:: to core:: in core library documentation

### DIFF
--- a/library/core/src/alloc/global.rs
+++ b/library/core/src/alloc/global.rs
@@ -21,10 +21,10 @@ use crate::ptr;
 /// # Example
 ///
 /// ```
-/// use std::alloc::{GlobalAlloc, Layout};
-/// use std::cell::UnsafeCell;
-/// use std::ptr::null_mut;
-/// use std::sync::atomic::{
+/// use core::alloc::{GlobalAlloc, Layout};
+/// use core::cell::UnsafeCell;
+/// use core::ptr::null_mut;
+/// use core::sync::atomic::{
 ///     AtomicUsize,
 ///     Ordering::{Acquire, SeqCst},
 /// };
@@ -110,7 +110,7 @@ use crate::ptr;
 ///   ```rust,ignore (unsound and has placeholders)
 ///   drop(Box::new(42));
 ///   let number_of_heap_allocs = /* call private allocator API */;
-///   unsafe { std::intrinsics::assume(number_of_heap_allocs > 0); }
+///   unsafe { core::intrinsics::assume(number_of_heap_allocs > 0); }
 ///   ```
 ///
 ///   Note that the optimizations mentioned above are not the only

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -355,7 +355,7 @@ impl Layout {
     /// the fields from its fields' layouts:
     ///
     /// ```rust
-    /// # use std::alloc::{Layout, LayoutError};
+    /// # use core::alloc::{Layout, LayoutError};
     /// pub fn repr_c(fields: &[Layout]) -> Result<(Layout, Vec<usize>), LayoutError> {
     ///     let mut offsets = Vec::new();
     ///     let mut layout = Layout::from_size_align(0, 1)?;

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -25,7 +25,7 @@
 //! the object's `TypeId`. For example:
 //!
 //! ```
-//! use std::any::{Any, TypeId};
+//! use core::any::{Any, TypeId};
 //!
 //! let boxed: Box<dyn Any> = Box::new(3_i32);
 //!
@@ -48,8 +48,8 @@
 //! use runtime reflection instead.
 //!
 //! ```rust
-//! use std::fmt::Debug;
-//! use std::any::Any;
+//! use core::fmt::Debug;
+//! use core::any::Any;
 //!
 //! // Logger function for any type that implements Debug.
 //! fn log<T: Any + Debug>(value: &T) {
@@ -111,7 +111,7 @@
 //!
 //! ```
 //! # #![feature(provide_any)]
-//! use std::any::{Provider, Demand, request_ref};
+//! use core::any::{Provider, Demand, request_ref};
 //!
 //! // Definition of MyTrait, a data provider.
 //! trait MyTrait: Provider {
@@ -183,7 +183,7 @@ pub trait Any: 'static {
     /// # Examples
     ///
     /// ```
-    /// use std::any::{Any, TypeId};
+    /// use core::any::{Any, TypeId};
     ///
     /// fn is_string(s: &dyn Any) -> bool {
     ///     TypeId::of::<String>() == s.type_id()
@@ -237,7 +237,7 @@ impl dyn Any {
     /// # Examples
     ///
     /// ```
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// fn is_string(s: &dyn Any) {
     ///     if s.is::<String>() {
@@ -269,7 +269,7 @@ impl dyn Any {
     /// # Examples
     ///
     /// ```
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// fn print_if_string(s: &dyn Any) {
     ///     if let Some(string) = s.downcast_ref::<String>() {
@@ -301,7 +301,7 @@ impl dyn Any {
     /// # Examples
     ///
     /// ```
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// fn modify_if_u32(s: &mut dyn Any) {
     ///     if let Some(num) = s.downcast_mut::<u32>() {
@@ -338,7 +338,7 @@ impl dyn Any {
     /// ```
     /// #![feature(downcast_unchecked)]
     ///
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// let x: Box<dyn Any> = Box::new(1_usize);
     ///
@@ -366,7 +366,7 @@ impl dyn Any {
     /// ```
     /// #![feature(downcast_unchecked)]
     ///
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// let mut x: Box<dyn Any> = Box::new(1_usize);
     ///
@@ -396,7 +396,7 @@ impl dyn Any + Send {
     /// # Examples
     ///
     /// ```
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// fn is_string(s: &(dyn Any + Send)) {
     ///     if s.is::<String>() {
@@ -420,7 +420,7 @@ impl dyn Any + Send {
     /// # Examples
     ///
     /// ```
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// fn print_if_string(s: &(dyn Any + Send)) {
     ///     if let Some(string) = s.downcast_ref::<String>() {
@@ -444,7 +444,7 @@ impl dyn Any + Send {
     /// # Examples
     ///
     /// ```
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// fn modify_if_u32(s: &mut (dyn Any + Send)) {
     ///     if let Some(num) = s.downcast_mut::<u32>() {
@@ -474,7 +474,7 @@ impl dyn Any + Send {
     /// ```
     /// #![feature(downcast_unchecked)]
     ///
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// let x: Box<dyn Any> = Box::new(1_usize);
     ///
@@ -500,7 +500,7 @@ impl dyn Any + Send {
     /// ```
     /// #![feature(downcast_unchecked)]
     ///
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// let mut x: Box<dyn Any> = Box::new(1_usize);
     ///
@@ -528,7 +528,7 @@ impl dyn Any + Send + Sync {
     /// # Examples
     ///
     /// ```
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// fn is_string(s: &(dyn Any + Send + Sync)) {
     ///     if s.is::<String>() {
@@ -552,7 +552,7 @@ impl dyn Any + Send + Sync {
     /// # Examples
     ///
     /// ```
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// fn print_if_string(s: &(dyn Any + Send + Sync)) {
     ///     if let Some(string) = s.downcast_ref::<String>() {
@@ -576,7 +576,7 @@ impl dyn Any + Send + Sync {
     /// # Examples
     ///
     /// ```
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// fn modify_if_u32(s: &mut (dyn Any + Send + Sync)) {
     ///     if let Some(num) = s.downcast_mut::<u32>() {
@@ -606,7 +606,7 @@ impl dyn Any + Send + Sync {
     /// ```
     /// #![feature(downcast_unchecked)]
     ///
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// let x: Box<dyn Any> = Box::new(1_usize);
     ///
@@ -628,7 +628,7 @@ impl dyn Any + Send + Sync {
     /// ```
     /// #![feature(downcast_unchecked)]
     ///
-    /// use std::any::Any;
+    /// use core::any::Any;
     ///
     /// let mut x: Box<dyn Any> = Box::new(1_usize);
     ///
@@ -676,7 +676,7 @@ impl TypeId {
     /// # Examples
     ///
     /// ```
-    /// use std::any::{Any, TypeId};
+    /// use core::any::{Any, TypeId};
     ///
     /// fn is_string<T: ?Sized + Any>(_s: &T) -> bool {
     ///     TypeId::of::<String>() == TypeId::of::<T>()
@@ -701,7 +701,7 @@ impl TypeId {
 /// string returned are not specified, other than being a best-effort
 /// description of the type. For example, amongst the strings
 /// that `type_name::<Option<String>>()` might return are `"Option<String>"` and
-/// `"std::option::Option<std::string::String>"`.
+/// `"core::option::Option<core::string::String>"`.
 ///
 /// The returned string must not be considered to be a unique identifier of a
 /// type as multiple types may map to the same type name. Similarly, there is no
@@ -716,7 +716,7 @@ impl TypeId {
 ///
 /// ```rust
 /// assert_eq!(
-///     std::any::type_name::<Option<String>>(),
+///     core::any::type_name::<Option<String>>(),
 ///     "core::option::Option<alloc::string::String>",
 /// );
 /// ```
@@ -736,7 +736,7 @@ pub const fn type_name<T: ?Sized>() -> &'static str {
 /// This is intended for diagnostic use. The exact contents and format of the
 /// string are not specified, other than being a best-effort description of the
 /// type. For example, `type_name_of_val::<Option<String>>(None)` could return
-/// `"Option<String>"` or `"std::option::Option<std::string::String>"`, but not
+/// `"Option<String>"` or `"core::option::Option<core::string::String>"`, but not
 /// `"foobar"`. In addition, the output may change between versions of the
 /// compiler.
 ///
@@ -756,7 +756,7 @@ pub const fn type_name<T: ?Sized>() -> &'static str {
 ///
 /// ```rust
 /// #![feature(type_name_of_val)]
-/// use std::any::type_name_of_val;
+/// use core::any::type_name_of_val;
 ///
 /// let x = 1;
 /// println!("{}", type_name_of_val(&x));
@@ -791,7 +791,7 @@ pub trait Provider {
     ///
     /// ```rust
     /// # #![feature(provide_any)]
-    /// use std::any::{Provider, Demand};
+    /// use core::any::{Provider, Demand};
     /// # struct SomeConcreteType { field: String, num_field: i32 }
     ///
     /// impl Provider for SomeConcreteType {
@@ -813,7 +813,7 @@ pub trait Provider {
 ///
 /// ```rust
 /// # #![feature(provide_any)]
-/// use std::any::{Provider, request_value};
+/// use core::any::{Provider, request_value};
 ///
 /// fn get_string(provider: &impl Provider) -> String {
 ///     request_value::<String>(provider).unwrap()
@@ -835,7 +835,7 @@ where
 ///
 /// ```rust
 /// # #![feature(provide_any)]
-/// use std::any::{Provider, request_ref};
+/// use core::any::{Provider, request_ref};
 ///
 /// fn get_str(provider: &impl Provider) -> &str {
 ///     request_ref::<str>(provider).unwrap()
@@ -887,7 +887,7 @@ impl<'a> Demand<'a> {
     /// ```rust
     /// #![feature(provide_any)]
     ///
-    /// use std::any::{Provider, Demand};
+    /// use core::any::{Provider, Demand};
     /// # struct SomeConcreteType { field: u8 }
     ///
     /// impl Provider for SomeConcreteType {
@@ -913,7 +913,7 @@ impl<'a> Demand<'a> {
     /// ```rust
     /// #![feature(provide_any)]
     ///
-    /// use std::any::{Provider, Demand};
+    /// use core::any::{Provider, Demand};
     /// # struct SomeConcreteType { field: String }
     ///
     /// impl Provider for SomeConcreteType {
@@ -940,7 +940,7 @@ impl<'a> Demand<'a> {
     /// ```rust
     /// #![feature(provide_any)]
     ///
-    /// use std::any::{Provider, Demand};
+    /// use core::any::{Provider, Demand};
     /// # struct SomeConcreteType { field: String }
     ///
     /// impl Provider for SomeConcreteType {
@@ -964,7 +964,7 @@ impl<'a> Demand<'a> {
     /// ```rust
     /// #![feature(provide_any)]
     ///
-    /// use std::any::{Provider, Demand};
+    /// use core::any::{Provider, Demand};
     /// # struct SomeConcreteType { business: String, party: String }
     /// # fn today_is_a_weekday() -> bool { true }
     ///
@@ -1022,7 +1022,7 @@ impl<'a> Demand<'a> {
     /// ```rust
     /// #![feature(provide_any)]
     ///
-    /// use std::any::{Provider, Demand};
+    /// use core::any::{Provider, Demand};
     ///
     /// struct Parent(Option<u8>);
     ///
@@ -1067,11 +1067,11 @@ impl<'a> Demand<'a> {
     ///
     /// let parent = Parent(Some(42));
     /// let child = Child { parent };
-    /// assert_eq!(Some(42), std::any::request_value::<u8>(&child));
+    /// assert_eq!(Some(42), core::any::request_value::<u8>(&child));
     ///
     /// let parent = Parent(None);
     /// let child = Child { parent };
-    /// assert_eq!(Some(99), std::any::request_value::<u8>(&child));
+    /// assert_eq!(Some(99), core::any::request_value::<u8>(&child));
     /// ```
     #[unstable(feature = "provide_any", issue = "96024")]
     pub fn would_be_satisfied_by_value_of<T>(&self) -> bool
@@ -1093,7 +1093,7 @@ impl<'a> Demand<'a> {
     /// ```rust
     /// #![feature(provide_any)]
     ///
-    /// use std::any::{Provider, Demand};
+    /// use core::any::{Provider, Demand};
     ///
     /// struct Parent(Option<String>);
     ///
@@ -1139,11 +1139,11 @@ impl<'a> Demand<'a> {
     ///
     /// let parent = Parent(Some("parent".into()));
     /// let child = Child { parent, name: "child".into() };
-    /// assert_eq!(Some("parent"), std::any::request_ref::<str>(&child));
+    /// assert_eq!(Some("parent"), core::any::request_ref::<str>(&child));
     ///
     /// let parent = Parent(None);
     /// let child = Child { parent, name: "child".into() };
-    /// assert_eq!(Some("child"), std::any::request_ref::<str>(&child));
+    /// assert_eq!(Some("child"), core::any::request_ref::<str>(&child));
     /// ```
     #[unstable(feature = "provide_any", issue = "96024")]
     pub fn would_be_satisfied_by_ref_of<T>(&self) -> bool

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -107,8 +107,8 @@ impl<T, const N: usize> IntoIter<T, N> {
     /// #![feature(array_into_iter_constructors)]
     /// #![feature(maybe_uninit_uninit_array_transpose)]
     /// #![feature(maybe_uninit_uninit_array)]
-    /// use std::array::IntoIter;
-    /// use std::mem::MaybeUninit;
+    /// use core::array::IntoIter;
+    /// use core::mem::MaybeUninit;
     ///
     /// # // Hi!  Thanks for reading the code. This is restricted to `Copy` because
     /// # // otherwise it could leak. A fully-general version this would need a drop
@@ -165,20 +165,20 @@ impl<T, const N: usize> IntoIter<T, N> {
     ///
     /// ```
     /// #![feature(array_into_iter_constructors)]
-    /// use std::array::IntoIter;
+    /// use core::array::IntoIter;
     ///
     /// let empty = IntoIter::<i32, 3>::empty();
     /// assert_eq!(empty.len(), 0);
     /// assert_eq!(empty.as_slice(), &[]);
     ///
-    /// let empty = IntoIter::<std::convert::Infallible, 200>::empty();
+    /// let empty = IntoIter::<core::convert::Infallible, 200>::empty();
     /// assert_eq!(empty.len(), 0);
     /// ```
     ///
     /// `[1, 2].into_iter()` and `[].into_iter()` have different types
     /// ```should_fail,edition2021
     /// #![feature(array_into_iter_constructors)]
-    /// use std::array::IntoIter;
+    /// use core::array::IntoIter;
     ///
     /// pub fn get_bytes(b: bool) -> IntoIter<i8, 4> {
     ///     if b {
@@ -192,7 +192,7 @@ impl<T, const N: usize> IntoIter<T, N> {
     /// But using this method you can get an empty iterator of appropriate size:
     /// ```edition2021
     /// #![feature(array_into_iter_constructors)]
-    /// use std::array::IntoIter;
+    /// use core::array::IntoIter;
     ///
     /// pub fn get_bytes(b: bool) -> IntoIter<i8, 4> {
     ///     if b {

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -79,16 +79,16 @@ where
 /// ```rust
 /// #![feature(array_try_from_fn)]
 ///
-/// let array: Result<[u8; 5], _> = std::array::try_from_fn(|i| i.try_into());
+/// let array: Result<[u8; 5], _> = core::array::try_from_fn(|i| i.try_into());
 /// assert_eq!(array, Ok([0, 1, 2, 3, 4]));
 ///
-/// let array: Result<[i8; 200], _> = std::array::try_from_fn(|i| i.try_into());
+/// let array: Result<[i8; 200], _> = core::array::try_from_fn(|i| i.try_into());
 /// assert!(array.is_err());
 ///
-/// let array: Option<[_; 4]> = std::array::try_from_fn(|i| i.checked_add(100));
+/// let array: Option<[_; 4]> = core::array::try_from_fn(|i| i.checked_add(100));
 /// assert_eq!(array, Some([100, 101, 102, 103]));
 ///
-/// let array: Option<[_; 4]> = std::array::try_from_fn(|i| i.checked_sub(100));
+/// let array: Option<[_; 4]> = core::array::try_from_fn(|i| i.checked_sub(100));
 /// assert_eq!(array, None);
 /// ```
 #[inline]
@@ -294,9 +294,9 @@ impl<'a, T, const N: usize> TryFrom<&'a mut [T]> for &'a mut [T; N] {
 ///
 /// ```
 /// #![feature(build_hasher_simple_hash_one)]
-/// use std::hash::BuildHasher;
+/// use core::hash::BuildHasher;
 ///
-/// let b = std::collections::hash_map::RandomState::new();
+/// let b = core::collections::hash_map::RandomState::new();
 /// let a: [u8; 3] = [0xa8, 0x3c, 0x09];
 /// let s: &[u8] = &[0xa8, 0x3c, 0x09];
 /// assert_eq!(b.hash_one(a), b.hash_one(s));
@@ -523,7 +523,7 @@ impl<T, const N: usize> [T; N] {
     /// let b = a.try_map(|v| v.parse::<u32>());
     /// assert!(b.is_err());
     ///
-    /// use std::num::NonZeroU32;
+    /// use core::num::NonZeroU32;
     /// let z = [1, 2, 0, 3, 4];
     /// assert_eq!(z.try_map(NonZeroU32::new), None);
     /// let a = [1, 2, 3];

--- a/library/core/src/ascii.rs
+++ b/library/core/src/ascii.rs
@@ -46,7 +46,7 @@ pub struct EscapeDefault {
 /// # Examples
 ///
 /// ```
-/// use std::ascii;
+/// use core::ascii;
 ///
 /// let escaped = ascii::escape_default(b'0').next().unwrap();
 /// assert_eq!(b'0', escaped);

--- a/library/core/src/borrow.rs
+++ b/library/core/src/borrow.rs
@@ -60,11 +60,11 @@
 /// this:
 ///
 /// ```
-/// use std::borrow::Borrow;
-/// use std::hash::Hash;
+/// use core::borrow::Borrow;
+/// use core::hash::Hash;
 ///
 /// pub struct HashMap<K, V> {
-///     # marker: ::std::marker::PhantomData<(K, V)>,
+///     # marker: ::core::marker::PhantomData<(K, V)>,
 ///     // fields omitted
 /// }
 ///
@@ -131,7 +131,7 @@
 /// implementation of `Hash` needs to ignore ASCII case, too:
 ///
 /// ```
-/// # use std::hash::{Hash, Hasher};
+/// # use core::hash::{Hash, Hasher};
 /// # pub struct CaseInsensitiveString(String);
 /// impl Hash for CaseInsensitiveString {
 ///     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -161,7 +161,7 @@ pub trait Borrow<Borrowed: ?Sized> {
     /// # Examples
     ///
     /// ```
-    /// use std::borrow::Borrow;
+    /// use core::borrow::Borrow;
     ///
     /// fn check<T: Borrow<str>>(s: T) {
     ///     assert_eq!("Hello", s.borrow());
@@ -192,7 +192,7 @@ pub trait BorrowMut<Borrowed: ?Sized>: Borrow<Borrowed> {
     /// # Examples
     ///
     /// ```
-    /// use std::borrow::BorrowMut;
+    /// use core::borrow::BorrowMut;
     ///
     /// fn check<T: BorrowMut<[i32]>>(mut v: T) {
     ///     assert_eq!(&mut [1, 2, 3], v.borrow_mut());

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -107,9 +107,9 @@
 //! mutability:
 //!
 //! ```
-//! use std::cell::{RefCell, RefMut};
-//! use std::collections::HashMap;
-//! use std::rc::Rc;
+//! use core::cell::{RefCell, RefMut};
+//! use core::collections::HashMap;
+//! use core::rc::Rc;
 //!
 //! fn main() {
 //!     let shared_map: Rc<RefCell<_>> = Rc::new(RefCell::new(HashMap::new()));
@@ -143,7 +143,7 @@
 //!
 //! ```
 //! # #![allow(dead_code)]
-//! use std::cell::RefCell;
+//! use core::cell::RefCell;
 //!
 //! struct Graph {
 //!     edges: Vec<(i32, i32)>,
@@ -173,10 +173,10 @@
 //! reference counts within a `Cell<T>`.
 //!
 //! ```
-//! use std::cell::Cell;
-//! use std::ptr::NonNull;
-//! use std::process::abort;
-//! use std::marker::PhantomData;
+//! use core::cell::Cell;
+//! use core::ptr::NonNull;
+//! use core::process::abort;
+//! use core::marker::PhantomData;
 //!
 //! struct Rc<T: ?Sized> {
 //!     ptr: NonNull<RcBox<T>>,
@@ -264,7 +264,7 @@ pub use once::OnceCell;
 /// immutable struct. In other words, it enables "interior mutability".
 ///
 /// ```
-/// use std::cell::Cell;
+/// use core::cell::Cell;
 ///
 /// struct SomeStruct {
 ///     regular_field: u8,
@@ -384,7 +384,7 @@ impl<T> Cell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let c = Cell::new(5);
     /// ```
@@ -400,7 +400,7 @@ impl<T> Cell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let c = Cell::new(5);
     ///
@@ -414,12 +414,12 @@ impl<T> Cell<T> {
     }
 
     /// Swaps the values of two `Cell`s.
-    /// Difference with `std::mem::swap` is that this function doesn't require `&mut` reference.
+    /// Difference with `core::mem::swap` is that this function doesn't require `&mut` reference.
     ///
     /// # Examples
     ///
     /// ```
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let c1 = Cell::new(5i32);
     /// let c2 = Cell::new(10i32);
@@ -447,7 +447,7 @@ impl<T> Cell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let cell = Cell::new(5);
     /// assert_eq!(cell.get(), 5);
@@ -467,7 +467,7 @@ impl<T> Cell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let c = Cell::new(5);
     /// let five = c.into_inner();
@@ -487,7 +487,7 @@ impl<T: Copy> Cell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let c = Cell::new(5);
     ///
@@ -508,7 +508,7 @@ impl<T: Copy> Cell<T> {
     /// ```
     /// #![feature(cell_update)]
     ///
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let c = Cell::new(5);
     /// let new = c.update(|x| x + 1);
@@ -535,7 +535,7 @@ impl<T: ?Sized> Cell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let c = Cell::new(5);
     ///
@@ -563,7 +563,7 @@ impl<T: ?Sized> Cell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let mut c = Cell::new(5);
     /// *c.get_mut() += 1;
@@ -581,7 +581,7 @@ impl<T: ?Sized> Cell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let slice: &mut [i32] = &mut [1, 2, 3];
     /// let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
@@ -603,7 +603,7 @@ impl<T: Default> Cell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let c = Cell::new(5);
     /// let five = c.take();
@@ -636,7 +636,7 @@ impl<T> Cell<[T]> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let slice: &mut [i32] = &mut [1, 2, 3];
     /// let cell_slice: &Cell<[i32]> = Cell::from_mut(slice);
@@ -658,7 +658,7 @@ impl<T, const N: usize> Cell<[T; N]> {
     ///
     /// ```
     /// #![feature(as_array_of_cells)]
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let mut array: [i32; 3] = [1, 2, 3];
     /// let cell_array: &Cell<[i32; 3]> = Cell::from_mut(&mut array);
@@ -773,7 +773,7 @@ impl<T> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let c = RefCell::new(5);
     /// ```
@@ -794,7 +794,7 @@ impl<T> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let c = RefCell::new(5);
     ///
@@ -812,7 +812,7 @@ impl<T> RefCell<T> {
     /// Replaces the wrapped value with a new one, returning the old value,
     /// without deinitializing either one.
     ///
-    /// This function corresponds to [`std::mem::replace`](../mem/fn.replace.html).
+    /// This function corresponds to [`core::mem::replace`](../mem/fn.replace.html).
     ///
     /// # Panics
     ///
@@ -821,7 +821,7 @@ impl<T> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     /// let cell = RefCell::new(5);
     /// let old_value = cell.replace(6);
     /// assert_eq!(old_value, 5);
@@ -844,7 +844,7 @@ impl<T> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     /// let cell = RefCell::new(5);
     /// let old_value = cell.replace_with(|&mut old| old + 1);
     /// assert_eq!(old_value, 5);
@@ -862,7 +862,7 @@ impl<T> RefCell<T> {
     /// Swaps the wrapped value of `self` with the wrapped value of `other`,
     /// without deinitializing either one.
     ///
-    /// This function corresponds to [`std::mem::swap`](../mem/fn.swap.html).
+    /// This function corresponds to [`core::mem::swap`](../mem/fn.swap.html).
     ///
     /// # Panics
     ///
@@ -872,7 +872,7 @@ impl<T> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     /// let c = RefCell::new(5);
     /// let d = RefCell::new(6);
     /// c.swap(&d);
@@ -900,7 +900,7 @@ impl<T: ?Sized> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let c = RefCell::new(5);
     ///
@@ -911,7 +911,7 @@ impl<T: ?Sized> RefCell<T> {
     /// An example of panic:
     ///
     /// ```should_panic
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let c = RefCell::new(5);
     ///
@@ -936,7 +936,7 @@ impl<T: ?Sized> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let c = RefCell::new(5);
     ///
@@ -992,7 +992,7 @@ impl<T: ?Sized> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let c = RefCell::new("hello".to_owned());
     ///
@@ -1004,7 +1004,7 @@ impl<T: ?Sized> RefCell<T> {
     /// An example of panic:
     ///
     /// ```should_panic
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let c = RefCell::new(5);
     /// let m = c.borrow();
@@ -1029,7 +1029,7 @@ impl<T: ?Sized> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let c = RefCell::new(5);
     ///
@@ -1069,7 +1069,7 @@ impl<T: ?Sized> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let c = RefCell::new(5);
     ///
@@ -1101,7 +1101,7 @@ impl<T: ?Sized> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let mut c = RefCell::new(5);
     /// *c.get_mut() += 1;
@@ -1126,10 +1126,10 @@ impl<T: ?Sized> RefCell<T> {
     ///
     /// ```
     /// #![feature(cell_leak)]
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let mut c = RefCell::new(0);
-    /// std::mem::forget(c.borrow_mut());
+    /// core::mem::forget(c.borrow_mut());
     ///
     /// assert!(c.try_borrow().is_err());
     /// c.undo_leak();
@@ -1154,7 +1154,7 @@ impl<T: ?Sized> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let c = RefCell::new(5);
     ///
@@ -1199,7 +1199,7 @@ impl<T: Default> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::RefCell;
+    /// use core::cell::RefCell;
     ///
     /// let c = RefCell::new(5);
     /// let five = c.take();
@@ -1434,7 +1434,7 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::{RefCell, Ref};
+    /// use core::cell::{RefCell, Ref};
     ///
     /// let c = RefCell::new((5, 'b'));
     /// let b1: Ref<(u32, char)> = c.borrow();
@@ -1463,7 +1463,7 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::{RefCell, Ref};
+    /// use core::cell::{RefCell, Ref};
     ///
     /// let c = RefCell::new(vec![1, 2, 3]);
     /// let b1: Ref<Vec<u32>> = c.borrow();
@@ -1494,7 +1494,7 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::{Ref, RefCell};
+    /// use core::cell::{Ref, RefCell};
     ///
     /// let cell = RefCell::new([1, 2, 3, 4]);
     /// let borrow = cell.borrow();
@@ -1531,7 +1531,7 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     ///
     /// ```
     /// #![feature(cell_leak)]
-    /// use std::cell::{RefCell, Ref};
+    /// use core::cell::{RefCell, Ref};
     /// let cell = RefCell::new(0);
     ///
     /// let value = Ref::leak(cell.borrow());
@@ -1575,7 +1575,7 @@ impl<'b, T: ?Sized> RefMut<'b, T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::{RefCell, RefMut};
+    /// use core::cell::{RefCell, RefMut};
     ///
     /// let c = RefCell::new((5, 'b'));
     /// {
@@ -1609,7 +1609,7 @@ impl<'b, T: ?Sized> RefMut<'b, T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::{RefCell, RefMut};
+    /// use core::cell::{RefCell, RefMut};
     ///
     /// let c = RefCell::new(vec![1, 2, 3]);
     ///
@@ -1657,7 +1657,7 @@ impl<'b, T: ?Sized> RefMut<'b, T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::{RefCell, RefMut};
+    /// use core::cell::{RefCell, RefMut};
     ///
     /// let cell = RefCell::new([1, 2, 3, 4]);
     /// let borrow = cell.borrow_mut();
@@ -1697,7 +1697,7 @@ impl<'b, T: ?Sized> RefMut<'b, T> {
     ///
     /// ```
     /// #![feature(cell_leak)]
-    /// use std::cell::{RefCell, RefMut};
+    /// use core::cell::{RefCell, RefMut};
     /// let cell = RefCell::new(0);
     ///
     /// let value = RefMut::leak(cell.borrow_mut());
@@ -1896,7 +1896,7 @@ impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
 /// same memory layout, the following is not allowed and undefined behavior:
 ///
 /// ```rust,no_run
-/// # use std::cell::UnsafeCell;
+/// # use core::cell::UnsafeCell;
 /// unsafe fn not_allowed<T>(ptr: &UnsafeCell<T>) -> &mut T {
 ///   let t = ptr as *const UnsafeCell<T> as *mut T;
 ///   // This is undefined behavior, because the `*mut T` pointer
@@ -1908,7 +1908,7 @@ impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
 /// Instead, do this:
 ///
 /// ```rust
-/// # use std::cell::UnsafeCell;
+/// # use core::cell::UnsafeCell;
 /// // Safety: the caller must ensure that there are no references that
 /// // point to the *contents* of the `UnsafeCell`.
 /// unsafe fn get_mut<T>(ptr: &UnsafeCell<T>) -> &mut T {
@@ -1920,7 +1920,7 @@ impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
 /// to an `&UnsafeCell<T>` is allowed:
 ///
 /// ```rust
-/// # use std::cell::UnsafeCell;
+/// # use core::cell::UnsafeCell;
 /// fn get_shared<T>(ptr: &mut T) -> &UnsafeCell<T> {
 ///   let t = ptr as *mut T as *const UnsafeCell<T>;
 ///   // SAFETY: `T` and `UnsafeCell<T>` have the same memory layout
@@ -1937,7 +1937,7 @@ impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
 /// there being multiple references aliasing the cell:
 ///
 /// ```
-/// use std::cell::UnsafeCell;
+/// use core::cell::UnsafeCell;
 ///
 /// let x: UnsafeCell<i32> = 42.into();
 /// // Get multiple / concurrent / shared references to the same `x`.
@@ -1967,7 +1967,7 @@ impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
 /// #![forbid(unsafe_code)] // with exclusive accesses,
 ///                         // `UnsafeCell` is a transparent no-op wrapper,
 ///                         // so no need for `unsafe` here.
-/// use std::cell::UnsafeCell;
+/// use core::cell::UnsafeCell;
 ///
 /// let mut x: UnsafeCell<i32> = 42.into();
 ///
@@ -2001,7 +2001,7 @@ impl<T> UnsafeCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::UnsafeCell;
+    /// use core::cell::UnsafeCell;
     ///
     /// let uc = UnsafeCell::new(5);
     /// ```
@@ -2017,7 +2017,7 @@ impl<T> UnsafeCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::UnsafeCell;
+    /// use core::cell::UnsafeCell;
     ///
     /// let uc = UnsafeCell::new(5);
     ///
@@ -2042,7 +2042,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::UnsafeCell;
+    /// use core::cell::UnsafeCell;
     ///
     /// let uc = UnsafeCell::new(5);
     ///
@@ -2066,7 +2066,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::UnsafeCell;
+    /// use core::cell::UnsafeCell;
     ///
     /// let mut c = UnsafeCell::new(5);
     /// *c.get_mut() += 1;
@@ -2097,8 +2097,8 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// calling `get` would require creating a reference to uninitialized data:
     ///
     /// ```
-    /// use std::cell::UnsafeCell;
-    /// use std::mem::MaybeUninit;
+    /// use core::cell::UnsafeCell;
+    /// use core::mem::MaybeUninit;
     ///
     /// let m = MaybeUninit::<UnsafeCell<i32>>::uninit();
     /// unsafe { UnsafeCell::raw_get(m.as_ptr()).write(5); }

--- a/library/core/src/cell/lazy.rs
+++ b/library/core/src/cell/lazy.rs
@@ -11,16 +11,16 @@ enum State<T, F> {
 
 /// A value which is initialized on the first access.
 ///
-/// For a thread-safe version of this struct, see [`std::sync::LazyLock`].
+/// For a thread-safe version of this struct, see [`core::sync::LazyLock`].
 ///
-/// [`std::sync::LazyLock`]: ../../std/sync/struct.LazyLock.html
+/// [`core::sync::LazyLock`]: ../../std/sync/struct.LazyLock.html
 ///
 /// # Examples
 ///
 /// ```
 /// #![feature(lazy_cell)]
 ///
-/// use std::cell::LazyCell;
+/// use core::cell::LazyCell;
 ///
 /// let lazy: LazyCell<i32> = LazyCell::new(|| {
 ///     println!("initializing");
@@ -49,7 +49,7 @@ impl<T, F: FnOnce() -> T> LazyCell<T, F> {
     /// ```
     /// #![feature(lazy_cell)]
     ///
-    /// use std::cell::LazyCell;
+    /// use core::cell::LazyCell;
     ///
     /// let hello = "Hello, World!".to_string();
     ///
@@ -73,7 +73,7 @@ impl<T, F: FnOnce() -> T> LazyCell<T, F> {
     /// ```
     /// #![feature(lazy_cell)]
     ///
-    /// use std::cell::LazyCell;
+    /// use core::cell::LazyCell;
     ///
     /// let lazy = LazyCell::new(|| 92);
     ///

--- a/library/core/src/cell/once.rs
+++ b/library/core/src/cell/once.rs
@@ -9,16 +9,16 @@ use crate::mem;
 /// only immutable references can be obtained unless one has a mutable reference to the cell
 /// itself.
 ///
-/// For a thread-safe version of this struct, see [`std::sync::OnceLock`].
+/// For a thread-safe version of this struct, see [`core::sync::OnceLock`].
 ///
 /// [`RefCell`]: crate::cell::RefCell
 /// [`Cell`]: crate::cell::Cell
-/// [`std::sync::OnceLock`]: ../../std/sync/struct.OnceLock.html
+/// [`core::sync::OnceLock`]: ../../std/sync/struct.OnceLock.html
 ///
 /// # Examples
 ///
 /// ```
-/// use std::cell::OnceCell;
+/// use core::cell::OnceCell;
 ///
 /// let cell = OnceCell::new();
 /// assert!(cell.get().is_none());
@@ -74,7 +74,7 @@ impl<T> OnceCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::OnceCell;
+    /// use core::cell::OnceCell;
     ///
     /// let cell = OnceCell::new();
     /// assert!(cell.get().is_none());
@@ -116,7 +116,7 @@ impl<T> OnceCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::OnceCell;
+    /// use core::cell::OnceCell;
     ///
     /// let cell = OnceCell::new();
     /// let value = cell.get_or_init(|| 92);
@@ -152,7 +152,7 @@ impl<T> OnceCell<T> {
     /// ```
     /// #![feature(once_cell_try)]
     ///
-    /// use std::cell::OnceCell;
+    /// use core::cell::OnceCell;
     ///
     /// let cell = OnceCell::new();
     /// assert_eq!(cell.get_or_try_init(|| Err(())), Err(()));
@@ -196,7 +196,7 @@ impl<T> OnceCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::OnceCell;
+    /// use core::cell::OnceCell;
     ///
     /// let cell: OnceCell<String> = OnceCell::new();
     /// assert_eq!(cell.into_inner(), None);
@@ -222,7 +222,7 @@ impl<T> OnceCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::cell::OnceCell;
+    /// use core::cell::OnceCell;
     ///
     /// let mut cell: OnceCell<String> = OnceCell::new();
     /// assert_eq!(cell.take(), None);

--- a/library/core/src/char/convert.rs
+++ b/library/core/src/char/convert.rs
@@ -34,7 +34,7 @@ impl const From<char> for u32 {
     /// # Examples
     ///
     /// ```
-    /// use std::mem;
+    /// use core::mem;
     ///
     /// let c = 'c';
     /// let u = u32::from(c);
@@ -54,7 +54,7 @@ impl const From<char> for u64 {
     /// # Examples
     ///
     /// ```
-    /// use std::mem;
+    /// use core::mem;
     ///
     /// let c = '👤';
     /// let u = u64::from(c);
@@ -76,7 +76,7 @@ impl const From<char> for u128 {
     /// # Examples
     ///
     /// ```
-    /// use std::mem;
+    /// use core::mem;
     ///
     /// let c = '⚙';
     /// let u = u128::from(c);
@@ -130,7 +130,7 @@ impl const From<u8> for char {
     /// # Examples
     ///
     /// ```
-    /// use std::mem;
+    /// use core::mem;
     ///
     /// let u = 32 as u8;
     /// let c = char::from(u);

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -321,7 +321,7 @@ pub struct AssertParamIsEq<T: Eq + ?Sized> {
 /// # Examples
 ///
 /// ```
-/// use std::cmp::Ordering;
+/// use core::cmp::Ordering;
 ///
 /// let result = 1.cmp(&2);
 /// assert_eq!(Ordering::Less, result);
@@ -354,7 +354,7 @@ impl Ordering {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// assert_eq!(Ordering::Less.is_eq(), false);
     /// assert_eq!(Ordering::Equal.is_eq(), true);
@@ -373,7 +373,7 @@ impl Ordering {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// assert_eq!(Ordering::Less.is_ne(), true);
     /// assert_eq!(Ordering::Equal.is_ne(), false);
@@ -392,7 +392,7 @@ impl Ordering {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// assert_eq!(Ordering::Less.is_lt(), true);
     /// assert_eq!(Ordering::Equal.is_lt(), false);
@@ -411,7 +411,7 @@ impl Ordering {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// assert_eq!(Ordering::Less.is_gt(), false);
     /// assert_eq!(Ordering::Equal.is_gt(), false);
@@ -430,7 +430,7 @@ impl Ordering {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// assert_eq!(Ordering::Less.is_le(), true);
     /// assert_eq!(Ordering::Equal.is_le(), true);
@@ -449,7 +449,7 @@ impl Ordering {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// assert_eq!(Ordering::Less.is_ge(), false);
     /// assert_eq!(Ordering::Equal.is_ge(), true);
@@ -474,7 +474,7 @@ impl Ordering {
     /// Basic behavior:
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// assert_eq!(Ordering::Less.reverse(), Ordering::Greater);
     /// assert_eq!(Ordering::Equal.reverse(), Ordering::Equal);
@@ -511,7 +511,7 @@ impl Ordering {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// let result = Ordering::Equal.then(Ordering::Less);
     /// assert_eq!(result, Ordering::Less);
@@ -550,7 +550,7 @@ impl Ordering {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// let result = Ordering::Equal.then_with(|| Ordering::Less);
     /// assert_eq!(result, Ordering::Less);
@@ -591,7 +591,7 @@ impl Ordering {
 /// # Examples
 ///
 /// ```
-/// use std::cmp::Reverse;
+/// use core::cmp::Reverse;
 ///
 /// let mut v = vec![1, 2, 3, 4, 5, 6];
 /// v.sort_by_key(|&num| (num > 3, Reverse(num)));
@@ -727,7 +727,7 @@ impl<T: Clone> Clone for Reverse<T> {
 /// and `name`:
 ///
 /// ```
-/// use std::cmp::Ordering;
+/// use core::cmp::Ordering;
 ///
 /// #[derive(Eq)]
 /// struct Person {
@@ -772,7 +772,7 @@ pub trait Ord: Eq + PartialOrd<Self> {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// assert_eq!(5.cmp(&10), Ordering::Less);
     /// assert_eq!(10.cmp(&5), Ordering::Greater);
@@ -956,7 +956,7 @@ pub macro Ord($item:item) {
 /// If your type is [`Ord`], you can implement [`partial_cmp`] by using [`cmp`]:
 ///
 /// ```
-/// use std::cmp::Ordering;
+/// use core::cmp::Ordering;
 ///
 /// #[derive(Eq)]
 /// struct Person {
@@ -989,7 +989,7 @@ pub macro Ord($item:item) {
 /// is the only field to be used for sorting:
 ///
 /// ```
-/// use std::cmp::Ordering;
+/// use core::cmp::Ordering;
 ///
 /// struct Person {
 ///     id: u32,
@@ -1041,7 +1041,7 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// let result = 1.0.partial_cmp(&2.0);
     /// assert_eq!(result, Some(Ordering::Less));
@@ -1155,7 +1155,7 @@ pub macro PartialOrd($item:item) {
 /// # Examples
 ///
 /// ```
-/// use std::cmp;
+/// use core::cmp;
 ///
 /// assert_eq!(1, cmp::min(1, 2));
 /// assert_eq!(2, cmp::min(2, 2));
@@ -1176,7 +1176,7 @@ pub const fn min<T: ~const Ord + ~const Destruct>(v1: T, v2: T) -> T {
 /// # Examples
 ///
 /// ```
-/// use std::cmp;
+/// use core::cmp;
 ///
 /// assert_eq!(cmp::min_by(-2, 1, |x: &i32, y: &i32| x.abs().cmp(&y.abs())), 1);
 /// assert_eq!(cmp::min_by(-2, 2, |x: &i32, y: &i32| x.abs().cmp(&y.abs())), -2);
@@ -1203,7 +1203,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use std::cmp;
+/// use core::cmp;
 ///
 /// assert_eq!(cmp::min_by_key(-2, 1, |x: &i32| x.abs()), 1);
 /// assert_eq!(cmp::min_by_key(-2, 2, |x: &i32| x.abs()), -2);
@@ -1230,7 +1230,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use std::cmp;
+/// use core::cmp;
 ///
 /// assert_eq!(2, cmp::max(1, 2));
 /// assert_eq!(2, cmp::max(2, 2));
@@ -1251,7 +1251,7 @@ pub const fn max<T: ~const Ord + ~const Destruct>(v1: T, v2: T) -> T {
 /// # Examples
 ///
 /// ```
-/// use std::cmp;
+/// use core::cmp;
 ///
 /// assert_eq!(cmp::max_by(-2, 1, |x: &i32, y: &i32| x.abs().cmp(&y.abs())), -2);
 /// assert_eq!(cmp::max_by(-2, 2, |x: &i32, y: &i32| x.abs().cmp(&y.abs())), 2);
@@ -1278,7 +1278,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use std::cmp;
+/// use core::cmp;
 ///
 /// assert_eq!(cmp::max_by_key(-2, 1, |x: &i32| x.abs()), -2);
 /// assert_eq!(cmp::max_by_key(-2, 2, |x: &i32| x.abs()), 2);

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -62,7 +62,7 @@ pub use num::FloatToInt;
 /// functions:
 ///
 /// ```rust
-/// use std::convert::identity;
+/// use core::convert::identity;
 ///
 /// fn manipulation(x: u32) -> u32 {
 ///     // Let's pretend that adding one is an interesting function.
@@ -75,7 +75,7 @@ pub use num::FloatToInt;
 /// Using `identity` as a "do nothing" base case in a conditional:
 ///
 /// ```rust
-/// use std::convert::identity;
+/// use core::convert::identity;
 ///
 /// # let condition = true;
 /// #
@@ -91,7 +91,7 @@ pub use num::FloatToInt;
 /// Using `identity` to keep the `Some` variants of an iterator of `Option<T>`:
 ///
 /// ```rust
-/// use std::convert::identity;
+/// use core::convert::identity;
 ///
 /// let iter = [Some(1), None, Some(3)].into_iter();
 /// let filtered = iter.filter_map(identity).collect::<Vec<_>>();
@@ -502,9 +502,9 @@ pub trait Into<T>: Sized {
 /// implementing `From`. The compiler then infers which implementation of `Into` should be used.
 ///
 /// ```
-/// use std::fs;
-/// use std::io;
-/// use std::num;
+/// use core::fs;
+/// use core::io;
+/// use core::num;
 ///
 /// enum CliError {
 ///     IoError(io::Error),
@@ -536,7 +536,7 @@ pub trait Into<T>: Sized {
 #[rustc_diagnostic_item = "From"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented(on(
-    all(_Self = "&str", T = "std::string::String"),
+    all(_Self = "&str", T = "core::string::String"),
     note = "to coerce a `{T}` into a `{Self}`, use `&*` as a prefix",
 ))]
 #[const_trait]
@@ -864,7 +864,7 @@ impl AsMut<str> for str {
 /// ```
 /// trait MyTrait {}
 /// impl MyTrait for fn() -> ! {}
-/// impl MyTrait for fn() -> std::convert::Infallible {}
+/// impl MyTrait for fn() -> core::convert::Infallible {}
 /// ```
 ///
 /// With `Infallible` being an enum, this code is valid.

--- a/library/core/src/default.rs
+++ b/library/core/src/default.rs
@@ -143,7 +143,7 @@ pub trait Default: Sized {
 /// ```
 /// #![feature(default_free_fn)]
 ///
-/// use std::default::default;
+/// use core::default::default;
 ///
 /// #[derive(Default)]
 /// struct AppConfig {

--- a/library/core/src/error.md
+++ b/library/core/src/error.md
@@ -52,7 +52,7 @@ Of the two, `expect` is generally preferred since its `msg` field allows you
 to convey your intent and assumptions which makes tracking down the source
 of a panic easier. `unwrap` on the other hand can still be a good fit in
 situations where you can trivially show that a piece of code will never
-panic, such as `"127.0.0.1".parse::<std::net::IpAddr>().unwrap()` or early
+panic, such as `"127.0.0.1".parse::<core::net::IpAddr>().unwrap()` or early
 prototyping.
 
 # Common Message Styles
@@ -67,14 +67,14 @@ has occurred which is considered a bug. Consider the following example:
 
 ```should_panic
 // Read environment variable, panic if it is not present
-let path = std::env::var("IMPORTANT_PATH").unwrap();
+let path = core::env::var("IMPORTANT_PATH").unwrap();
 ```
 
 In the "expect as error message" style we would use expect to describe
 that the environment variable was not set when it should have been:
 
 ```should_panic
-let path = std::env::var("IMPORTANT_PATH")
+let path = core::env::var("IMPORTANT_PATH")
     .expect("env variable `IMPORTANT_PATH` is not set");
 ```
 
@@ -83,7 +83,7 @@ reason we _expect_ the `Result` should be `Ok`. With this style we would
 prefer to write:
 
 ```should_panic
-let path = std::env::var("IMPORTANT_PATH")
+let path = core::env::var("IMPORTANT_PATH")
     .expect("env variable `IMPORTANT_PATH` should be set by `wrapper_script.sh`");
 ```
 

--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -35,8 +35,8 @@ pub trait Error: Debug + Display {
     /// # Examples
     ///
     /// ```
-    /// use std::error::Error;
-    /// use std::fmt;
+    /// use core::error::Error;
+    /// use core::fmt;
     ///
     /// #[derive(Debug)]
     /// struct SuperError {
@@ -157,7 +157,7 @@ pub trait Error: Debug + Display {
     ///     }
     /// }
     ///
-    /// impl std::error::Error for SourceError {}
+    /// impl core::error::Error for SourceError {}
     ///
     /// #[derive(Debug)]
     /// struct Error {
@@ -171,11 +171,11 @@ pub trait Error: Debug + Display {
     ///     }
     /// }
     ///
-    /// impl std::error::Error for Error {
+    /// impl core::error::Error for Error {
     ///     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
     ///         demand
     ///             .provide_ref::<MyBacktrace>(&self.backtrace)
-    ///             .provide_ref::<dyn std::error::Error + 'static>(&self.source);
+    ///             .provide_ref::<dyn core::error::Error + 'static>(&self.source);
     ///     }
     /// }
     ///
@@ -183,7 +183,7 @@ pub trait Error: Debug + Display {
     ///     let backtrace = MyBacktrace::new();
     ///     let source = SourceError {};
     ///     let error = Error { source, backtrace };
-    ///     let dyn_error = &error as &dyn std::error::Error;
+    ///     let dyn_error = &error as &dyn core::error::Error;
     ///     let backtrace_ref = dyn_error.request_ref::<MyBacktrace>().unwrap();
     ///
     ///     assert!(core::ptr::eq(&error.backtrace, backtrace_ref));
@@ -353,8 +353,8 @@ impl dyn Error {
     ///
     /// ```
     /// #![feature(error_iter)]
-    /// use std::error::Error;
-    /// use std::fmt;
+    /// use core::error::Error;
+    /// use core::fmt;
     ///
     /// #[derive(Debug)]
     /// struct A;

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -33,8 +33,8 @@ use crate::str;
 /// Inspecting a foreign C string:
 ///
 /// ```ignore (extern-declaration)
-/// use std::ffi::CStr;
-/// use std::os::raw::c_char;
+/// use core::ffi::CStr;
+/// use core::os::raw::c_char;
 ///
 /// extern "C" { fn my_string() -> *const c_char; }
 ///
@@ -47,8 +47,8 @@ use crate::str;
 /// Passing a Rust-originating C string:
 ///
 /// ```ignore (extern-declaration)
-/// use std::ffi::{CString, CStr};
-/// use std::os::raw::c_char;
+/// use core::ffi::{CString, CStr};
+/// use core::os::raw::c_char;
 ///
 /// fn work(data: &CStr) {
 ///     extern "C" { fn work_with(data: *const c_char); }
@@ -63,8 +63,8 @@ use crate::str;
 /// Converting a foreign C string into a Rust `String`:
 ///
 /// ```ignore (extern-declaration)
-/// use std::ffi::CStr;
-/// use std::os::raw::c_char;
+/// use core::ffi::CStr;
+/// use core::os::raw::c_char;
 ///
 /// extern "C" { fn my_string() -> *const c_char; }
 ///
@@ -107,7 +107,7 @@ pub struct CStr {
 /// # Examples
 ///
 /// ```
-/// use std::ffi::{CStr, FromBytesWithNulError};
+/// use core::ffi::{CStr, FromBytesWithNulError};
 ///
 /// let _: FromBytesWithNulError = CStr::from_bytes_with_nul(b"f\0oo").unwrap_err();
 /// ```
@@ -228,7 +228,7 @@ impl CStr {
     /// # Examples
     ///
     /// ```ignore (extern-declaration)
-    /// use std::ffi::{c_char, CStr};
+    /// use core::ffi::{c_char, CStr};
     ///
     /// extern "C" {
     ///     fn my_string() -> *const c_char;
@@ -243,7 +243,7 @@ impl CStr {
     /// ```
     /// #![feature(const_cstr_methods)]
     ///
-    /// use std::ffi::{c_char, CStr};
+    /// use core::ffi::{c_char, CStr};
     ///
     /// const HELLO_PTR: *const c_char = {
     ///     const BYTES: &[u8] = b"Hello, world!\0";
@@ -310,7 +310,7 @@ impl CStr {
     ///
     /// # Examples
     /// ```
-    /// use std::ffi::CStr;
+    /// use core::ffi::CStr;
     ///
     /// let mut buffer = [0u8; 16];
     /// unsafe {
@@ -352,7 +352,7 @@ impl CStr {
     /// # Examples
     ///
     /// ```
-    /// use std::ffi::CStr;
+    /// use core::ffi::CStr;
     ///
     /// let cstr = CStr::from_bytes_with_nul(b"hello\0");
     /// assert!(cstr.is_ok());
@@ -361,7 +361,7 @@ impl CStr {
     /// Creating a `CStr` without a trailing nul terminator is an error:
     ///
     /// ```
-    /// use std::ffi::CStr;
+    /// use core::ffi::CStr;
     ///
     /// let cstr = CStr::from_bytes_with_nul(b"hello");
     /// assert!(cstr.is_err());
@@ -370,7 +370,7 @@ impl CStr {
     /// Creating a `CStr` with an interior nul byte is an error:
     ///
     /// ```
-    /// use std::ffi::CStr;
+    /// use core::ffi::CStr;
     ///
     /// let cstr = CStr::from_bytes_with_nul(b"he\0llo\0");
     /// assert!(cstr.is_err());
@@ -402,7 +402,7 @@ impl CStr {
     /// # Examples
     ///
     /// ```
-    /// use std::ffi::{CStr, CString};
+    /// use core::ffi::{CStr, CString};
     ///
     /// unsafe {
     ///     let cstring = CString::new("hello").expect("CString::new failed");
@@ -473,7 +473,7 @@ impl CStr {
     ///
     /// ```no_run
     /// # #![allow(unused_must_use)] #![allow(temporary_cstring_as_ptr)]
-    /// use std::ffi::CString;
+    /// use core::ffi::CString;
     ///
     /// // Do not do this:
     /// let ptr = CString::new("Hello").expect("CString::new failed").as_ptr();
@@ -491,7 +491,7 @@ impl CStr {
     ///
     /// ```no_run
     /// # #![allow(unused_must_use)]
-    /// use std::ffi::CString;
+    /// use core::ffi::CString;
     ///
     /// let hello = CString::new("Hello").expect("CString::new failed");
     /// let ptr = hello.as_ptr();
@@ -518,8 +518,8 @@ impl CStr {
     /// ```
     /// #![feature(cstr_is_empty)]
     ///
-    /// use std::ffi::CStr;
-    /// # use std::ffi::FromBytesWithNulError;
+    /// use core::ffi::CStr;
+    /// # use core::ffi::FromBytesWithNulError;
     ///
     /// # fn main() { test().unwrap(); }
     /// # fn test() -> Result<(), FromBytesWithNulError> {
@@ -551,7 +551,7 @@ impl CStr {
     /// # Examples
     ///
     /// ```
-    /// use std::ffi::CStr;
+    /// use core::ffi::CStr;
     ///
     /// let cstr = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed");
     /// assert_eq!(cstr.to_bytes(), b"foo");
@@ -579,7 +579,7 @@ impl CStr {
     /// # Examples
     ///
     /// ```
-    /// use std::ffi::CStr;
+    /// use core::ffi::CStr;
     ///
     /// let cstr = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed");
     /// assert_eq!(cstr.to_bytes_with_nul(), b"foo\0");
@@ -606,7 +606,7 @@ impl CStr {
     /// # Examples
     ///
     /// ```
-    /// use std::ffi::CStr;
+    /// use core::ffi::CStr;
     ///
     /// let cstr = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed");
     /// assert_eq!(cstr.to_str(), Ok("foo"));

--- a/library/core/src/ffi/c_void.md
+++ b/library/core/src/ffi/c_void.md
@@ -8,7 +8,7 @@ To model pointers to opaque types in FFI, until `extern type` is
 stabilized, it is recommended to use a newtype wrapper around an empty
 byte array. See the [Nomicon] for details.
 
-One could use `std::os::raw::c_void` if they want to support old Rust
+One could use `core::os::raw::c_void` if they want to support old Rust
 compiler down to 1.1.0. After Rust 1.30.0, it was re-exported by
 this definition. For more information, please read [RFC 2521].
 

--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -52,7 +52,7 @@ impl fmt::Write for PadAdapter<'_, '_> {
 /// # Examples
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Foo {
 ///     bar: i32,
@@ -96,7 +96,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Bar {
     ///     bar: i32,
@@ -152,7 +152,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Bar {
     ///     bar: i32,
@@ -197,7 +197,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Bar {
     ///     bar: i32,
@@ -244,7 +244,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
 /// # Examples
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Foo(i32, String);
 ///
@@ -286,7 +286,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(i32, String);
     ///
@@ -332,7 +332,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(i32, String);
     ///
@@ -413,7 +413,7 @@ impl<'a, 'b: 'a> DebugInner<'a, 'b> {
 /// # Examples
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Foo(Vec<i32>);
 ///
@@ -446,7 +446,7 @@ impl<'a, 'b: 'a> DebugSet<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<i32>, Vec<u32>);
     ///
@@ -475,7 +475,7 @@ impl<'a, 'b: 'a> DebugSet<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<i32>, Vec<u32>);
     ///
@@ -510,7 +510,7 @@ impl<'a, 'b: 'a> DebugSet<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<i32>);
     ///
@@ -543,7 +543,7 @@ impl<'a, 'b: 'a> DebugSet<'a, 'b> {
 /// # Examples
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Foo(Vec<i32>);
 ///
@@ -576,7 +576,7 @@ impl<'a, 'b: 'a> DebugList<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<i32>, Vec<u32>);
     ///
@@ -605,7 +605,7 @@ impl<'a, 'b: 'a> DebugList<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<i32>, Vec<u32>);
     ///
@@ -640,7 +640,7 @@ impl<'a, 'b: 'a> DebugList<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<i32>);
     ///
@@ -673,7 +673,7 @@ impl<'a, 'b: 'a> DebugList<'a, 'b> {
 /// # Examples
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Foo(Vec<(String, i32)>);
 ///
@@ -711,7 +711,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<(String, i32)>);
     ///
@@ -747,7 +747,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<(String, i32)>);
     ///
@@ -811,7 +811,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<(String, i32)>);
     ///
@@ -855,7 +855,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<(String, i32)>);
     ///
@@ -897,7 +897,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<(String, i32)>);
     ///

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -49,7 +49,7 @@ pub mod rt {
 /// # Examples
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// #[derive(Debug)]
 /// struct Triangle {
@@ -78,16 +78,16 @@ pub type Result = result::Result<(), Error>;
 /// some other means.
 ///
 /// An important thing to remember is that the type `fmt::Error` should not be
-/// confused with [`std::io::Error`] or [`std::error::Error`], which you may also
+/// confused with [`core::io::Error`] or [`core::error::Error`], which you may also
 /// have in scope.
 ///
-/// [`std::io::Error`]: ../../std/io/struct.Error.html
-/// [`std::error::Error`]: ../../std/error/trait.Error.html
+/// [`core::io::Error`]: ../../std/io/struct.Error.html
+/// [`core::error::Error`]: ../../std/error/trait.Error.html
 ///
 /// # Examples
 ///
 /// ```rust
-/// use std::fmt::{self, write};
+/// use core::fmt::{self, write};
 ///
 /// let mut output = String::new();
 /// if let Err(fmt::Error) = write(&mut output, format_args!("Hello {}!", "world")) {
@@ -102,9 +102,9 @@ pub struct Error;
 ///
 /// This trait only accepts UTF-8–encoded data and is not [flushable]. If you only
 /// want to accept Unicode and you don't need flushing, you should implement this trait;
-/// otherwise you should implement [`std::io::Write`].
+/// otherwise you should implement [`core::io::Write`].
 ///
-/// [`std::io::Write`]: ../../std/io/trait.Write.html
+/// [`core::io::Write`]: ../../std/io/trait.Write.html
 /// [flushable]: ../../std/io/trait.Write.html#tymethod.flush
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Write {
@@ -119,14 +119,14 @@ pub trait Write {
     ///
     /// This function will return an instance of [`Error`] on error.
     ///
-    /// The purpose of std::fmt::Error is to abort the formatting operation when the underlying
+    /// The purpose of core::fmt::Error is to abort the formatting operation when the underlying
     /// destination encounters some error preventing it from accepting more text; it should
     /// generally be propagated rather than handled, at least when implementing formatting traits.
     ///
     /// # Examples
     ///
     /// ```
-    /// use std::fmt::{Error, Write};
+    /// use core::fmt::{Error, Write};
     ///
     /// fn writer<W: Write>(f: &mut W, s: &str) -> Result<(), Error> {
     ///     f.write_str(s)
@@ -153,7 +153,7 @@ pub trait Write {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt::{Error, Write};
+    /// use core::fmt::{Error, Write};
     ///
     /// fn writer<W: Write>(f: &mut W, c: char) -> Result<(), Error> {
     ///     f.write_char(c)
@@ -182,7 +182,7 @@ pub trait Write {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt::{Error, Write};
+    /// use core::fmt::{Error, Write};
     ///
     /// fn writer<W: Write>(f: &mut W, s: &str) -> Result<(), Error> {
     ///     f.write_fmt(format_args!("{s}"))
@@ -537,7 +537,7 @@ impl<'a> Arguments<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use std::fmt::Arguments;
+    /// use core::fmt::Arguments;
     ///
     /// fn write_str(_: &str) { /* ... */ }
     ///
@@ -553,7 +553,7 @@ impl<'a> Arguments<'a> {
     /// ```rust
     /// assert_eq!(format_args!("hello").as_str(), Some("hello"));
     /// assert_eq!(format_args!("").as_str(), Some(""));
-    /// assert_eq!(format_args!("{:?}", std::env::current_dir()).as_str(), None);
+    /// assert_eq!(format_args!("{:?}", core::env::current_dir()).as_str(), None);
     /// ```
     #[stable(feature = "fmt_as_str", since = "1.52.0")]
     #[rustc_const_unstable(feature = "const_arguments_as_str", issue = "103900")]
@@ -626,7 +626,7 @@ impl Display for Arguments<'_> {
 /// Manually implementing:
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Point {
 ///     x: i32,
@@ -658,7 +658,7 @@ impl Display for Arguments<'_> {
 /// manually writing an arbitrary representation to the `Formatter`.
 ///
 /// ```
-/// # use std::fmt;
+/// # use core::fmt;
 /// # struct Point {
 /// #     x: i32,
 /// #     y: i32,
@@ -711,7 +711,7 @@ pub trait Debug {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Position {
     ///     longitude: f32,
@@ -774,7 +774,7 @@ pub use macros::Debug;
 /// Implementing `Display` on a type:
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Point {
 ///     x: i32,
@@ -793,7 +793,7 @@ pub use macros::Debug;
 /// ```
 #[rustc_on_unimplemented(
     on(
-        any(_Self = "std::path::Path", _Self = "std::path::PathBuf"),
+        any(_Self = "core::path::Path", _Self = "core::path::PathBuf"),
         label = "`{Self}` cannot be formatted with the default formatter; call `.display()` on it",
         note = "call `.display()` or `.to_string_lossy()` to safely print paths, \
                 as they may contain non-Unicode data"
@@ -811,7 +811,7 @@ pub trait Display {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Position {
     ///     longitude: f32,
@@ -860,7 +860,7 @@ pub trait Display {
 /// Implementing `Octal` on a type:
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Length(i32);
 ///
@@ -914,7 +914,7 @@ pub trait Octal {
 /// Implementing `Binary` on a type:
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Length(i32);
 ///
@@ -972,7 +972,7 @@ pub trait Binary {
 /// Implementing `LowerHex` on a type:
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Length(i32);
 ///
@@ -1027,7 +1027,7 @@ pub trait LowerHex {
 /// Implementing `UpperHex` on a type:
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Length(i32);
 ///
@@ -1074,7 +1074,7 @@ pub trait UpperHex {
 /// Implementing `Pointer` on a type:
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Length(i32);
 ///
@@ -1124,7 +1124,7 @@ pub trait Pointer {
 /// Implementing `LowerExp` on a type:
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Length(i32);
 ///
@@ -1175,7 +1175,7 @@ pub trait LowerExp {
 /// Implementing `UpperExp` on a type:
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// struct Length(i32);
 ///
@@ -1216,7 +1216,7 @@ pub trait UpperExp {
 /// Basic usage:
 ///
 /// ```
-/// use std::fmt;
+/// use core::fmt;
 ///
 /// let mut output = String::new();
 /// fmt::write(&mut output, format_args!("Hello {}!", "world"))
@@ -1227,7 +1227,7 @@ pub trait UpperExp {
 /// Please note that using [`write!`] might be preferable. Example:
 ///
 /// ```
-/// use std::fmt::Write;
+/// use core::fmt::Write;
 ///
 /// let mut output = String::new();
 /// write!(&mut output, "Hello {}!", "world")
@@ -1375,7 +1375,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo { nb: i32 }
     ///
@@ -1483,7 +1483,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo;
     ///
@@ -1665,7 +1665,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo;
     ///
@@ -1690,7 +1690,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(i32);
     ///
@@ -1725,7 +1725,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo;
     ///
@@ -1760,7 +1760,7 @@ impl<'a> Formatter<'a> {
     /// ```
     /// extern crate core;
     ///
-    /// use std::fmt::{self, Alignment};
+    /// use core::fmt::{self, Alignment};
     ///
     /// struct Foo;
     ///
@@ -1800,7 +1800,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(i32);
     ///
@@ -1831,7 +1831,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(f32);
     ///
@@ -1861,7 +1861,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(i32);
     ///
@@ -1893,7 +1893,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(i32);
     ///
@@ -1922,7 +1922,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(i32);
     ///
@@ -1950,7 +1950,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(i32);
     ///
@@ -1989,8 +1989,8 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use std::fmt;
-    /// use std::net::Ipv4Addr;
+    /// use core::fmt;
+    /// use core::net::Ipv4Addr;
     ///
     /// struct Foo {
     ///     bar: i32,
@@ -2151,8 +2151,8 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use std::fmt;
-    /// use std::marker::PhantomData;
+    /// use core::fmt;
+    /// use core::marker::PhantomData;
     ///
     /// struct Foo<T>(i32, String, PhantomData<T>);
     ///
@@ -2284,7 +2284,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<i32>);
     ///
@@ -2307,7 +2307,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<i32>);
     ///
@@ -2326,7 +2326,7 @@ impl<'a> Formatter<'a> {
     /// to build a list of match arms:
     ///
     /// ```rust
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Arm<'a, L: 'a, R: 'a>(&'a (L, R));
     /// struct Table<'a, K: 'a, V: 'a>(&'a [(K, V)], V);
@@ -2365,7 +2365,7 @@ impl<'a> Formatter<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// struct Foo(Vec<(String, i32)>);
     ///

--- a/library/core/src/future/into_future.rs
+++ b/library/core/src/future/into_future.rs
@@ -13,7 +13,7 @@ use crate::future::Future;
 /// on all futures.
 ///
 /// ```no_run
-/// use std::future::IntoFuture;
+/// use core::future::IntoFuture;
 ///
 /// # async fn foo() {
 /// let v = async { "meow" };
@@ -31,7 +31,7 @@ use crate::future::Future;
 /// multiple times before being `.await`ed.
 ///
 /// ```rust
-/// use std::future::{ready, Ready, IntoFuture};
+/// use core::future::{ready, Ready, IntoFuture};
 ///
 /// /// Eventually multiply two numbers
 /// pub struct Multiply {
@@ -87,13 +87,13 @@ use crate::future::Future;
 /// `IntoFuture::into_future` to obtain an instance of `Future`:
 ///
 /// ```rust
-/// use std::future::IntoFuture;
+/// use core::future::IntoFuture;
 ///
 /// /// Convert the output of a future to a string.
 /// async fn fut_to_string<Fut>(fut: Fut) -> String
 /// where
 ///     Fut: IntoFuture,
-///     Fut::Output: std::fmt::Debug,
+///     Fut::Output: core::fmt::Debug,
 /// {
 ///     format!("{:?}", fut.await)
 /// }
@@ -115,7 +115,7 @@ pub trait IntoFuture {
     /// Basic usage:
     ///
     /// ```no_run
-    /// use std::future::IntoFuture;
+    /// use core::future::IntoFuture;
     ///
     /// # async fn foo() {
     /// let v = async { "meow" };

--- a/library/core/src/future/join.rs
+++ b/library/core/src/future/join.rs
@@ -17,7 +17,7 @@ use crate::task::{Context, Poll};
 /// ```
 /// #![feature(future_join)]
 ///
-/// use std::future::join;
+/// use core::future::join;
 ///
 /// async fn one() -> usize { 1 }
 /// async fn two() -> usize { 2 }
@@ -33,7 +33,7 @@ use crate::task::{Context, Poll};
 /// ```
 /// #![feature(future_join)]
 ///
-/// use std::future::join;
+/// use core::future::join;
 ///
 /// async fn one() -> usize { 1 }
 /// async fn two() -> usize { 2 }

--- a/library/core/src/future/pending.rs
+++ b/library/core/src/future/pending.rs
@@ -21,7 +21,7 @@ pub struct Pending<T> {
 /// # Examples
 ///
 /// ```no_run
-/// use std::future;
+/// use core::future;
 ///
 /// # async fn run() {
 /// let future = future::pending();

--- a/library/core/src/future/poll_fn.rs
+++ b/library/core/src/future/poll_fn.rs
@@ -14,7 +14,7 @@ use crate::task::{Context, Poll};
 /// ```
 /// # async fn run() {
 /// use core::future::poll_fn;
-/// use std::task::{Context, Poll};
+/// use core::task::{Context, Poll};
 ///
 /// fn read_line(_cx: &mut Context<'_>) -> Poll<String> {
 ///     Poll::Ready("Hello, World!".into())

--- a/library/core/src/future/ready.rs
+++ b/library/core/src/future/ready.rs
@@ -35,7 +35,7 @@ impl<T> Ready<T> {
     ///
     /// ```
     /// #![feature(ready_into_inner)]
-    /// use std::future;
+    /// use core::future;
     ///
     /// let a = future::ready(1);
     /// assert_eq!(a.into_inner(), 1);
@@ -57,7 +57,7 @@ impl<T> Ready<T> {
 /// # Examples
 ///
 /// ```
-/// use std::future;
+/// use core::future;
 ///
 /// # async fn run() {
 /// let a = future::ready(1);

--- a/library/core/src/hash/mod.rs
+++ b/library/core/src/hash/mod.rs
@@ -12,8 +12,8 @@
 //! # Examples
 //!
 //! ```rust
-//! use std::collections::hash_map::DefaultHasher;
-//! use std::hash::{Hash, Hasher};
+//! use core::collections::hash_map::DefaultHasher;
+//! use core::hash::{Hash, Hasher};
 //!
 //! #[derive(Hash)]
 //! struct Person {
@@ -46,8 +46,8 @@
 //! the [`Hash`] trait:
 //!
 //! ```rust
-//! use std::collections::hash_map::DefaultHasher;
-//! use std::hash::{Hash, Hasher};
+//! use core::collections::hash_map::DefaultHasher;
+//! use core::hash::{Hash, Hasher};
 //!
 //! struct Person {
 //!     id: u32,
@@ -123,7 +123,7 @@ mod sip;
 /// implement the `Hash` trait yourself:
 ///
 /// ```
-/// use std::hash::{Hash, Hasher};
+/// use core::hash::{Hash, Hasher};
 ///
 /// struct Person {
 ///     id: u32,
@@ -191,8 +191,8 @@ pub trait Hash {
     /// # Examples
     ///
     /// ```
-    /// use std::collections::hash_map::DefaultHasher;
-    /// use std::hash::{Hash, Hasher};
+    /// use core::collections::hash_map::DefaultHasher;
+    /// use core::hash::{Hash, Hasher};
     ///
     /// let mut hasher = DefaultHasher::new();
     /// 7920.hash(&mut hasher);
@@ -221,8 +221,8 @@ pub trait Hash {
     /// # Examples
     ///
     /// ```
-    /// use std::collections::hash_map::DefaultHasher;
-    /// use std::hash::{Hash, Hasher};
+    /// use core::collections::hash_map::DefaultHasher;
+    /// use core::hash::{Hash, Hasher};
     ///
     /// let mut hasher = DefaultHasher::new();
     /// let numbers = [6, 28, 496, 8128];
@@ -288,14 +288,14 @@ pub use macros::Hash;
 /// equivalent to four calls of [`write_u8`].  Nor can you assume that adjacent
 /// `write` calls are merged, so it's possible, for example, that
 /// ```
-/// # fn foo(hasher: &mut impl std::hash::Hasher) {
+/// # fn foo(hasher: &mut impl core::hash::Hasher) {
 /// hasher.write(&[1, 2]);
 /// hasher.write(&[3, 4, 5, 6]);
 /// # }
 /// ```
 /// and
 /// ```
-/// # fn foo(hasher: &mut impl std::hash::Hasher) {
+/// # fn foo(hasher: &mut impl core::hash::Hasher) {
 /// hasher.write(&[1, 2, 3, 4]);
 /// hasher.write(&[5, 6]);
 /// # }
@@ -309,8 +309,8 @@ pub use macros::Hash;
 /// # Examples
 ///
 /// ```
-/// use std::collections::hash_map::DefaultHasher;
-/// use std::hash::Hasher;
+/// use core::collections::hash_map::DefaultHasher;
+/// use core::hash::Hasher;
 ///
 /// let mut hasher = DefaultHasher::new();
 ///
@@ -339,8 +339,8 @@ pub trait Hasher {
     /// # Examples
     ///
     /// ```
-    /// use std::collections::hash_map::DefaultHasher;
-    /// use std::hash::Hasher;
+    /// use core::collections::hash_map::DefaultHasher;
+    /// use core::hash::Hasher;
     ///
     /// let mut hasher = DefaultHasher::new();
     /// hasher.write(b"Cool!");
@@ -357,8 +357,8 @@ pub trait Hasher {
     /// # Examples
     ///
     /// ```
-    /// use std::collections::hash_map::DefaultHasher;
-    /// use std::hash::Hasher;
+    /// use core::collections::hash_map::DefaultHasher;
+    /// use core::hash::Hasher;
     ///
     /// let mut hasher = DefaultHasher::new();
     /// let data = [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef];
@@ -477,11 +477,11 @@ pub trait Hasher {
     /// # }
     /// # impl<'a, T> IntoIterator for &'a MyCollection<T> {
     /// #     type Item = T;
-    /// #     type IntoIter = std::iter::Empty<T>;
+    /// #     type IntoIter = core::iter::Empty<T>;
     /// #     fn into_iter(self) -> Self::IntoIter { todo!() }
     /// # }
     ///
-    /// use std::hash::{Hash, Hasher};
+    /// use core::hash::{Hash, Hasher};
     /// impl<T: Hash> Hash for MyCollection<T> {
     ///     fn hash<H: Hasher>(&self, state: &mut H) {
     ///         state.write_length_prefix(self.len());
@@ -524,7 +524,7 @@ pub trait Hasher {
     /// ```
     /// # #![feature(hasher_prefixfree_extras)]
     /// # struct Foo;
-    /// # impl std::hash::Hasher for Foo {
+    /// # impl core::hash::Hasher for Foo {
     /// # fn finish(&self) -> u64 { unimplemented!() }
     /// # fn write(&mut self, _bytes: &[u8]) { unimplemented!() }
     /// fn write_str(&mut self, s: &str) {
@@ -547,7 +547,7 @@ pub trait Hasher {
     /// ```
     /// # #![feature(hasher_prefixfree_extras)]
     /// # struct Foo;
-    /// # impl std::hash::Hasher for Foo {
+    /// # impl core::hash::Hasher for Foo {
     /// # fn finish(&self) -> u64 { unimplemented!() }
     /// # fn write(&mut self, _bytes: &[u8]) { unimplemented!() }
     /// fn write_str(&mut self, s: &str) {
@@ -638,8 +638,8 @@ impl<H: ~const Hasher + ?Sized> const Hasher for &mut H {
 /// # Examples
 ///
 /// ```
-/// use std::collections::hash_map::RandomState;
-/// use std::hash::{BuildHasher, Hasher};
+/// use core::collections::hash_map::RandomState;
+/// use core::hash::{BuildHasher, Hasher};
 ///
 /// let s = RandomState::new();
 /// let mut hasher_1 = s.build_hasher();
@@ -668,8 +668,8 @@ pub trait BuildHasher {
     /// # Examples
     ///
     /// ```
-    /// use std::collections::hash_map::RandomState;
-    /// use std::hash::BuildHasher;
+    /// use core::collections::hash_map::RandomState;
+    /// use core::hash::BuildHasher;
     ///
     /// let s = RandomState::new();
     /// let new_s = s.build_hasher();
@@ -693,8 +693,8 @@ pub trait BuildHasher {
     /// ```
     /// #![feature(build_hasher_simple_hash_one)]
     ///
-    /// use std::cmp::{max, min};
-    /// use std::hash::{BuildHasher, Hash, Hasher};
+    /// use core::cmp::{max, min};
+    /// use core::hash::{BuildHasher, Hash, Hasher};
     /// struct OrderAmbivalentPair<T: Ord>(T, T);
     /// impl<T: Ord + Hash> Hash for OrderAmbivalentPair<T> {
     ///     fn hash<H: Hasher>(&self, hasher: &mut H) {
@@ -704,7 +704,7 @@ pub trait BuildHasher {
     /// }
     ///
     /// // Then later, in a `#[test]` for the type...
-    /// let bh = std::collections::hash_map::RandomState::new();
+    /// let bh = core::collections::hash_map::RandomState::new();
     /// assert_eq!(
     ///     bh.hash_one(OrderAmbivalentPair(1, 2)),
     ///     bh.hash_one(OrderAmbivalentPair(2, 1))
@@ -744,8 +744,8 @@ pub trait BuildHasher {
 /// [`HashMap`]:
 ///
 /// ```
-/// use std::collections::HashMap;
-/// use std::hash::{BuildHasherDefault, Hasher};
+/// use core::collections::HashMap;
+/// use core::hash::{BuildHasherDefault, Hasher};
 ///
 /// #[derive(Default)]
 /// struct MyHasher;

--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -14,7 +14,7 @@ use crate::ptr;
 ///
 /// See: <https://131002.net/siphash>
 #[unstable(feature = "hashmap_internals", issue = "none")]
-#[deprecated(since = "1.13.0", note = "use `std::collections::hash_map::DefaultHasher` instead")]
+#[deprecated(since = "1.13.0", note = "use `core::collections::hash_map::DefaultHasher` instead")]
 #[derive(Debug, Clone, Default)]
 #[doc(hidden)]
 pub struct SipHasher13 {
@@ -25,7 +25,7 @@ pub struct SipHasher13 {
 ///
 /// See: <https://131002.net/siphash/>
 #[unstable(feature = "hashmap_internals", issue = "none")]
-#[deprecated(since = "1.13.0", note = "use `std::collections::hash_map::DefaultHasher` instead")]
+#[deprecated(since = "1.13.0", note = "use `core::collections::hash_map::DefaultHasher` instead")]
 #[derive(Debug, Clone, Default)]
 struct SipHasher24 {
     hasher: Hasher<Sip24Rounds>,
@@ -44,7 +44,7 @@ struct SipHasher24 {
 /// it is not intended for cryptographic purposes. As such, all
 /// cryptographic uses of this implementation are _strongly discouraged_.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "1.13.0", note = "use `std::collections::hash_map::DefaultHasher` instead")]
+#[deprecated(since = "1.13.0", note = "use `core::collections::hash_map::DefaultHasher` instead")]
 #[derive(Debug, Clone, Default)]
 pub struct SipHasher(SipHasher24);
 
@@ -149,7 +149,7 @@ impl SipHasher {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[deprecated(
         since = "1.13.0",
-        note = "use `std::collections::hash_map::DefaultHasher` instead"
+        note = "use `core::collections::hash_map::DefaultHasher` instead"
     )]
     #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     #[must_use]
@@ -162,7 +162,7 @@ impl SipHasher {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[deprecated(
         since = "1.13.0",
-        note = "use `std::collections::hash_map::DefaultHasher` instead"
+        note = "use `core::collections::hash_map::DefaultHasher` instead"
     )]
     #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     #[must_use]
@@ -177,7 +177,7 @@ impl SipHasher13 {
     #[unstable(feature = "hashmap_internals", issue = "none")]
     #[deprecated(
         since = "1.13.0",
-        note = "use `std::collections::hash_map::DefaultHasher` instead"
+        note = "use `core::collections::hash_map::DefaultHasher` instead"
     )]
     #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     pub const fn new() -> SipHasher13 {
@@ -189,7 +189,7 @@ impl SipHasher13 {
     #[unstable(feature = "hashmap_internals", issue = "none")]
     #[deprecated(
         since = "1.13.0",
-        note = "use `std::collections::hash_map::DefaultHasher` instead"
+        note = "use `core::collections::hash_map::DefaultHasher` instead"
     )]
     #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher13 {

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -51,7 +51,7 @@ use crate::intrinsics;
 ///             // Safety: `divisor` can't be zero because of `prepare_inputs`,
 ///             // but the compiler does not know about this. We *promise*
 ///             // that we always call `prepare_inputs`.
-///             std::hint::unreachable_unchecked()
+///             core::hint::unreachable_unchecked()
 ///         }
 ///         // The compiler would normally introduce a check here that prevents
 ///         // a division by zero. However, if `divisor` was zero, the branch
@@ -80,7 +80,7 @@ use crate::intrinsics;
 ///
 /// ```
 /// fn div_1(a: u32, b: u32) -> u32 {
-///     use std::hint::unreachable_unchecked;
+///     use core::hint::unreachable_unchecked;
 ///
 ///     // `b.saturating_add(1)` is always positive (not zero),
 ///     // hence `checked_div` will never return `None`.
@@ -128,9 +128,9 @@ pub const unsafe fn unreachable_unchecked() -> ! {
 /// # Examples
 ///
 /// ```
-/// use std::sync::atomic::{AtomicBool, Ordering};
-/// use std::sync::Arc;
-/// use std::{hint, thread};
+/// use core::sync::atomic::{AtomicBool, Ordering};
+/// use core::sync::Arc;
+/// use core::{hint, thread};
 ///
 /// // A shared atomic value that threads will use to coordinate
 /// let live = Arc::new(AtomicBool::new(false));
@@ -209,7 +209,7 @@ pub fn spin_loop() {
 /// An identity function that *__hints__* to the compiler to be maximally pessimistic about what
 /// `black_box` could do.
 ///
-/// Unlike [`std::convert::identity`], a Rust compiler is encouraged to assume that `black_box` can
+/// Unlike [`core::convert::identity`], a Rust compiler is encouraged to assume that `black_box` can
 /// use `dummy` in any possible valid way that Rust code is allowed to without introducing undefined
 /// behavior in the calling code. This property makes `black_box` useful for writing code in which
 /// certain optimizations are not desired, such as benchmarks.
@@ -219,7 +219,7 @@ pub fn spin_loop() {
 /// backend used. Programs cannot rely on `black_box` for *correctness*, beyond it behaving as the
 /// identity function.
 ///
-/// [`std::convert::identity`]: crate::convert::identity
+/// [`core::convert::identity`]: crate::convert::identity
 ///
 /// # When is this useful?
 ///
@@ -262,7 +262,7 @@ pub fn spin_loop() {
 /// in:
 ///
 /// ```
-/// use std::hint::black_box;
+/// use core::hint::black_box;
 ///
 /// // Same `contains` function
 /// fn contains(haystack: &[&str], needle: &str) -> bool {

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -801,7 +801,7 @@ extern "rust-intrinsic" {
     /// Therefore, implementations must not require the user to uphold
     /// any safety invariants.
     ///
-    /// [`std::process::abort`](../../std/process/fn.abort.html) is to be preferred if possible,
+    /// [`core::process::abort`](../../std/process/fn.abort.html) is to be preferred if possible,
     /// as its behavior is more user-friendly and more stable.
     ///
     /// The current implementation of `intrinsics::abort` is to invoke an invalid instruction,
@@ -957,7 +957,7 @@ extern "rust-intrinsic" {
     #[rustc_safe_intrinsic]
     pub fn assert_zero_valid<T>();
 
-    /// A guard for `std::mem::uninitialized`. This will statically either panic, or do nothing.
+    /// A guard for `core::mem::uninitialized`. This will statically either panic, or do nothing.
     ///
     /// This intrinsic does not have a stable counterpart.
     #[rustc_const_unstable(feature = "const_assert_type2", issue = "none")]
@@ -1038,7 +1038,7 @@ extern "rust-intrinsic" {
     /// // Transmuting between raw pointers and function pointers (i.e., two pointer types) is fine.
     /// let pointer = foo as *const ();
     /// let function = unsafe {
-    ///     std::mem::transmute::<*const (), fn() -> i32>(pointer)
+    ///     core::mem::transmute::<*const (), fn() -> i32>(pointer)
     /// };
     /// assert_eq!(function(), 0);
     /// ```
@@ -1049,12 +1049,12 @@ extern "rust-intrinsic" {
     /// ```
     /// struct R<'a>(&'a i32);
     /// unsafe fn extend_lifetime<'b>(r: R<'b>) -> R<'static> {
-    ///     std::mem::transmute::<R<'b>, R<'static>>(r)
+    ///     core::mem::transmute::<R<'b>, R<'static>>(r)
     /// }
     ///
     /// unsafe fn shorten_invariant_lifetime<'b, 'c>(r: &'b mut R<'static>)
     ///                                              -> &'b mut R<'c> {
-    ///     std::mem::transmute::<&'b mut R<'static>, &'b mut R<'c>>(r)
+    ///     core::mem::transmute::<&'b mut R<'static>, &'b mut R<'c>>(r)
     /// }
     /// ```
     ///
@@ -1070,7 +1070,7 @@ extern "rust-intrinsic" {
     /// let raw_bytes = [0x78, 0x56, 0x34, 0x12];
     ///
     /// let num = unsafe {
-    ///     std::mem::transmute::<[u8; 4], u32>(raw_bytes)
+    ///     core::mem::transmute::<[u8; 4], u32>(raw_bytes)
     /// };
     ///
     /// // use `u32::from_ne_bytes` instead
@@ -1087,7 +1087,7 @@ extern "rust-intrinsic" {
     /// ```no_run
     /// let ptr = &0;
     /// let ptr_num_transmute = unsafe {
-    ///     std::mem::transmute::<&i32, usize>(ptr)
+    ///     core::mem::transmute::<&i32, usize>(ptr)
     /// };
     ///
     /// // Use an `as` cast instead
@@ -1109,7 +1109,7 @@ extern "rust-intrinsic" {
     /// ```
     /// let ptr: *mut i32 = &mut 0;
     /// let ref_transmuted = unsafe {
-    ///     std::mem::transmute::<*mut i32, &mut i32>(ptr)
+    ///     core::mem::transmute::<*mut i32, &mut i32>(ptr)
     /// };
     ///
     /// // Use a reborrow instead
@@ -1121,7 +1121,7 @@ extern "rust-intrinsic" {
     /// ```
     /// let ptr = &mut 0;
     /// let val_transmuted = unsafe {
-    ///     std::mem::transmute::<&mut i32, &mut u32>(ptr)
+    ///     core::mem::transmute::<&mut i32, &mut u32>(ptr)
     /// };
     ///
     /// // Now, put together `as` and reborrowing - note the chaining of `as`
@@ -1133,7 +1133,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// // this is not a good way to do this.
-    /// let slice = unsafe { std::mem::transmute::<&str, &[u8]>("Rust") };
+    /// let slice = unsafe { core::mem::transmute::<&str, &[u8]>("Rust") };
     /// assert_eq!(slice, &[82, 117, 115, 116]);
     ///
     /// // You could use `str::as_bytes`
@@ -1164,7 +1164,7 @@ extern "rust-intrinsic" {
     /// // bad idea and could cause Undefined Behavior.
     /// // However, it is no-copy.
     /// let v_transmuted = unsafe {
-    ///     std::mem::transmute::<Vec<&i32>, Vec<Option<&i32>>>(v_clone)
+    ///     core::mem::transmute::<Vec<&i32>, Vec<Option<&i32>>>(v_clone)
     /// };
     ///
     /// let v_clone = v_orig.clone();
@@ -1185,7 +1185,7 @@ extern "rust-intrinsic" {
     /// let v_from_raw = unsafe {
     // FIXME Update this when vec_into_raw_parts is stabilized
     ///     // Ensure the original vector is not dropped.
-    ///     let mut v_clone = std::mem::ManuallyDrop::new(v_clone);
+    ///     let mut v_clone = core::mem::ManuallyDrop::new(v_clone);
     ///     Vec::from_raw_parts(v_clone.as_mut_ptr() as *mut Option<&i32>,
     ///                         v_clone.len(),
     ///                         v_clone.capacity())
@@ -1197,7 +1197,7 @@ extern "rust-intrinsic" {
     /// Implementing `split_at_mut`:
     ///
     /// ```
-    /// use std::{slice, mem};
+    /// use core::{slice, mem};
     ///
     /// // There are multiple ways to do this, and there are multiple problems
     /// // with the following (transmute) way.
@@ -1695,7 +1695,7 @@ extern "rust-intrinsic" {
     /// ```
     /// #![feature(core_intrinsics)]
     ///
-    /// use std::intrinsics::ctlz;
+    /// use core::intrinsics::ctlz;
     ///
     /// let x = 0b0001_1100_u8;
     /// let num_leading = ctlz(x);
@@ -1707,7 +1707,7 @@ extern "rust-intrinsic" {
     /// ```
     /// #![feature(core_intrinsics)]
     ///
-    /// use std::intrinsics::ctlz;
+    /// use core::intrinsics::ctlz;
     ///
     /// let x = 0u16;
     /// let num_leading = ctlz(x);
@@ -1727,7 +1727,7 @@ extern "rust-intrinsic" {
     /// ```
     /// #![feature(core_intrinsics)]
     ///
-    /// use std::intrinsics::ctlz_nonzero;
+    /// use core::intrinsics::ctlz_nonzero;
     ///
     /// let x = 0b0001_1100_u8;
     /// let num_leading = unsafe { ctlz_nonzero(x) };
@@ -1752,7 +1752,7 @@ extern "rust-intrinsic" {
     /// ```
     /// #![feature(core_intrinsics)]
     ///
-    /// use std::intrinsics::cttz;
+    /// use core::intrinsics::cttz;
     ///
     /// let x = 0b0011_1000_u8;
     /// let num_trailing = cttz(x);
@@ -1764,7 +1764,7 @@ extern "rust-intrinsic" {
     /// ```
     /// #![feature(core_intrinsics)]
     ///
-    /// use std::intrinsics::cttz;
+    /// use core::intrinsics::cttz;
     ///
     /// let x = 0u16;
     /// let num_trailing = cttz(x);
@@ -1784,7 +1784,7 @@ extern "rust-intrinsic" {
     /// ```
     /// #![feature(core_intrinsics)]
     ///
-    /// use std::intrinsics::cttz_nonzero;
+    /// use core::intrinsics::cttz_nonzero;
     ///
     /// let x = 0b0011_1000_u8;
     /// let num_trailing = unsafe { cttz_nonzero(x) };
@@ -2138,9 +2138,9 @@ extern "rust-intrinsic" {
     #[rustc_const_unstable(feature = "const_intrinsic_raw_eq", issue = "none")]
     pub fn raw_eq<T>(a: &T, b: &T) -> bool;
 
-    /// See documentation of [`std::hint::black_box`] for details.
+    /// See documentation of [`core::hint::black_box`] for details.
     ///
-    /// [`std::hint::black_box`]: crate::hint::black_box
+    /// [`core::hint::black_box`]: crate::hint::black_box
     #[rustc_const_unstable(feature = "const_black_box", issue = "none")]
     #[rustc_safe_intrinsic]
     pub fn black_box<T>(dummy: T) -> T;
@@ -2180,8 +2180,8 @@ extern "rust-intrinsic" {
     /// ```no_run
     /// #![feature(const_eval_select)]
     /// #![feature(core_intrinsics)]
-    /// use std::hint::unreachable_unchecked;
-    /// use std::intrinsics::const_eval_select;
+    /// use core::hint::unreachable_unchecked;
+    /// use core::intrinsics::const_eval_select;
     ///
     /// // Crate A
     /// pub const fn inconsistent() -> i32 {
@@ -2343,7 +2343,7 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 /// Manually implement [`Vec::append`]:
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// /// Moves all the elements of `src` into `dst`, leaving `src` empty.
 /// fn append<T>(dst: &mut Vec<T>, src: &mut Vec<T>) {
@@ -2452,7 +2452,7 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 /// Efficiently create a Rust vector from an unsafe buffer:
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// /// # Safety
 /// ///
@@ -2536,7 +2536,7 @@ pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
 /// Basic usage:
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// let mut vec = vec![0u32; 4];
 /// unsafe {

--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -10,8 +10,8 @@ use crate::ops::Try;
 /// # Examples
 ///
 /// ```
-/// use std::iter::Chain;
-/// use std::slice::Iter;
+/// use core::iter::Chain;
+/// use core::slice::Iter;
 ///
 /// let a1 = [1, 2, 3];
 /// let a2 = [4, 5, 6];
@@ -280,8 +280,8 @@ impl<A: Default, B: Default> Default for Chain<A, B> {
     /// ```
     /// # use core::iter::Chain;
     /// # use core::slice;
-    /// # use std::collections::{btree_set, BTreeSet};
-    /// # use std::mem;
+    /// # use core::collections::{btree_set, BTreeSet};
+    /// # use core::mem;
     /// struct Foo<'a>(Chain<slice::Iter<'a, u8>, btree_set::Iter<'a, u8>>);
     ///
     /// let set = BTreeSet::<u8>::new();

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -268,7 +268,7 @@ impl<I: Default> Default for Enumerate<I> {
     /// Creates an `Enumerate` iterator from the default value of `I`
     /// ```
     /// # use core::slice;
-    /// # use std::iter::Enumerate;
+    /// # use core::iter::Enumerate;
     /// let iter: Enumerate<slice::Iter<'_, u8>> = Default::default();
     /// assert_eq!(iter.len(), 0);
     /// ```

--- a/library/core/src/iter/adapters/flatten.rs
+++ b/library/core/src/iter/adapters/flatten.rs
@@ -312,7 +312,7 @@ where
     ///
     /// ```
     /// # use core::slice;
-    /// # use std::iter::Flatten;
+    /// # use core::iter::Flatten;
     /// let iter: Flatten<slice::Iter<'_, [u8; 4]>> = Default::default();
     /// assert_eq!(iter.count(), 0);
     /// ```

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -187,7 +187,7 @@ impl<I: Default> Default for Fuse<I> {
     ///
     /// ```
     /// # use core::slice;
-    /// # use std::iter::Fuse;
+    /// # use core::iter::Fuse;
     /// let iter: Fuse<slice::Iter<'_, u8>> = Default::default();
     /// assert_eq!(iter.len(), 0);
     /// ```

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -94,11 +94,11 @@ pub use self::zip::zip;
 ///
 /// ```
 /// # #![feature(inplace_iteration)]
-/// # use std::iter::SourceIter;
+/// # use core::iter::SourceIter;
 ///
 /// let mut iter = vec![9, 9, 9].into_iter().map(|i| i * i);
 /// let _ = iter.next();
-/// let mut remainder = std::mem::replace(unsafe { iter.as_inner() }, Vec::new().into_iter());
+/// let mut remainder = core::mem::replace(unsafe { iter.as_inner() }, Vec::new().into_iter());
 /// println!("n = {} elements remaining", remainder.len());
 /// ```
 ///

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -40,7 +40,7 @@ impl<A: Iterator, B: Iterator> Zip<A, B> {
 /// # Examples
 ///
 /// ```
-/// use std::iter::zip;
+/// use core::iter::zip;
 ///
 /// let xs = [1, 2, 3];
 /// let ys = [4, 5, 6];
@@ -500,12 +500,12 @@ impl<A: Debug + TrustedRandomAccessNoCoerce, B: Debug + TrustedRandomAccessNoCoe
 ///    but `self.next_back()` calls that happened before the cloning count for both `self` and the clone.
 /// 4. After `self.__iterator_get_unchecked(idx)` has been called, then only the following methods
 ///    will be called on `self` or on any new clones of `self`:
-///     * `std::clone::Clone::clone`
-///     * `std::iter::Iterator::size_hint`
-///     * `std::iter::DoubleEndedIterator::next_back`
-///     * `std::iter::ExactSizeIterator::len`
-///     * `std::iter::Iterator::__iterator_get_unchecked`
-///     * `std::iter::TrustedRandomAccessNoCoerce::size`
+///     * `core::clone::Clone::clone`
+///     * `core::iter::Iterator::size_hint`
+///     * `core::iter::DoubleEndedIterator::next_back`
+///     * `core::iter::ExactSizeIterator::len`
+///     * `core::iter::Iterator::__iterator_get_unchecked`
+///     * `core::iter::TrustedRandomAccessNoCoerce::size`
 /// 5. If `T` is a subtype of `Self`, then `self` is allowed to be coerced
 ///    to `T`. If `self` is coerced to `T` after `self.__iterator_get_unchecked(idx)` has already
 ///    been called, then no methods except for the ones listed under 4. are allowed to be called

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -342,7 +342,7 @@
 //! successfully for any infinite iterators.
 //!
 //! ```no_run
-//! let ones = std::iter::repeat(1);
+//! let ones = core::iter::repeat(1);
 //! let least = ones.min().unwrap(); // Oh no! An infinite loop!
 //! // `ones.min()` causes an infinite loop, so we won't reach this point!
 //! println!("The smallest number one is {least}.");

--- a/library/core/src/iter/sources/empty.rs
+++ b/library/core/src/iter/sources/empty.rs
@@ -9,7 +9,7 @@ use crate::marker;
 /// Basic usage:
 ///
 /// ```
-/// use std::iter;
+/// use core::iter;
 ///
 /// // this could have been an iterator over i32, but alas, it's just not.
 /// let mut nope = iter::empty::<i32>();

--- a/library/core/src/iter/sources/from_fn.rs
+++ b/library/core/src/iter/sources/from_fn.rs
@@ -25,7 +25,7 @@ use crate::fmt;
 ///
 /// ```
 /// let mut count = 0;
-/// let counter = std::iter::from_fn(move || {
+/// let counter = core::iter::from_fn(move || {
 ///     // Increment our count. This is why we started at zero.
 ///     count += 1;
 ///

--- a/library/core/src/iter/sources/from_generator.rs
+++ b/library/core/src/iter/sources/from_generator.rs
@@ -14,7 +14,7 @@ use crate::pin::Pin;
 /// #![feature(generators)]
 /// #![feature(iter_from_generator)]
 ///
-/// let it = std::iter::from_generator(|| {
+/// let it = core::iter::from_generator(|| {
 ///     yield 1;
 ///     yield 2;
 ///     yield 3;

--- a/library/core/src/iter/sources/once.rs
+++ b/library/core/src/iter/sources/once.rs
@@ -14,7 +14,7 @@ use crate::iter::{FusedIterator, TrustedLen};
 /// Basic usage:
 ///
 /// ```
-/// use std::iter;
+/// use core::iter;
 ///
 /// // one is the loneliest number
 /// let mut one = iter::once(1);
@@ -30,9 +30,9 @@ use crate::iter::{FusedIterator, TrustedLen};
 /// `.foorc`:
 ///
 /// ```no_run
-/// use std::iter;
-/// use std::fs;
-/// use std::path::PathBuf;
+/// use core::iter;
+/// use core::fs;
+/// use core::path::PathBuf;
 ///
 /// let dirs = fs::read_dir(".foo").unwrap();
 ///

--- a/library/core/src/iter/sources/once_with.rs
+++ b/library/core/src/iter/sources/once_with.rs
@@ -19,7 +19,7 @@ use crate::iter::{FusedIterator, TrustedLen};
 /// Basic usage:
 ///
 /// ```
-/// use std::iter;
+/// use core::iter;
 ///
 /// // one is the loneliest number
 /// let mut one = iter::once_with(|| 1);
@@ -35,9 +35,9 @@ use crate::iter::{FusedIterator, TrustedLen};
 /// `.foorc`:
 ///
 /// ```no_run
-/// use std::iter;
-/// use std::fs;
-/// use std::path::PathBuf;
+/// use core::iter;
+/// use core::fs;
+/// use core::path::PathBuf;
 ///
 /// let dirs = fs::read_dir(".foo").unwrap();
 ///

--- a/library/core/src/iter/sources/repeat.rs
+++ b/library/core/src/iter/sources/repeat.rs
@@ -19,7 +19,7 @@ use crate::num::NonZeroUsize;
 /// Basic usage:
 ///
 /// ```
-/// use std::iter;
+/// use core::iter;
 ///
 /// // the number four 4ever:
 /// let mut fours = iter::repeat(4);
@@ -37,7 +37,7 @@ use crate::num::NonZeroUsize;
 /// Going finite with [`Iterator::take()`]:
 ///
 /// ```
-/// use std::iter;
+/// use core::iter;
 ///
 /// // that last example was too many fours. Let's only have four fours.
 /// let mut four_fours = iter::repeat(4).take(4);

--- a/library/core/src/iter/sources/repeat_n.rs
+++ b/library/core/src/iter/sources/repeat_n.rs
@@ -19,7 +19,7 @@ use crate::num::NonZeroUsize;
 ///
 /// ```
 /// #![feature(iter_repeat_n)]
-/// use std::iter;
+/// use core::iter;
 ///
 /// // four of the number four:
 /// let mut four_fours = iter::repeat_n(4, 4);
@@ -37,7 +37,7 @@ use crate::num::NonZeroUsize;
 ///
 /// ```
 /// #![feature(iter_repeat_n)]
-/// use std::iter;
+/// use core::iter;
 ///
 /// let v: Vec<i32> = Vec::with_capacity(123);
 /// let mut it = iter::repeat_n(v, 5);

--- a/library/core/src/iter/sources/repeat_with.rs
+++ b/library/core/src/iter/sources/repeat_with.rs
@@ -26,7 +26,7 @@ use crate::ops::Try;
 /// Basic usage:
 ///
 /// ```
-/// use std::iter;
+/// use core::iter;
 ///
 /// // let's assume we have some value of a type that is not `Clone`
 /// // or which we don't want to have in memory just yet because it is expensive:
@@ -46,7 +46,7 @@ use crate::ops::Try;
 /// Using mutation and going finite:
 ///
 /// ```rust
-/// use std::iter;
+/// use core::iter;
 ///
 /// // From the zeroth to the third power of two:
 /// let mut curr = 1;

--- a/library/core/src/iter/sources/successors.rs
+++ b/library/core/src/iter/sources/successors.rs
@@ -6,7 +6,7 @@ use crate::{fmt, iter::FusedIterator};
 /// and calls the given `FnMut(&T) -> Option<T>` closure to compute each item’s successor.
 ///
 /// ```
-/// use std::iter::successors;
+/// use core::iter::successors;
 ///
 /// let powers_of_10 = successors(Some(1_u16), |n| n.checked_mul(10));
 /// assert_eq!(powers_of_10.collect::<Vec<_>>(), &[1, 10, 100, 1_000, 10_000]);

--- a/library/core/src/iter/traits/accum.rs
+++ b/library/core/src/iter/traits/accum.rs
@@ -12,7 +12,7 @@ use crate::num::Wrapping;
 #[stable(feature = "iter_arith_traits", since = "1.12.0")]
 #[rustc_on_unimplemented(
     message = "a value of type `{Self}` cannot be made by summing an iterator over elements of type `{A}`",
-    label = "value of type `{Self}` cannot be made by summing a `std::iter::Iterator<Item={A}>`"
+    label = "value of type `{Self}` cannot be made by summing a `core::iter::Iterator<Item={A}>`"
 )]
 pub trait Sum<A = Self>: Sized {
     /// Method which takes an iterator and generates `Self` from the elements by
@@ -33,7 +33,7 @@ pub trait Sum<A = Self>: Sized {
 #[stable(feature = "iter_arith_traits", since = "1.12.0")]
 #[rustc_on_unimplemented(
     message = "a value of type `{Self}` cannot be made by multiplying all elements of type `{A}` from an iterator",
-    label = "value of type `{Self}` cannot be made by multiplying all elements from a `std::iter::Iterator<Item={A}>`"
+    label = "value of type `{Self}` cannot be made by multiplying all elements from a `core::iter::Iterator<Item={A}>`"
 )]
 pub trait Product<A = Self>: Sized {
     /// Method which takes an iterator and generates `Self` from the elements by

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -17,7 +17,7 @@
 /// Basic usage:
 ///
 /// ```
-/// let five_fives = std::iter::repeat(5).take(5);
+/// let five_fives = core::iter::repeat(5).take(5);
 ///
 /// let v = Vec::from_iter(five_fives);
 ///
@@ -27,7 +27,7 @@
 /// Using [`Iterator::collect()`] to implicitly use `FromIterator`:
 ///
 /// ```
-/// let five_fives = std::iter::repeat(5).take(5);
+/// let five_fives = core::iter::repeat(5).take(5);
 ///
 /// let v: Vec<i32> = five_fives.collect();
 ///
@@ -38,7 +38,7 @@
 /// [`Iterator::collect()`]:
 ///
 /// ```
-/// use std::collections::VecDeque;
+/// use core::collections::VecDeque;
 /// let first = (0..10).collect::<VecDeque<i32>>();
 /// let second = VecDeque::from_iter(0..10);
 ///
@@ -116,7 +116,7 @@
     ),
     message = "a value of type `{Self}` cannot be built from an iterator \
                over elements of type `{A}`",
-    label = "value of type `{Self}` cannot be built from `std::iter::Iterator<Item={A}>`"
+    label = "value of type `{Self}` cannot be built from `core::iter::Iterator<Item={A}>`"
 )]
 #[rustc_diagnostic_item = "FromIterator"]
 pub trait FromIterator<A>: Sized {
@@ -131,7 +131,7 @@ pub trait FromIterator<A>: Sized {
     /// Basic usage:
     ///
     /// ```
-    /// let five_fives = std::iter::repeat(5).take(5);
+    /// let five_fives = core::iter::repeat(5).take(5);
     ///
     /// let v = Vec::from_iter(five_fives);
     ///
@@ -187,7 +187,7 @@ pub trait FromIterator<A>: Sized {
 /// // and we'll implement IntoIterator
 /// impl IntoIterator for MyCollection {
 ///     type Item = i32;
-///     type IntoIter = std::vec::IntoIter<Self::Item>;
+///     type IntoIter = core::vec::IntoIter<Self::Item>;
 ///
 ///     fn into_iter(self) -> Self::IntoIter {
 ///         self.0.into_iter()
@@ -217,7 +217,7 @@ pub trait FromIterator<A>: Sized {
 /// fn collect_as_strings<T>(collection: T) -> Vec<String>
 /// where
 ///     T: IntoIterator,
-///     T::Item: std::fmt::Debug,
+///     T::Item: core::fmt::Debug,
 /// {
 ///     collection
 ///         .into_iter()

--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -76,7 +76,7 @@ pub trait DoubleEndedIterator: Iterator {
     /// ```
     /// let vec = vec![(1, 'a'), (1, 'b'), (1, 'c'), (2, 'a'), (2, 'b')];
     /// let uniq_by_fst_comp = || {
-    ///     let mut seen = std::collections::HashSet::new();
+    ///     let mut seen = core::collections::HashSet::new();
     ///     vec.iter().copied().filter(move |x| seen.insert(x.0))
     /// };
     ///
@@ -122,7 +122,7 @@ pub trait DoubleEndedIterator: Iterator {
     /// ```
     /// #![feature(iter_advance_by)]
     ///
-    /// use std::num::NonZeroUsize;
+    /// use core::num::NonZeroUsize;
     /// let a = [3, 4, 5, 6];
     /// let mut iter = a.iter();
     ///

--- a/library/core/src/iter/traits/exact_size.rs
+++ b/library/core/src/iter/traits/exact_size.rs
@@ -135,7 +135,7 @@ pub trait ExactSizeIterator: Iterator {
     /// ```
     /// #![feature(exact_size_is_empty)]
     ///
-    /// let mut one_element = std::iter::once(0);
+    /// let mut one_element = core::iter::once(0);
     /// assert!(!one_element.is_empty());
     ///
     /// assert_eq!(one_element.next(), Some(0));

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -27,13 +27,13 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item = ()>) {}
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented(
     on(
-        _Self = "std::ops::RangeTo<Idx>",
+        _Self = "core::ops::RangeTo<Idx>",
         label = "if you meant to iterate until a value, add a starting value",
         note = "`..end` is a `RangeTo`, which cannot be iterated on; you might have meant to have a \
               bounded `Range`: `0..end`"
     ),
     on(
-        _Self = "std::ops::RangeToInclusive<Idx>",
+        _Self = "core::ops::RangeToInclusive<Idx>",
         label = "if you meant to iterate until a value (including it), add a starting value",
         note = "`..=end` is a `RangeToInclusive`, which cannot be iterated on; you might have meant \
               to have a bounded `RangeInclusive`: `0..=end`"
@@ -44,7 +44,7 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item = ()>) {}
     ),
     on(_Self = "&[]", label = "`{Self}` is not an iterator; try calling `.iter()`"),
     on(
-        _Self = "std::vec::Vec<T, A>",
+        _Self = "core::vec::Vec<T, A>",
         label = "`{Self}` is not an iterator; try calling `.into_iter()` or `.iter()`"
     ),
     on(
@@ -52,7 +52,7 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item = ()>) {}
         label = "`{Self}` is not an iterator; try calling `.chars()` or `.bytes()`"
     ),
     on(
-        _Self = "std::string::String",
+        _Self = "core::string::String",
         label = "`{Self}` is not an iterator; try calling `.chars()` or `.bytes()`"
     ),
     on(
@@ -329,7 +329,7 @@ pub trait Iterator {
     /// ```
     /// #![feature(iter_advance_by)]
     ///
-    /// use std::num::NonZeroUsize;
+    /// use core::num::NonZeroUsize;
     /// let a = [1, 2, 3, 4];
     /// let mut iter = a.iter();
     ///
@@ -511,9 +511,9 @@ pub trait Iterator {
     ///
     /// ```
     /// #[cfg(windows)]
-    /// fn os_str_to_utf16(s: &std::ffi::OsStr) -> Vec<u16> {
-    ///     use std::os::windows::ffi::OsStrExt;
-    ///     s.encode_wide().chain(std::iter::once(0)).collect()
+    /// fn os_str_to_utf16(s: &core::ffi::OsStr) -> Vec<u16> {
+    ///     use core::os::windows::ffi::OsStrExt;
+    ///     s.encode_wide().chain(core::iter::once(0)).collect()
     /// }
     /// ```
     ///
@@ -603,7 +603,7 @@ pub trait Iterator {
     /// If both iterators have roughly equivalent syntax, it may be more readable to use [`zip`]:
     ///
     /// ```
-    /// use std::iter::zip;
+    /// use core::iter::zip;
     ///
     /// let a = [1, 2, 3];
     /// let b = [2, 3, 4];
@@ -828,7 +828,7 @@ pub trait Iterator {
     /// Basic usage:
     ///
     /// ```
-    /// use std::sync::mpsc::channel;
+    /// use core::sync::mpsc::channel;
     ///
     /// let (tx, rx) = channel();
     /// (0..5).map(|x| x * 2 + 1)
@@ -1823,7 +1823,7 @@ pub trait Iterator {
     /// [`VecDeque<T>`]: ../../std/collections/struct.VecDeque.html
     ///
     /// ```
-    /// use std::collections::VecDeque;
+    /// use core::collections::VecDeque;
     ///
     /// let a = [1, 2, 3];
     ///
@@ -2276,7 +2276,7 @@ pub trait Iterator {
     /// a similar idea:
     ///
     /// ```
-    /// use std::ops::ControlFlow;
+    /// use core::ops::ControlFlow;
     ///
     /// let triangular = (1..30).try_fold(0_i8, |prev, x| {
     ///     if let Some(next) = prev.checked_add(x) {
@@ -2324,9 +2324,9 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
-    /// use std::fs::rename;
-    /// use std::io::{stdout, Write};
-    /// use std::path::Path;
+    /// use core::fs::rename;
+    /// use core::io::{stdout, Write};
+    /// use core::path::Path;
     ///
     /// let data = ["no_tea.txt", "stale_bread.json", "torrential_rain.png"];
     ///
@@ -2344,7 +2344,7 @@ pub trait Iterator {
     /// in which you'd use `break` and `continue` in a normal loop:
     ///
     /// ```
-    /// use std::ops::ControlFlow;
+    /// use core::ops::ControlFlow;
     ///
     /// let r = (2..100).try_for_each(|x| {
     ///     if 323 % x == 0 {
@@ -2579,7 +2579,7 @@ pub trait Iterator {
     /// #![feature(iterator_try_reduce)]
     ///
     /// let numbers = vec!["1", "2", "3", "4", "5"];
-    /// let max: Result<Option<_>, <usize as std::str::FromStr>::Err> =
+    /// let max: Result<Option<_>, <usize as core::str::FromStr>::Err> =
     ///     numbers.into_iter().try_reduce(|x, y| {
     ///         if x.parse::<usize>()? > y.parse::<usize>()? { Ok(x) } else { Ok(y) }
     ///     });
@@ -2826,7 +2826,7 @@ pub trait Iterator {
     ///
     /// let a = ["1", "2", "lol", "NaN", "5"];
     ///
-    /// let is_my_num = |s: &str, search: i32| -> Result<bool, std::num::ParseIntError> {
+    /// let is_my_num = |s: &str, search: i32| -> Result<bool, core::num::ParseIntError> {
     ///     Ok(s.parse::<i32>()?  == search)
     /// };
     ///
@@ -2841,7 +2841,7 @@ pub trait Iterator {
     /// ```
     /// #![feature(try_find)]
     ///
-    /// use std::num::NonZeroU32;
+    /// use core::num::NonZeroU32;
     /// let a = [3, 5, 7, 4, 9, 0, 11];
     /// let result = a.iter().try_find(|&&x| NonZeroU32::new(x).map(|y| y.is_power_of_two()));
     /// assert_eq!(result, Some(Some(&4)));
@@ -3522,7 +3522,7 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// assert_eq!([1].iter().cmp([1].iter()), Ordering::Equal);
     /// assert_eq!([1].iter().cmp([1, 2].iter()), Ordering::Less);
@@ -3549,7 +3549,7 @@ pub trait Iterator {
     /// ```
     /// #![feature(iter_order_by)]
     ///
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// let xs = [1, 2, 3, 4];
     /// let ys = [1, 4, 9, 16];
@@ -3591,7 +3591,7 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// assert_eq!([1.].iter().partial_cmp([1.].iter()), Some(Ordering::Equal));
     /// assert_eq!([1.].iter().partial_cmp([1., 2.].iter()), Some(Ordering::Less));
@@ -3608,7 +3608,7 @@ pub trait Iterator {
     /// The results are determined by the order of evaluation.
     ///
     /// ```
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// assert_eq!([1.0, f64::NAN].iter().partial_cmp([2.0, f64::NAN].iter()), Some(Ordering::Less));
     /// assert_eq!([2.0, f64::NAN].iter().partial_cmp([1.0, f64::NAN].iter()), Some(Ordering::Greater));
@@ -3636,7 +3636,7 @@ pub trait Iterator {
     /// ```
     /// #![feature(iter_order_by)]
     ///
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// let xs = [1.0, 2.0, 3.0, 4.0];
     /// let ys = [1.0, 4.0, 9.0, 16.0];
@@ -3863,7 +3863,7 @@ pub trait Iterator {
     /// assert!([1, 2, 2, 9].iter().is_sorted());
     /// assert!(![1, 3, 2, 4].iter().is_sorted());
     /// assert!([0].iter().is_sorted());
-    /// assert!(std::iter::empty::<i32>().is_sorted());
+    /// assert!(core::iter::empty::<i32>().is_sorted());
     /// assert!(![0.0, 1.0, f32::NAN].iter().is_sorted());
     /// ```
     #[inline]
@@ -3891,7 +3891,7 @@ pub trait Iterator {
     /// assert!([1, 2, 2, 9].iter().is_sorted_by(|a, b| a.partial_cmp(b)));
     /// assert!(![1, 3, 2, 4].iter().is_sorted_by(|a, b| a.partial_cmp(b)));
     /// assert!([0].iter().is_sorted_by(|a, b| a.partial_cmp(b)));
-    /// assert!(std::iter::empty::<i32>().is_sorted_by(|a, b| a.partial_cmp(b)));
+    /// assert!(core::iter::empty::<i32>().is_sorted_by(|a, b| a.partial_cmp(b)));
     /// assert!(![0.0, 1.0, f32::NAN].iter().is_sorted_by(|a, b| a.partial_cmp(b)));
     /// ```
     ///

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -128,7 +128,7 @@ macro_rules! assert_ne {
 /// ```
 /// #![feature(assert_matches)]
 ///
-/// use std::assert_matches::assert_matches;
+/// use core::assert_matches::assert_matches;
 ///
 /// let a = 1u32.checked_add(2);
 /// let b = 1u32.checked_sub(2);
@@ -302,7 +302,7 @@ macro_rules! debug_assert_ne {
 /// ```
 /// #![feature(assert_matches)]
 ///
-/// use std::assert_matches::debug_assert_matches;
+/// use core::assert_matches::debug_assert_matches;
 ///
 /// let a = 1u32.checked_add(2);
 /// let b = 1u32.checked_sub(2);
@@ -372,9 +372,9 @@ macro_rules! matches {
 /// # Examples
 ///
 /// ```
-/// use std::io;
-/// use std::fs::File;
-/// use std::io::prelude::*;
+/// use core::io;
+/// use core::fs::File;
+/// use core::io::prelude::*;
 ///
 /// enum MyError {
 ///     FileWriteError
@@ -434,9 +434,9 @@ macro_rules! r#try {
 /// returns whatever the `write_fmt` method returns; commonly a [`fmt::Result`], or an
 /// [`io::Result`].
 ///
-/// See [`std::fmt`] for more information on the format string syntax.
+/// See [`core::fmt`] for more information on the format string syntax.
 ///
-/// [`std::fmt`]: ../std/fmt/index.html
+/// [`core::fmt`]: ../std/fmt/index.html
 /// [`fmt::Write`]: crate::fmt::Write
 /// [`io::Write`]: ../std/io/trait.Write.html
 /// [`fmt::Result`]: crate::fmt::Result
@@ -445,9 +445,9 @@ macro_rules! r#try {
 /// # Examples
 ///
 /// ```
-/// use std::io::Write;
+/// use core::io::Write;
 ///
-/// fn main() -> std::io::Result<()> {
+/// fn main() -> core::io::Result<()> {
 ///     let mut w = Vec::new();
 ///     write!(&mut w, "test")?;
 ///     write!(&mut w, "formatted {}", "arguments")?;
@@ -457,16 +457,16 @@ macro_rules! r#try {
 /// }
 /// ```
 ///
-/// A module can import both `std::fmt::Write` and `std::io::Write` and call `write!` on objects
+/// A module can import both `core::fmt::Write` and `core::io::Write` and call `write!` on objects
 /// implementing either, as objects do not typically implement both. However, the module must
 /// avoid conflict between the trait names, such as by importing them as `_` or otherwise renaming
 /// them:
 ///
 /// ```
-/// use std::fmt::Write as _;
-/// use std::io::Write as _;
+/// use core::fmt::Write as _;
+/// use core::io::Write as _;
 ///
-/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// fn main() -> Result<(), Box<dyn core::error::Error>> {
 ///     let mut s = String::new();
 ///     let mut v = Vec::new();
 ///
@@ -482,8 +482,8 @@ macro_rules! r#try {
 ///
 /// ```
 /// # #![allow(unused_imports)]
-/// use std::fmt::{self, Write as _};
-/// use std::io::{self, Write as _};
+/// use core::fmt::{self, Write as _};
+/// use core::io::{self, Write as _};
 ///
 /// struct Example;
 ///
@@ -527,14 +527,14 @@ macro_rules! write {
 /// (no additional CARRIAGE RETURN (`\r`/`U+000D`).
 ///
 /// For more information, see [`write!`]. For information on the format string syntax, see
-/// [`std::fmt`].
+/// [`core::fmt`].
 ///
-/// [`std::fmt`]: ../std/fmt/index.html
+/// [`core::fmt`]: ../std/fmt/index.html
 ///
 /// # Examples
 ///
 /// ```
-/// use std::io::{Write, Result};
+/// use core::io::{Write, Result};
 ///
 /// fn main() -> Result<()> {
 ///     let mut w = Vec::new();
@@ -834,7 +834,7 @@ pub(crate) mod builtin {
     /// [`Debug`] implementation be passed to a `{:?}` within the formatting string.
     ///
     /// This macro produces a value of type [`fmt::Arguments`]. This value can be
-    /// passed to the macros within [`std::fmt`] for performing useful redirection.
+    /// passed to the macros within [`core::fmt`] for performing useful redirection.
     /// All other formatting macros ([`format!`], [`write!`], [`println!`], etc) are
     /// proxied through this one. `format_args!`, unlike its derived macros, avoids
     /// heap allocations.
@@ -851,19 +851,19 @@ pub(crate) mod builtin {
     /// assert_eq!(display, debug);
     /// ```
     ///
-    /// For more information, see the documentation in [`std::fmt`].
+    /// For more information, see the documentation in [`core::fmt`].
     ///
     /// [`Display`]: crate::fmt::Display
     /// [`Debug`]: crate::fmt::Debug
     /// [`fmt::Arguments`]: crate::fmt::Arguments
-    /// [`std::fmt`]: ../std/fmt/index.html
+    /// [`core::fmt`]: ../std/fmt/index.html
     /// [`format!`]: ../std/macro.format.html
     /// [`println!`]: ../std/macro.println.html
     ///
     /// # Examples
     ///
     /// ```
-    /// use std::fmt;
+    /// use core::fmt;
     ///
     /// let s = fmt::format(format_args!("hello {}", "world"));
     /// assert_eq!(s, format!("hello {}", "world"));
@@ -912,9 +912,9 @@ pub(crate) mod builtin {
     ///
     /// This macro will expand to the value of the named environment variable at
     /// compile time, yielding an expression of type `&'static str`. Use
-    /// [`std::env::var`] instead if you want to read the value at runtime.
+    /// [`core::env::var`] instead if you want to read the value at runtime.
     ///
-    /// [`std::env::var`]: ../std/env/fn.var.html
+    /// [`core::env::var`]: ../std/env/fn.var.html
     ///
     /// If the environment variable is not defined, then a compilation error
     /// will be emitted. To not emit a compile error, use the [`option_env!`]
@@ -955,9 +955,9 @@ pub(crate) mod builtin {
     /// `Some` of the value of the environment variable. If the environment
     /// variable is not present, then this will expand to `None`. See
     /// [`Option<T>`][Option] for more information on this type.  Use
-    /// [`std::env::var`] instead if you want to read the value at runtime.
+    /// [`core::env::var`] instead if you want to read the value at runtime.
     ///
-    /// [`std::env::var`]: ../std/env/fn.var.html
+    /// [`core::env::var`]: ../std/env/fn.var.html
     ///
     /// A compile time error is never emitted when using this macro regardless
     /// of whether the environment variable is present or not.
@@ -1400,11 +1400,11 @@ pub(crate) mod builtin {
     /// # Custom Messages
     ///
     /// This macro has a second form, where a custom panic message can
-    /// be provided with or without arguments for formatting. See [`std::fmt`]
+    /// be provided with or without arguments for formatting. See [`core::fmt`]
     /// for syntax for this form. Expressions used as format arguments will only
     /// be evaluated if the assertion fails.
     ///
-    /// [`std::fmt`]: ../std/fmt/index.html
+    /// [`core::fmt`]: ../std/fmt/index.html
     ///
     /// # Examples
     ///
@@ -1523,7 +1523,7 @@ pub(crate) mod builtin {
 
     /// Attribute macro applied to a static to register it as a global allocator.
     ///
-    /// See also [`std::alloc::GlobalAlloc`](../../../std/alloc/trait.GlobalAlloc.html).
+    /// See also [`core::alloc::GlobalAlloc`](../../../std/alloc/trait.GlobalAlloc.html).
     #[stable(feature = "global_allocator", since = "1.28.0")]
     #[allow_internal_unstable(rustc_attrs)]
     #[rustc_builtin_macro]
@@ -1533,7 +1533,7 @@ pub(crate) mod builtin {
 
     /// Attribute macro applied to a function to register it as a handler for allocation failure.
     ///
-    /// See also [`std::alloc::handle_alloc_error`](../../../std/alloc/fn.handle_alloc_error.html).
+    /// See also [`core::alloc::handle_alloc_error`](../../../std/alloc/fn.handle_alloc_error.html).
     #[unstable(feature = "alloc_error_handler", issue = "51540")]
     #[allow_internal_unstable(rustc_attrs)]
     #[rustc_builtin_macro]

--- a/library/core/src/macros/panic.md
+++ b/library/core/src/macros/panic.md
@@ -15,7 +15,7 @@ the calling Rust thread, causing the thread to panic entirely.
 The behavior of the default `std` hook, i.e. the code that runs directly
 after the panic is invoked, is to print the message payload to
 `stderr` along with the file/line/column information of the `panic!()`
-call. You can override the panic hook using [`std::panic::set_hook()`].
+call. You can override the panic hook using [`core::panic::set_hook()`].
 Inside the hook a panic can be accessed as a `&dyn Any + Send`,
 which contains either a `&str` or `String` for regular `panic!()` invocations.
 To panic with a value of another other type, [`panic_any`] can be used.
@@ -47,17 +47,17 @@ encounter. `Result` must be propagated manually, often with the the help of the
 the help of the `Error` trait.
 
 For more detailed information about error handling check out the [book] or the
-[`std::result`] module docs.
+[`core::result`] module docs.
 
 [ounwrap]: Option::unwrap
 [runwrap]: Result::unwrap
-[`std::panic::set_hook()`]: ../std/panic/fn.set_hook.html
+[`core::panic::set_hook()`]: ../std/panic/fn.set_hook.html
 [`panic_any`]: ../std/panic/fn.panic_any.html
 [`Box`]: ../std/boxed/struct.Box.html
 [`Any`]: crate::any::Any
 [`format!`]: ../std/macro.format.html
 [book]: ../book/ch09-00-error-handling.html
-[`std::result`]: ../std/result/index.html
+[`core::result`]: ../std/result/index.html
 
 # Current implementation
 
@@ -71,5 +71,5 @@ program with code `101`.
 panic!();
 panic!("this is a terrible mistake!");
 panic!("this is a {} {message}", "fancy", message = "message");
-std::panic::panic_any(4); // panic with the value of 4 to be collected elsewhere
+core::panic::panic_any(4); // panic with the value of 4 to be collected elsewhere
 ```

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -471,60 +471,60 @@ pub macro Copy($item:item) {
 #[lang = "sync"]
 #[rustc_on_unimplemented(
     on(
-        _Self = "std::cell::OnceCell<T>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::OnceLock` instead"
+        _Self = "core::cell::OnceCell<T>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::OnceLock` instead"
     ),
     on(
-        _Self = "std::cell::Cell<u8>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU8` instead",
+        _Self = "core::cell::Cell<u8>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock` or `core::sync::atomic::AtomicU8` instead",
     ),
     on(
-        _Self = "std::cell::Cell<u16>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU16` instead",
+        _Self = "core::cell::Cell<u16>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock` or `core::sync::atomic::AtomicU16` instead",
     ),
     on(
-        _Self = "std::cell::Cell<u32>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead",
+        _Self = "core::cell::Cell<u32>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock` or `core::sync::atomic::AtomicU32` instead",
     ),
     on(
-        _Self = "std::cell::Cell<u64>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU64` instead",
+        _Self = "core::cell::Cell<u64>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock` or `core::sync::atomic::AtomicU64` instead",
     ),
     on(
-        _Self = "std::cell::Cell<usize>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicUsize` instead",
+        _Self = "core::cell::Cell<usize>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock` or `core::sync::atomic::AtomicUsize` instead",
     ),
     on(
-        _Self = "std::cell::Cell<i8>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicI8` instead",
+        _Self = "core::cell::Cell<i8>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock` or `core::sync::atomic::AtomicI8` instead",
     ),
     on(
-        _Self = "std::cell::Cell<i16>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicI16` instead",
+        _Self = "core::cell::Cell<i16>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock` or `core::sync::atomic::AtomicI16` instead",
     ),
     on(
-        _Self = "std::cell::Cell<i32>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicI32` instead",
+        _Self = "core::cell::Cell<i32>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock` or `core::sync::atomic::AtomicI32` instead",
     ),
     on(
-        _Self = "std::cell::Cell<i64>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicI64` instead",
+        _Self = "core::cell::Cell<i64>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock` or `core::sync::atomic::AtomicI64` instead",
     ),
     on(
-        _Self = "std::cell::Cell<isize>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicIsize` instead",
+        _Self = "core::cell::Cell<isize>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock` or `core::sync::atomic::AtomicIsize` instead",
     ),
     on(
-        _Self = "std::cell::Cell<bool>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicBool` instead",
+        _Self = "core::cell::Cell<bool>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock` or `core::sync::atomic::AtomicBool` instead",
     ),
     on(
-        _Self = "std::cell::Cell<T>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock`",
+        _Self = "core::cell::Cell<T>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock`",
     ),
     on(
-        _Self = "std::cell::RefCell<T>",
-        note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead",
+        _Self = "core::cell::RefCell<T>",
+        note = "if you want to do aliasing and mutation between multiple threads, use `core::sync::RwLock` instead",
     ),
     message = "`{Self}` cannot be shared between threads safely",
     label = "`{Self}` cannot be shared between threads safely"
@@ -588,7 +588,7 @@ impl<T: ?Sized> !Sync for *mut T {}
 /// `Slice` struct contained a reference `&'a T`:
 ///
 /// ```
-/// use std::marker::PhantomData;
+/// use core::marker::PhantomData;
 ///
 /// # #[allow(dead_code)]
 /// struct Slice<'a, T: 'a> {
@@ -606,7 +606,7 @@ impl<T: ?Sized> !Sync for *mut T {}
 ///
 /// ```
 /// # #![allow(dead_code)]
-/// # use std::marker::PhantomData;
+/// # use core::marker::PhantomData;
 /// # struct Slice<'a, T: 'a> {
 /// #     start: *const T,
 /// #     end: *const T,
@@ -643,8 +643,8 @@ impl<T: ?Sized> !Sync for *mut T {}
 /// #     pub fn do_stuff(_: *mut (), _: usize) {}
 /// # }
 /// # fn convert_params(_: ParamType) -> usize { 42 }
-/// use std::marker::PhantomData;
-/// use std::mem;
+/// use core::marker::PhantomData;
+/// use core::mem;
 ///
 /// struct ExternalResource<R> {
 ///    resource_handle: *mut (),
@@ -804,8 +804,8 @@ unsafe impl<T: ?Sized> Freeze for &mut T {}
 ///
 /// ```rust
 /// # #![allow(unused_must_use)]
-/// use std::mem;
-/// use std::pin::Pin;
+/// use core::mem;
+/// use core::pin::Pin;
 ///
 /// let mut string = "this".to_string();
 /// let mut pinned_string = Pin::new(&mut string);

--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -57,7 +57,7 @@ impl<T> ManuallyDrop<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use std::mem::ManuallyDrop;
+    /// use core::mem::ManuallyDrop;
     /// let mut x = ManuallyDrop::new(String::from("Hello World!"));
     /// x.truncate(5); // You can still safely operate on the value
     /// assert_eq!(*x, "Hello");
@@ -78,7 +78,7 @@ impl<T> ManuallyDrop<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use std::mem::ManuallyDrop;
+    /// use core::mem::ManuallyDrop;
     /// let x = ManuallyDrop::new(Box::new(()));
     /// let _: Box<()> = ManuallyDrop::into_inner(x); // This drops the `Box`.
     /// ```

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -18,7 +18,7 @@ use crate::slice;
 ///
 /// ```rust,no_run
 /// # #![allow(invalid_value)]
-/// use std::mem::{self, MaybeUninit};
+/// use core::mem::{self, MaybeUninit};
 ///
 /// let x: &i32 = unsafe { mem::zeroed() }; // undefined behavior! ⚠️
 /// // The equivalent code with `MaybeUninit<&i32>`:
@@ -33,7 +33,7 @@ use crate::slice;
 ///
 /// ```rust,no_run
 /// # #![allow(invalid_value)]
-/// use std::mem::{self, MaybeUninit};
+/// use core::mem::{self, MaybeUninit};
 ///
 /// let b: bool = unsafe { mem::uninitialized() }; // undefined behavior! ⚠️
 /// // The equivalent code with `MaybeUninit<bool>`:
@@ -48,7 +48,7 @@ use crate::slice;
 ///
 /// ```rust,no_run
 /// # #![allow(invalid_value)]
-/// use std::mem::{self, MaybeUninit};
+/// use core::mem::{self, MaybeUninit};
 ///
 /// let x: i32 = unsafe { mem::uninitialized() }; // undefined behavior! ⚠️
 /// // The equivalent code with `MaybeUninit<i32>`:
@@ -71,7 +71,7 @@ use crate::slice;
 /// be initialized:
 ///
 /// ```rust
-/// use std::mem::MaybeUninit;
+/// use core::mem::MaybeUninit;
 ///
 /// // Create an explicitly uninitialized reference. The compiler knows that data inside
 /// // a `MaybeUninit<T>` may be invalid, and hence this is not UB:
@@ -97,7 +97,7 @@ use crate::slice;
 /// unnecessary moves.
 ///
 /// ```
-/// use std::mem::MaybeUninit;
+/// use core::mem::MaybeUninit;
 ///
 /// unsafe fn make_vec(out: *mut Vec<i32>) {
 ///     // `write` does not drop the old contents, which is important.
@@ -117,7 +117,7 @@ use crate::slice;
 /// `MaybeUninit<T>` can be used to initialize a large array element-by-element:
 ///
 /// ```
-/// use std::mem::{self, MaybeUninit};
+/// use core::mem::{self, MaybeUninit};
 ///
 /// let data = {
 ///     // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
@@ -145,7 +145,7 @@ use crate::slice;
 /// be found in low-level datastructures.
 ///
 /// ```
-/// use std::mem::MaybeUninit;
+/// use core::mem::MaybeUninit;
 ///
 /// // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
 /// // safe because the type we are claiming to have initialized here is a
@@ -167,11 +167,11 @@ use crate::slice;
 ///
 /// ## Initializing a struct field-by-field
 ///
-/// You can use `MaybeUninit<T>`, and the [`std::ptr::addr_of_mut`] macro, to initialize structs field by field:
+/// You can use `MaybeUninit<T>`, and the [`core::ptr::addr_of_mut`] macro, to initialize structs field by field:
 ///
 /// ```rust
-/// use std::mem::MaybeUninit;
-/// use std::ptr::addr_of_mut;
+/// use core::mem::MaybeUninit;
+/// use core::ptr::addr_of_mut;
 ///
 /// #[derive(Debug, PartialEq)]
 /// pub struct Foo {
@@ -204,7 +204,7 @@ use crate::slice;
 ///     }
 /// );
 /// ```
-/// [`std::ptr::addr_of_mut`]: crate::ptr::addr_of_mut
+/// [`core::ptr::addr_of_mut`]: crate::ptr::addr_of_mut
 /// [ub]: ../../reference/behavior-considered-undefined.html
 ///
 /// # Layout
@@ -212,7 +212,7 @@ use crate::slice;
 /// `MaybeUninit<T>` is guaranteed to have the same size, alignment, and ABI as `T`:
 ///
 /// ```rust
-/// use std::mem::{MaybeUninit, size_of, align_of};
+/// use core::mem::{MaybeUninit, size_of, align_of};
 /// assert_eq!(size_of::<MaybeUninit<u64>>(), size_of::<u64>());
 /// assert_eq!(align_of::<MaybeUninit<u64>>(), align_of::<u64>());
 /// ```
@@ -224,7 +224,7 @@ use crate::slice;
 /// optimizations, potentially resulting in a larger size:
 ///
 /// ```rust
-/// # use std::mem::{MaybeUninit, size_of};
+/// # use core::mem::{MaybeUninit, size_of};
 /// assert_eq!(size_of::<Option<bool>>(), 1);
 /// assert_eq!(size_of::<Option<MaybeUninit<bool>>>(), 2);
 /// ```
@@ -277,7 +277,7 @@ impl<T> MaybeUninit<T> {
     /// # Example
     ///
     /// ```
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let v: MaybeUninit<Vec<u8>> = MaybeUninit::new(vec![42]);
     /// ```
@@ -301,7 +301,7 @@ impl<T> MaybeUninit<T> {
     /// # Example
     ///
     /// ```
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let v: MaybeUninit<String> = MaybeUninit::uninit();
     /// ```
@@ -326,7 +326,7 @@ impl<T> MaybeUninit<T> {
     /// ```no_run
     /// #![feature(maybe_uninit_uninit_array, maybe_uninit_slice)]
     ///
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// extern "C" {
     ///     fn read_into_buffer(ptr: *mut u8, max_len: usize) -> usize;
@@ -367,7 +367,7 @@ impl<T> MaybeUninit<T> {
     /// fields of the struct can hold the bit-pattern 0 as a valid value.
     ///
     /// ```rust
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let x = MaybeUninit::<(u8, bool)>::zeroed();
     /// let x = unsafe { x.assume_init() };
@@ -378,7 +378,7 @@ impl<T> MaybeUninit<T> {
     /// when `0` is not a valid bit-pattern for the type:
     ///
     /// ```rust,no_run
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// enum NotZero { One = 1, Two = 2 }
     ///
@@ -425,7 +425,7 @@ impl<T> MaybeUninit<T> {
     /// Correct usage of this method:
     ///
     /// ```rust
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut x = MaybeUninit::<Vec<u8>>::uninit();
     ///
@@ -443,7 +443,7 @@ impl<T> MaybeUninit<T> {
     /// This usage of the method causes a leak:
     ///
     /// ```rust
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut x = MaybeUninit::<String>::uninit();
     ///
@@ -501,7 +501,7 @@ impl<T> MaybeUninit<T> {
     /// Correct usage of this method:
     ///
     /// ```rust
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut x = MaybeUninit::<Vec<u32>>::uninit();
     /// x.write(vec![0, 1, 2]);
@@ -513,7 +513,7 @@ impl<T> MaybeUninit<T> {
     /// *Incorrect* usage of this method:
     ///
     /// ```rust,no_run
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let x = MaybeUninit::<Vec<u32>>::uninit();
     /// let x_vec = unsafe { &*x.as_ptr() };
@@ -538,7 +538,7 @@ impl<T> MaybeUninit<T> {
     /// Correct usage of this method:
     ///
     /// ```rust
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut x = MaybeUninit::<Vec<u32>>::uninit();
     /// x.write(vec![0, 1, 2]);
@@ -552,7 +552,7 @@ impl<T> MaybeUninit<T> {
     /// *Incorrect* usage of this method:
     ///
     /// ```rust,no_run
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut x = MaybeUninit::<Vec<u32>>::uninit();
     /// let x_vec = unsafe { &mut *x.as_mut_ptr() };
@@ -597,7 +597,7 @@ impl<T> MaybeUninit<T> {
     /// Correct usage of this method:
     ///
     /// ```rust
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut x = MaybeUninit::<bool>::uninit();
     /// x.write(true);
@@ -608,7 +608,7 @@ impl<T> MaybeUninit<T> {
     /// *Incorrect* usage of this method:
     ///
     /// ```rust,no_run
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let x = MaybeUninit::<Vec<u32>>::uninit();
     /// let x_init = unsafe { x.assume_init() };
@@ -656,7 +656,7 @@ impl<T> MaybeUninit<T> {
     /// Correct usage of this method:
     ///
     /// ```rust
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut x = MaybeUninit::<u32>::uninit();
     /// x.write(13);
@@ -676,7 +676,7 @@ impl<T> MaybeUninit<T> {
     /// *Incorrect* usage of this method:
     ///
     /// ```rust,no_run
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut x = MaybeUninit::<Option<Vec<u32>>>::uninit();
     /// x.write(Some(vec![0, 1, 2]));
@@ -745,7 +745,7 @@ impl<T> MaybeUninit<T> {
     /// ### Correct usage of this method:
     ///
     /// ```rust
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut x = MaybeUninit::<Vec<u32>>::uninit();
     /// // Initialize `x`:
@@ -762,7 +762,7 @@ impl<T> MaybeUninit<T> {
     /// ### *Incorrect* usages of this method:
     ///
     /// ```rust,no_run
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let x = MaybeUninit::<Vec<u32>>::uninit();
     /// let x_vec: &Vec<u32> = unsafe { x.assume_init_ref() };
@@ -770,7 +770,7 @@ impl<T> MaybeUninit<T> {
     /// ```
     ///
     /// ```rust,no_run
-    /// use std::{cell::Cell, mem::MaybeUninit};
+    /// use core::{cell::Cell, mem::MaybeUninit};
     ///
     /// let b = MaybeUninit::<Cell<bool>>::uninit();
     /// // Initialize the `MaybeUninit` using `Cell::set`:
@@ -811,7 +811,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// ```rust
     /// # #![allow(unexpected_cfgs)]
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// # unsafe extern "C" fn initialize_buffer(buf: *mut [u8; 1024]) { *buf = [0; 1024] }
     /// # #[cfg(FALSE)]
@@ -846,7 +846,7 @@ impl<T> MaybeUninit<T> {
     /// You cannot use `.assume_init_mut()` to initialize a value:
     ///
     /// ```rust,no_run
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut b = MaybeUninit::<bool>::uninit();
     /// unsafe {
@@ -861,7 +861,7 @@ impl<T> MaybeUninit<T> {
     /// [`Read`]: ../../std/io/trait.Read.html
     ///
     /// ```rust,no_run
-    /// use std::{io, mem::MaybeUninit};
+    /// use core::{io, mem::MaybeUninit};
     ///
     /// fn read_chunk (reader: &'_ mut dyn io::Read) -> io::Result<[u8; 64]>
     /// {
@@ -877,7 +877,7 @@ impl<T> MaybeUninit<T> {
     /// Nor can you use direct field access to do field-by-field gradual initialization:
     ///
     /// ```rust,no_run
-    /// use std::{mem::MaybeUninit, ptr};
+    /// use core::{mem::MaybeUninit, ptr};
     ///
     /// struct Foo {
     ///     a: u32,
@@ -921,7 +921,7 @@ impl<T> MaybeUninit<T> {
     /// ```
     /// #![feature(maybe_uninit_uninit_array)]
     /// #![feature(maybe_uninit_array_assume_init)]
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut array: [MaybeUninit<i32>; 3] = MaybeUninit::uninit_array();
     /// array[0].write(0);
@@ -1027,7 +1027,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// ```
     /// #![feature(maybe_uninit_write_slice)]
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut dst = [MaybeUninit::uninit(); 32];
     /// let src = [0; 32];
@@ -1039,7 +1039,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// ```
     /// #![feature(maybe_uninit_write_slice)]
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut vec = Vec::with_capacity(32);
     /// let src = [0; 16];
@@ -1087,7 +1087,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// ```
     /// #![feature(maybe_uninit_write_slice)]
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut dst = [MaybeUninit::uninit(), MaybeUninit::uninit(), MaybeUninit::uninit(), MaybeUninit::uninit(), MaybeUninit::uninit()];
     /// let src = ["wibbly".to_string(), "wobbly".to_string(), "timey".to_string(), "wimey".to_string(), "stuff".to_string()];
@@ -1099,7 +1099,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// ```
     /// #![feature(maybe_uninit_write_slice)]
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut vec = Vec::with_capacity(32);
     /// let src = ["rust", "is", "a", "pretty", "cool", "language"];
@@ -1170,7 +1170,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// ```
     /// #![feature(maybe_uninit_as_bytes, maybe_uninit_slice)]
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let val = 0x12345678_i32;
     /// let uninit = MaybeUninit::new(val);
@@ -1196,7 +1196,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// ```
     /// #![feature(maybe_uninit_as_bytes)]
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let val = 0x12345678_i32;
     /// let mut uninit = MaybeUninit::new(val);
@@ -1230,7 +1230,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// ```
     /// #![feature(maybe_uninit_as_bytes, maybe_uninit_write_slice, maybe_uninit_slice)]
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let uninit = [MaybeUninit::new(0x1234u16), MaybeUninit::new(0x5678u16)];
     /// let uninit_bytes = MaybeUninit::slice_as_bytes(&uninit);
@@ -1260,7 +1260,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// ```
     /// #![feature(maybe_uninit_as_bytes, maybe_uninit_write_slice, maybe_uninit_slice)]
-    /// use std::mem::MaybeUninit;
+    /// use core::mem::MaybeUninit;
     ///
     /// let mut uninit = [MaybeUninit::<u16>::uninit(), MaybeUninit::<u16>::uninit()];
     /// let uninit_bytes = MaybeUninit::slice_as_bytes_mut(&mut uninit);
@@ -1291,7 +1291,7 @@ impl<T, const N: usize> MaybeUninit<[T; N]> {
     ///
     /// ```
     /// #![feature(maybe_uninit_uninit_array_transpose)]
-    /// # use std::mem::MaybeUninit;
+    /// # use core::mem::MaybeUninit;
     ///
     /// let data: [MaybeUninit<u8>; 1000] = MaybeUninit::uninit().transpose();
     /// ```
@@ -1310,7 +1310,7 @@ impl<T, const N: usize> [MaybeUninit<T>; N] {
     ///
     /// ```
     /// #![feature(maybe_uninit_uninit_array_transpose)]
-    /// # use std::mem::MaybeUninit;
+    /// # use core::mem::MaybeUninit;
     ///
     /// let data = [MaybeUninit::<u8>::uninit(); 1000];
     /// let data: MaybeUninit<[u8; 1000]> = data.transpose();

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -67,8 +67,8 @@ pub use crate::intrinsics::transmute;
 /// the space taken by the variable but never close the underlying system resource:
 ///
 /// ```no_run
-/// use std::mem;
-/// use std::fs::File;
+/// use core::mem;
+/// use core::fs::File;
 ///
 /// let file = File::open("foo.txt").unwrap();
 /// mem::forget(file);
@@ -84,7 +84,7 @@ pub use crate::intrinsics::transmute;
 /// [`ManuallyDrop`] should be used instead. Consider, for example, this code:
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// let mut v = vec![65, 122];
 /// // Build a `String` using the contents of `v`
@@ -110,7 +110,7 @@ pub use crate::intrinsics::transmute;
 /// Switching to `ManuallyDrop` avoids both issues:
 ///
 /// ```
-/// use std::mem::ManuallyDrop;
+/// use core::mem::ManuallyDrop;
 ///
 /// let v = vec![65, 122];
 /// // Before we disassemble `v` into its raw parts, make sure it
@@ -230,7 +230,7 @@ pub fn forget_unsized<T: ?Sized>(t: T) {
 /// # Examples
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// // Some primitives
 /// assert_eq!(4, mem::size_of::<i32>());
@@ -253,7 +253,7 @@ pub fn forget_unsized<T: ?Sized>(t: T) {
 /// Using `#[repr(C)]`.
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// #[repr(C)]
 /// struct FieldStruct {
@@ -320,7 +320,7 @@ pub const fn size_of<T>() -> usize {
 /// # Examples
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// assert_eq!(4, mem::size_of_val(&5i32));
 ///
@@ -370,7 +370,7 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 ///
 /// ```
 /// #![feature(layout_for_ptr)]
-/// use std::mem;
+/// use core::mem;
 ///
 /// assert_eq!(4, mem::size_of_val(&5i32));
 ///
@@ -399,7 +399,7 @@ pub const unsafe fn size_of_val_raw<T: ?Sized>(val: *const T) -> usize {
 ///
 /// ```
 /// # #![allow(deprecated)]
-/// use std::mem;
+/// use core::mem;
 ///
 /// assert_eq!(4, mem::min_align_of::<i32>());
 /// ```
@@ -422,7 +422,7 @@ pub fn min_align_of<T>() -> usize {
 ///
 /// ```
 /// # #![allow(deprecated)]
-/// use std::mem;
+/// use core::mem;
 ///
 /// assert_eq!(4, mem::min_align_of_val(&5i32));
 /// ```
@@ -446,7 +446,7 @@ pub fn min_align_of_val<T: ?Sized>(val: &T) -> usize {
 /// # Examples
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// assert_eq!(4, mem::align_of::<i32>());
 /// ```
@@ -469,7 +469,7 @@ pub const fn align_of<T>() -> usize {
 /// # Examples
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// assert_eq!(4, mem::align_of_val(&5i32));
 /// ```
@@ -516,7 +516,7 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 ///
 /// ```
 /// #![feature(layout_for_ptr)]
-/// use std::mem;
+/// use core::mem;
 ///
 /// assert_eq!(4, unsafe { mem::align_of_val_raw(&5i32) });
 /// ```
@@ -560,7 +560,7 @@ pub const unsafe fn align_of_val_raw<T: ?Sized>(val: *const T) -> usize {
 /// Here's an example of how a collection might make use of `needs_drop`:
 ///
 /// ```
-/// use std::{mem, ptr};
+/// use core::{mem, ptr};
 ///
 /// pub struct MyCollection<T> {
 /// #   data: [T; 1],
@@ -618,7 +618,7 @@ pub const fn needs_drop<T: ?Sized>() -> bool {
 /// Correct usage of this function: initializing an integer with zero.
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// let x: i32 = unsafe { mem::zeroed() };
 /// assert_eq!(0, x);
@@ -628,7 +628,7 @@ pub const fn needs_drop<T: ?Sized>() -> bool {
 ///
 /// ```rust,no_run
 /// # #![allow(invalid_value)]
-/// use std::mem;
+/// use core::mem;
 ///
 /// let _x: &i32 = unsafe { mem::zeroed() }; // Undefined behavior!
 /// let _y: fn() = unsafe { mem::zeroed() }; // And again!
@@ -703,7 +703,7 @@ pub unsafe fn uninitialized<T>() -> T {
 /// # Examples
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// let mut x = 5;
 /// let mut y = 42;
@@ -787,7 +787,7 @@ pub(crate) const fn swap_simple<T>(x: &mut T, y: &mut T) {
 /// A simple example:
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// let mut v: Vec<i32> = vec![1, 2];
 ///
@@ -817,7 +817,7 @@ pub(crate) const fn swap_simple<T>(x: &mut T, y: &mut T) {
 /// `self`, allowing it to be returned:
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// # struct Buffer<T> { buf: Vec<T> }
 /// impl<T> Buffer<T> {
@@ -850,7 +850,7 @@ pub fn take<T: Default>(dest: &mut T) -> T {
 /// A simple example:
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// let mut v: Vec<i32> = vec![1, 2];
 ///
@@ -881,7 +881,7 @@ pub fn take<T: Default>(dest: &mut T) -> T {
 ///
 /// ```
 /// # #![allow(dead_code)]
-/// use std::mem;
+/// use core::mem;
 ///
 /// # struct Buffer<T> { buf: Vec<T> }
 /// impl<T> Buffer<T> {
@@ -945,7 +945,7 @@ pub const fn replace<T>(dest: &mut T, src: T) -> T {
 /// release a [`RefCell`] borrow:
 ///
 /// ```
-/// use std::cell::RefCell;
+/// use core::cell::RefCell;
 ///
 /// let x = RefCell::new(1);
 ///
@@ -1018,7 +1018,7 @@ pub const fn copy<T: Copy>(x: &T) -> T {
 /// # Examples
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// #[repr(packed)]
 /// struct Foo {
@@ -1124,7 +1124,7 @@ impl<T> fmt::Debug for Discriminant<T> {
 /// the actual data:
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// enum Foo { A(&'static str), B(i32), C(i32) }
 ///
@@ -1186,7 +1186,7 @@ impl<T> fmt::Debug for Discriminant<T> {
 /// assert_eq!(2, struct_like.discriminant());
 ///
 /// // ⚠️ This is undefined behavior. Don't do this. ⚠️
-/// // assert_eq!(0, unsafe { std::mem::transmute::<_, u8>(std::mem::discriminant(&unit_like)) });
+/// // assert_eq!(0, unsafe { core::mem::transmute::<_, u8>(core::mem::discriminant(&unit_like)) });
 /// ```
 #[stable(feature = "discriminant_value", since = "1.21.0")]
 #[rustc_const_unstable(feature = "const_discriminant", issue = "69821")]
@@ -1212,7 +1212,7 @@ pub const fn discriminant<T>(v: &T) -> Discriminant<T> {
 /// # #![feature(never_type)]
 /// # #![feature(variant_count)]
 ///
-/// use std::mem;
+/// use core::mem;
 ///
 /// enum Void {}
 /// enum Foo { A(&'static str), B(i32), C(i32) }

--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -12,7 +12,7 @@ use super::display_buffer::DisplayBuffer;
 /// # Examples
 ///
 /// ```
-/// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+/// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 ///
 /// let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 /// let localhost_v6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
@@ -57,7 +57,7 @@ pub enum IpAddr {
 /// # Examples
 ///
 /// ```
-/// use std::net::Ipv4Addr;
+/// use core::net::Ipv4Addr;
 ///
 /// let localhost = Ipv4Addr::new(127, 0, 0, 1);
 /// assert_eq!("127.0.0.1".parse(), Ok(localhost));
@@ -142,7 +142,7 @@ pub struct Ipv4Addr {
 /// # Examples
 ///
 /// ```
-/// use std::net::Ipv6Addr;
+/// use core::net::Ipv6Addr;
 ///
 /// let localhost = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
 /// assert_eq!("::1".parse(), Ok(localhost));
@@ -166,8 +166,8 @@ pub struct Ipv6Addr {
 /// ```
 /// #![feature(ip)]
 ///
-/// use std::net::Ipv6Addr;
-/// use std::net::Ipv6MulticastScope::*;
+/// use core::net::Ipv6Addr;
+/// use core::net::Ipv6MulticastScope::*;
 ///
 /// // An IPv6 multicast address with global scope (`ff0e::`).
 /// let address = Ipv6Addr::new(0xff0e, 0, 0, 0, 0, 0, 0, 0);
@@ -218,7 +218,7 @@ impl IpAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)).is_unspecified(), true);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)).is_unspecified(), true);
@@ -242,7 +242,7 @@ impl IpAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)).is_loopback(), true);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0x1)).is_loopback(), true);
@@ -268,7 +268,7 @@ impl IpAddr {
     /// ```
     /// #![feature(ip)]
     ///
-    /// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(80, 9, 12, 3)).is_global(), true);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0, 0, 0x1c9, 0, 0, 0xafc8, 0, 0x1)).is_global(), true);
@@ -292,7 +292,7 @@ impl IpAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(224, 254, 0, 0)).is_multicast(), true);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0)).is_multicast(), true);
@@ -318,7 +318,7 @@ impl IpAddr {
     /// ```
     /// #![feature(ip)]
     ///
-    /// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 6)).is_documentation(), true);
     /// assert_eq!(
@@ -347,7 +347,7 @@ impl IpAddr {
     /// ```
     /// #![feature(ip)]
     ///
-    /// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(198, 19, 255, 255)).is_benchmarking(), true);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0x2001, 0x2, 0, 0, 0, 0, 0, 0)).is_benchmarking(), true);
@@ -370,7 +370,7 @@ impl IpAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 6)).is_ipv4(), true);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0)).is_ipv4(), false);
@@ -391,7 +391,7 @@ impl IpAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 6)).is_ipv6(), false);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0)).is_ipv6(), true);
@@ -411,7 +411,7 @@ impl IpAddr {
     ///
     /// ```
     /// #![feature(ip)]
-    /// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)).to_canonical().is_loopback(), true);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x1)).is_loopback(), false);
@@ -438,7 +438,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::new(127, 0, 0, 1);
     /// ```
@@ -455,7 +455,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::LOCALHOST;
     /// assert_eq!(addr, Ipv4Addr::new(127, 0, 0, 1));
@@ -470,7 +470,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::UNSPECIFIED;
     /// assert_eq!(addr, Ipv4Addr::new(0, 0, 0, 0));
@@ -484,7 +484,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::BROADCAST;
     /// assert_eq!(addr, Ipv4Addr::new(255, 255, 255, 255));
@@ -497,7 +497,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::new(127, 0, 0, 1);
     /// assert_eq!(addr.octets(), [127, 0, 0, 1]);
@@ -520,7 +520,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// assert_eq!(Ipv4Addr::new(0, 0, 0, 0).is_unspecified(), true);
     /// assert_eq!(Ipv4Addr::new(45, 22, 13, 197).is_unspecified(), false);
@@ -542,7 +542,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// assert_eq!(Ipv4Addr::new(127, 0, 0, 1).is_loopback(), true);
     /// assert_eq!(Ipv4Addr::new(45, 22, 13, 197).is_loopback(), false);
@@ -568,7 +568,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// assert_eq!(Ipv4Addr::new(10, 0, 0, 1).is_private(), true);
     /// assert_eq!(Ipv4Addr::new(10, 10, 10, 10).is_private(), true);
@@ -600,7 +600,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// assert_eq!(Ipv4Addr::new(169, 254, 0, 0).is_link_local(), true);
     /// assert_eq!(Ipv4Addr::new(169, 254, 10, 65).is_link_local(), true);
@@ -645,7 +645,7 @@ impl Ipv4Addr {
     /// ```
     /// #![feature(ip)]
     ///
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// // Most IPv4 addresses are globally reachable:
     /// assert_eq!(Ipv4Addr::new(80, 9, 12, 3).is_global(), true);
@@ -713,7 +713,7 @@ impl Ipv4Addr {
     ///
     /// ```
     /// #![feature(ip)]
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// assert_eq!(Ipv4Addr::new(100, 64, 0, 0).is_shared(), true);
     /// assert_eq!(Ipv4Addr::new(100, 127, 255, 255).is_shared(), true);
@@ -738,7 +738,7 @@ impl Ipv4Addr {
     ///
     /// ```
     /// #![feature(ip)]
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// assert_eq!(Ipv4Addr::new(198, 17, 255, 255).is_benchmarking(), false);
     /// assert_eq!(Ipv4Addr::new(198, 18, 0, 0).is_benchmarking(), true);
@@ -771,7 +771,7 @@ impl Ipv4Addr {
     ///
     /// ```
     /// #![feature(ip)]
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// assert_eq!(Ipv4Addr::new(240, 0, 0, 0).is_reserved(), true);
     /// assert_eq!(Ipv4Addr::new(255, 255, 255, 254).is_reserved(), true);
@@ -798,7 +798,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// assert_eq!(Ipv4Addr::new(224, 254, 0, 0).is_multicast(), true);
     /// assert_eq!(Ipv4Addr::new(236, 168, 10, 65).is_multicast(), true);
@@ -821,7 +821,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// assert_eq!(Ipv4Addr::new(255, 255, 255, 255).is_broadcast(), true);
     /// assert_eq!(Ipv4Addr::new(236, 168, 10, 65).is_broadcast(), false);
@@ -847,7 +847,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// assert_eq!(Ipv4Addr::new(192, 0, 2, 255).is_documentation(), true);
     /// assert_eq!(Ipv4Addr::new(198, 51, 100, 65).is_documentation(), true);
@@ -875,7 +875,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{Ipv4Addr, Ipv6Addr};
+    /// use core::net::{Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(
     ///     Ipv4Addr::new(192, 0, 2, 255).to_ipv6_compatible(),
@@ -902,7 +902,7 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{Ipv4Addr, Ipv6Addr};
+    /// use core::net::{Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(Ipv4Addr::new(192, 0, 2, 255).to_ipv6_mapped(),
     ///            Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc000, 0x2ff));
@@ -942,7 +942,7 @@ impl From<Ipv4Addr> for IpAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr};
+    /// use core::net::{IpAddr, Ipv4Addr};
     ///
     /// let addr = Ipv4Addr::new(127, 0, 0, 1);
     ///
@@ -964,7 +964,7 @@ impl From<Ipv6Addr> for IpAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv6Addr};
     ///
     /// let addr = Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff);
     ///
@@ -1074,7 +1074,7 @@ impl From<Ipv4Addr> for u32 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::new(0x12, 0x34, 0x56, 0x78);
     /// assert_eq!(0x12345678, u32::from(addr));
@@ -1092,7 +1092,7 @@ impl From<u32> for Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::from(0x12345678);
     /// assert_eq!(Ipv4Addr::new(0x12, 0x34, 0x56, 0x78), addr);
@@ -1110,7 +1110,7 @@ impl From<[u8; 4]> for Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::from([13u8, 12u8, 11u8, 10u8]);
     /// assert_eq!(Ipv4Addr::new(13, 12, 11, 10), addr);
@@ -1128,7 +1128,7 @@ impl From<[u8; 4]> for IpAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr};
+    /// use core::net::{IpAddr, Ipv4Addr};
     ///
     /// let addr = IpAddr::from([13u8, 12u8, 11u8, 10u8]);
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(13, 12, 11, 10)), addr);
@@ -1147,7 +1147,7 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff);
     /// ```
@@ -1181,7 +1181,7 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::LOCALHOST;
     /// assert_eq!(addr, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
@@ -1198,7 +1198,7 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::UNSPECIFIED;
     /// assert_eq!(addr, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0));
@@ -1213,7 +1213,7 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).segments(),
     ///            [0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff]);
@@ -1248,7 +1248,7 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).is_unspecified(), false);
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0).is_unspecified(), true);
@@ -1272,7 +1272,7 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).is_loopback(), false);
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0x1).is_loopback(), true);
@@ -1318,7 +1318,7 @@ impl Ipv6Addr {
     /// ```
     /// #![feature(ip)]
     ///
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// // Most IPv6 addresses are globally reachable:
     /// assert_eq!(Ipv6Addr::new(0x26, 0, 0x1c9, 0, 0, 0xafc8, 0x10, 0x1).is_global(), true);
@@ -1392,7 +1392,7 @@ impl Ipv6Addr {
     /// ```
     /// #![feature(ip)]
     ///
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).is_unique_local(), false);
     /// assert_eq!(Ipv6Addr::new(0xfc02, 0, 0, 0, 0, 0, 0, 0).is_unique_local(), true);
@@ -1416,7 +1416,7 @@ impl Ipv6Addr {
     /// ```
     /// #![feature(ip)]
     ///
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// // The unspecified and loopback addresses are unicast.
     /// assert_eq!(Ipv6Addr::UNSPECIFIED.is_unicast(), true);
@@ -1465,7 +1465,7 @@ impl Ipv6Addr {
     /// ```
     /// #![feature(ip)]
     ///
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// // The loopback address (`::1`) does not actually have link-local scope.
     /// assert_eq!(Ipv6Addr::LOCALHOST.is_unicast_link_local(), false);
@@ -1498,7 +1498,7 @@ impl Ipv6Addr {
     /// ```
     /// #![feature(ip)]
     ///
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).is_documentation(), false);
     /// assert_eq!(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0).is_documentation(), true);
@@ -1522,7 +1522,7 @@ impl Ipv6Addr {
     /// ```
     /// #![feature(ip)]
     ///
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc613, 0x0).is_benchmarking(), false);
     /// assert_eq!(Ipv6Addr::new(0x2001, 0x2, 0, 0, 0, 0, 0, 0).is_benchmarking(), true);
@@ -1559,7 +1559,7 @@ impl Ipv6Addr {
     /// ```
     /// #![feature(ip)]
     ///
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// assert_eq!(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0).is_unicast_global(), false);
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).is_unicast_global(), true);
@@ -1585,7 +1585,7 @@ impl Ipv6Addr {
     /// ```
     /// #![feature(ip)]
     ///
-    /// use std::net::{Ipv6Addr, Ipv6MulticastScope};
+    /// use core::net::{Ipv6Addr, Ipv6MulticastScope};
     ///
     /// assert_eq!(
     ///     Ipv6Addr::new(0xff0e, 0, 0, 0, 0, 0, 0, 0).multicast_scope(),
@@ -1623,7 +1623,7 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// assert_eq!(Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0).is_multicast(), true);
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).is_multicast(), false);
@@ -1649,7 +1649,7 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{Ipv4Addr, Ipv6Addr};
+    /// use core::net::{Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0).to_ipv4_mapped(), None);
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).to_ipv4_mapped(),
@@ -1690,7 +1690,7 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{Ipv4Addr, Ipv6Addr};
+    /// use core::net::{Ipv4Addr, Ipv6Addr};
     ///
     /// assert_eq!(Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0).to_ipv4(), None);
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).to_ipv4(),
@@ -1720,7 +1720,7 @@ impl Ipv6Addr {
     ///
     /// ```
     /// #![feature(ip)]
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x1).is_loopback(), false);
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x1).to_canonical().is_loopback(), true);
@@ -1740,7 +1740,7 @@ impl Ipv6Addr {
     /// Returns the sixteen eight-bit integers the IPv6 address consists of.
     ///
     /// ```
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// assert_eq!(Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0).octets(),
     ///            [255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
@@ -1916,7 +1916,7 @@ impl From<Ipv6Addr> for u128 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::new(
     ///     0x1020, 0x3040, 0x5060, 0x7080,
@@ -1936,7 +1936,7 @@ impl From<u128> for Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::from(0x102030405060708090A0B0C0D0E0F00D_u128);
     /// assert_eq!(
@@ -1959,7 +1959,7 @@ impl From<[u8; 16]> for Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::from([
     ///     25u8, 24u8, 23u8, 22u8, 21u8, 20u8, 19u8, 18u8,
@@ -1988,7 +1988,7 @@ impl From<[u16; 8]> for Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::from([
     ///     525u16, 524u16, 523u16, 522u16,
@@ -2018,7 +2018,7 @@ impl From<[u8; 16]> for IpAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv6Addr};
     ///
     /// let addr = IpAddr::from([
     ///     25u8, 24u8, 23u8, 22u8, 21u8, 20u8, 19u8, 18u8,
@@ -2047,7 +2047,7 @@ impl From<[u16; 8]> for IpAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv6Addr};
     ///
     /// let addr = IpAddr::from([
     ///     525u16, 524u16, 523u16, 522u16,

--- a/library/core/src/net/parser.rs
+++ b/library/core/src/net/parser.rs
@@ -277,7 +277,7 @@ impl IpAddr {
     /// ```
     /// #![feature(addr_parse_ascii)]
     ///
-    /// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    /// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     ///
     /// let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     /// let localhost_v6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
@@ -305,7 +305,7 @@ impl Ipv4Addr {
     /// ```
     /// #![feature(addr_parse_ascii)]
     ///
-    /// use std::net::Ipv4Addr;
+    /// use core::net::Ipv4Addr;
     ///
     /// let localhost = Ipv4Addr::new(127, 0, 0, 1);
     ///
@@ -336,7 +336,7 @@ impl Ipv6Addr {
     /// ```
     /// #![feature(addr_parse_ascii)]
     ///
-    /// use std::net::Ipv6Addr;
+    /// use core::net::Ipv6Addr;
     ///
     /// let localhost = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
     ///
@@ -362,7 +362,7 @@ impl SocketAddrV4 {
     /// ```
     /// #![feature(addr_parse_ascii)]
     ///
-    /// use std::net::{Ipv4Addr, SocketAddrV4};
+    /// use core::net::{Ipv4Addr, SocketAddrV4};
     ///
     /// let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
     ///
@@ -388,7 +388,7 @@ impl SocketAddrV6 {
     /// ```
     /// #![feature(addr_parse_ascii)]
     ///
-    /// use std::net::{Ipv6Addr, SocketAddrV6};
+    /// use core::net::{Ipv6Addr, SocketAddrV6};
     ///
     /// let socket = SocketAddrV6::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
     ///
@@ -414,7 +414,7 @@ impl SocketAddr {
     /// ```
     /// #![feature(addr_parse_ascii)]
     ///
-    /// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+    /// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
     ///
     /// let socket_v4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     /// let socket_v6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
@@ -458,14 +458,14 @@ enum AddrKind {
 /// often because it includes information only handled by a different address type.
 ///
 /// ```should_panic
-/// use std::net::IpAddr;
+/// use core::net::IpAddr;
 /// let _foo: IpAddr = "127.0.0.1:8080".parse().expect("Cannot handle the socket port");
 /// ```
 ///
 /// [`IpAddr`] doesn't handle the port. Use [`SocketAddr`] instead.
 ///
 /// ```
-/// use std::net::SocketAddr;
+/// use core::net::SocketAddr;
 ///
 /// // No problem, the `panic!` message has disappeared.
 /// let _foo: SocketAddr = "127.0.0.1:8080".parse().expect("unreachable panic");

--- a/library/core/src/net/socket_addr.rs
+++ b/library/core/src/net/socket_addr.rs
@@ -19,7 +19,7 @@ use super::display_buffer::DisplayBuffer;
 /// # Examples
 ///
 /// ```
-/// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+/// use core::net::{IpAddr, Ipv4Addr, SocketAddr};
 ///
 /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
 ///
@@ -55,7 +55,7 @@ pub enum SocketAddr {
 /// # Examples
 ///
 /// ```
-/// use std::net::{Ipv4Addr, SocketAddrV4};
+/// use core::net::{Ipv4Addr, SocketAddrV4};
 ///
 /// let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
 ///
@@ -88,7 +88,7 @@ pub struct SocketAddrV4 {
 /// # Examples
 ///
 /// ```
-/// use std::net::{Ipv6Addr, SocketAddrV6};
+/// use core::net::{Ipv6Addr, SocketAddrV6};
 ///
 /// let socket = SocketAddrV6::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
 ///
@@ -113,7 +113,7 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    /// use core::net::{IpAddr, Ipv4Addr, SocketAddr};
     ///
     /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     /// assert_eq!(socket.ip(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
@@ -134,7 +134,7 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    /// use core::net::{IpAddr, Ipv4Addr, SocketAddr};
     ///
     /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     /// assert_eq!(socket.ip(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
@@ -154,7 +154,7 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    /// use core::net::{IpAddr, Ipv4Addr, SocketAddr};
     ///
     /// let mut socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     /// socket.set_ip(IpAddr::V4(Ipv4Addr::new(10, 10, 0, 1)));
@@ -175,7 +175,7 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    /// use core::net::{IpAddr, Ipv4Addr, SocketAddr};
     ///
     /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     /// assert_eq!(socket.port(), 8080);
@@ -195,7 +195,7 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    /// use core::net::{IpAddr, Ipv4Addr, SocketAddr};
     ///
     /// let mut socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     /// socket.set_port(1025);
@@ -218,7 +218,7 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    /// use core::net::{IpAddr, Ipv4Addr, SocketAddr};
     ///
     /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     /// assert_eq!(socket.is_ipv4(), true);
@@ -240,7 +240,7 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+    /// use core::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
     /// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 65535, 0, 1)), 8080);
     /// assert_eq!(socket.is_ipv4(), false);
@@ -262,7 +262,7 @@ impl SocketAddrV4 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV4, Ipv4Addr};
+    /// use core::net::{SocketAddrV4, Ipv4Addr};
     ///
     /// let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
     /// ```
@@ -278,7 +278,7 @@ impl SocketAddrV4 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV4, Ipv4Addr};
+    /// use core::net::{SocketAddrV4, Ipv4Addr};
     ///
     /// let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
     /// assert_eq!(socket.ip(), &Ipv4Addr::new(127, 0, 0, 1));
@@ -295,7 +295,7 @@ impl SocketAddrV4 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV4, Ipv4Addr};
+    /// use core::net::{SocketAddrV4, Ipv4Addr};
     ///
     /// let mut socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
     /// socket.set_ip(Ipv4Addr::new(192, 168, 0, 1));
@@ -311,7 +311,7 @@ impl SocketAddrV4 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV4, Ipv4Addr};
+    /// use core::net::{SocketAddrV4, Ipv4Addr};
     ///
     /// let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
     /// assert_eq!(socket.port(), 8080);
@@ -328,7 +328,7 @@ impl SocketAddrV4 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV4, Ipv4Addr};
+    /// use core::net::{SocketAddrV4, Ipv4Addr};
     ///
     /// let mut socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
     /// socket.set_port(4242);
@@ -353,7 +353,7 @@ impl SocketAddrV6 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV6, Ipv6Addr};
+    /// use core::net::{SocketAddrV6, Ipv6Addr};
     ///
     /// let socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
     /// ```
@@ -369,7 +369,7 @@ impl SocketAddrV6 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV6, Ipv6Addr};
+    /// use core::net::{SocketAddrV6, Ipv6Addr};
     ///
     /// let socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
     /// assert_eq!(socket.ip(), &Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
@@ -386,7 +386,7 @@ impl SocketAddrV6 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV6, Ipv6Addr};
+    /// use core::net::{SocketAddrV6, Ipv6Addr};
     ///
     /// let mut socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
     /// socket.set_ip(Ipv6Addr::new(76, 45, 0, 0, 0, 0, 0, 0));
@@ -402,7 +402,7 @@ impl SocketAddrV6 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV6, Ipv6Addr};
+    /// use core::net::{SocketAddrV6, Ipv6Addr};
     ///
     /// let socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
     /// assert_eq!(socket.port(), 8080);
@@ -419,7 +419,7 @@ impl SocketAddrV6 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV6, Ipv6Addr};
+    /// use core::net::{SocketAddrV6, Ipv6Addr};
     ///
     /// let mut socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
     /// socket.set_port(4242);
@@ -445,7 +445,7 @@ impl SocketAddrV6 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV6, Ipv6Addr};
+    /// use core::net::{SocketAddrV6, Ipv6Addr};
     ///
     /// let socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 10, 0);
     /// assert_eq!(socket.flowinfo(), 10);
@@ -464,7 +464,7 @@ impl SocketAddrV6 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV6, Ipv6Addr};
+    /// use core::net::{SocketAddrV6, Ipv6Addr};
     ///
     /// let mut socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 10, 0);
     /// socket.set_flowinfo(56);
@@ -485,7 +485,7 @@ impl SocketAddrV6 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV6, Ipv6Addr};
+    /// use core::net::{SocketAddrV6, Ipv6Addr};
     ///
     /// let socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 78);
     /// assert_eq!(socket.scope_id(), 78);
@@ -504,7 +504,7 @@ impl SocketAddrV6 {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{SocketAddrV6, Ipv6Addr};
+    /// use core::net::{SocketAddrV6, Ipv6Addr};
     ///
     /// let mut socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 78);
     /// socket.set_scope_id(42);

--- a/library/core/src/num/dec2flt/mod.rs
+++ b/library/core/src/num/dec2flt/mod.rs
@@ -171,7 +171,7 @@ from_str_float_impl!(f64);
 /// # Example
 ///
 /// ```
-/// use std::str::FromStr;
+/// use core::str::FromStr;
 ///
 /// if let Err(e) = f64::from_str("a.12") {
 ///     println!("Failed conversion to f64: {e}");

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -25,7 +25,7 @@ use crate::num::FpCategory;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let r = std::f32::RADIX;
+/// let r = core::f32::RADIX;
 ///
 /// // intended way
 /// let r = f32::RADIX;
@@ -42,7 +42,7 @@ pub const RADIX: u32 = f32::RADIX;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let d = std::f32::MANTISSA_DIGITS;
+/// let d = core::f32::MANTISSA_DIGITS;
 ///
 /// // intended way
 /// let d = f32::MANTISSA_DIGITS;
@@ -62,7 +62,7 @@ pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let d = std::f32::DIGITS;
+/// let d = core::f32::DIGITS;
 ///
 /// // intended way
 /// let d = f32::DIGITS;
@@ -83,7 +83,7 @@ pub const DIGITS: u32 = f32::DIGITS;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let e = std::f32::EPSILON;
+/// let e = core::f32::EPSILON;
 ///
 /// // intended way
 /// let e = f32::EPSILON;
@@ -100,7 +100,7 @@ pub const EPSILON: f32 = f32::EPSILON;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let min = std::f32::MIN;
+/// let min = core::f32::MIN;
 ///
 /// // intended way
 /// let min = f32::MIN;
@@ -117,7 +117,7 @@ pub const MIN: f32 = f32::MIN;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let min = std::f32::MIN_POSITIVE;
+/// let min = core::f32::MIN_POSITIVE;
 ///
 /// // intended way
 /// let min = f32::MIN_POSITIVE;
@@ -134,7 +134,7 @@ pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let max = std::f32::MAX;
+/// let max = core::f32::MAX;
 ///
 /// // intended way
 /// let max = f32::MAX;
@@ -151,7 +151,7 @@ pub const MAX: f32 = f32::MAX;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let min = std::f32::MIN_EXP;
+/// let min = core::f32::MIN_EXP;
 ///
 /// // intended way
 /// let min = f32::MIN_EXP;
@@ -168,7 +168,7 @@ pub const MIN_EXP: i32 = f32::MIN_EXP;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let max = std::f32::MAX_EXP;
+/// let max = core::f32::MAX_EXP;
 ///
 /// // intended way
 /// let max = f32::MAX_EXP;
@@ -185,7 +185,7 @@ pub const MAX_EXP: i32 = f32::MAX_EXP;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let min = std::f32::MIN_10_EXP;
+/// let min = core::f32::MIN_10_EXP;
 ///
 /// // intended way
 /// let min = f32::MIN_10_EXP;
@@ -202,7 +202,7 @@ pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let max = std::f32::MAX_10_EXP;
+/// let max = core::f32::MAX_10_EXP;
 ///
 /// // intended way
 /// let max = f32::MAX_10_EXP;
@@ -219,7 +219,7 @@ pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let nan = std::f32::NAN;
+/// let nan = core::f32::NAN;
 ///
 /// // intended way
 /// let nan = f32::NAN;
@@ -236,7 +236,7 @@ pub const NAN: f32 = f32::NAN;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let inf = std::f32::INFINITY;
+/// let inf = core::f32::INFINITY;
 ///
 /// // intended way
 /// let inf = f32::INFINITY;
@@ -253,7 +253,7 @@ pub const INFINITY: f32 = f32::INFINITY;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let ninf = std::f32::NEG_INFINITY;
+/// let ninf = core::f32::NEG_INFINITY;
 ///
 /// // intended way
 /// let ninf = f32::NEG_INFINITY;
@@ -546,7 +546,7 @@ impl f32 {
     /// predicate instead.
     ///
     /// ```
-    /// use std::num::FpCategory;
+    /// use core::num::FpCategory;
     ///
     /// let num = 12.4_f32;
     /// let inf = f32::INFINITY;
@@ -796,7 +796,7 @@ impl f32 {
     /// Converts radians to degrees.
     ///
     /// ```
-    /// let angle = std::f32::consts::PI;
+    /// let angle = core::f32::consts::PI;
     ///
     /// let abs_difference = (angle.to_degrees() - 180.0).abs();
     ///
@@ -817,7 +817,7 @@ impl f32 {
     /// ```
     /// let angle = 180.0f32;
     ///
-    /// let abs_difference = (angle.to_radians() - std::f32::consts::PI).abs();
+    /// let abs_difference = (angle.to_radians() - core::f32::consts::PI).abs();
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -25,7 +25,7 @@ use crate::num::FpCategory;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let r = std::f64::RADIX;
+/// let r = core::f64::RADIX;
 ///
 /// // intended way
 /// let r = f64::RADIX;
@@ -42,7 +42,7 @@ pub const RADIX: u32 = f64::RADIX;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let d = std::f64::MANTISSA_DIGITS;
+/// let d = core::f64::MANTISSA_DIGITS;
 ///
 /// // intended way
 /// let d = f64::MANTISSA_DIGITS;
@@ -62,7 +62,7 @@ pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let d = std::f64::DIGITS;
+/// let d = core::f64::DIGITS;
 ///
 /// // intended way
 /// let d = f64::DIGITS;
@@ -83,7 +83,7 @@ pub const DIGITS: u32 = f64::DIGITS;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let e = std::f64::EPSILON;
+/// let e = core::f64::EPSILON;
 ///
 /// // intended way
 /// let e = f64::EPSILON;
@@ -100,7 +100,7 @@ pub const EPSILON: f64 = f64::EPSILON;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let min = std::f64::MIN;
+/// let min = core::f64::MIN;
 ///
 /// // intended way
 /// let min = f64::MIN;
@@ -117,7 +117,7 @@ pub const MIN: f64 = f64::MIN;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let min = std::f64::MIN_POSITIVE;
+/// let min = core::f64::MIN_POSITIVE;
 ///
 /// // intended way
 /// let min = f64::MIN_POSITIVE;
@@ -134,7 +134,7 @@ pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let max = std::f64::MAX;
+/// let max = core::f64::MAX;
 ///
 /// // intended way
 /// let max = f64::MAX;
@@ -151,7 +151,7 @@ pub const MAX: f64 = f64::MAX;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let min = std::f64::MIN_EXP;
+/// let min = core::f64::MIN_EXP;
 ///
 /// // intended way
 /// let min = f64::MIN_EXP;
@@ -168,7 +168,7 @@ pub const MIN_EXP: i32 = f64::MIN_EXP;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let max = std::f64::MAX_EXP;
+/// let max = core::f64::MAX_EXP;
 ///
 /// // intended way
 /// let max = f64::MAX_EXP;
@@ -185,7 +185,7 @@ pub const MAX_EXP: i32 = f64::MAX_EXP;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let min = std::f64::MIN_10_EXP;
+/// let min = core::f64::MIN_10_EXP;
 ///
 /// // intended way
 /// let min = f64::MIN_10_EXP;
@@ -202,7 +202,7 @@ pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let max = std::f64::MAX_10_EXP;
+/// let max = core::f64::MAX_10_EXP;
 ///
 /// // intended way
 /// let max = f64::MAX_10_EXP;
@@ -219,7 +219,7 @@ pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let nan = std::f64::NAN;
+/// let nan = core::f64::NAN;
 ///
 /// // intended way
 /// let nan = f64::NAN;
@@ -236,7 +236,7 @@ pub const NAN: f64 = f64::NAN;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let inf = std::f64::INFINITY;
+/// let inf = core::f64::INFINITY;
 ///
 /// // intended way
 /// let inf = f64::INFINITY;
@@ -253,7 +253,7 @@ pub const INFINITY: f64 = f64::INFINITY;
 /// ```rust
 /// // deprecated way
 /// # #[allow(deprecated, deprecated_in_future)]
-/// let ninf = std::f64::NEG_INFINITY;
+/// let ninf = core::f64::NEG_INFINITY;
 ///
 /// // intended way
 /// let ninf = f64::NEG_INFINITY;
@@ -547,7 +547,7 @@ impl f64 {
     /// predicate instead.
     ///
     /// ```
-    /// use std::num::FpCategory;
+    /// use core::num::FpCategory;
     ///
     /// let num = 12.4_f64;
     /// let inf = f64::INFINITY;
@@ -806,7 +806,7 @@ impl f64 {
     /// Converts radians to degrees.
     ///
     /// ```
-    /// let angle = std::f64::consts::PI;
+    /// let angle = core::f64::consts::PI;
     ///
     /// let abs_difference = (angle.to_degrees() - 180.0).abs();
     ///
@@ -828,7 +828,7 @@ impl f64 {
     /// ```
     /// let angle = 180.0_f64;
     ///
-    /// let abs_difference = (angle.to_radians() - std::f64::consts::PI).abs();
+    /// let abs_difference = (angle.to_radians() - core::f64::consts::PI).abs();
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2740,7 +2740,7 @@ macro_rules! int_impl {
         ///
         /// ```
         #[doc = concat!("fn read_be_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {")]
-        #[doc = concat!("    let (int_bytes, rest) = input.split_at(std::mem::size_of::<", stringify!($SelfT), ">());")]
+        #[doc = concat!("    let (int_bytes, rest) = input.split_at(core::mem::size_of::<", stringify!($SelfT), ">());")]
         ///     *input = rest;
         #[doc = concat!("    ", stringify!($SelfT), "::from_be_bytes(int_bytes.try_into().unwrap())")]
         /// }
@@ -2769,7 +2769,7 @@ macro_rules! int_impl {
         ///
         /// ```
         #[doc = concat!("fn read_le_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {")]
-        #[doc = concat!("    let (int_bytes, rest) = input.split_at(std::mem::size_of::<", stringify!($SelfT), ">());")]
+        #[doc = concat!("    let (int_bytes, rest) = input.split_at(core::mem::size_of::<", stringify!($SelfT), ">());")]
         ///     *input = rest;
         #[doc = concat!("    ", stringify!($SelfT), "::from_le_bytes(int_bytes.try_into().unwrap())")]
         /// }
@@ -2809,7 +2809,7 @@ macro_rules! int_impl {
         ///
         /// ```
         #[doc = concat!("fn read_ne_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {")]
-        #[doc = concat!("    let (int_bytes, rest) = input.split_at(std::mem::size_of::<", stringify!($SelfT), ">());")]
+        #[doc = concat!("    let (int_bytes, rest) = input.split_at(core::mem::size_of::<", stringify!($SelfT), ">());")]
         ///     *input = rest;
         #[doc = concat!("    ", stringify!($SelfT), "::from_ne_bytes(int_bytes.try_into().unwrap())")]
         /// }

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1238,7 +1238,7 @@ impl usize {
 /// # Examples
 ///
 /// ```
-/// use std::num::FpCategory;
+/// use core::num::FpCategory;
 ///
 /// let num = 12.4_f32;
 /// let inf = f32::INFINITY;

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -31,7 +31,7 @@ macro_rules! nonzero_integers {
             #[doc = concat!("For example, `Option<", stringify!($Ty), ">` is the same size as `", stringify!($Int), "`:")]
             ///
             /// ```rust
-            /// use std::mem::size_of;
+            /// use core::mem::size_of;
             #[doc = concat!("assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", stringify!($Int), ">());")]
             /// ```
             ///
@@ -214,7 +214,7 @@ macro_rules! nonzero_leading_trailing_zeros {
                 /// Basic usage:
                 ///
                 /// ```
-                #[doc = concat!("let n = std::num::", stringify!($Ty), "::new(", stringify!($LeadingTestExpr), ").unwrap();")]
+                #[doc = concat!("let n = core::num::", stringify!($Ty), "::new(", stringify!($LeadingTestExpr), ").unwrap();")]
                 ///
                 /// assert_eq!(n.leading_zeros(), 0);
                 /// ```
@@ -238,7 +238,7 @@ macro_rules! nonzero_leading_trailing_zeros {
                 /// Basic usage:
                 ///
                 /// ```
-                #[doc = concat!("let n = std::num::", stringify!($Ty), "::new(0b0101000).unwrap();")]
+                #[doc = concat!("let n = core::num::", stringify!($Ty), "::new(0b0101000).unwrap();")]
                 ///
                 /// assert_eq!(n.trailing_zeros(), 3);
                 /// ```
@@ -327,7 +327,7 @@ macro_rules! nonzero_unsigned_operations {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let one = ", stringify!($Ty), "::new(1)?;")]
@@ -361,7 +361,7 @@ macro_rules! nonzero_unsigned_operations {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let one = ", stringify!($Ty), "::new(1)?;")]
@@ -397,7 +397,7 @@ macro_rules! nonzero_unsigned_operations {
                 /// ```
                 /// #![feature(nonzero_ops)]
                 ///
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let one = ", stringify!($Ty), "::new(1)?;")]
@@ -424,7 +424,7 @@ macro_rules! nonzero_unsigned_operations {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
@@ -464,7 +464,7 @@ macro_rules! nonzero_unsigned_operations {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(7).unwrap().ilog2(), 2);")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(8).unwrap().ilog2(), 3);")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(9).unwrap().ilog2(), 3);")]
@@ -488,7 +488,7 @@ macro_rules! nonzero_unsigned_operations {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(99).unwrap().ilog10(), 1);")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(100).unwrap().ilog10(), 2);")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(101).unwrap().ilog10(), 2);")]
@@ -527,7 +527,7 @@ macro_rules! nonzero_signed_operations {
                 /// # Example
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
@@ -556,7 +556,7 @@ macro_rules! nonzero_signed_operations {
                 /// # Example
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
@@ -590,7 +590,7 @@ macro_rules! nonzero_signed_operations {
                 /// # Example
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
@@ -624,7 +624,7 @@ macro_rules! nonzero_signed_operations {
                 /// # Example
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
@@ -659,7 +659,7 @@ macro_rules! nonzero_signed_operations {
                 /// # Example
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
@@ -693,8 +693,8 @@ macro_rules! nonzero_signed_operations {
                 /// # Example
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
-                #[doc = concat!("# use std::num::", stringify!($Uty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Uty), ";")]
                 ///
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
@@ -730,7 +730,7 @@ macro_rules! nonzero_signed_operations {
                 /// ```
                 /// #![feature(nonzero_negation_ops)]
                 ///
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos_five = ", stringify!($Ty), "::new(5)?;")]
@@ -755,7 +755,7 @@ macro_rules! nonzero_signed_operations {
                 /// ```
                 /// #![feature(nonzero_negation_ops)]
                 ///
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos_five = ", stringify!($Ty), "::new(5)?;")]
@@ -788,7 +788,7 @@ macro_rules! nonzero_signed_operations {
                 /// ```
                 /// #![feature(nonzero_negation_ops)]
                 ///
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos_five = ", stringify!($Ty), "::new(5)?;")]
@@ -817,7 +817,7 @@ macro_rules! nonzero_signed_operations {
                 /// ```
                 /// #![feature(nonzero_negation_ops)]
                 ///
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos_five = ", stringify!($Ty), "::new(5)?;")]
@@ -855,7 +855,7 @@ macro_rules! nonzero_signed_operations {
                 /// ```
                 /// #![feature(nonzero_negation_ops)]
                 ///
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos_five = ", stringify!($Ty), "::new(5)?;")]
@@ -901,7 +901,7 @@ macro_rules! nonzero_unsigned_signed_operations {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
@@ -936,7 +936,7 @@ macro_rules! nonzero_unsigned_signed_operations {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
@@ -982,7 +982,7 @@ macro_rules! nonzero_unsigned_signed_operations {
                 /// ```
                 /// #![feature(nonzero_ops)]
                 ///
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
@@ -1008,7 +1008,7 @@ macro_rules! nonzero_unsigned_signed_operations {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let three = ", stringify!($Ty), "::new(3)?;")]
@@ -1051,7 +1051,7 @@ macro_rules! nonzero_unsigned_signed_operations {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 /// # fn main() { test().unwrap(); }
                 /// # fn test() -> Option<()> {
                 #[doc = concat!("let three = ", stringify!($Ty), "::new(3)?;")]
@@ -1119,9 +1119,9 @@ macro_rules! nonzero_unsigned_is_power_of_two {
                 /// Basic usage:
                 ///
                 /// ```
-                #[doc = concat!("let eight = std::num::", stringify!($Ty), "::new(8).unwrap();")]
+                #[doc = concat!("let eight = core::num::", stringify!($Ty), "::new(8).unwrap();")]
                 /// assert!(eight.is_power_of_two());
-                #[doc = concat!("let ten = std::num::", stringify!($Ty), "::new(10).unwrap();")]
+                #[doc = concat!("let ten = core::num::", stringify!($Ty), "::new(10).unwrap();")]
                 /// assert!(!ten.is_power_of_two());
                 /// ```
                 #[must_use]
@@ -1154,7 +1154,7 @@ macro_rules! nonzero_min_max_unsigned {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN.get(), 1", stringify!($Int), ");")]
                 /// ```
                 #[stable(feature = "nonzero_min_max", since = "CURRENT_RUSTC_VERSION")]
@@ -1167,7 +1167,7 @@ macro_rules! nonzero_min_max_unsigned {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX.get(), ", stringify!($Int), "::MAX);")]
                 /// ```
                 #[stable(feature = "nonzero_min_max", since = "CURRENT_RUSTC_VERSION")]
@@ -1192,7 +1192,7 @@ macro_rules! nonzero_min_max_signed {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN.get(), ", stringify!($Int), "::MIN);")]
                 /// ```
                 #[stable(feature = "nonzero_min_max", since = "CURRENT_RUSTC_VERSION")]
@@ -1209,7 +1209,7 @@ macro_rules! nonzero_min_max_signed {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX.get(), ", stringify!($Int), "::MAX);")]
                 /// ```
                 #[stable(feature = "nonzero_min_max", since = "CURRENT_RUSTC_VERSION")]
@@ -1248,7 +1248,7 @@ macro_rules! nonzero_bits {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use core::num::", stringify!($Ty), ";")]
                 ///
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::BITS, ", stringify!($Int), "::BITS);")]
                 /// ```

--- a/library/core/src/num/saturating.rs
+++ b/library/core/src/num/saturating.rs
@@ -25,7 +25,7 @@ use crate::ops::{Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign};
 ///
 /// ```
 /// #![feature(saturating_int_impl)]
-/// use std::num::Saturating;
+/// use core::num::Saturating;
 ///
 /// let max = Saturating(u32::MAX);
 /// let one = Saturating(1u32);
@@ -301,7 +301,7 @@ macro_rules! saturating_impl {
         ///
         /// ```
         /// #![feature(saturating_int_impl)]
-        /// use std::num::Saturating;
+        /// use core::num::Saturating;
         ///
         #[doc = concat!("assert_eq!(Saturating(2", stringify!($t), "), Saturating(5", stringify!($t), ") / Saturating(2));")]
         #[doc = concat!("assert_eq!(Saturating(", stringify!($t), "::MAX), Saturating(", stringify!($t), "::MAX) / Saturating(1));")]
@@ -310,7 +310,7 @@ macro_rules! saturating_impl {
         ///
         /// ```should_panic
         /// #![feature(saturating_int_impl)]
-        /// use std::num::Saturating;
+        /// use core::num::Saturating;
         ///
         #[doc = concat!("let _ = Saturating(0", stringify!($t), ") / Saturating(0);")]
         /// ```
@@ -493,7 +493,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("assert_eq!(<Saturating<", stringify!($t), ">>::MIN, Saturating(", stringify!($t), "::MIN));")]
             /// ```
@@ -508,7 +508,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("assert_eq!(<Saturating<", stringify!($t), ">>::MAX, Saturating(", stringify!($t), "::MAX));")]
             /// ```
@@ -523,7 +523,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("assert_eq!(<Saturating<", stringify!($t), ">>::BITS, ", stringify!($t), "::BITS);")]
             /// ```
@@ -538,7 +538,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("let n = Saturating(0b01001100", stringify!($t), ");")]
             ///
@@ -562,7 +562,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("assert_eq!(Saturating(!0", stringify!($t), ").count_zeros(), 0);")]
             /// ```
@@ -582,7 +582,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("let n = Saturating(0b0101000", stringify!($t), ");")]
             ///
@@ -609,7 +609,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             /// let n: Saturating<i64> = Saturating(0x0123456789ABCDEF);
             /// let m: Saturating<i64> = Saturating(-0x76543210FEDCBA99);
@@ -637,7 +637,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             /// let n: Saturating<i64> = Saturating(0x0123456789ABCDEF);
             /// let m: Saturating<i64> = Saturating(-0xFEDCBA987654322);
@@ -660,7 +660,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             /// let n: Saturating<i16> = Saturating(0b0000000_01010101);
             /// assert_eq!(n, Saturating(85));
@@ -689,7 +689,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             /// let n = Saturating(0b0000000_01010101i16);
             /// assert_eq!(n, Saturating(85));
@@ -719,7 +719,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("let n = Saturating(0x1A", stringify!($t), ");")]
             ///
@@ -747,7 +747,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("let n = Saturating(0x1A", stringify!($t), ");")]
             ///
@@ -775,7 +775,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("let n = Saturating(0x1A", stringify!($t), ");")]
             ///
@@ -804,7 +804,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("let n = Saturating(0x1A", stringify!($t), ");")]
             ///
@@ -830,7 +830,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("assert_eq!(Saturating(3", stringify!($t), ").pow(4), Saturating(81));")]
             /// ```
@@ -839,7 +839,7 @@ macro_rules! saturating_int_impl {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             /// assert_eq!(Saturating(3i8).pow(5), Saturating(127));
             /// assert_eq!(Saturating(3i8).pow(6), Saturating(127));
@@ -868,7 +868,7 @@ macro_rules! saturating_int_impl_signed {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("let n = Saturating(", stringify!($t), "::MAX >> 2);")]
             ///
@@ -891,7 +891,7 @@ macro_rules! saturating_int_impl_signed {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("assert_eq!(Saturating(100", stringify!($t), ").abs(), Saturating(100));")]
             #[doc = concat!("assert_eq!(Saturating(-100", stringify!($t), ").abs(), Saturating(100));")]
@@ -919,7 +919,7 @@ macro_rules! saturating_int_impl_signed {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("assert_eq!(Saturating(10", stringify!($t), ").signum(), Saturating(1));")]
             #[doc = concat!("assert_eq!(Saturating(0", stringify!($t), ").signum(), Saturating(0));")]
@@ -942,7 +942,7 @@ macro_rules! saturating_int_impl_signed {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("assert!(Saturating(10", stringify!($t), ").is_positive());")]
             #[doc = concat!("assert!(!Saturating(-10", stringify!($t), ").is_positive());")]
@@ -963,7 +963,7 @@ macro_rules! saturating_int_impl_signed {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("assert!(Saturating(-10", stringify!($t), ").is_negative());")]
             #[doc = concat!("assert!(!Saturating(10", stringify!($t), ").is_negative());")]
@@ -1002,7 +1002,7 @@ macro_rules! saturating_int_impl_unsigned {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("let n = Saturating(", stringify!($t), "::MAX >> 2);")]
             ///
@@ -1024,7 +1024,7 @@ macro_rules! saturating_int_impl_unsigned {
             ///
             /// ```
             /// #![feature(saturating_int_impl)]
-            /// use std::num::Saturating;
+            /// use core::num::Saturating;
             ///
             #[doc = concat!("assert!(Saturating(16", stringify!($t), ").is_power_of_two());")]
             #[doc = concat!("assert!(!Saturating(10", stringify!($t), ").is_power_of_two());")]

--- a/library/core/src/num/shells/int_macros.rs
+++ b/library/core/src/num/shells/int_macros.rs
@@ -12,7 +12,7 @@ macro_rules! int_module {
         ///
         /// ```rust
         /// // deprecated way
-        #[doc = concat!("let min = std::", stringify!($T), "::MIN;")]
+        #[doc = concat!("let min = core::", stringify!($T), "::MIN;")]
         ///
         /// // intended way
         #[doc = concat!("let min = ", stringify!($T), "::MIN;")]
@@ -31,7 +31,7 @@ macro_rules! int_module {
         ///
         /// ```rust
         /// // deprecated way
-        #[doc = concat!("let max = std::", stringify!($T), "::MAX;")]
+        #[doc = concat!("let max = core::", stringify!($T), "::MAX;")]
         ///
         /// // intended way
         #[doc = concat!("let max = ", stringify!($T), "::MAX;")]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2359,7 +2359,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("fn read_be_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {")]
-        #[doc = concat!("    let (int_bytes, rest) = input.split_at(std::mem::size_of::<", stringify!($SelfT), ">());")]
+        #[doc = concat!("    let (int_bytes, rest) = input.split_at(core::mem::size_of::<", stringify!($SelfT), ">());")]
         ///     *input = rest;
         #[doc = concat!("    ", stringify!($SelfT), "::from_be_bytes(int_bytes.try_into().unwrap())")]
         /// }
@@ -2388,7 +2388,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("fn read_le_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {")]
-        #[doc = concat!("    let (int_bytes, rest) = input.split_at(std::mem::size_of::<", stringify!($SelfT), ">());")]
+        #[doc = concat!("    let (int_bytes, rest) = input.split_at(core::mem::size_of::<", stringify!($SelfT), ">());")]
         ///     *input = rest;
         #[doc = concat!("    ", stringify!($SelfT), "::from_le_bytes(int_bytes.try_into().unwrap())")]
         /// }
@@ -2428,7 +2428,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("fn read_ne_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {")]
-        #[doc = concat!("    let (int_bytes, rest) = input.split_at(std::mem::size_of::<", stringify!($SelfT), ">());")]
+        #[doc = concat!("    let (int_bytes, rest) = input.split_at(core::mem::size_of::<", stringify!($SelfT), ">());")]
         ///     *input = rest;
         #[doc = concat!("    ", stringify!($SelfT), "::from_ne_bytes(int_bytes.try_into().unwrap())")]
         /// }

--- a/library/core/src/num/wrapping.rs
+++ b/library/core/src/num/wrapping.rs
@@ -25,7 +25,7 @@ use crate::ops::{Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign};
 /// # Examples
 ///
 /// ```
-/// use std::num::Wrapping;
+/// use core::num::Wrapping;
 ///
 /// let zero = Wrapping(0u32);
 /// let one = Wrapping(1u32);
@@ -521,7 +521,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("assert_eq!(<Wrapping<", stringify!($t), ">>::MIN, Wrapping(", stringify!($t), "::MIN));")]
             /// ```
@@ -536,7 +536,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("assert_eq!(<Wrapping<", stringify!($t), ">>::MAX, Wrapping(", stringify!($t), "::MAX));")]
             /// ```
@@ -551,7 +551,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("assert_eq!(<Wrapping<", stringify!($t), ">>::BITS, ", stringify!($t), "::BITS);")]
             /// ```
@@ -566,7 +566,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("let n = Wrapping(0b01001100", stringify!($t), ");")]
             ///
@@ -590,7 +590,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("assert_eq!(Wrapping(!0", stringify!($t), ").count_zeros(), 0);")]
             /// ```
@@ -610,7 +610,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("let n = Wrapping(0b0101000", stringify!($t), ");")]
             ///
@@ -637,7 +637,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             /// let n: Wrapping<i64> = Wrapping(0x0123456789ABCDEF);
             /// let m: Wrapping<i64> = Wrapping(-0x76543210FEDCBA99);
@@ -665,7 +665,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             /// let n: Wrapping<i64> = Wrapping(0x0123456789ABCDEF);
             /// let m: Wrapping<i64> = Wrapping(-0xFEDCBA987654322);
@@ -688,7 +688,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             /// let n: Wrapping<i16> = Wrapping(0b0000000_01010101);
             /// assert_eq!(n, Wrapping(85));
@@ -716,7 +716,7 @@ macro_rules! wrapping_int_impl {
             /// Basic usage:
             ///
             /// ```
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             /// let n = Wrapping(0b0000000_01010101i16);
             /// assert_eq!(n, Wrapping(85));
@@ -746,7 +746,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("let n = Wrapping(0x1A", stringify!($t), ");")]
             ///
@@ -774,7 +774,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("let n = Wrapping(0x1A", stringify!($t), ");")]
             ///
@@ -802,7 +802,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("let n = Wrapping(0x1A", stringify!($t), ");")]
             ///
@@ -831,7 +831,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("let n = Wrapping(0x1A", stringify!($t), ");")]
             ///
@@ -857,7 +857,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("assert_eq!(Wrapping(3", stringify!($t), ").pow(4), Wrapping(81));")]
             /// ```
@@ -866,7 +866,7 @@ macro_rules! wrapping_int_impl {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             /// assert_eq!(Wrapping(3i8).pow(5), Wrapping(-13));
             /// assert_eq!(Wrapping(3i8).pow(6), Wrapping(-39));
@@ -895,7 +895,7 @@ macro_rules! wrapping_int_impl_signed {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("let n = Wrapping(", stringify!($t), "::MAX) >> 2;")]
             ///
@@ -922,7 +922,7 @@ macro_rules! wrapping_int_impl_signed {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("assert_eq!(Wrapping(100", stringify!($t), ").abs(), Wrapping(100));")]
             #[doc = concat!("assert_eq!(Wrapping(-100", stringify!($t), ").abs(), Wrapping(100));")]
@@ -949,7 +949,7 @@ macro_rules! wrapping_int_impl_signed {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("assert_eq!(Wrapping(10", stringify!($t), ").signum(), Wrapping(1));")]
             #[doc = concat!("assert_eq!(Wrapping(0", stringify!($t), ").signum(), Wrapping(0));")]
@@ -972,7 +972,7 @@ macro_rules! wrapping_int_impl_signed {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("assert!(Wrapping(10", stringify!($t), ").is_positive());")]
             #[doc = concat!("assert!(!Wrapping(-10", stringify!($t), ").is_positive());")]
@@ -993,7 +993,7 @@ macro_rules! wrapping_int_impl_signed {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("assert!(Wrapping(-10", stringify!($t), ").is_negative());")]
             #[doc = concat!("assert!(!Wrapping(10", stringify!($t), ").is_negative());")]
@@ -1021,7 +1021,7 @@ macro_rules! wrapping_int_impl_unsigned {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("let n = Wrapping(", stringify!($t), "::MAX) >> 2;")]
             ///
@@ -1043,7 +1043,7 @@ macro_rules! wrapping_int_impl_unsigned {
             ///
             /// ```
             /// #![feature(wrapping_int_impl)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("assert!(Wrapping(16", stringify!($t), ").is_power_of_two());")]
             #[doc = concat!("assert!(!Wrapping(10", stringify!($t), ").is_power_of_two());")]
@@ -1066,7 +1066,7 @@ macro_rules! wrapping_int_impl_unsigned {
             ///
             /// ```
             /// #![feature(wrapping_next_power_of_two)]
-            /// use std::num::Wrapping;
+            /// use core::num::Wrapping;
             ///
             #[doc = concat!("assert_eq!(Wrapping(2", stringify!($t), ").next_power_of_two(), Wrapping(2));")]
             #[doc = concat!("assert_eq!(Wrapping(3", stringify!($t), ").next_power_of_two(), Wrapping(4));")]

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -1,17 +1,17 @@
 /// The addition operator `+`.
 ///
 /// Note that `Rhs` is `Self` by default, but this is not mandatory. For
-/// example, [`std::time::SystemTime`] implements `Add<Duration>`, which permits
+/// example, [`core::time::SystemTime`] implements `Add<Duration>`, which permits
 /// operations of the form `SystemTime = SystemTime + Duration`.
 ///
-/// [`std::time::SystemTime`]: ../../std/time/struct.SystemTime.html
+/// [`core::time::SystemTime`]: ../../std/time/struct.SystemTime.html
 ///
 /// # Examples
 ///
 /// ## `Add`able points
 ///
 /// ```
-/// use std::ops::Add;
+/// use core::ops::Add;
 ///
 /// #[derive(Debug, Copy, Clone, PartialEq)]
 /// struct Point {
@@ -40,7 +40,7 @@
 /// using generics.
 ///
 /// ```
-/// use std::ops::Add;
+/// use core::ops::Add;
 ///
 /// #[derive(Debug, Copy, Clone, PartialEq)]
 /// struct Point<T> {
@@ -113,17 +113,17 @@ add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// The subtraction operator `-`.
 ///
 /// Note that `Rhs` is `Self` by default, but this is not mandatory. For
-/// example, [`std::time::SystemTime`] implements `Sub<Duration>`, which permits
+/// example, [`core::time::SystemTime`] implements `Sub<Duration>`, which permits
 /// operations of the form `SystemTime = SystemTime - Duration`.
 ///
-/// [`std::time::SystemTime`]: ../../std/time/struct.SystemTime.html
+/// [`core::time::SystemTime`]: ../../std/time/struct.SystemTime.html
 ///
 /// # Examples
 ///
 /// ## `Sub`tractable points
 ///
 /// ```
-/// use std::ops::Sub;
+/// use core::ops::Sub;
 ///
 /// #[derive(Debug, Copy, Clone, PartialEq)]
 /// struct Point {
@@ -152,7 +152,7 @@ add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// using generics.
 ///
 /// ```
-/// use std::ops::Sub;
+/// use core::ops::Sub;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct Point<T> {
@@ -229,7 +229,7 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ## `Mul`tipliable rational numbers
 ///
 /// ```
-/// use std::ops::Mul;
+/// use core::ops::Mul;
 ///
 /// // By the fundamental theorem of arithmetic, rational numbers in lowest
 /// // terms are unique. So, by keeping `Rational`s in reduced form, we can
@@ -288,7 +288,7 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ## Multiplying vectors by scalars as in linear algebra
 ///
 /// ```
-/// use std::ops::Mul;
+/// use core::ops::Mul;
 ///
 /// struct Scalar { value: usize }
 ///
@@ -360,7 +360,7 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ## `Div`idable rational numbers
 ///
 /// ```
-/// use std::ops::Div;
+/// use core::ops::Div;
 ///
 /// // By the fundamental theorem of arithmetic, rational numbers in lowest
 /// // terms are unique. So, by keeping `Rational`s in reduced form, we can
@@ -423,7 +423,7 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ## Dividing vectors by scalars as in linear algebra
 ///
 /// ```
-/// use std::ops::Div;
+/// use core::ops::Div;
 ///
 /// struct Scalar { value: f32 }
 ///
@@ -523,7 +523,7 @@ div_impl_float! { f32 f64 }
 /// given length.
 ///
 /// ```
-/// use std::ops::Rem;
+/// use core::ops::Rem;
 ///
 /// #[derive(PartialEq, Debug)]
 /// struct SplitSlice<'a, T: 'a> {
@@ -638,7 +638,7 @@ rem_impl_float! { f32 f64 }
 /// negate its value.
 ///
 /// ```
-/// use std::ops::Neg;
+/// use core::ops::Neg;
 ///
 /// #[derive(Debug, PartialEq)]
 /// enum Sign {
@@ -715,7 +715,7 @@ neg_impl! { isize i8 i16 i32 i64 i128 f32 f64 }
 /// trait, and then demonstrates add-assigning to a mutable `Point`.
 ///
 /// ```
-/// use std::ops::AddAssign;
+/// use core::ops::AddAssign;
 ///
 /// #[derive(Debug, Copy, Clone, PartialEq)]
 /// struct Point {
@@ -783,7 +783,7 @@ add_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// trait, and then demonstrates sub-assigning to a mutable `Point`.
 ///
 /// ```
-/// use std::ops::SubAssign;
+/// use core::ops::SubAssign;
 ///
 /// #[derive(Debug, Copy, Clone, PartialEq)]
 /// struct Point {
@@ -848,7 +848,7 @@ sub_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// # Examples
 ///
 /// ```
-/// use std::ops::MulAssign;
+/// use core::ops::MulAssign;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct Frequency { hertz: f64 }
@@ -907,7 +907,7 @@ mul_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// # Examples
 ///
 /// ```
-/// use std::ops::DivAssign;
+/// use core::ops::DivAssign;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct Frequency { hertz: f64 }
@@ -965,7 +965,7 @@ div_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// # Examples
 ///
 /// ```
-/// use std::ops::RemAssign;
+/// use core::ops::RemAssign;
 ///
 /// struct CookieJar { cookies: u32 }
 ///

--- a/library/core/src/ops/bit.rs
+++ b/library/core/src/ops/bit.rs
@@ -6,7 +6,7 @@
 /// invert its value.
 ///
 /// ```
-/// use std::ops::Not;
+/// use core::ops::Not;
 ///
 /// #[derive(Debug, PartialEq)]
 /// enum Answer {
@@ -89,7 +89,7 @@ impl const Not for ! {
 /// An implementation of `BitAnd` for a wrapper around `bool`.
 ///
 /// ```
-/// use std::ops::BitAnd;
+/// use core::ops::BitAnd;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct Scalar(bool);
@@ -112,7 +112,7 @@ impl const Not for ! {
 /// An implementation of `BitAnd` for a wrapper around `Vec<bool>`.
 ///
 /// ```
-/// use std::ops::BitAnd;
+/// use core::ops::BitAnd;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct BooleanVector(Vec<bool>);
@@ -191,7 +191,7 @@ bitand_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// An implementation of `BitOr` for a wrapper around `bool`.
 ///
 /// ```
-/// use std::ops::BitOr;
+/// use core::ops::BitOr;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct Scalar(bool);
@@ -214,7 +214,7 @@ bitand_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// An implementation of `BitOr` for a wrapper around `Vec<bool>`.
 ///
 /// ```
-/// use std::ops::BitOr;
+/// use core::ops::BitOr;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct BooleanVector(Vec<bool>);
@@ -293,7 +293,7 @@ bitor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// An implementation of `BitXor` that lifts `^` to a wrapper around `bool`.
 ///
 /// ```
-/// use std::ops::BitXor;
+/// use core::ops::BitXor;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct Scalar(bool);
@@ -316,7 +316,7 @@ bitor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// An implementation of `BitXor` trait for a wrapper around `Vec<bool>`.
 ///
 /// ```
-/// use std::ops::BitXor;
+/// use core::ops::BitXor;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct BooleanVector(Vec<bool>);
@@ -399,7 +399,7 @@ bitxor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// wrapper around `usize`.
 ///
 /// ```
-/// use std::ops::Shl;
+/// use core::ops::Shl;
 ///
 /// #[derive(PartialEq, Debug)]
 /// struct Scalar(usize);
@@ -419,7 +419,7 @@ bitxor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// An implementation of `Shl` that spins a vector leftward by a given amount.
 ///
 /// ```
-/// use std::ops::Shl;
+/// use core::ops::Shl;
 ///
 /// #[derive(PartialEq, Debug)]
 /// struct SpinVector<T: Clone> {
@@ -519,7 +519,7 @@ shl_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 isize i128 }
 /// wrapper around `usize`.
 ///
 /// ```
-/// use std::ops::Shr;
+/// use core::ops::Shr;
 ///
 /// #[derive(PartialEq, Debug)]
 /// struct Scalar(usize);
@@ -539,7 +539,7 @@ shl_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 isize i128 }
 /// An implementation of `Shr` that spins a vector rightward by a given amount.
 ///
 /// ```
-/// use std::ops::Shr;
+/// use core::ops::Shr;
 ///
 /// #[derive(PartialEq, Debug)]
 /// struct SpinVector<T: Clone> {
@@ -634,7 +634,7 @@ shr_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize }
 /// wrapper around `bool`.
 ///
 /// ```
-/// use std::ops::BitAndAssign;
+/// use core::ops::BitAndAssign;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct Scalar(bool);
@@ -667,7 +667,7 @@ shr_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize }
 /// `Vec<bool>`.
 ///
 /// ```
-/// use std::ops::BitAndAssign;
+/// use core::ops::BitAndAssign;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct BooleanVector(Vec<bool>);
@@ -745,7 +745,7 @@ bitand_assign_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// # Examples
 ///
 /// ```
-/// use std::ops::BitOrAssign;
+/// use core::ops::BitOrAssign;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct PersonalPreferences {
@@ -818,7 +818,7 @@ bitor_assign_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// # Examples
 ///
 /// ```
-/// use std::ops::BitXorAssign;
+/// use core::ops::BitXorAssign;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct Personality {
@@ -893,7 +893,7 @@ bitxor_assign_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// An implementation of `ShlAssign` for a wrapper around `usize`.
 ///
 /// ```
-/// use std::ops::ShlAssign;
+/// use core::ops::ShlAssign;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct Scalar(usize);
@@ -977,7 +977,7 @@ shl_assign_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize }
 /// An implementation of `ShrAssign` for a wrapper around `usize`.
 ///
 /// ```
-/// use std::ops::ShrAssign;
+/// use core::ops::ShrAssign;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct Scalar(usize);

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -15,7 +15,7 @@ use crate::{convert, ops};
 ///
 /// Early-exiting from [`Iterator::try_for_each`]:
 /// ```
-/// use std::ops::ControlFlow;
+/// use core::ops::ControlFlow;
 ///
 /// let r = (2..100).try_for_each(|x| {
 ///     if 403 % x == 0 {
@@ -29,7 +29,7 @@ use crate::{convert, ops};
 ///
 /// A basic tree traversal:
 /// ```
-/// use std::ops::ControlFlow;
+/// use core::ops::ControlFlow;
 ///
 /// pub struct TreeNode<T> {
 ///     value: T,
@@ -139,7 +139,7 @@ impl<B, C> ControlFlow<B, C> {
     /// # Examples
     ///
     /// ```
-    /// use std::ops::ControlFlow;
+    /// use core::ops::ControlFlow;
     ///
     /// assert!(ControlFlow::<i32, String>::Break(3).is_break());
     /// assert!(!ControlFlow::<String, i32>::Continue(3).is_break());
@@ -155,7 +155,7 @@ impl<B, C> ControlFlow<B, C> {
     /// # Examples
     ///
     /// ```
-    /// use std::ops::ControlFlow;
+    /// use core::ops::ControlFlow;
     ///
     /// assert!(!ControlFlow::<i32, String>::Break(3).is_continue());
     /// assert!(ControlFlow::<String, i32>::Continue(3).is_continue());
@@ -173,7 +173,7 @@ impl<B, C> ControlFlow<B, C> {
     ///
     /// ```
     /// #![feature(control_flow_enum)]
-    /// use std::ops::ControlFlow;
+    /// use core::ops::ControlFlow;
     ///
     /// assert_eq!(ControlFlow::<i32, String>::Break(3).break_value(), Some(3));
     /// assert_eq!(ControlFlow::<String, i32>::Continue(3).break_value(), None);
@@ -208,7 +208,7 @@ impl<B, C> ControlFlow<B, C> {
     ///
     /// ```
     /// #![feature(control_flow_enum)]
-    /// use std::ops::ControlFlow;
+    /// use core::ops::ControlFlow;
     ///
     /// assert_eq!(ControlFlow::<i32, String>::Break(3).continue_value(), None);
     /// assert_eq!(ControlFlow::<String, i32>::Continue(3).continue_value(), Some(3));

--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -39,7 +39,7 @@
 /// struct.
 ///
 /// ```
-/// use std::ops::Deref;
+/// use core::ops::Deref;
 ///
 /// struct DerefExample<T> {
 ///     value: T
@@ -143,7 +143,7 @@ impl<T: ?Sized> const Deref for &mut T {
 /// struct.
 ///
 /// ```
-/// use std::ops::{Deref, DerefMut};
+/// use core::ops::{Deref, DerefMut};
 ///
 /// struct DerefMutExample<T> {
 ///     value: T

--- a/library/core/src/ops/generator.rs
+++ b/library/core/src/ops/generator.rs
@@ -41,8 +41,8 @@ pub enum GeneratorState<Y, R> {
 /// ```rust
 /// #![feature(generators, generator_trait)]
 ///
-/// use std::ops::{Generator, GeneratorState};
-/// use std::pin::Pin;
+/// use core::ops::{Generator, GeneratorState};
+/// use core::pin::Pin;
 ///
 /// fn main() {
 ///     let mut generator = || {

--- a/library/core/src/ops/index.rs
+++ b/library/core/src/ops/index.rs
@@ -11,7 +11,7 @@
 /// container, enabling individual counts to be retrieved with index syntax.
 ///
 /// ```
-/// use std::ops::Index;
+/// use core::ops::Index;
 ///
 /// enum Nucleotide {
 ///     A,
@@ -84,7 +84,7 @@ pub trait Index<Idx: ?Sized> {
 /// each can be indexed mutably and immutably.
 ///
 /// ```
-/// use std::ops::{Index, IndexMut};
+/// use core::ops::{Index, IndexMut};
 ///
 /// #[derive(Debug)]
 /// enum Side {
@@ -153,7 +153,7 @@ see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#ind
 see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>"
     ),
     on(
-        _Self = "std::string::String",
+        _Self = "core::string::String",
         note = "you can use `.chars().nth()` or `.bytes().nth()`
 see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>"
     ),

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -40,7 +40,7 @@
 //! and then demonstrates adding and subtracting two `Point`s.
 //!
 //! ```rust
-//! use std::ops::{Add, Sub};
+//! use core::ops::{Add, Sub};
 //!
 //! #[derive(Debug, Copy, Clone, PartialEq)]
 //! struct Point {

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -11,7 +11,7 @@ use crate::hash::Hash;
 /// The `..` syntax is a `RangeFull`:
 ///
 /// ```
-/// assert_eq!((..), std::ops::RangeFull);
+/// assert_eq!((..), core::ops::RangeFull);
 /// ```
 ///
 /// It does not have an [`IntoIterator`] implementation, so you can't use it in
@@ -60,7 +60,7 @@ impl fmt::Debug for RangeFull {
 /// The `start..end` syntax is a `Range`:
 ///
 /// ```
-/// assert_eq!((3..5), std::ops::Range { start: 3, end: 5 });
+/// assert_eq!((3..5), core::ops::Range { start: 3, end: 5 });
 /// assert_eq!(3 + 4 + 5, (3..6).sum());
 /// ```
 ///
@@ -169,7 +169,7 @@ impl<Idx: ~const PartialOrd<Idx>> Range<Idx> {
 /// The `start..` syntax is a `RangeFrom`:
 ///
 /// ```
-/// assert_eq!((2..), std::ops::RangeFrom { start: 2 });
+/// assert_eq!((2..), core::ops::RangeFrom { start: 2 });
 /// assert_eq!(2 + 3 + 4, (2..).take(3).sum());
 /// ```
 ///
@@ -236,15 +236,15 @@ impl<Idx: ~const PartialOrd<Idx>> RangeFrom<Idx> {
 /// The `..end` syntax is a `RangeTo`:
 ///
 /// ```
-/// assert_eq!((..5), std::ops::RangeTo { end: 5 });
+/// assert_eq!((..5), core::ops::RangeTo { end: 5 });
 /// ```
 ///
 /// It does not have an [`IntoIterator`] implementation, so you can't use it in
 /// a `for` loop directly. This won't compile:
 ///
 /// ```compile_fail,E0277
-/// // error[E0277]: the trait bound `std::ops::RangeTo<{integer}>:
-/// // std::iter::Iterator` is not satisfied
+/// // error[E0277]: the trait bound `core::ops::RangeTo<{integer}>:
+/// // core::iter::Iterator` is not satisfied
 /// for i in ..5 {
 ///     // ...
 /// }
@@ -325,7 +325,7 @@ impl<Idx: ~const PartialOrd<Idx>> RangeTo<Idx> {
 /// The `start..=end` syntax is a `RangeInclusive`:
 ///
 /// ```
-/// assert_eq!((3..=5), std::ops::RangeInclusive::new(3, 5));
+/// assert_eq!((3..=5), core::ops::RangeInclusive::new(3, 5));
 /// assert_eq!(3 + 4 + 5, (3..=5).sum());
 /// ```
 ///
@@ -366,7 +366,7 @@ impl<Idx> RangeInclusive<Idx> {
     /// # Examples
     ///
     /// ```
-    /// use std::ops::RangeInclusive;
+    /// use core::ops::RangeInclusive;
     ///
     /// assert_eq!(3..=5, RangeInclusive::new(3, 5));
     /// ```
@@ -558,15 +558,15 @@ impl<Idx: ~const PartialOrd<Idx>> RangeInclusive<Idx> {
 /// The `..=end` syntax is a `RangeToInclusive`:
 ///
 /// ```
-/// assert_eq!((..=5), std::ops::RangeToInclusive{ end: 5 });
+/// assert_eq!((..=5), core::ops::RangeToInclusive{ end: 5 });
 /// ```
 ///
 /// It does not have an [`IntoIterator`] implementation, so you can't use it in a
 /// `for` loop directly. This won't compile:
 ///
 /// ```compile_fail,E0277
-/// // error[E0277]: the trait bound `std::ops::RangeToInclusive<{integer}>:
-/// // std::iter::Iterator` is not satisfied
+/// // error[E0277]: the trait bound `core::ops::RangeToInclusive<{integer}>:
+/// // core::iter::Iterator` is not satisfied
 /// for i in ..=5 {
 ///     // ...
 /// }
@@ -640,8 +640,8 @@ impl<Idx: ~const PartialOrd<Idx>> RangeToInclusive<Idx> {
 /// `Bound`s are range endpoints:
 ///
 /// ```
-/// use std::ops::Bound::*;
-/// use std::ops::RangeBounds;
+/// use core::ops::Bound::*;
+/// use core::ops::RangeBounds;
 ///
 /// assert_eq!((..100).start_bound(), Unbounded);
 /// assert_eq!((1..12).start_bound(), Included(&1));
@@ -652,8 +652,8 @@ impl<Idx: ~const PartialOrd<Idx>> RangeToInclusive<Idx> {
 /// Note that in most cases, it's better to use range syntax (`1..5`) instead.
 ///
 /// ```
-/// use std::collections::BTreeMap;
-/// use std::ops::Bound::{Excluded, Included, Unbounded};
+/// use core::collections::BTreeMap;
+/// use core::ops::Bound::{Excluded, Included, Unbounded};
 ///
 /// let mut map = BTreeMap::new();
 /// map.insert(3, "a");
@@ -712,7 +712,7 @@ impl<T> Bound<T> {
     ///
     /// ```
     /// #![feature(bound_map)]
-    /// use std::ops::Bound::*;
+    /// use core::ops::Bound::*;
     ///
     /// let bound_string = Included("Hello, World!");
     ///
@@ -721,7 +721,7 @@ impl<T> Bound<T> {
     ///
     /// ```
     /// #![feature(bound_map)]
-    /// use std::ops::Bound;
+    /// use core::ops::Bound;
     /// use Bound::*;
     ///
     /// let unbounded_string: Bound<String> = Unbounded;
@@ -745,8 +745,8 @@ impl<T: Clone> Bound<&T> {
     /// # Examples
     ///
     /// ```
-    /// use std::ops::Bound::*;
-    /// use std::ops::RangeBounds;
+    /// use core::ops::Bound::*;
+    /// use core::ops::RangeBounds;
     ///
     /// assert_eq!((1..12).start_bound(), Included(&1));
     /// assert_eq!((1..12).start_bound().cloned(), Included(1));
@@ -775,8 +775,8 @@ pub trait RangeBounds<T: ?Sized> {
     ///
     /// ```
     /// # fn main() {
-    /// use std::ops::Bound::*;
-    /// use std::ops::RangeBounds;
+    /// use core::ops::Bound::*;
+    /// use core::ops::RangeBounds;
     ///
     /// assert_eq!((..10).start_bound(), Unbounded);
     /// assert_eq!((3..10).start_bound(), Included(&3));
@@ -793,8 +793,8 @@ pub trait RangeBounds<T: ?Sized> {
     ///
     /// ```
     /// # fn main() {
-    /// use std::ops::Bound::*;
-    /// use std::ops::RangeBounds;
+    /// use core::ops::Bound::*;
+    /// use core::ops::RangeBounds;
     ///
     /// assert_eq!((3..).end_bound(), Unbounded);
     /// assert_eq!((3..10).end_bound(), Excluded(&10));

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -41,7 +41,7 @@ use crate::ops::ControlFlow;
 /// output type that we want:
 /// ```
 /// # #![feature(try_trait_v2)]
-/// # use std::ops::Try;
+/// # use core::ops::Try;
 /// fn simple_try_fold_1<A, T, R: Try<Output = A>>(
 ///     iter: impl Iterator<Item = T>,
 ///     mut accum: A,
@@ -55,7 +55,7 @@ use crate::ops::ControlFlow;
 /// into the return type using [`Try::from_output`]:
 /// ```
 /// # #![feature(try_trait_v2)]
-/// # use std::ops::{ControlFlow, Try};
+/// # use core::ops::{ControlFlow, Try};
 /// fn simple_try_fold_2<A, T, R: Try<Output = A>>(
 ///     iter: impl Iterator<Item = T>,
 ///     mut accum: A,
@@ -78,7 +78,7 @@ use crate::ops::ControlFlow;
 /// recreated from their corresponding residual, so we'll just call it:
 /// ```
 /// # #![feature(try_trait_v2)]
-/// # use std::ops::{ControlFlow, Try};
+/// # use core::ops::{ControlFlow, Try};
 /// pub fn simple_try_fold_3<A, T, R: Try<Output = A>>(
 ///     iter: impl Iterator<Item = T>,
 ///     mut accum: A,
@@ -100,7 +100,7 @@ use crate::ops::ControlFlow;
 /// do all this manually, we can just use `?` instead:
 /// ```
 /// # #![feature(try_trait_v2)]
-/// # use std::ops::Try;
+/// # use core::ops::Try;
 /// fn simple_try_fold<A, T, R: Try<Output = A>>(
 ///     iter: impl Iterator<Item = T>,
 ///     mut accum: A,
@@ -152,7 +152,7 @@ pub trait Try: ~const FromResidual {
     /// and thus `?` on `ControlFlow` cannot be used in a method returning `Result`.
     ///
     /// If you're making a generic type `Foo<T>` that implements `Try<Output = T>`,
-    /// then typically you can use `Foo<std::convert::Infallible>` as its `Residual`
+    /// then typically you can use `Foo<core::convert::Infallible>` as its `Residual`
     /// type: that type will have a "hole" in the correct place, and will maintain the
     /// "foo-ness" of the residual so other types need to opt-in to interconversion.
     #[unstable(feature = "try_trait_v2", issue = "84277")]
@@ -168,13 +168,13 @@ pub trait Try: ~const FromResidual {
     ///
     /// ```
     /// #![feature(try_trait_v2)]
-    /// use std::ops::Try;
+    /// use core::ops::Try;
     ///
     /// assert_eq!(<Result<_, String> as Try>::from_output(3), Ok(3));
     /// assert_eq!(<Option<_> as Try>::from_output(4), Some(4));
     /// assert_eq!(
-    ///     <std::ops::ControlFlow<String, _> as Try>::from_output(5),
-    ///     std::ops::ControlFlow::Continue(5),
+    ///     <core::ops::ControlFlow<String, _> as Try>::from_output(5),
+    ///     core::ops::ControlFlow::Continue(5),
     /// );
     ///
     /// # fn make_question_mark_work() -> Option<()> {
@@ -183,7 +183,7 @@ pub trait Try: ~const FromResidual {
     /// # make_question_mark_work();
     ///
     /// // This is used, for example, on the accumulator in `try_fold`:
-    /// let r = std::iter::empty().try_fold(4, |_, ()| -> Option<_> { unreachable!() });
+    /// let r = core::iter::empty().try_fold(4, |_, ()| -> Option<_> { unreachable!() });
     /// assert_eq!(r, Some(4));
     /// ```
     #[lang = "from_output"]
@@ -199,7 +199,7 @@ pub trait Try: ~const FromResidual {
     ///
     /// ```
     /// #![feature(try_trait_v2)]
-    /// use std::ops::{ControlFlow, Try};
+    /// use core::ops::{ControlFlow, Try};
     ///
     /// assert_eq!(Ok::<_, String>(3).branch(), ControlFlow::Continue(3));
     /// assert_eq!(Err::<String, _>(3).branch(), ControlFlow::Break(Err(3)));
@@ -227,8 +227,8 @@ pub trait Try: ~const FromResidual {
     on(
         all(
             from_desugaring = "QuestionMark",
-            _Self = "std::result::Result<T, E>",
-            R = "std::option::Option<std::convert::Infallible>"
+            _Self = "core::result::Result<T, E>",
+            R = "core::option::Option<core::convert::Infallible>"
         ),
         message = "the `?` operator can only be used on `Result`s, not `Option`s, \
             in {ItemContext} that returns `Result`",
@@ -238,7 +238,7 @@ pub trait Try: ~const FromResidual {
     on(
         all(
             from_desugaring = "QuestionMark",
-            _Self = "std::result::Result<T, E>",
+            _Self = "core::result::Result<T, E>",
         ),
         // There's a special error message in the trait selection code for
         // `From` in `?`, so this is not shown for result-in-result errors,
@@ -251,8 +251,8 @@ pub trait Try: ~const FromResidual {
     on(
         all(
             from_desugaring = "QuestionMark",
-            _Self = "std::option::Option<T>",
-            R = "std::result::Result<T, E>",
+            _Self = "core::option::Option<T>",
+            R = "core::result::Result<T, E>",
         ),
         message = "the `?` operator can only be used on `Option`s, not `Result`s, \
             in {ItemContext} that returns `Option`",
@@ -262,7 +262,7 @@ pub trait Try: ~const FromResidual {
     on(
         all(
             from_desugaring = "QuestionMark",
-            _Self = "std::option::Option<T>",
+            _Self = "core::option::Option<T>",
         ),
         // `Option`-in-`Option` always works, as there's only one possible
         // residual, so this can also be phrased strongly.
@@ -274,8 +274,8 @@ pub trait Try: ~const FromResidual {
     on(
         all(
             from_desugaring = "QuestionMark",
-            _Self = "std::ops::ControlFlow<B, C>",
-            R = "std::ops::ControlFlow<B, C>",
+            _Self = "core::ops::ControlFlow<B, C>",
+            R = "core::ops::ControlFlow<B, C>",
         ),
         message = "the `?` operator in {ItemContext} that returns `ControlFlow<B, _>` \
             can only be used on other `ControlFlow<B, _>`s (with the same Break type)",
@@ -286,7 +286,7 @@ pub trait Try: ~const FromResidual {
     on(
         all(
             from_desugaring = "QuestionMark",
-            _Self = "std::ops::ControlFlow<B, C>",
+            _Self = "core::ops::ControlFlow<B, C>",
             // `R` is not a `ControlFlow`, as that case was matched previously
         ),
         message = "the `?` operator can only be used on `ControlFlow`s \
@@ -318,7 +318,7 @@ pub trait FromResidual<R = <Self as Try>::Residual> {
     ///
     /// ```
     /// #![feature(try_trait_v2)]
-    /// use std::ops::{ControlFlow, FromResidual};
+    /// use core::ops::{ControlFlow, FromResidual};
     ///
     /// assert_eq!(Result::<String, i64>::from_residual(Err(3_u8)), Err(3));
     /// assert_eq!(Option::<String>::from_residual(None), None);

--- a/library/core/src/ops/unsize.rs
+++ b/library/core/src/ops/unsize.rs
@@ -105,8 +105,8 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
 ///
 /// ```
 /// # #![feature(dispatch_from_dyn, unsize)]
-/// # use std::{ops::DispatchFromDyn, marker::Unsize};
-/// # struct Rc<T: ?Sized>(std::rc::Rc<T>);
+/// # use core::{ops::DispatchFromDyn, marker::Unsize};
+/// # struct Rc<T: ?Sized>(core::rc::Rc<T>);
 /// impl<T: ?Sized, U: ?Sized> DispatchFromDyn<Rc<U>> for Rc<T>
 /// where
 ///     T: Unsize<U>,

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -312,7 +312,7 @@
 //! message if it receives [`None`].
 //!
 //! ```
-//! # use std::collections::BTreeMap;
+//! # use core::collections::BTreeMap;
 //! let mut bt = BTreeMap::new();
 //! bt.insert(20u8, "foo");
 //! bt.insert(42u8, "bar");
@@ -414,7 +414,7 @@
 //! [`once()`]: crate::iter::once
 //!
 //! ```compile_fail,E0308
-//! # use std::iter::{empty, once};
+//! # use core::iter::{empty, once};
 //! // This won't compile because all possible returns from the function
 //! // must have the same concrete type.
 //! fn make_iter(do_insert: bool) -> impl Iterator<Item = i32> {
@@ -739,7 +739,7 @@ impl<T> Option<T> {
     /// iterator over an `Option` or slice.
     ///
     /// Note: Should you have an `Option<&T>` and wish to get a slice of `T`,
-    /// you can unpack it via `opt.map_or(&[], std::slice::from_ref)`.
+    /// you can unpack it via `opt.map_or(&[], core::slice::from_ref)`.
     ///
     /// # Examples
     ///
@@ -797,7 +797,7 @@ impl<T> Option<T> {
     ///
     /// Note: Should you have an `Option<&mut T>` instead of a
     /// `&mut Option<T>`, which this method takes, you can obtain a mutable
-    /// slice via `opt.map_or(&mut [], std::slice::from_mut)`.
+    /// slice via `opt.map_or(&mut [], core::slice::from_mut)`.
     ///
     /// # Examples
     ///
@@ -902,7 +902,7 @@ impl<T> Option<T> {
     ///
     /// For more detail on expect message styles and the reasoning behind our
     /// recommendation please refer to the section on ["Common Message
-    /// Styles"](../../std/error/index.html#common-message-styles) in the [`std::error`](../../std/error/index.html) module docs.
+    /// Styles"](../../std/error/index.html#common-message-styles) in the [`core::error`](../../std/error/index.html) module docs.
     #[inline]
     #[track_caller]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -9,7 +9,7 @@ use crate::fmt;
 /// # Examples
 ///
 /// ```should_panic
-/// use std::panic;
+/// use core::panic;
 ///
 /// panic::set_hook(Box::new(|panic_info| {
 ///     if let Some(location) = panic_info.location() {
@@ -44,7 +44,7 @@ impl<'a> Location<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::panic::Location;
+    /// use core::panic::Location;
     ///
     /// /// Returns the [`Location`] at which it is called.
     /// #[track_caller]
@@ -109,7 +109,7 @@ impl<'a> Location<'a> {
     /// # Examples
     ///
     /// ```should_panic
-    /// use std::panic;
+    /// use core::panic;
     ///
     /// panic::set_hook(Box::new(|panic_info| {
     ///     if let Some(location) = panic_info.location() {
@@ -134,7 +134,7 @@ impl<'a> Location<'a> {
     /// # Examples
     ///
     /// ```should_panic
-    /// use std::panic;
+    /// use core::panic;
     ///
     /// panic::set_hook(Box::new(|panic_info| {
     ///     if let Some(location) = panic_info.location() {
@@ -159,7 +159,7 @@ impl<'a> Location<'a> {
     /// # Examples
     ///
     /// ```should_panic
-    /// use std::panic;
+    /// use core::panic;
     ///
     /// panic::set_hook(Box::new(|panic_info| {
     ///     if let Some(location) = panic_info.location() {

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -12,7 +12,7 @@ use crate::panic::Location;
 /// # Examples
 ///
 /// ```should_panic
-/// use std::panic;
+/// use core::panic;
 ///
 /// panic::set_hook(Box::new(|panic_info| {
 ///     if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
@@ -71,7 +71,7 @@ impl<'a> PanicInfo<'a> {
     /// # Examples
     ///
     /// ```should_panic
-    /// use std::panic;
+    /// use core::panic;
     ///
     /// panic::set_hook(Box::new(|panic_info| {
     ///     if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
@@ -107,7 +107,7 @@ impl<'a> PanicInfo<'a> {
     /// # Examples
     ///
     /// ```should_panic
-    /// use std::panic;
+    /// use core::panic;
     ///
     /// panic::set_hook(Box::new(|panic_info| {
     ///     if let Some(location) = panic_info.location() {
@@ -126,7 +126,7 @@ impl<'a> PanicInfo<'a> {
     #[stable(feature = "panic_hooks", since = "1.10.0")]
     pub fn location(&self) -> Option<&Location<'_>> {
         // NOTE: If this is changed to sometimes return None,
-        // deal with that case in std::panicking::default_hook and core::panicking::panic_fmt.
+        // deal with that case in core::panicking::default_hook and core::panicking::panic_fmt.
         Some(&self.location)
     }
 
@@ -158,7 +158,7 @@ impl fmt::Display for PanicInfo<'_> {
         }
         // NOTE: we cannot use downcast_ref::<String>() here
         // since String is not available in core!
-        // The payload is a String when `std::panic!` is called with multiple arguments,
+        // The payload is a String when `core::panic!` is called with multiple arguments,
         // but in that case the message is also available.
 
         self.location.fmt(formatter)

--- a/library/core/src/panic/unwind_safe.rs
+++ b/library/core/src/panic/unwind_safe.rs
@@ -125,7 +125,7 @@ pub auto trait RefUnwindSafe {}
 /// itself is unwind safe, bypassing all checks for all variables:
 ///
 /// ```
-/// use std::panic::{self, AssertUnwindSafe};
+/// use core::panic::{self, AssertUnwindSafe};
 ///
 /// let mut variable = 4;
 ///
@@ -153,7 +153,7 @@ pub auto trait RefUnwindSafe {}
 /// not.
 ///
 /// ```
-/// use std::panic::{self, AssertUnwindSafe};
+/// use core::panic::{self, AssertUnwindSafe};
 ///
 /// let mut variable = 4;
 /// let other_capture = 3;

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -25,7 +25,7 @@
 //! as [`mem::swap`]:
 //!
 //! ```
-//! use std::pin::Pin;
+//! use core::pin::Pin;
 //! fn swap_pins<T>(x: Pin<&mut T>, y: Pin<&mut T>) {
 //!     // `mem::swap` needs `&mut T`, but we cannot get it.
 //!     // We are stuck, we cannot swap the contents of these references.
@@ -71,9 +71,9 @@
 //! Feel free to [skip to where the theoretical discussion continues](#drop-guarantee).
 //!
 //! ```rust
-//! use std::pin::Pin;
-//! use std::marker::PhantomPinned;
-//! use std::ptr::NonNull;
+//! use core::pin::Pin;
+//! use core::marker::PhantomPinned;
+//! use core::ptr::NonNull;
 //!
 //! // This is a self-referential struct because the slice field points to the data field.
 //! // We cannot inform the compiler about that with a normal reference,
@@ -120,7 +120,7 @@
 //!
 //! // Since our type doesn't implement Unpin, this will fail to compile:
 //! // let mut new_unmoved = Unmovable::new("world".to_string());
-//! // std::mem::swap(&mut *still_unmoved, &mut *new_unmoved);
+//! // core::mem::swap(&mut *still_unmoved, &mut *new_unmoved);
 //! ```
 //!
 //! # Example: intrusive doubly-linked list
@@ -181,7 +181,7 @@
 //! For example, you could implement [`Drop`][Drop] as follows:
 //!
 //! ```rust,no_run
-//! # use std::pin::Pin;
+//! # use core::pin::Pin;
 //! # struct Type { }
 //! impl Drop for Type {
 //!     fn drop(&mut self) {
@@ -240,7 +240,7 @@
 //! <code>[Pin]<[&mut] Struct></code> into <code>[&mut] Field</code>:
 //!
 //! ```rust,no_run
-//! # use std::pin::Pin;
+//! # use core::pin::Pin;
 //! # type Field = i32;
 //! # struct Struct { field: Field }
 //! impl Struct {
@@ -264,7 +264,7 @@
 //! witnessing that the field is pinned:
 //!
 //! ```rust,no_run
-//! # use std::pin::Pin;
+//! # use core::pin::Pin;
 //! # type Field = i32;
 //! # struct Struct { field: Field }
 //! impl Struct {
@@ -489,7 +489,7 @@ impl<P: Deref<Target: Unpin>> Pin<P> {
     /// # Examples
     ///
     /// ```
-    /// use std::pin::Pin;
+    /// use core::pin::Pin;
     ///
     /// let mut val: u8 = 5;
     /// // We can pin the value, since it doesn't care about being moved
@@ -512,7 +512,7 @@ impl<P: Deref<Target: Unpin>> Pin<P> {
     /// # Examples
     ///
     /// ```
-    /// use std::pin::Pin;
+    /// use core::pin::Pin;
     ///
     /// let mut val: u8 = 5;
     /// let pinned: Pin<&mut u8> = Pin::new(&mut val);
@@ -557,8 +557,8 @@ impl<P: Deref> Pin<P> {
     /// while you are able to pin it for the given lifetime `'a`, you have no control
     /// over whether it is kept pinned once `'a` ends:
     /// ```
-    /// use std::mem;
-    /// use std::pin::Pin;
+    /// use core::mem;
+    /// use core::pin::Pin;
     ///
     /// fn move_pinned_ref<T>(mut a: T, mut b: T) {
     ///     unsafe {
@@ -575,8 +575,8 @@ impl<P: Deref> Pin<P> {
     /// Similarly, calling `Pin::new_unchecked` on an `Rc<T>` is unsafe because there could be
     /// aliases to the same data that are not subject to the pinning restrictions:
     /// ```
-    /// use std::rc::Rc;
-    /// use std::pin::Pin;
+    /// use core::rc::Rc;
+    /// use core::pin::Pin;
     ///
     /// fn move_pinned_rc<T>(mut x: Rc<T>) {
     ///     let pinned = unsafe { Pin::new_unchecked(Rc::clone(&x)) };
@@ -599,9 +599,9 @@ impl<P: Deref> Pin<P> {
     /// implicitly makes the promise that the closure itself is pinned, and that *all* uses
     /// of this closure capture respect that pinning.
     /// ```
-    /// use std::pin::Pin;
-    /// use std::task::Context;
-    /// use std::future::Future;
+    /// use core::pin::Pin;
+    /// use core::task::Context;
+    /// use core::future::Future;
     ///
     /// fn move_pinned_closure(mut x: impl Future, cx: &mut Context<'_>) {
     ///     // Create a closure that moves `x`, and then internally uses it in a pinned way.
@@ -624,9 +624,9 @@ impl<P: Deref> Pin<P> {
     /// The better alternative is to avoid all that trouble and do the pinning in the outer function
     /// instead (here using the [`pin!`][crate::pin::pin] macro):
     /// ```
-    /// use std::pin::pin;
-    /// use std::task::Context;
-    /// use std::future::Future;
+    /// use core::pin::pin;
+    /// use core::task::Context;
+    /// use core::future::Future;
     ///
     /// fn move_pinned_closure(mut x: impl Future, cx: &mut Context<'_>) {
     ///     let mut x = pin!(x);
@@ -702,7 +702,7 @@ impl<P: DerefMut> Pin<P> {
     /// # Example
     ///
     /// ```
-    /// use std::pin::Pin;
+    /// use core::pin::Pin;
     ///
     /// # struct Type {}
     /// impl Type {
@@ -732,7 +732,7 @@ impl<P: DerefMut> Pin<P> {
     /// # Example
     ///
     /// ```
-    /// use std::pin::Pin;
+    /// use core::pin::Pin;
     ///
     /// let mut val: u8 = 5;
     /// let mut pinned: Pin<&mut u8> = Pin::new(&mut val);
@@ -1045,13 +1045,13 @@ impl<P, U> DispatchFromDyn<Pin<U>> for Pin<P> where P: DispatchFromDyn<U> {}
 /// ### Manually polling a `Future` (without `Unpin` bounds)
 ///
 /// ```rust
-/// use std::{
+/// use core::{
 ///     future::Future,
 ///     pin::pin,
 ///     task::{Context, Poll},
 ///     thread,
 /// };
-/// # use std::{sync::Arc, task::Wake, thread::Thread};
+/// # use core::{sync::Arc, task::Wake, thread::Thread};
 ///
 /// # /// A waker that wakes up the current thread when called.
 /// # struct ThreadWaker(Thread);

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -133,7 +133,7 @@ mod prim_bool {}
 ///
 /// ```
 /// #![feature(exhaustive_patterns)]
-/// use std::str::FromStr;
+/// use core::str::FromStr;
 /// let Ok(s) = String::from_str("hello");
 /// ```
 ///
@@ -204,7 +204,7 @@ mod prim_bool {}
 /// words, they can't return `!` from every code path. As an example, this code doesn't compile:
 ///
 /// ```compile_fail
-/// use std::ops::Add;
+/// use core::ops::Add;
 ///
 /// fn foo() -> impl Add<u32> {
 ///     unimplemented!()
@@ -214,7 +214,7 @@ mod prim_bool {}
 /// But this code does:
 ///
 /// ```
-/// use std::ops::Add;
+/// use core::ops::Add;
 ///
 /// fn foo() -> impl Add<u32> {
 ///     if true {
@@ -238,7 +238,7 @@ mod prim_bool {}
 ///
 /// ```
 /// #![feature(never_type)]
-/// # use std::fmt;
+/// # use core::fmt;
 /// # trait Debug {
 /// #     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result;
 /// # }
@@ -287,7 +287,7 @@ mod prim_never {}
 ///
 /// This documentation describes a number of methods and trait implementations on the
 /// `char` type. For technical reasons, there is additional, separate
-/// documentation in [the `std::char` module](char/index.html) as well.
+/// documentation in [the `core::char` module](char/index.html) as well.
 ///
 /// # Validity
 ///
@@ -350,12 +350,12 @@ mod prim_never {}
 /// let v = vec!['h', 'e', 'l', 'l', 'o'];
 ///
 /// // five elements times four bytes for each element
-/// assert_eq!(20, v.len() * std::mem::size_of::<char>());
+/// assert_eq!(20, v.len() * core::mem::size_of::<char>());
 ///
 /// let s = String::from("hello");
 ///
 /// // five elements times one byte per element
-/// assert_eq!(5, s.len() * std::mem::size_of::<u8>());
+/// assert_eq!(5, s.len() * core::mem::size_of::<u8>());
 /// ```
 ///
 #[doc = concat!("[`String`]: ", include_str!("../primitive_docs/string_string.md"))]
@@ -395,8 +395,8 @@ mod prim_never {}
 /// let s = String::from("love: ❤️");
 /// let v: Vec<char> = s.chars().collect();
 ///
-/// assert_eq!(12, std::mem::size_of_val(&s[..]));
-/// assert_eq!(32, std::mem::size_of_val(&v[..]));
+/// assert_eq!(12, core::mem::size_of_val(&s[..]));
+/// assert_eq!(32, core::mem::size_of_val(&v[..]));
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_char {}
@@ -473,7 +473,7 @@ impl Copy for () {
 //
 /// Raw, unsafe pointers, `*const T`, and `*mut T`.
 ///
-/// *[See also the `std::ptr` module](ptr).*
+/// *[See also the `core::ptr` module](ptr).*
 ///
 /// Working with raw pointers in Rust is uncommon, typically limited to a few patterns.
 /// Raw pointers can be unaligned or [`null`]. However, when a raw pointer is
@@ -548,7 +548,7 @@ impl Copy for () {
 ///     unaligned: u32,
 /// }
 /// let s = S::default();
-/// let p = std::ptr::addr_of!(s.unaligned); // not allowed with coercion
+/// let p = core::ptr::addr_of!(s.unaligned); // not allowed with coercion
 /// ```
 ///
 /// ## 4. Get it from C.
@@ -557,7 +557,7 @@ impl Copy for () {
 /// # #![feature(rustc_private)]
 /// extern crate libc;
 ///
-/// use std::mem;
+/// use core::mem;
 ///
 /// unsafe {
 ///     let my_num: *mut i32 = libc::malloc(mem::size_of::<i32>()) as *mut i32;
@@ -793,7 +793,7 @@ mod prim_array {}
 /// means that elements are laid out so that every element is the same
 /// distance from its neighbors.
 ///
-/// *[See also the `std::slice` module](crate::slice).*
+/// *[See also the `core::slice` module](crate::slice).*
 ///
 /// Slices are a view into a block of memory represented as a pointer and a
 /// length.
@@ -824,12 +824,12 @@ mod prim_array {}
 /// [dynamically sized types](../reference/dynamically-sized-types.html).
 ///
 /// ```
-/// # use std::rc::Rc;
-/// let pointer_size = std::mem::size_of::<&u8>();
-/// assert_eq!(2 * pointer_size, std::mem::size_of::<&[u8]>());
-/// assert_eq!(2 * pointer_size, std::mem::size_of::<*const [u8]>());
-/// assert_eq!(2 * pointer_size, std::mem::size_of::<Box<[u8]>>());
-/// assert_eq!(2 * pointer_size, std::mem::size_of::<Rc<[u8]>>());
+/// # use core::rc::Rc;
+/// let pointer_size = core::mem::size_of::<&u8>();
+/// assert_eq!(2 * pointer_size, core::mem::size_of::<&[u8]>());
+/// assert_eq!(2 * pointer_size, core::mem::size_of::<*const [u8]>());
+/// assert_eq!(2 * pointer_size, core::mem::size_of::<Box<[u8]>>());
+/// assert_eq!(2 * pointer_size, core::mem::size_of::<Rc<[u8]>>());
 /// ```
 ///
 /// ## Trait Implementations
@@ -881,7 +881,7 @@ mod prim_slice {}
 #[cfg_attr(not(bootstrap), rustc_doc_primitive = "str")]
 /// String slices.
 ///
-/// *[See also the `std::str` module](crate::str).*
+/// *[See also the `core::str` module](crate::str).*
 ///
 /// The `str` type, also called a 'string slice', is the most primitive string
 /// type. It is usually seen in its borrowed form, `&str`. It is also the type
@@ -912,8 +912,8 @@ mod prim_slice {}
 /// length. You can look at these with the [`as_ptr`] and [`len`] methods:
 ///
 /// ```
-/// use std::slice;
-/// use std::str;
+/// use core::slice;
+/// use core::str;
 ///
 /// let story = "Once upon a time...";
 ///
@@ -1151,7 +1151,7 @@ impl<T: Copy> Copy for (T,) {
 ///
 /// For more information on floating point numbers, see [Wikipedia][wikipedia].
 ///
-/// *[See also the `std::f32::consts` module](crate::f32::consts).*
+/// *[See also the `core::f32::consts` module](crate::f32::consts).*
 ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Single-precision_floating-point_format
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1166,7 +1166,7 @@ mod prim_f32 {}
 /// `f32`][`f32`] or [Wikipedia on double precision
 /// values][wikipedia] for more information.
 ///
-/// *[See also the `std::f64::consts` module](crate::f64::consts).*
+/// *[See also the `core::f64::consts` module](crate::f64::consts).*
 ///
 /// [`f32`]: prim@f32
 /// [wikipedia]: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
@@ -1305,7 +1305,7 @@ mod prim_usize {}
 /// [`PartialEq`] compares values.
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// let five = 5;
 /// let other_five = 5;
@@ -1352,7 +1352,7 @@ mod prim_usize {}
 /// The following traits are implemented on `&T` references if the underlying `T` also implements
 /// that trait:
 ///
-/// * All the traits in [`std::fmt`] except [`fmt::Pointer`] (which is implemented regardless of the type of its referent) and [`fmt::Write`]
+/// * All the traits in [`core::fmt`] except [`fmt::Pointer`] (which is implemented regardless of the type of its referent) and [`fmt::Write`]
 /// * [`PartialOrd`]
 /// * [`Ord`]
 /// * [`PartialEq`]
@@ -1363,7 +1363,7 @@ mod prim_usize {}
 /// * [`ToSocketAddrs`]
 /// * [`Send`] \(`&T` references also require <code>T: [Sync]</code>)
 ///
-/// [`std::fmt`]: fmt
+/// [`core::fmt`]: fmt
 /// [`Hash`]: hash::Hash
 #[doc = concat!("[`ToSocketAddrs`]: ", include_str!("../primitive_docs/net_tosocketaddrs.md"))]
 ///
@@ -1491,7 +1491,7 @@ mod prim_ref {}
 /// This zero-sized type *coerces* to a regular function pointer. For example:
 ///
 /// ```rust
-/// use std::mem;
+/// use core::mem;
 ///
 /// fn bar(x: i32) {}
 ///
@@ -1524,7 +1524,7 @@ mod prim_ref {}
 /// # let fnptr: fn(i32) -> i32 = |x| x+2;
 /// # let fnptr_addr = fnptr as usize;
 /// let fnptr = fnptr_addr as *const ();
-/// let fnptr: fn(i32) -> i32 = unsafe { std::mem::transmute(fnptr) };
+/// let fnptr: fn(i32) -> i32 = unsafe { core::mem::transmute(fnptr) };
 /// assert_eq!(fnptr(40), 42);
 /// # }
 /// ```

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -31,7 +31,7 @@ impl Alignment {
     ///
     /// ```
     /// #![feature(ptr_alignment_type)]
-    /// use std::ptr::Alignment;
+    /// use core::ptr::Alignment;
     ///
     /// assert_eq!(Alignment::MIN.as_usize(), 1);
     /// ```
@@ -113,7 +113,7 @@ impl Alignment {
     ///
     /// ```
     /// #![feature(ptr_alignment_type)]
-    /// use std::ptr::Alignment;
+    /// use core::ptr::Alignment;
     ///
     /// assert_eq!(Alignment::of::<u8>().log2(), 0);
     /// assert_eq!(Alignment::new(1024).unwrap().log2(), 10);

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -154,7 +154,7 @@ impl<T: ?Sized> *const T {
     /// ```
     /// #![feature(ptr_to_from_bits)]
     /// # #[cfg(not(miri))] { // doctest does not work with strict provenance
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     /// let dangling: *const u8 = NonNull::dangling().as_ptr();
     /// assert_eq!(<*const u8>::from_bits(1), dangling);
     /// # }
@@ -1303,7 +1303,7 @@ impl<T: ?Sized> *const T {
     /// Accessing adjacent `u8` as `u16`
     ///
     /// ```
-    /// use std::mem::align_of;
+    /// use core::mem::align_of;
     ///
     /// # unsafe {
     /// let x = [5_u8, 6, 7, 8, 9];
@@ -1598,7 +1598,7 @@ impl<T> *const [T] {
     /// ```rust
     /// #![feature(slice_ptr_len)]
     ///
-    /// use std::ptr;
+    /// use core::ptr;
     ///
     /// let slice: *const [i8] = ptr::slice_from_raw_parts(ptr::null(), 3);
     /// assert_eq!(slice.len(), 3);
@@ -1618,7 +1618,7 @@ impl<T> *const [T] {
     ///
     /// ```rust
     /// #![feature(slice_ptr_get)]
-    /// use std::ptr;
+    /// use core::ptr;
     ///
     /// let slice: *const [i8] = ptr::slice_from_raw_parts(ptr::null(), 3);
     /// assert_eq!(slice.as_ptr(), ptr::null());

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -69,8 +69,8 @@ pub trait Pointee {
 /// ```rust
 /// #![feature(ptr_metadata)]
 ///
-/// fn this_never_panics<T: std::ptr::Thin>() {
-///     assert_eq!(std::mem::size_of::<&T>(), std::mem::size_of::<usize>())
+/// fn this_never_panics<T: core::ptr::Thin>() {
+///     assert_eq!(core::mem::size_of::<&T>(), core::mem::size_of::<usize>())
 /// }
 /// ```
 #[unstable(feature = "ptr_metadata", issue = "81513")]
@@ -87,7 +87,7 @@ pub trait Thin = Pointee<Metadata = ()>;
 /// ```
 /// #![feature(ptr_metadata)]
 ///
-/// assert_eq!(std::ptr::metadata("foo"), 3_usize);
+/// assert_eq!(core::ptr::metadata("foo"), 3_usize);
 /// ```
 #[rustc_const_unstable(feature = "ptr_metadata", issue = "81513")]
 #[inline]

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -460,8 +460,8 @@ mod mut_ptr;
 /// Manually remove the last item from a vector:
 ///
 /// ```
-/// use std::ptr;
-/// use std::rc::Rc;
+/// use core::ptr;
+/// use core::rc::Rc;
 ///
 /// let last = Rc::new(1);
 /// let weak = Rc::downgrade(&last);
@@ -500,7 +500,7 @@ pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
 /// # Examples
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// let p: *const i32 = ptr::null();
 /// assert!(p.is_null());
@@ -521,7 +521,7 @@ pub const fn null<T: ?Sized + Thin>() -> *const T {
 /// # Examples
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// let p: *mut i32 = ptr::null_mut();
 /// assert!(p.is_null());
@@ -718,7 +718,7 @@ pub const fn from_mut<T: ?Sized>(r: &mut T) -> *mut T {
 /// # Examples
 ///
 /// ```rust
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// // create a slice pointer when starting out with a pointer to the first element
 /// let x = [5, 6, 7];
@@ -747,7 +747,7 @@ pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
 /// # Examples
 ///
 /// ```rust
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// let x = &mut [5, 6, 7];
 /// let raw_pointer = x.as_mut_ptr();
@@ -799,7 +799,7 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 /// Swapping two non-overlapping regions:
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// let mut array = [0, 1, 2, 3];
 ///
@@ -816,7 +816,7 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 /// Swapping two overlapping regions:
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// let mut array: [i32; 4] = [0, 1, 2, 3];
 ///
@@ -884,7 +884,7 @@ pub const unsafe fn swap<T>(x: *mut T, y: *mut T) {
 /// Basic usage:
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// let mut x = [1, 2, 3, 4];
 /// let mut y = [7, 8, 9];
@@ -994,7 +994,7 @@ const unsafe fn swap_nonoverlapping_simple_untyped<T>(x: *mut T, y: *mut T, coun
 /// # Examples
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// let mut rust = vec!['b', 'u', 's', 't'];
 ///
@@ -1050,14 +1050,14 @@ pub const unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
 /// let y = &x as *const i32;
 ///
 /// unsafe {
-///     assert_eq!(std::ptr::read(y), 12);
+///     assert_eq!(core::ptr::read(y), 12);
 /// }
 /// ```
 ///
 /// Manually implement [`mem::swap`]:
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// fn swap<T>(a: &mut T, b: &mut T) {
 ///     unsafe {
@@ -1103,7 +1103,7 @@ pub const unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
 /// [`write()`] can be used to overwrite data without causing it to be dropped.
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// let mut s = String::from("foo");
 /// unsafe {
@@ -1242,9 +1242,9 @@ pub const unsafe fn read<T>(src: *const T) -> T {
 ///
 /// // Take the address of a 32-bit integer which is not aligned.
 /// // In contrast to `&packed.unaligned as *const _`, this has no undefined behavior.
-/// let unaligned = std::ptr::addr_of!(packed.unaligned);
+/// let unaligned = core::ptr::addr_of!(packed.unaligned);
 ///
-/// let v = unsafe { std::ptr::read_unaligned(unaligned) };
+/// let v = unsafe { core::ptr::read_unaligned(unaligned) };
 /// assert_eq!(v, 0x01020304);
 /// ```
 ///
@@ -1255,7 +1255,7 @@ pub const unsafe fn read<T>(src: *const T) -> T {
 /// Read a usize value from a byte buffer:
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// fn read_usize(x: &[u8]) -> usize {
 ///     assert!(x.len() >= mem::size_of::<usize>());
@@ -1319,15 +1319,15 @@ pub const unsafe fn read_unaligned<T>(src: *const T) -> T {
 /// let z = 12;
 ///
 /// unsafe {
-///     std::ptr::write(y, z);
-///     assert_eq!(std::ptr::read(y), 12);
+///     core::ptr::write(y, z);
+///     assert_eq!(core::ptr::read(y), 12);
 /// }
 /// ```
 ///
 /// Manually implement [`mem::swap`]:
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// fn swap<T>(a: &mut T, b: &mut T) {
 ///     unsafe {
@@ -1435,13 +1435,13 @@ pub const unsafe fn write<T>(dst: *mut T, src: T) {
 ///     unaligned: u32,
 /// }
 ///
-/// let mut packed: Packed = unsafe { std::mem::zeroed() };
+/// let mut packed: Packed = unsafe { core::mem::zeroed() };
 ///
 /// // Take the address of a 32-bit integer which is not aligned.
 /// // In contrast to `&packed.unaligned as *mut _`, this has no undefined behavior.
-/// let unaligned = std::ptr::addr_of_mut!(packed.unaligned);
+/// let unaligned = core::ptr::addr_of_mut!(packed.unaligned);
 ///
-/// unsafe { std::ptr::write_unaligned(unaligned, 42) };
+/// unsafe { core::ptr::write_unaligned(unaligned, 42) };
 ///
 /// assert_eq!({packed.unaligned}, 42); // `{...}` forces copying the field instead of creating a reference.
 /// ```
@@ -1454,7 +1454,7 @@ pub const unsafe fn write<T>(dst: *mut T, src: T) {
 /// Write a usize value to a byte buffer:
 ///
 /// ```
-/// use std::mem;
+/// use core::mem;
 ///
 /// fn write_usize(x: &mut [u8], val: usize) {
 ///     assert!(x.len() >= mem::size_of::<usize>());
@@ -1536,7 +1536,7 @@ pub const unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 /// let y = &x as *const i32;
 ///
 /// unsafe {
-///     assert_eq!(std::ptr::read_volatile(y), 12);
+///     assert_eq!(core::ptr::read_volatile(y), 12);
 /// }
 /// ```
 #[inline]
@@ -1609,8 +1609,8 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 /// let z = 12;
 ///
 /// unsafe {
-///     std::ptr::write_volatile(y, z);
-///     assert_eq!(std::ptr::read_volatile(y), 12);
+///     core::ptr::write_volatile(y, z);
+///     assert_eq!(core::ptr::read_volatile(y), 12);
 /// }
 /// ```
 #[inline]
@@ -1830,7 +1830,7 @@ pub(crate) const unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usiz
 /// # Examples
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// let five = 5;
 /// let other_five = 5;
@@ -1849,9 +1849,9 @@ pub(crate) const unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usiz
 ///
 /// ```
 /// let a = [1, 2, 3];
-/// assert!(std::ptr::eq(&a[..3], &a[..3]));
-/// assert!(!std::ptr::eq(&a[..2], &a[..3]));
-/// assert!(!std::ptr::eq(&a[0..2], &a[1..3]));
+/// assert!(core::ptr::eq(&a[..3], &a[..3]));
+/// assert!(!core::ptr::eq(&a[..2], &a[..3]));
+/// assert!(!core::ptr::eq(&a[0..2], &a[1..3]));
 /// ```
 #[stable(feature = "ptr_eq", since = "1.17.0")]
 #[inline(always)]
@@ -1868,9 +1868,9 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 /// # Examples
 ///
 /// ```
-/// use std::collections::hash_map::DefaultHasher;
-/// use std::hash::{Hash, Hasher};
-/// use std::ptr;
+/// use core::collections::hash_map::DefaultHasher;
+/// use core::hash::{Hash, Hasher};
+/// use core::ptr;
 ///
 /// let five = 5;
 /// let five_ref = &five;
@@ -2106,7 +2106,7 @@ mod new_fn_ptr_impl {
 /// # Example
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// #[repr(packed)]
 /// struct Packed {
@@ -2148,7 +2148,7 @@ pub macro addr_of($place:expr) {
 /// **Creating a pointer to unaligned data:**
 ///
 /// ```
-/// use std::ptr;
+/// use core::ptr;
 ///
 /// #[repr(packed)]
 /// struct Packed {
@@ -2166,7 +2166,7 @@ pub macro addr_of($place:expr) {
 /// **Creating a pointer to uninitialized data:**
 ///
 /// ```rust
-/// use std::{ptr, mem::MaybeUninit};
+/// use core::{ptr, mem::MaybeUninit};
 ///
 /// struct Demo {
 ///     field: bool,

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -160,7 +160,7 @@ impl<T: ?Sized> *mut T {
     /// ```
     /// #![feature(ptr_to_from_bits)]
     /// # #[cfg(not(miri))] { // doctest does not work with strict provenance
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     /// let dangling: *mut u8 = NonNull::dangling().as_ptr();
     /// assert_eq!(<*mut u8>::from_bits(1), dangling);
     /// }
@@ -1567,7 +1567,7 @@ impl<T: ?Sized> *mut T {
     /// Accessing adjacent `u8` as `u16`
     ///
     /// ```
-    /// use std::mem::align_of;
+    /// use core::mem::align_of;
     ///
     /// # unsafe {
     /// let mut x = [5_u8, 6, 7, 8, 9];
@@ -1867,7 +1867,7 @@ impl<T> *mut [T] {
     ///
     /// ```rust
     /// #![feature(slice_ptr_len)]
-    /// use std::ptr;
+    /// use core::ptr;
     ///
     /// let slice: *mut [i8] = ptr::slice_from_raw_parts_mut(ptr::null_mut(), 3);
     /// assert_eq!(slice.len(), 3);
@@ -2003,7 +2003,7 @@ impl<T> *mut [T] {
     ///
     /// ```rust
     /// #![feature(slice_ptr_get)]
-    /// use std::ptr;
+    /// use core::ptr;
     ///
     /// let slice: *mut [i8] = ptr::slice_from_raw_parts_mut(ptr::null_mut(), 3);
     /// assert_eq!(slice.as_mut_ptr(), ptr::null_mut());

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -78,7 +78,7 @@ impl<T: Sized> NonNull<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// let ptr = NonNull::<u32>::dangling();
     /// // Important: don't try to access the value of `ptr` without
@@ -177,7 +177,7 @@ impl<T: ?Sized> NonNull<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// let mut x = 0u32;
     /// let ptr = unsafe { NonNull::new_unchecked(&mut x as *mut _) };
@@ -186,10 +186,10 @@ impl<T: ?Sized> NonNull<T> {
     /// *Incorrect* usage of this function:
     ///
     /// ```rust,no_run
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// // NEVER DO THAT!!! This is undefined behavior. ⚠️
-    /// let ptr = unsafe { NonNull::<u32>::new_unchecked(std::ptr::null_mut()) };
+    /// let ptr = unsafe { NonNull::<u32>::new_unchecked(core::ptr::null_mut()) };
     /// ```
     #[stable(feature = "nonnull", since = "1.25.0")]
     #[rustc_const_stable(feature = "const_nonnull_new_unchecked", since = "1.25.0")]
@@ -207,12 +207,12 @@ impl<T: ?Sized> NonNull<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// let mut x = 0u32;
     /// let ptr = NonNull::<u32>::new(&mut x as *mut _).expect("ptr is null!");
     ///
-    /// if let Some(ptr) = NonNull::<u32>::new(std::ptr::null_mut()) {
+    /// if let Some(ptr) = NonNull::<u32>::new(core::ptr::null_mut()) {
     ///     unreachable!();
     /// }
     /// ```
@@ -228,12 +228,12 @@ impl<T: ?Sized> NonNull<T> {
         }
     }
 
-    /// Performs the same functionality as [`std::ptr::from_raw_parts`], except that a
+    /// Performs the same functionality as [`core::ptr::from_raw_parts`], except that a
     /// `NonNull` pointer is returned, as opposed to a raw `*const` pointer.
     ///
-    /// See the documentation of [`std::ptr::from_raw_parts`] for more details.
+    /// See the documentation of [`core::ptr::from_raw_parts`] for more details.
     ///
-    /// [`std::ptr::from_raw_parts`]: crate::ptr::from_raw_parts
+    /// [`core::ptr::from_raw_parts`]: crate::ptr::from_raw_parts
     #[unstable(feature = "ptr_metadata", issue = "81513")]
     #[rustc_const_unstable(feature = "ptr_metadata", issue = "81513")]
     #[inline]
@@ -306,7 +306,7 @@ impl<T: ?Sized> NonNull<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// let mut x = 0u32;
     /// let ptr = NonNull::new(&mut x).expect("ptr is null!");
@@ -356,7 +356,7 @@ impl<T: ?Sized> NonNull<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// let mut x = 0u32;
     /// let ptr = NonNull::new(&mut x as *mut _).expect("ptr is null!");
@@ -405,7 +405,7 @@ impl<T: ?Sized> NonNull<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// let mut x = 0u32;
     /// let mut ptr = NonNull::new(&mut x).expect("null pointer");
@@ -432,7 +432,7 @@ impl<T: ?Sized> NonNull<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// let mut x = 0u32;
     /// let ptr = NonNull::new(&mut x as *mut _).expect("null pointer");
@@ -462,7 +462,7 @@ impl<T> NonNull<[T]> {
     /// # Examples
     ///
     /// ```rust
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// // create a slice pointer when starting out with a pointer to the first element
     /// let mut x = [5, 6, 7];
@@ -492,7 +492,7 @@ impl<T> NonNull<[T]> {
     /// # Examples
     ///
     /// ```rust
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// let slice: NonNull<[i8]> = NonNull::slice_from_raw_parts(NonNull::dangling(), 3);
     /// assert_eq!(slice.len(), 3);
@@ -512,7 +512,7 @@ impl<T> NonNull<[T]> {
     ///
     /// ```rust
     /// #![feature(slice_ptr_get)]
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// let slice: NonNull<[i8]> = NonNull::slice_from_raw_parts(NonNull::dangling(), 3);
     /// assert_eq!(slice.as_non_null_ptr(), NonNull::<i8>::dangling());
@@ -532,7 +532,7 @@ impl<T> NonNull<[T]> {
     ///
     /// ```rust
     /// #![feature(slice_ptr_get)]
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// let slice: NonNull<[i8]> = NonNull::slice_from_raw_parts(NonNull::dangling(), 3);
     /// assert_eq!(slice.as_mut_ptr(), NonNull::<i8>::dangling().as_ptr());
@@ -634,16 +634,16 @@ impl<T> NonNull<[T]> {
     /// ```rust
     /// #![feature(allocator_api, ptr_as_uninit)]
     ///
-    /// use std::alloc::{Allocator, Layout, Global};
-    /// use std::mem::MaybeUninit;
-    /// use std::ptr::NonNull;
+    /// use core::alloc::{Allocator, Layout, Global};
+    /// use core::mem::MaybeUninit;
+    /// use core::ptr::NonNull;
     ///
     /// let memory: NonNull<[u8]> = Global.allocate(Layout::new::<[u8; 32]>())?;
     /// // This is safe as `memory` is valid for reads and writes for `memory.len()` many bytes.
     /// // Note that calling `memory.as_mut()` is not allowed here as the content may be uninitialized.
     /// # #[allow(unused_variables)]
     /// let slice: &mut [MaybeUninit<u8>] = unsafe { memory.as_uninit_slice_mut() };
-    /// # Ok::<_, std::alloc::AllocError>(())
+    /// # Ok::<_, core::alloc::AllocError>(())
     /// ```
     #[inline]
     #[must_use]
@@ -666,7 +666,7 @@ impl<T> NonNull<[T]> {
     ///
     /// ```
     /// #![feature(slice_ptr_get)]
-    /// use std::ptr::NonNull;
+    /// use core::ptr::NonNull;
     ///
     /// let x = &mut [1, 2, 4];
     /// let x = NonNull::slice_from_raw_parts(NonNull::new(x.as_mut_ptr()).unwrap(), x.len());

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -80,7 +80,7 @@
 //! by the [`Write`] trait:
 //!
 //! ```
-//! use std::io;
+//! use core::io;
 //!
 //! trait Write {
 //!     fn write_all(&mut self, bytes: &[u8]) -> Result<(), io::Error>;
@@ -96,8 +96,8 @@
 //!
 //! ```no_run
 //! # #![allow(unused_must_use)] // \o/
-//! use std::fs::File;
-//! use std::io::prelude::*;
+//! use core::fs::File;
+//! use core::io::prelude::*;
 //!
 //! let mut file = File::create("valuable_data.txt").unwrap();
 //! // If `write_all` errors, then we'll never know, because the return
@@ -113,8 +113,8 @@
 //! write fails, providing a marginally useful message indicating why:
 //!
 //! ```no_run
-//! use std::fs::File;
-//! use std::io::prelude::*;
+//! use core::fs::File;
+//! use core::io::prelude::*;
 //!
 //! let mut file = File::create("valuable_data.txt").unwrap();
 //! file.write_all(b"important message").expect("failed to write message");
@@ -123,8 +123,8 @@
 //! You might also simply assert success:
 //!
 //! ```no_run
-//! # use std::fs::File;
-//! # use std::io::prelude::*;
+//! # use core::fs::File;
+//! # use core::io::prelude::*;
 //! # let mut file = File::create("valuable_data.txt").unwrap();
 //! assert!(file.write_all(b"important message").is_ok());
 //! ```
@@ -132,9 +132,9 @@
 //! Or propagate the error up the call stack with [`?`]:
 //!
 //! ```
-//! # use std::fs::File;
-//! # use std::io::prelude::*;
-//! # use std::io;
+//! # use core::fs::File;
+//! # use core::io::prelude::*;
+//! # use core::io;
 //! # #[allow(dead_code)]
 //! fn write_message() -> io::Result<()> {
 //!     let mut file = File::create("valuable_data.txt")?;
@@ -154,9 +154,9 @@
 //!
 //! ```
 //! # #![allow(dead_code)]
-//! use std::fs::File;
-//! use std::io::prelude::*;
-//! use std::io;
+//! use core::fs::File;
+//! use core::io::prelude::*;
+//! use core::io;
 //!
 //! struct Info {
 //!     name: String,
@@ -187,9 +187,9 @@
 //!
 //! ```
 //! # #![allow(dead_code)]
-//! use std::fs::File;
-//! use std::io::prelude::*;
-//! use std::io;
+//! use core::fs::File;
+//! use core::io::prelude::*;
+//! use core::io;
 //!
 //! struct Info {
 //!     name: String,
@@ -432,7 +432,7 @@
 //! [`Ok`] values using [`flatten`][Iterator::flatten].
 //!
 //! ```
-//! # use std::str::FromStr;
+//! # use core::str::FromStr;
 //! let mut results = vec![];
 //! let mut errs = vec![];
 //! let nums: Vec<_> = ["17", "not a number", "99", "-27", "768"]
@@ -588,7 +588,7 @@ impl<T, E> Result<T, E> {
     /// # Examples
     ///
     /// ```
-    /// use std::io::{Error, ErrorKind};
+    /// use core::io::{Error, ErrorKind};
     ///
     /// let x: Result<u32, Error> = Err(Error::new(ErrorKind::NotFound, "!"));
     /// assert_eq!(x.is_err_and(|x| x.kind() == ErrorKind::NotFound), true);
@@ -872,7 +872,7 @@ impl<T, E> Result<T, E> {
     /// ```
     /// #![feature(result_option_inspect)]
     ///
-    /// use std::{fs, io};
+    /// use core::{fs, io};
     ///
     /// fn read() -> io::Result<String> {
     ///     fs::read_to_string("address.txt")
@@ -1021,7 +1021,7 @@ impl<T, E> Result<T, E> {
     /// _expect_ the `Result` should be `Ok`.
     ///
     /// ```should_panic
-    /// let path = std::env::var("IMPORTANT_PATH")
+    /// let path = core::env::var("IMPORTANT_PATH")
     ///     .expect("env variable `IMPORTANT_PATH` should be set by `wrapper_script.sh`");
     /// ```
     ///
@@ -1033,7 +1033,7 @@ impl<T, E> Result<T, E> {
     /// For more detail on expect message styles and the reasoning behind our recommendation please
     /// refer to the section on ["Common Message
     /// Styles"](../../std/error/index.html#common-message-styles) in the
-    /// [`std::error`](../../std/error/index.html) module docs.
+    /// [`core::error`](../../std/error/index.html) module docs.
     #[inline]
     #[track_caller]
     #[stable(feature = "result_expect", since = "1.4.0")]
@@ -1323,7 +1323,7 @@ impl<T, E> Result<T, E> {
     /// Often used to chain fallible operations that may return [`Err`].
     ///
     /// ```
-    /// use std::{io::ErrorKind, path::Path};
+    /// use core::{io::ErrorKind, path::Path};
     ///
     /// // Note: on Windows "/" maps to "C:\"
     /// let root_modified_time = Path::new("/").metadata().and_then(|md| md.modified());

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -154,7 +154,7 @@ mod private_slice_index {
 #[rustc_on_unimplemented(
     on(T = "str", label = "string indices are ranges of `usize`",),
     on(
-        all(any(T = "str", T = "&str", T = "std::string::String"), _Self = "{integer}"),
+        all(any(T = "str", T = "&str", T = "core::string::String"), _Self = "{integer}"),
         note = "you can use `.chars().nth()` or `.bytes().nth()`\n\
                 for more information, see chapter 8 in The Book: \
                 <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>"
@@ -654,7 +654,7 @@ unsafe impl<T> const SliceIndex<[T]> for ops::RangeToInclusive<usize> {
 /// ```
 /// #![feature(slice_range)]
 ///
-/// use std::slice;
+/// use core::slice;
 ///
 /// let v = [10, 40, 30];
 /// assert_eq!(1..2, slice::range(1..2, ..v.len()));
@@ -667,7 +667,7 @@ unsafe impl<T> const SliceIndex<[T]> for ops::RangeToInclusive<usize> {
 /// ```should_panic
 /// #![feature(slice_range)]
 ///
-/// use std::slice;
+/// use core::slice;
 ///
 /// let _ = slice::range(2..1, ..3);
 /// ```
@@ -675,7 +675,7 @@ unsafe impl<T> const SliceIndex<[T]> for ops::RangeToInclusive<usize> {
 /// ```should_panic
 /// #![feature(slice_range)]
 ///
-/// use std::slice;
+/// use core::slice;
 ///
 /// let _ = slice::range(1..4, ..3);
 /// ```
@@ -683,7 +683,7 @@ unsafe impl<T> const SliceIndex<[T]> for ops::RangeToInclusive<usize> {
 /// ```should_panic
 /// #![feature(slice_range)]
 ///
-/// use std::slice;
+/// use core::slice;
 ///
 /// let _ = slice::range(1..=usize::MAX, ..3);
 /// ```

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1,8 +1,8 @@
 //! Slice management and manipulation.
 //!
-//! For more details see [`std::slice`].
+//! For more details see [`core::slice`].
 //!
-//! [`std::slice`]: ../../std/slice/index.html
+//! [`core::slice`]: ../../std/slice/index.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -793,7 +793,7 @@ impl<T> [T] {
     /// use [`Cell::as_slice_of_cells`](crate::cell::Cell::as_slice_of_cells) in
     /// conjunction with `windows` to accomplish something similar:
     /// ```
-    /// use std::cell::Cell;
+    /// use core::cell::Cell;
     ///
     /// let mut array = ['R', 'u', 's', 't', ' ', '2', '0', '1', '5'];
     /// let slice = &mut array[..];
@@ -3699,8 +3699,8 @@ impl<T> [T] {
     /// assert_eq!(it.collect::<Vec<_>>(), vec![1, 2, 3]);
     ///
     /// fn basic_simd_sum(x: &[f32]) -> f32 {
-    ///     use std::ops::Add;
-    ///     use std::simd::f32x4;
+    ///     use core::ops::Add;
+    ///     use core::simd::f32x4;
     ///     let (prefix, middle, suffix) = x.as_simd();
     ///     let sums = f32x4::from_array([
     ///         prefix.iter().copied().sum(),

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -46,7 +46,7 @@ use crate::ptr;
 /// # Examples
 ///
 /// ```
-/// use std::slice;
+/// use core::slice;
 ///
 /// // manifest a slice for a single element
 /// let x = 42;
@@ -60,7 +60,7 @@ use crate::ptr;
 /// The following `join_slices` function is **unsound** ⚠️
 ///
 /// ```rust,no_run
-/// use std::slice;
+/// use core::slice;
 ///
 /// fn join_slices<'a, T>(fst: &'a [T], snd: &'a [T]) -> &'a [T] {
 ///     let fst_end = fst.as_ptr().wrapping_add(fst.len());

--- a/library/core/src/str/converts.rs
+++ b/library/core/src/str/converts.rs
@@ -43,7 +43,7 @@ use super::Utf8Error;
 /// Basic usage:
 ///
 /// ```
-/// use std::str;
+/// use core::str;
 ///
 /// // some bytes, in a vector
 /// let sparkle_heart = vec![240, 159, 146, 150];
@@ -57,7 +57,7 @@ use super::Utf8Error;
 /// Incorrect bytes:
 ///
 /// ```
-/// use std::str;
+/// use core::str;
 ///
 /// // some invalid bytes, in a vector
 /// let sparkle_heart = vec![0, 159, 146, 150];
@@ -71,7 +71,7 @@ use super::Utf8Error;
 /// A "stack allocated string":
 ///
 /// ```
-/// use std::str;
+/// use core::str;
 ///
 /// // some bytes, in a stack-allocated array
 /// let sparkle_heart = [240, 159, 146, 150];
@@ -102,7 +102,7 @@ pub const fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 /// Basic usage:
 ///
 /// ```
-/// use std::str;
+/// use core::str;
 ///
 /// // "Hello, Rust!" as a mutable vector
 /// let mut hellorust = vec![72, 101, 108, 108, 111, 44, 32, 82, 117, 115, 116, 33];
@@ -116,7 +116,7 @@ pub const fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 /// Incorrect bytes:
 ///
 /// ```
-/// use std::str;
+/// use core::str;
 ///
 /// // Some invalid bytes in a mutable vector
 /// let mut invalid = vec![128, 223];
@@ -152,7 +152,7 @@ pub const fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
 /// Basic usage:
 ///
 /// ```
-/// use std::str;
+/// use core::str;
 ///
 /// // some bytes, in a vector
 /// let sparkle_heart = vec![240, 159, 146, 150];
@@ -183,7 +183,7 @@ pub const unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {
 /// Basic usage:
 ///
 /// ```
-/// use std::str;
+/// use core::str;
 ///
 /// let mut heart = vec![240, 159, 146, 150];
 /// let heart = unsafe { str::from_utf8_unchecked_mut(&mut heart) };

--- a/library/core/src/str/error.rs
+++ b/library/core/src/str/error.rs
@@ -20,7 +20,7 @@ use crate::fmt;
 /// ```
 /// fn from_utf8_lossy<F>(mut input: &[u8], mut push: F) where F: FnMut(&str) {
 ///     loop {
-///         match std::str::from_utf8(input) {
+///         match core::str::from_utf8(input) {
 ///             Ok(valid) => {
 ///                 push(valid);
 ///                 break
@@ -28,7 +28,7 @@ use crate::fmt;
 ///             Err(error) => {
 ///                 let (valid, after_valid) = input.split_at(error.valid_up_to());
 ///                 unsafe {
-///                     push(std::str::from_utf8_unchecked(valid))
+///                     push(core::str::from_utf8_unchecked(valid))
 ///                 }
 ///                 push("\u{FFFD}");
 ///
@@ -61,12 +61,12 @@ impl Utf8Error {
     /// Basic usage:
     ///
     /// ```
-    /// use std::str;
+    /// use core::str;
     ///
     /// // some invalid bytes, in a vector
     /// let sparkle_heart = vec![0, 159, 146, 150];
     ///
-    /// // std::str::from_utf8 returns a Utf8Error
+    /// // core::str::from_utf8 returns a Utf8Error
     /// let error = str::from_utf8(&sparkle_heart).unwrap_err();
     ///
     /// // the second byte is invalid here

--- a/library/core/src/str/lossy.rs
+++ b/library/core/src/str/lossy.rs
@@ -16,7 +16,7 @@ use super::validations::utf8_char_width;
 /// ```
 /// #![feature(utf8_chunks)]
 ///
-/// use std::str::Utf8Chunks;
+/// use core::str::Utf8Chunks;
 ///
 /// // An invalid UTF-8 string
 /// let bytes = b"foo\xF1\x80bar";
@@ -125,7 +125,7 @@ impl fmt::Debug for Debug<'_> {
 /// ```
 /// #![feature(utf8_chunks)]
 ///
-/// use std::str::Utf8Chunks;
+/// use core::str::Utf8Chunks;
 ///
 /// fn from_utf8_lossy<F>(input: &[u8], mut push: F) where F: FnMut(&str) {
 ///     for chunk in Utf8Chunks::new(input) {

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1,8 +1,8 @@
 //! String manipulation.
 //!
-//! For more details, see the [`std::str`] module.
+//! For more details, see the [`core::str`] module.
 //!
-//! [`std::str`]: ../../std/str/index.html
+//! [`core::str`]: ../../std/str/index.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -512,7 +512,7 @@ unsafe impl const SliceIndex<str> for ops::RangeToInclusive<usize> {
 /// Basic implementation of `FromStr` on an example `Point` type:
 ///
 /// ```
-/// use std::str::FromStr;
+/// use core::str::FromStr;
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct Point {
@@ -566,7 +566,7 @@ pub trait FromStr: Sized {
     /// Basic usage with [`i32`], a type that implements `FromStr`:
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use core::str::FromStr;
     ///
     /// let s = "5";
     /// let x = i32::from_str(s).unwrap();
@@ -589,7 +589,7 @@ impl FromStr for bool {
     /// # Examples
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use core::str::FromStr;
     ///
     /// assert_eq!(FromStr::from_str("true"), Ok(true));
     /// assert_eq!(FromStr::from_str("false"), Ok(false));

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -84,9 +84,9 @@
 //! A simple spinlock:
 //!
 //! ```
-//! use std::sync::Arc;
-//! use std::sync::atomic::{AtomicUsize, Ordering};
-//! use std::{hint, thread};
+//! use core::sync::Arc;
+//! use core::sync::atomic::{AtomicUsize, Ordering};
+//! use core::{hint, thread};
 //!
 //! fn main() {
 //!     let spinlock = Arc::new(AtomicUsize::new(1));
@@ -110,7 +110,7 @@
 //! Keep a global count of live threads:
 //!
 //! ```
-//! use std::sync::atomic::{AtomicUsize, Ordering};
+//! use core::sync::atomic::{AtomicUsize, Ordering};
 //!
 //! static GLOBAL_THREAD_COUNT: AtomicUsize = AtomicUsize::new(0);
 //!
@@ -292,7 +292,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::AtomicBool;
+    /// use core::sync::atomic::AtomicBool;
     ///
     /// let atomic_true = AtomicBool::new(true);
     /// let atomic_false = AtomicBool::new(false);
@@ -311,8 +311,8 @@ impl AtomicBool {
     ///
     /// ```
     /// #![feature(atomic_from_ptr, pointer_is_aligned)]
-    /// use std::sync::atomic::{self, AtomicBool};
-    /// use std::mem::align_of;
+    /// use core::sync::atomic::{self, AtomicBool};
+    /// use core::mem::align_of;
     ///
     /// // Get a pointer to an allocated value
     /// let ptr: *mut bool = Box::into_raw(Box::new(false));
@@ -357,7 +357,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let mut some_bool = AtomicBool::new(true);
     /// assert_eq!(*some_bool.get_mut(), true);
@@ -377,7 +377,7 @@ impl AtomicBool {
     ///
     /// ```
     /// #![feature(atomic_from_mut)]
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let mut some_bool = true;
     /// let a = AtomicBool::from_mut(&mut some_bool);
@@ -402,7 +402,7 @@ impl AtomicBool {
     ///
     /// ```
     /// #![feature(atomic_from_mut, inline_const)]
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let mut some_bools = [const { AtomicBool::new(false) }; 10];
     ///
@@ -410,7 +410,7 @@ impl AtomicBool {
     /// assert_eq!(view, [false; 10]);
     /// view[..5].copy_from_slice(&[true; 5]);
     ///
-    /// std::thread::scope(|s| {
+    /// core::thread::scope(|s| {
     ///     for t in &some_bools[..5] {
     ///         s.spawn(move || assert_eq!(t.load(Ordering::Relaxed), true));
     ///     }
@@ -433,11 +433,11 @@ impl AtomicBool {
     ///
     /// ```
     /// #![feature(atomic_from_mut)]
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let mut some_bools = [false; 10];
     /// let a = &*AtomicBool::from_mut_slice(&mut some_bools);
-    /// std::thread::scope(|s| {
+    /// core::thread::scope(|s| {
     ///     for i in 0..a.len() {
     ///         s.spawn(move || a[i].store(true, Ordering::Relaxed));
     ///     }
@@ -461,7 +461,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::AtomicBool;
+    /// use core::sync::atomic::AtomicBool;
     ///
     /// let some_bool = AtomicBool::new(true);
     /// assert_eq!(some_bool.into_inner(), true);
@@ -485,7 +485,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let some_bool = AtomicBool::new(true);
     ///
@@ -512,7 +512,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let some_bool = AtomicBool::new(true);
     ///
@@ -543,7 +543,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let some_bool = AtomicBool::new(true);
     ///
@@ -593,7 +593,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let some_bool = AtomicBool::new(true);
     ///
@@ -637,7 +637,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let some_bool = AtomicBool::new(true);
     ///
@@ -696,7 +696,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let val = AtomicBool::new(false);
     ///
@@ -748,7 +748,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let foo = AtomicBool::new(true);
     /// assert_eq!(foo.fetch_and(false, Ordering::SeqCst), true);
@@ -789,7 +789,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let foo = AtomicBool::new(true);
     /// assert_eq!(foo.fetch_nand(false, Ordering::SeqCst), true);
@@ -842,7 +842,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let foo = AtomicBool::new(true);
     /// assert_eq!(foo.fetch_or(false, Ordering::SeqCst), true);
@@ -883,7 +883,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let foo = AtomicBool::new(true);
     /// assert_eq!(foo.fetch_xor(false, Ordering::SeqCst), true);
@@ -925,7 +925,7 @@ impl AtomicBool {
     ///
     /// ```
     /// #![feature(atomic_bool_fetch_not)]
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let foo = AtomicBool::new(true);
     /// assert_eq!(foo.fetch_not(Ordering::SeqCst), true);
@@ -959,7 +959,7 @@ impl AtomicBool {
     ///
     /// ```ignore (extern-declaration)
     /// # fn main() {
-    /// use std::sync::atomic::AtomicBool;
+    /// use core::sync::atomic::AtomicBool;
     ///
     /// extern "C" {
     ///     fn my_atomic_op(arg: *mut bool);
@@ -1012,7 +1012,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```rust
-    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use core::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let x = AtomicBool::new(false);
     /// assert_eq!(x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |_| None), Err(false));
@@ -1051,7 +1051,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::AtomicPtr;
+    /// use core::sync::atomic::AtomicPtr;
     ///
     /// let ptr = &mut 5;
     /// let atomic_ptr = AtomicPtr::new(ptr);
@@ -1069,11 +1069,11 @@ impl<T> AtomicPtr<T> {
     ///
     /// ```
     /// #![feature(atomic_from_ptr, pointer_is_aligned)]
-    /// use std::sync::atomic::{self, AtomicPtr};
-    /// use std::mem::align_of;
+    /// use core::sync::atomic::{self, AtomicPtr};
+    /// use core::mem::align_of;
     ///
     /// // Get a pointer to an allocated value
-    /// let ptr: *mut *mut u8 = Box::into_raw(Box::new(std::ptr::null_mut()));
+    /// let ptr: *mut *mut u8 = Box::into_raw(Box::new(core::ptr::null_mut()));
     ///
     /// assert!(ptr.is_aligned_to(align_of::<AtomicPtr<u8>>()));
     ///
@@ -1082,7 +1082,7 @@ impl<T> AtomicPtr<T> {
     ///     let atomic = unsafe { AtomicPtr::from_ptr(ptr) };
     ///
     ///     // Use `atomic` for atomic operations, possibly share it with other threads
-    ///     atomic.store(std::ptr::NonNull::dangling().as_ptr(), atomic::Ordering::Relaxed);
+    ///     atomic.store(core::ptr::NonNull::dangling().as_ptr(), atomic::Ordering::Relaxed);
     /// }
     ///
     /// // It's ok to non-atomically access the value behind `ptr`,
@@ -1115,7 +1115,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let mut data = 10;
     /// let mut atomic_ptr = AtomicPtr::new(&mut data);
@@ -1135,7 +1135,7 @@ impl<T> AtomicPtr<T> {
     ///
     /// ```
     /// #![feature(atomic_from_mut)]
-    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let mut data = 123;
     /// let mut some_ptr = &mut data as *mut i32;
@@ -1166,8 +1166,8 @@ impl<T> AtomicPtr<T> {
     ///
     /// ```
     /// #![feature(atomic_from_mut, inline_const)]
-    /// use std::ptr::null_mut;
-    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    /// use core::ptr::null_mut;
+    /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let mut some_ptrs = [const { AtomicPtr::new(null_mut::<String>()) }; 10];
     ///
@@ -1178,7 +1178,7 @@ impl<T> AtomicPtr<T> {
     ///     .enumerate()
     ///     .for_each(|(i, ptr)| *ptr = Box::into_raw(Box::new(format!("iteration#{i}"))));
     ///
-    /// std::thread::scope(|s| {
+    /// core::thread::scope(|s| {
     ///     for ptr in &some_ptrs {
     ///         s.spawn(move || {
     ///             let ptr = ptr.load(Ordering::Relaxed);
@@ -1203,12 +1203,12 @@ impl<T> AtomicPtr<T> {
     ///
     /// ```
     /// #![feature(atomic_from_mut)]
-    /// use std::ptr::null_mut;
-    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    /// use core::ptr::null_mut;
+    /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let mut some_ptrs = [null_mut::<String>(); 10];
     /// let a = &*AtomicPtr::from_mut_slice(&mut some_ptrs);
-    /// std::thread::scope(|s| {
+    /// core::thread::scope(|s| {
     ///     for i in 0..a.len() {
     ///         s.spawn(move || {
     ///             let name = Box::new(format!("thread{i}"));
@@ -1241,7 +1241,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::AtomicPtr;
+    /// use core::sync::atomic::AtomicPtr;
     ///
     /// let mut data = 5;
     /// let atomic_ptr = AtomicPtr::new(&mut data);
@@ -1266,7 +1266,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let ptr = &mut 5;
     /// let some_ptr = AtomicPtr::new(ptr);
@@ -1293,7 +1293,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let ptr = &mut 5;
     /// let some_ptr = AtomicPtr::new(ptr);
@@ -1325,7 +1325,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let ptr = &mut 5;
     /// let some_ptr = AtomicPtr::new(ptr);
@@ -1377,7 +1377,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let ptr = &mut 5;
     /// let some_ptr = AtomicPtr::new(ptr);
@@ -1420,7 +1420,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let ptr = &mut 5;
     /// let some_ptr = AtomicPtr::new(ptr);
@@ -1466,7 +1466,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let some_ptr = AtomicPtr::new(&mut 5);
     ///
@@ -1531,7 +1531,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let ptr: *mut _ = &mut 5;
     /// let some_ptr = AtomicPtr::new(ptr);
@@ -1892,7 +1892,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```ignore (extern-declaration)
-    /// use std::sync::atomic::AtomicPtr;
+    /// use core::sync::atomic::AtomicPtr;
     ///
     /// extern "C" {
     ///     fn my_atomic_op(arg: *mut *mut u32);
@@ -1923,7 +1923,7 @@ impl const From<bool> for AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomic::AtomicBool;
+    /// use core::sync::atomic::AtomicBool;
     /// let atomic_bool = AtomicBool::from(true);
     /// assert_eq!(format!("{atomic_bool:?}"), "true")
     /// ```
@@ -2035,7 +2035,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::", stringify!($atomic_type), ";")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::", stringify!($atomic_type), ";")]
             ///
             #[doc = concat!("let atomic_forty_two = ", stringify!($atomic_type), "::new(42);")]
             /// ```
@@ -2053,8 +2053,8 @@ macro_rules! atomic_int {
             ///
             /// ```
             /// #![feature(atomic_from_ptr, pointer_is_aligned)]
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{self, ", stringify!($atomic_type), "};")]
-            /// use std::mem::align_of;
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{self, ", stringify!($atomic_type), "};")]
+            /// use core::mem::align_of;
             ///
             /// // Get a pointer to an allocated value
             #[doc = concat!("let ptr: *mut ", stringify!($int_type), " = Box::into_raw(Box::new(0));")]
@@ -2102,7 +2102,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let mut some_var = ", stringify!($atomic_type), "::new(10);")]
             /// assert_eq!(*some_var.get_mut(), 10);
@@ -2129,7 +2129,7 @@ macro_rules! atomic_int {
             ///
             /// ```
             /// #![feature(atomic_from_mut)]
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             /// let mut some_int = 123;
             #[doc = concat!("let a = ", stringify!($atomic_type), "::from_mut(&mut some_int);")]
@@ -2159,7 +2159,7 @@ macro_rules! atomic_int {
             ///
             /// ```
             /// #![feature(atomic_from_mut, inline_const)]
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let mut some_ints = [const { ", stringify!($atomic_type), "::new(0) }; 10];")]
             ///
@@ -2170,7 +2170,7 @@ macro_rules! atomic_int {
             ///     .enumerate()
             ///     .for_each(|(idx, int)| *int = idx as _);
             ///
-            /// std::thread::scope(|s| {
+            /// core::thread::scope(|s| {
             ///     some_ints
             ///         .iter()
             ///         .enumerate()
@@ -2192,11 +2192,11 @@ macro_rules! atomic_int {
             ///
             /// ```
             /// #![feature(atomic_from_mut)]
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             /// let mut some_ints = [0; 10];
             #[doc = concat!("let a = &*", stringify!($atomic_type), "::from_mut_slice(&mut some_ints);")]
-            /// std::thread::scope(|s| {
+            /// core::thread::scope(|s| {
             ///     for i in 0..a.len() {
             ///         s.spawn(move || a[i].store(i as _, Ordering::Relaxed));
             ///     }
@@ -2226,7 +2226,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::", stringify!($atomic_type), ";")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::", stringify!($atomic_type), ";")]
             ///
             #[doc = concat!("let some_var = ", stringify!($atomic_type), "::new(5);")]
             /// assert_eq!(some_var.into_inner(), 5);
@@ -2250,7 +2250,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let some_var = ", stringify!($atomic_type), "::new(5);")]
             ///
@@ -2276,7 +2276,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let some_var = ", stringify!($atomic_type), "::new(5);")]
             ///
@@ -2304,7 +2304,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let some_var = ", stringify!($atomic_type), "::new(5);")]
             ///
@@ -2354,7 +2354,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let some_var = ", stringify!($atomic_type), "::new(5);")]
             ///
@@ -2406,7 +2406,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let some_var = ", stringify!($atomic_type), "::new(5);")]
             ///
@@ -2458,7 +2458,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let val = ", stringify!($atomic_type), "::new(4);")]
             ///
@@ -2501,7 +2501,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let foo = ", stringify!($atomic_type), "::new(0);")]
             /// assert_eq!(foo.fetch_add(10, Ordering::SeqCst), 0);
@@ -2531,7 +2531,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let foo = ", stringify!($atomic_type), "::new(20);")]
             /// assert_eq!(foo.fetch_sub(10, Ordering::SeqCst), 20);
@@ -2564,7 +2564,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let foo = ", stringify!($atomic_type), "::new(0b101101);")]
             /// assert_eq!(foo.fetch_and(0b110011, Ordering::SeqCst), 0b101101);
@@ -2597,7 +2597,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let foo = ", stringify!($atomic_type), "::new(0x13);")]
             /// assert_eq!(foo.fetch_nand(0x31, Ordering::SeqCst), 0x13);
@@ -2630,7 +2630,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let foo = ", stringify!($atomic_type), "::new(0b101101);")]
             /// assert_eq!(foo.fetch_or(0b110011, Ordering::SeqCst), 0b101101);
@@ -2663,7 +2663,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let foo = ", stringify!($atomic_type), "::new(0b101101);")]
             /// assert_eq!(foo.fetch_xor(0b110011, Ordering::SeqCst), 0b101101);
@@ -2712,7 +2712,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```rust
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let x = ", stringify!($atomic_type), "::new(7);")]
             /// assert_eq!(x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |_| None), Err(7));
@@ -2757,7 +2757,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let foo = ", stringify!($atomic_type), "::new(23);")]
             /// assert_eq!(foo.fetch_max(42, Ordering::SeqCst), 23);
@@ -2767,7 +2767,7 @@ macro_rules! atomic_int {
             /// If you want to obtain the maximum value in one step, you can use the following:
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let foo = ", stringify!($atomic_type), "::new(23);")]
             /// let bar = 42;
@@ -2801,7 +2801,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let foo = ", stringify!($atomic_type), "::new(23);")]
             /// assert_eq!(foo.fetch_min(42, Ordering::Relaxed), 23);
@@ -2813,7 +2813,7 @@ macro_rules! atomic_int {
             /// If you want to obtain the minimum value in one step, you can use the following:
             ///
             /// ```
-            #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let foo = ", stringify!($atomic_type), "::new(23);")]
             /// let bar = 12;
@@ -2845,7 +2845,7 @@ macro_rules! atomic_int {
             ///
             /// ```ignore (extern-declaration)
             /// # fn main() {
-            #[doc = concat!($extra_feature, "use std::sync::atomic::", stringify!($atomic_type), ";")]
+            #[doc = concat!($extra_feature, "use core::sync::atomic::", stringify!($atomic_type), ";")]
             ///
             /// extern "C" {
             #[doc = concat!("    fn my_atomic_op(arg: *mut ", stringify!($int_type), ");")]
@@ -3459,9 +3459,9 @@ unsafe fn atomic_umin<T: Copy>(dst: *mut T, val: T, order: Ordering) -> T {
 /// # Examples
 ///
 /// ```
-/// use std::sync::atomic::AtomicBool;
-/// use std::sync::atomic::fence;
-/// use std::sync::atomic::Ordering;
+/// use core::sync::atomic::AtomicBool;
+/// use core::sync::atomic::fence;
+/// use core::sync::atomic::Ordering;
 ///
 /// // A mutual exclusion primitive based on spinlock.
 /// pub struct Mutex {
@@ -3552,9 +3552,9 @@ pub fn fence(order: Ordering) {
 /// Using a `compiler_fence` remedies this situation.
 ///
 /// ```
-/// use std::sync::atomic::{AtomicBool, AtomicUsize};
-/// use std::sync::atomic::Ordering;
-/// use std::sync::atomic::compiler_fence;
+/// use core::sync::atomic::{AtomicBool, AtomicUsize};
+/// use core::sync::atomic::Ordering;
+/// use core::sync::atomic::compiler_fence;
 ///
 /// static IMPORTANT_VARIABLE: AtomicUsize = AtomicUsize::new(0);
 /// static IS_READY: AtomicBool = AtomicBool::new(false);

--- a/library/core/src/task/poll.rs
+++ b/library/core/src/task/poll.rs
@@ -107,9 +107,9 @@ impl<T> Poll<T> {
     /// ```rust
     /// #![feature(poll_ready)]
     ///
-    /// use std::task::{Context, Poll};
-    /// use std::future::{self, Future};
-    /// use std::pin::Pin;
+    /// use core::task::{Context, Poll};
+    /// use core::future::{self, Future};
+    /// use core::pin::Pin;
     ///
     /// pub fn do_poll(cx: &mut Context<'_>) -> Poll<()> {
     ///     let mut fut = future::ready(42);

--- a/library/core/src/task/ready.rs
+++ b/library/core/src/task/ready.rs
@@ -13,9 +13,9 @@ use core::task::Poll;
 /// # Examples
 ///
 /// ```
-/// use std::task::{ready, Context, Poll};
-/// use std::future::{self, Future};
-/// use std::pin::Pin;
+/// use core::task::{ready, Context, Poll};
+/// use core::future::{self, Future};
+/// use core::pin::Pin;
 ///
 /// pub fn do_poll(cx: &mut Context<'_>) -> Poll<()> {
 ///     let mut fut = future::ready(42);
@@ -32,9 +32,9 @@ use core::task::Poll;
 /// The `ready!` call expands to:
 ///
 /// ```
-/// # use std::task::{Context, Poll};
-/// # use std::future::{self, Future};
-/// # use std::pin::Pin;
+/// # use core::task::{Context, Poll};
+/// # use core::future::{self, Future};
+/// # use core::pin::Pin;
 /// #
 /// # pub fn do_poll(cx: &mut Context<'_>) -> Poll<()> {
 ///     # let mut fut = future::ready(42);

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -7,7 +7,7 @@
 //! There are multiple ways to create a new [`Duration`]:
 //!
 //! ```
-//! # use std::time::Duration;
+//! # use core::time::Duration;
 //! let five_seconds = Duration::from_secs(5);
 //! assert_eq!(five_seconds, Duration::from_millis(5_000));
 //! assert_eq!(five_seconds, Duration::from_micros(5_000_000));
@@ -59,7 +59,7 @@ impl Default for Nanoseconds {
 /// # Examples
 ///
 /// ```
-/// use std::time::Duration;
+/// use core::time::Duration;
 ///
 /// let five_seconds = Duration::new(5, 0);
 /// let five_seconds_and_five_nanos = five_seconds + Duration::new(0, 5);
@@ -95,7 +95,7 @@ impl Duration {
     ///
     /// ```
     /// #![feature(duration_constants)]
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert_eq!(Duration::SECOND, Duration::from_secs(1));
     /// ```
@@ -108,7 +108,7 @@ impl Duration {
     ///
     /// ```
     /// #![feature(duration_constants)]
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert_eq!(Duration::MILLISECOND, Duration::from_millis(1));
     /// ```
@@ -121,7 +121,7 @@ impl Duration {
     ///
     /// ```
     /// #![feature(duration_constants)]
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert_eq!(Duration::MICROSECOND, Duration::from_micros(1));
     /// ```
@@ -134,7 +134,7 @@ impl Duration {
     ///
     /// ```
     /// #![feature(duration_constants)]
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert_eq!(Duration::NANOSECOND, Duration::from_nanos(1));
     /// ```
@@ -146,7 +146,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let duration = Duration::ZERO;
     /// assert!(duration.is_zero());
@@ -165,7 +165,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert_eq!(Duration::MAX, Duration::new(u64::MAX, 1_000_000_000 - 1));
     /// ```
@@ -188,7 +188,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let five_seconds = Duration::new(5, 0);
     /// ```
@@ -211,7 +211,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let duration = Duration::from_secs(5);
     ///
@@ -231,7 +231,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let duration = Duration::from_millis(2569);
     ///
@@ -251,7 +251,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let duration = Duration::from_micros(1_000_002);
     ///
@@ -271,7 +271,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let duration = Duration::from_nanos(1_000_000_123);
     ///
@@ -291,7 +291,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert!(Duration::ZERO.is_zero());
     /// assert!(Duration::new(0, 0).is_zero());
@@ -318,7 +318,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_secs(), 5);
@@ -347,7 +347,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let duration = Duration::from_millis(5432);
     /// assert_eq!(duration.as_secs(), 5);
@@ -370,7 +370,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let duration = Duration::from_micros(1_234_567);
     /// assert_eq!(duration.as_secs(), 1);
@@ -393,7 +393,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let duration = Duration::from_millis(5010);
     /// assert_eq!(duration.as_secs(), 5);
@@ -412,7 +412,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_millis(), 5730);
@@ -430,7 +430,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_micros(), 5730023);
@@ -448,7 +448,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_nanos(), 5730023852);
@@ -469,7 +469,7 @@ impl Duration {
     /// Basic usage:
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert_eq!(Duration::new(0, 0).checked_add(Duration::new(0, 1)), Some(Duration::new(0, 1)));
     /// assert_eq!(Duration::new(1, 0).checked_add(Duration::new(u64::MAX, 0)), None);
@@ -504,7 +504,7 @@ impl Duration {
     ///
     /// ```
     /// #![feature(duration_constants)]
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert_eq!(Duration::new(0, 0).saturating_add(Duration::new(0, 1)), Duration::new(0, 1));
     /// assert_eq!(Duration::new(1, 0).saturating_add(Duration::new(u64::MAX, 0)), Duration::MAX);
@@ -529,7 +529,7 @@ impl Duration {
     /// Basic usage:
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert_eq!(Duration::new(0, 1).checked_sub(Duration::new(0, 0)), Some(Duration::new(0, 1)));
     /// assert_eq!(Duration::new(0, 0).checked_sub(Duration::new(0, 1)), None);
@@ -562,7 +562,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert_eq!(Duration::new(0, 1).saturating_sub(Duration::new(0, 0)), Duration::new(0, 1));
     /// assert_eq!(Duration::new(0, 0).saturating_sub(Duration::new(0, 1)), Duration::ZERO);
@@ -587,7 +587,7 @@ impl Duration {
     /// Basic usage:
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert_eq!(Duration::new(0, 500_000_001).checked_mul(2), Some(Duration::new(1, 2)));
     /// assert_eq!(Duration::new(u64::MAX - 1, 0).checked_mul(2), None);
@@ -618,7 +618,7 @@ impl Duration {
     ///
     /// ```
     /// #![feature(duration_constants)]
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert_eq!(Duration::new(0, 500_000_001).saturating_mul(2), Duration::new(1, 2));
     /// assert_eq!(Duration::new(u64::MAX - 1, 0).saturating_mul(2), Duration::MAX);
@@ -643,7 +643,7 @@ impl Duration {
     /// Basic usage:
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// assert_eq!(Duration::new(2, 0).checked_div(2), Some(Duration::new(1, 0)));
     /// assert_eq!(Duration::new(1, 0).checked_div(2), Some(Duration::new(0, 500_000_000)));
@@ -673,7 +673,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
     /// assert_eq!(dur.as_secs_f64(), 2.7);
@@ -692,7 +692,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
     /// assert_eq!(dur.as_secs_f32(), 2.7);
@@ -713,7 +713,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let res = Duration::from_secs_f64(0.0);
     /// assert_eq!(res, Duration::new(0, 0));
@@ -751,7 +751,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let res = Duration::from_secs_f32(0.0);
     /// assert_eq!(res, Duration::new(0, 0));
@@ -788,7 +788,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
     /// assert_eq!(dur.mul_f64(3.14), Duration::new(8, 478_000_000));
@@ -810,7 +810,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
     /// assert_eq!(dur.mul_f32(3.14), Duration::new(8, 478_000_641));
@@ -832,7 +832,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
     /// assert_eq!(dur.div_f64(3.14), Duration::new(0, 859_872_611));
@@ -854,7 +854,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
     /// // note that due to rounding errors result is slightly
@@ -876,7 +876,7 @@ impl Duration {
     /// # Examples
     /// ```
     /// #![feature(div_duration)]
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let dur1 = Duration::new(2, 700_000_000);
     /// let dur2 = Duration::new(5, 400_000_000);
@@ -896,7 +896,7 @@ impl Duration {
     /// # Examples
     /// ```
     /// #![feature(div_duration)]
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let dur1 = Duration::new(2, 700_000_000);
     /// let dur2 = Duration::new(5, 400_000_000);
@@ -1225,7 +1225,7 @@ impl fmt::Debug for Duration {
 /// # Example
 ///
 /// ```
-/// use std::time::Duration;
+/// use core::time::Duration;
 ///
 /// if let Err(e) = Duration::try_from_secs_f32(-1.0) {
 ///     println!("Failed conversion to Duration: {e}");
@@ -1354,7 +1354,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let res = Duration::try_from_secs_f32(0.0);
     /// assert_eq!(res, Ok(Duration::new(0, 0)));
@@ -1423,7 +1423,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let res = Duration::try_from_secs_f64(0.0);
     /// assert_eq!(res, Ok(Duration::new(0, 0)));

--- a/library/core/src/unicode/unicode_data.rs
+++ b/library/core/src/unicode/unicode_data.rs
@@ -65,7 +65,7 @@ fn skip_search<const SOR: usize, const OFFSETS: usize>(
     offsets: &[u8; OFFSETS],
 ) -> bool {
     // Note that this *cannot* be past the end of the array, as the last
-    // element is greater than std::char::MAX (the largest possible needle).
+    // element is greater than core::char::MAX (the largest possible needle).
     //
     // So, we cannot have found it (i.e. Ok(idx) + 1 != length) and the correct
     // location cannot be past it, so Err(idx) != length either.

--- a/library/core/src/unit.rs
+++ b/library/core/src/unit.rs
@@ -6,7 +6,7 @@ use crate::iter::FromIterator;
 /// collecting to a `Result<(), E>` where you only care about errors:
 ///
 /// ```
-/// use std::io::*;
+/// use core::io::*;
 /// let data = vec![1, 2, 3, 4, 5];
 /// let res: Result<()> = data.iter()
 ///     .map(|x| writeln!(stdout(), "{x}"))


### PR DESCRIPTION
I noticed while reading the core documentation that many times it instructs the user to `use std::` instead of `use core::`, and this seems wrong to me since, as far as I know, you use core when you are in a nostd environment.

I am currently busy and can't compile it at the moment to make sure I didn't break anything, but I did a simple `grep -rl "std::" src/ | xargs sed -i "s/std::/core::/g"` in the /libraries/core directory and this should do the trick.

I didn't put a massive amount of effort into this I'm willing to admit but I do think this minor change is a decent correction to the documentation.

Feel free to correct me or point out any places where I may have broke the code.