### PR TITLE
disable `needs_drop` special-case for `[T; 0]`

### DIFF
--- a/tests/ui/consts/const-eval/generic-slice.rs
+++ b/tests/ui/consts/const-eval/generic-slice.rs
@@ -8,15 +8,14 @@ impl<'a, T: 'static> Generic<'a, T> {
     const EMPTY_SLICE: &'a [T] = {
         let x: &'a [T] = &[];
         //~^ ERROR destructor of `[T; 0]` cannot be evaluated at compile-time
-        x 
+        x
     };
 
     const EMPTY_SLICE_REF: &'a &'static [T] = {
-        let x: &'static [T] = &[]; 
+        let x: &'static [T] = &[];
         //~^ ERROR destructor of `[T; 0]` cannot be evaluated at compile-time
         &x
         //~^ ERROR `x` does not live long enough
-        
     };
 }
 

--- a/tests/ui/consts/const-eval/generic-slice.rs
+++ b/tests/ui/consts/const-eval/generic-slice.rs
@@ -7,23 +7,28 @@ struct Generic<'a, T>(std::marker::PhantomData<&'a T>);
 impl<'a, T: 'static> Generic<'a, T> {
     const EMPTY_SLICE: &'a [T] = {
         let x: &'a [T] = &[];
-        x
+        //~^ ERROR destructor of `[T; 0]` cannot be evaluated at compile-time
+        x 
     };
 
     const EMPTY_SLICE_REF: &'a &'static [T] = {
-        let x: &'static [T] = &[];
+        let x: &'static [T] = &[]; 
+        //~^ ERROR destructor of `[T; 0]` cannot be evaluated at compile-time
         &x
         //~^ ERROR `x` does not live long enough
+        
     };
 }
 
 static mut INTERIOR_MUT_AND_DROP: &'static [std::cell::RefCell<Vec<i32>>] = {
     let x: &[_] = &[];
+    //~^ ERROR destructor of `[RefCell<Vec<i32>>; 0]` cannot be evaluated at compile-time
     x
 };
 
 static mut INTERIOR_MUT_AND_DROP_REF: &'static &'static [std::cell::RefCell<Vec<i32>>] = {
     let x: &[_] = &[];
+    //~^ ERROR destructor of `[RefCell<Vec<i32>>; 0]` cannot be evaluated at compile-time
     &x
     //~^ ERROR `x` does not live long enough
 };

--- a/tests/ui/consts/const-eval/generic-slice.stderr
+++ b/tests/ui/consts/const-eval/generic-slice.stderr
@@ -1,5 +1,23 @@
+error[E0493]: destructor of `[T; 0]` cannot be evaluated at compile-time
+  --> $DIR/generic-slice.rs:9:27
+   |
+LL |         let x: &'a [T] = &[];
+   |                           ^^ the destructor for this type cannot be evaluated in constants
+...
+LL |     };
+   |     - value is dropped here
+
+error[E0493]: destructor of `[T; 0]` cannot be evaluated at compile-time
+  --> $DIR/generic-slice.rs:15:32
+   |
+LL |         let x: &'static [T] = &[]; 
+   |                                ^^ the destructor for this type cannot be evaluated in constants
+...
+LL |     };
+   |     - value is dropped here
+
 error[E0597]: `x` does not live long enough
-  --> $DIR/generic-slice.rs:15:9
+  --> $DIR/generic-slice.rs:17:9
    |
 LL | impl<'a, T: 'static> Generic<'a, T> {
    |      -- lifetime `'a` defined here
@@ -9,12 +27,30 @@ LL |         &x
    |         |
    |         borrowed value does not live long enough
    |         using this value as a constant requires that `x` is borrowed for `'a`
-LL |
+...
 LL |     };
    |     - `x` dropped here while still borrowed
 
+error[E0493]: destructor of `[RefCell<Vec<i32>>; 0]` cannot be evaluated at compile-time
+  --> $DIR/generic-slice.rs:24:20
+   |
+LL |     let x: &[_] = &[];
+   |                    ^^ the destructor for this type cannot be evaluated in statics
+...
+LL | };
+   | - value is dropped here
+
+error[E0493]: destructor of `[RefCell<Vec<i32>>; 0]` cannot be evaluated at compile-time
+  --> $DIR/generic-slice.rs:30:20
+   |
+LL |     let x: &[_] = &[];
+   |                    ^^ the destructor for this type cannot be evaluated in statics
+...
+LL | };
+   | - value is dropped here
+
 error[E0597]: `x` does not live long enough
