### PR TITLE
Remove `..` from return type notation

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -167,9 +167,6 @@ pub enum GenericArgs {
     AngleBracketed(AngleBracketedArgs),
     /// The `(A, B)` and `C` in `Foo(A, B) -> C`.
     Parenthesized(ParenthesizedArgs),
-    /// Associated return type bounds, like `T: Trait<method(..): Send>`
-    /// which applies the `Send` bound to the return-type of `method`.
-    ReturnTypeNotation(Span),
 }
 
 impl GenericArgs {
@@ -181,7 +178,6 @@ impl GenericArgs {
         match self {
             AngleBracketed(data) => data.span,
             Parenthesized(data) => data.span,
-            ReturnTypeNotation(span) => *span,
         }
     }
 }

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -561,7 +561,6 @@ pub fn noop_visit_generic_args<T: MutVisitor>(generic_args: &mut GenericArgs, vi
     match generic_args {
         GenericArgs::AngleBracketed(data) => vis.visit_angle_bracketed_parameter_data(data),
         GenericArgs::Parenthesized(data) => vis.visit_parenthesized_parameter_data(data),
-        GenericArgs::ReturnTypeNotation(_span) => {}
     }
 }
 

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -482,7 +482,6 @@ where
             walk_list!(visitor, visit_ty, &data.inputs);
             walk_fn_ret_ty(visitor, &data.output);
         }
-        GenericArgs::ReturnTypeNotation(_span) => {}
     }
 }
 

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -353,13 +353,7 @@ pub enum BadReturnTypeNotation {
     #[diag(ast_lowering_bad_return_type_notation_inputs)]
     Inputs {
         #[primary_span]
-        #[suggestion(code = "(..)", applicability = "maybe-incorrect")]
-        span: Span,
-    },
-    #[diag(ast_lowering_bad_return_type_notation_needs_dots)]
-    NeedsDots {
-        #[primary_span]
-        #[suggestion(code = "(..)", applicability = "maybe-incorrect")]
+        #[suggestion(code = "()", applicability = "maybe-incorrect")]
         span: Span,
     },
     #[diag(ast_lowering_bad_return_type_notation_output)]

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -13,7 +13,6 @@ use rustc_span::symbol::{kw, sym, Ident};
 use rustc_span::{BytePos, Span, DUMMY_SP};
 
 use smallvec::{smallvec, SmallVec};
-use thin_vec::ThinVec;
 
 impl<'a, 'hir> LoweringContext<'a, 'hir> {
     #[instrument(level = "trace", skip(self))]
@@ -219,18 +218,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         )
                     }
                 },
-                &GenericArgs::ReturnTypeNotation(span) => {
-                    self.tcx.sess.emit_err(GenericTypeWithParentheses { span, sub: None });
-                    (
-                        self.lower_angle_bracketed_parameter_data(
-                            &AngleBracketedArgs { span, args: ThinVec::default() },
-                            param_mode,
-                            itctx,
-                        )
-                        .0,
-                        false,
-                    )
-                }
             }
         } else {
             (

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1075,7 +1075,6 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     self.with_impl_trait(None, |this| this.visit_ty(ty));
                 }
             }
-            GenericArgs::ReturnTypeNotation(_span) => {}
         }
     }
 
@@ -1386,7 +1385,6 @@ fn deny_equality_constraints(
                                     match &mut assoc_path.segments[len].args {
                                         Some(args) => match args.deref_mut() {
                                             GenericArgs::Parenthesized(_) => continue,
-                                            GenericArgs::ReturnTypeNotation(_span) => continue,
                                             GenericArgs::AngleBracketed(args) => {
                                                 args.args.push(arg);
                                             }

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -936,10 +936,6 @@ impl<'a> PrintState<'a> for State<'a> {
                 self.word(")");
                 self.print_fn_ret_ty(&data.output);
             }
-
-            ast::GenericArgs::ReturnTypeNotation(_span) => {
-                self.word("(..)");
-            }
         }
     }
 }

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -738,3 +738,7 @@ parse_box_syntax_removed = `box_syntax` has been removed
 parse_bad_return_type_notation_output =
     return type not allowed with return type notation
     .suggestion = remove the return type
+
+parse_bad_return_type_notation_dotdot =
+    return type notation uses `()` instead of `(..)` for elided arguments
+    .suggestion = remove the `..`

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2324,3 +2324,11 @@ pub(crate) struct BadReturnTypeNotationOutput {
     #[suggestion(code = "", applicability = "maybe-incorrect")]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(parse_bad_return_type_notation_dotdot)]
+pub(crate) struct BadReturnTypeNotationDotDot {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    pub span: Span,
+}

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -666,7 +666,7 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
     fn visit_generic_args(&mut self, g: &'v ast::GenericArgs) {
         record_variants!(
             (self, g, g, Id::None, ast, GenericArgs, GenericArgs),
-            [AngleBracketed, Parenthesized, ReturnTypeNotation]
+            [AngleBracketed, Parenthesized]
         );
         ast_visit::walk_generic_args(self, g)
     }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1116,7 +1116,6 @@ impl<'a: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast,
                         }
                     }
                 }
