### PR TITLE
rustdoc: stop passing a title to `replaceState` second argument

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -275,8 +275,7 @@ function preLoadCss(cssUrl) {
             document.title = searchState.titleBeforeSearch;
             // We also remove the query parameter from the URL.
             if (browserSupportsHistoryApi()) {
-                history.replaceState(null, window.currentCrate + " - Rust",
-                    getNakedUrl() + window.location.hash);
+                history.replaceState(null, "", getNakedUrl() + window.location.hash);
             }
         },
         getQueryStringParams: () => {
@@ -378,8 +377,7 @@ function preLoadCss(cssUrl) {
         searchState.clearInputTimeout();
         switchDisplayedElement(null);
         if (browserSupportsHistoryApi()) {
-            history.replaceState(null, window.currentCrate + " - Rust",
-                getNakedUrl() + window.location.hash);
+            history.replaceState(null, "", getNakedUrl() + window.location.hash);
         }
         ev.preventDefault();
         searchState.defocus();


### PR DESCRIPTION
As described on [MDN's replaceState page], this parameter is not currently used, and the empty string is "safe against future changes to the method."

[MDN's replaceState page]: https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState