### PR TITLE
Check for body owner fallibly in error reporting

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2380,8 +2380,8 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 }
 
                 if let Some(ty::subst::GenericArgKind::Type(_)) = subst.map(|subst| subst.unpack())
+                    && let Some(body_id) = self.tcx.hir().maybe_body_owned_by(obligation.cause.body_id)
                 {
-                    let body_id = self.tcx.hir().body_owned_by(obligation.cause.body_id);
                     let mut expr_finder = FindExprBySpan::new(span);
                     expr_finder.visit_expr(&self.tcx.hir().body(body_id).value);
 

--- a/tests/ui/wf/issue-110157.rs
+++ b/tests/ui/wf/issue-110157.rs
@@ -1,0 +1,12 @@
+struct NeedsDropTypes<'tcx, F>(std::marker::PhantomData<&'tcx F>);
+
+impl<'tcx, F, I> Iterator for NeedsDropTypes<'tcx, F>
+//~^ ERROR type annotations needed
+where
+    F: Fn(&Missing) -> Result<I, ()>,
+    //~^ ERROR cannot find type `Missing` in this scope
+    I: Iterator<Item = Missing>,
+    //~^ ERROR cannot find type `Missing` in this scope
+{}
+
+fn main() {}

--- a/tests/ui/wf/issue-110157.stderr
+++ b/tests/ui/wf/issue-110157.stderr
@@ -1,0 +1,32 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/issue-110157.rs:6:12
+   |
+LL |     F: Fn(&Missing) -> Result<I, ()>,
+   |            ^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/issue-110157.rs:8:24
+   |
+LL |     I: Iterator<Item = Missing>,
+   |                        ^^^^^^^ not found in this scope
+
+error[E0283]: type annotations needed
+  --> $DIR/issue-110157.rs:3:31
+   |
+LL | impl<'tcx, F, I> Iterator for NeedsDropTypes<'tcx, F>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `I`
+   |
+   = note: cannot satisfy `_: Iterator`
+note: required for `NeedsDropTypes<'tcx, F>` to implement `Iterator`
+  --> $DIR/issue-110157.rs:3:18
+   |
+LL | impl<'tcx, F, I> Iterator for NeedsDropTypes<'tcx, F>
+   |                  ^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     I: Iterator<Item = Missing>,
+   |        ------------------------ unsatisfied trait bound introduced here
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0283, E0412.
+For more information about an error, try `rustc --explain E0283`.


### PR DESCRIPTION
Sometimes the "body id" we use for an obligation cause is not actually a body owner, like when we're doing WF checking on items.

Fixes #110157