### PR TITLE
ci: add a runner for vanilla LLVM 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,10 @@ jobs:
           - name: x86_64-gnu-distcheck
             os: ubuntu-20.04-8core-32gb
             env: {}
+          - name: x86_64-gnu-llvm-16
+            env:
+              RUST_BACKTRACE: 1
+            os: ubuntu-20.04-8core-32gb
           - name: x86_64-gnu-llvm-15
             env:
               RUST_BACKTRACE: 1

--- a/src/ci/docker/host-x86_64/dist-x86_64-illumos/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-illumos/Dockerfile
@@ -6,12 +6,13 @@ RUN sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list
 COPY scripts/cross-apt-packages.sh /tmp/
 RUN bash /tmp/cross-apt-packages.sh
 
-# Required for cross-build gcc
+# Required for cross-build gcc, and we install python2 to test general compatibility.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     libgmp-dev \
     libmpfr-dev \
     libmpc-dev \
+    python2.7 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/illumos-toolchain.sh /tmp/
@@ -35,4 +36,4 @@ ENV \
 ENV HOSTS=x86_64-unknown-illumos
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-16/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-16/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10
+FROM ubuntu:23.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   cmake \
   sudo \
   gdb \
-  llvm-15-tools \
-  llvm-15-dev \
+  llvm-16-tools \
+  llvm-16-dev \
   libedit-dev \
   libssl-dev \
   pkg-config \
@@ -41,7 +41,7 @@ ENV NO_DOWNLOAD_CI_LLVM 1
 # Using llvm-link-shared due to libffi issues -- see #34486
 ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
-      --llvm-root=/usr/lib/llvm-15 \
+      --llvm-root=/usr/lib/llvm-16 \
       --enable-llvm-link-shared \
       --set rust.thin-lto-import-instr-limit=10
 

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -457,6 +457,11 @@ jobs:
           - name: x86_64-gnu-distcheck
             <<: *job-linux-8c
 
+          - name: x86_64-gnu-llvm-16
+            env:
+              RUST_BACKTRACE: 1
+            <<: *job-linux-8c
+
           - name: x86_64-gnu-llvm-15
             env:
               RUST_BACKTRACE: 1

--- a/tests/codegen/option-as-slice.rs
+++ b/tests/codegen/option-as-slice.rs
@@ -1,5 +1,7 @@
 // compile-flags: -O -Z randomize-layout=no
 // only-x86_64
+// ignore-llvm-version: 16.0.0
+// ^ needs https://reviews.llvm.org/D146149 in 16.0.1
 
 #![crate_type = "lib"]
 #![feature(option_as_slice)]

--- a/tests/debuginfo/unsized.rs
+++ b/tests/debuginfo/unsized.rs
@@ -1,4 +1,6 @@
 // compile-flags:-g
+// ignore-gdb-version: 13.1 - 99.0
+// ^ https://sourceware.org/bugzilla/show_bug.cgi?id=30330
 
 // === GDB TESTS ===================================================================================
 


### PR DESCRIPTION
Like #107044, this will let us track compatibility with LLVM 16 going
forward, especially after we eventually upgrade our own to the next.

This also drops `tidy` here and in `x86_64-gnu-llvm-15`, syncing with
that change in #106085.
