### PR TITLE
[compiletest] Add more test ignore reasons, `needs-` validation, and improved error messages

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -851,6 +851,7 @@ pub fn make_test_description<R: Read>(
     path: &Path,
     src: R,
     cfg: Option<&str>,
+    poisoned: &mut bool,
 ) -> test::TestDesc {
     let mut ignore = false;
     let mut ignore_message = None;
@@ -875,7 +876,8 @@ pub fn make_test_description<R: Read>(
                     }
                     IgnoreDecision::Error { message } => {
                         eprintln!("error: {}: {message}", path.display());
-                        panic!();
+                        *poisoned = true;
+                        return;
                     }
                     IgnoreDecision::Continue => {}
                 }

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -943,14 +943,6 @@ pub fn make_test_description<R: Read>(
             }
         }
 
-        if config.debugger == Some(Debugger::Lldb) && !config.lldb_native_rust {
-            if config.parse_name_directive(ln, "rust-lldb") {
-                decision!(IgnoreDecision::Ignore {
-                    reason: "ignored on targets wihtout Rust's LLDB".into()
-                });
-            }
-        }
-
         should_fail |= config.parse_name_directive(ln, "should-fail");
     });
 

--- a/src/tools/compiletest/src/header/needs.rs
+++ b/src/tools/compiletest/src/header/needs.rs
@@ -1,0 +1,226 @@
+use crate::common::Config;
+use crate::header::IgnoreDecision;
+use crate::util;
+
+pub(super) fn handle_needs(
+    cache: &CachedNeedsConditions,
+    config: &Config,
+    ln: &str,
+) -> IgnoreDecision {
+    // Note thet we intentionally still put the needs- prefix here to make the file show up when
+    // grepping for a directive name, even though we could technically strip that.
+    let needs = &[
+        Need {
+            name: "needs-asm-support",
+            condition: config.has_asm_support(),
+            ignore_reason: "ignored on targets without inline assembly support",
+        },
+        Need {
+            name: "needs-sanitizer-support",
+            condition: cache.sanitizer_support,
+            ignore_reason: "ignored on targets without sanitizers support",
+        },
+        Need {
+            name: "needs-sanitizer-address",
+            condition: cache.sanitizer_address,
+            ignore_reason: "ignored on targets without address sanitizer",
+        },
+        Need {
+            name: "needs-sanitizer-cfi",
+            condition: cache.sanitizer_cfi,
+            ignore_reason: "ignored on targets without CFI sanitizer",
+        },
+        Need {
+            name: "needs-sanitizer-kcfi",
+            condition: cache.sanitizer_kcfi,
+            ignore_reason: "ignored on targets without kernel CFI sanitizer",
+        },
+        Need {
+            name: "needs-sanitizer-kasan",
+            condition: cache.sanitizer_kasan,
+            ignore_reason: "ignored on targets without kernel address sanitizer",
+        },
+        Need {
+            name: "needs-sanitizer-leak",
+            condition: cache.sanitizer_leak,
+            ignore_reason: "ignored on targets without leak sanitizer",
+        },
+        Need {
+            name: "needs-sanitizer-memory",
+            condition: cache.sanitizer_memory,
+            ignore_reason: "ignored on targets without memory sanitizer",
+        },
+        Need {
+            name: "needs-sanitizer-thread",
+            condition: cache.sanitizer_thread,
+            ignore_reason: "ignored on targets without thread sanitizer",
+        },
+        Need {
+            name: "needs-sanitizer-hwaddress",
+            condition: cache.sanitizer_hwaddress,
+            ignore_reason: "ignored on targets without hardware-assisted address sanitizer",
+        },
+        Need {
+            name: "needs-sanitizer-memtag",
+            condition: cache.sanitizer_memtag,
+            ignore_reason: "ignored on targets without memory tagging sanitizer",
+        },
+        Need {
+            name: "needs-sanitizer-shadow-call-stack",
+            condition: cache.sanitizer_shadow_call_stack,
+            ignore_reason: "ignored on targets without shadow call stacks",
+        },
+        Need {
+            name: "needs-run-enabled",
+            condition: config.run_enabled(),
+            ignore_reason: "ignored when running the resulting test binaries is disabled",
+        },
+        Need {
+            name: "needs-unwind",
+            condition: config.can_unwind(),
+            ignore_reason: "ignored on targets without unwinding support",
+        },
+        Need {
+            name: "needs-profiler-support",
+            condition: std::env::var_os("RUSTC_PROFILER_SUPPORT").is_some(),
+            ignore_reason: "ignored when profiler support is disabled",
+        },
+        Need {
+            name: "needs-matching-clang",
+            condition: config.run_clang_based_tests_with.is_some(),
+            ignore_reason: "ignored when the used clang does not match the built LLVM",
+        },
+        Need {
+            name: "needs-xray",
+            condition: cache.xray,
+            ignore_reason: "ignored on targets without xray tracing",
+        },
+        Need {
+            name: "needs-rust-lld",
+            condition: cache.rust_lld,
+            ignore_reason: "ignored on targets without Rust's LLD",
+        },
+        Need {
+            name: "needs-i686-dlltool",
+            condition: cache.i686_dlltool,
+            ignore_reason: "ignored when dlltool for i686 is not present",
+        },
+        Need {
+            name: "needs-x86_64-dlltool",
+            condition: cache.x86_64_dlltool,
+            ignore_reason: "ignored when dlltool for x86_64 is not present",
+        },
+    ];
+
+    let (name, comment) = match ln.split_once([':', ' ']) {
+        Some((name, comment)) => (name, Some(comment)),
+        None => (ln, None),
+    };
+
+    if !name.starts_with("needs-") {
+        return IgnoreDecision::Continue;
+    }
+
+    let mut found_valid = false;
+    for need in needs {
+        if need.name == name {
+            if need.condition {
+                found_valid = true;
+                break;
+            } else {
+                return IgnoreDecision::Ignore {
+                    reason: if let Some(comment) = comment {
+                        format!("{} ({comment})", need.ignore_reason)
+                    } else {
+                        need.ignore_reason.into()
+                    },
+                };
+            }
+        }
+    }
+
+    if found_valid {
+        IgnoreDecision::Continue
+    } else {
+        IgnoreDecision::Error { message: format!("invalid needs directive: {name}") }
+    }
+}
+
+struct Need {
+    name: &'static str,
+    condition: bool,
+    ignore_reason: &'static str,
+}
+
+pub(super) struct CachedNeedsConditions {
+    sanitizer_support: bool,
+    sanitizer_address: bool,
+    sanitizer_cfi: bool,
+    sanitizer_kcfi: bool,
+    sanitizer_kasan: bool,
+    sanitizer_leak: bool,
+    sanitizer_memory: bool,
+    sanitizer_thread: bool,
+    sanitizer_hwaddress: bool,
+    sanitizer_memtag: bool,
+    sanitizer_shadow_call_stack: bool,
+    xray: bool,
+    rust_lld: bool,
+    i686_dlltool: bool,
+    x86_64_dlltool: bool,
+}
+
+impl CachedNeedsConditions {
+    pub(super) fn load(config: &Config) -> Self {
+        let path = std::env::var_os("PATH").expect("missing PATH environment variable");
+        let path = std::env::split_paths(&path).collect::<Vec<_>>();
+
+        let target = &&*config.target;
+        Self {
+            sanitizer_support: std::env::var_os("RUSTC_SANITIZER_SUPPORT").is_some(),
+            sanitizer_address: util::ASAN_SUPPORTED_TARGETS.contains(target),
+            sanitizer_cfi: util::CFI_SUPPORTED_TARGETS.contains(target),
+            sanitizer_kcfi: util::KCFI_SUPPORTED_TARGETS.contains(target),
+            sanitizer_kasan: util::KASAN_SUPPORTED_TARGETS.contains(target),
+            sanitizer_leak: util::LSAN_SUPPORTED_TARGETS.contains(target),
+            sanitizer_memory: util::MSAN_SUPPORTED_TARGETS.contains(target),
+            sanitizer_thread: util::TSAN_SUPPORTED_TARGETS.contains(target),
+            sanitizer_hwaddress: util::HWASAN_SUPPORTED_TARGETS.contains(target),
+            sanitizer_memtag: util::MEMTAG_SUPPORTED_TARGETS.contains(target),
+            sanitizer_shadow_call_stack: util::SHADOWCALLSTACK_SUPPORTED_TARGETS.contains(target),
+            xray: util::XRAY_SUPPORTED_TARGETS.contains(target),
+
+            // For tests using the `needs-rust-lld` directive (e.g. for `-Zgcc-ld=lld`), we need to find
+            // whether `rust-lld` is present in the compiler under test.
+            //
+            // The --compile-lib-path is the path to host shared libraries, but depends on the OS. For
+            // example:
+            // - on linux, it can be <sysroot>/lib
+            // - on windows, it can be <sysroot>/bin
+            //
+            // However, `rust-lld` is only located under the lib path, so we look for it there.
+            rust_lld: config
+                .compile_lib_path
+                .parent()
+                .expect("couldn't traverse to the parent of the specified --compile-lib-path")
+                .join("lib")
+                .join("rustlib")
+                .join(target)
+                .join("bin")
+                .join(if config.host.contains("windows") { "rust-lld.exe" } else { "rust-lld" })
+                .exists(),
+
+            // On Windows, dlltool.exe is used for all architectures.
+            #[cfg(windows)]
+            i686_dlltool: path.iter().any(|dir| dir.join("dlltool.exe").is_file()),
+            #[cfg(windows)]
+            x86_64_dlltool: path.iter().any(|dir| dir.join("dlltool.exe").is_file()),
+
+            // For non-Windows, there are architecture specific dlltool binaries.
+            #[cfg(not(windows))]
+            i686_dlltool: path.iter().any(|dir| dir.join("i686-w64-mingw32-dlltool").is_file()),
+            #[cfg(not(windows))]
+            x86_64_dlltool: path.iter().any(|dir| dir.join("x86_64-w64-mingw32-dlltool").is_file()),
+        }
+    }
+}

