### PR TITLE
Fix typos in library

### DIFF
--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -246,7 +246,7 @@
 //!     - The exception is the last arm, which must be `_ => basic_block` and corresponds to the
 //!       otherwise branch.
 //!  - [`Call`] has an associated function as well. The third argument of this function is a normal
-//!    function call expresion, for example `my_other_function(a, 5)`.
+//!    function call expression, for example `my_other_function(a, 5)`.
 //!
 
 #![unstable(

--- a/library/core/src/slice/sort.rs
+++ b/library/core/src/slice/sort.rs
@@ -1486,7 +1486,7 @@ where
 }
 
 /// Finds a streak of presorted elements starting at the beginning of the slice. Returns the first
-/// value that is not part of said streak, and a bool denoting wether the streak was reversed.
+/// value that is not part of said streak, and a bool denoting whether the streak was reversed.
 /// Streaks can be increasing or decreasing.
 fn find_streak<T, F>(v: &[T], is_less: &mut F) -> (usize, bool)
 where

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -1891,7 +1891,7 @@ unsafe fn small_slice_eq(x: &[u8], y: &[u8]) -> bool {
 
     // SAFETY: Via the conditional above, we know that both `px` and `py`
     // have the same length, so `px < pxend` implies that `py < pyend`.
-    // Thus, derefencing both `px` and `py` in the loop below is safe.
+    // Thus, dereferencing both `px` and `py` in the loop below is safe.
     //
     // Moreover, we set `pxend` and `pyend` to be 4 bytes before the actual
     // end of `px` and `py`. Thus, the final dereference outside of the

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -1892,7 +1892,7 @@ mod remove_dir_impl {
         // file descriptor is automatically closed by libc::closedir() now, so give up ownership
         let new_parent_fd = dir_fd.into_raw_fd();
         // a valid root is not needed because we do not call any functions involving the full path
-        // of the DirEntrys.
+        // of the `DirEntry`s.
         let dummy_root = PathBuf::new();
         let inner = InnerReadDir { dirp, root: dummy_root };
         Ok((ReadDir::new(inner), new_parent_fd))

--- a/library/std/src/sys/windows/c/errors.rs
+++ b/library/std/src/sys/windows/c/errors.rs
@@ -12,7 +12,7 @@ pub const ERROR_RESOURCE_CALL_TIMED_OUT: DWORD = 5910;
 pub const FRS_ERR_SYSVOL_POPULATE_TIMEOUT: DWORD = 8014;
 pub const DNS_ERROR_RECORD_TIMED_OUT: DWORD = 9705;
 
-// The followiung list was obtained from
+// The following list was obtained from
 //   `/usr/x86_64-w64-mingw32/include/winerror.h`
 // in the Debian package
 //   mingw-w64_6.0.0-3_all.deb

--- a/library/std/src/sys_common/thread_parking/id.rs
+++ b/library/std/src/sys_common/thread_parking/id.rs
@@ -79,7 +79,7 @@ impl Parker {
             park_timeout(dur, self.state.as_ptr().addr());
             // Swap to ensure that we observe all state changes with acquire
             // ordering, even if the state has been changed after the timeout
-            // occured.
+            // occurred.
             self.state.swap(EMPTY, Acquire);
         }
     }

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -220,14 +220,14 @@ pub fn assert_test_result<T: Termination>(result: T) -> Result<(), String> {
 
 struct FilteredTests {
     tests: Vec<(TestId, TestDescAndFn)>,
-    benchs: Vec<(TestId, TestDescAndFn)>,
+    benches: Vec<(TestId, TestDescAndFn)>,
     next_id: usize,
 }
 
 impl FilteredTests {
     fn add_bench(&mut self, desc: TestDesc, testfn: TestFn) {
         let test = TestDescAndFn { desc, testfn };
-        self.benchs.push((TestId(self.next_id), test));
+        self.benches.push((TestId(self.next_id), test));
         self.next_id += 1;
     }
     fn add_test(&mut self, desc: TestDesc, testfn: TestFn) {
@@ -246,7 +246,7 @@ impl FilteredTests {
         self.add_test(desc, testfn);
     }
     fn total_len(&self) -> usize {
-        self.tests.len() + self.benchs.len()
+        self.tests.len() + self.benches.len()
     }
 }
 
@@ -291,7 +291,7 @@ where
 
     let tests_len = tests.len();
 
-    let mut filtered = FilteredTests { tests: Vec::new(), benchs: Vec::new(), next_id: 0 };
+    let mut filtered = FilteredTests { tests: Vec::new(), benches: Vec::new(), next_id: 0 };
 
     for test in filter_tests(opts, tests) {
         let mut desc = test.desc;
@@ -458,7 +458,7 @@ where
 
     if opts.bench_benchmarks {
         // All benchmarks run at the end, in serial.
-        for (id, b) in filtered.benchs {
+        for (id, b) in filtered.benches {
             let event = TestEvent::TeWait(b.desc.clone());
             notify_about_test_event(event)?;
             let join_handle = run_test(opts, false, id, b, run_strategy, tx.clone());


### PR DESCRIPTION
I ran [`typos -w library`](https://github.com/crate-ci/typos) to fix typos in the `library` directory.

Refs #110150