### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics/caller_location.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/caller_location.rs
@@ -77,7 +77,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         line: u32,
         col: u32,
     ) -> MPlaceTy<'tcx, M::Provenance> {
-        let loc_details = &self.tcx.sess.opts.unstable_opts.location_detail;
+        let loc_details = self.tcx.sess.opts.unstable_opts.location_detail;
         // This can fail if rustc runs out of memory right here. Trying to emit an error would be
         // pointless, since that would require allocating more memory than these short strings.
         let file = if loc_details.file {

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1226,10 +1226,11 @@ pub fn fn_can_unwind(tcx: TyCtxt<'_>, fn_def_id: Option<DefId>, abi: SpecAbi) ->
         | AvrNonBlockingInterrupt
         | CCmseNonSecureCall
         | Wasm
-        | RustIntrinsic
         | PlatformIntrinsic
         | Unadjusted => false,
-        Rust | RustCall | RustCold => tcx.sess.panic_strategy() == PanicStrategy::Unwind,
+        Rust | RustCall | RustCold | RustIntrinsic => {
+            tcx.sess.panic_strategy() == PanicStrategy::Unwind
+        }
     }
 }
 

--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -1,5 +1,6 @@
 use crate::MirPass;
 use rustc_hir::def_id::DefId;
+use rustc_hir::lang_items::LangItem;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::*;
 use rustc_middle::mir::{
@@ -17,6 +18,12 @@ impl<'tcx> MirPass<'tcx> for CheckAlignment {
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        // This pass emits new panics. If for whatever reason we do not have a panic
+        // implementation, running this pass may cause otherwise-valid code to not compile.
+        if tcx.lang_items().get(LangItem::PanicImpl).is_none() {
+            return;
+        }
+
         let basic_blocks = body.basic_blocks.as_mut();
         let local_decls = &mut body.local_decls;
 

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -712,12 +712,12 @@ impl<'tcx> DeadVisitor<'tcx> {
 
         let parent_info = if let Some(parent_item) = parent_item {
             let parent_descr = tcx.def_descr(parent_item.to_def_id());
-            Some(ParentInfo {
-                num,
-                descr,
-                parent_descr,
-                span: tcx.def_ident_span(parent_item).unwrap(),
-            })
+            let span = if let DefKind::Impl { .. } = tcx.def_kind(parent_item) {
+                tcx.def_span(parent_item)
+            } else {
+                tcx.def_ident_span(parent_item).unwrap()
+            };
+            Some(ParentInfo { num, descr, parent_descr, span })
         } else {
             None
         };
@@ -800,16 +800,7 @@ impl<'tcx> DeadVisitor<'tcx> {
     }
 
     fn check_definition(&mut self, def_id: LocalDefId) {
-        if self.live_symbols.contains(&def_id) {
-            return;
-        }
-        if has_allow_dead_code_or_lang_attr(self.tcx, def_id) {
-            return;
-        }
-        let Some(name) = self.tcx.opt_item_name(def_id.to_def_id()) else {
-            return
-        };
-        if name.as_str().starts_with('_') {
+        if self.is_live_code(def_id) {
             return;
         }
         match self.tcx.def_kind(def_id) {
@@ -827,6 +818,18 @@ impl<'tcx> DeadVisitor<'tcx> {
             _ => {}
         }
     }
+
+    fn is_live_code(&self, def_id: LocalDefId) -> bool {
+        // if we cannot get a name for the item, then we just assume that it is
+        // live. I mean, we can't really emit a lint.
+        let Some(name) = self.tcx.opt_item_name(def_id.to_def_id()) else {
+            return true;
+        };
+
+        self.live_symbols.contains(&def_id)
+            || has_allow_dead_code_or_lang_attr(self.tcx, def_id)
+            || name.as_str().starts_with('_')
+    }
 }
 
 fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalDefId) {
@@ -837,9 +840,26 @@ fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalDefId) {
 
     for item in module_items.items() {
         if let hir::ItemKind::Impl(impl_item) = tcx.hir().item(item).kind {
+            let mut dead_items = Vec::new();
             for item in impl_item.items {
-                visitor.check_definition(item.id.owner_id.def_id);
+                match item.kind {
+                    hir::AssocItemKind::Const | hir::AssocItemKind::Type => {
+                        visitor.check_definition(item.id.owner_id.def_id)
+                    }
+                    hir::AssocItemKind::Fn { .. } => {
+                        let did = item.id.owner_id.def_id;
+                        if !visitor.is_live_code(did) {
+                            dead_items.push(did)
+                        }
+                    }
+                }
             }
+            visitor.warn_multiple_dead_codes(
+                &dead_items,
+                "used",
+                Some(item.owner_id.def_id),
+                false,
+            );
             continue;
         }
 

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -836,6 +836,13 @@ fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalDefId) {
     let module_items = tcx.hir_module_items(module);
 
     for item in module_items.items() {
+        if let hir::ItemKind::Impl(impl_item) = tcx.hir().item(item).kind {
+            for item in impl_item.items {
+                visitor.check_definition(item.id.owner_id.def_id);
+            }
+            continue;
+        }
+
         if !live_symbols.contains(&item.owner_id.def_id) {
             let parent = tcx.local_parent(item.owner_id.def_id);
             if parent != module && !live_symbols.contains(&parent) {
@@ -898,10 +905,6 @@ fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalDefId) {
                 false,
             );
         }
-    }
-
-    for impl_item in module_items.impl_items() {
-        visitor.check_definition(impl_item.owner_id.def_id);
     }
 
     for foreign_item in module_items.foreign_items() {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -222,7 +222,7 @@ impl LinkerPluginLto {
 }
 
 /// The different settings that can be enabled via the `-Z location-detail` flag.
-#[derive(Clone, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Hash, Debug)]
 pub struct LocationDetail {
     pub file: bool,
     pub line: bool,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2380,8 +2380,8 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 }
 
                 if let Some(ty::subst::GenericArgKind::Type(_)) = subst.map(|subst| subst.unpack())
+                    && let Some(body_id) = self.tcx.hir().maybe_body_owned_by(obligation.cause.body_id)
                 {
-                    let body_id = self.tcx.hir().body_owned_by(obligation.cause.body_id);
                     let mut expr_finder = FindExprBySpan::new(span);
                     expr_finder.visit_expr(&self.tcx.hir().body(body_id).value);
 

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -615,12 +615,15 @@ impl<'f> Drop for VaListImpl<'f> {
 extern "rust-intrinsic" {
     /// Destroy the arglist `ap` after initialization with `va_start` or
     /// `va_copy`.
+    #[rustc_nounwind]
     fn va_end(ap: &mut VaListImpl<'_>);
 
     /// Copies the current location of arglist `src` to the arglist `dst`.
+    #[rustc_nounwind]
     fn va_copy<'f>(dest: *mut VaListImpl<'f>, src: &VaListImpl<'f>);
 
     /// Loads an argument of type `T` from the `va_list` `ap` and increment the
     /// argument `ap` points to.
+    #[rustc_nounwind]
     fn va_arg<T: sealed_trait::VaArgSafe>(ap: &mut VaListImpl<'_>) -> T;
 }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -84,6 +84,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::Relaxed`] as both the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_relaxed_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -91,6 +92,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::Relaxed`] and [`Ordering::Acquire`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_relaxed_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -98,6 +100,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::Relaxed`] and [`Ordering::SeqCst`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_relaxed_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -105,6 +108,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::Acquire`] and [`Ordering::Relaxed`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_acquire_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -112,6 +116,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::Acquire`] as both the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_acquire_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -119,6 +124,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::Acquire`] and [`Ordering::SeqCst`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_acquire_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -126,6 +132,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::Release`] and [`Ordering::Relaxed`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_release_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -133,6 +140,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::Release`] and [`Ordering::Acquire`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_release_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -140,6 +148,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::Release`] and [`Ordering::SeqCst`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_release_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -147,6 +156,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::AcqRel`] and [`Ordering::Relaxed`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_acqrel_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -154,6 +164,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::AcqRel`] and [`Ordering::Acquire`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_acqrel_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -161,6 +172,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::AcqRel`] and [`Ordering::SeqCst`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_acqrel_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -168,6 +180,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::SeqCst`] and [`Ordering::Relaxed`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_seqcst_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -175,6 +188,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::SeqCst`] and [`Ordering::Acquire`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_seqcst_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -182,6 +196,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange` method by passing
     /// [`Ordering::SeqCst`] as both the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange`].
+    #[rustc_nounwind]
     pub fn atomic_cxchg_seqcst_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 
     /// Stores a value if the current value is the same as the `old` value.
@@ -190,6 +205,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::Relaxed`] as both the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_relaxed_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -197,6 +213,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::Relaxed`] and [`Ordering::Acquire`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_relaxed_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -204,6 +221,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::Relaxed`] and [`Ordering::SeqCst`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_relaxed_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -211,6 +229,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::Acquire`] and [`Ordering::Relaxed`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_acquire_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -218,6 +237,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::Acquire`] as both the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_acquire_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -225,6 +245,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::Acquire`] and [`Ordering::SeqCst`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_acquire_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -232,6 +253,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::Release`] and [`Ordering::Relaxed`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_release_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -239,6 +261,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::Release`] and [`Ordering::Acquire`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_release_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -246,6 +269,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::Release`] and [`Ordering::SeqCst`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_release_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -253,6 +277,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::AcqRel`] and [`Ordering::Relaxed`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_acqrel_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -260,6 +285,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::AcqRel`] and [`Ordering::Acquire`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_acqrel_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -267,6 +293,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::AcqRel`] and [`Ordering::SeqCst`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_acqrel_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -274,6 +301,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::SeqCst`] and [`Ordering::Relaxed`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_seqcst_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -281,6 +309,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::SeqCst`] and [`Ordering::Acquire`] as the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_seqcst_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -288,6 +317,7 @@ extern "rust-intrinsic" {
     /// [`atomic`] types via the `compare_exchange_weak` method by passing
     /// [`Ordering::SeqCst`] as both the success and failure parameters.
     /// For example, [`AtomicBool::compare_exchange_weak`].
+    #[rustc_nounwind]
     pub fn atomic_cxchgweak_seqcst_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 
     /// Loads the current value of the pointer.
@@ -295,19 +325,23 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `load` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::load`].
+    #[rustc_nounwind]
     pub fn atomic_load_seqcst<T: Copy>(src: *const T) -> T;
     /// Loads the current value of the pointer.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `load` method by passing
     /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::load`].
+    #[rustc_nounwind]
     pub fn atomic_load_acquire<T: Copy>(src: *const T) -> T;
     /// Loads the current value of the pointer.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `load` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::load`].
+    #[rustc_nounwind]
     pub fn atomic_load_relaxed<T: Copy>(src: *const T) -> T;
+    #[rustc_nounwind]
     pub fn atomic_load_unordered<T: Copy>(src: *const T) -> T;
 
     /// Stores the value at the specified memory location.
@@ -315,19 +349,23 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `store` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::store`].
+    #[rustc_nounwind]
     pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
     /// Stores the value at the specified memory location.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `store` method by passing
     /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::store`].
+    #[rustc_nounwind]
     pub fn atomic_store_release<T: Copy>(dst: *mut T, val: T);
     /// Stores the value at the specified memory location.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `store` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::store`].
+    #[rustc_nounwind]
     pub fn atomic_store_relaxed<T: Copy>(dst: *mut T, val: T);
+    #[rustc_nounwind]
     pub fn atomic_store_unordered<T: Copy>(dst: *mut T, val: T);
 
     /// Stores the value at the specified memory location, returning the old value.
@@ -335,30 +373,35 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `swap` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::swap`].
+    #[rustc_nounwind]
     pub fn atomic_xchg_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `swap` method by passing
     /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::swap`].
+    #[rustc_nounwind]
     pub fn atomic_xchg_acquire<T: Copy>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `swap` method by passing
     /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::swap`].
+    #[rustc_nounwind]
     pub fn atomic_xchg_release<T: Copy>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `swap` method by passing
     /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::swap`].
+    #[rustc_nounwind]
     pub fn atomic_xchg_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `swap` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::swap`].
+    #[rustc_nounwind]
     pub fn atomic_xchg_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Adds to the current value, returning the previous value.
@@ -366,30 +409,35 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_add` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicIsize::fetch_add`].
+    #[rustc_nounwind]
     pub fn atomic_xadd_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_add` method by passing
     /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicIsize::fetch_add`].
+    #[rustc_nounwind]
     pub fn atomic_xadd_acquire<T: Copy>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_add` method by passing
     /// [`Ordering::Release`] as the `order`. For example, [`AtomicIsize::fetch_add`].
+    #[rustc_nounwind]
     pub fn atomic_xadd_release<T: Copy>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_add` method by passing
     /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicIsize::fetch_add`].
+    #[rustc_nounwind]
     pub fn atomic_xadd_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_add` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicIsize::fetch_add`].
+    #[rustc_nounwind]
     pub fn atomic_xadd_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Subtract from the current value, returning the previous value.
@@ -397,30 +445,35 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_sub` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
+    #[rustc_nounwind]
     pub fn atomic_xsub_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_sub` method by passing
     /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
+    #[rustc_nounwind]
     pub fn atomic_xsub_acquire<T: Copy>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_sub` method by passing
     /// [`Ordering::Release`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
+    #[rustc_nounwind]
     pub fn atomic_xsub_release<T: Copy>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_sub` method by passing
     /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
+    #[rustc_nounwind]
     pub fn atomic_xsub_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_sub` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
+    #[rustc_nounwind]
     pub fn atomic_xsub_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Bitwise and with the current value, returning the previous value.
@@ -428,30 +481,35 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_and` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::fetch_and`].
+    #[rustc_nounwind]
     pub fn atomic_and_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_and` method by passing
     /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::fetch_and`].
+    #[rustc_nounwind]
     pub fn atomic_and_acquire<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_and` method by passing
     /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::fetch_and`].
+    #[rustc_nounwind]
     pub fn atomic_and_release<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_and` method by passing
     /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::fetch_and`].
+    #[rustc_nounwind]
     pub fn atomic_and_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_and` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::fetch_and`].
+    #[rustc_nounwind]
     pub fn atomic_and_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Bitwise nand with the current value, returning the previous value.
@@ -459,30 +517,35 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`AtomicBool`] type via the `fetch_nand` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::fetch_nand`].
+    #[rustc_nounwind]
     pub fn atomic_nand_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`AtomicBool`] type via the `fetch_nand` method by passing
     /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::fetch_nand`].
+    #[rustc_nounwind]
     pub fn atomic_nand_acquire<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`AtomicBool`] type via the `fetch_nand` method by passing
     /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::fetch_nand`].
