### PR TITLE
Tagged pointers, now with strict provenance!

### DIFF
--- a/compiler/rustc_data_structures/src/aligned.rs
+++ b/compiler/rustc_data_structures/src/aligned.rs
@@ -1,10 +1,10 @@
-use std::mem;
+use std::ptr::Alignment;
 
 /// Returns the ABI-required minimum alignment of a type in bytes.
 ///
 /// This is equivalent to [`mem::align_of`], but also works for some unsized
 /// types (e.g. slices or rustc's `List`s).
-pub const fn align_of<T: ?Sized + Aligned>() -> usize {
+pub const fn align_of<T: ?Sized + Aligned>() -> Alignment {
     T::ALIGN
 }
 
@@ -19,13 +19,13 @@ pub const fn align_of<T: ?Sized + Aligned>() -> usize {
 /// [`mem::align_of<Self>()`]: mem::align_of
 pub unsafe trait Aligned {
     /// Alignment of `Self`.
-    const ALIGN: usize;
+    const ALIGN: Alignment;
 }
 
 unsafe impl<T> Aligned for T {
-    const ALIGN: usize = mem::align_of::<Self>();
+    const ALIGN: Alignment = Alignment::of::<Self>();
 }
 
 unsafe impl<T> Aligned for [T] {
-    const ALIGN: usize = mem::align_of::<T>();
+    const ALIGN: Alignment = Alignment::of::<T>();
 }

--- a/compiler/rustc_data_structures/src/aligned.rs
+++ b/compiler/rustc_data_structures/src/aligned.rs
@@ -1,0 +1,31 @@
+use std::mem;
+
+/// Returns the ABI-required minimum alignment of a type in bytes.
+///
+/// This is equivalent to [`mem::align_of`], but also works for some unsized
+/// types (e.g. slices or rustc's `List`s).
+pub const fn align_of<T: ?Sized + Aligned>() -> usize {
+    T::ALIGN
+}
+
+/// A type with a statically known alignment.
+///
+/// # Safety
+///
+/// `Self::ALIGN` must be equal to the alignment of `Self`. For sized types it
+/// is [`mem::align_of<Self>()`], for unsized types it depends on the type, for
+/// example `[T]` has alignment of `T`.
+///
+/// [`mem::align_of<Self>()`]: mem::align_of
+pub unsafe trait Aligned {
+    /// Alignment of `Self`.
+    const ALIGN: usize;
+}
+
+unsafe impl<T> Aligned for T {
+    const ALIGN: usize = mem::align_of::<Self>();
+}
+
+unsafe impl<T> Aligned for [T] {
+    const ALIGN: usize = mem::align_of::<T>();
+}

--- a/compiler/rustc_data_structures/src/aligned.rs
+++ b/compiler/rustc_data_structures/src/aligned.rs
@@ -4,6 +4,8 @@ use std::ptr::Alignment;
 ///
 /// This is equivalent to [`mem::align_of`], but also works for some unsized
 /// types (e.g. slices or rustc's `List`s).
+///
+/// [`mem::align_of`]: std::mem::align_of
 pub const fn align_of<T: ?Sized + Aligned>() -> Alignment {
     T::ALIGN
 }
@@ -16,7 +18,7 @@ pub const fn align_of<T: ?Sized + Aligned>() -> Alignment {
 /// is [`mem::align_of<Self>()`], for unsized types it depends on the type, for
 /// example `[T]` has alignment of `T`.
 ///
-/// [`mem::align_of<Self>()`]: mem::align_of
+/// [`mem::align_of<Self>()`]: std::mem::align_of
 pub unsafe trait Aligned {
     /// Alignment of `Self`.
     const ALIGN: Alignment;

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -83,6 +83,7 @@ pub mod transitive_relation;
 pub mod vec_linked_list;
 pub mod work_queue;
 pub use atomic_ref::AtomicRef;
+pub mod aligned;
 pub mod frozen;
 pub mod owned_slice;
 pub mod sso;

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -30,6 +30,7 @@
 #![feature(lint_reasons)]
 #![feature(unwrap_infallible)]
 #![feature(strict_provenance)]
+#![feature(ptr_alignment_type)]
 #![allow(rustc::default_hash_types)]
 #![allow(rustc::potential_query_instability)]
 #![deny(rustc::untranslatable_diagnostic)]

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -29,6 +29,7 @@
 #![feature(get_mut_unchecked)]
 #![feature(lint_reasons)]
 #![feature(unwrap_infallible)]
+#![feature(strict_provenance)]
 #![allow(rustc::default_hash_types)]
 #![allow(rustc::potential_query_instability)]
 #![deny(rustc::untranslatable_diagnostic)]

--- a/compiler/rustc_data_structures/src/tagged_ptr.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr.rs
@@ -261,3 +261,10 @@ unsafe impl Tag for Tag2 {
         }
     }
 }
+
+#[cfg(test)]
+impl<HCX> crate::stable_hasher::HashStable<HCX> for Tag2 {
+    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut crate::stable_hasher::StableHasher) {
+        (*self as u8).hash_stable(hcx, hasher);
+    }
+}

--- a/compiler/rustc_data_structures/src/tagged_ptr.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr.rs
@@ -40,8 +40,8 @@ pub use drop::TaggedPtr;
 /// [`into_ptr`] must be valid for writes (and thus calling [`NonNull::as_mut`]
 /// on it must be safe).
 ///
-/// The [`BITS`] constant must be correct. At least [`BITS`] least significant
-/// bits, must be zero on all pointers returned from [`into_ptr`].
+/// The [`BITS`] constant must be correct. [`BITS`] least-significant bits,
+/// must be zero on all pointers returned from [`into_ptr`].
 ///
 /// For example, if the alignment of [`Self::Target`] is 2, then `BITS` should be 1.
 ///
@@ -52,8 +52,11 @@ pub use drop::TaggedPtr;
 /// [`Self::Target`]: Deref::Target
 /// [`DerefMut`]: std::ops::DerefMut
 pub unsafe trait Pointer: Deref {
-    /// Number of unused (always zero) **least significant bits** in this
+    /// Number of unused (always zero) **least-significant bits** in this
     /// pointer, usually related to the pointees alignment.
+    ///
+    /// For example if [`BITS`] = `2`, then given `ptr = Self::into_ptr(..)`,
+    /// `ptr.addr() & 0b11 == 0` must be true.
     ///
     /// Most likely the value you want to use here is the following, unless
     /// your [`Self::Target`] type is unsized (e.g., `ty::List<T>` in rustc)
@@ -71,6 +74,7 @@ pub unsafe trait Pointer: Deref {
     /// # }
     /// ```
     ///
+    /// [`BITS`]: Pointer::BITS
     /// [`Self::Target`]: Deref::Target
     const BITS: usize;
 
@@ -105,7 +109,7 @@ pub unsafe trait Pointer: Deref {
 ///
 /// The [`BITS`] constant must be correct.
 ///
-/// No more than [`BITS`] least significant bits may be set in the returned usize.
+/// No more than [`BITS`] least-significant bits may be set in the returned usize.
 ///
 /// [`BITS`]: Tag::BITS
 pub unsafe trait Tag: Copy {

--- a/compiler/rustc_data_structures/src/tagged_ptr.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr.rs
@@ -60,8 +60,12 @@ pub unsafe trait Pointer: Deref {
     ///
     /// ```rust
     /// # use std::ops::Deref;
-    /// # type Self = &'static u64;
-    /// bits_for::<Self::Target>()
+    /// # use rustc_data_structures::tagged_ptr::bits_for;
+    /// # struct T;
+    /// # impl Deref for T { type Target = u8; fn deref(&self) -> &u8 { &0 } }
+    /// # impl T {
+    /// const BITS: usize = bits_for::<<Self as Deref>::Target>();
+    /// # }
     /// ```
     ///
     /// [`Self::Target`]: Deref::Target

--- a/compiler/rustc_data_structures/src/tagged_ptr.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr.rs
@@ -232,3 +232,32 @@ pub const fn bits_for<T: ?Sized + Aligned>() -> usize {
 
     bits as usize
 }
+
+/// A tag type used in [`CopyTaggedPtr`] and [`TaggedPtr`] tests.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg(test)]
+enum Tag2 {
+    B00 = 0b00,
+    B01 = 0b01,
+    B10 = 0b10,
+    B11 = 0b11,
+}
+
+#[cfg(test)]
+unsafe impl Tag for Tag2 {
+    const BITS: usize = 2;
+
+    fn into_usize(self) -> usize {
+        self as _
+    }
+
+    unsafe fn from_usize(tag: usize) -> Self {
+        match tag {
+            0b00 => Tag2::B00,
+            0b01 => Tag2::B01,
+            0b10 => Tag2::B10,
+            0b11 => Tag2::B11,
+            _ => unreachable!(),
+        }
+    }
+}

--- a/compiler/rustc_data_structures/src/tagged_ptr.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr.rs
@@ -40,11 +40,12 @@ pub use drop::TaggedPtr;
 /// [`into_ptr`] must be valid for writes (and thus calling [`NonNull::as_mut`]
 /// on it must be safe).
 ///
-/// The `BITS` constant must be correct. At least `BITS` bits, least-significant,
-/// must be zero on all pointers returned from [`into_ptr`].
+/// The [`BITS`] constant must be correct. At least [`BITS`] least significant
+/// bits, must be zero on all pointers returned from [`into_ptr`].
 ///
 /// For example, if the alignment of [`Self::Target`] is 2, then `BITS` should be 1.
 ///
+/// [`BITS`]: Pointer::BITS
 /// [`into_ptr`]: Pointer::into_ptr
 /// [valid]: std::ptr#safety
 /// [`<Self as Deref>::Target`]: Deref::Target
@@ -122,7 +123,7 @@ pub unsafe trait Tag: Copy {
     /// This function guarantees that only the least-significant [`Self::BITS`]
     /// bits can be non-zero.
     ///
-    /// [`from_usize`]: Pointer::from_usize
+    /// [`from_usize`]: Tag::from_usize
     /// [`Self::BITS`]: Tag::BITS
     fn into_usize(self) -> usize;
 

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
@@ -203,3 +203,33 @@ where
         self.tag().hash_stable(hcx, hasher);
     }
 }
+
+/// Test that `new` does not compile if there is not enough alignment for the
+/// tag in the pointer.
+///
+/// ```compile_fail,E0080
+/// use rustc_data_structures::tagged_ptr::{CopyTaggedPtr, Tag};
+///
+/// #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+/// enum Tag2 { B00 = 0b00, B01 = 0b01, B10 = 0b10, B11 = 0b11 };
+///
+/// unsafe impl Tag for Tag2 {
+///     const BITS: usize = 2;
+///
+///     fn into_usize(self) -> usize { todo!() }
+///     unsafe fn from_usize(tag: usize) -> Self { todo!() }
+/// }
+///
+/// let value = 12u16;
+/// let reference = &value;
+/// let tag = Tag2::B01;
+///
+/// let _ptr = CopyTaggedPtr::<_, _, true>::new(reference, tag);
+/// ```
+// For some reason miri does not get the compile error
+// probably it `check`s instead of `build`ing?
+#[cfg(not(miri))]
+const _: () = ();
+
+#[cfg(test)]
+mod tests;

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
@@ -163,15 +163,13 @@ where
 
 impl<P, T, const COMPARE_PACKED: bool> fmt::Debug for CopyTaggedPtr<P, T, COMPARE_PACKED>
 where
-    P: Pointer,
-    P::Target: fmt::Debug,
+    P: Pointer + fmt::Debug,
     T: Tag + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CopyTaggedPtr")
-            .field("pointer", &self.pointer_ref())
-            .field("tag", &self.tag())
-            .finish()
+        self.with_pointer_ref(|ptr| {
+            f.debug_struct("CopyTaggedPtr").field("pointer", ptr).field("tag", &self.tag()).finish()
+        })
     }
 }
 

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
@@ -115,19 +115,6 @@ where
         unsafe { P::from_ptr(self.pointer_raw()) }
     }
 
-    pub fn pointer_ref(&self) -> &P::Target {
-        // SAFETY: pointer_raw returns the original pointer
-        unsafe { self.pointer_raw().as_ref() }
-    }
-
-    pub fn pointer_mut(&mut self) -> &mut P::Target
-    where
-        P: DerefMut,
-    {
-        // SAFETY: pointer_raw returns the original pointer
-        unsafe { self.pointer_raw().as_mut() }
-    }
-
     #[inline]
     pub fn tag(&self) -> T {
         unsafe { T::from_usize(self.packed.addr().get() >> Self::TAG_BIT_SHIFT) }
@@ -147,7 +134,10 @@ where
     type Target = P::Target;
 
     fn deref(&self) -> &Self::Target {
-        self.pointer_ref()
+        // Safety:
+        // `pointer_raw` returns the original pointer from `P::into_ptr` which,
+        // by the `Pointer`'s contract, must be valid.
+        unsafe { self.pointer_raw().as_ref() }
     }
 }
 
@@ -157,7 +147,11 @@ where
     T: Tag,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.pointer_mut()
+        // Safety:
+        // `pointer_raw` returns the original pointer from `P::into_ptr` which,
+        // by the `Pointer`'s contract, must be valid for writes if
+        // `P: DerefMut`.
+        unsafe { self.pointer_raw().as_mut() }
     }
 }
 

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
@@ -116,7 +116,7 @@ where
         self.packed = Self::pack(self.pointer_raw(), tag);
     }
 
