### PR TITLE
run tidy's style check from the root path

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -30,7 +30,7 @@ Language
 --------
 
 - [Stabilize default_alloc_error_handler](https://github.com/rust-lang/rust/pull/102318/)
-  This allows usage of `alloc` on stable without requiring the 
+  This allows usage of `alloc` on stable without requiring the
   definition of a handler for allocation failure. Defining custom handlers is still unstable.
 - [Stabilize `efiapi` calling convention.](https://github.com/rust-lang/rust/pull/105795/)
 - [Remove implicit promotion for types with drop glue](https://github.com/rust-lang/rust/pull/105085/)

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -110,10 +110,7 @@ fn main() {
             check!(bins, &root_path);
         }
 
-        check!(style, &src_path);
-        check!(style, &tests_path);
-        check!(style, &compiler_path);
-        check!(style, &library_path);
+        check!(style, &root_path);
 
         check!(edition, &src_path);
         check!(edition, &compiler_path);

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -210,6 +210,7 @@ fn skip_markdown_path(path: &Path) -> bool {
         "src/doc/reference",
         "src/doc/rust-by-example",
         "src/doc/rustc-dev-guide",
+        "RELEASES.md",
     ];
     SKIP_MD.iter().any(|p| path.ends_with(p))
 }


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/110307/files#r1166327524.

:crossed_fingers: the change in `RELEASES.md` is ok? maybe cc @Mark-Simulacrum 