### PR TITLE
Do not use ImplDerivedObligationCause for inherent impl method error reporting

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1522,23 +1522,18 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
 
                     // Convert the bounds into obligations.
                     let impl_obligations = traits::predicates_for_generics(
-                        |_idx, span| {
-                            let misc = traits::ObligationCause::misc(span, self.body_id);
-                            let parent_trait_pred = ty::Binder::dummy(ty::TraitPredicate {
-                                trait_ref: ty::TraitRef::from_method(self.tcx, impl_def_id, substs),
-                                constness: ty::BoundConstness::NotConst,
-                                polarity: ty::ImplPolarity::Positive,
-                            });
-                            misc.derived_cause(parent_trait_pred, |derived| {
-                                traits::ImplDerivedObligation(Box::new(
-                                    traits::ImplDerivedObligationCause {
-                                        derived,
-                                        impl_or_alias_def_id: impl_def_id,
-                                        impl_def_predicate_index: None,
-                                        span,
-                                    },
-                                ))
-                            })
+                        |idx, span| {
+                            let code = if span.is_dummy() {
+                                traits::ExprItemObligation(impl_def_id, self.scope_expr_id, idx)
+                            } else {
+                                traits::ExprBindingObligation(
+                                    impl_def_id,
+                                    span,
+                                    self.scope_expr_id,
+                                    idx,
+                                )
+                            };
+                            ObligationCause::new(self.span, self.body_id, code)
                         },
                         self.param_env,
                         impl_bounds,

--- a/tests/ui/methods/inherent-bound-in-probe.rs
+++ b/tests/ui/methods/inherent-bound-in-probe.rs
@@ -1,0 +1,49 @@
+// normalize-stderr-test: "long-type-\d+" -> "long-type-hash"
+
+// Fixes #110131
+//
+// The issue is that we were constructing an `ImplDerived` cause code for the
+// `&'a T: IntoIterator<Item = &'a u8>` obligation for `Helper::new`, which is
+// incorrect because derived obligations are only expected to come from *traits*.
+
+struct SeqBuffer<'a, T>
+where
+    &'a T: IntoIterator<Item = &'a u8>,
+{
+    iter: <&'a T as IntoIterator>::IntoIter,
+}
+
+struct Helper<'a, T>
+where
+    &'a T: IntoIterator<Item = &'a u8>,
+{
+    buf: SeqBuffer<'a, T>,
+}
+
+impl<'a, T> Helper<'a, T>
+where
+    &'a T: IntoIterator<Item = &'a u8>,
+{
+    fn new(sq: &'a T) -> Self {
+        loop {}
+    }
+}
+
+struct BitReaderWrapper<T>(T);
+
+impl<'a, T> IntoIterator for &'a BitReaderWrapper<T>
+where
+    &'a T: IntoIterator<Item = &'a u8>,
+{
+    type Item = u32;
+
+    type IntoIter = Helper<'a, T>;
+    //~^ ERROR `Helper<'a, T>` is not an iterator
+
+    fn into_iter(self) -> Self::IntoIter {
+        Helper::new(&self.0)
+        //~^ ERROR overflow evaluating the requirement `&_: IntoIterator`
+    }
+}
+
+fn main() {}

--- a/tests/ui/methods/inherent-bound-in-probe.stderr
+++ b/tests/ui/methods/inherent-bound-in-probe.stderr
@@ -1,0 +1,38 @@
+error[E0277]: `Helper<'a, T>` is not an iterator
+  --> $DIR/inherent-bound-in-probe.rs:40:21
+   |
+LL |     type IntoIter = Helper<'a, T>;
+   |                     ^^^^^^^^^^^^^ `Helper<'a, T>` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `Helper<'a, T>`
+note: required by a bound in `std::iter::IntoIterator::IntoIter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+
+error[E0275]: overflow evaluating the requirement `&_: IntoIterator`
+  --> $DIR/inherent-bound-in-probe.rs:44:17
+   |
+LL |         Helper::new(&self.0)
+   |                 ^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`inherent_bound_in_probe`)
+note: required for `&BitReaderWrapper<_>` to implement `IntoIterator`
+  --> $DIR/inherent-bound-in-probe.rs:34:13
+   |
+LL | impl<'a, T> IntoIterator for &'a BitReaderWrapper<T>
+   |             ^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^
+LL | where
+LL |     &'a T: IntoIterator<Item = &'a u8>,
+   |                         ------------- unsatisfied trait bound introduced here
+   = note: 126 redundant requirements hidden
+   = note: required for `&BitReaderWrapper<BitReaderWrapper<BitReaderWrapper<BitReaderWrapper<BitReaderWrapper<...>>>>>` to implement `IntoIterator`
+   = note: the full type name has been written to '$TEST_BUILD_DIR/methods/inherent-bound-in-probe/inherent-bound-in-probe.long-type-hash.txt'
+note: required by a bound in `Helper<'a, T>`
+  --> $DIR/inherent-bound-in-probe.rs:25:25
+   |
+LL |     &'a T: IntoIterator<Item = &'a u8>,
+   |                         ^^^^^^^^^^^^^ required by this bound in `Helper<'a, T>`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0275, E0277.
+For more information about an error, try `rustc --explain E0275`.


### PR DESCRIPTION
We were constructing a `TraitRef` out of impl substs, for an *inherent* impl that has no corresponding trait. Instead of doing that, let's construct a meaningful obligation cause code, and instead adjust the error reporting machinery to handle that correctly.

Fixes #110131
cc #106702, which introduced this regression