### PR TITLE
Remove all but one of the spans in `BoundRegionKind::BrAnon`

### DIFF
--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -293,10 +293,7 @@ pub fn resolve_interior<'a, 'tcx>(
             type_causes,
             FnMutDelegate {
                 regions: &mut |br| {
-                    let kind = match br.kind {
-                        ty::BrAnon(span) => ty::BrAnon(span),
-                        _ => br.kind,
-                    };
+                    let kind = br.kind;
                     let var = ty::BoundVar::from_usize(bound_vars.len());
                     bound_vars.push(ty::BoundVariableKind::Region(kind));
                     counter += 1;

--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -258,7 +258,7 @@ pub fn resolve_interior<'a, 'tcx>(
                     }
                     // FIXME: these should use `BrNamed`
                     ty::ReEarlyBound(region) => {
-                        mk_bound_region(ty::BrAnon(Some(fcx.tcx.def_span(region.def_id))))
+                        mk_bound_region(ty::BrNamed(region.def_id, region.name))
                     }
                     ty::ReLateBound(_, ty::BoundRegion { kind, .. })
                     | ty::ReFree(ty::FreeRegion { bound_region: kind, .. }) => match kind {

--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -239,8 +239,7 @@ pub fn resolve_interior<'a, 'tcx>(
             // typeck had previously found constraints that would cause them to be related.
 
             let mut counter = 0;
-            let mut mk_bound_region = |span| {
-                let kind = ty::BrAnon(span);
+            let mut mk_bound_region = |kind| {
                 let var = ty::BoundVar::from_u32(counter);
                 counter += 1;
                 ty::BoundRegion { var, kind }
@@ -252,24 +251,24 @@ pub fn resolve_interior<'a, 'tcx>(
                         let origin = fcx.region_var_origin(vid);
                         match origin {
                             RegionVariableOrigin::EarlyBoundRegion(span, _) => {
-                                mk_bound_region(Some(span))
+                                mk_bound_region(ty::BrAnon(Some(span)))
                             }
-                            _ => mk_bound_region(None),
+                            _ => mk_bound_region(ty::BrAnon(None)),
                         }
                     }
                     // FIXME: these should use `BrNamed`
                     ty::ReEarlyBound(region) => {
-                        mk_bound_region(Some(fcx.tcx.def_span(region.def_id)))
+                        mk_bound_region(ty::BrAnon(Some(fcx.tcx.def_span(region.def_id))))
                     }
                     ty::ReLateBound(_, ty::BoundRegion { kind, .. })
                     | ty::ReFree(ty::FreeRegion { bound_region: kind, .. }) => match kind {
-                        ty::BoundRegionKind::BrAnon(span) => mk_bound_region(span),
+                        ty::BoundRegionKind::BrAnon(span) => mk_bound_region(ty::BrAnon(span)),
                         ty::BoundRegionKind::BrNamed(def_id, _) => {
-                            mk_bound_region(Some(fcx.tcx.def_span(def_id)))
+                            mk_bound_region(ty::BrAnon(Some(fcx.tcx.def_span(def_id))))
                         }
-                        ty::BoundRegionKind::BrEnv => mk_bound_region(None),
+                        ty::BoundRegionKind::BrEnv => mk_bound_region(ty::BrAnon(None)),
                     },
-                    _ => mk_bound_region(None),
+                    _ => mk_bound_region(ty::BrAnon(None)),
                 };
                 let r = fcx.tcx.mk_re_late_bound(current_depth, br);
                 r

--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -256,15 +256,14 @@ pub fn resolve_interior<'a, 'tcx>(
                             _ => mk_bound_region(ty::BrAnon(None)),
                         }
                     }
-                    // FIXME: these should use `BrNamed`
                     ty::ReEarlyBound(region) => {
                         mk_bound_region(ty::BrNamed(region.def_id, region.name))
                     }
                     ty::ReLateBound(_, ty::BoundRegion { kind, .. })
                     | ty::ReFree(ty::FreeRegion { bound_region: kind, .. }) => match kind {
                         ty::BoundRegionKind::BrAnon(span) => mk_bound_region(ty::BrAnon(span)),
-                        ty::BoundRegionKind::BrNamed(def_id, _) => {
-                            mk_bound_region(ty::BrAnon(Some(fcx.tcx.def_span(def_id))))
+                        ty::BoundRegionKind::BrNamed(def_id, sym) => {
+                            mk_bound_region(ty::BrNamed(def_id, sym))
                         }
                         ty::BoundRegionKind::BrEnv => mk_bound_region(ty::BrAnon(None)),
                     },

--- a/tests/ui/generic-associated-types/bugs/issue-100013.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-100013.stderr
@@ -62,12 +62,12 @@ LL | |         async {}.await; // a yield point
 LL | |     }
    | |_____^
    |
-note: the lifetime defined here...
+note: the lifetime `'b` defined here...
   --> $DIR/issue-100013.rs:28:18
    |
 LL | fn call3<'a: 'b, 'b, I: FutureIterator>() -> impl Send {
    |                  ^^
-note: ...must outlive the lifetime defined here
+note: ...must outlive the lifetime `'a` defined here
   --> $DIR/issue-100013.rs:28:10
    |
 LL | fn call3<'a: 'b, 'b, I: FutureIterator>() -> impl Send {

--- a/tests/ui/generic-associated-types/bugs/issue-100013.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-100013.stderr
@@ -28,12 +28,12 @@ LL | |         async {}.await; // a yield point
 LL | |     }
    | |_____^
    |
-note: the lifetime defined here...
+note: the lifetime `'b` defined here...
   --> $DIR/issue-100013.rs:21:14
    |
 LL | fn call2<'a, 'b, I: FutureIterator>() -> impl Send {
    |              ^^
-note: ...must outlive the lifetime defined here
+note: ...must outlive the lifetime `'a` defined here
   --> $DIR/issue-100013.rs:21:10
    |
 LL | fn call2<'a, 'b, I: FutureIterator>() -> impl Send {


### PR DESCRIPTION
There are only three places where `BoundRegionKind::BrAnon` uses `Some(span)` instead of `None`. Two of them are easy to remove, which this PR does.

r? @jackh726 