### PR TITLE
Rewrite `pointer::with_addr` implementation

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -258,14 +258,15 @@ impl<T: ?Sized> *const T {
         // FIXME(strict_provenance_magic): I am magic and should be a compiler intrinsic.
         //
         // In the mean-time, this operation is defined to be "as if" it was
-        // a wrapping_offset, so we can emulate it as such. This should properly
+        // two `wrapping_offset`s, so we can emulate it as such. This should properly
         // restore pointer provenance even under today's compiler.
-        let self_addr = self.addr() as isize;
-        let dest_addr = addr as isize;
-        let offset = dest_addr.wrapping_sub(self_addr);
-
-        // This is the canonical desugarring of this operation
-        self.wrapping_byte_offset(offset)
+        //
+        // This is the canonical desugaring of this operation.
+        //
+        // Note that we are using two offsets, instead of precomputing offset
+        // with `addr - self.addr()`. This is because it is easier for LLVM to
+        // optimize such code.
+        self.wrapping_byte_sub(self.addr()).wrapping_byte_add(addr)
     }
 
     /// Creates a new pointer by mapping `self`'s address to a new one.

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -264,14 +264,15 @@ impl<T: ?Sized> *mut T {
         // FIXME(strict_provenance_magic): I am magic and should be a compiler intrinsic.
         //
         // In the mean-time, this operation is defined to be "as if" it was
-        // a wrapping_offset, so we can emulate it as such. This should properly
+        // two `wrapping_offset`s, so we can emulate it as such. This should properly
         // restore pointer provenance even under today's compiler.
-        let self_addr = self.addr() as isize;
-        let dest_addr = addr as isize;
-        let offset = dest_addr.wrapping_sub(self_addr);
-
-        // This is the canonical desugarring of this operation
-        self.wrapping_byte_offset(offset)
+        //
+        // This is the canonical desugaring of this operation.
+        //
+        // Note that we are using two offsets, instead of precomputing offset
+        // with `addr - self.addr()`. This is because it is easier for LLVM to
+        // optimize such code.
+        self.wrapping_byte_sub(self.addr()).wrapping_byte_add(addr)
     }
 
     /// Creates a new pointer by mapping `self`'s address to a new one.


### PR DESCRIPTION
This commit changes the impl from (essentially)
```rust
ptr.wrapping_byte_offset(new_addr - self.addr())
```
to
```rust
ptr.wrapping_byte_sub(self.addr()).wrapping_byte_add(new_addr)
```

While being essentially the same (`a-a+b` vs `a+(b-a)`) new implementation generation 2 GEPs, instead of an arithmetic + 1 GEP, which turns out to be easier for LLVM to optimize and reason about.
<sub>(`ptradd` instead of `getelementptr` when .-.)</sub>

----

[Idea](https://discord.com/channels/273534239310479360/957720175619215380/1096158809153617980) by @scottmcm, should fix the problem I've found while working on https://github.com/rust-lang/rust/pull/110243, which I documented in the LLVM issue: https://github.com/llvm/llvm-project/issues/62093 (TL;DR: the code for `.map_addr(|a| a << 2)` does not get optimized properly).

- Here is a comparison specifically for `addr << 2`: https://rust.godbolt.org/z/T4oWfx4sb
- LLVM-IR comparison between different impls: https://rust.godbolt.org/z/WhKa7b8dd (the new impl is technically more llvm-ir, but it looks like this form is easier to optimize/reason about/etc at least atm)