+    #[rustc_nounwind]
     pub fn atomic_nand_release<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`AtomicBool`] type via the `fetch_nand` method by passing
     /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::fetch_nand`].
+    #[rustc_nounwind]
     pub fn atomic_nand_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`AtomicBool`] type via the `fetch_nand` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::fetch_nand`].
+    #[rustc_nounwind]
     pub fn atomic_nand_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Bitwise or with the current value, returning the previous value.
@@ -490,30 +553,35 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_or` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::fetch_or`].
+    #[rustc_nounwind]
     pub fn atomic_or_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_or` method by passing
     /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::fetch_or`].
+    #[rustc_nounwind]
     pub fn atomic_or_acquire<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_or` method by passing
     /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::fetch_or`].
+    #[rustc_nounwind]
     pub fn atomic_or_release<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_or` method by passing
     /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::fetch_or`].
+    #[rustc_nounwind]
     pub fn atomic_or_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_or` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::fetch_or`].
+    #[rustc_nounwind]
     pub fn atomic_or_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Bitwise xor with the current value, returning the previous value.
@@ -521,30 +589,35 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_xor` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::fetch_xor`].
+    #[rustc_nounwind]
     pub fn atomic_xor_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_xor` method by passing
     /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::fetch_xor`].
+    #[rustc_nounwind]
     pub fn atomic_xor_acquire<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_xor` method by passing
     /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::fetch_xor`].
+    #[rustc_nounwind]
     pub fn atomic_xor_release<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_xor` method by passing
     /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::fetch_xor`].
+    #[rustc_nounwind]
     pub fn atomic_xor_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] types via the `fetch_xor` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::fetch_xor`].
+    #[rustc_nounwind]
     pub fn atomic_xor_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Maximum with the current value using a signed comparison.
@@ -552,30 +625,35 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] signed integer types via the `fetch_max` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicI32::fetch_max`].
+    #[rustc_nounwind]
     pub fn atomic_max_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] signed integer types via the `fetch_max` method by passing
     /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicI32::fetch_max`].
+    #[rustc_nounwind]
     pub fn atomic_max_acquire<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] signed integer types via the `fetch_max` method by passing
     /// [`Ordering::Release`] as the `order`. For example, [`AtomicI32::fetch_max`].
+    #[rustc_nounwind]
     pub fn atomic_max_release<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] signed integer types via the `fetch_max` method by passing
     /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicI32::fetch_max`].
+    #[rustc_nounwind]
     pub fn atomic_max_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] signed integer types via the `fetch_max` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicI32::fetch_max`].
+    #[rustc_nounwind]
     pub fn atomic_max_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Minimum with the current value using a signed comparison.
@@ -583,18 +661,21 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] signed integer types via the `fetch_min` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicI32::fetch_min`].
+    #[rustc_nounwind]
     pub fn atomic_min_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] signed integer types via the `fetch_min` method by passing
     /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicI32::fetch_min`].
+    #[rustc_nounwind]
     pub fn atomic_min_acquire<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] signed integer types via the `fetch_min` method by passing
     /// [`Ordering::Release`] as the `order`. For example, [`AtomicI32::fetch_min`].
+    #[rustc_nounwind]
     pub fn atomic_min_release<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using a signed comparison.
     ///
@@ -607,6 +688,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] signed integer types via the `fetch_min` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicI32::fetch_min`].
+    #[rustc_nounwind]
     pub fn atomic_min_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Minimum with the current value using an unsigned comparison.
@@ -614,30 +696,35 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] unsigned integer types via the `fetch_min` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicU32::fetch_min`].
+    #[rustc_nounwind]
     pub fn atomic_umin_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] unsigned integer types via the `fetch_min` method by passing
     /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicU32::fetch_min`].
+    #[rustc_nounwind]
     pub fn atomic_umin_acquire<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] unsigned integer types via the `fetch_min` method by passing
     /// [`Ordering::Release`] as the `order`. For example, [`AtomicU32::fetch_min`].
+    #[rustc_nounwind]
     pub fn atomic_umin_release<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] unsigned integer types via the `fetch_min` method by passing
     /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicU32::fetch_min`].
+    #[rustc_nounwind]
     pub fn atomic_umin_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] unsigned integer types via the `fetch_min` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicU32::fetch_min`].
+    #[rustc_nounwind]
     pub fn atomic_umin_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Maximum with the current value using an unsigned comparison.
@@ -645,30 +732,35 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] unsigned integer types via the `fetch_max` method by passing
     /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicU32::fetch_max`].
+    #[rustc_nounwind]
     pub fn atomic_umax_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] unsigned integer types via the `fetch_max` method by passing
     /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicU32::fetch_max`].
+    #[rustc_nounwind]
     pub fn atomic_umax_acquire<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] unsigned integer types via the `fetch_max` method by passing
     /// [`Ordering::Release`] as the `order`. For example, [`AtomicU32::fetch_max`].
+    #[rustc_nounwind]
     pub fn atomic_umax_release<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] unsigned integer types via the `fetch_max` method by passing
     /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicU32::fetch_max`].
+    #[rustc_nounwind]
     pub fn atomic_umax_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
     /// [`atomic`] unsigned integer types via the `fetch_max` method by passing
     /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicU32::fetch_max`].
+    #[rustc_nounwind]
     pub fn atomic_umax_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// An atomic fence.
@@ -676,24 +768,28 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`atomic::fence`] by passing [`Ordering::SeqCst`]
     /// as the `order`.
+    #[rustc_nounwind]
     pub fn atomic_fence_seqcst();
     /// An atomic fence.
     ///
     /// The stabilized version of this intrinsic is available in
     /// [`atomic::fence`] by passing [`Ordering::Acquire`]
     /// as the `order`.
+    #[rustc_nounwind]
     pub fn atomic_fence_acquire();
     /// An atomic fence.
     ///
     /// The stabilized version of this intrinsic is available in
     /// [`atomic::fence`] by passing [`Ordering::Release`]
     /// as the `order`.
+    #[rustc_nounwind]
     pub fn atomic_fence_release();
     /// An atomic fence.
     ///
     /// The stabilized version of this intrinsic is available in
     /// [`atomic::fence`] by passing [`Ordering::AcqRel`]
     /// as the `order`.
+    #[rustc_nounwind]
     pub fn atomic_fence_acqrel();
 
     /// A compiler-only memory barrier.
@@ -706,6 +802,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`atomic::compiler_fence`] by passing [`Ordering::SeqCst`]
     /// as the `order`.
+    #[rustc_nounwind]
     pub fn atomic_singlethreadfence_seqcst();
     /// A compiler-only memory barrier.
     ///
@@ -717,6 +814,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`atomic::compiler_fence`] by passing [`Ordering::Acquire`]
     /// as the `order`.
+    #[rustc_nounwind]
     pub fn atomic_singlethreadfence_acquire();
     /// A compiler-only memory barrier.
     ///
@@ -728,6 +826,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`atomic::compiler_fence`] by passing [`Ordering::Release`]
     /// as the `order`.
+    #[rustc_nounwind]
     pub fn atomic_singlethreadfence_release();
     /// A compiler-only memory barrier.
     ///
@@ -739,6 +838,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`atomic::compiler_fence`] by passing [`Ordering::AcqRel`]
     /// as the `order`.
+    #[rustc_nounwind]
     pub fn atomic_singlethreadfence_acqrel();
 
     /// The `prefetch` intrinsic is a hint to the code generator to insert a prefetch instruction
