### PR TITLE
Make pointer_structural_match normal and warn

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2277,19 +2277,16 @@ declare_lint! {
     ///
     /// ### Explanation
     ///
-    /// Previous versions of Rust allowed function pointers and wide raw pointers in patterns.
-    /// While these work in many cases as expected by users, it is possible that due to
-    /// optimizations pointers are "not equal to themselves" or pointers to different functions
-    /// compare as equal during runtime. This is because LLVM optimizations can deduplicate
-    /// functions if their bodies are the same, thus also making pointers to these functions point
-    /// to the same location. Additionally functions may get duplicated if they are instantiated
+    /// Use of function pointers and wide raw pointers in patterns works in many cases as
+    /// expected by users. However, it is possible that due to optimizations pointers are "not equal
+    /// to themselves" or pointers to different functions compare as equal during runtime.
+    /// This is because LLVM optimizations can deduplicate functions if their bodies are the same,
+    /// thus also making pointers to these functions point to the same location.
+    /// Additionally, functions may get duplicated if they are instantiated
     /// in different crates and not deduplicated again via LTO.
     pub POINTER_STRUCTURAL_MATCH,
-    Allow,
-    "pointers are not structural-match",
-    @future_incompatible = FutureIncompatibleInfo {
-        reference: "issue #62411 <https://github.com/rust-lang/rust/issues/70861>",
-    };
+    Warn,
+    "pointers are not structural-match"
 }
 
 declare_lint! {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2282,7 +2282,7 @@ declare_lint! {
     /// to themselves" or pointers to different functions compare as equal during runtime.
     /// This is because LLVM optimizations can deduplicate functions if their bodies are the same,
     /// thus also making pointers to these functions point to the same location.
-    /// Additionally, functions may get duplicated if they are instantiated
+    /// Additionally, functions and vtables may get duplicated if they are instantiated
     /// in different crates and not deduplicated again via LTO.
     pub POINTER_STRUCTURAL_MATCH,
     Warn,

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -243,6 +243,7 @@ pub trait StructuralPartialEq {
 ///
 /// const CFN: Wrap<fn(&())> = Wrap(higher_order);
 ///
+/// # #[allow(pointer_structural_match)]
 /// fn main() {
 ///     match CFN {
 ///         CFN => {}

--- a/tests/ui/consts/const_in_pattern/issue-44333.rs
+++ b/tests/ui/consts/const_in_pattern/issue-44333.rs
@@ -1,7 +1,5 @@
 // run-pass
 
-#![warn(pointer_structural_match)]
-
 type Func = fn(usize, usize) -> usize;
 
 fn foo(a: usize, b: usize) -> usize { a + b }
@@ -17,9 +15,7 @@ const BAR: Func = bar;
 fn main() {
     match test(std::env::consts::ARCH.len()) {
         FOO => println!("foo"), //~ WARN pointers in patterns behave unpredictably
-        //~^ WARN will become a hard error
         BAR => println!("bar"), //~ WARN pointers in patterns behave unpredictably
-        //~^ WARN will become a hard error
         _ => unreachable!(),
     }
 }

--- a/tests/ui/consts/const_in_pattern/issue-44333.stderr
+++ b/tests/ui/consts/const_in_pattern/issue-44333.stderr
@@ -1,25 +1,16 @@
 warning: function pointers and unsized pointers in patterns behave unpredictably and should not be relied upon. See https://github.com/rust-lang/rust/issues/70861 for details.
-  --> $DIR/issue-44333.rs:19:9
+  --> $DIR/issue-44333.rs:17:9
    |
 LL |         FOO => println!("foo"),
    |         ^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/70861>
-note: the lint level is defined here
-  --> $DIR/issue-44333.rs:3:9
-   |
-LL | #![warn(pointer_structural_match)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(pointer_structural_match)]` on by default
 
 warning: function pointers and unsized pointers in patterns behave unpredictably and should not be relied upon. See https://github.com/rust-lang/rust/issues/70861 for details.
-  --> $DIR/issue-44333.rs:21:9
+  --> $DIR/issue-44333.rs:18:9
    |
 LL |         BAR => println!("bar"),
    |         ^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/70861>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/consts/issue-34784.rs
+++ b/tests/ui/consts/issue-34784.rs
@@ -1,6 +1,6 @@
 // run-pass
 
-#![warn(pointer_structural_match)]
+
 #![allow(dead_code)]
 const C: *const u8 = &0;
 

--- a/tests/ui/pattern/usefulness/consts-opaque.rs
+++ b/tests/ui/pattern/usefulness/consts-opaque.rs
@@ -2,7 +2,7 @@
 // unnecessary warnings because const_to_pat.rs converts a constant pattern to a wildcard when the
 // constant is not allowed as a pattern. This is an edge case so we may not care to fix it.
 // See also https://github.com/rust-lang/rust/issues/78057
-
+#![allow(pointer_structural_match)]
 #![deny(unreachable_patterns)]
 
 #[derive(PartialEq)]

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-direct-unsafe-ptr-embedded.rs
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-direct-unsafe-ptr-embedded.rs
@@ -3,7 +3,7 @@
 
 // run-pass
 
-#![warn(pointer_structural_match)]
+#![deny(pointer_structural_match)]
 
 struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
 

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-direct-unsafe-ptr-param.rs
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-direct-unsafe-ptr-param.rs
@@ -3,7 +3,7 @@
 
 // run-pass
 
-#![warn(pointer_structural_match)]
+#![deny(pointer_structural_match)]
 
 struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
 

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-indirect-unsafe-ptr-embedded.rs
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-indirect-unsafe-ptr-embedded.rs
@@ -3,7 +3,7 @@
 
 // run-pass
 
-#![warn(pointer_structural_match)]
+#![deny(pointer_structural_match)]
 
 struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
 

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-indirect-unsafe-ptr-param.rs
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-indirect-unsafe-ptr-param.rs
@@ -3,7 +3,7 @@
 
 // run-pass
 
-#![warn(pointer_structural_match)]
+#![deny(pointer_structural_match)]
 
 struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
 

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/fn-ptr-is-structurally-matchable.rs
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/fn-ptr-is-structurally-matchable.rs
@@ -3,6 +3,8 @@
 // This file checks that fn ptrs are considered structurally matchable.
 // See also rust-lang/rust#63479.
 
+#![allow(pointer_structural_match)]
+
 fn main() {
     let mut count = 0;
 

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/issue-63479-match-fnptr.rs
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/issue-63479-match-fnptr.rs
@@ -5,8 +5,6 @@
 // cover the case this hit; I've since expanded it accordingly, but the
 // experience left me wary of leaving this regression test out.)
 
-#![warn(pointer_structural_match)]
-
 #[derive(Eq)]
 struct A {
   a: i64
@@ -34,7 +32,6 @@ fn main() {
   match s {
     B(TEST) => println!("matched"),
      //~^ WARN pointers in patterns behave unpredictably
-    //~| WARN this was previously accepted by the compiler but is being phased out
     _ => panic!("didn't match")
   };
 }

--- a/tests/ui/rfc-1445-restrict-constants-in-patterns/issue-63479-match-fnptr.stderr
+++ b/tests/ui/rfc-1445-restrict-constants-in-patterns/issue-63479-match-fnptr.stderr
@@ -1,16 +1,10 @@
 warning: function pointers and unsized pointers in patterns behave unpredictably and should not be relied upon. See https://github.com/rust-lang/rust/issues/70861 for details.
-  --> $DIR/issue-63479-match-fnptr.rs:35:7
+  --> $DIR/issue-63479-match-fnptr.rs:33:7
    |
 LL |     B(TEST) => println!("matched"),
    |       ^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/70861>
-note: the lint level is defined here
-  --> $DIR/issue-63479-match-fnptr.rs:8:9
-   |
-LL | #![warn(pointer_structural_match)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(pointer_structural_match)]` on by default
 
 warning: 1 warning emitted
 


### PR DESCRIPTION
This PR does two things:

* Changes the default level of `pointer_structural_match` from allow to warn
* Turns `pointer_structural_match` into a normal lint instead of being a forward compatibility lint

The `pointer_structural_match` lint was added in #70743 to look for code that matches on a function pointer. As pointed out in #70861, and #54685, LLVM's behaviour makes function pointers behave in unexpected ways: function pointers might not be equal to "themselves" if function pointers for the same function were created in two different crates, and on the other hand, two different functions might end up with the same address if LLVM detects that they have the same body. See the linked issues for examples.

Thus, in #70743 an allow-by-default forward compatibility lint was added to address matching on pointers.

In https://github.com/rust-lang/rust/issues/70861#issuecomment-610065569 preferences were expressed that there should be a lint for matching on function pointers, but it should not be disallowed completely. I'd interpret that as wanting a warn-by-default non forward compatibility lint. Therefore, there are two possible ways forward:

* turn `pointer_structural_match` into a normal lint that's not a forward compatibility lint, and make it warn by default, OR
* keep it as a forward compatibility lint, to eventually forbid it via a compiler error, but first make it warn by default, then deny by default.

I think one should at least do one of the two things, even if it is only going to be a warning lint in the end.

The lang team has given the green light for the first approach. There is still the possibility that it will be forbidden in the future, but this will require concrete deprecation plans which don't exist right now.

cc @eddyb @pnkfelix @oli-obk 