-    const TAG_BIT_SHIFT: usize = usize::BITS as usize - T::BITS;
+    const TAG_BIT_SHIFT: u32 = usize::BITS - T::BITS;
     const ASSERTION: () = { assert!(T::BITS <= P::BITS) };
 
     /// Pack pointer `ptr` that comes from [`P::into_ptr`] with a `tag`,
@@ -298,7 +298,7 @@ where
 /// enum Tag2 { B00 = 0b00, B01 = 0b01, B10 = 0b10, B11 = 0b11 };
 ///
 /// unsafe impl Tag for Tag2 {
-///     const BITS: usize = 2;
+///     const BITS: u32 = 2;
 ///
 ///     fn into_usize(self) -> usize { todo!() }
 ///     unsafe fn from_usize(tag: usize) -> Self { todo!() }

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
@@ -20,7 +20,7 @@ where
     T: Tag,
 {
     packed: NonNull<P::Target>,
-    data: PhantomData<(P, T)>,
+    tag_ghost: PhantomData<T>,
 }
 
 impl<P, T, const COMPARE_PACKED: bool> Copy for CopyTaggedPtr<P, T, COMPARE_PACKED>
@@ -51,7 +51,7 @@ where
     T: Tag,
 {
     pub fn new(pointer: P, tag: T) -> Self {
-        Self { packed: Self::pack(P::into_ptr(pointer), tag), data: PhantomData }
+        Self { packed: Self::pack(P::into_ptr(pointer), tag), tag_ghost: PhantomData }
     }
 
     const TAG_BIT_SHIFT: usize = usize::BITS as usize - T::BITS;

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
@@ -24,7 +24,7 @@ where
     tag_ghost: PhantomData<T>,
 }
 