-                GenericArgs::ReturnTypeNotation(_span) => {}
             }
         }
     }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -312,7 +312,6 @@ impl<'a> From<&'a ast::PathSegment> for Segment {
                     (args.span, found_lifetimes)
                 }
                 GenericArgs::Parenthesized(args) => (args.span, true),
-                GenericArgs::ReturnTypeNotation(span) => (*span, false),
             }
         } else {
             (DUMMY_SP, false)

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
@@ -12,11 +12,11 @@ fn foo<T: Trait<method(i32): Send>>() {}
 //~^ ERROR argument types not allowed with return type notation
 //~| ERROR associated type bounds are unstable
 
-fn bar<T: Trait<method(..) -> (): Send>>() {}
+fn bar<T: Trait<method() -> (): Send>>() {}
 //~^ ERROR return type not allowed with return type notation
-
-fn baz<T: Trait<method(): Send>>() {}
-//~^ ERROR return type notation arguments must be elided with `..`
 //~| ERROR associated type bounds are unstable
+
+fn baz<T: Trait<method(..): Send>>() {}
+//~^ ERROR return type notation uses `()` instead of `(..)` for elided arguments
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
@@ -1,8 +1,8 @@
-error: return type not allowed with return type notation
-  --> $DIR/bad-inputs-and-output.rs:15:28
+error: return type notation uses `()` instead of `(..)` for elided arguments
+  --> $DIR/bad-inputs-and-output.rs:19:24
    |
-LL | fn bar<T: Trait<method(..) -> (): Send>>() {}
-   |                            ^^^^^ help: remove the return type
+LL | fn baz<T: Trait<method(..): Send>>() {}
+   |                        ^^ help: remove the `..`
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/bad-inputs-and-output.rs:11:17
@@ -14,10 +14,10 @@ LL | fn foo<T: Trait<method(i32): Send>>() {}
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
-  --> $DIR/bad-inputs-and-output.rs:18:17
+  --> $DIR/bad-inputs-and-output.rs:15:17
    |
-LL | fn baz<T: Trait<method(): Send>>() {}
-   |                 ^^^^^^^^^^^^^^
+LL | fn bar<T: Trait<method() -> (): Send>>() {}
+   |                 ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
@@ -43,13 +43,13 @@ error: argument types not allowed with return type notation
   --> $DIR/bad-inputs-and-output.rs:11:23
    |
 LL | fn foo<T: Trait<method(i32): Send>>() {}
-   |                       ^^^^^ help: remove the input types: `(..)`
+   |                       ^^^^^ help: remove the input types: `()`
 
-error: return type notation arguments must be elided with `..`
-  --> $DIR/bad-inputs-and-output.rs:18:23
+error: return type not allowed with return type notation
+  --> $DIR/bad-inputs-and-output.rs:15:25
    |
-LL | fn baz<T: Trait<method(): Send>>() {}
-   |                       ^^ help: add `..`: `(..)`
+LL | fn bar<T: Trait<method() -> (): Send>>() {}
+   |                         ^^^^^^ help: remove the return type
 
 error: aborting due to 5 previous errors; 2 warnings emitted
 

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.rs
@@ -18,7 +18,7 @@ async fn foo<T: Foo>() -> Result<(), ()> {
 fn is_send(_: impl Send) {}
 
 fn test<
-    #[cfg(with)] T: Foo<method(..): Send>,
+    #[cfg(with)] T: Foo<method(): Send>,
     #[cfg(without)] T: Foo,
 >() {
     is_send(foo::<T>());

--- a/tests/ui/associated-type-bounds/return-type-notation/equality.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/equality.rs
@@ -10,7 +10,7 @@ trait Trait {
     async fn method() {}
 }
 
-fn test<T: Trait<method(..) = Box<dyn Future<Output = ()>>>>() {}
+fn test<T: Trait<method() = Box<dyn Future<Output = ()>>>>() {}
 //~^ ERROR return type notation is not allowed to use type equality
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/equality.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/equality.stderr
@@ -18,8 +18,8 @@ LL | #![feature(return_type_notation, async_fn_in_trait)]
 error: return type notation is not allowed to use type equality
   --> $DIR/equality.rs:13:18
    |
-LL | fn test<T: Trait<method(..) = Box<dyn Future<Output = ()>>>>() {}
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn test<T: Trait<method() = Box<dyn Future<Output = ()>>>>() {}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 2 warnings emitted
 

--- a/tests/ui/associated-type-bounds/return-type-notation/missing.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/missing.rs
@@ -8,7 +8,7 @@ trait Trait {
     async fn method() {}
 }
 
-fn bar<T: Trait<methid(..): Send>>() {}
+fn bar<T: Trait<methid(): Send>>() {}
 //~^ ERROR cannot find associated function `methid` in trait `Trait`
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/missing.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/missing.stderr
@@ -18,8 +18,8 @@ LL | #![feature(return_type_notation, async_fn_in_trait)]
 error: cannot find associated function `methid` in trait `Trait`
   --> $DIR/missing.rs:11:17
    |
-LL | fn bar<T: Trait<methid(..): Send>>() {}
-   |                 ^^^^^^^^^^^^^^^^
+LL | fn bar<T: Trait<methid(): Send>>() {}
+   |                 ^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 2 warnings emitted
 

--- a/tests/ui/associated-type-bounds/return-type-notation/non-rpitit.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/non-rpitit.rs
@@ -5,7 +5,7 @@ trait Trait {
     fn method() {}
 }
 
-fn test<T: Trait<method(..): Send>>() {}
+fn test<T: Trait<method(): Send>>() {}
 //~^ ERROR  return type notation used on function that is not `async` and does not return `impl Trait`
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/non-rpitit.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/non-rpitit.stderr
@@ -13,8 +13,8 @@ error: return type notation used on function that is not `async` and does not re
 LL |     fn method() {}
    |     ----------- this function must be `async` or return `impl Trait`
 ...
-LL | fn test<T: Trait<method(..): Send>>() {}
-   |                  ^^^^^^^^^^^^^^^^
+LL | fn test<T: Trait<method(): Send>>() {}
+   |                  ^^^^^^^^^^^^^^
    |
    = note: function returns `()`, which is not compatible with associated type return bounds
 

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.cfg.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.cfg.stderr
@@ -1,14 +1,14 @@
 error[E0658]: return type notation is experimental
-  --> $DIR/feature-gate-return_type_notation.rs:12:18
+  --> $DIR/feature-gate-return_type_notation.rs:15:17
    |
-LL | fn foo<T: Trait<m(..): Send>>() {}
-   |                  ^^^^
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^^^^^^^^^
    |
    = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
    = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
 
 warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/feature-gate-return_type_notation.rs:4:12
+  --> $DIR/feature-gate-return_type_notation.rs:7:12
    |
 LL | #![feature(async_fn_in_trait)]
    |            ^^^^^^^^^^^^^^^^^
@@ -16,6 +16,21 @@ LL | #![feature(async_fn_in_trait)]
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to previous error; 1 warning emitted
+error: parenthesized generic arguments cannot be used in associated type constraints
+  --> $DIR/feature-gate-return_type_notation.rs:15:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^--
+   |                  |
+   |                  help: remove these parentheses
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0220]: associated type `m` not found for `Trait`
+  --> $DIR/feature-gate-return_type_notation.rs:15:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^ associated type `m` not found
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0220, E0658.
+For more information about an error, try `rustc --explain E0220`.

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.no.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.no.stderr
@@ -1,14 +1,5 @@
-error[E0658]: return type notation is experimental
-  --> $DIR/feature-gate-return_type_notation.rs:12:18
-   |
-LL | fn foo<T: Trait<m(..): Send>>() {}
-   |                  ^^^^
-   |
-   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
-   = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
-
 warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/feature-gate-return_type_notation.rs:4:12
+  --> $DIR/feature-gate-return_type_notation.rs:7:12
    |
 LL | #![feature(async_fn_in_trait)]
    |            ^^^^^^^^^^^^^^^^^
@@ -16,6 +7,16 @@ LL | #![feature(async_fn_in_trait)]
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to previous error; 1 warning emitted
+warning: return type notation is experimental
+  --> $DIR/feature-gate-return_type_notation.rs:15:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
+   = warning: unstable syntax can change at any point in the future, causing a hard error!
+   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 
-For more information about this error, try `rustc --explain E0658`.
+warning: 2 warnings emitted
+

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.rs
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.rs
@@ -1,6 +1,9 @@
 // edition: 2021
 // revisions: cfg no
 
+//[no] check-pass
+// Since we're not adding new syntax, `cfg`'d out RTN must pass.
+
 #![feature(async_fn_in_trait)]
 //~^ WARN the feature `async_fn_in_trait` is incomplete
 
@@ -9,7 +12,11 @@ trait Trait {
 }
 
 #[cfg(cfg)]
-fn foo<T: Trait<m(..): Send>>() {}
-//~^ ERROR return type notation is experimental
+fn foo<T: Trait<m(): Send>>() {}
+//[cfg]~^ ERROR return type notation is experimental
+//[cfg]~| ERROR parenthesized generic arguments cannot be used in associated type constraints
+//[cfg]~| ERROR associated type `m` not found for `Trait`
+//[no]~^^^^ WARN return type notation is experimental
+//[no]~| WARN unstable syntax can change at any point in the future, causing a hard error!
 
 fn main() {}


### PR DESCRIPTION
@nikomatsakis and I decided that using `..` in the return-type notation syntax is probably overkill.

r? @eholk since you reviewed the last one

Since this is piggybacking now totally off of a pre-existing syntax (parenthesized generics), let me know if you need any explanation of the logic here, since it's a bit more complicated now.