### PR TITLE
Reduce core counts for a number of builders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,70 +181,70 @@ jobs:
               - ARM64
               - linux
           - name: arm-android
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: armhf-gnu
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-aarch64-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-android
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-arm-linux
             os: ubuntu-20.04-16core-64gb
             env: {}
           - name: dist-armhf-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-armv7-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-i586-gnu-i586-i686-musl
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-i686-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-mips-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-mips64-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-mips64el-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-mipsel-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-powerpc-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-powerpc64-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-powerpc64le-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-riscv64-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-s390x-linux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-various-1
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-various-2
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-x86_64-freebsd
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-x86_64-illumos
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-x86_64-linux
             os: ubuntu-20.04-16core-64gb
@@ -254,10 +254,10 @@ jobs:
               IMAGE: dist-x86_64-linux
             os: ubuntu-20.04-16core-64gb
           - name: dist-x86_64-musl
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: dist-x86_64-netbsd
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: i686-gnu
             os: ubuntu-20.04-16core-64gb
@@ -266,51 +266,51 @@ jobs:
             os: ubuntu-20.04-16core-64gb
             env: {}
           - name: mingw-check
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: test-various
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: wasm32
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: x86_64-gnu
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: x86_64-gnu-stable
             env:
               IMAGE: x86_64-gnu
               RUST_CI_OVERRIDE_RELEASE_CHANNEL: stable
               CI_ONLY_WHEN_CHANNEL: nightly
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
           - name: x86_64-gnu-aux
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: x86_64-gnu-debug
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: x86_64-gnu-distcheck
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: x86_64-gnu-llvm-15
             env:
               RUST_BACKTRACE: 1
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
           - name: x86_64-gnu-llvm-14
             env:
               RUST_BACKTRACE: 1
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
           - name: x86_64-gnu-llvm-14-stage1
             env:
               RUST_BACKTRACE: 1
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
           - name: x86_64-gnu-nopt
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: x86_64-gnu-tools
             env:
               DEPLOY_TOOLSTATES_JSON: toolstates-linux.json
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
           - name: dist-x86_64-apple
             env:
               SCRIPT: "./x.py dist bootstrap --include-default-paths --host=x86_64-apple-darwin --target=x86_64-apple-darwin"

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -335,70 +335,70 @@ jobs:
             <<: *job-aarch64-linux
 
           - name: arm-android
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: armhf-gnu
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-aarch64-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-android
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-arm-linux
             <<: *job-linux-16c
 
           - name: dist-armhf-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-armv7-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-i586-gnu-i586-i686-musl
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-i686-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-mips-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-mips64-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-mips64el-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-mipsel-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-powerpc-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-powerpc64-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-powerpc64le-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-riscv64-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-s390x-linux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-various-1
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-various-2
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-x86_64-freebsd
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-x86_64-illumos
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - &dist-x86_64-linux
             name: dist-x86_64-linux
@@ -410,10 +410,10 @@ jobs:
             <<: *job-linux-16c
 
           - name: dist-x86_64-musl
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: dist-x86_64-netbsd
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: i686-gnu
             <<: *job-linux-16c
@@ -422,16 +422,16 @@ jobs:
             <<: *job-linux-16c
 
           - name: mingw-check
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: test-various
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: wasm32
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: x86_64-gnu
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           # This job ensures commits landing on nightly still pass the full
           # test suite on the stable channel. There are some UI tests that
@@ -446,39 +446,39 @@ jobs:
               # could cause failures when `dev: 1` in `stage0.txt`, and running
               # this on stable is useless.
               CI_ONLY_WHEN_CHANNEL: nightly
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: x86_64-gnu-aux
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: x86_64-gnu-debug
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: x86_64-gnu-distcheck
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: x86_64-gnu-llvm-15
             env:
               RUST_BACKTRACE: 1
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: x86_64-gnu-llvm-14
             env:
               RUST_BACKTRACE: 1
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: x86_64-gnu-llvm-14-stage1
             env:
               RUST_BACKTRACE: 1
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: x86_64-gnu-nopt
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: x86_64-gnu-tools
             env:
               DEPLOY_TOOLSTATES_JSON: toolstates-linux.json
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           ####################
           #  macOS Builders  #

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -73,7 +73,11 @@ x--expand-yaml-anchors--remove:
   - &base-job
     env: {}
 
-  - &job-linux-xl
+  - &job-linux-8c
+    os: ubuntu-20.04-8core-32gb
+    <<: *base-job
+
+  - &job-linux-16c
     os: ubuntu-20.04-16core-64gb
     <<: *base-job
 
@@ -81,8 +85,12 @@ x--expand-yaml-anchors--remove:
     os: macos-12-xl
     <<: *base-job
 
-  - &job-windows-xl
+  - &job-windows-8c
     os: windows-2019-8core-32gb
+    <<: *base-job
+
+  - &job-windows-16c
+    os: windows-2019-16core-64gb
     <<: *base-job
 
   - &job-aarch64-linux
