### PR TITLE
Add GNU Property Note

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -12,6 +12,7 @@ use object::{
 
 use snap::write::FrameEncoder;
 
+use object::elf::NT_GNU_PROPERTY_TYPE_0;
 use rustc_data_structures::memmap::Mmap;
 use rustc_data_structures::owned_slice::try_slice_owned;
 use rustc_data_structures::sync::MetadataRef;
@@ -91,6 +92,46 @@ pub(super) fn search_for_section<'a>(
         .ok_or_else(|| format!("no `{}` section in '{}'", section, path.display()))?
         .data()
         .map_err(|e| format!("failed to read {} section in '{}': {}", section, path.display(), e))
+}
+
+fn add_gnu_property_note(
+    file: &mut write::Object<'static>,
+    architecture: Architecture,
+    binary_format: BinaryFormat,
+) {
+    // check bti protection
+    if binary_format != BinaryFormat::Elf
+        || !matches!(architecture, Architecture::X86_64 | Architecture::Aarch64)
+    {
+        return;
+    }
+
+    let section = file.add_section(
+        file.segment_name(StandardSegment::Data).to_vec(),
+        b".note.gnu.property".to_vec(),
+        SectionKind::Note,
+    );
+    let mut data: Vec<u8> = Vec::new();
+    let n_namsz: u32 = 4; // Size of the n_name field
+    let n_descsz: u32 = 16; // Size of the n_desc field
+    let n_type: u32 = NT_GNU_PROPERTY_TYPE_0; // Type of note descriptor
+    let values = [n_namsz, n_descsz, n_type];
+    values.map(|v| data.extend_from_slice(&(v.to_le_bytes())));
+    data.push(b'G'); // Owner of the program property note
+    data.push(b'N');
+    data.push(b'U');
+    data.push(0);
+    let pr_type: u32 = match architecture {
+        Architecture::X86_64 => 0xc0000002,
+        Architecture::Aarch64 => 0xc0000000,
+        _ => unreachable!(),
+    };
+    let pr_datasz: u32 = 4; //size of the pr_data field
+    let pr_data: u32 = 3; //program property descriptor
+    let pr_padding: u32 = 3;
+    let values = [pr_type, pr_datasz, pr_data, pr_padding];
+    values.map(|v| data.extend_from_slice(&(v.to_le_bytes())));
+    file.append_section_data(section, &data, 4);
 }
 
 pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static>> {
@@ -205,6 +246,7 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
         _ => elf::ELFOSABI_NONE,
     };
     let abi_version = 0;
+    add_gnu_property_note(&mut file, architecture, binary_format);
     file.flags = FileFlags::Elf { os_abi, abi_version, e_flags };
     Some(file)
 }

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -98,6 +98,7 @@ fn add_gnu_property_note(
     file: &mut write::Object<'static>,
     architecture: Architecture,
     binary_format: BinaryFormat,
+    endianness: Endianness,
 ) {
     // check bti protection
     if binary_format != BinaryFormat::Elf
@@ -115,12 +116,12 @@ fn add_gnu_property_note(
     let n_namsz: u32 = 4; // Size of the n_name field
     let n_descsz: u32 = 16; // Size of the n_desc field
     let n_type: u32 = NT_GNU_PROPERTY_TYPE_0; // Type of note descriptor
-    let values = [n_namsz, n_descsz, n_type];
-    values.map(|v| data.extend_from_slice(&(v.to_le_bytes())));
-    data.push(b'G'); // Owner of the program property note
-    data.push(b'N');
-    data.push(b'U');
-    data.push(0);
+    let header_values = [n_namsz, n_descsz, n_type];
+    match endianness {
+        Endianness::Little => header_values.map(|v| data.extend_from_slice(&(v.to_le_bytes()))),
+        Endianness::Big => header_values.map(|v| data.extend_from_slice(&(v.to_be_bytes()))),
+    };
+    data.extend_from_slice(b"GNU\0"); // Owner of the program property note
     let pr_type: u32 = match architecture {
         Architecture::X86_64 => 0xc0000002,
         Architecture::Aarch64 => 0xc0000000,
@@ -128,10 +129,13 @@ fn add_gnu_property_note(
     };
     let pr_datasz: u32 = 4; //size of the pr_data field
     let pr_data: u32 = 3; //program property descriptor
-    let pr_padding: u32 = 3;
-    let values = [pr_type, pr_datasz, pr_data, pr_padding];
-    values.map(|v| data.extend_from_slice(&(v.to_le_bytes())));
-    file.append_section_data(section, &data, 4);
+    let pr_padding: u32 = 0;
+    let property_values = [pr_type, pr_datasz, pr_data, pr_padding];
+    match endianness {
+        Endianness::Little => property_values.map(|v| data.extend_from_slice(&(v.to_le_bytes()))),
+        Endianness::Big => property_values.map(|v| data.extend_from_slice(&(v.to_be_bytes()))),
+    };
+    file.append_section_data(section, &data, 8);
 }
 
 pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static>> {
@@ -246,7 +250,7 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
         _ => elf::ELFOSABI_NONE,
     };
     let abi_version = 0;
-    add_gnu_property_note(&mut file, architecture, binary_format);
+    add_gnu_property_note(&mut file, architecture, binary_format, endianness);
     file.flags = FileFlags::Elf { os_abi, abi_version, e_flags };
     Some(file)
 }

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -117,10 +117,17 @@ fn add_gnu_property_note(
     let n_descsz: u32 = 16; // Size of the n_desc field
     let n_type: u32 = NT_GNU_PROPERTY_TYPE_0; // Type of note descriptor
     let header_values = [n_namsz, n_descsz, n_type];
+    header_values.iter().for_each(|v| {
+        data.extend_from_slice(&match endianness {
+            Endianness::Little => v.to_le_bytes(),
+            Endianness::Big => v.to_be_bytes(),
+        })
+    });
+    /*
     match endianness {
         Endianness::Little => header_values.map(|v| data.extend_from_slice(&(v.to_le_bytes()))),
         Endianness::Big => header_values.map(|v| data.extend_from_slice(&(v.to_be_bytes()))),
-    };
+    };*/
     data.extend_from_slice(b"GNU\0"); // Owner of the program property note
     let pr_type: u32 = match architecture {
         Architecture::X86_64 => 0xc0000002,

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -123,11 +123,6 @@ fn add_gnu_property_note(
             Endianness::Big => v.to_be_bytes(),
         })
     });
