### PR TITLE
Pack some `AdtFlags` into `AdtDef` directly

### DIFF
--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -1,4 +1,3 @@
-use rustc_data_structures::intern::Interned;
 use rustc_hir::def_id::CrateNum;
 use rustc_hir::definitions::DisambiguatedDefPathData;
 use rustc_middle::ty::{
@@ -56,8 +55,8 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
             }
 
             // Types with identity (print the module path).
-            ty::Adt(ty::AdtDef(Interned(&ty::AdtDefData { did: def_id, .. }, _)), substs)
-            | ty::FnDef(def_id, substs)
+            ty::Adt(adt_def, substs) => self.print_def_path(adt_def.did(), substs),
+            ty::FnDef(def_id, substs)
             | ty::Alias(_, ty::AliasTy { def_id, substs, .. })
             | ty::Closure(def_id, substs)
             | ty::Generator(def_id, substs, _) => self.print_def_path(def_id, substs),

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -24,6 +24,7 @@
 #![feature(rustc_attrs)]
 #![feature(negative_impls)]
 #![feature(test)]
+#![feature(strict_provenance)]
 #![feature(thread_id_value)]
 #![feature(vec_into_raw_parts)]
 #![feature(get_mut_unchecked)]

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
@@ -70,6 +70,10 @@ where
         }
     }
 
+    pub fn packed_repr(&self) -> NonZeroUsize {
+        self.packed
+    }
+
     pub(super) fn pointer_raw(&self) -> usize {
         self.packed.get() << T::BITS
     }

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -1,6 +1,5 @@
 use rustc_data_structures::base_n;
 use rustc_data_structures::fx::FxHashMap;
-use rustc_data_structures::intern::Interned;
 use rustc_hir as hir;
 use rustc_hir::def::CtorKind;
 use rustc_hir::def_id::{CrateNum, DefId};
@@ -431,8 +430,11 @@ impl<'tcx> Printer<'tcx> for &mut SymbolMangler<'tcx> {
             }
 
             // Mangle all nominal types as paths.
-            ty::Adt(ty::AdtDef(Interned(&ty::AdtDefData { did: def_id, .. }, _)), substs)
-            | ty::FnDef(def_id, substs)
+            ty::Adt(adt_def, substs) => {
+                let def_id = adt_def.did();
+                self = self.print_def_path(def_id, substs)?;
+            }
+            ty::FnDef(def_id, substs)
             | ty::Alias(_, ty::AliasTy { def_id, substs, .. })
             | ty::Closure(def_id, substs)
             | ty::Generator(def_id, substs, _) => {

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -4,10 +4,7 @@
 
 use pulldown_cmark::LinkType;
 use rustc_ast::util::comments::may_have_doc_links;
-use rustc_data_structures::{
-    fx::{FxHashMap, FxHashSet},
-    intern::Interned,
-};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{Applicability, Diagnostic};
 use rustc_hir::def::Namespace::*;
 use rustc_hir::def::{DefKind, Namespace, PerNS};
@@ -504,9 +501,8 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
             ty::FnDef(..) => panic!("type alias to a function definition"),
             ty::FnPtr(_) => Res::Primitive(Fn),
             ty::Never => Res::Primitive(Never),
-            ty::Adt(ty::AdtDef(Interned(&ty::AdtDefData { did, .. }, _)), _) | ty::Foreign(did) => {
-                Res::from_def_id(self.cx.tcx, did)
-            }
+            ty::Adt(adt_def, _) => Res::from_def_id(self.cx.tcx, adt_def.did()),
+            ty::Foreign(did) => Res::from_def_id(self.cx.tcx, did),
             ty::Alias(..)
             | ty::Closure(..)
             | ty::Generator(..)


### PR DESCRIPTION
This avoids having to chase the pointer for looking them up, but does introduce additional work when chasing the pointer.

Let's see how this goes.

This is based on measurements from the most frequent `AdtFlags` accesses:
```
--- core Opt
AdtDef is_union                             1253885
AdtDef is_enum                               240231
AdtDef is_box                                134921
AdtDef is_variant_list_non_exhaustive        108140
AdtDef is_struct                              49992
AdtDef is_phantom_data                         4696
AdtDef is_unsafe_cell                          4075
AdtDef is_manually_drop                        3059
AdtDef is_fundamental                          1740
AdtDef has_ctor                                  99
--- std Opt
AdtDef is_union                              347677
AdtDef is_box                                149748
AdtDef is_enum                               114011
AdtDef is_variant_list_non_exhaustive         36666
AdtDef is_struct                              29760
AdtDef is_unsafe_cell                          7067
AdtDef is_phantom_data                         3654
AdtDef is_manually_drop                        3201
AdtDef is_fundamental                           504
AdtDef has_ctor                                  16
--- regex Debug
AdtDef is_union                               98756
AdtDef is_box                                 54564
AdtDef is_enum                                44570
AdtDef is_struct                              26162
AdtDef is_variant_list_non_exhaustive          8219
AdtDef is_unsafe_cell                          2692
AdtDef is_phantom_data                         1425
AdtDef is_manually_drop                         946
AdtDef is_fundamental                           182
--- cranelift-codegen Check
AdtDef is_union                              430872
AdtDef is_enum                               205557
AdtDef is_box                                179276
AdtDef is_variant_list_non_exhaustive         75667
AdtDef is_struct                              36816
AdtDef is_unsafe_cell                          1392
AdtDef is_manually_drop                        1331
AdtDef is_fundamental                           586
AdtDef is_phantom_data                          583
AdtDef has_ctor                                  72

```