### PR TITLE
Cover edge cases for {f32, f64}.hypot() docs

### DIFF
--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -581,8 +581,10 @@ impl f32 {
         unsafe { cmath::cbrtf(self) }
     }
 
-    /// Calculates the length of the hypotenuse of a right-angle triangle given
-    /// legs of length `x` and `y`.
+    /// Compute the distance between the origin and a point (`x`, `y`) on the
+    /// Euclidean plane. Equivalently, compute the length of the hypotenuse of a
+    /// right-angle triangle with other sides having length `x.abs()` and
+    /// `y.abs()`.
     ///
     /// # Examples
     ///

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -583,8 +583,10 @@ impl f64 {
         unsafe { cmath::cbrt(self) }
     }
 
-    /// Calculates the length of the hypotenuse of a right-angle triangle given
-    /// legs of length `x` and `y`.
+    /// Compute the distance between the origin and a point (`x`, `y`) on the
+    /// Euclidean plane. Equivalently, compute the length of the hypotenuse of a
+    /// right-angle triangle with other sides having length `x.abs()` and
+    /// `y.abs()`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Fixes #88944 

The Euclidean distance is a more general way to express what these functions do, and covers the edge cases of zero and negative inputs.

Does not cover the case of non-normal input values (as the [POSIX docs](https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/) do), but the docs for the rest of the functions in these modules do not address this, I assumed it was not desired.