### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be36bc9e0546df253c0cc41fd0af34f5e92845ad8509462ec76672fac6997f5b"
+checksum = "89511277159354bea13ae1e53e0c9ab85ba1b20d7e91618fa30e6bc5566857fb"
 dependencies = [
  "bitflags",
  "libc",
@@ -1856,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "git2-curl"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7577f4e6341ba7c90d883511130a45b956c274ba5f4d205d9f9da990f654cd33"
+checksum = "f8f8b7432b72928cff76f69e59ed5327f94a52763731e71274960dee72fe5f8c"
 dependencies = [
  "curl",
  "git2",
@@ -2962,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.1+1.5.0"
+version = "0.15.0+1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a07fb2692bc3593bda59de45a502bb3071659f2c515e28c71e728306b038e17"
+checksum = "032e537ae4dd4e50c877f258dc55fcd0657b5021f454094a425bb6bcc9edea4c"
 dependencies = [
  "cc",
  "libc",
@@ -3002,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.23"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
17 commits in 0e474cfd7b16b018cf46e95da3f6a5b2f1f6a9e7..7bf43f028ba5eb1f4d70d271c2546c38512c9875
2023-03-31 23:15:58 +0000 to 2023-04-10 16:01:41 +0000

- docs(pkgid): Consistently use @ (rust-lang/cargo#11956)
- Fix credential token format validation. (rust-lang/cargo#11951)
- Validate token on publish. (rust-lang/cargo#11952)
- Clarify docs on `-C` that it appears before the command. (rust-lang/cargo#11947)
- Add `try_canonicalize` and use it over `std::fs::canonicalize` (rust-lang/cargo#11866)
- Fix typo (rust-lang/cargo#11944)
- docs(changelog): Change wording about auto-fix message (rust-lang/cargo#11943)
- Update home repo URL (rust-lang/cargo#11941)
- doc(changelog): `[env]` is a table, not a stable (rust-lang/cargo#11942)
- Stop using UncanonicalizedIter for QueryKind::Exact (rust-lang/cargo#11937)
- Don't query permutations of the path prefix. (rust-lang/cargo#11936)
- Fix typo in variable name (rust-lang/cargo#11931)
- Fix Cargo warning about unused sparse configuration key (rust-lang/cargo#11930)
- Switch benchsuite to the index archive. (rust-lang/cargo#11933)
- Update git2 (rust-lang/cargo#11928)
- Publish docs: Clarify requirements about the state of the index after publish. (rust-lang/cargo#11926)
- Call out the differences between the index JSON and the API or metadata. (rust-lang/cargo#11927)

