### PR TITLE
Replace the `AlignmentEnum16/32/64` types with a single `AlignmentEnum`.

### DIFF
--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -193,136 +193,111 @@ impl hash::Hash for Alignment {
     }
 }
 
-#[cfg(target_pointer_width = "16")]
-type AlignmentEnum = AlignmentEnum16;
-#[cfg(target_pointer_width = "32")]
-type AlignmentEnum = AlignmentEnum32;
-#[cfg(target_pointer_width = "64")]
-type AlignmentEnum = AlignmentEnum64;
+macro_rules! alignment_enum {
+    (
+        $( #[$attrs:meta] )+
+        enum $enum:ident {
+            #[$width16:meta]
+            $( $variant16:ident => $align16:literal, )+
+            #[$width32:meta]
+            $( $variant32:ident => $align32:literal, )+
+            #[$width64:meta]
+            $( $variant64:ident => $align64:literal, )+
+        }
+    ) => {
+        #[$width16]
+        $( #[$attrs] )+
+        enum $enum {
+            $( $variant16 = 1 << $align16, )+
+        }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
-#[repr(u16)]
-enum AlignmentEnum16 {
-    _Align1Shl0 = 1 << 0,
-    _Align1Shl1 = 1 << 1,
-    _Align1Shl2 = 1 << 2,
-    _Align1Shl3 = 1 << 3,
-    _Align1Shl4 = 1 << 4,
-    _Align1Shl5 = 1 << 5,
-    _Align1Shl6 = 1 << 6,
-    _Align1Shl7 = 1 << 7,
-    _Align1Shl8 = 1 << 8,
-    _Align1Shl9 = 1 << 9,
-    _Align1Shl10 = 1 << 10,
-    _Align1Shl11 = 1 << 11,
-    _Align1Shl12 = 1 << 12,
-    _Align1Shl13 = 1 << 13,
-    _Align1Shl14 = 1 << 14,
-    _Align1Shl15 = 1 << 15,
+        #[$width32]
+        $( #[$attrs] )+
+        enum $enum {
+            $( $variant16 = 1 << $align16, )+
+            $( $variant32 = 1 << $align32, )+
+        }
+
+        #[$width64]
+        $( #[$attrs] )+
+        enum $enum {
+            $( $variant16 = 1 << $align16, )+
+            $( $variant32 = 1 << $align32, )+
+            $( $variant64 = 1 << $align64, )+
+        }
+    };
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
-#[repr(u32)]
-enum AlignmentEnum32 {
-    _Align1Shl0 = 1 << 0,
-    _Align1Shl1 = 1 << 1,
-    _Align1Shl2 = 1 << 2,
-    _Align1Shl3 = 1 << 3,
-    _Align1Shl4 = 1 << 4,
-    _Align1Shl5 = 1 << 5,
-    _Align1Shl6 = 1 << 6,
-    _Align1Shl7 = 1 << 7,
-    _Align1Shl8 = 1 << 8,
-    _Align1Shl9 = 1 << 9,
-    _Align1Shl10 = 1 << 10,
-    _Align1Shl11 = 1 << 11,
-    _Align1Shl12 = 1 << 12,
-    _Align1Shl13 = 1 << 13,
-    _Align1Shl14 = 1 << 14,
-    _Align1Shl15 = 1 << 15,
-    _Align1Shl16 = 1 << 16,
-    _Align1Shl17 = 1 << 17,
-    _Align1Shl18 = 1 << 18,
-    _Align1Shl19 = 1 << 19,
-    _Align1Shl20 = 1 << 20,
-    _Align1Shl21 = 1 << 21,
-    _Align1Shl22 = 1 << 22,
-    _Align1Shl23 = 1 << 23,
-    _Align1Shl24 = 1 << 24,
-    _Align1Shl25 = 1 << 25,
-    _Align1Shl26 = 1 << 26,
-    _Align1Shl27 = 1 << 27,
-    _Align1Shl28 = 1 << 28,
-    _Align1Shl29 = 1 << 29,
-    _Align1Shl30 = 1 << 30,
-    _Align1Shl31 = 1 << 31,
-}
-
-#[derive(Copy, Clone, PartialEq, Eq)]
-#[repr(u64)]
-enum AlignmentEnum64 {
-    _Align1Shl0 = 1 << 0,
-    _Align1Shl1 = 1 << 1,
-    _Align1Shl2 = 1 << 2,
-    _Align1Shl3 = 1 << 3,
-    _Align1Shl4 = 1 << 4,
-    _Align1Shl5 = 1 << 5,
-    _Align1Shl6 = 1 << 6,
-    _Align1Shl7 = 1 << 7,
-    _Align1Shl8 = 1 << 8,
-    _Align1Shl9 = 1 << 9,
-    _Align1Shl10 = 1 << 10,
-    _Align1Shl11 = 1 << 11,
-    _Align1Shl12 = 1 << 12,
-    _Align1Shl13 = 1 << 13,
-    _Align1Shl14 = 1 << 14,
-    _Align1Shl15 = 1 << 15,
-    _Align1Shl16 = 1 << 16,
-    _Align1Shl17 = 1 << 17,
-    _Align1Shl18 = 1 << 18,
-    _Align1Shl19 = 1 << 19,
-    _Align1Shl20 = 1 << 20,
-    _Align1Shl21 = 1 << 21,
-    _Align1Shl22 = 1 << 22,
-    _Align1Shl23 = 1 << 23,
-    _Align1Shl24 = 1 << 24,
-    _Align1Shl25 = 1 << 25,
-    _Align1Shl26 = 1 << 26,
-    _Align1Shl27 = 1 << 27,
-    _Align1Shl28 = 1 << 28,
-    _Align1Shl29 = 1 << 29,
-    _Align1Shl30 = 1 << 30,
-    _Align1Shl31 = 1 << 31,
-    _Align1Shl32 = 1 << 32,
-    _Align1Shl33 = 1 << 33,
-    _Align1Shl34 = 1 << 34,
-    _Align1Shl35 = 1 << 35,
-    _Align1Shl36 = 1 << 36,
-    _Align1Shl37 = 1 << 37,
-    _Align1Shl38 = 1 << 38,
-    _Align1Shl39 = 1 << 39,
-    _Align1Shl40 = 1 << 40,
-    _Align1Shl41 = 1 << 41,
-    _Align1Shl42 = 1 << 42,
-    _Align1Shl43 = 1 << 43,
-    _Align1Shl44 = 1 << 44,
-    _Align1Shl45 = 1 << 45,
-    _Align1Shl46 = 1 << 46,
-    _Align1Shl47 = 1 << 47,
-    _Align1Shl48 = 1 << 48,
-    _Align1Shl49 = 1 << 49,
-    _Align1Shl50 = 1 << 50,
-    _Align1Shl51 = 1 << 51,
-    _Align1Shl52 = 1 << 52,
-    _Align1Shl53 = 1 << 53,
-    _Align1Shl54 = 1 << 54,
-    _Align1Shl55 = 1 << 55,
-    _Align1Shl56 = 1 << 56,
-    _Align1Shl57 = 1 << 57,
-    _Align1Shl58 = 1 << 58,
-    _Align1Shl59 = 1 << 59,
-    _Align1Shl60 = 1 << 60,
-    _Align1Shl61 = 1 << 61,
-    _Align1Shl62 = 1 << 62,
-    _Align1Shl63 = 1 << 63,
+alignment_enum! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[repr(usize)]
+    enum AlignmentEnum {
+        #[cfg(target_pointer_width = "16")]
+        _Align1Shl0 => 0,
+        _Align1Shl1 => 1,
+        _Align1Shl2 => 2,
+        _Align1Shl3 => 3,
+        _Align1Shl4 => 4,
+        _Align1Shl5 => 5,
+        _Align1Shl6 => 6,
+        _Align1Shl7 => 7,
+        _Align1Shl8 => 8,
+        _Align1Shl9 => 9,
+        _Align1Shl10 => 10,
+        _Align1Shl11 => 11,
+        _Align1Shl12 => 12,
+        _Align1Shl13 => 13,
+        _Align1Shl14 => 14,
+        _Align1Shl15 => 15,
+        #[cfg(target_pointer_width = "32")]
+        _Align1Shl16 => 16,
+        _Align1Shl17 => 17,
+        _Align1Shl18 => 18,
+        _Align1Shl19 => 19,
+        _Align1Shl20 => 20,
+        _Align1Shl21 => 21,
+        _Align1Shl22 => 22,
+        _Align1Shl23 => 23,
+        _Align1Shl24 => 24,
+        _Align1Shl25 => 25,
+        _Align1Shl26 => 26,
+        _Align1Shl27 => 27,
+        _Align1Shl28 => 28,
+        _Align1Shl29 => 29,
+        _Align1Shl30 => 30,
+        _Align1Shl31 => 31,
+        #[cfg(target_pointer_width = "64")]
+        _Align1Shl32 => 32,
+        _Align1Shl33 => 33,
+        _Align1Shl34 => 34,
+        _Align1Shl35 => 35,
+        _Align1Shl36 => 36,
+        _Align1Shl37 => 37,
+        _Align1Shl38 => 38,
+        _Align1Shl39 => 39,
+        _Align1Shl40 => 40,
+        _Align1Shl41 => 41,
+        _Align1Shl42 => 42,
+        _Align1Shl43 => 43,
+        _Align1Shl44 => 44,
+        _Align1Shl45 => 45,
+        _Align1Shl46 => 46,
+        _Align1Shl47 => 47,
+        _Align1Shl48 => 48,
+        _Align1Shl49 => 49,
+        _Align1Shl50 => 50,
+        _Align1Shl51 => 51,
+        _Align1Shl52 => 52,
+        _Align1Shl53 => 53,
+        _Align1Shl54 => 54,
+        _Align1Shl55 => 55,
+        _Align1Shl56 => 56,
+        _Align1Shl57 => 57,
+        _Align1Shl58 => 58,
+        _Align1Shl59 => 59,
+        _Align1Shl60 => 60,
+        _Align1Shl61 => 61,
+        _Align1Shl62 => 62,
+        _Align1Shl63 => 63,
+    }
 }

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1327,9 +1327,7 @@ impl<T: ?Sized> *const T {
     where
         T: Sized,
     {
-        if !align.is_power_of_two() {
-            panic!("align_offset: align is not a power-of-two");
-        }
+        assert!(align.is_power_of_two(), "align_offset: align is not a power-of-two");
 
         {
             // SAFETY: `align` has been checked to be a power of 2 above
@@ -1562,9 +1560,7 @@ impl<T: ?Sized> *const T {
     #[unstable(feature = "pointer_is_aligned", issue = "96284")]
     #[rustc_const_unstable(feature = "const_pointer_is_aligned", issue = "104203")]
     pub const fn is_aligned_to(self, align: usize) -> bool {
-        if !align.is_power_of_two() {
-            panic!("is_aligned_to: align is not a power-of-two");
-        }
+        assert!(align.is_power_of_two(), "is_aligned_to: align is not a power-of-two");
 
         #[inline]
         fn runtime_impl(ptr: *const (), align: usize) -> bool {

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1593,9 +1593,7 @@ impl<T: ?Sized> *mut T {
     where
         T: Sized,
     {
-        if !align.is_power_of_two() {
-            panic!("align_offset: align is not a power-of-two");
-        }
+        assert!(align.is_power_of_two(), "align_offset: align is not a power-of-two");
 
         {
             // SAFETY: `align` has been checked to be a power of 2 above
@@ -1832,9 +1830,7 @@ impl<T: ?Sized> *mut T {
     #[unstable(feature = "pointer_is_aligned", issue = "96284")]
     #[rustc_const_unstable(feature = "const_pointer_is_aligned", issue = "104203")]
     pub const fn is_aligned_to(self, align: usize) -> bool {
-        if !align.is_power_of_two() {
-            panic!("is_aligned_to: align is not a power-of-two");
-        }
+        assert!(align.is_power_of_two(), "is_aligned_to: align is not a power-of-two");
 
         #[inline]
         fn runtime_impl(ptr: *mut (), align: usize) -> bool {


### PR DESCRIPTION
Replace the `AlignmentEnum16/32/64` types with a single `AlignmentEnum` which is conditionally defined for each pointer width with the use of the `alignment_enum!` macro.