-impl<P, T, const COMPARE_PACKED: bool> Copy for CopyTaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, const CP: bool> Copy for CopyTaggedPtr<P, T, CP>
 where
     P: Pointer,
     T: Tag,
@@ -32,7 +32,7 @@ where
 {
 }
 
-impl<P, T, const COMPARE_PACKED: bool> Clone for CopyTaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, const CP: bool> Clone for CopyTaggedPtr<P, T, CP>
 where
     P: Pointer,
     T: Tag,
@@ -46,7 +46,7 @@ where
 // We pack the tag into the *upper* bits of the pointer to ease retrieval of the
 // value; a left shift is a multiplication and those are embeddable in
 // instruction encoding.
-impl<P, T, const COMPARE_PACKED: bool> CopyTaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, const CP: bool> CopyTaggedPtr<P, T, CP>
 where
     P: Pointer,
     T: Tag,
@@ -126,7 +126,7 @@ where
     }
 }
 
-impl<P, T, const COMPARE_PACKED: bool> Deref for CopyTaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, const CP: bool> Deref for CopyTaggedPtr<P, T, CP>
 where
     P: Pointer,
     T: Tag,
@@ -141,7 +141,7 @@ where
     }
 }
 
-impl<P, T, const COMPARE_PACKED: bool> DerefMut for CopyTaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, const CP: bool> DerefMut for CopyTaggedPtr<P, T, CP>
 where
     P: Pointer + DerefMut,
     T: Tag,
