### PR TITLE
fix: use `--retry-connrefused` in curl invocations of bootstrap download

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -92,7 +92,7 @@ def _download(path, url, probably_big, verbose, exception):
                 "-L", # Follow redirect.
                 "-y", "30", "-Y", "10",    # timeout if speed is < 10 bytes/sec for > 30 seconds
                 "--connect-timeout", "30",  # timeout if cannot connect within 30 seconds
-                "--retry", "3", "-Sf", url],
+                "--retry", "3", "--retry-connrefused", "-Sf", url],
                 stdout=outfile,    #Implements cli redirect operator '>'
                 verbose=verbose,
                 exception=True, # Will raise RuntimeError on failure

--- a/src/bootstrap/download.rs
+++ b/src/bootstrap/download.rs
@@ -219,6 +219,7 @@ impl Config {
             "30", // timeout if cannot connect within 30 seconds
             "--retry",
             "3",
+            "--retry-connrefused",
             "-Sf",
         ]);
         curl.arg(url);


### PR DESCRIPTION
helps with #110178.