-  --> $DIR/generic-slice.rs:27:5
+  --> $DIR/generic-slice.rs:32:5
    |
 LL |     &x
    |     ^^
@@ -25,6 +61,7 @@ LL |
 LL | };
    | - `x` dropped here while still borrowed
 
-error: aborting due to 2 previous errors
+error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0597`.
+Some errors have detailed explanations: E0493, E0597.
+For more information about an error, try `rustc --explain E0493`.

--- a/tests/ui/consts/const-eval/generic-slice.stderr
+++ b/tests/ui/consts/const-eval/generic-slice.stderr
@@ -10,7 +10,7 @@ LL |     };
 error[E0493]: destructor of `[T; 0]` cannot be evaluated at compile-time
   --> $DIR/generic-slice.rs:15:32
    |
-LL |         let x: &'static [T] = &[]; 
+LL |         let x: &'static [T] = &[];
    |                                ^^ the destructor for this type cannot be evaluated in constants
 ...
 LL |     };
@@ -27,12 +27,12 @@ LL |         &x
    |         |
    |         borrowed value does not live long enough
    |         using this value as a constant requires that `x` is borrowed for `'a`
-...
+LL |
 LL |     };
    |     - `x` dropped here while still borrowed
 
 error[E0493]: destructor of `[RefCell<Vec<i32>>; 0]` cannot be evaluated at compile-time
-  --> $DIR/generic-slice.rs:24:20
+  --> $DIR/generic-slice.rs:23:20
    |
 LL |     let x: &[_] = &[];
    |                    ^^ the destructor for this type cannot be evaluated in statics
@@ -41,7 +41,7 @@ LL | };
    | - value is dropped here
 
 error[E0493]: destructor of `[RefCell<Vec<i32>>; 0]` cannot be evaluated at compile-time
-  --> $DIR/generic-slice.rs:30:20
+  --> $DIR/generic-slice.rs:29:20
    |
 LL |     let x: &[_] = &[];
    |                    ^^ the destructor for this type cannot be evaluated in statics
@@ -50,7 +50,7 @@ LL | };
    | - value is dropped here
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/generic-slice.rs:32:5
+  --> $DIR/generic-slice.rs:31:5
    |
 LL |     &x
    |     ^^

--- a/tests/ui/consts/issue-65348.rs
+++ b/tests/ui/consts/issue-65348.rs
@@ -1,5 +1,3 @@
-// check-pass
-
 struct Generic<T>(T);
 
 impl<T> Generic<T> {
@@ -10,14 +8,17 @@ impl<T> Generic<T> {
 
 pub const fn array<T>() ->  &'static T {
     &Generic::<T>::ARRAY[0]
+    //~^ ERROR destructor of `[T; 0]` cannot be evaluated at compile-time
 }
 
 pub const fn newtype_array<T>() ->  &'static T {
     &Generic::<T>::NEWTYPE_ARRAY.0[0]
+    //~^ ERROR destructor of `Generic<[T; 0]>` cannot be evaluated at compile-time
 }
 
 pub const fn array_field<T>() ->  &'static T {
     &(Generic::<T>::ARRAY_FIELD.0).1[0]
+    //~^ ERROR destructor of `Generic<(i32, [T; 0])>` cannot be evaluated at compile-time
 }
 
 fn main() {}

--- a/tests/ui/consts/issue-65348.stderr
+++ b/tests/ui/consts/issue-65348.stderr
@@ -1,0 +1,30 @@
+error[E0493]: destructor of `[T; 0]` cannot be evaluated at compile-time
+  --> $DIR/issue-65348.rs:10:6
+   |
+LL |     &Generic::<T>::ARRAY[0]
+   |      ^^^^^^^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constant functions
+LL |
+LL | }
+   | - value is dropped here
+
+error[E0493]: destructor of `Generic<[T; 0]>` cannot be evaluated at compile-time
+  --> $DIR/issue-65348.rs:15:6
+   |
+LL |     &Generic::<T>::NEWTYPE_ARRAY.0[0]
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constant functions
+LL |
+LL | }
+   | - value is dropped here
+
+error[E0493]: destructor of `Generic<(i32, [T; 0])>` cannot be evaluated at compile-time
+  --> $DIR/issue-65348.rs:20:7
+   |
+LL |     &(Generic::<T>::ARRAY_FIELD.0).1[0]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constant functions
+LL |
+LL | }
+   | - value is dropped here
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0493`.


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/110288#issuecomment-1508445703

an alternative approach where we remove the special-case in `needs_drop` instead of also adding the special-case in `dropck_outlives`.

r? @RalfJung