@@ -155,7 +155,7 @@ where
     }
 }
 
-impl<P, T, const COMPARE_PACKED: bool> fmt::Debug for CopyTaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, const CP: bool> fmt::Debug for CopyTaggedPtr<P, T, CP>
 where
     P: Pointer + fmt::Debug,
     T: Tag + fmt::Debug,
@@ -194,7 +194,7 @@ where
     }
 }
 
-impl<P, T, HCX, const COMPARE_PACKED: bool> HashStable<HCX> for CopyTaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, HCX, const CP: bool> HashStable<HCX> for CopyTaggedPtr<P, T, CP>
 where
     P: Pointer + HashStable<HCX>,
     T: Tag + HashStable<HCX>,

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
@@ -253,6 +253,26 @@ where
     }
 }
 
+// Safety:
+// `CopyTaggedPtr<P, T, ..>` is semantically just `{ ptr: P, tag: T }`, as such
+// it's ok to implement `Sync` as long as `P: Sync, T: Sync`
+unsafe impl<P, T, const CP: bool> Sync for CopyTaggedPtr<P, T, CP>
+where
+    P: Sync + Pointer,
+    T: Sync + Tag,
+{
+}
+
+// Safety:
+// `CopyTaggedPtr<P, T, ..>` is semantically just `{ ptr: P, tag: T }`, as such
+// it's ok to implement `Send` as long as `P: Send, T: Send`
+unsafe impl<P, T, const CP: bool> Send for CopyTaggedPtr<P, T, CP>
+where
+    P: Send + Pointer,
+    T: Send + Tag,
+{
+}
+
 /// Test that `new` does not compile if there is not enough alignment for the
 /// tag in the pointer.
 ///

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
@@ -55,12 +55,7 @@ where
     }
 
     const TAG_BIT_SHIFT: usize = usize::BITS as usize - T::BITS;
-    const ASSERTION: () = {
-        assert!(T::BITS <= P::BITS);
-        // Used for the transmute_copy's below
-        // TODO(waffle): do we need this assert anymore?
-        assert!(std::mem::size_of::<&P::Target>() == std::mem::size_of::<usize>());
-    };
+    const ASSERTION: () = { assert!(T::BITS <= P::BITS) };
 
     /// Pack pointer `ptr` that comes from [`P::into_ptr`] with a `tag`.
     ///

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy/tests.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy/tests.rs
@@ -1,36 +1,6 @@
 use std::ptr;
 
