### PR TITLE
bootstrap: drop some windows features

### DIFF
--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -69,13 +69,9 @@ version = "0.46.0"
 features = [
     "Win32_Foundation",
     "Win32_Security",
-    "Win32_Storage_FileSystem",
     "Win32_System_Diagnostics_Debug",
-    "Win32_System_IO",
-    "Win32_System_Ioctl",
     "Win32_System_JobObjects",
     "Win32_System_ProcessStatus",
-    "Win32_System_SystemServices",
     "Win32_System_Threading",
     "Win32_System_Time",
 ]


### PR DESCRIPTION
They became unused after https://github.com/rust-lang/rust/pull/109960