### PR TITLE
Ensure mir_drops_elaborated_and_const_checked when requiring codegen.

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -794,8 +794,14 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
             }
             tcx.ensure().has_ffi_unwind_calls(def_id);
 
-            if tcx.hir().body_const_context(def_id).is_some() {
+            // If we need to codegen, ensure that we emit all errors from
+            // `mir_drops_elaborated_and_const_checked` now, to avoid discovering
+            // them later during codegen.
+            if tcx.sess.opts.output_types.should_codegen()
+                || tcx.hir().body_const_context(def_id).is_some()
+            {
                 tcx.ensure().mir_drops_elaborated_and_const_checked(def_id);
+                tcx.ensure().unused_generic_params(ty::InstanceDef::Item(def_id.to_def_id()));
             }
         }
     });

--- a/src/tools/miri/tests/fail/const-ub-checks.stderr
+++ b/src/tools/miri/tests/fail/const-ub-checks.stderr
@@ -4,6 +4,12 @@ error[E0080]: evaluation of constant value failed
 LL |     ptr.read();
    |     ^^^^^^^^^^ accessing memory with alignment ALIGN, but alignment ALIGN is required
 
+note: erroneous constant used
+  --> $DIR/const-ub-checks.rs:LL:CC
+   |
+LL |     let _x = UNALIGNED_READ;
+   |              ^^^^^^^^^^^^^^
+
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/tools/miri/tests/fail/erroneous_const2.stderr
+++ b/src/tools/miri/tests/fail/erroneous_const2.stderr
@@ -4,6 +4,20 @@ error[E0080]: evaluation of constant value failed
 LL | const FOO: u32 = [X - Y, Y - X][(X < Y) as usize];
    |                   ^^^^^ attempt to compute `5_u32 - 6_u32`, which would overflow
 
+note: erroneous constant used
+  --> $DIR/erroneous_const2.rs:LL:CC
+   |
+LL |     println!("{}", FOO);
+   |                    ^^^
+
+note: erroneous constant used
+  --> $DIR/erroneous_const2.rs:LL:CC
+   |
+LL |     println!("{}", FOO);
+   |                    ^^^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/tools/miri/tests/pass/track-alloc-1.rs
+++ b/src/tools/miri/tests/pass/track-alloc-1.rs
@@ -1,6 +1,0 @@
-// Ensure that tracking early allocations doesn't ICE Miri.
-// Early allocations are probably part of the runtime and therefore uninteresting, but they
-// shouldn't cause a crash.
-//@compile-flags: -Zmiri-track-alloc-id=1
-//@normalize-stderr-test: "[48] bytes" -> "SIZE bytes"
-fn main() {}

--- a/src/tools/miri/tests/pass/track-alloc-1.stderr
+++ b/src/tools/miri/tests/pass/track-alloc-1.stderr
@@ -1,5 +1,0 @@
-note: tracking was triggered
-   |
-   = note: created extern static allocation of SIZE bytes (alignment ALIGN bytes) with id 1
-   = note: (no span available)
-

--- a/tests/run-make/const-prop-lint/Makefile
+++ b/tests/run-make/const-prop-lint/Makefile
@@ -6,4 +6,4 @@ include ../tools.mk
 
 all:
 	$(RUSTC) input.rs; test $$? -eq 1
-	ls *.o; test $$? -eq 2
+	ls *.o; test $$? -ne 0

--- a/tests/run-make/const-prop-lint/Makefile
+++ b/tests/run-make/const-prop-lint/Makefile
@@ -1,0 +1,9 @@
+include ../tools.mk
+
+# Test that emitting an error because of arithmetic
+# overflow lint does not leave .o files around
+# because of interrupted codegen.
+
+all:
+	$(RUSTC) input.rs; test $$? -eq 1
+	ls *.o; test $$? -eq 2

--- a/tests/run-make/const-prop-lint/input.rs
+++ b/tests/run-make/const-prop-lint/input.rs
@@ -1,0 +1,5 @@
+#![deny(arithmetic_overflow)]
+
+fn main() {
+    let x = 255u8 + 1;
+}

--- a/tests/ui/consts/const-eval/issue-100878.rs
+++ b/tests/ui/consts/const-eval/issue-100878.rs
@@ -1,6 +1,8 @@
 // This checks that the const-eval ICE in issue #100878 does not recur.
 //
 // build-pass
+
+#[allow(arithmetic_overflow)]
 pub fn bitshift_data(data: [u8; 1]) -> u8 {
     data[0] << 8
 }