-use crate::tagged_ptr::{CopyTaggedPtr, Pointer, Tag};
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum Tag2 {
-    B00 = 0b00,
-    B01 = 0b01,
-    B10 = 0b10,
-    B11 = 0b11,
-}
-
-unsafe impl Tag for Tag2 {
-    const BITS: usize = 2;
-
-    fn into_usize(self) -> usize {
-        self as _
-    }
-
-    unsafe fn from_usize(tag: usize) -> Self {
-        const B00: usize = Tag2::B00 as _;
-        const B01: usize = Tag2::B01 as _;
-        const B10: usize = Tag2::B10 as _;
-        const B11: usize = Tag2::B11 as _;
-        match tag {
-            B00 => Tag2::B00,
-            B01 => Tag2::B01,
-            B10 => Tag2::B10,
-            B11 => Tag2::B11,
-            _ => unreachable!(),
-        }
-    }
-}
+use crate::tagged_ptr::{CopyTaggedPtr, Pointer, Tag, Tag2};
 
 #[test]
 fn smoke() {

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy/tests.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy/tests.rs
@@ -1,5 +1,6 @@
 use std::ptr;
 
+use crate::stable_hasher::{HashStable, StableHasher};
 use crate::tagged_ptr::{CopyTaggedPtr, Pointer, Tag, Tag2};
 
 #[test]
@@ -23,6 +24,24 @@ fn smoke() {
     assert_eq!(copy.tag(), tag);
     assert_eq!(*copy, 12);
     assert!(ptr::eq(copy.pointer(), reference));
+}
+
+#[test]
+fn stable_hash_hashes_as_tuple() {
+    let hash_packed = {
+        let mut hasher = StableHasher::new();
+        tag_ptr(&12, Tag2::B11).hash_stable(&mut (), &mut hasher);
+
+        hasher.finalize()
+    };
+
+    let hash_tupled = {
+        let mut hasher = StableHasher::new();
+        (&12, Tag2::B11).hash_stable(&mut (), &mut hasher);
+        hasher.finalize()
+    };
+
+    assert_eq!(hash_packed, hash_tupled);
 }
 
 /// Helper to create tagged pointers without specifying `COMPARE_PACKED` if it does not matter.

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy/tests.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy/tests.rs
@@ -1,0 +1,61 @@
+use std::ptr;
+
+use crate::tagged_ptr::{CopyTaggedPtr, Pointer, Tag};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Tag2 {
+    B00 = 0b00,
+    B01 = 0b01,
+    B10 = 0b10,
+    B11 = 0b11,
+}
+
+unsafe impl Tag for Tag2 {
+    const BITS: usize = 2;
+
+    fn into_usize(self) -> usize {
+        self as _
+    }
+
+    unsafe fn from_usize(tag: usize) -> Self {
+        const B00: usize = Tag2::B00 as _;
+        const B01: usize = Tag2::B01 as _;
+        const B10: usize = Tag2::B10 as _;
+        const B11: usize = Tag2::B11 as _;
+        match tag {
+            B00 => Tag2::B00,
+            B01 => Tag2::B01,
+            B10 => Tag2::B10,
+            B11 => Tag2::B11,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[test]
+fn smoke() {
+    let value = 12u32;
+    let reference = &value;
+    let tag = Tag2::B01;
+
+    let ptr = tag_ptr(reference, tag);
+
+    assert_eq!(ptr.tag(), tag);
+    assert_eq!(*ptr, 12);
+    assert!(ptr::eq(ptr.pointer(), reference));
+
+    let copy = ptr;
+
+    let mut ptr = ptr;
+    ptr.set_tag(Tag2::B00);
+    assert_eq!(ptr.tag(), Tag2::B00);
+
+    assert_eq!(copy.tag(), tag);
+    assert_eq!(*copy, 12);
+    assert!(ptr::eq(copy.pointer(), reference));
+}
+
+/// Helper to create tagged pointers without specifying `COMPARE_PACKED` if it does not matter.
+fn tag_ptr<P: Pointer, T: Tag>(ptr: P, tag: T) -> CopyTaggedPtr<P, T, true> {
+    CopyTaggedPtr::new(ptr, tag)
+}

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
@@ -34,6 +34,10 @@ where
     pub fn tag(&self) -> T {
         self.raw.tag()
     }
+
+    pub fn set_tag(&mut self, tag: T) {
+        self.raw.set_tag(tag)
+    }
 }
 
 impl<P, T, const CP: bool> Clone for TaggedPtr<P, T, CP>

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
@@ -150,7 +150,7 @@ where
 /// enum Tag2 { B00 = 0b00, B01 = 0b01, B10 = 0b10, B11 = 0b11 };
 ///
 /// unsafe impl Tag for Tag2 {
-///     const BITS: usize = 2;
+///     const BITS: u32 = 2;
 ///
 ///     fn into_usize(self) -> usize { todo!() }
 ///     unsafe fn from_usize(tag: usize) -> Self { todo!() }

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
@@ -134,3 +134,33 @@ where
         self.raw.hash_stable(hcx, hasher);
     }
 }
+
+/// Test that `new` does not compile if there is not enough alignment for the
+/// tag in the pointer.
+///
+/// ```compile_fail,E0080
+/// use rustc_data_structures::tagged_ptr::{TaggedPtr, Tag};
+///
+/// #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+/// enum Tag2 { B00 = 0b00, B01 = 0b01, B10 = 0b10, B11 = 0b11 };
+///
+/// unsafe impl Tag for Tag2 {
+///     const BITS: usize = 2;
+///
+///     fn into_usize(self) -> usize { todo!() }
+///     unsafe fn from_usize(tag: usize) -> Self { todo!() }
+/// }
+///
+/// let value = 12u16;
+/// let reference = &value;
+/// let tag = Tag2::B01;
+///
+/// let _ptr = TaggedPtr::<_, _, true>::new(reference, tag);
+/// ```
+// For some reason miri does not get the compile error
+// probably it `check`s instead of `build`ing?
+#[cfg(not(miri))]
+const _: () = ();
+
+#[cfg(test)]
+mod tests;

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
@@ -1,4 +1,6 @@
 use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::{Deref, DerefMut};
 
 use super::CopyTaggedPtr;
 use super::{Pointer, Tag};
@@ -15,18 +17,6 @@ where
     T: Tag,
 {
     raw: CopyTaggedPtr<P, T, COMPARE_PACKED>,
-}
-
-impl<P, T, const CP: bool> Clone for TaggedPtr<P, T, CP>
-where
-    P: Pointer + Clone,
-    T: Tag,
-{
-    fn clone(&self) -> Self {
-        let ptr = self.raw.with_pointer_ref(P::clone);
-
-        Self::new(ptr, self.tag())
-    }
 }
 
 // We pack the tag into the *upper* bits of the pointer to ease retrieval of the
@@ -46,7 +36,19 @@ where
     }
 }
 
-impl<P, T, const CP: bool> std::ops::Deref for TaggedPtr<P, T, CP>
+impl<P, T, const CP: bool> Clone for TaggedPtr<P, T, CP>
+where
+    P: Pointer + Clone,
+    T: Tag,
+{
+    fn clone(&self) -> Self {
+        let ptr = self.raw.with_pointer_ref(P::clone);
+
+        Self::new(ptr, self.tag())
+    }
+}
+
+impl<P, T, const CP: bool> Deref for TaggedPtr<P, T, CP>
 where
     P: Pointer,
     T: Tag,
@@ -57,9 +59,9 @@ where
     }
 }
 
-impl<P, T, const CP: bool> std::ops::DerefMut for TaggedPtr<P, T, CP>
+impl<P, T, const CP: bool> DerefMut for TaggedPtr<P, T, CP>
 where
-    P: Pointer + std::ops::DerefMut,
+    P: Pointer + DerefMut,
     T: Tag,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
