### PR TITLE
Only emit alignment checks if we have a panic_impl

### DIFF
--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -1,5 +1,6 @@
 use crate::MirPass;
 use rustc_hir::def_id::DefId;
+use rustc_hir::lang_items::LangItem;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::*;
 use rustc_middle::mir::{
@@ -17,6 +18,12 @@ impl<'tcx> MirPass<'tcx> for CheckAlignment {
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        // This pass emits new panics. If for whatever reason we do not have a panic
+        // implementation, running this pass may cause otherwise-valid code to not compile.
+        if tcx.lang_items().get(LangItem::PanicImpl).is_none() {
+            return;
+        }
+
         let basic_blocks = body.basic_blocks.as_mut();
         let local_decls = &mut body.local_decls;
 

--- a/tests/ui/mir/checks_without_panic_impl.rs
+++ b/tests/ui/mir/checks_without_panic_impl.rs
@@ -1,0 +1,17 @@
+// Ensures that the alignment check we insert for raw pointer dereferences
+// does not prevent crates without a panic_impl from compiling.
+// See rust-lang/rust#109996
+
+// build-pass
+// compile-flags: -Cdebug-assertions=yes
+
+#![crate_type = "lib"]
+
+#![feature(lang_items)]
+#![feature(no_core)]
+#![no_core]
+
+#[lang = "sized"]
+trait Foo {}
+
+pub unsafe fn foo(x: *const i32) -> &'static i32 { unsafe { &*x } }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/109996

r? @bjorn3 because you commented that this situation could impact you as well