@@ -293,19 +301,19 @@ jobs:
       matrix:
         include:
           - name: mingw-check
-            <<: *job-linux-xl
+            <<: *job-linux-16c
             tidy: false
 
           - name: mingw-check-tidy
-            <<: *job-linux-xl
+            <<: *job-linux-16c
             tidy: true
 
           - name: x86_64-gnu-llvm-14
-            <<: *job-linux-xl
+            <<: *job-linux-16c
             tidy: false
 
           - name: x86_64-gnu-tools
-            <<: *job-linux-xl
+            <<: *job-linux-16c
             tidy: false
 
   auto:
@@ -327,103 +335,103 @@ jobs:
             <<: *job-aarch64-linux
 
           - name: arm-android
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: armhf-gnu
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-aarch64-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-android
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-arm-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-armhf-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-armv7-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-i586-gnu-i586-i686-musl
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-i686-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-mips-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-mips64-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-mips64el-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-mipsel-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-powerpc-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-powerpc64-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-powerpc64le-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-riscv64-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-s390x-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-various-1
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-various-2
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-x86_64-freebsd
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-x86_64-illumos
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - &dist-x86_64-linux
             name: dist-x86_64-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-x86_64-linux-alt
             env:
               IMAGE: dist-x86_64-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-x86_64-musl
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: dist-x86_64-netbsd
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: i686-gnu
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: i686-gnu-nopt
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: mingw-check
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: test-various
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: wasm32
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: x86_64-gnu
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           # This job ensures commits landing on nightly still pass the full
           # test suite on the stable channel. There are some UI tests that
@@ -438,39 +446,39 @@ jobs:
               # could cause failures when `dev: 1` in `stage0.txt`, and running
               # this on stable is useless.
               CI_ONLY_WHEN_CHANNEL: nightly
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: x86_64-gnu-aux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: x86_64-gnu-debug
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: x86_64-gnu-distcheck
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: x86_64-gnu-llvm-15
             env:
               RUST_BACKTRACE: 1
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: x86_64-gnu-llvm-14
             env:
               RUST_BACKTRACE: 1
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: x86_64-gnu-llvm-14-stage1
             env:
               RUST_BACKTRACE: 1
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: x86_64-gnu-nopt
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           - name: x86_64-gnu-tools
             env:
               DEPLOY_TOOLSTATES_JSON: toolstates-linux.json
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
           ####################
           #  macOS Builders  #
@@ -572,38 +580,38 @@ jobs:
             env:
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
               SCRIPT: make ci-subset-1
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: x86_64-msvc-2
             env:
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
               SCRIPT: make ci-subset-2
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: i686-msvc-1
             env:
               RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
               SCRIPT: make ci-subset-1
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: i686-msvc-2
             env:
               RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
               SCRIPT: make ci-subset-2
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: x86_64-msvc-cargo
             env:
               SCRIPT: python x.py --stage 2 test src/tools/cargotest src/tools/cargo
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: x86_64-msvc-tools
             env:
               SCRIPT: src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh x.py /tmp/toolstate/toolstates.json windows
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --save-toolstates=/tmp/toolstate/toolstates.json
               DEPLOY_TOOLSTATES_JSON: toolstates-windows.json
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           # 32/64-bit MinGW builds.
           #
@@ -629,7 +637,7 @@ jobs:
               # incompatible with LLVM downloads today).
               NO_DOWNLOAD_CI_LLVM: 1
               CUSTOM_MINGW: 1
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: i686-mingw-2
             env:
@@ -639,7 +647,7 @@ jobs:
               # incompatible with LLVM downloads today).
               NO_DOWNLOAD_CI_LLVM: 1
               CUSTOM_MINGW: 1
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: x86_64-mingw-1
             env:
@@ -651,7 +659,7 @@ jobs:
               # incompatible with LLVM downloads today).
               NO_DOWNLOAD_CI_LLVM: 1
               CUSTOM_MINGW: 1
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: x86_64-mingw-2
             env:
@@ -663,7 +671,7 @@ jobs:
               # incompatible with LLVM downloads today).
               NO_DOWNLOAD_CI_LLVM: 1
               CUSTOM_MINGW: 1
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: dist-x86_64-msvc
             env:
@@ -675,7 +683,7 @@ jobs:
                 --enable-profiler
               SCRIPT: PGO_HOST=x86_64-pc-windows-msvc python src/ci/stage-build.py python x.py dist bootstrap --include-default-paths
               DIST_REQUIRE_ALL_TOOLS: 1
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: dist-i686-msvc
             env:
@@ -687,7 +695,7 @@ jobs:
                 --enable-profiler
               SCRIPT: python x.py dist bootstrap --include-default-paths
               DIST_REQUIRE_ALL_TOOLS: 1
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: dist-aarch64-msvc
             env:
