### PR TITLE
fix broken example with pin

### DIFF
--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1084,7 +1084,7 @@ impl<P, U> DispatchFromDyn<Pin<U>> for Pin<P> where P: DispatchFromDyn<U> {}
 ///
 /// ```rust
 /// #![feature(generators, generator_trait)]
-/// use core::{
+/// use std::{
 ///     ops::{Generator, GeneratorState},
 ///     pin::pin,
 /// };


### PR DESCRIPTION
```
$ rustc --version
rustc 1.70.0-nightly (88fb1b922 2023-04-10)
```

at the attempt to build the example the following error emerges:
```
error[E0433]: failed to resolve: maybe a missing crate `core`?
```

replacement with `std` solves the problem.