### PR TITLE
clean up `transmute`s in `core`

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1287,7 +1287,7 @@ impl<T, const N: usize> MaybeUninit<[T; N]> {
     #[inline]
     pub const fn transpose(self) -> [MaybeUninit<T>; N] {
         // SAFETY: T and MaybeUninit<T> have the same layout
-        unsafe { super::transmute_copy(&ManuallyDrop::new(self)) }
+        unsafe { intrinsics::transmute_unchecked(self) }
     }
 }
 
@@ -1307,6 +1307,6 @@ impl<T, const N: usize> [MaybeUninit<T>; N] {
     #[inline]
     pub const fn transpose(self) -> MaybeUninit<[T; N]> {
         // SAFETY: T and MaybeUninit<T> have the same layout
-        unsafe { super::transmute_copy(&ManuallyDrop::new(self)) }
+        unsafe { intrinsics::transmute_unchecked(self) }
     }
 }


### PR DESCRIPTION
* Use `transmute_unchecked` instead of `transmute_copy` for `MaybeUninit::transpose`.
* Use manual transmute for `Option<Ordering>` → `i8`.