### PR TITLE
Greatly decrease the size of `rustc_driver.so` when debuginfo is enabled

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1673,7 +1673,15 @@ impl<'a> Builder<'a> {
                 self.config.rust_debuginfo_level_tools
             }
         };
-        cargo.env(profile_var("DEBUG"), debuginfo_level.to_string());
+        if debuginfo_level == 1 {
+            // Use less debuginfo than the default to save on disk space.
+            cargo.env(profile_var("DEBUG"), "line-tables-only");
+        } else {
+            cargo.env(profile_var("DEBUG"), debuginfo_level.to_string());
+        };
+        if self.cc[&target].args().iter().any(|arg| arg == "-gz") {
+            rustflags.arg("-Clink-arg=-gz");
+        }
         cargo.env(
             profile_var("DEBUG_ASSERTIONS"),
             if mode == Mode::Std {

--- a/src/bootstrap/cc_detect.rs
+++ b/src/bootstrap/cc_detect.rs
@@ -69,6 +69,8 @@ fn new_cc_build(build: &Build, target: TargetSelection) -> cc::Build {
         .opt_level(2)
         .warnings(false)
         .debug(false)
+        // Compress debuginfo
+        .flag_if_supported("-gz")
         .target(&target.triple)
         .host(&build.build.triple);
     match build.crt_static(target) {


### PR DESCRIPTION
- Don't include extra unnecessary debuginfo when only debuginfo-level=1 is set
- Compress debuginfo sections to reduce the size of debuginfo on disk.

before: 650 MB
line tables only: 335 MB
compressed only: 216 MB
compressed and line tables: 186 MB
no debuginfo at all: 130 MB

Here's an example backtrace:

<details><summary>with `debuginfo=1` (what we emit currently for `debuginfo-level-rustc = 1`)</summary>

```
stack backtrace:
   0:     0x7f480fac6097 - std::backtrace_rs::backtrace::libunwind::trace::h8966ca44d9a34123
                               at /home/jyn/src/rust3/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x7f480fac6097 - std::backtrace_rs::backtrace::trace_unsynchronized::h4d58a1c9cd2d9e24
                               at /home/jyn/src/rust3/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x7f480faeb577 - std::sys_common::backtrace::_print_fmt::h95c3301848eb0632
                               at /home/jyn/src/rust3/library/std/src/sys_common/backtrace.rs:65:5
   3:     0x7f480faeb577 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h723a24a56fc95abd
                               at /home/jyn/src/rust3/library/std/src/sys_common/backtrace.rs:44:22
   4:     0x7f480fb45b39 - core::fmt::write::hfd80e5a0f5ad2c26
                               at /home/jyn/src/rust3/library/core/src/fmt/mod.rs:1254:17
   5:     0x7f480fa8a591 - std::io::Write::write_fmt::he06ca70f402de9f9
                               at /home/jyn/src/rust3/library/std/src/io/mod.rs:1698:15
   6:     0x7f480faeb3db - std::sys_common::backtrace::_print::h5c042881d187dfdd
                               at /home/jyn/src/rust3/library/std/src/sys_common/backtrace.rs:47:5
   7:     0x7f480faeb3db - std::sys_common::backtrace::print::h63ca06eeb2d47b55
                               at /home/jyn/src/rust3/library/std/src/sys_common/backtrace.rs:34:9
   8:     0x7f480fac5397 - std::panicking::default_hook::{{closure}}::h1f5c92be2aff3285
   9:     0x7f480fac5115 - std::panicking::default_hook::h6dc3715b1746d160
                               at /home/jyn/src/rust3/library/std/src/panicking.rs:288:9
  10:     0x7f48108534ff - rustc_driver_impl[51f301ed0be6f62f]::DEFAULT_HOOK::{closure#0}::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_driver_impl/src/lib.rs:1188:17
  11:     0x7f480fac5aa4 - std::panicking::rust_panic_with_hook::h84ebf72507cc7aca
                               at /home/jyn/src/rust3/library/std/src/panicking.rs:694:13
  12:     0x7f480fabfec2 - std::panicking::begin_panic_handler::{{closure}}::h2ee673746838829d
                               at /home/jyn/src/rust3/library/std/src/panicking.rs:579:13
  13:     0x7f480fabfe36 - std::sys_common::backtrace::__rust_end_short_backtrace::h5f7b4d3d0568679c
                               at /home/jyn/src/rust3/library/std/src/sys_common/backtrace.rs:150:18
  14:     0x7f480fac5492 - rust_begin_unwind
                               at /home/jyn/src/rust3/library/std/src/panicking.rs:577:5
  15:     0x7f480fa80bd3 - core::panicking::panic_fmt::h53276e9f07775686
                               at /home/jyn/src/rust3/library/core/src/panicking.rs:67:14
  16:     0x7f4813a5999a - <rustc_errors[ce8323ca4cc1fd17]::HandlerInner>::panic_if_treat_err_as_bug
  17:     0x7f4813a5953d - <rustc_errors[ce8323ca4cc1fd17]::HandlerInner>::emit_diagnostic::{closure#2}
  18:     0x7f481094f589 - rustc_interface[850741d9ad1ee353]::callbacks::track_diagnostic::{closure#0}::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/callbacks.rs:41:53
  19:     0x7f481094f589 - rustc_middle[42813831790177f8]::ty::context::tls::enter_context::<rustc_interface[850741d9ad1ee353]::callbacks::track_diagnostic::{closure#0}::{closure#0}, ()>::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:82:9
  20:     0x7f481094f589 - <std[4b96690c503973c9]::thread::local::LocalKey<core[9f6b914a8323238a]::cell::Cell<*const ()>>>::try_with::<rustc_middle[42813831790177f8]::ty::context::tls::enter_context<rustc_interface[850741d9ad1ee353]::callbacks::track_diagnostic::{closure#0}::{closure#0}, ()>::{closure#0}, ()>
                               at /home/jyn/src/rust3/library/std/src/thread/local.rs:252:16
  21:     0x7f481094f589 - <std[4b96690c503973c9]::thread::local::LocalKey<core[9f6b914a8323238a]::cell::Cell<*const ()>>>::with::<rustc_middle[42813831790177f8]::ty::context::tls::enter_context<rustc_interface[850741d9ad1ee353]::callbacks::track_diagnostic::{closure#0}::{closure#0}, ()>::{closure#0}, ()>
                               at /home/jyn/src/rust3/library/std/src/thread/local.rs:228:9
  22:     0x7f481093ea5a - rustc_middle[42813831790177f8]::ty::context::tls::enter_context::<rustc_interface[850741d9ad1ee353]::callbacks::track_diagnostic::{closure#0}::{closure#0}, ()>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:79:5
  23:     0x7f481093ea5a - rustc_interface[850741d9ad1ee353]::callbacks::track_diagnostic::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/callbacks.rs:41:20
  24:     0x7f481093ea5a - rustc_middle[42813831790177f8]::ty::context::tls::with_context_opt::<rustc_interface[850741d9ad1ee353]::callbacks::track_diagnostic::{closure#0}, ()>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:100:18
  25:     0x7f481093ea5a - rustc_interface[850741d9ad1ee353]::callbacks::track_diagnostic
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/callbacks.rs:31:5
  26:     0x7f4813a58b31 - <rustc_errors[ce8323ca4cc1fd17]::HandlerInner>::emit_diagnostic
                               at /home/jyn/src/rust3/compiler/rustc_errors/src/lib.rs:1370:9
  27:     0x7f4813a576a3 - <rustc_errors[ce8323ca4cc1fd17]::Handler>::emit_diagnostic
                               at /home/jyn/src/rust3/compiler/rustc_errors/src/lib.rs:1121:9
  28:     0x7f4813a9a00a - <rustc_span[c31f71685094a917]::ErrorGuaranteed as rustc_errors[ce8323ca4cc1fd17]::diagnostic_builder::EmissionGuarantee>::diagnostic_builder_emit_producing_guarantee
                               at /home/jyn/src/rust3/compiler/rustc_errors/src/diagnostic_builder.rs:169:28
  29:     0x7f48116f1e82 - <rustc_resolve[ae3e8cdb7693af44]::Resolver>::report_error
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/diagnostics.rs:533:9
  30:     0x7f4811799349 - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::report_error
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:3665:13
  31:     0x7f4811799349 - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::smart_resolve_path_fragment
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:3630:21
  32:     0x7f48117fb10c - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::with_optional_trait_ref::<(), <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::resolve_implementation::{closure#0}::{closure#0}::{closure#0}::{closure#0}>
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2680:23
  33:     0x7f48117fb10c - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::resolve_implementation::{closure#0}::{closure#0}::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2741:29
  34:     0x7f48117fb10c - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::with_lifetime_rib::<(), <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::resolve_implementation::{closure#0}::{closure#0}::{closure#0}>
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:1427:19
  35:     0x7f48117fb10c - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::resolve_implementation::{closure#0}::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2734:21
  36:     0x7f48117fb10c - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::with_self_rib_ns::<<rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::resolve_implementation::{closure#0}::{closure#0}>
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2704:9
  37:     0x7f48117fb10c - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::with_self_rib::<<rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::resolve_implementation::{closure#0}::{closure#0}>
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2709:9
  38:     0x7f48117fb10c - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::resolve_implementation::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2733:17
  39:     0x7f48117fb10c - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::with_generic_param_rib::<<rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::resolve_implementation::{closure#0}>
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2530:9
  40:     0x7f481178f9d6 - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::resolve_implementation
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2723:9
  41:     0x7f481178f9d6 - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::resolve_item
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2280:17
  42:     0x7f481181041f - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor as rustc_ast[c8db5f01609d59c8]::visit::Visitor>::visit_item::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:638:62
  43:     0x7f481181041f - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>::with_lifetime_rib::<(), <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor as rustc_ast[c8db5f01609d59c8]::visit::Visitor>::visit_item::{closure#0}>
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:1427:19
  44:     0x7f4811788dfc - <rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor as rustc_ast[c8db5f01609d59c8]::visit::Visitor>::visit_item
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:638:9
  45:     0x7f4811727b72 - rustc_ast[c8db5f01609d59c8]::visit::walk_crate::<rustc_resolve[ae3e8cdb7693af44]::late::LateResolutionVisitor>
                               at /home/jyn/src/rust3/compiler/rustc_ast/src/visit.rs:266:5
  46:     0x7f48117009fe - <rustc_resolve[ae3e8cdb7693af44]::Resolver>::late_resolve_crate
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:4355:9
  47:     0x7f4811718769 - <rustc_resolve[ae3e8cdb7693af44]::Resolver>::resolve_crate::{closure#0}::{closure#4}
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/lib.rs:1486:57
  48:     0x7f4811718769 - <rustc_data_structures[eb5e208c37d0260d]::profiling::VerboseTimingGuard>::run::<(), <rustc_resolve[ae3e8cdb7693af44]::Resolver>::resolve_crate::{closure#0}::{closure#4}>
                               at /home/jyn/src/rust3/compiler/rustc_data_structures/src/profiling.rs:752:9
  49:     0x7f4811718769 - <rustc_session[1a3952bb48d6309d]::session::Session>::time::<(), <rustc_resolve[ae3e8cdb7693af44]::Resolver>::resolve_crate::{closure#0}::{closure#4}>
                               at /home/jyn/src/rust3/compiler/rustc_session/src/utils.rs:11:9
  50:     0x7f4811718769 - <rustc_resolve[ae3e8cdb7693af44]::Resolver>::resolve_crate::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/lib.rs:1486:13
  51:     0x7f4811718769 - <rustc_data_structures[eb5e208c37d0260d]::profiling::VerboseTimingGuard>::run::<(), <rustc_resolve[ae3e8cdb7693af44]::Resolver>::resolve_crate::{closure#0}>
                               at /home/jyn/src/rust3/compiler/rustc_data_structures/src/profiling.rs:752:9
  52:     0x7f4811718769 - <rustc_session[1a3952bb48d6309d]::session::Session>::time::<(), <rustc_resolve[ae3e8cdb7693af44]::Resolver>::resolve_crate::{closure#0}>
                               at /home/jyn/src/rust3/compiler/rustc_session/src/utils.rs:11:9
  53:     0x7f481170cb11 - <rustc_resolve[ae3e8cdb7693af44]::Resolver>::resolve_crate
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/lib.rs:1477:9
  54:     0x7f481093a0a2 - rustc_interface[850741d9ad1ee353]::passes::configure_and_expand
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/passes.rs:309:5
  55:     0x7f481093a0a2 - rustc_interface[850741d9ad1ee353]::passes::resolver_for_lowering
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/passes.rs:566:17
  56:     0x7f481276b314 - <rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering as rustc_query_system[79c28ca66b9d8600]::query::config::QueryConfig<rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>>::compute
                               at /home/jyn/src/rust3/compiler/rustc_query_impl/src/plumbing.rs:519:21
  57:     0x7f481276b314 - rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr::<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_query_system/src/query/plumbing.rs:443:72
  58:     0x7f481276b314 - rustc_middle[42813831790177f8]::ty::context::tls::enter_context::<rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:82:9
  59:     0x7f481276b314 - <std[4b96690c503973c9]::thread::local::LocalKey<core[9f6b914a8323238a]::cell::Cell<*const ()>>>::try_with::<rustc_middle[42813831790177f8]::ty::context::tls::enter_context<rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>
                               at /home/jyn/src/rust3/library/std/src/thread/local.rs:252:16
  60:     0x7f481276b314 - <std[4b96690c503973c9]::thread::local::LocalKey<core[9f6b914a8323238a]::cell::Cell<*const ()>>>::with::<rustc_middle[42813831790177f8]::ty::context::tls::enter_context<rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>
                               at /home/jyn/src/rust3/library/std/src/thread/local.rs:228:9
  61:     0x7f48125abd27 - rustc_middle[42813831790177f8]::ty::context::tls::enter_context::<rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:79:5
  62:     0x7f48125abd27 - <rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt as rustc_query_system[79c28ca66b9d8600]::query::QueryContext>::start_query::<&rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>, rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}>::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_query_impl/src/plumbing.rs:127:13
  63:     0x7f48125abd27 - rustc_middle[42813831790177f8]::ty::context::tls::with_related_context::<<rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt as rustc_query_system[79c28ca66b9d8600]::query::QueryContext>::start_query<&rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>, rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:133:9
  64:     0x7f48125abd27 - rustc_middle[42813831790177f8]::ty::context::tls::with_context::<rustc_middle[42813831790177f8]::ty::context::tls::with_related_context<<rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt as rustc_query_system[79c28ca66b9d8600]::query::QueryContext>::start_query<&rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>, rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:111:36
  65:     0x7f48125abd27 - rustc_middle[42813831790177f8]::ty::context::tls::with_context_opt::<rustc_middle[42813831790177f8]::ty::context::tls::with_context<rustc_middle[42813831790177f8]::ty::context::tls::with_related_context<<rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt as rustc_query_system[79c28ca66b9d8600]::query::QueryContext>::start_query<&rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>, rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:100:18
  66:     0x7f48125abd27 - rustc_middle[42813831790177f8]::ty::context::tls::with_context::<rustc_middle[42813831790177f8]::ty::context::tls::with_related_context<<rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt as rustc_query_system[79c28ca66b9d8600]::query::QueryContext>::start_query<&rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>, rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:111:5
  67:     0x7f48125abd27 - rustc_middle[42813831790177f8]::ty::context::tls::with_related_context::<<rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt as rustc_query_system[79c28ca66b9d8600]::query::QueryContext>::start_query<&rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>, rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:124:5
  68:     0x7f48125abd27 - <rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt as rustc_query_system[79c28ca66b9d8600]::query::QueryContext>::start_query::<&rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>, rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}>
                               at /home/jyn/src/rust3/compiler/rustc_query_impl/src/plumbing.rs:112:9
  69:     0x7f48125abd27 - rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job_non_incr::<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>
                               at /home/jyn/src/rust3/compiler/rustc_query_system/src/query/plumbing.rs:443:18
  70:     0x7f48125abd27 - rustc_query_system[79c28ca66b9d8600]::query::plumbing::execute_job::<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>
                               at /home/jyn/src/rust3/compiler/rustc_query_system/src/query/plumbing.rs:401:17
  71:     0x7f48125abd27 - rustc_query_system[79c28ca66b9d8600]::query::plumbing::try_execute_query::<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>
                               at /home/jyn/src/rust3/compiler/rustc_query_system/src/query/plumbing.rs:357:13
  72:     0x7f481244276f - rustc_query_system[79c28ca66b9d8600]::query::plumbing::get_query::<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_query_system/src/query/plumbing.rs:800:36
  73:     0x7f481244276f - stacker[d946eb825266a062]::maybe_grow::<(&rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>, core[9f6b914a8323238a]::option::Option<rustc_query_system[79c28ca66b9d8600]::dep_graph::graph::DepNodeIndex>), rustc_query_system[79c28ca66b9d8600]::query::plumbing::get_query<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}>
                               at /home/jyn/.local/lib/cargo/registry/src/index.crates.io-6f17d22bba15001f/stacker-0.1.15/src/lib.rs:55:9
  74:     0x7f481244276f - rustc_data_structures[eb5e208c37d0260d]::stack::ensure_sufficient_stack::<(&rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>, core[9f6b914a8323238a]::option::Option<rustc_query_system[79c28ca66b9d8600]::dep_graph::graph::DepNodeIndex>), rustc_query_system[79c28ca66b9d8600]::query::plumbing::get_query<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>::{closure#0}>
                               at /home/jyn/src/rust3/compiler/rustc_data_structures/src/stack.rs:17:5
  75:     0x7f481244276f - rustc_query_system[79c28ca66b9d8600]::query::plumbing::get_query::<rustc_query_impl[d74f45b2a9c18a73]::queries::resolver_for_lowering, rustc_query_impl[d74f45b2a9c18a73]::plumbing::QueryCtxt>
                               at /home/jyn/src/rust3/compiler/rustc_query_system/src/query/plumbing.rs:800:9
  76:     0x7f481244276f - <rustc_query_impl[d74f45b2a9c18a73]::Queries as rustc_middle[42813831790177f8]::ty::query::QueryEngine>::resolver_for_lowering::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_query_impl/src/plumbing.rs:805:17
  77:     0x7f481244276f - <rustc_query_impl[d74f45b2a9c18a73]::Queries as rustc_middle[42813831790177f8]::ty::query::QueryEngine>::resolver_for_lowering
                               at /home/jyn/src/rust3/compiler/rustc_query_impl/src/lib.rs:46:1
  78:     0x7f4810902093 - <rustc_middle[42813831790177f8]::ty::query::TyCtxtAt>::resolver_for_lowering
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/query.rs:400:29
  79:     0x7f4810902093 - <rustc_middle[42813831790177f8]::ty::context::TyCtxt>::resolver_for_lowering
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/query.rs:386:17
  80:     0x7f4810902093 - rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}::{closure#2}::{closure#2}
                               at /home/jyn/src/rust3/compiler/rustc_driver_impl/src/lib.rs:369:48
  81:     0x7f4810902093 - <rustc_middle[42813831790177f8]::ty::context::GlobalCtxt>::enter::<rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}::{closure#2}::{closure#2}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context.rs:559:37
  82:     0x7f4810902093 - rustc_middle[42813831790177f8]::ty::context::tls::enter_context::<<rustc_middle[42813831790177f8]::ty::context::GlobalCtxt>::enter<rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}::{closure#2}::{closure#2}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:82:9
  83:     0x7f4810902093 - <std[4b96690c503973c9]::thread::local::LocalKey<core[9f6b914a8323238a]::cell::Cell<*const ()>>>::try_with::<rustc_middle[42813831790177f8]::ty::context::tls::enter_context<<rustc_middle[42813831790177f8]::ty::context::GlobalCtxt>::enter<rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}::{closure#2}::{closure#2}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>
                               at /home/jyn/src/rust3/library/std/src/thread/local.rs:252:16
  84:     0x7f4810902093 - <std[4b96690c503973c9]::thread::local::LocalKey<core[9f6b914a8323238a]::cell::Cell<*const ()>>>::with::<rustc_middle[42813831790177f8]::ty::context::tls::enter_context<<rustc_middle[42813831790177f8]::ty::context::GlobalCtxt>::enter<rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}::{closure#2}::{closure#2}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>
                               at /home/jyn/src/rust3/library/std/src/thread/local.rs:228:9
  85:     0x7f48108d8388 - rustc_middle[42813831790177f8]::ty::context::tls::enter_context::<<rustc_middle[42813831790177f8]::ty::context::GlobalCtxt>::enter<rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}::{closure#2}::{closure#2}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:79:5
  86:     0x7f48108d8388 - <rustc_middle[42813831790177f8]::ty::context::GlobalCtxt>::enter::<rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}::{closure#2}::{closure#2}, &rustc_data_structures[eb5e208c37d0260d]::steal::Steal<(rustc_middle[42813831790177f8]::ty::ResolverAstLowering, alloc[7616734a6a699536]::rc::Rc<rustc_ast[c8db5f01609d59c8]::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context.rs:559:9
  87:     0x7f48108dfcf8 - rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}::{closure#2}
                               at /home/jyn/src/rust3/compiler/rustc_driver_impl/src/lib.rs:369:13
  88:     0x7f48108dfcf8 - <rustc_interface[850741d9ad1ee353]::interface::Compiler>::enter::<rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}::{closure#2}, core[9f6b914a8323238a]::result::Result<core[9f6b914a8323238a]::option::Option<rustc_interface[850741d9ad1ee353]::queries::Linker>, rustc_span[c31f71685094a917]::ErrorGuaranteed>>
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/queries.rs:394:19
  89:     0x7f4810903a60 - rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}
                               at /home/jyn/src/rust3/compiler/rustc_driver_impl/src/lib.rs:330:22
  90:     0x7f4810903a60 - rustc_interface[850741d9ad1ee353]::interface::run_compiler::<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/interface.rs:301:21
  91:     0x7f4810903a60 - rustc_span[c31f71685094a917]::set_source_map::<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_interface[850741d9ad1ee353]::interface::run_compiler<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}::{closure#0}>
                               at /home/jyn/src/rust3/compiler/rustc_span/src/lib.rs:1040:5
  92:     0x7f481086922e - rustc_interface[850741d9ad1ee353]::interface::run_compiler::<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/interface.rs:295:13
  93:     0x7f481086922e - <scoped_tls[edf8690d0b030835]::ScopedKey<rustc_span[c31f71685094a917]::SessionGlobals>>::set::<rustc_interface[850741d9ad1ee353]::interface::run_compiler<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>
                               at /home/jyn/.local/lib/cargo/registry/src/index.crates.io-6f17d22bba15001f/scoped-tls-1.0.0/src/lib.rs:137:9
  94:     0x7f48109001e7 - rustc_span[c31f71685094a917]::create_session_globals_then::<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_interface[850741d9ad1ee353]::interface::run_compiler<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}>
                               at /home/jyn/src/rust3/compiler/rustc_span/src/lib.rs:120:5
  95:     0x7f48109001e7 - rustc_interface[850741d9ad1ee353]::util::run_in_thread_pool_with_globals::<rustc_interface[850741d9ad1ee353]::interface::run_compiler<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#0}::{closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/util.rs:152:38
  96:     0x7f48109001e7 - std[4b96690c503973c9]::sys_common::backtrace::__rust_begin_short_backtrace::<rustc_interface[850741d9ad1ee353]::util::run_in_thread_pool_with_globals<rustc_interface[850741d9ad1ee353]::interface::run_compiler<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>
                               at /home/jyn/src/rust3/library/std/src/sys_common/backtrace.rs:134:18
  97:     0x7f4810900784 - <std[4b96690c503973c9]::thread::Builder>::spawn_unchecked_::<rustc_interface[850741d9ad1ee353]::util::run_in_thread_pool_with_globals<rustc_interface[850741d9ad1ee353]::interface::run_compiler<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#1}::{closure#0}
                               at /home/jyn/src/rust3/library/std/src/thread/mod.rs:525:17
  98:     0x7f4810900784 - <core[9f6b914a8323238a]::panic::unwind_safe::AssertUnwindSafe<<std[4b96690c503973c9]::thread::Builder>::spawn_unchecked_<rustc_interface[850741d9ad1ee353]::util::run_in_thread_pool_with_globals<rustc_interface[850741d9ad1ee353]::interface::run_compiler<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#1}::{closure#0}> as core[9f6b914a8323238a]::ops::function::FnOnce<()>>::call_once
                               at /home/jyn/src/rust3/library/core/src/panic/unwind_safe.rs:271:9
  99:     0x7f48108dd115 - std[4b96690c503973c9]::panicking::try::do_call::<core[9f6b914a8323238a]::panic::unwind_safe::AssertUnwindSafe<<std[4b96690c503973c9]::thread::Builder>::spawn_unchecked_<rustc_interface[850741d9ad1ee353]::util::run_in_thread_pool_with_globals<rustc_interface[850741d9ad1ee353]::interface::run_compiler<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#1}::{closure#0}>, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>
                               at /home/jyn/src/rust3/library/std/src/panicking.rs:485:40
 100:     0x7f48108dd115 - std[4b96690c503973c9]::panicking::try::<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, core[9f6b914a8323238a]::panic::unwind_safe::AssertUnwindSafe<<std[4b96690c503973c9]::thread::Builder>::spawn_unchecked_<rustc_interface[850741d9ad1ee353]::util::run_in_thread_pool_with_globals<rustc_interface[850741d9ad1ee353]::interface::run_compiler<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#1}::{closure#0}>>
                               at /home/jyn/src/rust3/library/std/src/panicking.rs:449:19
 101:     0x7f48108ff5a9 - std[4b96690c503973c9]::panic::catch_unwind::<core[9f6b914a8323238a]::panic::unwind_safe::AssertUnwindSafe<<std[4b96690c503973c9]::thread::Builder>::spawn_unchecked_<rustc_interface[850741d9ad1ee353]::util::run_in_thread_pool_with_globals<rustc_interface[850741d9ad1ee353]::interface::run_compiler<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#1}::{closure#0}>, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>
                               at /home/jyn/src/rust3/library/std/src/panic.rs:140:14
 102:     0x7f4810906dce - <std[4b96690c503973c9]::thread::Builder>::spawn_unchecked_::<rustc_interface[850741d9ad1ee353]::util::run_in_thread_pool_with_globals<rustc_interface[850741d9ad1ee353]::interface::run_compiler<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#1}
                               at /home/jyn/src/rust3/library/std/src/thread/mod.rs:524:30
 103:     0x7f4810906dce - <<std[4b96690c503973c9]::thread::Builder>::spawn_unchecked_<rustc_interface[850741d9ad1ee353]::util::run_in_thread_pool_with_globals<rustc_interface[850741d9ad1ee353]::interface::run_compiler<core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>, rustc_driver_impl[51f301ed0be6f62f]::run_compiler::{closure#1}>::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[9f6b914a8323238a]::result::Result<(), rustc_span[c31f71685094a917]::ErrorGuaranteed>>::{closure#1} as core[9f6b914a8323238a]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
                               at /home/jyn/src/rust3/library/core/src/ops/function.rs:250:5
 104:     0x7f480fade618 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h204dfbd14fd98aa2
                               at /home/jyn/src/rust3/library/alloc/src/boxed.rs:1976:9
 105:     0x7f480fade618 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h86fe0f298afbbb0f
                               at /home/jyn/src/rust3/library/alloc/src/boxed.rs:1976:9
 106:     0x7f480faab62f - std::sys::unix::thread::Thread::new::thread_start::h3c9bf2d63800d28c
                               at /home/jyn/src/rust3/library/std/src/sys/unix/thread.rs:108:17
 107:     0x7f480f694b43 - start_thread
                               at ./nptl/./nptl/pthread_create.c:442:8
 108:     0x7f480f726a00 - clone3
                               at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
 109:                0x0 - <unknown>
```

</details>

<details><summary>with `debuginfo=line-tables-only` (what we'll emit for  `debuginfo-level-rustc = 1`) after this change</summary>

```
thread 'rustc' panicked at 'aborting due to `-Z treat-err-as-bug=1`', compiler/rustc_errors/src/lib.rs:1705:30
stack backtrace:
   0:     0x7fac39acb0b7 - trace
                               at /home/jyn/src/rust3/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x7fac39acb0b7 - trace_unsynchronized<std::sys_common::backtrace::_print_fmt::{closure_env#1}>
                               at /home/jyn/src/rust3/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x7fac39aaa745 - _print_fmt
                               at /home/jyn/src/rust3/library/std/src/sys_common/backtrace.rs:65:5
   3:     0x7fac39aaa745 - fmt
                               at /home/jyn/src/rust3/library/std/src/sys_common/backtrace.rs:44:22
   4:     0x7fac39b67463 - write
                               at /home/jyn/src/rust3/library/core/src/fmt/mod.rs:1254:17
   5:     0x7fac39acf2a1 - write_fmt<std::sys::unix::stdio::Stderr>
                               at /home/jyn/src/rust3/library/std/src/io/mod.rs:1698:15
   6:     0x7fac39aaa5ad - _print
                               at /home/jyn/src/rust3/library/std/src/sys_common/backtrace.rs:47:5
   7:     0x7fac39aaa5ad - print
                               at /home/jyn/src/rust3/library/std/src/sys_common/backtrace.rs:34:9
   8:     0x7fac39ab4d47 - {closure#1}
   9:     0x7fac39ab4a8c - default_hook
                               at /home/jyn/src/rust3/library/std/src/panicking.rs:288:9
  10:     0x7fac3a87f74f - {closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_driver_impl/src/lib.rs:1188:17
  11:     0x7fac39ab5452 - rust_panic_with_hook
                               at /home/jyn/src/rust3/library/std/src/panicking.rs:694:13
  12:     0x7fac39aab252 - {closure#0}
                               at /home/jyn/src/rust3/library/std/src/panicking.rs:579:13
  13:     0x7fac39aab1c6 - __rust_end_short_backtrace<std::panicking::begin_panic_handler::{closure_env#0}, !>
                               at /home/jyn/src/rust3/library/std/src/sys_common/backtrace.rs:150:18
  14:     0x7fac39ab4e42 - begin_panic_handler
                               at /home/jyn/src/rust3/library/std/src/panicking.rs:577:5
  15:     0x7fac39a81e13 - panic_fmt
                               at /home/jyn/src/rust3/library/core/src/panicking.rs:67:14
  16:     0x7fac3dbc79ba - panic_if_treat_err_as_bug
  17:     0x7fac3dbc756b - {closure#2}
  18:     0x7fac3a966278 - {closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/callbacks.rs:41:53
  19:     0x7fac3a966278 - {closure#0}<rustc_interface::callbacks::track_diagnostic::{closure#0}::{closure_env#0}, ()>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:82:9
  20:     0x7fac3a966278 - try_with<core::cell::Cell<*const ()>, rustc_middle::ty::context::tls::enter_context::{closure_env#0}<rustc_interface::callbacks::track_diagnostic::{closure#0}::{closure_env#0}, ()>, ()>
                               at /home/jyn/src/rust3/library/std/src/thread/local.rs:252:16
  21:     0x7fac3a966278 - with<core::cell::Cell<*const ()>, rustc_middle::ty::context::tls::enter_context::{closure_env#0}<rustc_interface::callbacks::track_diagnostic::{closure#0}::{closure_env#0}, ()>, ()>
                               at /home/jyn/src/rust3/library/std/src/thread/local.rs:228:9
  22:     0x7fac3a954798 - enter_context<rustc_interface::callbacks::track_diagnostic::{closure#0}::{closure_env#0}, ()>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:79:5
  23:     0x7fac3a954798 - {closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/callbacks.rs:41:20
  24:     0x7fac3a954798 - with_context_opt<rustc_interface::callbacks::track_diagnostic::{closure_env#0}, ()>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:100:18
  25:     0x7fac3a954798 - track_diagnostic
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/callbacks.rs:31:5
  26:     0x7fac3dbc6b6d - emit_diagnostic
                               at /home/jyn/src/rust3/compiler/rustc_errors/src/lib.rs:1370:9
  27:     0x7fac3dbc5683 - emit_diagnostic
                               at /home/jyn/src/rust3/compiler/rustc_errors/src/lib.rs:1121:9
  28:     0x7fac3dbd974a - diagnostic_builder_emit_producing_guarantee
                               at /home/jyn/src/rust3/compiler/rustc_errors/src/diagnostic_builder.rs:169:28
  29:     0x7fac3b7e8012 - <rustc_resolve[f1b0f8896e774b]::Resolver>::report_error
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/diagnostics.rs:533:9
  30:     0x7fac3b75c083 - report_error
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:3665:13
  31:     0x7fac3b75c083 - smart_resolve_path_fragment
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:3630:21
  32:     0x7fac3b7b62d4 - with_optional_trait_ref<(), rustc_resolve::late::{impl#10}::resolve_implementation::{closure#0}::{closure#0}::{closure#0}::{closure_env#0}>
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2680:23
  33:     0x7fac3b7b62d4 - {closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2741:29
  34:     0x7fac3b7b62d4 - with_lifetime_rib<(), rustc_resolve::late::{impl#10}::resolve_implementation::{closure#0}::{closure#0}::{closure_env#0}>
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:1427:19
  35:     0x7fac3b7b62d4 - {closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2734:21
  36:     0x7fac3b7b62d4 - with_self_rib_ns<rustc_resolve::late::{impl#10}::resolve_implementation::{closure#0}::{closure_env#0}>
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2704:9
  37:     0x7fac3b7b62d4 - with_self_rib<rustc_resolve::late::{impl#10}::resolve_implementation::{closure#0}::{closure_env#0}>
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2709:9
  38:     0x7fac3b7b62d4 - {closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2733:17
  39:     0x7fac3b7b62d4 - with_generic_param_rib<rustc_resolve::late::{impl#10}::resolve_implementation::{closure_env#0}>
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2530:9
  40:     0x7fac3b752055 - resolve_implementation
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2723:9
  41:     0x7fac3b752055 - resolve_item
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:2280:17
  42:     0x7fac3b7cf6d1 - {closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:638:62
  43:     0x7fac3b7cf6d1 - with_lifetime_rib<(), rustc_resolve::late::{impl#9}::visit_item::{closure_env#0}>
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:1427:19
  44:     0x7fac3b74b179 - visit_item
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:638:9
  45:     0x7fac3b84b7e8 - walk_crate<rustc_resolve::late::LateResolutionVisitor>
                               at /home/jyn/src/rust3/compiler/rustc_ast/src/visit.rs:266:5
  46:     0x7fac3b7f731e - late_resolve_crate
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/late.rs:4355:9
  47:     0x7fac3b811562 - {closure#4}
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/lib.rs:1486:57
  48:     0x7fac3b811562 - run<(), rustc_resolve::{impl#17}::resolve_crate::{closure#0}::{closure_env#4}>
                               at /home/jyn/src/rust3/compiler/rustc_data_structures/src/profiling.rs:752:9
  49:     0x7fac3b811562 - time<(), rustc_resolve::{impl#17}::resolve_crate::{closure#0}::{closure_env#4}>
                               at /home/jyn/src/rust3/compiler/rustc_session/src/utils.rs:11:9
  50:     0x7fac3b811562 - {closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/lib.rs:1486:13
  51:     0x7fac3b811562 - run<(), rustc_resolve::{impl#17}::resolve_crate::{closure_env#0}>
                               at /home/jyn/src/rust3/compiler/rustc_data_structures/src/profiling.rs:752:9
  52:     0x7fac3b811562 - time<(), rustc_resolve::{impl#17}::resolve_crate::{closure_env#0}>
                               at /home/jyn/src/rust3/compiler/rustc_session/src/utils.rs:11:9
  53:     0x7fac3b803761 - resolve_crate
                               at /home/jyn/src/rust3/compiler/rustc_resolve/src/lib.rs:1477:9
  54:     0x7fac3a96976f - configure_and_expand
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/passes.rs:309:5
  55:     0x7fac3a96976f - resolver_for_lowering
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/passes.rs:566:17
  56:     0x7fac3c61f894 - compute
                               at /home/jyn/src/rust3/compiler/rustc_query_impl/src/plumbing.rs:519:21
  57:     0x7fac3c61f894 - {closure#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>
                               at /home/jyn/src/rust3/compiler/rustc_query_system/src/query/plumbing.rs:443:72
  58:     0x7fac3c61f894 - {closure#0}<rustc_query_system::query::plumbing::execute_job_non_incr::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:82:9
  59:     0x7fac3c61f894 - try_with<core::cell::Cell<*const ()>, rustc_middle::ty::context::tls::enter_context::{closure_env#0}<rustc_query_system::query::plumbing::execute_job_non_incr::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/library/std/src/thread/local.rs:252:16
  60:     0x7fac3c61f894 - with<core::cell::Cell<*const ()>, rustc_middle::ty::context::tls::enter_context::{closure_env#0}<rustc_query_system::query::plumbing::execute_job_non_incr::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/library/std/src/thread/local.rs:228:9
  61:     0x7fac3c73544b - enter_context<rustc_query_system::query::plumbing::execute_job_non_incr::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:79:5
  62:     0x7fac3c73544b - {closure#0}<&rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>, rustc_query_system::query::plumbing::execute_job_non_incr::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>>
                               at /home/jyn/src/rust3/compiler/rustc_query_impl/src/plumbing.rs:127:13
  63:     0x7fac3c73544b - {closure#0}<rustc_query_impl::plumbing::{impl#2}::start_query::{closure_env#0}<&rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>, rustc_query_system::query::plumbing::execute_job_non_incr::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:133:9
  64:     0x7fac3c73544b - {closure#0}<rustc_middle::ty::context::tls::with_related_context::{closure_env#0}<rustc_query_impl::plumbing::{impl#2}::start_query::{closure_env#0}<&rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>, rustc_query_system::query::plumbing::execute_job_non_incr::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:111:36
  65:     0x7fac3c73544b - with_context_opt<rustc_middle::ty::context::tls::with_context::{closure_env#0}<rustc_middle::ty::context::tls::with_related_context::{closure_env#0}<rustc_query_impl::plumbing::{impl#2}::start_query::{closure_env#0}<&rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>, rustc_query_system::query::plumbing::execute_job_non_incr::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:100:18
  66:     0x7fac3c73544b - with_context<rustc_middle::ty::context::tls::with_related_context::{closure_env#0}<rustc_query_impl::plumbing::{impl#2}::start_query::{closure_env#0}<&rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>, rustc_query_system::query::plumbing::execute_job_non_incr::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:111:5
  67:     0x7fac3c73544b - with_related_context<rustc_query_impl::plumbing::{impl#2}::start_query::{closure_env#0}<&rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>, rustc_query_system::query::plumbing::execute_job_non_incr::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:124:5
  68:     0x7fac3c73544b - start_query<&rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>, rustc_query_system::query::plumbing::execute_job_non_incr::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>>
                               at /home/jyn/src/rust3/compiler/rustc_query_impl/src/plumbing.rs:112:9
  69:     0x7fac3c73544b - execute_job_non_incr<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>
                               at /home/jyn/src/rust3/compiler/rustc_query_system/src/query/plumbing.rs:443:18
  70:     0x7fac3c73544b - execute_job<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>
                               at /home/jyn/src/rust3/compiler/rustc_query_system/src/query/plumbing.rs:401:17
  71:     0x7fac3c73544b - try_execute_query<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>
                               at /home/jyn/src/rust3/compiler/rustc_query_system/src/query/plumbing.rs:357:13
  72:     0x7fac3c3e4191 - {closure#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>
                               at /home/jyn/src/rust3/compiler/rustc_query_system/src/query/plumbing.rs:800:36
  73:     0x7fac3c3e4191 - maybe_grow<(&rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>, core::option::Option<rustc_query_system::dep_graph::graph::DepNodeIndex>), rustc_query_system::query::plumbing::get_query::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>>
                               at /home/jyn/.local/lib/cargo/registry/src/index.crates.io-6f17d22bba15001f/stacker-0.1.15/src/lib.rs:55:9
  74:     0x7fac3c3e4191 - ensure_sufficient_stack<(&rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>, core::option::Option<rustc_query_system::dep_graph::graph::DepNodeIndex>), rustc_query_system::query::plumbing::get_query::{closure_env#0}<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>>
                               at /home/jyn/src/rust3/compiler/rustc_data_structures/src/stack.rs:17:5
  75:     0x7fac3c3e4191 - get_query<rustc_query_impl::queries::resolver_for_lowering, rustc_query_impl::plumbing::QueryCtxt>
                               at /home/jyn/src/rust3/compiler/rustc_query_system/src/query/plumbing.rs:800:9
  76:     0x7fac3c3e4191 - {closure#0}
                               at /home/jyn/src/rust3/compiler/rustc_query_impl/src/plumbing.rs:805:17
  77:     0x7fac3c3e4191 - resolver_for_lowering
                               at /home/jyn/src/rust3/compiler/rustc_query_impl/src/lib.rs:46:1
  78:     0x7fac3a927bc4 - resolver_for_lowering
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/query.rs:400:29
  79:     0x7fac3a927bc4 - resolver_for_lowering
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/query.rs:386:17
  80:     0x7fac3a927bc4 - {closure#2}
                               at /home/jyn/src/rust3/compiler/rustc_driver_impl/src/lib.rs:369:48
  81:     0x7fac3a927bc4 - {closure#0}<rustc_driver_impl::run_compiler::{closure#1}::{closure#2}::{closure_env#2}, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context.rs:559:37
  82:     0x7fac3a927bc4 - {closure#0}<rustc_middle::ty::context::{impl#9}::enter::{closure_env#0}<rustc_driver_impl::run_compiler::{closure#1}::{closure#2}::{closure_env#2}, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:82:9
  83:     0x7fac3a927bc4 - try_with<core::cell::Cell<*const ()>, rustc_middle::ty::context::tls::enter_context::{closure_env#0}<rustc_middle::ty::context::{impl#9}::enter::{closure_env#0}<rustc_driver_impl::run_compiler::{closure#1}::{closure#2}::{closure_env#2}, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/library/std/src/thread/local.rs:252:16
  84:     0x7fac3a927bc4 - with<core::cell::Cell<*const ()>, rustc_middle::ty::context::tls::enter_context::{closure_env#0}<rustc_middle::ty::context::{impl#9}::enter::{closure_env#0}<rustc_driver_impl::run_compiler::{closure#1}::{closure#2}::{closure_env#2}, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/library/std/src/thread/local.rs:228:9
  85:     0x7fac3a920978 - enter_context<rustc_middle::ty::context::{impl#9}::enter::{closure_env#0}<rustc_driver_impl::run_compiler::{closure#1}::{closure#2}::{closure_env#2}, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context/tls.rs:79:5
  86:     0x7fac3a920978 - enter<rustc_driver_impl::run_compiler::{closure#1}::{closure#2}::{closure_env#2}, &rustc_data_structures::steal::Steal<(rustc_middle::ty::ResolverAstLowering, alloc::rc::Rc<rustc_ast::ast::Crate>)>>
                               at /home/jyn/src/rust3/compiler/rustc_middle/src/ty/context.rs:559:9
  87:     0x7fac3a898231 - {closure#2}
                               at /home/jyn/src/rust3/compiler/rustc_driver_impl/src/lib.rs:369:13
  88:     0x7fac3a898231 - enter<rustc_driver_impl::run_compiler::{closure#1}::{closure_env#2}, core::result::Result<core::option::Option<rustc_interface::queries::Linker>, rustc_span::ErrorGuaranteed>>
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/queries.rs:394:19
  89:     0x7fac3a92acd0 - {closure#1}
                               at /home/jyn/src/rust3/compiler/rustc_driver_impl/src/lib.rs:330:22
  90:     0x7fac3a92acd0 - {closure#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/interface.rs:301:21
  91:     0x7fac3a92acd0 - set_source_map<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_interface::interface::run_compiler::{closure#0}::{closure_env#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>>
                               at /home/jyn/src/rust3/compiler/rustc_span/src/lib.rs:1040:5
  92:     0x7fac3a90be75 - {closure#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/interface.rs:295:13
  93:     0x7fac3a90be75 - set<rustc_span::SessionGlobals, rustc_interface::interface::run_compiler::{closure_env#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
                               at /home/jyn/.local/lib/cargo/registry/src/index.crates.io-6f17d22bba15001f/scoped-tls-1.0.0/src/lib.rs:137:9
  94:     0x7fac3a936180 - create_session_globals_then<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_interface::interface::run_compiler::{closure_env#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>>
                               at /home/jyn/src/rust3/compiler/rustc_span/src/lib.rs:120:5
  95:     0x7fac3a936180 - {closure#0}<rustc_interface::interface::run_compiler::{closure_env#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
                               at /home/jyn/src/rust3/compiler/rustc_interface/src/util.rs:152:38
  96:     0x7fac3a936180 - __rust_begin_short_backtrace<rustc_interface::util::run_in_thread_pool_with_globals::{closure#0}::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
                               at /home/jyn/src/rust3/library/std/src/sys_common/backtrace.rs:134:18
  97:     0x7fac3a933f34 - {closure#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure#0}::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
                               at /home/jyn/src/rust3/library/std/src/thread/mod.rs:525:17
  98:     0x7fac3a933f34 - call_once<core::result::Result<(), rustc_span::ErrorGuaranteed>, std::thread::{impl#0}::spawn_unchecked_::{closure#1}::{closure_env#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure#0}::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>>
                               at /home/jyn/src/rust3/library/core/src/panic/unwind_safe.rs:271:9
  99:     0x7fac3a92edee - do_call<core::panic::unwind_safe::AssertUnwindSafe<std::thread::{impl#0}::spawn_unchecked_::{closure#1}::{closure_env#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure#0}::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
                               at /home/jyn/src/rust3/library/std/src/panicking.rs:485:40
 100:     0x7fac3a92edee - try<core::result::Result<(), rustc_span::ErrorGuaranteed>, core::panic::unwind_safe::AssertUnwindSafe<std::thread::{impl#0}::spawn_unchecked_::{closure#1}::{closure_env#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure#0}::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>>>
                               at /home/jyn/src/rust3/library/std/src/panicking.rs:449:19
 101:     0x7fac3a92b4a9 - std[87510a80a31d1ff5]::panic::catch_unwind::<core[d7640b29515502ef]::panic::unwind_safe::AssertUnwindSafe<<std[87510a80a31d1ff5]::thread::Builder>::spawn_unchecked_<rustc_interface[d7f3acd7fb1171d2]::util::run_in_thread_pool_with_globals<rustc_interface[d7f3acd7fb1171d2]::interface::run_compiler<core[d7640b29515502ef]::result::Result<(), rustc_span[a64d79e97ca68de]::ErrorGuaranteed>, rustc_driver_impl[c9cfc8bd445e3254]::run_compiler::{closure#1}>::{closure#0}, core[d7640b29515502ef]::result::Result<(), rustc_span[a64d79e97ca68de]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[d7640b29515502ef]::result::Result<(), rustc_span[a64d79e97ca68de]::ErrorGuaranteed>>::{closure#1}::{closure#0}>, core[d7640b29515502ef]::result::Result<(), rustc_span[a64d79e97ca68de]::ErrorGuaranteed>>
                               at /home/jyn/src/rust3/library/std/src/panic.rs:140:14
 102:     0x7fac3a93565a - {closure#1}<rustc_interface::util::run_in_thread_pool_with_globals::{closure#0}::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
                               at /home/jyn/src/rust3/library/std/src/thread/mod.rs:524:30
 103:     0x7fac3a93565a - call_once<std::thread::{impl#0}::spawn_unchecked_::{closure_env#1}<rustc_interface::util::run_in_thread_pool_with_globals::{closure#0}::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#0}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#1}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, ()>
                               at /home/jyn/src/rust3/library/core/src/ops/function.rs:250:5
 104:     0x7fac39abfb7a - call_once<(), dyn core::ops::function::FnOnce<(), Output=()>, alloc::alloc::Global>
                               at /home/jyn/src/rust3/library/alloc/src/boxed.rs:1976:9
 105:     0x7fac39abfb7a - call_once<(), alloc::boxed::Box<dyn core::ops::function::FnOnce<(), Output=()>, alloc::alloc::Global>, alloc::alloc::Global>
                               at /home/jyn/src/rust3/library/alloc/src/boxed.rs:1976:9
 106:     0x7fac39acc15f - thread_start
                               at /home/jyn/src/rust3/library/std/src/sys/unix/thread.rs:108:17
 107:     0x7fac39694b43 - start_thread
                               at ./nptl/./nptl/pthread_create.c:442:8
 108:     0x7fac39726a00 - clone3
                               at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
 109:                0x0 - <unknown>
```

</details>

<details><summary>with `debuginfo==0` (what we ship on nightly)</summary>

```
thread 'rustc' panicked at 'aborting due to `-Z treat-err-as-bug=1`', compiler/rustc_errors/src/lib.rs:1707:30
stack backtrace:
   0:     0x7fecab564dda - std::backtrace_rs::backtrace::libunwind::trace::hd890f297c35553be
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x7fecab564dda - std::backtrace_rs::backtrace::trace_unsynchronized::h5e501f63d322b5d9
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x7fecab564dda - std::sys_common::backtrace::_print_fmt::h4ea5404a8dc8a615
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/sys_common/backtrace.rs:65:5
   3:     0x7fecab564dda - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h528f1c63f2f0b5a2
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/sys_common/backtrace.rs:44:22
   4:     0x7fecab5c8e8f - core::fmt::write::h92fbcfdd55bf20e5
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/core/src/fmt/mod.rs:1254:17
   5:     0x7fecab557a15 - std::io::Write::write_fmt::hd6d4f06b4b60f7dd
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/io/mod.rs:1698:15
   6:     0x7fecab564ba5 - std::sys_common::backtrace::_print::hfe70f1a1dda7f547
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/sys_common/backtrace.rs:47:5
   7:     0x7fecab564ba5 - std::sys_common::backtrace::print::h204d02dc6e92a8d4
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/sys_common/backtrace.rs:34:9
   8:     0x7fecab56784e - std::panicking::default_hook::{{closure}}::h590499ac98120a02
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/panicking.rs:269:22
   9:     0x7fecab5675f5 - std::panicking::default_hook::h8432db3afafe8754
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/panicking.rs:288:9
  10:     0x7fecae86bc95 - <rustc_driver_impl[51bbdc723b4381e6]::DEFAULT_HOOK::{closure#0}::{closure#0} as core[b4e41bc4a7d98353]::ops::function::FnOnce<(&core[b4e41bc4a7d98353]::panic::panic_info::PanicInfo,)>>::call_once::{shim:vtable#0}
  11:     0x7fecab568044 - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::h6a5479add409cfec
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/alloc/src/boxed.rs:1990:9
  12:     0x7fecab568044 - std::panicking::rust_panic_with_hook::hc982020112517be5
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/panicking.rs:694:13
  13:     0x7fecab567d72 - std::panicking::begin_panic_handler::{{closure}}::h68df73769393a5df
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/panicking.rs:579:13
  14:     0x7fecab565246 - std::sys_common::backtrace::__rust_end_short_backtrace::h490338a02e715ea3
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/sys_common/backtrace.rs:150:18
  15:     0x7fecab567b12 - rust_begin_unwind
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/panicking.rs:577:5
  16:     0x7fecab5c51a3 - core::panicking::panic_fmt::hb91cac3667584009
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/core/src/panicking.rs:67:14
  17:     0x7fecadfa81c0 - <rustc_errors[2fd8e19074bb19a7]::HandlerInner>::panic_if_treat_err_as_bug
  18:     0x7fecadfa650f - <rustc_errors[2fd8e19074bb19a7]::HandlerInner>::emit_diagnostic::{closure#2}
  19:     0x7fecadfd04e9 - rustc_interface[868d1d6dcc7ce3f3]::callbacks::track_diagnostic
  20:     0x7fecac87941a - <rustc_errors[2fd8e19074bb19a7]::HandlerInner>::emit_diagnostic
  21:     0x7fecad75de51 - <rustc_errors[2fd8e19074bb19a7]::Handler>::emit_diagnostic
  22:     0x7fecad73392d - <rustc_span[d920f05353a0b67d]::ErrorGuaranteed as rustc_errors[2fd8e19074bb19a7]::diagnostic_builder::EmissionGuarantee>::diagnostic_builder_emit_producing_guarantee
  23:     0x7fecad81a421 - <rustc_resolve[cc3659b19ec6d104]::Resolver>::report_error
  24:     0x7fecad81a3e7 - <rustc_resolve[cc3659b19ec6d104]::late::LateResolutionVisitor>::report_error
  25:     0x7fecacd57edb - <rustc_resolve[cc3659b19ec6d104]::late::LateResolutionVisitor>::smart_resolve_path_fragment
  26:     0x7fecad7a9179 - <rustc_resolve[cc3659b19ec6d104]::late::LateResolutionVisitor>::resolve_item
  27:     0x7fecad7a7ce1 - <rustc_resolve[cc3659b19ec6d104]::late::LateResolutionVisitor as rustc_ast[46060e470f68bdeb]::visit::Visitor>::visit_item
  28:     0x7fecad7a7b4d - <rustc_resolve[cc3659b19ec6d104]::Resolver>::late_resolve_crate
  29:     0x7fecad7a6e07 - <rustc_session[34fa709a0c7b5987]::session::Session>::time::<(), <rustc_resolve[cc3659b19ec6d104]::Resolver>::resolve_crate::{closure#0}>
  30:     0x7fecad7a4524 - rustc_interface[868d1d6dcc7ce3f3]::passes::resolver_for_lowering
  31:     0x7fecae044e5e - rustc_query_system[eeb3ef4bd40de947]::query::plumbing::try_execute_query::<rustc_query_impl[2a438d6e87721fba]::queries::resolver_for_lowering, rustc_query_impl[2a438d6e87721fba]::plumbing::QueryCtxt>
  32:     0x7fecae044b4d - <rustc_query_impl[2a438d6e87721fba]::Queries as rustc_middle[957f224f93100ef5]::ty::query::QueryEngine>::resolver_for_lowering
  33:     0x7fecadee5ce8 - <std[db937e718f1a3e1c]::thread::local::LocalKey<core[b4e41bc4a7d98353]::cell::Cell<*const ()>>>::with::<rustc_middle[957f224f93100ef5]::ty::context::tls::enter_context<<rustc_middle[957f224f93100ef5]::ty::context::GlobalCtxt>::enter<rustc_driver_impl[51bbdc723b4381e6]::run_compiler::{closure#1}::{closure#2}::{closure#2}, &rustc_data_structures[410595481347da08]::steal::Steal<(rustc_middle[957f224f93100ef5]::ty::ResolverAstLowering, alloc[dc4e5414e8dd53a1]::rc::Rc<rustc_ast[46060e470f68bdeb]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[410595481347da08]::steal::Steal<(rustc_middle[957f224f93100ef5]::ty::ResolverAstLowering, alloc[dc4e5414e8dd53a1]::rc::Rc<rustc_ast[46060e470f68bdeb]::ast::Crate>)>>::{closure#0}, &rustc_data_structures[410595481347da08]::steal::Steal<(rustc_middle[957f224f93100ef5]::ty::ResolverAstLowering, alloc[dc4e5414e8dd53a1]::rc::Rc<rustc_ast[46060e470f68bdeb]::ast::Crate>)>>
  34:     0x7fecadae2583 - <rustc_interface[868d1d6dcc7ce3f3]::interface::Compiler>::enter::<rustc_driver_impl[51bbdc723b4381e6]::run_compiler::{closure#1}::{closure#2}, core[b4e41bc4a7d98353]::result::Result<core[b4e41bc4a7d98353]::option::Option<rustc_interface[868d1d6dcc7ce3f3]::queries::Linker>, rustc_span[d920f05353a0b67d]::ErrorGuaranteed>>
  35:     0x7fecadadd901 - rustc_span[d920f05353a0b67d]::set_source_map::<core[b4e41bc4a7d98353]::result::Result<(), rustc_span[d920f05353a0b67d]::ErrorGuaranteed>, rustc_interface[868d1d6dcc7ce3f3]::interface::run_compiler<core[b4e41bc4a7d98353]::result::Result<(), rustc_span[d920f05353a0b67d]::ErrorGuaranteed>, rustc_driver_impl[51bbdc723b4381e6]::run_compiler::{closure#1}>::{closure#0}::{closure#0}>
  36:     0x7fecadadceaf - std[db937e718f1a3e1c]::sys_common::backtrace::__rust_begin_short_backtrace::<rustc_interface[868d1d6dcc7ce3f3]::util::run_in_thread_pool_with_globals<rustc_interface[868d1d6dcc7ce3f3]::interface::run_compiler<core[b4e41bc4a7d98353]::result::Result<(), rustc_span[d920f05353a0b67d]::ErrorGuaranteed>, rustc_driver_impl[51bbdc723b4381e6]::run_compiler::{closure#1}>::{closure#0}, core[b4e41bc4a7d98353]::result::Result<(), rustc_span[d920f05353a0b67d]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[b4e41bc4a7d98353]::result::Result<(), rustc_span[d920f05353a0b67d]::ErrorGuaranteed>>
  37:     0x7fecae133881 - <<std[db937e718f1a3e1c]::thread::Builder>::spawn_unchecked_<rustc_interface[868d1d6dcc7ce3f3]::util::run_in_thread_pool_with_globals<rustc_interface[868d1d6dcc7ce3f3]::interface::run_compiler<core[b4e41bc4a7d98353]::result::Result<(), rustc_span[d920f05353a0b67d]::ErrorGuaranteed>, rustc_driver_impl[51bbdc723b4381e6]::run_compiler::{closure#1}>::{closure#0}, core[b4e41bc4a7d98353]::result::Result<(), rustc_span[d920f05353a0b67d]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[b4e41bc4a7d98353]::result::Result<(), rustc_span[d920f05353a0b67d]::ErrorGuaranteed>>::{closure#1} as core[b4e41bc4a7d98353]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
  38:     0x7fecab572125 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hef9df890a1678c59
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/alloc/src/boxed.rs:1976:9
  39:     0x7fecab572125 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h71aaab3d70b452a5
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/alloc/src/boxed.rs:1976:9
  40:     0x7fecab572125 - std::sys::unix::thread::Thread::new::thread_start::h235613601b6f7135
                               at /rustc/9df3a39fb30575d808e70800f9fad5362aac57a2/library/std/src/sys/unix/thread.rs:108:17
  41:     0x7fecab294b43 - start_thread
                               at ./nptl/./nptl/pthread_create.c:442:8
  42:     0x7fecab326a00 - clone3
                               at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
  43:                0x0 - <unknown>
```

</details>

I want to investigate why `-C line-tables-only` is still ~tripling the size of the binary (update: done https://github.com/rust-lang/rust/pull/110221#issuecomment-1507563024), but this seems like a good improvement in the meantime.

I've tested that both valgrind and perf can read the debuginfo:

<details>

```
(bash@dev-desktop-us-1.infra.rust-lang.org) ~/rust [08:31:08]
; valgrind $(rustup which rustc --toolchain rust_stage2) --version
==441671== Memcheck, a memory error detector
==441671== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==441671== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==441671== Command: /home/gh-jyn514/.local/lib/rustup/toolchains/rust_stage2/bin/rustc --version
==441671==
rustc 1.70.0-dev
==441671==
==441671== HEAP SUMMARY:
==441671==     in use at exit: 231,289 bytes in 1,874 blocks
==441671==   total heap usage: 2,538 allocs, 664 frees, 486,368 bytes allocated
==441671==
==441671== LEAK SUMMARY:
==441671==    definitely lost: 70,656 bytes in 1 blocks
==441671==    indirectly lost: 0 bytes in 0 blocks
==441671==      possibly lost: 0 bytes in 0 blocks
==441671==    still reachable: 160,633 bytes in 1,873 blocks
==441671==         suppressed: 0 bytes in 0 blocks
==441671== Rerun with --leak-check=full to see details of leaked memory
==441671==
==441671== For lists of detected and suppressed errors, rerun with: -s
==441671== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
; perf record $(rustup which rustc --toolchain rust_stage2) --version
rustc 1.70.0-dev
[ perf record: Woken up 1 times to write data ]
[ perf record: Captured and wrote 0.005 MB perf.data (70 samples) ]
; perf report
Samples: 70  of event 'cycles:u', Event count (approx.): 21356967
Overhead  Command  Shared Object                        Symbol
  51.55%  rustc    ld-linux-aarch64.so.1                [.] _dl_lookup_symbol_x
  18.70%  rustc    ld-linux-aarch64.so.1                [.] _dl_relocate_object
  11.95%  rustc    ld-linux-aarch64.so.1                [.] do_lookup_x
   5.55%  rustc    [unknown]                            [k] 0xffffa9ad41cfcfdc
   2.68%  rustc    libc.so.6                            [.] __GI___strlen_asimd
   2.42%  rustc    librustc_driver-1a385c366c35e81a.so  [.] llvm::StringMapImpl::LookupBucketFor
   2.16%  rustc    librustc_driver-1a385c366c35e81a.so  [.] _GLOBAL__sub_I_X86InstructionSelector.cpp
   1.96%  rustc    libstd-990fe978dab76ef3.so           [.] <alloc::vec::Vec<T,A> as core::clone::Clone>::clone
   1.60%  rustc    librustc_driver-1a385c366c35e81a.so  [.] llvm::cl::opt<bool, false, llvm::cl::parser<bool> >::~opt
   1.22%  rustc    ld-linux-aarch64.so.1                [.] strcmp
   0.13%  rustc    ld-linux-aarch64.so.1                [.] stat64
   0.05%  rustc    ld-linux-aarch64.so.1                [.] __minimal_calloc
   0.02%  rustc    ld-linux-aarch64.so.1                [.] __GI___tunables_init
   0.02%  rustc    ld-linux-aarch64.so.1                [.] _dl_start
   0.00%  rustc    [unknown]                            [k] 0xffffa9ad41cfd844
   0.00%  rustc    ld-linux-aarch64.so.1                [.] _start
```

</details>

To test this, you can run `x build --stage 0 cargo`, set `build.cargo = "build/host/stage0-tools-bin/cargo"`, and then `x build --stage 2 std`. You should be able to compare the rustc_driver.so outputs to each other:
```
; ls -lh build/host/stage{0,1,2}/lib/librustc_driver*.so
-rw-r--r-- 1 jyn jyn 130M Mar  6 15:24 build/host/stage0/lib/librustc_driver-f265b505c593f632.so
-rwxrwxr-x 3 jyn jyn 216M Apr 11 00:51 build/host/stage1/lib/librustc_driver-3aa1aa8c8214a2de.so
-rwxrwxr-x 4 jyn jyn 186M Apr 11 00:54 build/host/stage2/lib/librustc_driver-02d96489c468b21e.so
```

The difference between stage1 and stage2 is `debuginfo=1` vs `debuginfo=line-tables-only`. Both stages have `-gz` (compressed debuginfo) enabled.

This depends on https://github.com/rust-lang/cargo/pull/11958 (and the exact commit of the cargo submodule will need to change before merging).

Helps with https://github.com/rust-lang/rust/pull/104968.