### PR TITLE
Split out a separate feature gate for impl trait in associated types

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -416,6 +416,8 @@ declare_features! (
     (active, half_open_range_patterns_in_slices, "1.66.0", Some(67264), None),
     /// Allows `if let` guard in match arms.
     (active, if_let_guard, "1.47.0", Some(51114), None),
+    /// Allows `impl Trait` to be used inside associated types (RFC 2515).
+    (active, impl_trait_in_assoc_type, "CURRENT_RUSTC_VERSION", Some(63063), None),
     /// Allows `impl Trait` as output type in `Fn` traits in return position of functions.
     (active, impl_trait_in_fn_trait_return, "1.64.0", Some(99697), None),
     /// Allows referencing `Self` and projections in impl-trait.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -800,6 +800,7 @@ symbols! {
         ignore,
         impl_header_lifetime_elision,
         impl_lint_pass,
+        impl_trait_in_assoc_type,
         impl_trait_in_bindings,
         impl_trait_in_fn_trait_return,
         impl_trait_projections,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -15,6 +15,7 @@
 #![feature(type_ascription)]
 #![feature(iter_intersperse)]
 #![feature(type_alias_impl_trait)]
+#![cfg_attr(not(bootstrap), feature(impl_trait_in_assoc_type))]
 #![recursion_limit = "256"]
 #![warn(rustc::internal)]
 #![allow(clippy::collapsible_if, clippy::collapsible_else_if)]

--- a/tests/rustdoc/auxiliary/issue-73061.rs
+++ b/tests/rustdoc/auxiliary/issue-73061.rs
@@ -1,6 +1,6 @@
 //edition:2018
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub trait Foo {
     type X: std::future::Future<Output = ()>;

--- a/tests/ui/associated-types/issue-63591.rs
+++ b/tests/ui/associated-types/issue-63591.rs
@@ -1,11 +1,13 @@
 // check-pass
 
 #![feature(associated_type_bounds)]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 fn main() {}
 
-trait Bar { type Assoc; }
+trait Bar {
+    type Assoc;
+}
 
 trait Thing {
     type Out;
@@ -13,7 +15,9 @@ trait Thing {
 }
 
 struct AssocIsCopy;
-impl Bar for AssocIsCopy { type Assoc = u8; }
+impl Bar for AssocIsCopy {
+    type Assoc = u8;
+}
 
 impl Thing for AssocIsCopy {
     type Out = impl Bar<Assoc: Copy>;

--- a/tests/ui/async-await/in-trait/async-associated-types2.rs
+++ b/tests/ui/async-await/in-trait/async-associated-types2.rs
@@ -4,7 +4,7 @@
 // revisions: current next
 
 #![feature(async_fn_in_trait)]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 #![allow(incomplete_features)]
 
 use std::future::Future;
@@ -23,9 +23,7 @@ impl MyTrait for i32 {
         Self: 'a;
 
     fn foo<'a>(&'a self) -> Self::Fut<'a> {
-        async {
-            *self
-        }
+        async { *self }
     }
 }
 

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.rs
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.rs
@@ -1,0 +1,18 @@
+trait Foo {
+    type Bar;
+}
+
+impl Foo for () {
+    type Bar = impl std::fmt::Debug;
+    //~^ ERROR: `impl Trait` in associated types is unstable
+}
+
+struct Mop;
+
+impl Mop {
+    type Bop = impl std::fmt::Debug;
+    //~^ ERROR: `impl Trait` in associated types is unstable
+    //~| ERROR: inherent associated types are unstable
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.stderr
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.stderr
@@ -1,0 +1,30 @@
+error[E0658]: `impl Trait` in associated types is unstable
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:6:16
+   |
+LL |     type Bar = impl std::fmt::Debug;
+   |                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
+   = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
+
+error[E0658]: `impl Trait` in associated types is unstable
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:13:16
+   |
+LL |     type Bop = impl std::fmt::Debug;
+   |                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
+   = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
+
+error[E0658]: inherent associated types are unstable
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:13:5
+   |
+LL |     type Bop = impl std::fmt::Debug;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
+   = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/generator/issue-87142.rs
+++ b/tests/ui/generator/issue-87142.rs
@@ -4,7 +4,7 @@
 // Regression test for #87142
 // This test needs the above flags and the "lib" crate type.
 
-#![feature(type_alias_impl_trait, generator_trait, generators)]
+#![feature(impl_trait_in_assoc_type, generator_trait, generators)]
 #![crate_type = "lib"]
 
 use std::ops::Generator;

--- a/tests/ui/generic-associated-types/issue-86218-2.rs
+++ b/tests/ui/generic-associated-types/issue-86218-2.rs
@@ -1,6 +1,6 @@
 // check-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub trait Stream {
     type Item;
@@ -17,7 +17,9 @@ trait Yay<AdditionalValue> {
 
 impl<T> Yay<T> for () {
     type InnerStream<'s> = impl Stream<Item = i32> + 's;
-    fn foo<'s>() -> Self::InnerStream<'s> { () }
+    fn foo<'s>() -> Self::InnerStream<'s> {
+        ()
+    }
 }
 
 fn main() {}

--- a/tests/ui/generic-associated-types/issue-86218.rs
+++ b/tests/ui/generic-associated-types/issue-86218.rs
@@ -1,6 +1,6 @@
 // check-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub trait Stream {
     type Item;
@@ -18,7 +18,9 @@ trait Yay<AdditionalValue> {
 impl<'a> Yay<&'a ()> for () {
     type InnerStream<'s> = impl Stream<Item = i32> + 's;
     //^ ERROR does not fulfill the required lifetime
-    fn foo<'s>() -> Self::InnerStream<'s> { () }
+    fn foo<'s>() -> Self::InnerStream<'s> {
+        ()
+    }
 }
 
 fn main() {}

--- a/tests/ui/generic-associated-types/issue-87258_a.rs
+++ b/tests/ui/generic-associated-types/issue-87258_a.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 // See https://github.com/rust-lang/rust/issues/87258#issuecomment-883293367
 

--- a/tests/ui/generic-associated-types/issue-88595.rs
+++ b/tests/ui/generic-associated-types/issue-88595.rs
@@ -1,7 +1,8 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 fn main() {}
 
+#[rustfmt::skip]
 trait A<'a> {
     type B<'b>: Clone
     // FIXME(generic_associated_types): Remove one of the below bounds

--- a/tests/ui/generic-associated-types/issue-88595.stderr
+++ b/tests/ui/generic-associated-types/issue-88595.stderr
@@ -1,11 +1,11 @@
 error: non-defining opaque type use in defining scope
-  --> $DIR/issue-88595.rs:20:35
+  --> $DIR/issue-88595.rs:21:35
    |
 LL |     fn a(&'a self) -> Self::B<'a> {}
    |                                   ^^
    |
 note: lifetime used multiple times
-  --> $DIR/issue-88595.rs:17:6
+  --> $DIR/issue-88595.rs:18:6
    |
 LL | impl<'a> A<'a> for C {
    |      ^^

--- a/tests/ui/generic-associated-types/issue-89008.rs
+++ b/tests/ui/generic-associated-types/issue-89008.rs
@@ -1,7 +1,7 @@
 // check-pass
 // edition:2021
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use std::future::Future;
 use std::marker::PhantomData;

--- a/tests/ui/generic-associated-types/issue-90014.rs
+++ b/tests/ui/generic-associated-types/issue-90014.rs
@@ -1,11 +1,13 @@
 // edition:2018
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use std::future::Future;
 
 trait MakeFut {
-    type Fut<'a> where Self: 'a;
+    type Fut<'a>
+    where
+        Self: 'a;
     fn make_fut<'a>(&'a self) -> Self::Fut<'a>;
 }
 

--- a/tests/ui/generic-associated-types/issue-90014.stderr
+++ b/tests/ui/generic-associated-types/issue-90014.stderr
@@ -1,14 +1,14 @@
 error[E0477]: the type `&mut ()` does not fulfill the required lifetime
-  --> $DIR/issue-90014.rs:13:20
+  --> $DIR/issue-90014.rs:15:20
    |
-LL |     type Fut<'a> where Self: 'a;
+LL |     type Fut<'a>
    |     ------------ definition of `Fut` from trait
 ...
 LL |     type Fut<'a> = impl Future<Output = ()>;
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: type must outlive the lifetime `'a` as defined here
-  --> $DIR/issue-90014.rs:13:14
+  --> $DIR/issue-90014.rs:15:14
    |
 LL |     type Fut<'a> = impl Future<Output = ()>;
    |              ^^

--- a/tests/ui/impl-trait/associated-impl-trait-type-generic-trait.rs
+++ b/tests/ui/impl-trait/associated-impl-trait-type-generic-trait.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 // build-pass (FIXME(62277): could be check-pass?)
 
 trait Bar {}

--- a/tests/ui/impl-trait/associated-impl-trait-type-trivial.rs
+++ b/tests/ui/impl-trait/associated-impl-trait-type-trivial.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 // build-pass (FIXME(62277): could be check-pass?)
 
 trait Bar {}

--- a/tests/ui/impl-trait/associated-impl-trait-type.rs
+++ b/tests/ui/impl-trait/associated-impl-trait-type.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 // build-pass (FIXME(62277): could be check-pass?)
 
 trait Bar {}

--- a/tests/ui/impl-trait/issue-55872-1.rs
+++ b/tests/ui/impl-trait/issue-55872-1.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub trait Bar {
     type E: Copy;

--- a/tests/ui/impl-trait/issue-55872-2.rs
+++ b/tests/ui/impl-trait/issue-55872-2.rs
@@ -3,7 +3,7 @@
 // [drop_tracking_mir] compile-flags: -Zdrop-tracking-mir
 // edition:2018
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub trait Bar {
     type E: Send;

--- a/tests/ui/impl-trait/issue-55872-2.stderr
+++ b/tests/ui/impl-trait/issue-55872-2.stderr
@@ -1,8 +1,0 @@
-error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
-  --> $DIR/issue-55872-2.rs:17:9
-   |
-LL |         async {}
-   |         ^^^^^^^^
-
-error: aborting due to previous error
-

--- a/tests/ui/impl-trait/issue-55872-3.rs
+++ b/tests/ui/impl-trait/issue-55872-3.rs
@@ -1,7 +1,7 @@
 // edition:2018
 // ignore-compare-mode-chalk
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub trait Bar {
     type E: Copy;

--- a/tests/ui/impl-trait/issue-55872.rs
+++ b/tests/ui/impl-trait/issue-55872.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub trait Bar {
     type E: Copy;

--- a/tests/ui/impl-trait/issues/issue-82139.rs
+++ b/tests/ui/impl-trait/issues/issue-82139.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait Trait {
     type Associated;

--- a/tests/ui/impl-trait/issues/issue-83919.rs
+++ b/tests/ui/impl-trait/issues/issue-83919.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 // edition:2021
 
@@ -6,8 +6,8 @@ use std::future::Future;
 
 trait Foo {
     type T;
-    type Fut2: Future<Output=Self::T>; // ICE got triggered with traits other than Future here
-    type Fut: Future<Output=Self::Fut2>;
+    type Fut2: Future<Output = Self::T>; // ICE got triggered with traits other than Future here
+    type Fut: Future<Output = Self::Fut2>;
     fn get_fut(&self) -> Self::Fut;
 }
 
@@ -15,11 +15,11 @@ struct Implementor;
 
 impl Foo for Implementor {
     type T = u64;
-    type Fut2 = impl Future<Output=u64>;
-    type Fut = impl Future<Output=Self::Fut2>;
+    type Fut2 = impl Future<Output = u64>;
+    type Fut = impl Future<Output = Self::Fut2>;
 
     fn get_fut(&self) -> Self::Fut {
-    //~^ ERROR `{integer}` is not a future
+        //~^ ERROR `{integer}` is not a future
         async move {
             42
             // 42 does not impl Future and rustc does actually point out the error,

--- a/tests/ui/impl-trait/issues/issue-86719.rs
+++ b/tests/ui/impl-trait/issues/issue-86719.rs
@@ -1,11 +1,12 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait Bar {
     type E;
 }
 impl<S> Bar for S {
     type E = impl ; //~ ERROR at least one trait must be specified
-    fn foo() -> Self::E { //~ ERROR `foo` is not a member
+    fn foo() -> Self::E {
+        //~^ ERROR `foo` is not a member
         |_| true //~ ERROR type annotations needed
     }
 }

--- a/tests/ui/impl-trait/issues/issue-86719.stderr
+++ b/tests/ui/impl-trait/issues/issue-86719.stderr
@@ -8,12 +8,13 @@ error[E0407]: method `foo` is not a member of trait `Bar`
   --> $DIR/issue-86719.rs:8:5
    |
 LL | /     fn foo() -> Self::E {
+LL | |
 LL | |         |_| true
 LL | |     }
    | |_____^ not a member of trait `Bar`
 
 error[E0282]: type annotations needed
-  --> $DIR/issue-86719.rs:9:10
+  --> $DIR/issue-86719.rs:10:10
    |
 LL |         |_| true
    |          ^

--- a/tests/ui/impl-trait/issues/issue-87340.rs
+++ b/tests/ui/impl-trait/issues/issue-87340.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait X {
     type I;
@@ -6,7 +6,7 @@ trait X {
 }
 
 impl<T> X for () {
-//~^ ERROR `T` is not constrained by the impl trait, self type, or predicates
+    //~^ ERROR `T` is not constrained by the impl trait, self type, or predicates
     type I = impl Sized;
     fn f() -> Self::I {}
 }

--- a/tests/ui/impl-trait/type-alias-generic-param.rs
+++ b/tests/ui/impl-trait/type-alias-generic-param.rs
@@ -3,7 +3,7 @@
 // types in 'item' position when generic parameters are involved
 //
 // run-pass
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait Meow {
     type MeowType;

--- a/tests/ui/impl-trait/where-allowed.rs
+++ b/tests/ui/impl-trait/where-allowed.rs
@@ -1,6 +1,8 @@
 //! A simple test for testing many permutations of allowedness of
 //! impl Trait
 #![feature(impl_trait_in_fn_trait_return)]
+#![feature(custom_inner_attributes)]
+#![rustfmt::skip]
 use std::fmt::Debug;
 
 // Allowed
@@ -116,7 +118,7 @@ trait DummyTrait {
 }
 impl DummyTrait for () {
     type Out = impl Debug;
-    //~^ ERROR `impl Trait` in type aliases is unstable
+    //~^ ERROR `impl Trait` in associated types is unstable
 
     fn in_trait_impl_parameter(_: impl Debug) { }
     // Allowed

--- a/tests/ui/impl-trait/where-allowed.stderr
+++ b/tests/ui/impl-trait/where-allowed.stderr
@@ -1,5 +1,5 @@
 error[E0666]: nested `impl Trait` is not allowed
-  --> $DIR/where-allowed.rs:47:51
+  --> $DIR/where-allowed.rs:49:51
    |
 LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                           --------^^^^^^^^^^-
@@ -8,7 +8,7 @@ LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                           outer `impl Trait`
 
 error[E0666]: nested `impl Trait` is not allowed
-  --> $DIR/where-allowed.rs:56:57
+  --> $DIR/where-allowed.rs:58:57
    |
 LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
    |                                                 --------^^^^^^^^^^-
@@ -16,17 +16,17 @@ LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic
    |                                                 |       nested `impl Trait` here
    |                                                 outer `impl Trait`
 
-error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:118:16
+error[E0658]: `impl Trait` in associated types is unstable
+  --> $DIR/where-allowed.rs:120:16
    |
 LL |     type Out = impl Debug;
    |                ^^^^^^^^^^
    |
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
-   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+   = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:153:23
+  --> $DIR/where-allowed.rs:155:23
    |
 LL | type InTypeAlias<R> = impl Debug;
    |                       ^^^^^^^^^^
@@ -35,7 +35,7 @@ LL | type InTypeAlias<R> = impl Debug;
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:156:39
+  --> $DIR/where-allowed.rs:158:39
    |
 LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |                                       ^^^^^^^^^^
@@ -44,109 +44,109 @@ LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer params
-  --> $DIR/where-allowed.rs:16:40
+  --> $DIR/where-allowed.rs:18:40
    |
 LL | fn in_fn_parameter_in_parameters(_: fn(impl Debug)) { panic!() }
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
-  --> $DIR/where-allowed.rs:20:42
+  --> $DIR/where-allowed.rs:22:42
    |
 LL | fn in_fn_return_in_parameters(_: fn() -> impl Debug) { panic!() }
    |                                          ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer params
-  --> $DIR/where-allowed.rs:24:38
+  --> $DIR/where-allowed.rs:26:38
    |
 LL | fn in_fn_parameter_in_return() -> fn(impl Debug) { panic!() }
    |                                      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
-  --> $DIR/where-allowed.rs:28:40
+  --> $DIR/where-allowed.rs:30:40
    |
 LL | fn in_fn_return_in_return() -> fn() -> impl Debug { panic!() }
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
-  --> $DIR/where-allowed.rs:32:49
+  --> $DIR/where-allowed.rs:34:49
    |
 LL | fn in_dyn_Fn_parameter_in_parameters(_: &dyn Fn(impl Debug)) { panic!() }
    |                                                 ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
-  --> $DIR/where-allowed.rs:36:51
+  --> $DIR/where-allowed.rs:38:51
    |
 LL | fn in_dyn_Fn_return_in_parameters(_: &dyn Fn() -> impl Debug) { panic!() }
    |                                                   ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
-  --> $DIR/where-allowed.rs:40:55
+  --> $DIR/where-allowed.rs:42:55
    |
 LL | fn in_dyn_Fn_parameter_in_return() -> &'static dyn Fn(impl Debug) { panic!() }
    |                                                       ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
-  --> $DIR/where-allowed.rs:47:51
+  --> $DIR/where-allowed.rs:49:51
    |
 LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                                   ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
-  --> $DIR/where-allowed.rs:52:53
+  --> $DIR/where-allowed.rs:54:53
    |
 LL | fn in_impl_Fn_return_in_parameters(_: &impl Fn() -> impl Debug) { panic!() }
    |                                                     ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
-  --> $DIR/where-allowed.rs:56:57
+  --> $DIR/where-allowed.rs:58:57
    |
 LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
    |                                                         ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
-  --> $DIR/where-allowed.rs:64:38
+  --> $DIR/where-allowed.rs:66:38
    |
 LL | fn in_Fn_parameter_in_generics<F: Fn(impl Debug)> (_: F) { panic!() }
    |                                      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
-  --> $DIR/where-allowed.rs:68:40
+  --> $DIR/where-allowed.rs:70:40
    |
 LL | fn in_Fn_return_in_generics<F: Fn() -> impl Debug> (_: F) { panic!() }
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
-  --> $DIR/where-allowed.rs:81:32
+  --> $DIR/where-allowed.rs:83:32
    |
 LL | struct InBraceStructField { x: impl Debug }
    |                                ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
-  --> $DIR/where-allowed.rs:85:41
+  --> $DIR/where-allowed.rs:87:41
    |
 LL | struct InAdtInBraceStructField { x: Vec<impl Debug> }
    |                                         ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
-  --> $DIR/where-allowed.rs:89:27
+  --> $DIR/where-allowed.rs:91:27
    |
 LL | struct InTupleStructField(impl Debug);
    |                           ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
-  --> $DIR/where-allowed.rs:94:25
+  --> $DIR/where-allowed.rs:96:25
    |
 LL |     InBraceVariant { x: impl Debug },
    |                         ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in field types
-  --> $DIR/where-allowed.rs:96:20
+  --> $DIR/where-allowed.rs:98:20
    |
 LL |     InTupleVariant(impl Debug),
    |                    ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
-  --> $DIR/where-allowed.rs:107:23
+  --> $DIR/where-allowed.rs:109:23
    |
 LL |     fn in_return() -> impl Debug;
    |                       ^^^^^^^^^^
@@ -155,7 +155,7 @@ LL |     fn in_return() -> impl Debug;
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `impl` method return types
-  --> $DIR/where-allowed.rs:124:34
+  --> $DIR/where-allowed.rs:126:34
    |
 LL |     fn in_trait_impl_return() -> impl Debug { () }
    |                                  ^^^^^^^^^^
@@ -164,127 +164,127 @@ LL |     fn in_trait_impl_return() -> impl Debug { () }
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` params
-  --> $DIR/where-allowed.rs:137:33
+  --> $DIR/where-allowed.rs:139:33
    |
 LL |     fn in_foreign_parameters(_: impl Debug);
    |                                 ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` return types
-  --> $DIR/where-allowed.rs:140:31
+  --> $DIR/where-allowed.rs:142:31
    |
 LL |     fn in_foreign_return() -> impl Debug;
    |                               ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return types
-  --> $DIR/where-allowed.rs:156:39
+  --> $DIR/where-allowed.rs:158:39
    |
 LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |                                       ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in traits
-  --> $DIR/where-allowed.rs:161:16
+  --> $DIR/where-allowed.rs:163:16
    |
 LL | impl PartialEq<impl Debug> for () {
    |                ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl headers
-  --> $DIR/where-allowed.rs:166:24
+  --> $DIR/where-allowed.rs:168:24
    |
 LL | impl PartialEq<()> for impl Debug {
    |                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl headers
-  --> $DIR/where-allowed.rs:171:6
+  --> $DIR/where-allowed.rs:173:6
    |
 LL | impl impl Debug {
    |      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in impl headers
-  --> $DIR/where-allowed.rs:177:24
+  --> $DIR/where-allowed.rs:179:24
    |
 LL | impl InInherentImplAdt<impl Debug> {
    |                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bounds
-  --> $DIR/where-allowed.rs:183:11
+  --> $DIR/where-allowed.rs:185:11
    |
 LL |     where impl Debug: Debug
    |           ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bounds
-  --> $DIR/where-allowed.rs:190:15
+  --> $DIR/where-allowed.rs:192:15
    |
 LL |     where Vec<impl Debug>: Debug
    |               ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bounds
-  --> $DIR/where-allowed.rs:197:24
+  --> $DIR/where-allowed.rs:199:24
    |
 LL |     where T: PartialEq<impl Debug>
    |                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait params
-  --> $DIR/where-allowed.rs:204:17
+  --> $DIR/where-allowed.rs:206:17
    |
 LL |     where T: Fn(impl Debug)
    |                 ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return types
-  --> $DIR/where-allowed.rs:211:22
+  --> $DIR/where-allowed.rs:213:22
    |
 LL |     where T: Fn() -> impl Debug
    |                      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
-  --> $DIR/where-allowed.rs:217:40
+  --> $DIR/where-allowed.rs:219:40
    |
 LL | struct InStructGenericParamDefault<T = impl Debug>(T);
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
-  --> $DIR/where-allowed.rs:221:36
+  --> $DIR/where-allowed.rs:223:36
    |
 LL | enum InEnumGenericParamDefault<T = impl Debug> { Variant(T) }
    |                                    ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
-  --> $DIR/where-allowed.rs:225:38
+  --> $DIR/where-allowed.rs:227:38
    |
 LL | trait InTraitGenericParamDefault<T = impl Debug> {}
    |                                      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
-  --> $DIR/where-allowed.rs:229:41
+  --> $DIR/where-allowed.rs:231:41
    |
 LL | type InTypeAliasGenericParamDefault<T = impl Debug> = T;
    |                                         ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
-  --> $DIR/where-allowed.rs:233:11
+  --> $DIR/where-allowed.rs:235:11
    |
 LL | impl <T = impl Debug> T {}
    |           ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in generic parameter defaults
-  --> $DIR/where-allowed.rs:240:40
+  --> $DIR/where-allowed.rs:242:40
    |
 LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable bindings
-  --> $DIR/where-allowed.rs:246:29
+  --> $DIR/where-allowed.rs:248:29
    |
 LL |     let _in_local_variable: impl Fn() = || {};
    |                             ^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in closure return types
-  --> $DIR/where-allowed.rs:248:46
+  --> $DIR/where-allowed.rs:250:46
    |
 LL |     let _in_return_in_local_variable = || -> impl Fn() { || {} };
    |                                              ^^^^^^^^^
 
 error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/where-allowed.rs:233:7
+  --> $DIR/where-allowed.rs:235:7
    |
 LL | impl <T = impl Debug> T {}
    |       ^^^^^^^^^^^^^^
@@ -294,7 +294,7 @@ LL | impl <T = impl Debug> T {}
    = note: `#[deny(invalid_type_param_default)]` on by default
 
 error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/where-allowed.rs:240:36
+  --> $DIR/where-allowed.rs:242:36
    |
 LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    |                                    ^^^^^^^^^^^^^^
@@ -303,7 +303,7 @@ LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
 
 error[E0118]: no nominal type found for inherent implementation
-  --> $DIR/where-allowed.rs:233:1
+  --> $DIR/where-allowed.rs:235:1
    |
 LL | impl <T = impl Debug> T {}
    | ^^^^^^^^^^^^^^^^^^^^^^^ impl requires a nominal type

--- a/tests/ui/lint/inline-trait-and-foreign-items.rs
+++ b/tests/ui/lint/inline-trait-and-foreign-items.rs
@@ -1,5 +1,5 @@
 #![feature(extern_types)]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 #![warn(unused_attributes)]
 

--- a/tests/ui/lint/no-coverage.rs
+++ b/tests/ui/lint/no-coverage.rs
@@ -1,6 +1,6 @@
 #![feature(extern_types)]
 #![feature(no_coverage)]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 #![warn(unused_attributes)]
 #![no_coverage]
 //~^ WARN: `#[no_coverage]` does not propagate into items and must be applied to the contained functions directly

--- a/tests/ui/nll/issue-78561.rs
+++ b/tests/ui/nll/issue-78561.rs
@@ -1,5 +1,5 @@
 // check-pass
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub trait Trait {
     type A;

--- a/tests/ui/privacy/private-in-public-assoc-ty.rs
+++ b/tests/ui/privacy/private-in-public-assoc-ty.rs
@@ -2,7 +2,7 @@
 // This test also ensures that the checks are performed even inside private modules.
 
 #![feature(associated_type_defaults)]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 mod m {
     struct Priv;

--- a/tests/ui/privacy/private-in-public-type-alias-impl-trait.rs
+++ b/tests/ui/privacy/private-in-public-type-alias-impl-trait.rs
@@ -1,5 +1,5 @@
 // build-pass (FIXME(62277): could be check-pass?)
-
+#![feature(impl_trait_in_assoc_type)]
 #![feature(type_alias_impl_trait)]
 #![deny(private_in_public)]
 

--- a/tests/ui/type-alias-impl-trait/assoc-type-const.rs
+++ b/tests/ui/type-alias-impl-trait/assoc-type-const.rs
@@ -2,7 +2,7 @@
 // const generics in an associated opaque type
 // check-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait UnwrapItemsExt<'a, const C: usize> {
     type Iter;

--- a/tests/ui/type-alias-impl-trait/assoc-type-lifetime-unconstrained.rs
+++ b/tests/ui/type-alias-impl-trait/assoc-type-lifetime-unconstrained.rs
@@ -1,7 +1,7 @@
 // Tests that we don't allow unconstrained lifetime parameters in impls when
 // the lifetime is used in an associated opaque type.
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait UnwrapItemsExt {
     type Iter;

--- a/tests/ui/type-alias-impl-trait/assoc-type-lifetime.rs
+++ b/tests/ui/type-alias-impl-trait/assoc-type-lifetime.rs
@@ -2,7 +2,7 @@
 // lifetimes are used in an associated opaque type
 // check-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait UnwrapItemsExt<'a> {
     type Iter;

--- a/tests/ui/type-alias-impl-trait/associated-type-impl-trait-lifetime.rs
+++ b/tests/ui/type-alias-impl-trait/associated-type-impl-trait-lifetime.rs
@@ -1,6 +1,6 @@
 //check-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait Trait {
     type Opaque1;

--- a/tests/ui/type-alias-impl-trait/auxiliary/collect_hidden_types.rs
+++ b/tests/ui/type-alias-impl-trait/auxiliary/collect_hidden_types.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 // edition:2018
 

--- a/tests/ui/type-alias-impl-trait/auxiliary/cross_crate_ice2.rs
+++ b/tests/ui/type-alias-impl-trait/auxiliary/cross_crate_ice2.rs
@@ -1,7 +1,7 @@
 // Crate that exports an opaque `impl Trait` type. Used for testing cross-crate.
 
 #![crate_type = "rlib"]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub trait View {
     type Tmp: Iterator<Item = u32>;

--- a/tests/ui/type-alias-impl-trait/impl-with-unconstrained-param.rs
+++ b/tests/ui/type-alias-impl-trait/impl-with-unconstrained-param.rs
@@ -1,7 +1,7 @@
 // Ensure that we don't ICE if associated type impl trait is used in an impl
 // with an unconstrained type parameter.
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait X {
     type I;

--- a/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds.rs
+++ b/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds.rs
@@ -1,6 +1,6 @@
 // check-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait Callable {
     type Output;

--- a/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.rs
+++ b/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait Callable {
     type Output;
@@ -17,7 +17,9 @@ impl<'a> PlusOne for &'a mut i32 {
 
 impl<T: PlusOne> Callable for T {
     type Output = impl PlusOne;
-    fn call(t: T) -> Self::Output { t }
+    fn call(t: T) -> Self::Output {
+        t
+    }
 }
 
 fn test<'a>(y: &'a mut i32) -> impl PlusOne {

--- a/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.stderr
+++ b/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl PlusOne` captures lifetime that does not appear in bounds
-  --> $DIR/imply_bounds_from_bounds_param.rs:24:5
+  --> $DIR/imply_bounds_from_bounds_param.rs:26:5
    |
 LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne {
    |         --                     ------------ opaque type defined here

--- a/tests/ui/type-alias-impl-trait/incoherent-assoc-imp-trait.rs
+++ b/tests/ui/type-alias-impl-trait/incoherent-assoc-imp-trait.rs
@@ -1,7 +1,7 @@
 // Regression test for issue 67856
 
 #![feature(unboxed_closures)]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 #![feature(fn_traits)]
 
 trait MyTrait {}

--- a/tests/ui/type-alias-impl-trait/issue-53598.rs
+++ b/tests/ui/type-alias-impl-trait/issue-53598.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use std::fmt::Debug;
 

--- a/tests/ui/type-alias-impl-trait/issue-57188-associate-impl-capture.rs
+++ b/tests/ui/type-alias-impl-trait/issue-57188-associate-impl-capture.rs
@@ -2,7 +2,7 @@
 
 // check-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 struct Baz<'a> {
     source: &'a str,

--- a/tests/ui/type-alias-impl-trait/issue-57611-trait-alias.rs
+++ b/tests/ui/type-alias-impl-trait/issue-57611-trait-alias.rs
@@ -3,7 +3,7 @@
 // Ensures that we don't ICE
 
 #![feature(trait_alias)]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait Foo {
     type Bar: Baz<Self, Self>;

--- a/tests/ui/type-alias-impl-trait/issue-57700.rs
+++ b/tests/ui/type-alias-impl-trait/issue-57700.rs
@@ -1,5 +1,5 @@
 #![feature(arbitrary_self_types)]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use std::ops::Deref;
 

--- a/tests/ui/type-alias-impl-trait/issue-57807-associated-type.rs
+++ b/tests/ui/type-alias-impl-trait/issue-57807-associated-type.rs
@@ -2,7 +2,7 @@
 // that we properly unify associated types within
 // a type alias impl trait
 // check-pass
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait Bar {
     type A;

--- a/tests/ui/type-alias-impl-trait/issue-58887.rs
+++ b/tests/ui/type-alias-impl-trait/issue-58887.rs
@@ -1,6 +1,6 @@
 // run-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait UnwrapItemsExt {
     type Iter;

--- a/tests/ui/type-alias-impl-trait/issue-60371.rs
+++ b/tests/ui/type-alias-impl-trait/issue-60371.rs
@@ -5,7 +5,7 @@ trait Bug {
 }
 
 impl Bug for &() {
-    type Item = impl Bug; //~ ERROR `impl Trait` in type aliases is unstable
+    type Item = impl Bug; //~ ERROR `impl Trait` in associated types is unstable
 
     const FUN: fn() -> Self::Item = || ();
     //~^ ERROR the trait bound `(): Bug` is not satisfied

--- a/tests/ui/type-alias-impl-trait/issue-60371.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-60371.stderr
@@ -1,11 +1,11 @@
-error[E0658]: `impl Trait` in type aliases is unstable
+error[E0658]: `impl Trait` in associated types is unstable
   --> $DIR/issue-60371.rs:8:17
    |
 LL |     type Item = impl Bug;
    |                 ^^^^^^^^
    |
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
-   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+   = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `(): Bug` is not satisfied
   --> $DIR/issue-60371.rs:10:40

--- a/tests/ui/type-alias-impl-trait/issue-60564-working.rs
+++ b/tests/ui/type-alias-impl-trait/issue-60564-working.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 // check-pass
 

--- a/tests/ui/type-alias-impl-trait/issue-62000-associate-impl-trait-lifetimes.rs
+++ b/tests/ui/type-alias-impl-trait/issue-62000-associate-impl-trait-lifetimes.rs
@@ -2,7 +2,7 @@
 
 // check-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait MyTrait {
     type AssocType: Send;

--- a/tests/ui/type-alias-impl-trait/issue-74761-2.rs
+++ b/tests/ui/type-alias-impl-trait/issue-74761-2.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub trait A {
     type B;

--- a/tests/ui/type-alias-impl-trait/issue-74761.rs
+++ b/tests/ui/type-alias-impl-trait/issue-74761.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub trait A {
     type B;

--- a/tests/ui/type-alias-impl-trait/issue-78450.rs
+++ b/tests/ui/type-alias-impl-trait/issue-78450.rs
@@ -1,6 +1,6 @@
 // check-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub trait AssociatedImpl {
     type ImplTrait;

--- a/tests/ui/type-alias-impl-trait/issue-89952.rs
+++ b/tests/ui/type-alias-impl-trait/issue-89952.rs
@@ -1,6 +1,6 @@
 // check-pass
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait SomeTrait {}
 impl SomeTrait for () {}

--- a/tests/ui/type-alias-impl-trait/issue-90400-1.rs
+++ b/tests/ui/type-alias-impl-trait/issue-90400-1.rs
@@ -1,7 +1,7 @@
 // Regression test for #90400,
 // taken from https://github.com/rust-lang/rust/issues/90400#issuecomment-954927836
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait Bar {
     fn bar(&self);

--- a/tests/ui/type-alias-impl-trait/issue-90400-2.rs
+++ b/tests/ui/type-alias-impl-trait/issue-90400-2.rs
@@ -1,7 +1,7 @@
 // Regression test for #90400,
 // taken from https://github.com/rust-lang/rust/issues/90400#issuecomment-954927836
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait Bar {
     fn bar(&self);

--- a/tests/ui/type-alias-impl-trait/issue-94429.rs
+++ b/tests/ui/type-alias-impl-trait/issue-94429.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait, generator_trait, generators)]
+#![feature(impl_trait_in_assoc_type, generator_trait, generators)]
 use std::ops::Generator;
 
 trait Runnable {
@@ -13,7 +13,7 @@ impl Runnable for Implementor {
     type Gen = impl Generator<Yield = (), Return = ()>;
 
     fn run(&mut self) -> Self::Gen {
-    //~^ ERROR: type mismatch resolving
+        //~^ ERROR: type mismatch resolving
         move || {
             yield 1;
         }

--- a/tests/ui/type-alias-impl-trait/type-alias-impl-trait-unconstrained-lifetime.rs
+++ b/tests/ui/type-alias-impl-trait/type-alias-impl-trait-unconstrained-lifetime.rs
@@ -1,6 +1,6 @@
 // regression test for #74018
 
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 trait Trait {
     type Associated;


### PR DESCRIPTION
in https://github.com/rust-lang/rust/issues/107645 it was decided that we'll take a new route for type alias impl trait. The exact route isn't clear yet, so while I'm working on implementing some of these proposed changes (e.g. in https://github.com/rust-lang/rust/pull/110010) to be able to experiment with them, I will also work on stabilizing another sugar version first: impl trait in associated types. Similarly I'll look into creating feature gates for impl trait in const/static types.

This PR does nothing but split the feature gate, so that you need to enable a different feature gate for

```rust
impl Trait for Type {
    type Assoc = impl SomeTrait;
}
```

than what you need for `type Foo = impl SomeTrait;`
