### PR TITLE
Add `indent_style = tab` for `Makefile`s to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,6 @@ trim_trailing_whitespace = false
 
 [*.yml]
 indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Add `indent_style = tab` for `Makefile`s to `.editorconfig` as spaces don't work as indents in Makefiles.