### PR TITLE
fix: skip implied bounds if unconstrained lifetime exists

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -56,11 +56,12 @@ impl<'a, 'tcx: 'a> InferCtxtExt<'a, 'tcx> for InferCtxt<'tcx> {
         let ty = self.resolve_vars_if_possible(ty);
         let ty = OpportunisticRegionResolver::new(self).fold_ty(ty);
 
-        // We must avoid processing constrained lifetime variables in implied
+        // We must avoid processing unconstrained lifetime variables in implied
         // bounds. See #110161 for context.
+        assert!(!ty.has_non_region_infer());
         if ty.needs_infer() {
             self.tcx.sess.delay_span_bug(
-                self.tcx.source_span_untracked(body_id),
+                self.tcx.def_span(body_id),
                 "skipped implied_outlives_bounds due to unconstrained lifetimes",
             );
             return vec![];

--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -56,8 +56,9 @@ impl<'a, 'tcx: 'a> InferCtxtExt<'a, 'tcx> for InferCtxt<'tcx> {
         let ty = self.resolve_vars_if_possible(ty);
         let ty = OpportunisticRegionResolver::new(self).fold_ty(ty);
 
-        // We must avoid processing unconstrained lifetime variables in implied
-        // bounds. See #110161 for context.
+        // We do not expect existential variables in implied bounds.
+        // We may however encounter unconstrained lifetime variables in invalid
+        // code. See #110161 for context.
         assert!(!ty.has_non_region_infer());
         if ty.needs_infer() {
             self.tcx.sess.delay_span_bug(

--- a/tests/ui/implied-bounds/issue-110161.rs
+++ b/tests/ui/implied-bounds/issue-110161.rs
@@ -1,0 +1,24 @@
+// ICE regression relating to unconstrained lifetimes in implied
+// bounds. See #110161.
+
+// compile-flags: --crate-type=lib
+
+trait Trait {
+    type Ty;
+}
+
+// erroneous `Ty` impl
+impl Trait for () {
+//~^ ERROR not all trait items implemented, missing: `Ty` [E0046]
+}
+
+// `'lt` is not constrained by the erroneous `Ty`
+impl<'lt, T> Trait for Box<T>
+where
+    T: Trait<Ty = &'lt ()>,
+{
+    type Ty = &'lt ();
+}
+
+// unconstrained lifetime appears in implied bounds
+fn test(_: <Box<()> as Trait>::Ty) {}

--- a/tests/ui/implied-bounds/issue-110161.rs
+++ b/tests/ui/implied-bounds/issue-110161.rs
@@ -3,22 +3,24 @@
 
 // compile-flags: --crate-type=lib
 
-trait Trait {
+trait LtTrait {
     type Ty;
 }
 
 // erroneous `Ty` impl
-impl Trait for () {
+impl LtTrait for () {
 //~^ ERROR not all trait items implemented, missing: `Ty` [E0046]
 }
 
 // `'lt` is not constrained by the erroneous `Ty`
-impl<'lt, T> Trait for Box<T>
+impl<'lt, T> LtTrait for Box<T>
 where
-    T: Trait<Ty = &'lt ()>,
+    T: LtTrait<Ty = &'lt ()>,
 {
     type Ty = &'lt ();
 }
 
 // unconstrained lifetime appears in implied bounds
-fn test(_: <Box<()> as Trait>::Ty) {}
+fn test(_: <Box<()> as LtTrait>::Ty) {}
+
+fn test2<'x>(_: &'x <Box<()> as LtTrait>::Ty) {}

--- a/tests/ui/implied-bounds/issue-110161.stderr
+++ b/tests/ui/implied-bounds/issue-110161.stderr
@@ -1,0 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `Ty`
+  --> $DIR/issue-110161.rs:11:1
+   |
+LL |     type Ty;
+   |     ------- `Ty` from trait
+...
+LL | impl Trait for () {
+   | ^^^^^^^^^^^^^^^^^ missing `Ty` in implementation
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0046`.

--- a/tests/ui/implied-bounds/issue-110161.stderr
+++ b/tests/ui/implied-bounds/issue-110161.stderr
@@ -4,8 +4,8 @@ error[E0046]: not all trait items implemented, missing: `Ty`
 LL |     type Ty;
    |     ------- `Ty` from trait
 ...
-LL | impl Trait for () {
-   | ^^^^^^^^^^^^^^^^^ missing `Ty` in implementation
+LL | impl LtTrait for () {
+   | ^^^^^^^^^^^^^^^^^^^ missing `Ty` in implementation
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #110161

r? @aliemjay