### PR TITLE
Remove obsolete test case

### DIFF
--- a/library/core/tests/num/dec2flt/mod.rs
+++ b/library/core/tests/num/dec2flt/mod.rs
@@ -127,14 +127,3 @@ fn massive_exponent() {
     assert_eq!(format!("1e-{max}000").parse(), Ok(0.0));
     assert_eq!(format!("1e{max}000").parse(), Ok(f64::INFINITY));
 }
-
-#[test]
-fn borderline_overflow() {
-    let mut s = "0.".to_string();
-    for _ in 0..375 {
-        s.push('3');
-    }
-    // At the time of this writing, this returns Err(..), but this is a bug that should be fixed.
-    // It makes no sense to enshrine that in a test, the important part is that it doesn't panic.
-    let _ = s.parse::<f64>();
-}


### PR DESCRIPTION
This test case was supposed to cover issue #31109 at some point.
It never did anything, as the issue was still open at the time of its creation.
When the issue was resolved, the `issue31109` test case was created,
making the existence of this test pointless.