--- a/src/tools/compiletest/src/header/needs.rs
+++ b/src/tools/compiletest/src/header/needs.rs
@@ -1,4 +1,4 @@
-use crate::common::Config;
+use crate::common::{Config, Debugger};
 use crate::header::IgnoreDecision;
 use crate::util;
 
@@ -99,6 +99,11 @@ pub(super) fn handle_needs(
             name: "needs-rust-lld",
             condition: cache.rust_lld,
             ignore_reason: "ignored on targets without Rust's LLD",
+        },
+        Need {
+            name: "needs-rust-lldb",
+            condition: config.debugger != Some(Debugger::Lldb) || config.lldb_native_rust,
+            ignore_reason: "ignored on targets without Rust's LLDB",
         },
         Need {
             name: "needs-i686-dlltool",

--- a/src/tools/compiletest/src/header/needs.rs
+++ b/src/tools/compiletest/src/header/needs.rs
@@ -126,6 +126,11 @@ pub(super) fn handle_needs(
         return IgnoreDecision::Continue;
     }
 
+    // Handled elsewhere.
+    if name == "needs-llvm-components" {
+        return IgnoreDecision::Continue;
+    }
+
     let mut found_valid = false;
     for need in needs {
         if need.name == name {

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -1,7 +1,23 @@
+use std::io::Read;
 use std::path::Path;
 
 use crate::common::{Config, Debugger};
-use crate::header::{make_test_description, parse_normalization_string, EarlyProps};
+use crate::header::{parse_normalization_string, EarlyProps};
+
+fn make_test_description<R: Read>(
+    config: &Config,
+    name: test::TestName,
+    path: &Path,
+    src: R,
+    cfg: Option<&str>,
+) -> test::TestDesc {
+    let mut poisoned = false;
+    let test = crate::header::make_test_description(config, name, path, src, cfg, &mut poisoned);
+    if poisoned {
+        panic!("poisoned!");
+    }
+    test
+}
 
 #[test]
 fn test_parse_normalization_string() {

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 use std::path::Path;
 
 use crate::common::{Config, Debugger};
-use crate::header::{parse_normalization_string, EarlyProps};
+use crate::header::{parse_normalization_string, EarlyProps, HeadersCache};
 
 fn make_test_description<R: Read>(
     config: &Config,
@@ -11,8 +11,10 @@ fn make_test_description<R: Read>(
     src: R,
     cfg: Option<&str>,
 ) -> test::TestDesc {
+    let cache = HeadersCache::load(config);
     let mut poisoned = false;
-    let test = crate::header::make_test_description(config, name, path, src, cfg, &mut poisoned);
+    let test =
+        crate::header::make_test_description(config, &cache, name, path, src, cfg, &mut poisoned);
     if poisoned {
         panic!("poisoned!");
     }

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -25,6 +25,7 @@ use tracing::*;
 use walkdir::WalkDir;
 
 use self::header::{make_test_description, EarlyProps};
+use crate::header::HeadersCache;
 use std::sync::Arc;
 
 #[cfg(test)]
@@ -556,9 +557,11 @@ pub fn make_tests(
         panic!("modified_tests got error from dir: {}, error: {}", config.src_base.display(), err)
     });
 
+    let cache = HeadersCache::load(&config);
     let mut poisoned = false;
     collect_tests_from_dir(
         config.clone(),
+        &cache,
         &config.src_base,
         &PathBuf::new(),
         &inputs,
@@ -636,6 +639,7 @@ fn modified_tests(config: &Config, dir: &Path) -> Result<Vec<PathBuf>, String> {
 
 fn collect_tests_from_dir(
     config: Arc<Config>,
+    cache: &HeadersCache,
     dir: &Path,
     relative_dir_path: &Path,
     inputs: &Stamp,
@@ -654,7 +658,7 @@ fn collect_tests_from_dir(
             file: dir.to_path_buf(),
             relative_dir: relative_dir_path.parent().unwrap().to_path_buf(),
         };
-        tests.extend(make_test(config, &paths, inputs, poisoned));
+        tests.extend(make_test(config, cache, &paths, inputs, poisoned));
         return Ok(());
     }
 
@@ -680,13 +684,14 @@ fn collect_tests_from_dir(
             let paths =
                 TestPaths { file: file_path, relative_dir: relative_dir_path.to_path_buf() };
 
-            tests.extend(make_test(config.clone(), &paths, inputs, poisoned))
+            tests.extend(make_test(config.clone(), cache, &paths, inputs, poisoned))
         } else if file_path.is_dir() {
             let relative_file_path = relative_dir_path.join(file.file_name());
             if &file_name != "auxiliary" {
                 debug!("found directory: {:?}", file_path.display());
                 collect_tests_from_dir(
                     config.clone(),
+                    cache,
                     &file_path,
                     &relative_file_path,
                     inputs,
@@ -718,6 +723,7 @@ pub fn is_test(file_name: &OsString) -> bool {
 
 fn make_test(
     config: Arc<Config>,
+    cache: &HeadersCache,
     testpaths: &TestPaths,
     inputs: &Stamp,
     poisoned: &mut bool,
@@ -745,8 +751,9 @@ fn make_test(
                 std::fs::File::open(&test_path).expect("open test file to parse ignores");
             let cfg = revision.map(|v| &**v);
             let test_name = crate::make_test_name(&config, testpaths, revision);
-            let mut desc =
-                make_test_description(&config, test_name, &test_path, src_file, cfg, poisoned);
+            let mut desc = make_test_description(
+                &config, cache, test_name, &test_path, src_file, cfg, poisoned,
+            );
             // Ignore tests that already run and are up to date with respect to inputs.
             if !config.force_rerun {
                 desc.ignore |= is_up_to_date(

--- a/tests/debuginfo/associated-types.rs
+++ b/tests/debuginfo/associated-types.rs
@@ -1,6 +1,6 @@
 // Some versions of the non-rust-enabled LLDB print the wrong generic
 // parameter type names in this test.
-// rust-lldb
+// needs-rust-lldb
 
 // compile-flags:-g
 

--- a/tests/debuginfo/borrowed-enum.rs
+++ b/tests/debuginfo/borrowed-enum.rs
@@ -1,6 +1,6 @@
 // Require a gdb or lldb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
-// rust-lldb
+// needs-rust-lldb
 
 // compile-flags:-g
 

--- a/tests/debuginfo/generic-method-on-generic-struct.rs
+++ b/tests/debuginfo/generic-method-on-generic-struct.rs
@@ -2,7 +2,7 @@
 
 // Some versions of the non-rust-enabled LLDB print the wrong generic
 // parameter type names in this test.
-// rust-lldb
+// needs-rust-lldb
 
 // === GDB TESTS ===================================================================================
 

--- a/tests/debuginfo/generic-struct.rs
+++ b/tests/debuginfo/generic-struct.rs
@@ -1,6 +1,6 @@
 // Some versions of the non-rust-enabled LLDB print the wrong generic
 // parameter type names in this test.
-// rust-lldb
+// needs-rust-lldb
 
 // compile-flags:-g
 

--- a/tests/debuginfo/generic-tuple-style-enum.rs
+++ b/tests/debuginfo/generic-tuple-style-enum.rs
@@ -1,6 +1,6 @@
 // Require a gdb or lldb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
-// rust-lldb
+// needs-rust-lldb
 
 // compile-flags:-g
 

--- a/tests/debuginfo/method-on-generic-struct.rs
+++ b/tests/debuginfo/method-on-generic-struct.rs
@@ -1,6 +1,6 @@
 // Some versions of the non-rust-enabled LLDB print the wrong generic
 // parameter type names in this test.
-// rust-lldb
+// needs-rust-lldb
 
 // compile-flags:-g
 

--- a/tests/debuginfo/struct-style-enum.rs
+++ b/tests/debuginfo/struct-style-enum.rs
@@ -1,6 +1,6 @@
 // Require a gdb or lldb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
-// rust-lldb
+// needs-rust-lldb
 
 // compile-flags:-g
 

--- a/tests/debuginfo/tuple-style-enum.rs
+++ b/tests/debuginfo/tuple-style-enum.rs
@@ -1,6 +1,6 @@
 // Require a gdb or lldb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
-// rust-lldb
+// needs-rust-lldb
 
 // compile-flags:-g
 

--- a/tests/debuginfo/unique-enum.rs
+++ b/tests/debuginfo/unique-enum.rs
@@ -1,6 +1,6 @@
 // Require a gdb or lldb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
-// rust-lldb
+// needs-rust-lldb
 
 // compile-flags:-g
 


### PR DESCRIPTION
This PR makes more improvements to the way compiletest ignoring headers are handled, following up on #108905:

* Human-readable ignore reasons have been added for the remaining ignore causes (`needs-*` directives, `*llvm*` directives, and debugger version directives). All ignored tests should now have a human-readable reason.
* The code handling `needs-*` directives has been refactored, and now invalid `needs-*` directive emit errors like `ignore-*` and `only-*`.
* All errors are now displayed at startup (with line numbers) rather than just the first error of the first file.

This PR is best reviewed commit-by-commit.

r? @ehuss 