### PR TITLE
allow `repr(align = x)` on inherent methods

### DIFF
--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -627,13 +627,9 @@ passes_attr_application_struct_enum_union =
     attribute should be applied to a struct, enum, or union
     .label = not a struct, enum, or union
 
-passes_attr_application_struct_enum_function_union =
-    attribute should be applied to a struct, enum, function, or union
-    .label = not a struct, enum, function, or union
-
-passes_attr_application_struct_enum_function_inherent_method_union =
-    attribute should be applied to a struct, enum, function, inherent method, or union
-    .label = not a struct, enum, function, inherent method, or union
+passes_attr_application_struct_enum_function_method_union =
+    attribute should be applied to a struct, enum, function, associated function, or union
+    .label = not a struct, enum, function, associated function, or union
 
 passes_transparent_incompatible =
     transparent {$target} cannot have other repr hints

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -631,6 +631,10 @@ passes_attr_application_struct_enum_function_union =
     attribute should be applied to a struct, enum, function, or union
     .label = not a struct, enum, function, or union
 
+passes_attr_application_struct_enum_function_inherent_method_union =
+    attribute should be applied to a struct, enum, function, inherent method, or union
+    .label = not a struct, enum, function, inherent method, or union
+
 passes_transparent_incompatible =
     transparent {$target} cannot have other repr hints
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1745,10 +1745,10 @@ impl CheckAttrVisitor<'_> {
                         | Target::Union
                         | Target::Enum
                         | Target::Fn
-                        | Target::Method(MethodKind::Inherent) => continue,
+                        | Target::Method(_) => continue,
                         _ => {
                             self.tcx.sess.emit_err(
-                                errors::AttrApplication::StructEnumFunctionInherentMethodUnion {
+                                errors::AttrApplication::StructEnumFunctionMethodUnion {
                                     hint_span: hint.span(),
                                     span,
                                 },

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1728,7 +1728,9 @@ impl CheckAttrVisitor<'_> {
                     }
                 }
                 sym::align => {
-                    if let (Target::Fn, false) = (target, self.tcx.features().fn_align) {
+                    if let (Target::Fn | Target::Method(MethodKind::Inherent), false) =
+                        (target, self.tcx.features().fn_align)
+                    {
                         feature_err(
                             &self.tcx.sess.parse_sess,
                             sym::fn_align,
@@ -1739,10 +1741,14 @@ impl CheckAttrVisitor<'_> {
                     }
 
                     match target {
-                        Target::Struct | Target::Union | Target::Enum | Target::Fn => continue,
+                        Target::Struct
+                        | Target::Union
+                        | Target::Enum
+                        | Target::Fn
+                        | Target::Method(MethodKind::Inherent) => continue,
                         _ => {
                             self.tcx.sess.emit_err(
-                                errors::AttrApplication::StructEnumFunctionUnion {
+                                errors::AttrApplication::StructEnumFunctionInherentMethodUnion {
                                     hint_span: hint.span(),
                                     span,
                                 },

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1355,8 +1355,8 @@ pub enum AttrApplication {
         #[label]
         span: Span,
     },
-    #[diag(passes_attr_application_struct_enum_function_inherent_method_union, code = "E0517")]
-    StructEnumFunctionInherentMethodUnion {
+    #[diag(passes_attr_application_struct_enum_function_method_union, code = "E0517")]
+    StructEnumFunctionMethodUnion {
         #[primary_span]
         hint_span: Span,
         #[label]

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1355,8 +1355,8 @@ pub enum AttrApplication {
         #[label]
         span: Span,
     },
-    #[diag(passes_attr_application_struct_enum_function_union, code = "E0517")]
-    StructEnumFunctionUnion {
+    #[diag(passes_attr_application_struct_enum_function_inherent_method_union, code = "E0517")]
+    StructEnumFunctionInherentMethodUnion {
         #[primary_span]
         hint_span: Span,
         #[label]

--- a/tests/codegen/align-fn.rs
+++ b/tests/codegen/align-fn.rs
@@ -7,3 +7,12 @@
 #[no_mangle]
 #[repr(align(16))]
 pub fn fn_align() {}
+
+pub struct A;
+
+impl A {
+    // CHECK: align 16
+    #[no_mangle]
+    #[repr(align(16))]
+    pub fn method_align(self) {}
+}

--- a/tests/codegen/align-fn.rs
+++ b/tests/codegen/align-fn.rs
@@ -15,4 +15,35 @@ impl A {
     #[no_mangle]
     #[repr(align(16))]
     pub fn method_align(self) {}
+
+    // CHECK: align 16
+    #[no_mangle]
+    #[repr(align(16))]
+    pub fn associated_fn() {}
+}
+
+trait T: Sized {
+    fn trait_fn() {}
+
+    // CHECK: align 32
+    #[repr(align(32))]
+    fn trait_method(self) {}
+}
+
+impl T for A {
+    // CHECK: align 16
+    #[no_mangle]
+    #[repr(align(16))]
+    fn trait_fn() {}
+
+    // CHECK: align 16
+    #[no_mangle]
+    #[repr(align(16))]
+    fn trait_method(self) {}
+}
+
+impl T for () {}
+
+pub fn foo() {
+    ().trait_method();
 }

--- a/tests/ui/attributes/invalid-repr.rs
+++ b/tests/ui/attributes/invalid-repr.rs
@@ -1,0 +1,5 @@
+#[repr(align(16))]
+//~^ ERROR attribute should be applied to a struct, enum, function, associated function, or union
+pub type Foo = i32;
+
+fn main() {}

--- a/tests/ui/attributes/invalid-repr.stderr
+++ b/tests/ui/attributes/invalid-repr.stderr
@@ -1,0 +1,12 @@
+error[E0517]: attribute should be applied to a struct, enum, function, associated function, or union
+  --> $DIR/invalid-repr.rs:1:8
+   |
+LL | #[repr(align(16))]
+   |        ^^^^^^^^^
+LL |
+LL | pub type Foo = i32;
+   | ------------------- not a struct, enum, function, associated function, or union
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0517`.


### PR DESCRIPTION
Discussion: https://github.com/rust-lang/rust/issues/82232#issuecomment-905929314