### PR TITLE
Add a UI test for #79605

### DIFF
--- a/tests/ui/generics/issue-79605.rs
+++ b/tests/ui/generics/issue-79605.rs
@@ -1,0 +1,6 @@
+struct X<'a, T>(&'a T);
+
+impl X<'_, _> {}
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for implementations
+
+fn main() {}

--- a/tests/ui/generics/issue-79605.stderr
+++ b/tests/ui/generics/issue-79605.stderr
@@ -1,0 +1,14 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for implementations
+  --> $DIR/issue-79605.rs:3:12
+   |
+LL | impl X<'_, _> {}
+   |            ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL | impl<T> X<'_, T> {}
+   |     +++       ~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
#79605 was fixed somewhere between December 2020 and now, but it did not have a UI test.

This PR adds a UI test for the error.