### PR TITLE
rustdoc: remove redundant expandSection code from main.js

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -331,10 +331,6 @@ function preLoadCss(cssUrl) {
         },
     };
 
-    function getPageId() {
-        return window.location.hash.replace(/^#/, "");
-    }
-
     const toggleAllDocsId = "toggle-all-docs";
     let savedHash = "";
 
@@ -355,12 +351,12 @@ function preLoadCss(cssUrl) {
             }
         }
         // This part is used in case an element is not visible.
-        if (savedHash !== window.location.hash) {
-            savedHash = window.location.hash;
-            if (savedHash.length === 0) {
-                return;
+        const pageId = window.location.hash.replace(/^#/, "");
+        if (savedHash !== pageId) {
+            savedHash = pageId;
+            if (pageId !== "") {
+                expandSection(pageId);
             }
-            expandSection(savedHash.slice(1)); // we remove the '#'
         }
     }
 
@@ -699,11 +695,6 @@ function preLoadCss(cssUrl) {
             }
 
         });
-
-        const pageId = getPageId();
-        if (pageId !== "") {
-            expandSection(pageId);
-        }
     }());
 
     window.rustdoc_add_line_numbers_to_examples = () => {


### PR DESCRIPTION
This functionality is already tested in `hash-item-expansion.goml`, and was implemented twice:

* First, in code that ran at load time and at hash change: 917cdd295d2eed213c135d6f984c650f016ee3d6

* Later, the hash change event handler was itself run at load time, and the code handling both cases diverged in implementation, though their behavior still matches pretty well: f66a331335f3ac931afabca6f927a9d7dc17db3e