@@ -109,12 +111,12 @@ where
 {
 }
 
-impl<P, T> std::hash::Hash for TaggedPtr<P, T, true>
+impl<P, T> Hash for TaggedPtr<P, T, true>
 where
     P: Pointer,
     T: Tag,
 {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.raw.hash(state);
     }
 }

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
@@ -1,8 +1,8 @@
-use super::{Pointer, Tag};
-use crate::stable_hasher::{HashStable, StableHasher};
 use std::fmt;
 
 use super::CopyTaggedPtr;
+use super::{Pointer, Tag};
+use crate::stable_hasher::{HashStable, StableHasher};
 
 /// A TaggedPtr implementing `Drop`.
 ///
@@ -23,7 +23,9 @@ where
     T: Tag,
 {
     fn clone(&self) -> Self {
-        unsafe { Self::new(P::with_ref(self.raw.pointer_raw(), |p| p.clone()), self.raw.tag()) }
+        let ptr = self.raw.with_pointer_ref(P::clone);
+
+        Self::new(ptr, self.tag())
     }
 }
 

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
@@ -85,15 +85,13 @@ where
 
 impl<P, T, const COMPARE_PACKED: bool> fmt::Debug for TaggedPtr<P, T, COMPARE_PACKED>
 where
-    P: Pointer,
-    P::Target: fmt::Debug,
+    P: Pointer + fmt::Debug,
     T: Tag + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TaggedPtr")
-            .field("pointer", &self.pointer_ref())
-            .field("tag", &self.tag())
-            .finish()
+        self.raw.with_pointer_ref(|ptr| {
+            f.debug_struct("TaggedPtr").field("pointer", ptr).field("tag", &self.tag()).finish()
+        })
     }
 }
 

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
@@ -76,7 +76,7 @@ where
     fn drop(&mut self) {
         // No need to drop the tag, as it's Copy
         unsafe {
-            drop(P::from_usize(self.raw.pointer_raw()));
+            drop(P::from_ptr(self.raw.pointer_raw()));
         }
     }
 }

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
@@ -41,9 +41,6 @@ where
         TaggedPtr { raw: CopyTaggedPtr::new(pointer, tag) }
     }
 
-    pub fn pointer_ref(&self) -> &P::Target {
-        self.raw.pointer_ref()
-    }
     pub fn tag(&self) -> T {
         self.raw.tag()
     }
@@ -56,7 +53,7 @@ where
 {
     type Target = P::Target;
     fn deref(&self) -> &Self::Target {
-        self.raw.pointer_ref()
+        self.raw.deref()
     }
 }
 
@@ -66,7 +63,7 @@ where
     T: Tag,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.raw.pointer_mut()
+        self.raw.deref_mut()
     }
 }
 

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
@@ -6,11 +6,16 @@ use super::CopyTaggedPtr;
 use super::{Pointer, Tag};
 use crate::stable_hasher::{HashStable, StableHasher};
 
-/// A TaggedPtr implementing `Drop`.
+/// A tagged pointer that supports pointers that implement [`Drop`].
+///
+/// This is essentially `{ pointer: P, tag: T }` packed in a single pointer.
+///
+/// You should use [`CopyTaggedPtr`] instead of the this type in all cases
+/// where `P` implements [`Copy`].
 ///
 /// If `COMPARE_PACKED` is true, then the pointers will be compared and hashed without
-/// unpacking. Otherwise we don't implement PartialEq/Eq/Hash; if you want that,
-/// wrap the TaggedPtr.
+/// unpacking. Otherwise we don't implement [`PartialEq`], [`Eq`] and [`Hash`];
+/// if you want that, wrap the [`TaggedPtr`].
 pub struct TaggedPtr<P, T, const COMPARE_PACKED: bool>
 where
     P: Pointer,
@@ -19,22 +24,22 @@ where
     raw: CopyTaggedPtr<P, T, COMPARE_PACKED>,
 }
 
-// We pack the tag into the *upper* bits of the pointer to ease retrieval of the
-// value; a right shift is a multiplication and those are embeddable in
-// instruction encoding.
 impl<P, T, const CP: bool> TaggedPtr<P, T, CP>
 where
     P: Pointer,
     T: Tag,
 {
+    /// Tags `pointer` with `tag`.
     pub fn new(pointer: P, tag: T) -> Self {
         TaggedPtr { raw: CopyTaggedPtr::new(pointer, tag) }
     }
 
+    /// Retrieves the tag.
     pub fn tag(&self) -> T {
         self.raw.tag()
     }
 
+    /// Sets the tag to a new value.
     pub fn set_tag(&mut self, tag: T) {
         self.raw.set_tag(tag)
     }

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
@@ -17,7 +17,7 @@ where
     raw: CopyTaggedPtr<P, T, COMPARE_PACKED>,
 }
 
-impl<P, T, const COMPARE_PACKED: bool> Clone for TaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, const CP: bool> Clone for TaggedPtr<P, T, CP>
 where
     P: Pointer + Clone,
     T: Tag,
@@ -32,7 +32,7 @@ where
 // We pack the tag into the *upper* bits of the pointer to ease retrieval of the
 // value; a right shift is a multiplication and those are embeddable in
 // instruction encoding.
-impl<P, T, const COMPARE_PACKED: bool> TaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, const CP: bool> TaggedPtr<P, T, CP>
 where
     P: Pointer,
     T: Tag,