-    /*
-    match endianness {
-        Endianness::Little => header_values.map(|v| data.extend_from_slice(&(v.to_le_bytes()))),
-        Endianness::Big => header_values.map(|v| data.extend_from_slice(&(v.to_be_bytes()))),
-    };*/
     data.extend_from_slice(b"GNU\0"); // Owner of the program property note
     let pr_type: u32 = match architecture {
         Architecture::X86_64 => 0xc0000002,
@@ -138,10 +133,12 @@ fn add_gnu_property_note(
     let pr_data: u32 = 3; //program property descriptor
     let pr_padding: u32 = 0;
     let property_values = [pr_type, pr_datasz, pr_data, pr_padding];
-    match endianness {
-        Endianness::Little => property_values.map(|v| data.extend_from_slice(&(v.to_le_bytes()))),
-        Endianness::Big => property_values.map(|v| data.extend_from_slice(&(v.to_be_bytes()))),
-    };
+    property_values.iter().for_each(|v| {
+        data.extend_from_slice(&match endianness {
+            Endianness::Little => v.to_le_bytes(),
+            Endianness::Big => v.to_be_bytes(),
+        })
+    });
     file.append_section_data(section, &data, 8);
 }
 

--- a/tests/run-make/branch-protection-check-IBT/Makefile
+++ b/tests/run-make/branch-protection-check-IBT/Makefile
@@ -1,0 +1,15 @@
+# Check for GNU Property Note
+
+include ../tools.mk
+
+# How to run this
+# python3 x.py test --target x86_64-unknown-linux-gnu  tests/run-make/branch-protection-check-IBT/
+
+# only-x86_64
+
+all:
+ifeq ($(filter x86,$(LLVM_COMPONENTS)),x86_64)
+	$(RUSTC) --target x86_64-unknown-linux-gnu -Z cf-protection=branch -L$(TMPDIR) -C link-args='-nostartfiles'  -C save-temps  ./main.rs -o $(TMPDIR)/rsmain
+	 readelf -nW $(TMPDIR)/rsmain | $(CGREP) -e ".note.gnu.property"
+endif
+

--- a/tests/run-make/branch-protection-check-IBT/main.rs
+++ b/tests/run-make/branch-protection-check-IBT/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("hello world");
+}


### PR DESCRIPTION
Fix #103001 

Generates the missing property note:
```
Displaying notes found in: .note.gnu.property
  Owner                Data size 	Description
  GNU                  0x00000010	NT_GNU_PROPERTY_TYPE_0	      Properties: x86 feature: IBT
```