@@ -701,7 +709,7 @@ jobs:
               # Hack around this SDK version, because it doesn't work with clang.
               # See https://github.com/rust-lang/rust/issues/88796
               WINDOWS_SDK_20348_HACK: 1
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: dist-i686-mingw
             env:
@@ -715,7 +723,7 @@ jobs:
               SCRIPT: python x.py dist bootstrap --include-default-paths
               CUSTOM_MINGW: 1
               DIST_REQUIRE_ALL_TOOLS: 1
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: dist-x86_64-mingw
             env:
@@ -729,13 +737,13 @@ jobs:
               NO_DOWNLOAD_CI_LLVM: 1
               CUSTOM_MINGW: 1
               DIST_REQUIRE_ALL_TOOLS: 1
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
           - name: dist-x86_64-msvc-alt
             env:
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
               SCRIPT: python x.py dist bootstrap --include-default-paths
-            <<: *job-windows-xl
+            <<: *job-windows-8c
 
   try:
     permissions:
@@ -750,7 +758,7 @@ jobs:
         include:
           - &dist-x86_64-linux
             name: dist-x86_64-linux
-            <<: *job-linux-xl
+            <<: *job-linux-16c
 
   master:
     name: master


### PR DESCRIPTION
Best reviewed by-commit; first commit renames all builder names to include core counts.

Applied changes for these builders (only on the auto branch, haven't touched PR CI):

- arm-android -> 8 core (currently at 39 minutes; 25.58% CPU)
- armhf-gnu -> 8 core (currently at 31 minutes; 30.97% CPU)
- dist-aarch64-linux -> 8 core (currently at 35 minutes; 55.38% CPU)
- dist-android -> 8 core (currently at 18 minutes; 43.03% CPU)
- dist-armhf-linux -> 8 core (currently at 27 minutes; 54.71% CPU)
- dist-armv7-linux -> 8 core (currently at 29 minutes; 50.33% CPU)
- dist-i586-gnu-i586-i686-musl -> 8 core (currently at 27 minutes; 48.31% CPU)
- dist-i686-linux -> 8 core (currently at 32 minutes; 52.39% CPU)
- dist-mips-linux -> 8 core (currently at 25 minutes; 55.09% CPU)
- dist-mips64-linux -> 8 core (currently at 25 minutes; 55.33% CPU)
- dist-mips64el-linux -> 8 core (currently at 26 minutes; 54.93% CPU)
- dist-mipsel-linux -> 8 core (currently at 25 minutes; 55.38% CPU)
- dist-powerpc-linux -> 8 core (currently at 26 minutes; 55.77% CPU)
- dist-powerpc64-linux -> 8 core (currently at 27 minutes; 55.03% CPU)
- dist-powerpc64le-linux -> 8 core (currently at 27 minutes; 54.95% CPU)
- dist-riscv64-linux -> 8 core (currently at 26 minutes; 54.43% CPU)
- dist-s390x-linux -> 8 core (currently at 30 minutes; 55.97% CPU)
- dist-various-1 -> 8 core (currently at 36 minutes; 29.16% CPU)
- dist-various-2 -> 8 core (currently at 27 minutes; 32.69% CPU)
- dist-x86_64-freebsd -> 8 core (currently at 27 minutes; 51.69% CPU)
- dist-x86_64-illumos -> 8 core (currently at 30 minutes; 54.88% CPU)
- dist-x86_64-musl -> 8 core (currently at 39 minutes; 57.56% CPU)
- dist-x86_64-netbsd -> 8 core (currently at 26 minutes; 55.82% CPU)
- mingw-check -> 8 core (currently at 17 minutes; 35.00% CPU)
- test-various -> 8 core (currently at 22 minutes; 44.84% CPU)
- wasm32 -> 8 core (currently at 19 minutes; 62.94% CPU)
- x86_64-gnu -> 8 core (currently at 32 minutes; 50.31% CPU)
- x86_64-gnu-stable -> 8 core (currently at 32 minutes; 51.23% CPU)
- x86_64-gnu-aux -> 8 core (currently at 22 minutes; 46.39% CPU)
- x86_64-gnu-debug -> 8 core (currently at 21 minutes; 53.93% CPU)
- x86_64-gnu-distcheck -> 8 core (currently at 38 minutes; 55.93% CPU)
- x86_64-gnu-llvm-15 -> 8 core (currently at 34 minutes; 52.99% CPU)
- x86_64-gnu-llvm-14 -> 8 core (currently at 34 minutes; 52.09% CPU)
- x86_64-gnu-llvm-14-stage1 -> 8 core (currently at 33 minutes; 51.13% CPU)
- x86_64-gnu-nopt -> 8 core (currently at 29 minutes; 53.36% CPU)
- x86_64-gnu-tools -> 8 core (currently at 22 minutes; 40.56% CPU)

We may also want to look at merging some of these builders in the future (to deduplicate stage0 builds and such) but that can happen separately - and is more work than just adjusting core counts.

r? @pietroalbini 