### PR TITLE
fix running Miri tests

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -638,7 +638,10 @@ impl Step for Miri {
         // Forward test filters.
         cargo.arg("--").args(builder.config.cmd.test_args());
 
-        add_flags_and_try_run_tests(builder, &mut cargo.into());
+        // This can NOT be `add_flags_and_try_run_tests` since the Miri test runner
+        // does not understand those flags!
+        let mut cargo = Command::from(cargo);
+        builder.run(&mut cargo);
 
         // # Run `cargo miri test`.
         // This is just a smoke test (Miri's own CI invokes this in a bunch of different ways and ensures


### PR DESCRIPTION
This partially reverts https://github.com/rust-lang/rust/pull/108659 to fix https://github.com/rust-lang/rust/issues/110102: the Miri test runner does not support any flags, they are interpreted as filters instead which leads to no tests being run.

I have not checked any of the other test runners for whether they are having any trouble with these flags.

Cc @pietroalbini @Mark-Simulacrum @jyn514 