### PR TITLE
Strict region folders

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -428,7 +428,7 @@ fn try_extract_error_from_region_constraints<'tcx>(
             placeholder_region,
             vec![],
         ),
-        (Some(error_region), _) => {
+        (Some(error_region), ty::RePlaceholder(_)) => {
             RegionResolutionError::ConcreteFailure(cause.clone(), error_region, placeholder_region)
         }
         // Note universe here is wrong...
@@ -439,9 +439,11 @@ fn try_extract_error_from_region_constraints<'tcx>(
             cause.clone(),
             placeholder_region,
         ),
-        (None, _) => {
+        (None, ty::ReStatic) => {
             RegionResolutionError::ConcreteFailure(cause.clone(), sub_region, placeholder_region)
         }
+        (Some(_), r) => bug!("unexpected region with `Some`: {r:?}"),
+        (None, r) => bug!("unexpected region with `None`: {r:?}"),
     };
     NiceRegionError::new(&infcx.err_ctxt(), error).try_report_from_nll().or_else(|| {
         if let SubregionOrigin::Subtype(trace) = cause {

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -466,12 +466,10 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         // lifetimes without names with the value `'0`.
         if let ty::Ref(region, ..) = ty.kind() {
             match **region {
-                ty::ReLateBound(_, ty::BoundRegion { kind: br, .. })
-                | ty::RePlaceholder(ty::PlaceholderRegion {
-                    bound: ty::BoundRegion { kind: br, .. },
-                    ..
-                }) => printer.region_highlight_mode.highlighting_bound_region(br, counter),
-                _ => {}
+                ty::ReLateBound(_, ty::BoundRegion { kind: br, .. }) => {
+                    printer.region_highlight_mode.highlighting_bound_region(br, counter)
+                }
+                r => bug!("unexpected region: {r:?}"),
             }
         }
 
@@ -485,12 +483,10 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
         let region = if let ty::Ref(region, ..) = ty.kind() {
             match **region {
-                ty::ReLateBound(_, ty::BoundRegion { kind: br, .. })
-                | ty::RePlaceholder(ty::PlaceholderRegion {
-                    bound: ty::BoundRegion { kind: br, .. },
-                    ..
-                }) => printer.region_highlight_mode.highlighting_bound_region(br, counter),
-                _ => {}
+                ty::ReLateBound(_, ty::BoundRegion { kind: br, .. }) => {
+                    printer.region_highlight_mode.highlighting_bound_region(br, counter)
+                }
+                r => bug!("unexpected region: {r:?}"),
             }
             region
         } else {

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -357,11 +357,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
                 ty::BoundRegionKind::BrAnon(..) => None,
             },
 
-            ty::ReLateBound(..)
-            | ty::ReVar(..)
-            | ty::RePlaceholder(..)
-            | ty::ReErased
-            | ty::ReError(_) => None,
+            r => bug!("unexpected region: {r:?}"),
         }
     }
 

--- a/compiler/rustc_borrowck/src/renumber.rs
+++ b/compiler/rustc_borrowck/src/renumber.rs
@@ -75,8 +75,11 @@ impl<'a, 'tcx> RegionRenumberer<'a, 'tcx> {
         F: Fn() -> RegionCtxt,
     {
         let origin = NllRegionVariableOrigin::Existential { from_forall: false };
-        self.infcx.tcx.fold_regions(value, |_region, _depth| {
-            self.infcx.next_nll_region_var(origin, || region_ctxt_fn())
+        self.infcx.tcx.fold_regions(value, |region, _depth| match region.kind() {
+            ty::ReErased | ty::ReError(_) => {
+                self.infcx.next_nll_region_var(origin, || region_ctxt_fn())
+            }
+            r => bug!("unexpected region: {r:?}"),
         })
     }
 }

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -178,7 +178,8 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
                 ty::RePlaceholder(placeholder) => {
                     self.constraints.placeholder_region(self.infcx, placeholder)
                 }
-                _ => r,
+                ty::ReStatic | ty::ReVar(_) => r,
+                r => bug!("unexpected region: {r:?}"),
             })
         } else {
             value

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -3226,8 +3226,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
             hir::TyKind::Typeof(e) => {
                 let ty_erased = tcx.type_of(e.def_id).subst_identity();
-                let ty = tcx.fold_regions(ty_erased, |r, _| {
-                    if r.is_erased() { tcx.lifetimes.re_static } else { r }
+                let ty = tcx.fold_regions(ty_erased, |r, _| match r.kind() {
+                    ty::ReErased => tcx.lifetimes.re_static,
+                    r => bug!("unexpected region: {r:?}"),
                 });
                 let span = ast_ty.span;
                 let (ty, opt_sugg) = if let Some(ty) = ty.make_suggestable(tcx, false) {

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -419,7 +419,8 @@ fn check_opaque_meets_bounds<'tcx>(
     let hidden_ty = tcx.type_of(def_id.to_def_id()).subst(tcx, substs);
     let hidden_ty = tcx.fold_regions(hidden_ty, |re, _dbi| match re.kind() {
         ty::ReErased => infcx.next_region_var(RegionVariableOrigin::MiscVariable(span)),
-        _ => re,
+        ty::ReEarlyBound(_) | ty::ReStatic | ty::ReError(_) => re,
+        r => bug!("unexpected region: {r:?}"),
     });
 
     let misc_cause = traits::ObligationCause::misc(span, def_id);

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1574,17 +1574,10 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitFinder<'_, 'tcx> {
             && let hir::OpaqueTyOrigin::FnReturn(source) | hir::OpaqueTyOrigin::AsyncFn(source) = opaque.origin
             && source == self.fn_def_id
         {
-            let opaque_ty = tcx.fold_regions(unshifted_opaque_ty, |re, depth| {
-                if let ty::ReLateBound(index, bv) = re.kind() {
-                    if depth != ty::INNERMOST {
-                        return tcx.mk_re_error_with_message(
-                            DUMMY_SP,
-                            "we shouldn't walk non-predicate binders with `impl Trait`...",
-                        );
-                    }
-                    tcx.mk_re_late_bound(index.shifted_out_to_binder(self.depth), bv)
-                } else {
-                    re
+            let opaque_ty = tcx.fold_regions(unshifted_opaque_ty, |re, _depth| {
+                match re.kind() {
+                    ty::ReEarlyBound(_) | ty::ReFree(_) => re,
+                    r => bug!("unexpected region: {r:?}"),
                 }
             });
             for (bound, bound_span) in tcx

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -387,8 +387,10 @@ impl<'tcx> AstConv<'tcx> for ItemCtxt<'tcx> {
 
     fn ct_infer(&self, ty: Ty<'tcx>, _: Option<&ty::GenericParamDef>, span: Span) -> Const<'tcx> {
         let ty = self.tcx.fold_regions(ty, |r, _| match *r {
-            ty::ReErased => self.tcx.lifetimes.re_static,
-            _ => r,
+            // This is never reached in practice. If it ever is reached,
+            // `ReErased` should be changed to `ReStatic`, and any other region
+            // left alone.
+            r => bug!("unexpected region: {r:?}"),
         });
         self.tcx().const_error_with_message(ty, span, "bad placeholder constant")
     }
@@ -1142,7 +1144,7 @@ fn infer_return_ty_for_fn_sig<'tcx>(
             // Typeck doesn't expect erased regions to be returned from `type_of`.
             let fn_sig = tcx.fold_regions(fn_sig, |r, _| match *r {
                 ty::ReErased => tcx.lifetimes.re_static,
-                _ => r,
+                r => bug!("unexpected region: {r:?}"),
             });
 
             let mut visitor = HirPlaceholderCollector::default();

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -933,7 +933,7 @@ fn infer_placeholder_type<'a>(
     // Typeck doesn't expect erased regions to be returned from `type_of`.
     tcx.fold_regions(ty, |r, _| match *r {
         ty::ReErased => tcx.lifetimes.re_static,
-        _ => r,
+        r => bug!("unexpected region: {r:?}"),
     })
 }
 

--- a/compiler/rustc_hir_analysis/src/hir_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/hir_wf_check.rs
@@ -194,6 +194,10 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for EraseAllBoundRegions<'tcx> {
         self.tcx
     }
     fn fold_region(&mut self, r: Region<'tcx>) -> Region<'tcx> {
-        if r.is_late_bound() { self.tcx.lifetimes.re_erased } else { r }
+        match r.kind() {
+            ty::ReLateBound(..) => self.tcx.lifetimes.re_erased,
+            ty::ReEarlyBound(_) | ty::ReStatic | ty::ReError(_) => r,
+            r => bug!("unexpected region: {r:?}"),
+        }
     }
 }

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -270,7 +270,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Hack to make equality checks on types with inference variables and regions useful.
         let mut eraser = BottomUpFolder {
             tcx: self.tcx,
-            lt_op: |_| self.tcx.lifetimes.re_erased,
+            lt_op: |r| match r.kind() {
+                ty::ReStatic | ty::ReVar(_) | ty::ReErased => self.tcx.lifetimes.re_erased,
+                r => bug!("unexpected region: {r:?}"),
+            },
             ct_op: |c| c,
             ty_op: |t| match *t.kind() {
                 ty::Infer(ty::TyVar(_)) => self.tcx.mk_ty_var(ty::TyVid::from_u32(0)),

--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -257,19 +257,20 @@ pub fn resolve_interior<'a, 'tcx>(
                             _ => mk_bound_region(None),
                         }
                     }
-                    // FIXME: these should use `BrNamed`
+                    // // FIXME: these should use `BrNamed`
                     ty::ReEarlyBound(region) => {
                         mk_bound_region(Some(fcx.tcx.def_span(region.def_id)))
                     }
-                    ty::ReLateBound(_, ty::BoundRegion { kind, .. })
-                    | ty::ReFree(ty::FreeRegion { bound_region: kind, .. }) => match kind {
+                    // ty::ReLateBound(_, ty::BoundRegion { kind, .. })
+                    ty::ReFree(ty::FreeRegion { bound_region: kind, .. }) => match kind {
                         ty::BoundRegionKind::BrAnon(span) => mk_bound_region(span),
                         ty::BoundRegionKind::BrNamed(def_id, _) => {
                             mk_bound_region(Some(fcx.tcx.def_span(def_id)))
                         }
                         ty::BoundRegionKind::BrEnv => mk_bound_region(None),
                     },
-                    _ => mk_bound_region(None),
+                    ty::ReStatic | ty::ReErased => mk_bound_region(None),
+                    r => bug!("unexpected region: {r:?}"),
                 };
                 let r = fcx.tcx.mk_re_late_bound(current_depth, br);
                 r

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -343,6 +343,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'cx, 'tcx> {
 
     fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
         match *r {
+            // All region variants occur in this match.
             ty::ReLateBound(index, ..) => {
                 if index >= self.binder_index {
                     bug!("escaping late-bound region during canonicalization");

--- a/compiler/rustc_infer/src/infer/freshen.rs
+++ b/compiler/rustc_infer/src/infer/freshen.rs
@@ -110,11 +110,8 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for TypeFreshener<'a, 'tcx> {
 
     fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
         match *r {
-            ty::ReLateBound(..) => {
-                // leave bound regions alone
-                r
-            }
-
+            // All region variants occur in this match.
+            ty::ReLateBound(..) => r, // leave bound regions alone
             ty::ReEarlyBound(..)
             | ty::ReFree(_)
             | ty::ReVar(_)

--- a/compiler/rustc_infer/src/infer/fudge.rs
+++ b/compiler/rustc_infer/src/infer/fudge.rs
@@ -220,12 +220,19 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for InferenceFudger<'a, 'tcx> {
     }
 
     fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
-        if let ty::ReVar(vid) = *r && self.region_vars.0.contains(&vid) {
-            let idx = vid.index() - self.region_vars.0.start.index();
-            let origin = self.region_vars.1[idx];
-            return self.infcx.next_region_var(origin);
+        match r.kind() {
+            ty::ReVar(vid) if self.region_vars.0.contains(&vid) => {
+                let idx = vid.index() - self.region_vars.0.start.index();
+                let origin = self.region_vars.1[idx];
+                return self.infcx.next_region_var(origin);
+            }
+            ty::ReEarlyBound(_)
+            | ty::ReLateBound(..)
+            | ty::ReFree(_)
+            | ty::ReStatic
+            | ty::ReVar(_) => r,
+            r => bug!("unexpected region: {r:?}"),
         }
-        r
     }
 
     fn fold_const(&mut self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -989,7 +989,18 @@ impl<'tcx> LexicalRegionResolutions<'tcx> {
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
     {
-        tcx.fold_regions(value, |r, _db| self.resolve_region(tcx, r))
+        tcx.fold_regions(value, |r, _db| {
+            match r.kind() {
+                ty::ReEarlyBound(_)
+                | ty::ReFree(_)
+                | ty::ReStatic
+                | ty::ReVar(_)
+                | ty::RePlaceholder(_)
+                | ty::ReError(_) => {}
+                r => bug!("unexpected region: {r:?}"),
+            }
+            self.resolve_region(tcx, r)
+        })
     }
 
     fn value(&self, rid: RegionVid) -> &VarValue<'tcx> {

--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -91,7 +91,13 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for OpportunisticRegionResolver<'a, 'tcx
                 .borrow_mut()
                 .unwrap_region_constraints()
                 .opportunistic_resolve_var(TypeFolder::interner(self), vid),
-            _ => r,
+            ty::ReEarlyBound(_)
+            | ty::ReLateBound(..)
+            | ty::ReFree(_)
+            | ty::ReStatic
+            | ty::RePlaceholder(_)
+            | ty::ReErased => r,
+            r => bug!("unexpected region: {r:?}"),
         }
     }
 
@@ -238,7 +244,13 @@ impl<'a, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for FullTypeResolver<'a, 'tcx> {
                 .as_ref()
                 .expect("region resolution not performed")
                 .resolve_region(self.infcx.tcx, r)),
-            _ => Ok(r),
+            ty::ReEarlyBound(_)
+            | ty::ReLateBound(..)
+            | ty::ReFree(_)
+            | ty::ReStatic
+            | ty::RePlaceholder(_)
+            | ty::ReError(_) => Ok(r),
+            r => bug!("unexpected region: {r:?}"),
         }
     }
 

--- a/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
+++ b/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
@@ -104,7 +104,13 @@ impl<'tcx> LateLintPass<'tcx> for OpaqueHiddenInferredBound {
             let proj_replacer = &mut BottomUpFolder {
                 tcx: cx.tcx,
                 ty_op: |ty| if ty == proj_ty { proj_term } else { ty },
-                lt_op: |lt| lt,
+                lt_op: |lt| {
+                    match lt.kind() {
+                        ty::ReEarlyBound(_) | ty::ReFree(_) | ty::ReStatic => {}
+                        r => bug!("unexpected region: {r:?}"),
+                    }
+                    lt
+                },
                 ct_op: |ct| ct,
             };
             // For example, in `impl Trait<Assoc = impl Send>`, for all of the bounds on `Assoc`,

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -415,7 +415,7 @@ impl<'tcx> ClosureOutlivesSubjectTy<'tcx> {
                     ty::BoundRegion { var: ty::BoundVar::new(vid.index()), kind: ty::BrAnon(None) };
                 tcx.mk_re_late_bound(depth, br)
             }
-            _ => bug!("unexpected region in ClosureOutlivesSubjectTy: {r:?}"),
+            _ => bug!("unexpected region: {r:?}"),
         });
 
         Self { inner }

--- a/compiler/rustc_middle/src/ty/erase_regions.rs
+++ b/compiler/rustc_middle/src/ty/erase_regions.rs
@@ -52,7 +52,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for RegionEraserVisitor<'tcx> {
     }
 
     fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
-        // because late-bound regions affect subtyping, we can't
+        // Because late-bound regions affect subtyping, we can't
         // erase the bound/free distinction, but we can replace
         // all free regions with 'erased.
         //
@@ -61,8 +61,15 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for RegionEraserVisitor<'tcx> {
         // away. In codegen, they will always be erased to 'erased
         // whenever a substitution occurs.
         match *r {
+            // All region variants occur in this match.
             ty::ReLateBound(..) => r,
-            _ => self.tcx.lifetimes.re_erased,
+            ty::ReEarlyBound(_)
+            | ty::ReFree(_)
+            | ty::ReStatic
+            | ty::ReVar(_)
+            | ty::RePlaceholder(_)
+            | ty::ReErased
+            | ty::ReError(_) => self.tcx.lifetimes.re_erased,
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/opaque_types.rs
+++ b/compiler/rustc_middle/src/ty/opaque_types.rs
@@ -114,12 +114,10 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ReverseMapper<'tcx> {
             // The regions that we expect from borrow checking.
             ty::ReEarlyBound(_) | ty::ReFree(_) => {}
 
-            ty::RePlaceholder(_) | ty::ReVar(_) => {
-                // All of the regions in the type should either have been
-                // erased by writeback, or mapped back to named regions by
-                // borrow checking.
-                bug!("unexpected region kind in opaque type: {:?}", r);
-            }
+            // All of the regions in the type should either have been
+            // erased by writeback, or mapped back to named regions by
+            // borrow checking.
+            ty::RePlaceholder(_) | ty::ReVar(_) => bug!("unexpected region: {r:?}"),
         }
 
         match self.map.get(&r.into()).map(|k| k.unpack()) {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2258,6 +2258,7 @@ impl<'a, 'tcx> ty::TypeFolder<TyCtxt<'tcx>> for RegionFolder<'a, 'tcx> {
     fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
         let name = &mut self.name;
         let region = match *r {
+            // All region variants occur in this match.
             ty::ReLateBound(db, br) if db >= self.current_index => {
                 *self.region_map.entry(br).or_insert_with(|| name(Some(db), self.current_index, br))
             }
@@ -2279,7 +2280,13 @@ impl<'a, 'tcx> ty::TypeFolder<TyCtxt<'tcx>> for RegionFolder<'a, 'tcx> {
                     }
                 }
             }
-            _ => return r,
+            ty::ReEarlyBound(_)
+            | ty::ReLateBound(..)
+            | ty::ReFree(_)
+            | ty::ReStatic
+            | ty::ReVar(_)
+            | ty::ReErased
+            | ty::ReError(_) => return r,
         };
         if let ty::ReLateBound(debruijn1, br) = *region {
             assert_eq!(debruijn1, ty::INNERMOST);

--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -840,7 +840,8 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for SubstFolder<'a, 'tcx> {
                     None => region_param_out_of_range(data, self.substs),
                 }
             }
-            _ => r,
+            ty::ReLateBound(..) | ty::ReFree(_) | ty::ReStatic | ty::ReErased | ty::ReError(_) => r,
+            r => bug!("unexpected region: {r:?}"),
         }
     }
 

--- a/compiler/rustc_trait_selection/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/structural_traits.rs
@@ -85,20 +85,20 @@ pub(in crate::solve) fn instantiate_constituent_tys_for_auto_trait<'tcx>(
     }
 }
 
-pub(in crate::solve) fn replace_erased_lifetimes_with_bound_vars<'tcx>(
+fn replace_erased_lifetimes_with_bound_vars<'tcx>(
     tcx: TyCtxt<'tcx>,
     ty: Ty<'tcx>,
 ) -> ty::Binder<'tcx, Ty<'tcx>> {
     debug_assert!(!ty.has_late_bound_regions());
     let mut counter = 0;
-    let ty = tcx.fold_regions(ty, |mut r, current_depth| {
-        if let ty::ReErased = r.kind() {
+    let ty = tcx.fold_regions(ty, |r, current_depth| match r.kind() {
+        ty::ReErased => {
             let br =
                 ty::BoundRegion { var: ty::BoundVar::from_u32(counter), kind: ty::BrAnon(None) };
             counter += 1;
-            r = tcx.mk_re_late_bound(current_depth, br);
+            tcx.mk_re_late_bound(current_depth, br)
         }
-        r
+        r => bug!("unexpected region: {r:?}"),
     });
     let bound_vars = tcx.mk_bound_variable_kinds_from_iter(
         (0..counter).map(|_| ty::BoundVariableKind::Region(ty::BrAnon(None))),

--- a/compiler/rustc_trait_selection/src/solve/canonicalize.rs
+++ b/compiler/rustc_trait_selection/src/solve/canonicalize.rs
@@ -242,7 +242,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'_, 'tcx> {
                 }
             },
 
-            ty::ReError(_) => return r,
+            r => bug!("unexpected region: {r:?}"),
         };
 
         let existing_bound_var = match self.canonicalize_mode {

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -776,7 +776,12 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for BoundVarReplacer<'_, 'tcx> {
                 self.mapped_regions.insert(p, br);
                 self.infcx.tcx.mk_re_placeholder(p)
             }
-            _ => r,
+            ty::ReEarlyBound(_)
+            | ty::ReLateBound(..)
+            | ty::ReFree(_)
+            | ty::ReStatic
+            | ty::RePlaceholder(_) => r,
+            r => bug!("unexpected region: {r:?}"),
         }
     }
 
@@ -879,7 +884,12 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for PlaceholderReplacer<'_, 'tcx> {
                 .borrow_mut()
                 .unwrap_region_constraints()
                 .opportunistic_resolve_var(self.infcx.tcx, vid),
-            _ => r0,
+            ty::ReEarlyBound(_)
+            | ty::ReLateBound(..)
+            | ty::ReStatic
+            | ty::RePlaceholder(_)
+            | ty::ReErased => r0,
+            r => bug!("unexpected region: {r:?}"),
         };
 
         let r2 = match *r1 {

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -1045,7 +1045,8 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for NamedBoundVarSubstitutor<'a, 'tcx> {
                 ty::BrEnv => unimplemented!(),
                 ty::BrAnon(..) => {}
             },
-            _ => (),
+            ty::ReLateBound(..) | ty::ReStatic => (),
+            r => bug!("unexpected region: {r:?}"),
         };
 
         r.super_fold_with(self)
@@ -1141,8 +1142,9 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ParamsSubstitutor<'tcx> {
                     self.tcx.mk_re_late_bound(self.binder_index, br)
                 }
             },
-
-            _ => r.super_fold_with(self),
+            // Other region kinds might need the same treatment here.
+            ty::ReLateBound(..) => r.super_fold_with(self),
+            r => bug!("unexpected region: {r:?}"),
         }
     }
 }

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -1,7 +1,7 @@
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
 use rustc_hir::lang_items::LangItem;
-use rustc_middle::ty::{self, Region, RegionVid, TypeFoldable, TypeSuperFoldable};
+use rustc_middle::ty::{self, Region, RegionVid, TypeFoldable};
 use rustc_trait_selection::traits::auto_trait::{self, AutoTraitResult};
 use thin_vec::ThinVec;
 
@@ -740,10 +740,9 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for RegionReplacer<'a, 'tcx> {
     }
 
     fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
-        (match *r {
-            ty::ReVar(vid) => self.vid_to_region.get(&vid).cloned(),
-            _ => None,
-        })
-        .unwrap_or_else(|| r.super_fold_with(self))
+        match *r {
+            ty::ReVar(vid) => self.vid_to_region.get(&vid).cloned().unwrap_or(r),
+            _ => r,
+        }
     }
 }

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -742,7 +742,8 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for RegionReplacer<'a, 'tcx> {
     fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
         match *r {
             ty::ReVar(vid) => self.vid_to_region.get(&vid).cloned().unwrap_or(r),
-            _ => r,
+            ty::ReEarlyBound(_) | ty::ReStatic | ty::ReLateBound(..) => r,
+            r => bug!("unexpected region: {r:?}"),
         }
     }
 }


### PR DESCRIPTION
Some region folders expect certain region variants to never occur. Other region folders handle all region variants. I was wondering if we could be stricter. So I tried changing every region folder to not accept any variants, and then gradually allowed variants until the full test suite passed.

The results are less enlightening than I'd hoped. I was expecting to see some common patterns but there aren't any, there is no consistency at all. I'm ambivalent about whether this should be merged, but I figure it's worth showing others. If we do merge it, we should probably do a crater run first to flush out any edge cases not covered by the test suite.

r? @oli-obk 