### PR TITLE
Use `Display` in top-level example for `PanicInfo`

### DIFF
--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -15,14 +15,10 @@ use crate::panic::Location;
 /// use std::panic;
 ///
 /// panic::set_hook(Box::new(|panic_info| {
-///     if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
-///         println!("panic occurred: {s:?}");
-///     } else {
-///         println!("panic occurred");
-///     }
+///     println!("panic occurred: {panic_info}");
 /// }));
 ///
-/// panic!("Normal panic");
+/// panic!("critical system failure");
 /// ```
 #[lang = "panic_info"]
 #[stable(feature = "panic_hooks", since = "1.10.0")]


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/issues/110098.

This confused me as well, when I was writing a `no_std` panic handler for the first time, so here's a better top-level example.

`Display` is stable, prints the `.message()` if available, and falls back to `.payload().downcast_ref<&str>()` if the message is not available. So this example should provide strictly more information and also work for formatted panics.

The old example still exists on the `payload` method.