### PR TITLE
Erase lifetimes above `ty::INNERMOST` when probing ambiguous types

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -2514,24 +2514,16 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                     tcx,
                                     infcx.fresh_substs_for_item(DUMMY_SP, impl_def_id),
                                 );
-                                // I guess we don't need to make a universe unless we need it,
-                                // but also we're on the error path, so it doesn't matter here.
-                                let universe = infcx.create_next_universe();
+                                let value = tcx.fold_regions(qself_ty, |_, _| tcx.lifetimes.re_erased);
+                                // FIXME: Don't bother dealing with non-lifetime binders here...
+                                if value.has_escaping_bound_vars() {
+                                    return false;
+                                }
                                 infcx
                                     .can_eq(
                                         ty::ParamEnv::empty(),
                                         impl_.self_ty(),
-                                        tcx.replace_escaping_bound_vars_uncached(qself_ty, ty::fold::FnMutDelegate {
-                                            regions: &mut |_| tcx.lifetimes.re_erased,
-                                            types: &mut |bv| tcx.mk_placeholder(ty::PlaceholderType {
-                                                universe,
-                                                bound: bv,
-                                            }),
-                                            consts: &mut |bv, ty| tcx.mk_const(ty::PlaceholderConst {
-                                                universe,
-                                                bound: bv,
-                                            }, ty),
-                                        })
+                                        value,
                                     )
                             })
                             && tcx.impl_polarity(impl_def_id) != ty::ImplPolarity::Negative

--- a/tests/ui/traits/non_lifetime_binders/missing-assoc-item.stderr
+++ b/tests/ui/traits/non_lifetime_binders/missing-assoc-item.stderr
@@ -11,7 +11,12 @@ error[E0223]: ambiguous associated type
   --> $DIR/missing-assoc-item.rs:6:12
    |
 LL |     for<B> B::Item: Send,
-   |            ^^^^^^^ help: use the fully-qualified path: `<B as IntoIterator>::Item`
+   |            ^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `Item` implemented for `B`, you could use the fully-qualified path
+   |
+LL |     for<B> <B as Example>::Item: Send,
+   |            ~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/tests/ui/typeck/issue-110052.rs
+++ b/tests/ui/typeck/issue-110052.rs
@@ -1,0 +1,12 @@
+// Makes sure we deal with escaping lifetimes *above* INNERMOST when
+// suggesting trait for ambiguous associated type.
+
+impl<I, V> Validator<I> for ()
+where
+    for<'iter> dyn Validator<<&'iter I>::Item>:,
+    //~^ ERROR ambiguous associated type
+{}
+
+pub trait Validator<T> {}
+
+fn main() {}

--- a/tests/ui/typeck/issue-110052.stderr
+++ b/tests/ui/typeck/issue-110052.stderr
@@ -1,0 +1,9 @@
+error[E0223]: ambiguous associated type
+  --> $DIR/issue-110052.rs:6:30
+   |
+LL |     for<'iter> dyn Validator<<&'iter I>::Item>:,
+   |                              ^^^^^^^^^^^^^^^^ help: use the fully-qualified path: `<&'iter I as IntoIterator>::Item`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0223`.


### PR DESCRIPTION
Turns out that `TyCtxt::replace_escaping_bound_vars_uncached` only erases bound vars exactly at `ty::INNERMOST`, and not everything above. This regresses the suggestions for non-lifetime binders, but oh well, I don't really care about those.

Fixes #110052