@@ -750,6 +850,7 @@ extern "rust-intrinsic" {
     /// ranging from (0) - no locality, to (3) - extremely local keep in cache.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn prefetch_read_data<T>(data: *const T, locality: i32);
     /// The `prefetch` intrinsic is a hint to the code generator to insert a prefetch instruction
     /// if supported; otherwise, it is a no-op.
@@ -760,6 +861,7 @@ extern "rust-intrinsic" {
     /// ranging from (0) - no locality, to (3) - extremely local keep in cache.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn prefetch_write_data<T>(data: *const T, locality: i32);
     /// The `prefetch` intrinsic is a hint to the code generator to insert a prefetch instruction
     /// if supported; otherwise, it is a no-op.
@@ -770,6 +872,7 @@ extern "rust-intrinsic" {
     /// ranging from (0) - no locality, to (3) - extremely local keep in cache.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn prefetch_read_instruction<T>(data: *const T, locality: i32);
     /// The `prefetch` intrinsic is a hint to the code generator to insert a prefetch instruction
     /// if supported; otherwise, it is a no-op.
@@ -780,6 +883,7 @@ extern "rust-intrinsic" {
     /// ranging from (0) - no locality, to (3) - extremely local keep in cache.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn prefetch_write_instruction<T>(data: *const T, locality: i32);
 
     /// Magic intrinsic that derives its meaning from attributes
@@ -792,6 +896,7 @@ extern "rust-intrinsic" {
     ///
     /// This intrinsic should not be used outside of the compiler.
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn rustc_peek<T>(_: T) -> T;
 
     /// Aborts the execution of the process.
@@ -810,6 +915,7 @@ extern "rust-intrinsic" {
     /// process will probably terminate with a signal like `SIGABRT`, `SIGILL`, `SIGTRAP`, `SIGSEGV` or
     /// `SIGBUS`.  The precise behaviour is not guaranteed and not stable.
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn abort() -> !;
 
     /// Informs the optimizer that this point in the code is not reachable,
@@ -821,6 +927,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is [`core::hint::unreachable_unchecked`].
     #[rustc_const_stable(feature = "const_unreachable_unchecked", since = "1.57.0")]
+    #[rustc_nounwind]
     pub fn unreachable() -> !;
 
     /// Informs the optimizer that a condition is always true.
@@ -834,6 +941,7 @@ extern "rust-intrinsic" {
     ///
     /// This intrinsic does not have a stable counterpart.
     #[rustc_const_unstable(feature = "const_assume", issue = "76972")]
+    #[rustc_nounwind]
     pub fn assume(b: bool);
 
     /// Hints to the compiler that branch condition is likely to be true.
@@ -849,6 +957,7 @@ extern "rust-intrinsic" {
     /// This intrinsic does not have a stable counterpart.
     #[rustc_const_unstable(feature = "const_likely", issue = "none")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn likely(b: bool) -> bool;
 
     /// Hints to the compiler that branch condition is likely to be false.
@@ -864,11 +973,13 @@ extern "rust-intrinsic" {
     /// This intrinsic does not have a stable counterpart.
     #[rustc_const_unstable(feature = "const_likely", issue = "none")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn unlikely(b: bool) -> bool;
 
     /// Executes a breakpoint trap, for inspection by a debugger.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn breakpoint();
 
     /// The size of a type in bytes.
@@ -884,6 +995,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is [`core::mem::size_of`].
     #[rustc_const_stable(feature = "const_size_of", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn size_of<T>() -> usize;
 
     /// The minimum alignment of a type.
@@ -896,23 +1008,27 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is [`core::mem::align_of`].
     #[rustc_const_stable(feature = "const_min_align_of", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn min_align_of<T>() -> usize;
     /// The preferred alignment of a type.
     ///
     /// This intrinsic does not have a stable counterpart.
     /// It's "tracking issue" is [#91971](https://github.com/rust-lang/rust/issues/91971).
     #[rustc_const_unstable(feature = "const_pref_align_of", issue = "91971")]
+    #[rustc_nounwind]
     pub fn pref_align_of<T>() -> usize;
 
     /// The size of the referenced value in bytes.
     ///
     /// The stabilized version of this intrinsic is [`mem::size_of_val`].
     #[rustc_const_unstable(feature = "const_size_of_val", issue = "46571")]
+    #[rustc_nounwind]
     pub fn size_of_val<T: ?Sized>(_: *const T) -> usize;
     /// The required alignment of the referenced value.
     ///
     /// The stabilized version of this intrinsic is [`core::mem::align_of_val`].
     #[rustc_const_unstable(feature = "const_align_of_val", issue = "46571")]
+    #[rustc_nounwind]
     pub fn min_align_of_val<T: ?Sized>(_: *const T) -> usize;
 
     /// Gets a static string slice containing the name of a type.
@@ -925,6 +1041,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is [`core::any::type_name`].
     #[rustc_const_unstable(feature = "const_type_name", issue = "63084")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn type_name<T: ?Sized>() -> &'static str;
 
     /// Gets an identifier which is globally unique to the specified type. This
@@ -939,6 +1056,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is [`core::any::TypeId::of`].
     #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn type_id<T: ?Sized + 'static>() -> u64;
 
     /// A guard for unsafe functions that cannot ever be executed if `T` is uninhabited:
@@ -947,6 +1065,7 @@ extern "rust-intrinsic" {
     /// This intrinsic does not have a stable counterpart.
     #[rustc_const_stable(feature = "const_assert_type", since = "1.59.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn assert_inhabited<T>();
 
     /// A guard for unsafe functions that cannot ever be executed if `T` does not permit
@@ -955,6 +1074,7 @@ extern "rust-intrinsic" {
     /// This intrinsic does not have a stable counterpart.
     #[rustc_const_unstable(feature = "const_assert_type2", issue = "none")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn assert_zero_valid<T>();
 
     /// A guard for `std::mem::uninitialized`. This will statically either panic, or do nothing.
@@ -962,6 +1082,7 @@ extern "rust-intrinsic" {
     /// This intrinsic does not have a stable counterpart.
     #[rustc_const_unstable(feature = "const_assert_type2", issue = "none")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn assert_mem_uninitialized_valid<T>();
 
     /// Gets a reference to a static `Location` indicating where it was called.
@@ -974,6 +1095,7 @@ extern "rust-intrinsic" {
     /// Consider using [`core::panic::Location::caller`] instead.
     #[rustc_const_unstable(feature = "const_caller_location", issue = "76156")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn caller_location() -> &'static crate::panic::Location<'static>;
 
     /// Moves a value out of scope without running drop glue.
@@ -987,6 +1109,7 @@ extern "rust-intrinsic" {
     /// any safety invariants.
     #[rustc_const_unstable(feature = "const_intrinsic_forget", issue = "none")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn forget<T: ?Sized>(_: T);
 
     /// Reinterprets the bits of a value of one type as another type.
@@ -1250,6 +1373,7 @@ extern "rust-intrinsic" {
     #[rustc_allowed_through_unstable_modules]
     #[rustc_const_stable(feature = "const_transmute", since = "1.56.0")]
     #[rustc_diagnostic_item = "transmute"]
+    #[rustc_nounwind]
     pub fn transmute<Src, Dst>(src: Src) -> Dst;
 
     /// Returns `true` if the actual type given as `T` requires drop
@@ -1267,6 +1391,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is [`mem::needs_drop`](crate::mem::needs_drop).
     #[rustc_const_stable(feature = "const_needs_drop", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn needs_drop<T: ?Sized>() -> bool;
 
     /// Calculates the offset from a pointer.
@@ -1284,6 +1409,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is [`pointer::offset`].
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
+    #[rustc_nounwind]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
 
     /// Calculates the offset from a pointer, potentially wrapping.
@@ -1301,6 +1427,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is [`pointer::wrapping_offset`].
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
+    #[rustc_nounwind]
     pub fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
 
     /// Masks out bits of the pointer according to a mask.
@@ -1312,6 +1439,7 @@ extern "rust-intrinsic" {
     ///
     /// Consider using [`pointer::mask`] instead.
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn ptr_mask<T>(ptr: *const T, mask: usize) -> *const T;
 
     /// Equivalent to the appropriate `llvm.memcpy.p0i8.0i8.*` intrinsic, with
@@ -1322,6 +1450,7 @@ extern "rust-intrinsic" {
     /// unless size is equal to zero.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn volatile_copy_nonoverlapping_memory<T>(dst: *mut T, src: *const T, count: usize);
     /// Equivalent to the appropriate `llvm.memmove.p0i8.0i8.*` intrinsic, with
     /// a size of `count * size_of::<T>()` and an alignment of
@@ -1331,6 +1460,7 @@ extern "rust-intrinsic" {
     /// unless size is equal to zero.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn volatile_copy_memory<T>(dst: *mut T, src: *const T, count: usize);
     /// Equivalent to the appropriate `llvm.memset.p0i8.*` intrinsic, with a
     /// size of `count * size_of::<T>()` and an alignment of
@@ -1340,158 +1470,187 @@ extern "rust-intrinsic" {
     /// unless size is equal to zero.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn volatile_set_memory<T>(dst: *mut T, val: u8, count: usize);
 
     /// Performs a volatile load from the `src` pointer.
     ///
     /// The stabilized version of this intrinsic is [`core::ptr::read_volatile`].
+    #[rustc_nounwind]
     pub fn volatile_load<T>(src: *const T) -> T;
     /// Performs a volatile store to the `dst` pointer.
     ///
     /// The stabilized version of this intrinsic is [`core::ptr::write_volatile`].
+    #[rustc_nounwind]
     pub fn volatile_store<T>(dst: *mut T, val: T);
 
     /// Performs a volatile load from the `src` pointer
     /// The pointer is not required to be aligned.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn unaligned_volatile_load<T>(src: *const T) -> T;
     /// Performs a volatile store to the `dst` pointer.
     /// The pointer is not required to be aligned.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn unaligned_volatile_store<T>(dst: *mut T, val: T);
 
     /// Returns the square root of an `f32`
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::sqrt`](../../std/primitive.f32.html#method.sqrt)
+    #[rustc_nounwind]
     pub fn sqrtf32(x: f32) -> f32;
     /// Returns the square root of an `f64`
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::sqrt`](../../std/primitive.f64.html#method.sqrt)
+    #[rustc_nounwind]
     pub fn sqrtf64(x: f64) -> f64;
 
     /// Raises an `f32` to an integer power.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::powi`](../../std/primitive.f32.html#method.powi)
+    #[rustc_nounwind]
     pub fn powif32(a: f32, x: i32) -> f32;
     /// Raises an `f64` to an integer power.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::powi`](../../std/primitive.f64.html#method.powi)
+    #[rustc_nounwind]
     pub fn powif64(a: f64, x: i32) -> f64;
 
     /// Returns the sine of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::sin`](../../std/primitive.f32.html#method.sin)
+    #[rustc_nounwind]
     pub fn sinf32(x: f32) -> f32;
     /// Returns the sine of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::sin`](../../std/primitive.f64.html#method.sin)
+    #[rustc_nounwind]
     pub fn sinf64(x: f64) -> f64;
 
     /// Returns the cosine of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::cos`](../../std/primitive.f32.html#method.cos)
+    #[rustc_nounwind]
     pub fn cosf32(x: f32) -> f32;
     /// Returns the cosine of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::cos`](../../std/primitive.f64.html#method.cos)
+    #[rustc_nounwind]
     pub fn cosf64(x: f64) -> f64;
 
     /// Raises an `f32` to an `f32` power.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::powf`](../../std/primitive.f32.html#method.powf)
+    #[rustc_nounwind]
     pub fn powf32(a: f32, x: f32) -> f32;
     /// Raises an `f64` to an `f64` power.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::powf`](../../std/primitive.f64.html#method.powf)
+    #[rustc_nounwind]
     pub fn powf64(a: f64, x: f64) -> f64;
 
     /// Returns the exponential of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::exp`](../../std/primitive.f32.html#method.exp)
+    #[rustc_nounwind]
     pub fn expf32(x: f32) -> f32;
     /// Returns the exponential of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::exp`](../../std/primitive.f64.html#method.exp)
+    #[rustc_nounwind]
     pub fn expf64(x: f64) -> f64;
 
     /// Returns 2 raised to the power of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::exp2`](../../std/primitive.f32.html#method.exp2)
+    #[rustc_nounwind]
     pub fn exp2f32(x: f32) -> f32;
     /// Returns 2 raised to the power of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::exp2`](../../std/primitive.f64.html#method.exp2)
+    #[rustc_nounwind]
     pub fn exp2f64(x: f64) -> f64;
 
     /// Returns the natural logarithm of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::ln`](../../std/primitive.f32.html#method.ln)
+    #[rustc_nounwind]
     pub fn logf32(x: f32) -> f32;
     /// Returns the natural logarithm of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::ln`](../../std/primitive.f64.html#method.ln)
+    #[rustc_nounwind]
     pub fn logf64(x: f64) -> f64;
 
     /// Returns the base 10 logarithm of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::log10`](../../std/primitive.f32.html#method.log10)
+    #[rustc_nounwind]
     pub fn log10f32(x: f32) -> f32;
     /// Returns the base 10 logarithm of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::log10`](../../std/primitive.f64.html#method.log10)
+    #[rustc_nounwind]
     pub fn log10f64(x: f64) -> f64;
 
     /// Returns the base 2 logarithm of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::log2`](../../std/primitive.f32.html#method.log2)
+    #[rustc_nounwind]
     pub fn log2f32(x: f32) -> f32;
     /// Returns the base 2 logarithm of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::log2`](../../std/primitive.f64.html#method.log2)
+    #[rustc_nounwind]
     pub fn log2f64(x: f64) -> f64;
 
     /// Returns `a * b + c` for `f32` values.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::mul_add`](../../std/primitive.f32.html#method.mul_add)
+    #[rustc_nounwind]
     pub fn fmaf32(a: f32, b: f32, c: f32) -> f32;
     /// Returns `a * b + c` for `f64` values.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::mul_add`](../../std/primitive.f64.html#method.mul_add)
+    #[rustc_nounwind]
     pub fn fmaf64(a: f64, b: f64, c: f64) -> f64;
 
     /// Returns the absolute value of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::abs`](../../std/primitive.f32.html#method.abs)
+    #[rustc_nounwind]
     pub fn fabsf32(x: f32) -> f32;
     /// Returns the absolute value of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::abs`](../../std/primitive.f64.html#method.abs)
+    #[rustc_nounwind]
     pub fn fabsf64(x: f64) -> f64;
 
     /// Returns the minimum of two `f32` values.
@@ -1504,6 +1663,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is
     /// [`f32::min`]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn minnumf32(x: f32, y: f32) -> f32;
     /// Returns the minimum of two `f64` values.
     ///
@@ -1515,6 +1675,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is
     /// [`f64::min`]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn minnumf64(x: f64, y: f64) -> f64;
     /// Returns the maximum of two `f32` values.
     ///
@@ -1526,6 +1687,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is
     /// [`f32::max`]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn maxnumf32(x: f32, y: f32) -> f32;
     /// Returns the maximum of two `f64` values.
     ///
@@ -1537,50 +1699,59 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is
     /// [`f64::max`]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn maxnumf64(x: f64, y: f64) -> f64;
 
     /// Copies the sign from `y` to `x` for `f32` values.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::copysign`](../../std/primitive.f32.html#method.copysign)
+    #[rustc_nounwind]
     pub fn copysignf32(x: f32, y: f32) -> f32;
     /// Copies the sign from `y` to `x` for `f64` values.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::copysign`](../../std/primitive.f64.html#method.copysign)
+    #[rustc_nounwind]
     pub fn copysignf64(x: f64, y: f64) -> f64;
 
     /// Returns the largest integer less than or equal to an `f32`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::floor`](../../std/primitive.f32.html#method.floor)
+    #[rustc_nounwind]
     pub fn floorf32(x: f32) -> f32;
     /// Returns the largest integer less than or equal to an `f64`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::floor`](../../std/primitive.f64.html#method.floor)
+    #[rustc_nounwind]
     pub fn floorf64(x: f64) -> f64;
 
     /// Returns the smallest integer greater than or equal to an `f32`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::ceil`](../../std/primitive.f32.html#method.ceil)
+    #[rustc_nounwind]
     pub fn ceilf32(x: f32) -> f32;
     /// Returns the smallest integer greater than or equal to an `f64`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::ceil`](../../std/primitive.f64.html#method.ceil)
+    #[rustc_nounwind]
     pub fn ceilf64(x: f64) -> f64;
 
     /// Returns the integer part of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::trunc`](../../std/primitive.f32.html#method.trunc)
+    #[rustc_nounwind]
     pub fn truncf32(x: f32) -> f32;
     /// Returns the integer part of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::trunc`](../../std/primitive.f64.html#method.trunc)
+    #[rustc_nounwind]
     pub fn truncf64(x: f64) -> f64;
 
     /// Returns the nearest integer to an `f32`. May raise an inexact floating-point exception
@@ -1588,32 +1759,38 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::round_ties_even`](../../std/primitive.f32.html#method.round_ties_even)
+    #[rustc_nounwind]
     pub fn rintf32(x: f32) -> f32;
     /// Returns the nearest integer to an `f64`. May raise an inexact floating-point exception
     /// if the argument is not an integer.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::round_ties_even`](../../std/primitive.f64.html#method.round_ties_even)
+    #[rustc_nounwind]
     pub fn rintf64(x: f64) -> f64;
 
     /// Returns the nearest integer to an `f32`.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn nearbyintf32(x: f32) -> f32;
     /// Returns the nearest integer to an `f64`.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn nearbyintf64(x: f64) -> f64;
 
     /// Returns the nearest integer to an `f32`. Rounds half-way cases away from zero.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::round`](../../std/primitive.f32.html#method.round)
+    #[rustc_nounwind]
     pub fn roundf32(x: f32) -> f32;
     /// Returns the nearest integer to an `f64`. Rounds half-way cases away from zero.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::round`](../../std/primitive.f64.html#method.round)
+    #[rustc_nounwind]
     pub fn roundf64(x: f64) -> f64;
 
     /// Returns the nearest integer to an `f32`. Rounds half-way cases to the number
@@ -1621,48 +1798,56 @@ extern "rust-intrinsic" {
     ///
     /// This intrinsic does not have a stable counterpart.
     #[cfg(not(bootstrap))]
+    #[rustc_nounwind]
     pub fn roundevenf32(x: f32) -> f32;
     /// Returns the nearest integer to an `f64`. Rounds half-way cases to the number
     /// with an even least significant digit.
     ///
     /// This intrinsic does not have a stable counterpart.
     #[cfg(not(bootstrap))]
+    #[rustc_nounwind]
     pub fn roundevenf64(x: f64) -> f64;
 
     /// Float addition that allows optimizations based on algebraic rules.
     /// May assume inputs are finite.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn fadd_fast<T: Copy>(a: T, b: T) -> T;
 
     /// Float subtraction that allows optimizations based on algebraic rules.
     /// May assume inputs are finite.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn fsub_fast<T: Copy>(a: T, b: T) -> T;
 
     /// Float multiplication that allows optimizations based on algebraic rules.
     /// May assume inputs are finite.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn fmul_fast<T: Copy>(a: T, b: T) -> T;
 
     /// Float division that allows optimizations based on algebraic rules.
     /// May assume inputs are finite.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn fdiv_fast<T: Copy>(a: T, b: T) -> T;
 
     /// Float remainder that allows optimizations based on algebraic rules.
     /// May assume inputs are finite.
     ///
     /// This intrinsic does not have a stable counterpart.
+    #[rustc_nounwind]
     pub fn frem_fast<T: Copy>(a: T, b: T) -> T;
 
     /// Convert with LLVM’s fptoui/fptosi, which may return undef for values out of range
     /// (<https://github.com/rust-lang/rust/issues/10184>)
     ///
     /// Stabilized as [`f32::to_int_unchecked`] and [`f64::to_int_unchecked`].
+    #[rustc_nounwind]
     pub fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
     /// Returns the number of bits set in an integer type `T`
@@ -1677,6 +1862,7 @@ extern "rust-intrinsic" {
     /// [`u32::count_ones`]
     #[rustc_const_stable(feature = "const_ctpop", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn ctpop<T: Copy>(x: T) -> T;
 
     /// Returns the number of leading unset bits (zeroes) in an integer type `T`.
@@ -1715,6 +1901,7 @@ extern "rust-intrinsic" {
     /// ```
     #[rustc_const_stable(feature = "const_ctlz", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn ctlz<T: Copy>(x: T) -> T;
 
     /// Like `ctlz`, but extra-unsafe as it returns `undef` when
@@ -1734,6 +1921,7 @@ extern "rust-intrinsic" {
     /// assert_eq!(num_leading, 3);
     /// ```
     #[rustc_const_stable(feature = "constctlz", since = "1.50.0")]
+    #[rustc_nounwind]
     pub fn ctlz_nonzero<T: Copy>(x: T) -> T;
 
     /// Returns the number of trailing unset bits (zeroes) in an integer type `T`.
@@ -1772,6 +1960,7 @@ extern "rust-intrinsic" {
     /// ```
     #[rustc_const_stable(feature = "const_cttz", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn cttz<T: Copy>(x: T) -> T;
 
     /// Like `cttz`, but extra-unsafe as it returns `undef` when
@@ -1791,6 +1980,7 @@ extern "rust-intrinsic" {
     /// assert_eq!(num_trailing, 3);
     /// ```
     #[rustc_const_stable(feature = "const_cttz_nonzero", since = "1.53.0")]
+    #[rustc_nounwind]
     pub fn cttz_nonzero<T: Copy>(x: T) -> T;
 
     /// Reverses the bytes in an integer type `T`.
@@ -1805,6 +1995,7 @@ extern "rust-intrinsic" {
     /// [`u32::swap_bytes`]
     #[rustc_const_stable(feature = "const_bswap", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn bswap<T: Copy>(x: T) -> T;
 
     /// Reverses the bits in an integer type `T`.
@@ -1819,6 +2010,7 @@ extern "rust-intrinsic" {
     /// [`u32::reverse_bits`]
     #[rustc_const_stable(feature = "const_bitreverse", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn bitreverse<T: Copy>(x: T) -> T;
 
     /// Performs checked integer addition.
@@ -1833,6 +2025,7 @@ extern "rust-intrinsic" {
     /// [`u32::overflowing_add`]
     #[rustc_const_stable(feature = "const_int_overflow", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn add_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
     /// Performs checked integer subtraction
@@ -1847,6 +2040,7 @@ extern "rust-intrinsic" {
     /// [`u32::overflowing_sub`]
     #[rustc_const_stable(feature = "const_int_overflow", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn sub_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
     /// Performs checked integer multiplication
@@ -1861,6 +2055,7 @@ extern "rust-intrinsic" {
     /// [`u32::overflowing_mul`]
     #[rustc_const_stable(feature = "const_int_overflow", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn mul_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
     /// Performs an exact division, resulting in undefined behavior where
@@ -1868,6 +2063,7 @@ extern "rust-intrinsic" {
     ///
     /// This intrinsic does not have a stable counterpart.
     #[rustc_const_unstable(feature = "const_exact_div", issue = "none")]
+    #[rustc_nounwind]
     pub fn exact_div<T: Copy>(x: T, y: T) -> T;
 
     /// Performs an unchecked division, resulting in undefined behavior
@@ -1877,6 +2073,7 @@ extern "rust-intrinsic" {
     /// primitives via the `checked_div` method. For example,
     /// [`u32::checked_div`]
     #[rustc_const_stable(feature = "const_int_unchecked_div", since = "1.52.0")]
+    #[rustc_nounwind]
     pub fn unchecked_div<T: Copy>(x: T, y: T) -> T;
     /// Returns the remainder of an unchecked division, resulting in
     /// undefined behavior when `y == 0` or `x == T::MIN && y == -1`
@@ -1885,6 +2082,7 @@ extern "rust-intrinsic" {
     /// primitives via the `checked_rem` method. For example,
     /// [`u32::checked_rem`]
     #[rustc_const_stable(feature = "const_int_unchecked_rem", since = "1.52.0")]
+    #[rustc_nounwind]
     pub fn unchecked_rem<T: Copy>(x: T, y: T) -> T;
 
     /// Performs an unchecked left shift, resulting in undefined behavior when
@@ -1894,6 +2092,7 @@ extern "rust-intrinsic" {
     /// primitives via the `checked_shl` method. For example,
     /// [`u32::checked_shl`]
     #[rustc_const_stable(feature = "const_int_unchecked", since = "1.40.0")]
+    #[rustc_nounwind]
     pub fn unchecked_shl<T: Copy>(x: T, y: T) -> T;
     /// Performs an unchecked right shift, resulting in undefined behavior when
     /// `y < 0` or `y >= N`, where N is the width of T in bits.
@@ -1902,6 +2101,7 @@ extern "rust-intrinsic" {
     /// primitives via the `checked_shr` method. For example,
     /// [`u32::checked_shr`]
     #[rustc_const_stable(feature = "const_int_unchecked", since = "1.40.0")]
+    #[rustc_nounwind]
     pub fn unchecked_shr<T: Copy>(x: T, y: T) -> T;
 
     /// Returns the result of an unchecked addition, resulting in
@@ -1909,6 +2109,7 @@ extern "rust-intrinsic" {
     ///
     /// This intrinsic does not have a stable counterpart.
     #[rustc_const_unstable(feature = "const_int_unchecked_arith", issue = "none")]
+    #[rustc_nounwind]
     pub fn unchecked_add<T: Copy>(x: T, y: T) -> T;
 
     /// Returns the result of an unchecked subtraction, resulting in
@@ -1916,6 +2117,7 @@ extern "rust-intrinsic" {
     ///
     /// This intrinsic does not have a stable counterpart.
     #[rustc_const_unstable(feature = "const_int_unchecked_arith", issue = "none")]
+    #[rustc_nounwind]
     pub fn unchecked_sub<T: Copy>(x: T, y: T) -> T;
 
     /// Returns the result of an unchecked multiplication, resulting in
@@ -1923,6 +2125,7 @@ extern "rust-intrinsic" {
     ///
     /// This intrinsic does not have a stable counterpart.
     #[rustc_const_unstable(feature = "const_int_unchecked_arith", issue = "none")]
+    #[rustc_nounwind]
     pub fn unchecked_mul<T: Copy>(x: T, y: T) -> T;
 
     /// Performs rotate left.
@@ -1937,6 +2140,7 @@ extern "rust-intrinsic" {
     /// [`u32::rotate_left`]
     #[rustc_const_stable(feature = "const_int_rotate", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn rotate_left<T: Copy>(x: T, y: T) -> T;
 
     /// Performs rotate right.
@@ -1951,6 +2155,7 @@ extern "rust-intrinsic" {
     /// [`u32::rotate_right`]
     #[rustc_const_stable(feature = "const_int_rotate", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn rotate_right<T: Copy>(x: T, y: T) -> T;
 
     /// Returns (a + b) mod 2<sup>N</sup>, where N is the width of T in bits.
@@ -1965,6 +2170,7 @@ extern "rust-intrinsic" {
     /// [`u32::wrapping_add`]
     #[rustc_const_stable(feature = "const_int_wrapping", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn wrapping_add<T: Copy>(a: T, b: T) -> T;
     /// Returns (a - b) mod 2<sup>N</sup>, where N is the width of T in bits.
     ///
@@ -1978,6 +2184,7 @@ extern "rust-intrinsic" {
     /// [`u32::wrapping_sub`]
     #[rustc_const_stable(feature = "const_int_wrapping", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn wrapping_sub<T: Copy>(a: T, b: T) -> T;
     /// Returns (a * b) mod 2<sup>N</sup>, where N is the width of T in bits.
     ///
@@ -1991,6 +2198,7 @@ extern "rust-intrinsic" {
     /// [`u32::wrapping_mul`]
     #[rustc_const_stable(feature = "const_int_wrapping", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn wrapping_mul<T: Copy>(a: T, b: T) -> T;
 
     /// Computes `a + b`, saturating at numeric bounds.
@@ -2005,6 +2213,7 @@ extern "rust-intrinsic" {
     /// [`u32::saturating_add`]
     #[rustc_const_stable(feature = "const_int_saturating", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn saturating_add<T: Copy>(a: T, b: T) -> T;
     /// Computes `a - b`, saturating at numeric bounds.
     ///
@@ -2018,6 +2227,7 @@ extern "rust-intrinsic" {
     /// [`u32::saturating_sub`]
     #[rustc_const_stable(feature = "const_int_saturating", since = "1.40.0")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn saturating_sub<T: Copy>(a: T, b: T) -> T;
 
     /// This is an implementation detail of [`crate::ptr::read`] and should
@@ -2028,6 +2238,7 @@ extern "rust-intrinsic" {
     /// trivially obeys runtime-MIR rules about derefs in operands.
     #[cfg(not(bootstrap))]
     #[rustc_const_unstable(feature = "const_ptr_read", issue = "80377")]
+    #[rustc_nounwind]
     pub fn read_via_copy<T>(p: *const T) -> T;
 
     /// Returns the value of the discriminant for the variant in 'v';
@@ -2041,6 +2252,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is [`core::mem::discriminant`].
     #[rustc_const_unstable(feature = "const_discriminant", issue = "69821")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
 
     /// Returns the number of variants of the type `T` cast to a `usize`;
@@ -2054,6 +2266,7 @@ extern "rust-intrinsic" {
     /// The to-be-stabilized version of this intrinsic is [`mem::variant_count`].
     #[rustc_const_unstable(feature = "variant_count", issue = "73662")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn variant_count<T>() -> usize;
 
     /// Rust's "try catch" construct which invokes the function pointer `try_fn`
@@ -2063,18 +2276,22 @@ extern "rust-intrinsic" {
     /// takes the data pointer and a pointer to the target-specific exception
     /// object that was caught. For more information see the compiler's
     /// source as well as std's catch implementation.
+    #[rustc_nounwind]
     pub fn r#try(try_fn: fn(*mut u8), data: *mut u8, catch_fn: fn(*mut u8, *mut u8)) -> i32;
 
     /// Emits a `!nontemporal` store according to LLVM (see their docs).
     /// Probably will never become stable.
+    #[rustc_nounwind]
     pub fn nontemporal_store<T>(ptr: *mut T, val: T);
 
     /// See documentation of `<*const T>::offset_from` for details.
     #[rustc_const_stable(feature = "const_ptr_offset_from", since = "1.65.0")]
+    #[rustc_nounwind]
     pub fn ptr_offset_from<T>(ptr: *const T, base: *const T) -> isize;
 
     /// See documentation of `<*const T>::sub_ptr` for details.
     #[rustc_const_unstable(feature = "const_ptr_sub_ptr", issue = "95892")]
+    #[rustc_nounwind]
     pub fn ptr_offset_from_unsigned<T>(ptr: *const T, base: *const T) -> usize;
 
     /// See documentation of `<*const T>::guaranteed_eq` for details.
@@ -2088,6 +2305,7 @@ extern "rust-intrinsic" {
     /// any safety invariants.
     #[rustc_const_unstable(feature = "const_raw_ptr_comparison", issue = "53020")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn ptr_guaranteed_cmp<T>(ptr: *const T, other: *const T) -> u8;
 
     /// Allocates a block of memory at compile time.
@@ -2099,6 +2317,7 @@ extern "rust-intrinsic" {
     ///    - At compile time, a compile error occurs if this constraint is violated.
     ///    - At runtime, it is not checked.
     #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
+    #[rustc_nounwind]
     pub fn const_allocate(size: usize, align: usize) -> *mut u8;
 
     /// Deallocates a memory which allocated by `intrinsics::const_allocate` at compile time.
@@ -2112,6 +2331,7 @@ extern "rust-intrinsic" {
     /// - If the `ptr` is created in an another const, this intrinsic doesn't deallocate it.
     /// - If the `ptr` is pointing to a local variable, this intrinsic doesn't deallocate it.
     #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
+    #[rustc_nounwind]
     pub fn const_deallocate(ptr: *mut u8, size: usize, align: usize);
 
     /// Determines whether the raw bytes of the two values are equal.
@@ -2136,6 +2356,7 @@ extern "rust-intrinsic" {
     /// (The implementation is allowed to branch on the results of comparisons,
     /// which is UB if any of their inputs are `undef`.)
     #[rustc_const_unstable(feature = "const_intrinsic_raw_eq", issue = "none")]
+    #[rustc_nounwind]
     pub fn raw_eq<T>(a: &T, b: &T) -> bool;
 
     /// See documentation of [`std::hint::black_box`] for details.
@@ -2143,14 +2364,17 @@ extern "rust-intrinsic" {
     /// [`std::hint::black_box`]: crate::hint::black_box
     #[rustc_const_unstable(feature = "const_black_box", issue = "none")]
     #[rustc_safe_intrinsic]
+    #[rustc_nounwind]
     pub fn black_box<T>(dummy: T) -> T;
 
     /// `ptr` must point to a vtable.
     /// The intrinsic will return the size stored in that vtable.
+    #[rustc_nounwind]
     pub fn vtable_size(ptr: *const ()) -> usize;
 
     /// `ptr` must point to a vtable.
     /// The intrinsic will return the alignment stored in that vtable.
+    #[rustc_nounwind]
     pub fn vtable_align(ptr: *const ()) -> usize;
 
     /// Selects which function to call depending on the context.
@@ -2215,10 +2439,11 @@ extern "rust-intrinsic" {
         G: FnOnce<ARG, Output = RET>,
         F: FnOnce<ARG, Output = RET>;
 
-    #[cfg(not(bootstrap))]
     /// This method creates a pointer to any `Some` value. If the argument is
     /// `None`, an invalid within-bounds pointer (that is still acceptable for
     /// constructing an empty slice) is returned.
+    #[cfg(not(bootstrap))]
+    #[rustc_nounwind]
     pub fn option_payload_ptr<T>(arg: *const Option<T>) -> *const T;
 }
 
@@ -2392,6 +2617,7 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
     extern "rust-intrinsic" {
         #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
+        #[rustc_nounwind]
         pub fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
     }
 
@@ -2482,6 +2708,7 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     extern "rust-intrinsic" {
         #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
+        #[rustc_nounwind]
         fn copy<T>(src: *const T, dst: *mut T, count: usize);
     }
 
@@ -2554,6 +2781,7 @@ pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
 pub const unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize) {
     extern "rust-intrinsic" {
         #[rustc_const_unstable(feature = "const_ptr_write", issue = "86302")]
+        #[rustc_nounwind]
         fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
     }
 

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2276,6 +2276,8 @@ extern "rust-intrinsic" {
     /// takes the data pointer and a pointer to the target-specific exception
     /// object that was caught. For more information see the compiler's
     /// source as well as std's catch implementation.
+    ///
+    /// `catch_fn` must not unwind.
     #[rustc_nounwind]
     pub fn r#try(try_fn: fn(*mut u8), data: *mut u8, catch_fn: fn(*mut u8, *mut u8)) -> i32;
 

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -823,7 +823,7 @@ unsafe impl<T: ?Sized> Freeze for &mut T {}
 /// [`pin` module]: crate::pin
 #[stable(feature = "pin", since = "1.33.0")]
 #[rustc_on_unimplemented(
-    note = "consider using `Box::pin`",
+    note = "consider using the `pin!` macro\nconsider using `Box::pin` if you need to access the pinned value outside of the current scope",
     message = "`{Self}` cannot be unpinned"
 )]
 #[lang = "unpin"]

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1371,6 +1371,7 @@ pub const unsafe fn write<T>(dst: *mut T, src: T) {
     // as `intrinsics::copy_nonoverlapping` is a wrapper function.
     extern "rust-intrinsic" {
         #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
+        #[rustc_nounwind]
         fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
     }
 

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -498,6 +498,7 @@ pub unsafe fn r#try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>>
     // This function cannot be marked as `unsafe` because `intrinsics::r#try`
     // expects normal function pointers.
     #[inline]
+    #[rustc_nounwind] // `intrinsic::r#try` requires catch fn to be nounwind
     fn do_catch<F: FnOnce() -> R, R>(data: *mut u8, payload: *mut u8) {
         // SAFETY: this is the responsibility of the caller, see above.
         //

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -895,6 +895,8 @@ impl Step for Src {
 
     /// Creates the `rust-src` installer component
     fn run(self, builder: &Builder<'_>) -> GeneratedTarball {
+        builder.update_submodule(&Path::new("src/llvm-project"));
+
         let tarball = Tarball::new_targetless(builder, "rust-src");
 
         // A lot of tools expect the rust-src component to be entirely in this directory, so if you

--- a/src/bootstrap/llvm.rs
+++ b/src/bootstrap/llvm.rs
@@ -1087,6 +1087,8 @@ impl Step for CrtBeginEnd {
 
     /// Build crtbegin.o/crtend.o for musl target.
     fn run(self, builder: &Builder<'_>) -> Self::Output {
+        builder.update_submodule(&Path::new("src/llvm-project"));
+
         let out_dir = builder.native_dir(self.target).join("crt");
 
         if builder.config.dry_run() {
@@ -1153,6 +1155,8 @@ impl Step for Libunwind {
 
     /// Build linunwind.a
     fn run(self, builder: &Builder<'_>) -> Self::Output {
+        builder.update_submodule(&Path::new("src/llvm-project"));
+
         if builder.config.dry_run() {
             return PathBuf::new();
         }

--- a/tests/mir-opt/issue_104451_unwindable_intrinsics.main.AbortUnwindingCalls.after.mir
+++ b/tests/mir-opt/issue_104451_unwindable_intrinsics.main.AbortUnwindingCalls.after.mir
@@ -1,0 +1,25 @@
+// MIR for `main` after AbortUnwindingCalls
+
+fn main() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/issue_104451_unwindable_intrinsics.rs:+0:11: +0:11
+    let mut _1: !;                       // in scope 0 at $DIR/issue_104451_unwindable_intrinsics.rs:+2:9: +2:62
+    let mut _2: ();                      // in scope 0 at $DIR/issue_104451_unwindable_intrinsics.rs:+2:45: +2:47
+    scope 1 {
+    }
+
+    bb0: {
+        StorageLive(_1);                 // scope 1 at $DIR/issue_104451_unwindable_intrinsics.rs:+2:9: +2:62
+        StorageLive(_2);                 // scope 1 at $DIR/issue_104451_unwindable_intrinsics.rs:+2:45: +2:47
+        _2 = ();                         // scope 1 at $DIR/issue_104451_unwindable_intrinsics.rs:+2:45: +2:47
+        _1 = const_eval_select::<(), fn() -> ! {ow_ct}, fn() -> ! {ow_ct}, !>(move _2, ow_ct, ow_ct); // scope 1 at $DIR/issue_104451_unwindable_intrinsics.rs:+2:9: +2:62
+                                         // mir::Constant
+                                         // + span: $DIR/issue_104451_unwindable_intrinsics.rs:8:9: 8:44
+                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn((), fn() -> ! {ow_ct}, fn() -> ! {ow_ct}) -> ! {const_eval_select::<(), fn() -> ! {ow_ct}, fn() -> ! {ow_ct}, !>}, val: Value(<ZST>) }
+                                         // mir::Constant
+                                         // + span: $DIR/issue_104451_unwindable_intrinsics.rs:8:49: 8:54
+                                         // + literal: Const { ty: fn() -> ! {ow_ct}, val: Value(<ZST>) }
+                                         // mir::Constant
+                                         // + span: $DIR/issue_104451_unwindable_intrinsics.rs:8:56: 8:61
+                                         // + literal: Const { ty: fn() -> ! {ow_ct}, val: Value(<ZST>) }
+    }
+}

--- a/tests/mir-opt/issue_104451_unwindable_intrinsics.rs
+++ b/tests/mir-opt/issue_104451_unwindable_intrinsics.rs
@@ -1,0 +1,14 @@
+// Check that `UnwindAction::Unreachable` is not generated for unwindable intrinsics.
+// ignore-wasm32 compiled with panic=abort by default
+#![feature(core_intrinsics)]
+
+// EMIT_MIR issue_104451_unwindable_intrinsics.main.AbortUnwindingCalls.after.mir
+fn main() {
+    unsafe {
+        core::intrinsics::const_eval_select((), ow_ct, ow_ct)
+    }
+}
+
+const fn ow_ct() -> ! {
+    panic!();
+}

--- a/tests/mir-opt/lower_intrinsics.assume.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.assume.LowerIntrinsics.diff
@@ -11,7 +11,7 @@
           StorageLive(_1);                 // scope 1 at $DIR/lower_intrinsics.rs:+2:9: +2:38
 -         _1 = std::intrinsics::assume(const true) -> [return: bb1, unwind unreachable]; // scope 1 at $DIR/lower_intrinsics.rs:+2:9: +2:38
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:105:9: 105:32
+-                                          // + span: $DIR/lower_intrinsics.rs:106:9: 106:32
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(bool) {std::intrinsics::assume}, val: Value(<ZST>) }
 +         assume(const true);              // scope 1 at $DIR/lower_intrinsics.rs:+2:9: +2:38
 +         goto -> bb1;                     // scope 1 at $DIR/lower_intrinsics.rs:+2:9: +2:38

--- a/tests/mir-opt/lower_intrinsics.f_copy_nonoverlapping.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.f_copy_nonoverlapping.LowerIntrinsics.diff
@@ -49,7 +49,7 @@
           StorageDead(_9);                 // scope 3 at $DIR/lower_intrinsics.rs:+4:90: +4:91
 -         _3 = copy_nonoverlapping::<i32>(move _4, move _8, const 0_usize) -> [return: bb1, unwind unreachable]; // scope 3 at $DIR/lower_intrinsics.rs:+4:9: +4:95
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:98:9: 98:28
+-                                          // + span: $DIR/lower_intrinsics.rs:99:9: 99:28
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const i32, *mut i32, usize) {copy_nonoverlapping::<i32>}, val: Value(<ZST>) }
 +         copy_nonoverlapping(dst = move _8, src = move _4, count = const 0_usize); // scope 3 at $DIR/lower_intrinsics.rs:+4:9: +4:95
 +         goto -> bb1;                     // scope 3 at $DIR/lower_intrinsics.rs:+4:9: +4:95

--- a/tests/mir-opt/lower_intrinsics.option_payload.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.option_payload.LowerIntrinsics.diff
@@ -24,7 +24,7 @@
           _4 = &raw const (*_1);           // scope 1 at $DIR/lower_intrinsics.rs:+2:55: +2:56
 -         _3 = option_payload_ptr::<usize>(move _4) -> [return: bb1, unwind unreachable]; // scope 1 at $DIR/lower_intrinsics.rs:+2:18: +2:57
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:132:18: 132:54
+-                                          // + span: $DIR/lower_intrinsics.rs:133:18: 133:54
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const Option<usize>) -> *const usize {option_payload_ptr::<usize>}, val: Value(<ZST>) }
 +         _3 = &raw const (((*_4) as Some).0: usize); // scope 1 at $DIR/lower_intrinsics.rs:+2:18: +2:57
 +         goto -> bb1;                     // scope 1 at $DIR/lower_intrinsics.rs:+2:18: +2:57
@@ -37,7 +37,7 @@
           _6 = &raw const (*_2);           // scope 2 at $DIR/lower_intrinsics.rs:+3:55: +3:56
 -         _5 = option_payload_ptr::<String>(move _6) -> [return: bb2, unwind unreachable]; // scope 2 at $DIR/lower_intrinsics.rs:+3:18: +3:57
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:133:18: 133:54
+-                                          // + span: $DIR/lower_intrinsics.rs:134:18: 134:54
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const Option<String>) -> *const String {option_payload_ptr::<String>}, val: Value(<ZST>) }
 +         _5 = &raw const (((*_6) as Some).0: std::string::String); // scope 2 at $DIR/lower_intrinsics.rs:+3:18: +3:57
 +         goto -> bb2;                     // scope 2 at $DIR/lower_intrinsics.rs:+3:18: +3:57

--- a/tests/mir-opt/lower_intrinsics.read_via_copy_primitive.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.read_via_copy_primitive.LowerIntrinsics.diff
@@ -13,7 +13,7 @@
           _2 = &raw const (*_1);           // scope 1 at $DIR/lower_intrinsics.rs:+1:46: +1:47
 -         _0 = read_via_copy::<i32>(move _2) -> [return: bb1, unwind unreachable]; // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:48
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:118:14: 118:45
+-                                          // + span: $DIR/lower_intrinsics.rs:119:14: 119:45
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const i32) -> i32 {read_via_copy::<i32>}, val: Value(<ZST>) }
 +         _0 = (*_2);                      // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:48
 +         goto -> bb1;                     // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:48

--- a/tests/mir-opt/lower_intrinsics.read_via_copy_uninhabited.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.read_via_copy_uninhabited.LowerIntrinsics.diff
@@ -13,7 +13,7 @@
           _2 = &raw const (*_1);           // scope 1 at $DIR/lower_intrinsics.rs:+1:46: +1:47
 -         _0 = read_via_copy::<Never>(move _2) -> unwind unreachable; // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:48
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:123:14: 123:45
+-                                          // + span: $DIR/lower_intrinsics.rs:124:14: 124:45
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const Never) -> Never {read_via_copy::<Never>}, val: Value(<ZST>) }
 +         unreachable;                     // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:48
       }

--- a/tests/mir-opt/lower_intrinsics.rs
+++ b/tests/mir-opt/lower_intrinsics.rs
@@ -1,7 +1,7 @@
 // unit-test: LowerIntrinsics
 // ignore-wasm32 compiled with panic=abort by default
 
-#![feature(core_intrinsics, intrinsics)]
+#![feature(core_intrinsics, intrinsics, rustc_attrs)]
 #![crate_type = "lib"]
 
 // EMIT_MIR lower_intrinsics.wrapping.LowerIntrinsics.diff
@@ -87,6 +87,7 @@ pub fn discriminant<T>(t: T) {
 
 extern "rust-intrinsic" {
     // Cannot use `std::intrinsics::copy_nonoverlapping` as that is a wrapper function
+    #[rustc_nounwind]
     fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
 }
 

--- a/tests/mir-opt/lower_intrinsics.with_overflow.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.with_overflow.LowerIntrinsics.diff
@@ -32,7 +32,7 @@
           _5 = _2;                         // scope 0 at $DIR/lower_intrinsics.rs:+1:53: +1:54
 -         _3 = add_with_overflow::<i32>(move _4, move _5) -> [return: bb1, unwind unreachable]; // scope 0 at $DIR/lower_intrinsics.rs:+1:14: +1:55
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:111:14: 111:49
+-                                          // + span: $DIR/lower_intrinsics.rs:112:14: 112:49
 -                                          // + literal: Const { ty: extern "rust-intrinsic" fn(i32, i32) -> (i32, bool) {add_with_overflow::<i32>}, val: Value(<ZST>) }
 +         _3 = CheckedAdd(move _4, move _5); // scope 0 at $DIR/lower_intrinsics.rs:+1:14: +1:55
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:14: +1:55
@@ -48,7 +48,7 @@
           _8 = _2;                         // scope 1 at $DIR/lower_intrinsics.rs:+2:53: +2:54
 -         _6 = sub_with_overflow::<i32>(move _7, move _8) -> [return: bb2, unwind unreachable]; // scope 1 at $DIR/lower_intrinsics.rs:+2:14: +2:55
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:112:14: 112:49
+-                                          // + span: $DIR/lower_intrinsics.rs:113:14: 113:49
 -                                          // + literal: Const { ty: extern "rust-intrinsic" fn(i32, i32) -> (i32, bool) {sub_with_overflow::<i32>}, val: Value(<ZST>) }
 +         _6 = CheckedSub(move _7, move _8); // scope 1 at $DIR/lower_intrinsics.rs:+2:14: +2:55
 +         goto -> bb2;                     // scope 1 at $DIR/lower_intrinsics.rs:+2:14: +2:55
@@ -64,7 +64,7 @@
           _11 = _2;                        // scope 2 at $DIR/lower_intrinsics.rs:+3:53: +3:54
 -         _9 = mul_with_overflow::<i32>(move _10, move _11) -> [return: bb3, unwind unreachable]; // scope 2 at $DIR/lower_intrinsics.rs:+3:14: +3:55
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:113:14: 113:49
+-                                          // + span: $DIR/lower_intrinsics.rs:114:14: 114:49
 -                                          // + literal: Const { ty: extern "rust-intrinsic" fn(i32, i32) -> (i32, bool) {mul_with_overflow::<i32>}, val: Value(<ZST>) }
 +         _9 = CheckedMul(move _10, move _11); // scope 2 at $DIR/lower_intrinsics.rs:+3:14: +3:55
 +         goto -> bb3;                     // scope 2 at $DIR/lower_intrinsics.rs:+3:14: +3:55

--- a/tests/run-make/rustdoc-verify-output-files/Makefile
+++ b/tests/run-make/rustdoc-verify-output-files/Makefile
@@ -14,7 +14,7 @@ all:
 	$(RUSTDOC) src/lib.rs --crate-name foobar --crate-type lib --out-dir $(OUTPUT_DIR)
 
 	# Check if everything exactly same
-	$(DIFF) -r -q $(OUTPUT_DIR) $(TMP_OUTPUT_DIR)
+	$(DIFF) -r $(OUTPUT_DIR) $(TMP_OUTPUT_DIR)
 
 	# Generate json doc on the same output
 	$(RUSTDOC) src/lib.rs --crate-name foobar --crate-type lib --out-dir $(OUTPUT_DIR) -Z unstable-options --output-format json
@@ -29,4 +29,4 @@ all:
 	$(RUSTDOC) src/lib.rs --crate-name foobar --crate-type lib --out-dir $(OUTPUT_DIR) -Z unstable-options --output-format json
 
 	# Check if all docs(including both json and html formats) are still the same after multiple compilations
-	$(DIFF) -r -q $(OUTPUT_DIR) $(TMP_OUTPUT_DIR)
+	$(DIFF) -r $(OUTPUT_DIR) $(TMP_OUTPUT_DIR)

--- a/tests/ui/associated-consts/associated-const-dead-code.stderr
+++ b/tests/ui/associated-consts/associated-const-dead-code.stderr
@@ -1,6 +1,8 @@
 error: associated constant `BAR` is never used
   --> $DIR/associated-const-dead-code.rs:6:11
    |
+LL | impl MyFoo {
+   | ---------- associated constant in this implementation
 LL |     const BAR: u32 = 1;
    |           ^^^
    |

--- a/tests/ui/async-await/pin-needed-to-poll-2.stderr
+++ b/tests/ui/async-await/pin-needed-to-poll-2.stderr
@@ -6,7 +6,8 @@ LL |         Pin::new(&mut self.sleep).poll(cx)
    |         |
    |         required by a bound introduced by this call
    |
-   = note: consider using `Box::pin`
+   = note: consider using the `pin!` macro
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required because it appears within the type `Sleep`
   --> $DIR/pin-needed-to-poll-2.rs:8:8
    |

--- a/tests/ui/generator/static-not-unpin.stderr
+++ b/tests/ui/generator/static-not-unpin.stderr
@@ -6,7 +6,8 @@ LL |     assert_unpin(generator);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `Box::pin`
+   = note: consider using the `pin!` macro
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `assert_unpin`
   --> $DIR/static-not-unpin.rs:7:20
    |

--- a/tests/ui/lint/dead-code/issue-85255.rs
+++ b/tests/ui/lint/dead-code/issue-85255.rs
@@ -11,8 +11,8 @@ struct Foo {
 struct Bar;
 
 impl Bar {
-    fn a(&self) -> i32 { 5 } //~ WARNING: method `a` is never used
-    pub fn b(&self) -> i32 { 6 } //~ WARNING: method `b` is never used
+    fn a(&self) -> i32 { 5 } //~ WARNING: methods `a` and `b` are never used [dead_code]
+    pub fn b(&self) -> i32 { 6 }
 }
 
 pub(crate) struct Foo1 {
@@ -23,8 +23,8 @@ pub(crate) struct Foo1 {
 pub(crate) struct Bar1;
 
 impl Bar1 {
-    fn a(&self) -> i32 { 5 } //~ WARNING: method `a` is never used
-    pub fn b(&self) -> i32 { 6 } //~ WARNING: method `b` is never used
+    fn a(&self) -> i32 { 5 } //~ WARNING: methods `a` and `b` are never used [dead_code]
+    pub fn b(&self) -> i32 { 6 }
 }
 
 pub(crate) struct Foo2 {
@@ -35,8 +35,8 @@ pub(crate) struct Foo2 {
 pub(crate) struct Bar2;
 
 impl Bar2 {
-    fn a(&self) -> i32 { 5 } //~ WARNING: method `a` is never used
-    pub fn b(&self) -> i32 { 6 } //~ WARNING: method `b` is never used
+    fn a(&self) -> i32 { 5 } //~ WARNING: methods `a` and `b` are never used [dead_code]
+    pub fn b(&self) -> i32 { 6 }
 }
 
 

--- a/tests/ui/lint/dead-code/issue-85255.stderr
+++ b/tests/ui/lint/dead-code/issue-85255.stderr
@@ -14,26 +14,6 @@ note: the lint level is defined here
 LL | #![warn(dead_code)]
    |         ^^^^^^^^^
 
-warning: fields `a` and `b` are never read
-  --> $DIR/issue-85255.rs:19:5
-   |
-LL | pub(crate) struct Foo1 {
-   |                   ---- fields in this struct
-LL |     a: i32,
-   |     ^
-LL |     pub b: i32,
-   |         ^
-
-warning: fields `a` and `b` are never read
-  --> $DIR/issue-85255.rs:31:5
-   |
-LL | pub(crate) struct Foo2 {
-   |                   ---- fields in this struct
-LL |     a: i32,
-   |     ^
-LL |     pub b: i32,
-   |         ^
-
 warning: method `a` is never used
   --> $DIR/issue-85255.rs:14:8
    |
@@ -46,6 +26,16 @@ warning: method `b` is never used
 LL |     pub fn b(&self) -> i32 { 6 }
    |            ^
 
+warning: fields `a` and `b` are never read
+  --> $DIR/issue-85255.rs:19:5
+   |
+LL | pub(crate) struct Foo1 {
+   |                   ---- fields in this struct
+LL |     a: i32,
+   |     ^
+LL |     pub b: i32,
+   |         ^
+
 warning: method `a` is never used
   --> $DIR/issue-85255.rs:26:8
    |
@@ -57,6 +47,16 @@ warning: method `b` is never used
    |
 LL |     pub fn b(&self) -> i32 { 6 }
    |            ^
+
+warning: fields `a` and `b` are never read
+  --> $DIR/issue-85255.rs:31:5
+   |
+LL | pub(crate) struct Foo2 {
+   |                   ---- fields in this struct
+LL |     a: i32,
+   |     ^
+LL |     pub b: i32,
+   |         ^
 
 warning: method `a` is never used
   --> $DIR/issue-85255.rs:38:8

--- a/tests/ui/lint/dead-code/issue-85255.stderr
+++ b/tests/ui/lint/dead-code/issue-85255.stderr
@@ -14,15 +14,13 @@ note: the lint level is defined here
 LL | #![warn(dead_code)]
    |         ^^^^^^^^^
 
-warning: method `a` is never used
+warning: methods `a` and `b` are never used
   --> $DIR/issue-85255.rs:14:8
    |
+LL | impl Bar {
+   | -------- methods in this implementation
 LL |     fn a(&self) -> i32 { 5 }
    |        ^
-
-warning: method `b` is never used
-  --> $DIR/issue-85255.rs:15:12
-   |
 LL |     pub fn b(&self) -> i32 { 6 }
    |            ^
 
@@ -36,15 +34,13 @@ LL |     a: i32,
 LL |     pub b: i32,
    |         ^
 
-warning: method `a` is never used
+warning: methods `a` and `b` are never used
   --> $DIR/issue-85255.rs:26:8
    |
+LL | impl Bar1 {
+   | --------- methods in this implementation
 LL |     fn a(&self) -> i32 { 5 }
    |        ^
-
-warning: method `b` is never used
-  --> $DIR/issue-85255.rs:27:12
-   |
 LL |     pub fn b(&self) -> i32 { 6 }
    |            ^
 
@@ -58,17 +54,15 @@ LL |     a: i32,
 LL |     pub b: i32,
    |         ^
 
-warning: method `a` is never used
+warning: methods `a` and `b` are never used
   --> $DIR/issue-85255.rs:38:8
    |
+LL | impl Bar2 {
+   | --------- methods in this implementation
 LL |     fn a(&self) -> i32 { 5 }
    |        ^
-
-warning: method `b` is never used
-  --> $DIR/issue-85255.rs:39:12
-   |
 LL |     pub fn b(&self) -> i32 { 6 }
    |            ^
 
-warning: 9 warnings emitted
+warning: 6 warnings emitted
 

--- a/tests/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/tests/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -10,6 +10,12 @@ note: the lint level is defined here
 LL | #![deny(dead_code)]
    |         ^^^^^^^^^
 
+error: method `foo` is never used
+  --> $DIR/lint-dead-code-3.rs:16:8
+   |
+LL |     fn foo(&self) {
+   |        ^^^
+
 error: function `bar` is never used
   --> $DIR/lint-dead-code-3.rs:21:4
    |
@@ -33,12 +39,6 @@ error: function `blah` is never used
    |
 LL |         fn blah() {}
    |            ^^^^
-
-error: method `foo` is never used
-  --> $DIR/lint-dead-code-3.rs:16:8
-   |
-LL |     fn foo(&self) {
-   |        ^^^
 
 error: function `free` is never used
   --> $DIR/lint-dead-code-3.rs:62:8

--- a/tests/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/tests/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -13,6 +13,8 @@ LL | #![deny(dead_code)]
 error: method `foo` is never used
   --> $DIR/lint-dead-code-3.rs:16:8
    |
+LL | impl Foo {
+   | -------- method in this implementation
 LL |     fn foo(&self) {
    |        ^^^
 

--- a/tests/ui/lint/dead-code/lint-dead-code-6.rs
+++ b/tests/ui/lint/dead-code/lint-dead-code-6.rs
@@ -2,17 +2,16 @@
 
 struct UnusedStruct; //~ ERROR struct `UnusedStruct` is never constructed
 impl UnusedStruct {
-    fn unused_impl_fn_1() { //~ ERROR associated function `unused_impl_fn_1` is never used
+    fn unused_impl_fn_1() {
+        //~^ ERROR associated functions `unused_impl_fn_1`, `unused_impl_fn_2`, and `unused_impl_fn_3` are never used [dead_code]
         println!("blah");
     }
 
-    fn unused_impl_fn_2(var: i32) { //~ ERROR associated function `unused_impl_fn_2` is never used
+    fn unused_impl_fn_2(var: i32) {
         println!("foo {}", var);
     }
 
-    fn unused_impl_fn_3( //~ ERROR associated function `unused_impl_fn_3` is never used
-        var: i32,
-    ) {
+    fn unused_impl_fn_3(var: i32) {
         println!("bar {}", var);
     }
 }

--- a/tests/ui/lint/dead-code/lint-dead-code-6.stderr
+++ b/tests/ui/lint/dead-code/lint-dead-code-6.stderr
@@ -10,23 +10,19 @@ note: the lint level is defined here
 LL | #![deny(dead_code)]
    |         ^^^^^^^^^
 
-error: associated function `unused_impl_fn_1` is never used
+error: associated functions `unused_impl_fn_1`, `unused_impl_fn_2`, and `unused_impl_fn_3` are never used
   --> $DIR/lint-dead-code-6.rs:5:8
    |
+LL | impl UnusedStruct {
+   | ----------------- associated functions in this implementation
 LL |     fn unused_impl_fn_1() {
    |        ^^^^^^^^^^^^^^^^
-
-error: associated function `unused_impl_fn_2` is never used
-  --> $DIR/lint-dead-code-6.rs:9:8
-   |
+...
 LL |     fn unused_impl_fn_2(var: i32) {
    |        ^^^^^^^^^^^^^^^^
-
-error: associated function `unused_impl_fn_3` is never used
-  --> $DIR/lint-dead-code-6.rs:13:8
-   |
-LL |     fn unused_impl_fn_3(
+...
+LL |     fn unused_impl_fn_3(var: i32) {
    |        ^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/dead-code/unused-assoc-fns.rs
+++ b/tests/ui/lint/dead-code/unused-assoc-fns.rs
@@ -4,10 +4,9 @@ struct Foo;
 
 impl Foo {
     fn one() {}
-    //~^ ERROR associated function `one` is never used [dead_code]
+    //~^ ERROR associated functions `one`, `two`, and `three` are never used [dead_code]
 
     fn two(&self) {}
-    //~^ ERROR method `two` is never used [dead_code]
 
     // seperation between functions
     // ...
@@ -16,7 +15,6 @@ impl Foo {
     fn used() {}
 
     fn three(&self) {
-    //~^ ERROR method `three` is never used [dead_code]
         Foo::one();
         // ...
     }

--- a/tests/ui/lint/dead-code/unused-assoc-fns.rs
+++ b/tests/ui/lint/dead-code/unused-assoc-fns.rs
@@ -1,0 +1,27 @@
+#![deny(unused)]
+
+struct Foo;
+
+impl Foo {
+    fn one() {}
+    //~^ ERROR associated function `one` is never used [dead_code]
+
+    fn two(&self) {}
+    //~^ ERROR method `two` is never used [dead_code]
+
+    // seperation between functions
+    // ...
+    // ...
+
+    fn used() {}
+
+    fn three(&self) {
+    //~^ ERROR method `three` is never used [dead_code]
+        Foo::one();
+        // ...
+    }
+}
+
+fn main() {
+    Foo::used();
+}

--- a/tests/ui/lint/dead-code/unused-assoc-fns.rs
+++ b/tests/ui/lint/dead-code/unused-assoc-fns.rs
@@ -1,18 +1,28 @@
+#![feature(inherent_associated_types)]
+#![allow(incomplete_features)]
 #![deny(unused)]
 
 struct Foo;
 
 impl Foo {
     fn one() {}
-    //~^ ERROR associated functions `one`, `two`, and `three` are never used [dead_code]
+    //~^ ERROR associated items `one`, `two`, `CONSTANT`, `Type`, and `three` are never used [dead_code]
 
     fn two(&self) {}
 
-    // seperation between functions
+    // seperation between items
     // ...
     // ...
 
     fn used() {}
+
+    const CONSTANT: usize = 5;
+
+    // more seperation
+    // ...
+    // ...
+
+    type Type = usize;
 
     fn three(&self) {
         Foo::one();

--- a/tests/ui/lint/dead-code/unused-assoc-fns.stderr
+++ b/tests/ui/lint/dead-code/unused-assoc-fns.stderr
@@ -1,8 +1,16 @@
-error: associated function `one` is never used
+error: associated functions `one`, `two`, and `three` are never used
   --> $DIR/unused-assoc-fns.rs:6:8
    |
+LL | impl Foo {
+   | -------- associated functions in this implementation
 LL |     fn one() {}
    |        ^^^
+...
+LL |     fn two(&self) {}
+   |        ^^^
+...
+LL |     fn three(&self) {
+   |        ^^^^^
    |
 note: the lint level is defined here
   --> $DIR/unused-assoc-fns.rs:1:9
@@ -11,17 +19,5 @@ LL | #![deny(unused)]
    |         ^^^^^^
    = note: `#[deny(dead_code)]` implied by `#[deny(unused)]`
 
-error: method `two` is never used
-  --> $DIR/unused-assoc-fns.rs:9:8
-   |
-LL |     fn two(&self) {}
-   |        ^^^
-
-error: method `three` is never used
-  --> $DIR/unused-assoc-fns.rs:18:8
-   |
-LL |     fn three(&self) {
-   |        ^^^^^
-
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 

--- a/tests/ui/lint/dead-code/unused-assoc-fns.stderr
+++ b/tests/ui/lint/dead-code/unused-assoc-fns.stderr
@@ -1,0 +1,27 @@
+error: associated function `one` is never used
+  --> $DIR/unused-assoc-fns.rs:6:8
+   |
+LL |     fn one() {}
+   |        ^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-assoc-fns.rs:1:9
+   |
+LL | #![deny(unused)]
+   |         ^^^^^^
+   = note: `#[deny(dead_code)]` implied by `#[deny(unused)]`
+
+error: method `two` is never used
+  --> $DIR/unused-assoc-fns.rs:9:8
+   |
+LL |     fn two(&self) {}
+   |        ^^^
+
+error: method `three` is never used
+  --> $DIR/unused-assoc-fns.rs:18:8
+   |
+LL |     fn three(&self) {
+   |        ^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lint/dead-code/unused-assoc-fns.stderr
+++ b/tests/ui/lint/dead-code/unused-assoc-fns.stderr
@@ -1,19 +1,25 @@
-error: associated functions `one`, `two`, and `three` are never used
-  --> $DIR/unused-assoc-fns.rs:6:8
+error: associated items `one`, `two`, `CONSTANT`, `Type`, and `three` are never used
+  --> $DIR/unused-assoc-fns.rs:8:8
    |
 LL | impl Foo {
-   | -------- associated functions in this implementation
+   | -------- associated items in this implementation
 LL |     fn one() {}
    |        ^^^
 ...
 LL |     fn two(&self) {}
    |        ^^^
 ...
+LL |     const CONSTANT: usize = 5;
+   |           ^^^^^^^^
+...
+LL |     type Type = usize;
+   |          ^^^^
+LL |
 LL |     fn three(&self) {
    |        ^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/unused-assoc-fns.rs:1:9
+  --> $DIR/unused-assoc-fns.rs:3:9
    |
 LL | #![deny(unused)]
    |         ^^^^^^

--- a/tests/ui/mir/checks_without_panic_impl.rs
+++ b/tests/ui/mir/checks_without_panic_impl.rs
@@ -1,0 +1,17 @@
+// Ensures that the alignment check we insert for raw pointer dereferences
+// does not prevent crates without a panic_impl from compiling.
+// See rust-lang/rust#109996
+
+// build-pass
+// compile-flags: -Cdebug-assertions=yes
+
+#![crate_type = "lib"]
+
+#![feature(lang_items)]
+#![feature(no_core)]
+#![no_core]
+
+#[lang = "sized"]
+trait Foo {}
+
+pub unsafe fn foo(x: *const i32) -> &'static i32 { unsafe { &*x } }

--- a/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
+++ b/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
@@ -50,7 +50,8 @@ LL |     Pin::new(x)
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `Box::pin`
+   = note: consider using the `pin!` macro
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `Pin::<P>::new`
   --> $SRC_DIR/core/src/pin.rs:LL:COL
 
@@ -62,7 +63,8 @@ LL |     Pin::new(Box::new(x))
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `Box::pin`
+   = note: consider using the `pin!` macro
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `Pin::<P>::new`
   --> $SRC_DIR/core/src/pin.rs:LL:COL
 

--- a/tests/ui/suggestions/issue-84973-blacklist.stderr
+++ b/tests/ui/suggestions/issue-84973-blacklist.stderr
@@ -38,7 +38,8 @@ LL |     f_unpin(static || { yield; });
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `Box::pin`
+   = note: consider using the `pin!` macro
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `f_unpin`
   --> $DIR/issue-84973-blacklist.rs:8:15
    |

--- a/tests/ui/suggestions/suggest-pin-macro.rs
+++ b/tests/ui/suggestions/suggest-pin-macro.rs
@@ -1,0 +1,23 @@
+use std::pin::Pin;
+use std::marker::PhantomPinned;
+
+#[derive(Debug)]
+struct Test {
+    _marker: PhantomPinned,
+}
+impl Test {
+    fn new() -> Self {
+        Test {
+            _marker: PhantomPinned, // This makes our type `!Unpin`
+        }
+    }
+}
+
+fn dummy(_: &mut Test) {}
+
+pub fn main() {
+    let mut test1 = Test::new();
+    let mut test1 = unsafe { Pin::new_unchecked(&mut test1) };
+
+    dummy(test1.get_mut()); //~ ERROR E0277
+}

--- a/tests/ui/suggestions/suggest-pin-macro.stderr
+++ b/tests/ui/suggestions/suggest-pin-macro.stderr
@@ -1,0 +1,19 @@
+error[E0277]: `PhantomPinned` cannot be unpinned
+  --> $DIR/suggest-pin-macro.rs:22:17
+   |
+LL |     dummy(test1.get_mut());
+   |                 ^^^^^^^ within `Test`, the trait `Unpin` is not implemented for `PhantomPinned`
+   |
+   = note: consider using the `pin!` macro
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
+note: required because it appears within the type `Test`
+  --> $DIR/suggest-pin-macro.rs:5:8
+   |
+LL | struct Test {
+   |        ^^^^
+note: required by a bound in `Pin::<&'a mut T>::get_mut`
+  --> $SRC_DIR/core/src/pin.rs:LL:COL
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/typeck/issue-90164.stderr
+++ b/tests/ui/typeck/issue-90164.stderr
@@ -6,7 +6,8 @@ LL |     copy(r, w);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `Box::pin`
+   = note: consider using the `pin!` macro
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `copy`
   --> $DIR/issue-90164.rs:1:12
    |

--- a/tests/ui/wf/issue-110157.rs
+++ b/tests/ui/wf/issue-110157.rs
@@ -1,0 +1,12 @@
+struct NeedsDropTypes<'tcx, F>(std::marker::PhantomData<&'tcx F>);
+
+impl<'tcx, F, I> Iterator for NeedsDropTypes<'tcx, F>
+//~^ ERROR type annotations needed
+where
+    F: Fn(&Missing) -> Result<I, ()>,
+    //~^ ERROR cannot find type `Missing` in this scope
+    I: Iterator<Item = Missing>,
+    //~^ ERROR cannot find type `Missing` in this scope
+{}
+
+fn main() {}

--- a/tests/ui/wf/issue-110157.stderr
+++ b/tests/ui/wf/issue-110157.stderr
@@ -1,0 +1,32 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/issue-110157.rs:6:12
+   |
+LL |     F: Fn(&Missing) -> Result<I, ()>,
+   |            ^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/issue-110157.rs:8:24
+   |
+LL |     I: Iterator<Item = Missing>,
+   |                        ^^^^^^^ not found in this scope
+
+error[E0283]: type annotations needed
+  --> $DIR/issue-110157.rs:3:31
+   |
+LL | impl<'tcx, F, I> Iterator for NeedsDropTypes<'tcx, F>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `I`
+   |
+   = note: cannot satisfy `_: Iterator`
+note: required for `NeedsDropTypes<'tcx, F>` to implement `Iterator`
+  --> $DIR/issue-110157.rs:3:18
+   |
+LL | impl<'tcx, F, I> Iterator for NeedsDropTypes<'tcx, F>
+   |                  ^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     I: Iterator<Item = Missing>,
+   |        ------------------------ unsatisfied trait bound introduced here
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0283, E0412.
+For more information about an error, try `rustc --explain E0283`.


### PR DESCRIPTION
Successful merges:

 - #109036 (Fix diff option conflict in UI test)
 - #110193 (Check for body owner fallibly in error reporting)
 - #110233 (Make rust-intrinsic ABI unwindable)
 - #110259 (Added diagnostic for pin! macro in addition to Box::pin if Unpin isn't implemented)
 - #110265 (Automatically update the LLVM submodule for musl target (and other places))
 - #110277 (dead-code-lint: de-dup multiple unused assoc functions)
 - #110283 (Only emit alignment checks if we have a panic_impl)
 - #110291 (Implement `Copy` for `LocationDetail`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=109036,110193,110233,110259,110265,110277,110283,110291)
<!-- homu-ignore:end -->