### PR TITLE
Add a stable MIR way to get the main function

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -40,6 +40,10 @@ pub fn all_local_items() -> stable_mir::CrateItems {
     with(|tcx| tcx.mir_keys(()).iter().map(|item| crate_item(item.to_def_id())).collect())
 }
 
+pub fn entry_fn() -> Option<stable_mir::CrateItem> {
+    with(|tcx| Some(crate_item(tcx.entry_fn(())?.0)))
+}
+
 /// Build a stable mir crate from a given crate number.
 fn smir_crate(tcx: TyCtxt<'_>, crate_num: CrateNum) -> stable_mir::Crate {
     let crate_name = tcx.crate_name(crate_num).to_string();

--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -45,6 +45,13 @@ impl CrateItem {
     }
 }
 
+/// Return the function where execution starts if the current
+/// crate defines that. This is usually `main`, but could be
+/// `start` if the crate is a no-std crate.
+pub fn entry_fn() -> Option<CrateItem> {
+    crate::rustc_smir::entry_fn()
+}
+
 /// Access to the local crate.
 pub fn local_crate() -> Crate {
     crate::rustc_smir::local_crate()

--- a/tests/ui-fulldeps/stable-mir/crate-info.rs
+++ b/tests/ui-fulldeps/stable-mir/crate-info.rs
@@ -29,6 +29,8 @@ fn test_stable_mir(tcx: TyCtxt<'_>) {
     let local = stable_mir::local_crate();
     assert_eq!(&local.name, CRATE_NAME);
 
+    assert_eq!(stable_mir::entry_fn(), None);
+
     // Find items in the local crate.
     let items = stable_mir::all_local_items();
     assert!(get_item(tcx, &items, (DefKind::Fn, "foo_bar")).is_some());


### PR DESCRIPTION
This is useful for analysis tools that only analyze the code paths that a specific program actually goes through. Or for code generators built on top of stable MIR.