### PR TITLE
Fix typos in librustdoc, tools and config files

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -257,7 +257,7 @@ changelog-seen = 2
 #python = "python"
 
 # The path to the REUSE executable to use. Note that REUSE is not required in
-# most cases, as our tooling relies on a cached (and shrinked) copy of the
+# most cases, as our tooling relies on a cached (and shrunk) copy of the
 # REUSE output present in the git repository and in our source tarballs.
 #
 # REUSE is only needed if your changes caused the overall licensing of the

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -139,7 +139,7 @@ pub fn read_commit_info_file(root: &Path) -> Option<Info> {
                 sha: sha.to_owned(),
                 short_sha: short_sha.to_owned(),
             },
-            _ => panic!("the `git-comit-info` file is malformed"),
+            _ => panic!("the `git-commit-info` file is malformed"),
         };
         Some(info)
     } else {

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -643,7 +643,7 @@ Examples:
 ```rust
 match foo {
     foo => bar,
-    a_very_long_patten | another_pattern if an_expression() => {
+    a_very_long_pattern | another_pattern if an_expression() => {
         no_room_for_this_expression()
     }
     foo => {

--- a/src/doc/unstable-book/src/compiler-flags/dump-mono-stats-format.md
+++ b/src/doc/unstable-book/src/compiler-flags/dump-mono-stats-format.md
@@ -3,4 +3,4 @@
 --------------------
 
 The `-Z dump-mono-stats-format` compiler flag controls what file format to use for `-Z dump-mono-stats`.
-The default is markdown; currently JSON is also supported. JSON can be useful for programatically manipulating the results (e.g. to find the item that took the longest to compile).
+The default is markdown; currently JSON is also supported. JSON can be useful for programmatically manipulating the results (e.g. to find the item that took the longest to compile).

--- a/src/etc/installer/msi/rust.wxs
+++ b/src/etc/installer/msi/rust.wxs
@@ -119,7 +119,7 @@
         <SetProperty Sequence="ui" Before="CostFinalize"
             Id="WixAppFolder" Value="WixPerUserFolder">NOT ALLUSERS</SetProperty>
 
-        <!-- UI sets ALLUSERS per user selection; progagate this choice to MSIINSTALLPERUSER before executing installation actions -->
+        <!-- UI sets ALLUSERS per user selection; propagate this choice to MSIINSTALLPERUSER before executing installation actions -->
         <SetProperty Sequence="ui" Before="ExecuteAction"
             Id="MSIINSTALLPERUSER" Value="1">NOT ALLUSERS</SetProperty>
 

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2019,7 +2019,7 @@ impl Variant {
 
 #[derive(Clone, Debug)]
 pub(crate) struct Discriminant {
-    // In the case of cross crate re-exports, we don't have the nessesary information
+    // In the case of cross crate re-exports, we don't have the necessary information
     // to reconstruct the expression of the discriminant, only the value.
     pub(super) expr: Option<BodyId>,
     pub(super) value: DefId,

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -230,7 +230,7 @@ pub(crate) struct RenderOptions {
     pub(crate) extension_css: Option<PathBuf>,
     /// A map of crate names to the URL to use instead of querying the crate's `html_root_url`.
     pub(crate) extern_html_root_urls: BTreeMap<String, String>,
-    /// Whether to give precedence to `html_root_url` or `--exten-html-root-url`.
+    /// Whether to give precedence to `html_root_url` or `--extern-html-root-url`.
     pub(crate) extern_html_root_takes_precedence: bool,
     /// A map of the default settings (values are as for DOM storage API). Keys should lack the
     /// `rustdoc-` prefix.

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -349,10 +349,10 @@ pub(crate) fn print_where_clause<'a, 'tcx: 'a>(
             let mut br_with_padding = String::with_capacity(6 * indent + 28);
             br_with_padding.push_str("\n");
 
-            let padding_amout =
+            let padding_amount =
                 if ending == Ending::Newline { indent + 4 } else { indent + "fn where ".len() };
 
-            for _ in 0..padding_amout {
+            for _ in 0..padding_amount {
                 br_with_padding.push_str(" ");
             }
             let where_preds = where_preds.to_string().replace('\n', &br_with_padding);

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1796,10 +1796,11 @@ fn render_struct(
     }
     match ty {
         None => {
-            let where_diplayed = g.map(|g| print_where_clause_and_check(w, g, cx)).unwrap_or(false);
+            let where_displayed =
+                g.map(|g| print_where_clause_and_check(w, g, cx)).unwrap_or(false);
 
             // If there wasn't a `where` clause, we add a whitespace.
-            if !where_diplayed {
+            if !where_displayed {
                 w.write_str(" {");
             } else {
                 w.write_str("{");

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -550,7 +550,7 @@ pub enum Type {
     DynTrait(DynTrait),
     /// Parameterized types
     Generic(String),
-    /// Built in numberic (i*, u*, f*) types, bool, and char
+    /// Built in numeric (i*, u*, f*) types, bool, and char
     Primitive(String),
     /// `extern "ABI" fn`
     FunctionPointer(Box<FunctionPointer>),

--- a/src/tools/generate-copyright/src/main.rs
+++ b/src/tools/generate-copyright/src/main.rs
@@ -20,17 +20,17 @@ fn render_recursive(node: &Node, buffer: &mut Vec<u8>, depth: usize) -> Result<(
     let prefix = std::iter::repeat("> ").take(depth + 1).collect::<String>();
 
     match node {
-        Node::Root { childs } => {
-            for child in childs {
+        Node::Root { children } => {
+            for child in children {
                 render_recursive(child, buffer, depth)?;
             }
         }
-        Node::Directory { name, childs, license } => {
+        Node::Directory { name, children, license } => {
             render_license(&prefix, std::iter::once(name), license, buffer)?;
-            if !childs.is_empty() {
+            if !children.is_empty() {
                 writeln!(buffer, "{prefix}")?;
                 writeln!(buffer, "{prefix}*Exceptions:*")?;
-                for child in childs {
+                for child in children {
                     writeln!(buffer, "{prefix}")?;
                     render_recursive(child, buffer, depth + 1)?;
                 }
@@ -73,8 +73,8 @@ struct Metadata {
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "kebab-case", tag = "type")]
 pub(crate) enum Node {
-    Root { childs: Vec<Node> },
-    Directory { name: String, childs: Vec<Node>, license: License },
+    Root { children: Vec<Node> },
+    Directory { name: String, children: Vec<Node>, license: License },
     File { name: String, license: License },
     Group { files: Vec<String>, directories: Vec<String>, license: License },
 }

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -237,7 +237,7 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
 
             // Serde json doesn't implement Ord or Hash for Value, so we must
             // use a Vec here. While in theory that makes setwize equality
-            // O(n^2), in practice n will never be large enought to matter.
+            // O(n^2), in practice n will never be large enough to matter.
             let expected_values =
                 values.iter().map(|v| string_to_value(v, cache)).collect::<Vec<_>>();
             if expected_values.len() != got_values.len() {

--- a/src/tools/jsondoclint/src/item_kind.rs
+++ b/src/tools/jsondoclint/src/item_kind.rs
@@ -1,6 +1,6 @@
 use rustdoc_json_types::{Item, ItemEnum, ItemKind, ItemSummary};
 
-/// A univeral way to represent an [`ItemEnum`] or [`ItemKind`]
+/// A universal way to represent an [`ItemEnum`] or [`ItemKind`]
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Kind {
     Module,
@@ -53,7 +53,7 @@ impl Kind {
             Primitive => true,
             ForeignType => true,
 
-            // FIXME(adotinthevoid): I'm not sure if these are corrent
+            // FIXME(adotinthevoid): I'm not sure if these are correct
             Keyword => false,
             OpaqueTy => false,
             ProcAttribute => false,

--- a/src/tools/jsondoclint/src/main.rs
+++ b/src/tools/jsondoclint/src/main.rs
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
                         )
                     }
                     [sel] => eprintln!(
-                        "{} not in index or paths, but refered to at '{}'",
+                        "{} not in index or paths, but referred to at '{}'",
                         err.id.0,
                         json_find::to_jsonpath(&sel)
                     ),
@@ -85,12 +85,12 @@ fn main() -> Result<()> {
                                 .collect::<Vec<_>>()
                                 .join(", ");
                             eprintln!(
-                                "{} not in index or paths, but refered to at {sels}",
+                                "{} not in index or paths, but referred to at {sels}",
                                 err.id.0
                             );
                         } else {
                             eprintln!(
-                                "{} not in index or paths, but refered to at '{}' and {} more",
+                                "{} not in index or paths, but referred to at '{}' and {} more",
                                 err.id.0,
                                 json_find::to_jsonpath(&sel),
                                 sels.len() - 1,

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -86,7 +86,7 @@ def gh_url():
     return os.environ['TOOLSTATE_ISSUES_API_URL']
 
 
-def maybe_delink(message):
+def maybe_unlink(message):
     # type: (str) -> str
     if os.environ.get('TOOLSTATE_SKIP_MENTIONS') is not None:
         return message.replace("@", "")
@@ -109,7 +109,7 @@ def issue(
     else:
         status_description = 'no longer builds'
     request = json.dumps({
-        'body': maybe_delink(textwrap.dedent('''\
+        'body': maybe_unlink(textwrap.dedent('''\
         Hello, this is your friendly neighborhood mergebot.
         After merging PR {}, I observed that the tool {} {}.
         A follow-up PR to the repository {} is needed to fix the fallout.
@@ -285,7 +285,7 @@ try:
     issue_url = gh_url() + '/{}/comments'.format(number)
     response = urllib2.urlopen(urllib2.Request(
         issue_url,
-        json.dumps({'body': maybe_delink(message)}).encode(),
+        json.dumps({'body': maybe_unlink(message)}).encode(),
         {
             'Authorization': 'token ' + github_token,
             'Content-Type': 'application/json',

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -86,7 +86,7 @@ def gh_url():
     return os.environ['TOOLSTATE_ISSUES_API_URL']
 
 
-def maybe_unlink(message):
+def maybe_remove_mention(message):
     # type: (str) -> str
     if os.environ.get('TOOLSTATE_SKIP_MENTIONS') is not None:
         return message.replace("@", "")
@@ -109,7 +109,7 @@ def issue(
     else:
         status_description = 'no longer builds'
     request = json.dumps({
-        'body': maybe_unlink(textwrap.dedent('''\
+        'body': maybe_remove_mention(textwrap.dedent('''\
         Hello, this is your friendly neighborhood mergebot.
         After merging PR {}, I observed that the tool {} {}.
         A follow-up PR to the repository {} is needed to fix the fallout.
@@ -285,7 +285,7 @@ try:
     issue_url = gh_url() + '/{}/comments'.format(number)
     response = urllib2.urlopen(urllib2.Request(
         issue_url,
-        json.dumps({'body': maybe_unlink(message)}).encode(),
+        json.dumps({'body': maybe_remove_mention(message)}).encode(),
         {
             'Authorization': 'token ' + github_token,
             'Content-Type': 'application/json',

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -344,11 +344,11 @@ message = "Some changes occurred in `const_evaluatable.rs`"
 cc = ["@BoxyUwU"]
 
 [mentions."compiler/rustc_middle/src/ty/abstract_const.rs"]
-message = "Some changes occured in `abstract_const.rs`"
+message = "Some changes occurred in `abstract_const.rs`"
 cc = ["@BoxyUwU"]
 
 [mentions."compiler/rustc_ty_utils/src/consts.rs"]
-message = "Some changes occured in `rustc_ty_utils::consts.rs`"
+message = "Some changes occurred in `rustc_ty_utils::consts.rs`"
 cc = ["@BoxyUwU"]
 
 [mentions."compiler/rustc_trait_selection/src/solve/"]


### PR DESCRIPTION
I used [`typos`](https://github.com/crate-ci/typos) to fix all typos, minus the ones present in #110153 and in #110154.

Refs #110150