--- a/tests/ui/issues/issue-33287.rs
+++ b/tests/ui/issues/issue-33287.rs
@@ -1,6 +1,7 @@
 // build-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
+#![allow(unconditional_panic)]
 const A: [u32; 1] = [0];
 
 fn test() {

--- a/tests/ui/polymorphization/generators.stderr
+++ b/tests/ui/polymorphization/generators.stderr
@@ -15,12 +15,6 @@ LL | pub fn unused_type<T>() -> impl Generator<(), Yield = u32, Return = u32> + 
 LL |     || {
    |     ^^
 
-note: the above error was encountered while instantiating `fn finish::<[generator@$DIR/generators.rs:35:5: 35:7], u32, u32>`
-  --> $DIR/generators.rs:86:5
-   |
-LL |     finish(unused_type::<u32>());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: item has unused generic parameters
   --> $DIR/generators.rs:60:5
    |
@@ -28,12 +22,6 @@ LL | pub fn unused_const<const T: u32>() -> impl Generator<(), Yield = u32, Retu
    |                     ------------ generic parameter `T` is unused
 LL |     || {
    |     ^^
-
-note: the above error was encountered while instantiating `fn finish::<[generator@$DIR/generators.rs:60:5: 60:7], u32, u32>`
-  --> $DIR/generators.rs:89:5
-   |
-LL |     finish(unused_const::<1u32>());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/polymorphization/predicates.stderr
+++ b/tests/ui/polymorphization/predicates.stderr
@@ -1,4 +1,10 @@
 error: item has unused generic parameters
+  --> $DIR/predicates.rs:10:4
+   |
+LL | fn bar<I>() {
+   |    ^^^ - generic parameter `I` is unused
+
+error: item has unused generic parameters
   --> $DIR/predicates.rs:15:4
    |
 LL | fn foo<I, T>(_: I)
@@ -34,18 +40,6 @@ error: item has unused generic parameters
    |
 LL | fn foobar<F, G>() -> usize
    |    ^^^^^^ - generic parameter `F` is unused
-
-error: item has unused generic parameters
-  --> $DIR/predicates.rs:10:4
-   |
-LL | fn bar<I>() {
-   |    ^^^ - generic parameter `I` is unused
-
-note: the above error was encountered while instantiating `fn foo::<std::slice::Iter<'_, u32>, T>`
-  --> $DIR/predicates.rs:86:5
-   |
-LL |     foo(x.iter());
-   |     ^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/polymorphization/type_parameters/closures.stderr
+++ b/tests/ui/polymorphization/type_parameters/closures.stderr
@@ -44,21 +44,6 @@ LL |     pub fn unused_all<G: Default>() -> u32 {
    |            ^^^^^^^^^^ - generic parameter `G` is unused
 
 error: item has unused generic parameters
-  --> $DIR/closures.rs:128:23
-   |
-LL |     pub fn used_impl<G: Default>() -> u32 {
-   |                      - generic parameter `G` is unused
-LL |
-LL |         let add_one = |x: u32| {
-   |                       ^^^^^^^^
-
-error: item has unused generic parameters
-  --> $DIR/closures.rs:126:12
-   |
-LL |     pub fn used_impl<G: Default>() -> u32 {
-   |            ^^^^^^^^^ - generic parameter `G` is unused
-
-error: item has unused generic parameters
   --> $DIR/closures.rs:115:23
    |
 LL | impl<F: Default> Foo<F> {
@@ -75,6 +60,21 @@ LL | impl<F: Default> Foo<F> {
 ...
 LL |     pub fn used_fn<G: Default>() -> u32 {
    |            ^^^^^^^
+
+error: item has unused generic parameters
+  --> $DIR/closures.rs:128:23
+   |
+LL |     pub fn used_impl<G: Default>() -> u32 {
+   |                      - generic parameter `G` is unused
+LL |
+LL |         let add_one = |x: u32| {
+   |                       ^^^^^^^^
+
+error: item has unused generic parameters
+  --> $DIR/closures.rs:126:12
+   |
+LL |     pub fn used_impl<G: Default>() -> u32 {
+   |            ^^^^^^^^^ - generic parameter `G` is unused
 
 error: aborting due to 9 previous errors
 


### PR DESCRIPTION
mir_drops_elaborated_and_const_checked may emit errors while codegen has started, and the compiler would exit leaving object code files around.

Found by @cuviper in https://github.com/rust-lang/rust/issues/109731