### PR TITLE
Add the ability to see inherited envs on Command

### DIFF
--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -12,7 +12,7 @@ use crate::ptr;
 use crate::sys::fd::FileDesc;
 use crate::sys::fs::File;
 use crate::sys::pipe::{self, AnonPipe};
-use crate::sys_common::process::{CommandEnv, CommandEnvs};
+use crate::sys_common::process::{CapturedEnvs, CommandEnv, CommandEnvs};
 use crate::sys_common::{FromInner, IntoInner};
 
 #[cfg(not(target_os = "fuchsia"))]
@@ -300,6 +300,10 @@ impl Command {
 
     pub fn get_envs(&self) -> CommandEnvs<'_> {
         self.env.iter()
+    }
+
+    pub fn capture_envs(&self) -> CapturedEnvs {
+        self.env.capture_iter()
     }
 
     pub fn get_current_dir(&self) -> Option<&Path> {

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -26,7 +26,7 @@ use crate::sys::handle::Handle;
 use crate::sys::path;
 use crate::sys::pipe::{self, AnonPipe};
 use crate::sys::stdio;
-use crate::sys_common::process::{CommandEnv, CommandEnvs};
+use crate::sys_common::process::{CapturedEnvs, CommandEnv, CommandEnvs};
 use crate::sys_common::IntoInner;
 
 use core::ffi::c_void;
@@ -242,6 +242,10 @@ impl Command {
 
     pub fn get_envs(&self) -> CommandEnvs<'_> {
         self.env.iter()
+    }
+
+    pub fn capture_envs(&self) -> CapturedEnvs {
+        self.env.capture_iter()
     }
 
     pub fn get_current_dir(&self) -> Option<&Path> {

--- a/library/std/src/sys_common/process.rs
+++ b/library/std/src/sys_common/process.rs
@@ -98,9 +98,43 @@ impl CommandEnv {
         let iter = self.vars.iter();
         CommandEnvs { iter }
     }
+
+    pub fn capture_iter(&self) -> CapturedEnvs {
+        let iter = self.capture().into_iter();
+
+        CapturedEnvs { iter }
+    }
 }
 
-/// An iterator over the command environment variables.
+/// An iterator over captured [`Command`][crate::process::Command] environment variables.
+///
+/// This struct is created by
+/// [`Command::capture_envs`][crate::process::Command::capture_envs]. It includes inherited and
+/// explicitly set environment variables.
+///
+/// See [`Command::capture_envs`][crate::process::Command::capture_envs] documentation for more.
+pub struct CapturedEnvs {
+    iter: crate::collections::btree_map::IntoIter<OsString, OsString>,
+}
+impl Iterator for CapturedEnvs {
+    type Item = (OsString, OsString);
+    fn next(&mut self) -> Option<(OsString, OsString)> {
+        self.iter.next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+/// An iterator over the explicitly set [`Command`][crate::process::Command] environment variables.
+///
+/// Each element is a tuple key/value pair `(&OsStr, Option<&OsStr>)`. A [`None`] value
+/// indicates its key was explicitly removed. The associated key for the [`None`] value will no
+/// longer inherit from its parent process.
+///
+/// Note that this output does not include environment variables inherited from the parent process.
+/// To get the variables that will be set when the child spawns use
+/// [`Command::captured_envs`][crate::process::Command::captured_envs].
 ///
 /// This struct is created by
 /// [`Command::get_envs`][crate::process::Command::get_envs]. See its

--- a/library/std/src/sys_common/process.rs
+++ b/library/std/src/sys_common/process.rs
@@ -114,13 +114,16 @@ impl CommandEnv {
 ///
 /// See [`Command::capture_envs`][crate::process::Command::capture_envs] documentation for more.
 pub struct CapturedEnvs {
-    iter: crate::collections::btree_map::IntoIter<OsString, OsString>,
+    iter: crate::collections::btree_map::IntoIter<EnvKey, OsString>,
 }
+
 impl Iterator for CapturedEnvs {
     type Item = (OsString, OsString);
-    fn next(&mut self) -> Option<(OsString, OsString)> {
-        self.iter.next()
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().into()
     }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }


### PR DESCRIPTION
Add the ability to see inherited envs on Command

This is a reference implementation for one of the solution "sketches" in https://github.com/rust-lang/libs-team/issues/194.

## Problem statement(s)

- Problem 1: Cannot observe effects of `Command::env_clear`
- Problem 2: The "capture" logic has no exposed single source of truth

Problem 1 is a capability problem (I can't work around this). Problem 2 is a usability and stability problem.

### Problem 1: Cannot observe effects of `Command::env_clear`

As documented in [my merged PR](https://github.com/rust-lang/rust/pull/109272), calling `env_clear` will cause the "capture" logic to skip inheriting from the parent process. While a developer can set this value, they cannot programmatically observe if it has been set (though they can manually observe it via "alternative" debug formatting `{:#?}`).

The end goals of programmatically observing that effect is listed below in "Motivation".

This problem prevents me from reproducing the capture logic in a library where I cannot observe if `env_clear` has been called. Even if this problem is solved, a related problem is detailed below.

### Problem 2: The "capture" logic has no exposed single source of truth

Even if we could directly observe the effects of calling `env_clear`, every developer who needed this information would need to reproduce this "capture" logic https://github.com/rust-lang/rust/blob/3a5c8e91f094bb1cb1346651fe3512f0b603d826/library/std/src/sys_common/process.rs#L36-L51 and hope that it does not change or that their implementation does not diverge.

If the outcome of this logic is exposed, then it will:

- Solve problem 1
- Prevent divergent reimplementation of "capture" logic

### [sketch] Expose captured env logic via a new `capture_envs` method on `Command`

We could add a method that exposes that  information directly:

```rust
let command = Command::new("ls");

let envs: HashMap<OsString, OsString> = command.capture_envs().collect();
```

The name `capture` matches internal naming concepts and helps to reinforce that the value method will return a point in time value.

This sketch would solve problems 1 and 2. I'm open to name suggestions.