### PR TITLE
Fix rust-gdb on FreeBSD

### DIFF
--- a/src/etc/rust-gdb
+++ b/src/etc/rust-gdb
@@ -14,7 +14,7 @@ fi
 RUSTC_SYSROOT="$("$RUSTC" --print=sysroot)"
 GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
 # Get the commit hash for path remapping
-RUSTC_COMMIT_HASH="$("$RUSTC" -vV | sed -n 's/commit-hash: \(\w*\)/\1/p')"
+RUSTC_COMMIT_HASH="$("$RUSTC" -vV | sed -n 's/commit-hash: \([a-zA-z0-9_]*\)/\1/p')"
 
 # Run GDB with the additional arguments that load the pretty printers
 # Set the environment variable `RUST_GDB` to overwrite the call to a

--- a/src/etc/rust-gdb
+++ b/src/etc/rust-gdb
@@ -14,7 +14,7 @@ fi
 RUSTC_SYSROOT="$("$RUSTC" --print=sysroot)"
 GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
 # Get the commit hash for path remapping
-RUSTC_COMMIT_HASH="$("$RUSTC" -vV | sed -n 's/commit-hash: \([a-zA-z0-9_]*\)/\1/p')"
+RUSTC_COMMIT_HASH="$("$RUSTC" -vV | sed -n 's/commit-hash: \([a-zA-Z0-9_]*\)/\1/p')"
 
 # Run GDB with the additional arguments that load the pretty printers
 # Set the environment variable `RUST_GDB` to overwrite the call to a

--- a/src/etc/rust-gdbgui
+++ b/src/etc/rust-gdbgui
@@ -43,7 +43,7 @@ fi
 RUSTC_SYSROOT="$("$RUSTC" --print=sysroot)"
 GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
 # Get the commit hash for path remapping
-RUSTC_COMMIT_HASH="$("$RUSTC" -vV | sed -n 's/commit-hash: \(\w*\)/\1/p')"
+RUSTC_COMMIT_HASH="$("$RUSTC" -vV | sed -n 's/commit-hash: \([a-zA-Z0-9_]*\)/\1/p')"
 
 # Set the environment variable `RUST_GDB` to overwrite the call to a
 # different/specific command (defaults to `gdb`).


### PR DESCRIPTION
"\w" is a GNU-specific extension to sed.  Avoid it.

Fixes #110334
Signed-off-by: Alan Somers <asomers@gmail.com>