### PR TITLE
Correct default value for default-linker-libraries

### DIFF
--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -84,8 +84,8 @@ Note: The [`-g` flag][option-g-debug] is an alias for `-C debuginfo=2`.
 This flag controls whether or not the linker includes its default libraries.
 It takes one of the following values:
 
-* `y`, `yes`, `on`, `true` or no value: include default libraries (the default).
-* `n`, `no`, `off` or `false`: exclude default libraries.
+* `y`, `yes`, `on`, `true`: include default libraries.
+* `n`, `no`, `off` or `false` or no value: exclude default libraries (the default).
 
 For example, for gcc flavor linkers, this issues the `-nodefaultlibs` flag to
 the linker.


### PR DESCRIPTION
This setting is false by default according to rustc code here: https://github.com/rust-lang/rust/blob/master/compiler/rustc_session/src/options.rs#L1236

I tested on a project and confirmed the behavior described. First, with no value, the `-nodefaultlibs` linker flag is present. Setting this to false has no effect, as well. The linker flag still appears. Setting it to true removes the linker flag as expected.