@@ -46,7 +46,7 @@ where
     }
 }
 
-impl<P, T, const COMPARE_PACKED: bool> std::ops::Deref for TaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, const CP: bool> std::ops::Deref for TaggedPtr<P, T, CP>
 where
     P: Pointer,
     T: Tag,
@@ -57,7 +57,7 @@ where
     }
 }
 
-impl<P, T, const COMPARE_PACKED: bool> std::ops::DerefMut for TaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, const CP: bool> std::ops::DerefMut for TaggedPtr<P, T, CP>
 where
     P: Pointer + std::ops::DerefMut,
     T: Tag,
@@ -67,7 +67,7 @@ where
     }
 }
 
-impl<P, T, const COMPARE_PACKED: bool> Drop for TaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, const CP: bool> Drop for TaggedPtr<P, T, CP>
 where
     P: Pointer,
     T: Tag,
@@ -80,7 +80,7 @@ where
     }
 }
 
-impl<P, T, const COMPARE_PACKED: bool> fmt::Debug for TaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, const CP: bool> fmt::Debug for TaggedPtr<P, T, CP>
 where
     P: Pointer + fmt::Debug,
     T: Tag + fmt::Debug,
@@ -119,7 +119,7 @@ where
     }
 }
 
-impl<P, T, HCX, const COMPARE_PACKED: bool> HashStable<HCX> for TaggedPtr<P, T, COMPARE_PACKED>
+impl<P, T, HCX, const CP: bool> HashStable<HCX> for TaggedPtr<P, T, CP>
 where
     P: Pointer + HashStable<HCX>,
     T: Tag + HashStable<HCX>,

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop/tests.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop/tests.rs
@@ -1,36 +1,6 @@
 use std::{ptr, sync::Arc};
 
