### PR TITLE
rustdoc-search: use ES6 `Map` and `Set` where they make sense

### DIFF
--- a/src/librustdoc/html/static/js/externs.js
+++ b/src/librustdoc/html/static/js/externs.js
@@ -66,6 +66,11 @@ let Row;
 let ResultsTable;
 
 /**
+ * @typedef {Map<String, ResultObject>}
+ */
+let Results;
+
+/**
  * @typedef {{
  *     desc: string,
  *     displayPath: string,
@@ -80,7 +85,7 @@ let ResultsTable;
  *     ty: number,
  * }}
  */
-let Results;
+let ResultObject;
 
 /**
  * A pair of [inputs, outputs], or 0 for null. This is stored in the search index.

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -906,7 +906,7 @@ function initSearch(rawSearchIndex) {
         const results_others = {}, results_in_args = {}, results_returned = {};
 
         function transformResults(results) {
-            const duplicates = {};
+            const duplicates = new Set();
             const out = [];
 
             for (const result of results) {
@@ -919,10 +919,10 @@ function initSearch(rawSearchIndex) {
                     // To be sure than it some items aren't considered as duplicate.
                     obj.fullPath += "|" + obj.ty;
 
-                    if (duplicates[obj.fullPath]) {
+                    if (duplicates.has(obj.fullPath)) {
                         continue;
                     }
-                    duplicates[obj.fullPath] = true;
+                    duplicates.add(obj.fullPath);
 
                     obj.href = res[1];
                     out.push(obj);


### PR DESCRIPTION
Since all supported browsers now support these classes, and rustdoc has started using them in some places, it might as well use them everywhere it makes sense (because, as [MDN's Map page] says, it "performs better in scenarios involving frequent additions and removals of key-value pairs.").

[MDN's Map page]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
