### PR TITLE
rustdoc: Correctly handle built-in compiler proc-macros as proc-macro and not macro

### DIFF
--- a/tests/rustdoc/compiler-derive-proc-macro.rs
+++ b/tests/rustdoc/compiler-derive-proc-macro.rs
@@ -1,0 +1,15 @@
+// This test ensures that compiler builtin proc-macros are considered as such.
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html'
+// Each compiler builtin proc-macro has a trait equivalent so we should have
+// a trait section as well.
+// @count - '//*[@id="main-content"]//*[@class="small-section-header"]' 2
+// @has - '//*[@id="main-content"]//*[@class="small-section-header"]' 'Traits'
+// @has - '//*[@id="main-content"]//*[@class="small-section-header"]' 'Derive Macros'
+
+// Now checking the correct file is generated as well.
+// @has 'foo/derive.Clone.html'
+// @!has 'foo/macro.Clone.html'
+pub use std::clone::Clone;

--- a/tests/rustdoc/macro_pub_in_module.rs
+++ b/tests/rustdoc/macro_pub_in_module.rs
@@ -7,8 +7,8 @@
 #![crate_name = "krate"]
 #![no_core]
 
- // @has external_crate/some_module/macro.external_macro.html
-  // @!has external_crate/macro.external_macro.html
+// @has external_crate/some_module/macro.external_macro.html
+// @!has external_crate/macro.external_macro.html
 extern crate external_crate;
 
 pub mod inner {
@@ -16,13 +16,17 @@ pub mod inner {
     // @!has krate/macro.raw_const.html
     pub macro raw_const() {}
 
-    // @has krate/inner/macro.test.html
+    // @has krate/inner/attr.test.html
     // @!has krate/macro.test.html
+    // @!has krate/inner/macro.test.html
+    // @!has krate/attr.test.html
     #[rustc_builtin_macro]
     pub macro test($item:item) {}
 
-    // @has krate/inner/macro.Clone.html
+    // @has krate/inner/derive.Clone.html
+    // @!has krate/inner/macro.Clone.html
     // @!has krate/macro.Clone.html
+    // @!has krate/derive.Clone.html
     #[rustc_builtin_macro]
     pub macro Clone($item:item) {}
 


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/110111.

There were actually one issue split in two parts:
 * Compiler built-in proc-macro were incorrectly considered as macros and not proc-macros.
 * Re-exports of compiler built-in proc-macros were considering them as macros.

Both issues can be fixed by looking at the `MacroKind` variant instead of just relying on information extracted later on.

r? @fmease 