-use crate::tagged_ptr::{Pointer, Tag, TaggedPtr};
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum Tag2 {
-    B00 = 0b00,
-    B01 = 0b01,
-    B10 = 0b10,
-    B11 = 0b11,
-}
-
-unsafe impl Tag for Tag2 {
-    const BITS: usize = 2;
-
-    fn into_usize(self) -> usize {
-        self as _
-    }
-
-    unsafe fn from_usize(tag: usize) -> Self {
-        const B00: usize = Tag2::B00 as _;
-        const B01: usize = Tag2::B01 as _;
-        const B10: usize = Tag2::B10 as _;
-        const B11: usize = Tag2::B11 as _;
-        match tag {
-            B00 => Tag2::B00,
-            B01 => Tag2::B01,
-            B10 => Tag2::B10,
-            B11 => Tag2::B11,
-            _ => unreachable!(),
-        }
-    }
-}
+use crate::tagged_ptr::{Pointer, Tag, Tag2, TaggedPtr};
 
 #[test]
 fn smoke() {

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop/tests.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop/tests.rs
@@ -1,0 +1,101 @@
+use std::{ptr, sync::Arc};
+
+use crate::tagged_ptr::{Pointer, Tag, TaggedPtr};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Tag2 {
+    B00 = 0b00,
+    B01 = 0b01,
+    B10 = 0b10,
+    B11 = 0b11,
+}
+
+unsafe impl Tag for Tag2 {
+    const BITS: usize = 2;
+
+    fn into_usize(self) -> usize {
+        self as _
+    }
+
+    unsafe fn from_usize(tag: usize) -> Self {
+        const B00: usize = Tag2::B00 as _;
+        const B01: usize = Tag2::B01 as _;
+        const B10: usize = Tag2::B10 as _;
+        const B11: usize = Tag2::B11 as _;
+        match tag {
+            B00 => Tag2::B00,
+            B01 => Tag2::B01,
+            B10 => Tag2::B10,
+            B11 => Tag2::B11,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[test]
+fn smoke() {
+    let value = 12u32;
+    let reference = &value;
+    let tag = Tag2::B01;
+
+    let ptr = tag_ptr(reference, tag);
+
+    assert_eq!(ptr.tag(), tag);
+    assert_eq!(*ptr, 12);
+
+    let clone = ptr.clone();
+    assert_eq!(clone.tag(), tag);
+    assert_eq!(*clone, 12);
+
+    let mut ptr = ptr;
+    ptr.set_tag(Tag2::B00);
+    assert_eq!(ptr.tag(), Tag2::B00);
+
+    assert_eq!(clone.tag(), tag);
+    assert_eq!(*clone, 12);
+    assert!(ptr::eq(&*ptr, &*clone))
+}
+
+#[test]
+fn boxed() {
+    let value = 12u32;
+    let boxed = Box::new(value);
+    let tag = Tag2::B01;
+
+    let ptr = tag_ptr(boxed, tag);
+
+    assert_eq!(ptr.tag(), tag);
+    assert_eq!(*ptr, 12);
+
+    let clone = ptr.clone();
+    assert_eq!(clone.tag(), tag);
+    assert_eq!(*clone, 12);
+
+    let mut ptr = ptr;
+    ptr.set_tag(Tag2::B00);
+    assert_eq!(ptr.tag(), Tag2::B00);
+
+    assert_eq!(clone.tag(), tag);
+    assert_eq!(*clone, 12);
+    assert!(!ptr::eq(&*ptr, &*clone))
+}
+
+#[test]
+fn arclones() {
+    let value = 12u32;
+    let arc = Arc::new(value);
+    let tag = Tag2::B01;
+
+    let ptr = tag_ptr(arc, tag);
+
+    assert_eq!(ptr.tag(), tag);
+    assert_eq!(*ptr, 12);
+
+    let clone = ptr.clone();
+    assert!(ptr::eq(&*ptr, &*clone))
+}
+
+/// Helper to create tagged pointers without specifying `COMPARE_PACKED` if it does not matter.
+fn tag_ptr<P: Pointer, T: Tag>(ptr: P, tag: T) -> TaggedPtr<P, T, true> {
+    TaggedPtr::new(ptr, tag)
+}

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -59,6 +59,7 @@
 #![feature(result_option_inspect)]
 #![feature(const_option)]
 #![feature(trait_alias)]
+#![feature(ptr_alignment_type)]
 #![recursion_limit = "512"]
 #![allow(rustc::potential_query_instability)]
 

--- a/compiler/rustc_middle/src/ty/list.rs
+++ b/compiler/rustc_middle/src/ty/list.rs
@@ -1,4 +1,5 @@
 use crate::arena::Arena;
+use rustc_data_structures::tagged_ptr::bits_for;
 use rustc_serialize::{Encodable, Encoder};
 use std::alloc::Layout;
 use std::cmp::Ordering;
@@ -199,7 +200,7 @@ impl<'a, T: Copy> IntoIterator for &'a List<T> {
 unsafe impl<T: Sync> Sync for List<T> {}
 
 unsafe impl<'a, T: 'a> rustc_data_structures::tagged_ptr::Pointer for &'a List<T> {
-    const BITS: usize = std::mem::align_of::<usize>().trailing_zeros() as usize;
+    const BITS: usize = bits_for::<usize>();
 
     #[inline]
     fn into_usize(self) -> usize {

--- a/compiler/rustc_middle/src/ty/list.rs
+++ b/compiler/rustc_middle/src/ty/list.rs
@@ -1,5 +1,5 @@
 use crate::arena::Arena;
-use rustc_data_structures::aligned::Aligned;
+use rustc_data_structures::aligned::{align_of, Aligned};
 use rustc_serialize::{Encodable, Encoder};
 use std::alloc::Layout;
 use std::cmp::Ordering;
@@ -203,13 +203,13 @@ unsafe impl<T: Sync> Sync for List<T> {}
 // Layouts of `Equivalent<T>` and `List<T>` are the same, modulo opaque tail,
 // thus aligns of `Equivalent<T>` and `List<T>` must be the same.
 unsafe impl<T> Aligned for List<T> {
-    const ALIGN: usize = {
+    const ALIGN: ptr::Alignment = {
         #[repr(C)]
         struct Equivalent<T> {
             _len: usize,
             _data: [T; 0],
         }
 
-        mem::align_of::<Equivalent<T>>()
+        align_of::<Equivalent<T>>()
     };
 }

--- a/compiler/rustc_middle/src/ty/list.rs
+++ b/compiler/rustc_middle/src/ty/list.rs
@@ -8,7 +8,7 @@ use std::hash::{Hash, Hasher};
 use std::iter;
 use std::mem;
 use std::ops::Deref;
-use std::ptr;
+use std::ptr::{self, NonNull};
 use std::slice;
 
 /// `List<T>` is a bit like `&[T]`, but with some critical differences.
@@ -203,18 +203,16 @@ unsafe impl<'a, T: 'a> rustc_data_structures::tagged_ptr::Pointer for &'a List<T
     const BITS: usize = bits_for::<usize>();
 
     #[inline]
-    fn into_usize(self) -> usize {
-        self as *const List<T> as usize
+    fn into_ptr(self) -> NonNull<List<T>> {
+        NonNull::from(self)
     }
 
     #[inline]
-    unsafe fn from_usize(ptr: usize) -> &'a List<T> {
-        &*(ptr as *const List<T>)
+    unsafe fn from_ptr(ptr: NonNull<List<T>>) -> &'a List<T> {
+        ptr.as_ref()
     }
 
-    unsafe fn with_ref<R, F: FnOnce(&Self) -> R>(ptr: usize, f: F) -> R {
-        // `Self` is `&'a List<T>` which impls `Copy`, so this is fine.
-        let ptr = Self::from_usize(ptr);
-        f(&ptr)
+    unsafe fn with_ref<R, F: FnOnce(&Self) -> R>(ptr: NonNull<List<T>>, f: F) -> R {
+        f(&ptr.as_ref())
     }
 }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1626,7 +1626,8 @@ struct ParamTag {
 }
 
 unsafe impl rustc_data_structures::tagged_ptr::Tag for ParamTag {
-    const BITS: usize = 2;
+    const BITS: u32 = 2;
+
     #[inline]
     fn into_usize(self) -> usize {
         match self {
@@ -1636,6 +1637,7 @@ unsafe impl rustc_data_structures::tagged_ptr::Tag for ParamTag {
             Self { reveal: traits::Reveal::All, constness: hir::Constness::Const } => 3,
         }
     }
+
     #[inline]
     unsafe fn from_usize(ptr: usize) -> Self {
         match ptr {


### PR DESCRIPTION
This is a big refactor of tagged pointers in rustc, with three main goals:
1. Porting the code to the strict provenance
2. Cleanup the code
3. Document the code (and safety invariants) better

This PR has grown quite a bit (almost a complete rewrite at this point...), so I'm not sure what's the best way to review this, but reviewing commit-by-commit should be fine.

r? @Nilstrieb 