### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,7 +18,7 @@ Language
 Compiler
 --------
 
-- [Upgrade mingw-w64 on CI to GCC 12.3.](https://github.com/rust-lang/rust/pull/100178/)
+- [Upgrade `*-pc-windows-gnu` on CI to mingw-w64 v10 and GCC 12.2.](https://github.com/rust-lang/rust/pull/100178/)
 - [Rework min_choice algorithm of member constraints.](https://github.com/rust-lang/rust/pull/105300/)
 - [Support `true` and `false` as boolean flags in compiler arguments.](https://github.com/rust-lang/rust/pull/107043/)
 - [Default `repr(C)` enums to `c_int` size.](https://github.com/rust-lang/rust/pull/107592/)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -85,10 +85,10 @@ Compatibility Notes
 - [The `rust-analysis` component from `rustup` now only contains a warning placeholder.](https://github.com/rust-lang/rust/pull/101841/) This was primarily intended for RLS, and the corresponding `-Zsave-analysis` flag has been removed from the compiler as well.
 - [Unaligned references to packed fields are now a hard error.](https://github.com/rust-lang/rust/pull/102513/) This has been a warning since 1.53, and denied by default with a future-compatibility warning since 1.62.
 - [Update the minimum external LLVM to 14.](https://github.com/rust-lang/rust/pull/107573/)
-- [Cargo now emits errors on invalid alphanumeric token for crates.io.](https://github.com/rust-lang/cargo/pull/11600/)
+- [Cargo now emits errors on invalid characters in a registry token.](https://github.com/rust-lang/cargo/pull/11600/)
 - [When `default-features` is set to false of a workspace dependency, and an inherited dependency of a member has `default-features = true`, Cargo will enable default features of that dependency.](https://github.com/rust-lang/cargo/pull/11409/)
-- [Cargo denies `CARGO_HOME` in the `[env]` configuration table. Cargo itself doesn't pick up this value, but recursive calls to cargo will.](https://github.com/rust-lang/cargo/pull/11644/)
-- [Debuginfo for build dependencies is now off if not explicit set. This is expected to boost the overall build time.](https://github.com/rust-lang/cargo/pull/11252/)
+- [Cargo denies `CARGO_HOME` in the `[env]` configuration table. Cargo itself doesn't pick up this value, but recursive calls to cargo would, which was not intended.](https://github.com/rust-lang/cargo/pull/11644/)
+- [Debuginfo for build dependencies is now off if not explicitly set. This is expected to improve the overall build time.](https://github.com/rust-lang/cargo/pull/11252/)
 
 <a id="1.69.0-Internal-Changes"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -61,7 +61,6 @@ These APIs are now stable in const contexts:
 Cargo
 -----
 
-- [Added '-C' flag for changing current dir before build](https://github.com/rust-lang/cargo/pull/10952/)
 - [Cargo now suggests `cargo fix` or `cargo clippy --fix` when compilation warnings are auto-fixable.](https://github.com/rust-lang/cargo/pull/11558/)
 - [Cargo now suggests `cargo add` if you try to install a library crate.](https://github.com/rust-lang/cargo/pull/11410/)
 - [Cargo now sets the `CARGO_BIN_NAME` environment variable also for binary examples.](https://github.com/rust-lang/cargo/pull/11705/)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -99,7 +99,7 @@ These changes do not affect any public interfaces of Rust, but they represent
 significant improvements to the performance or internals of rustc and related
 tools.
 
-- [Move format_args!() into AST (and expand it during AST lowering)](https://github.com/rust-lang/rust/pull/106745/)
+- [Move `format_args!()` into AST (and expand it during AST lowering)](https://github.com/rust-lang/rust/pull/106745/)
 
 Version 1.68.2 (2023-03-28)
 ===========================

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -64,7 +64,7 @@ Cargo
 - [Added '-C' flag for changing current dir before build](https://github.com/rust-lang/cargo/pull/10952/)
 - [Cargo now suggests `cargo fix` or `cargo clippy --fix` when compilation warnings are auto-fixable.](https://github.com/rust-lang/cargo/pull/11558/)
 - [Cargo now suggests `cargo add` if you try to install a library crate.](https://github.com/rust-lang/cargo/pull/11410/)
-- [Cargo now sets `CARGO_BIN_NAME` environment variable also for binary examples.](https://github.com/rust-lang/cargo/pull/11705/)
+- [Cargo now sets the `CARGO_BIN_NAME` environment variable also for binary examples.](https://github.com/rust-lang/cargo/pull/11705/)
 
 <a id="1.69.0-Rustdoc"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,112 @@
+Version 1.69.0 (2023-04-20)
+==========================
+
+<a id="1.69.0-Language"></a>
+
+Language
+--------
+
+- [Deriving built-in traits on packed structs works with `Copy` fields.](https://github.com/rust-lang/rust/pull/104429/)
+- [Stabilize the `cmpxchg16b` target feature on x86 and x86_64.](https://github.com/rust-lang/rust/pull/106774/)
+- [Add normalization to satisfy trait bounds involving type projections.](https://github.com/rust-lang/rust/pull/103695/)
+- [Add normalization that allows type projections in union fields.](https://github.com/rust-lang/rust/pull/106938/)
+- [Allow `Self: Autotrait` bounds on dyn-safe trait methods.](https://github.com/rust-lang/rust/pull/107082/)
+- [Treat `str` as containing `[u8]` for auto trait purposes.](https://github.com/rust-lang/rust/pull/107941/)
+
+<a id="1.69.0-Compiler"></a>
+
+Compiler
+--------
+
+- [Upgrade mingw-w64 on CI to GCC 12.3.](https://github.com/rust-lang/rust/pull/100178/)
+- [Rework min_choice algorithm of member constraints.](https://github.com/rust-lang/rust/pull/105300/)
+- [Support `true` and `false` as boolean flags in compiler arguments.](https://github.com/rust-lang/rust/pull/107043/)
+- [Default `repr(C)` enums to `c_int` size.](https://github.com/rust-lang/rust/pull/107592/)
+
+<a id="1.69.0-Libraries"></a>
+
+Libraries
+---------
+
+- [Implement the unstable `DispatchFromDyn` for cell types, allowing downstream experimentation with custom method receivers.](https://github.com/rust-lang/rust/pull/97373/)
+- [Document that `fmt::Arguments::as_str()` may return `Some(_)` in more cases after optimization, subject to change.](https://github.com/rust-lang/rust/pull/106823/)
+- [Implement `AsFd` and `AsRawFd` for `Rc`.](https://github.com/rust-lang/rust/pull/107317/)
+- [Move `IpAddr`, `SocketAddr` and V4+V6 related types to `core`](https://github.com/rust-lang/rust/pull/104265/)
+
+<a id="1.69.0-Stabilized-APIs"></a>
+
+Stabilized APIs
+---------------
+
+- [`CStr::from_bytes_until_nul`](https://doc.rust-lang.org/stable/core/ffi/struct.CStr.html#method.from_bytes_until_nul)
+- [`core::ffi::FromBytesUntilNulError`](https://doc.rust-lang.org/stable/core/ffi/struct.FromBytesUntilNulError.html)
+
+These APIs are now stable in const contexts:
+
+- [`SocketAddr::new`](https://doc.rust-lang.org/stable/std/net/enum.SocketAddr.html#method.new)
+- [`SocketAddr::ip`](https://doc.rust-lang.org/stable/std/net/enum.SocketAddr.html#method.ip)
+- [`SocketAddr::port`](https://doc.rust-lang.org/stable/std/net/enum.SocketAddr.html#method.port)
+- [`SocketAddr::is_ipv4`](https://doc.rust-lang.org/stable/std/net/enum.SocketAddr.html#method.is_ipv4)
+- [`SocketAddr::is_ipv6`](https://doc.rust-lang.org/stable/std/net/enum.SocketAddr.html#method.is_ipv6)
+- [`SocketAddrV4::new`](https://doc.rust-lang.org/stable/std/net/struct.SocketAddrV4.html#method.new)
+- [`SocketAddrV4::ip`](https://doc.rust-lang.org/stable/std/net/struct.SocketAddrV4.html#method.ip)
+- [`SocketAddrV4::port`](https://doc.rust-lang.org/stable/std/net/struct.SocketAddrV4.html#method.port)
+- [`SocketAddrV6::new`](https://doc.rust-lang.org/stable/std/net/struct.SocketAddrV6.html#method.new)
+- [`SocketAddrV6::ip`](https://doc.rust-lang.org/stable/std/net/struct.SocketAddrV6.html#method.ip)
+- [`SocketAddrV6::port`](https://doc.rust-lang.org/stable/std/net/struct.SocketAddrV6.html#method.port)
+- [`SocketAddrV6::flowinfo`](https://doc.rust-lang.org/stable/std/net/struct.SocketAddrV6.html#method.flowinfo)
+- [`SocketAddrV6::scope_id`](https://doc.rust-lang.org/stable/std/net/struct.SocketAddrV6.html#method.scope_id)
+
+<a id="1.69.0-Cargo"></a>
+
+Cargo
+-----
+
+- [Added '-C' flag for changing current dir before build](https://github.com/rust-lang/cargo/pull/10952/)
+- [Cargo now suggests `cargo fix` or `cargo clippy --fix` when compilation warnings/errors are auto-fixable.](https://github.com/rust-lang/cargo/pull/11558/)
+- [Cargo now suggests `cargo add` if you try to install a library crate.](https://github.com/rust-lang/cargo/pull/11410/)
+- [Cargo now sets `CARGO_BIN_NAME` environment variable also for binary examples.](https://github.com/rust-lang/cargo/pull/11705/)
+
+<a id="1.69.0-Rustdoc"></a>
+
+Rustdoc
+-----
+
+- [Vertically compact trait bound formatting.](https://github.com/rust-lang/rust/pull/102842/)
+- [Only include stable lints in `rustdoc::all` group.](https://github.com/rust-lang/rust/pull/106316/)
+- [Compute maximum Levenshtein distance based on the query.](https://github.com/rust-lang/rust/pull/107141/)
+- [Remove inconsistently-present sidebar tooltips.](https://github.com/rust-lang/rust/pull/107490/)
+- [Search by macro when query ends with `!`.](https://github.com/rust-lang/rust/pull/108143/)
+
+<a id="1.69.0-Misc"></a>
+
+Misc
+----
+
+<a id="1.69.0-Compatibility-Notes"></a>
+
+Compatibility Notes
+-------------------
+
+- [Remove `-Zsave-analysis` from the compiler, which was primarily intended for RLS.](https://github.com/rust-lang/rust/pull/101841/) The `rust-analysis` component from `rustup` now only contains a warning placeholder.
+- [Unaligned references to packed fields are now a hard error.](https://github.com/rust-lang/rust/pull/102513/) This has been a warning since 1.53, and denied by default with a future-compatibility warning since 1.62.
+- [Update the minimum external LLVM to 14.](https://github.com/rust-lang/rust/pull/107573/)
+- [Cargo now emits errors on invalid alphanumeric token for crates.io.](https://github.com/rust-lang/cargo/pull/11600/)
+- [When `default-features` is set to false of a workspace dependency, and an inherited dependency of a member has `default-features = true`, Cargo will enable default features of that dependency.](https://github.com/rust-lang/cargo/pull/11409/)
+- [Cargo denies `CARGO_HOME` in the `[env]` configuration table. Cargo itself doesn't pick up this value, but recursive calls to cargo will.](https://github.com/rust-lang/cargo/pull/11644/)
+- [Debuginfo for build dependencies is now off if not explicit set. This is expected to boost the overall build time.](https://github.com/rust-lang/cargo/pull/11252/)
+
+<a id="1.69.0-Internal-Changes"></a>
+
+Internal Changes
+----------------
+
+These changes do not affect any public interfaces of Rust, but they represent
+significant improvements to the performance or internals of rustc and related
+tools.
+
+- [Move format_args!() into AST (and expand it during AST lowering)](https://github.com/rust-lang/rust/pull/106745/)
+
 Version 1.68.2 (2023-03-28)
 ===========================
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,8 +8,8 @@ Language
 
 - [Deriving built-in traits on packed structs works with `Copy` fields.](https://github.com/rust-lang/rust/pull/104429/)
 - [Stabilize the `cmpxchg16b` target feature on x86 and x86_64.](https://github.com/rust-lang/rust/pull/106774/)
-- [Add normalization to satisfy trait bounds involving type projections.](https://github.com/rust-lang/rust/pull/103695/)
-- [Add normalization that allows type projections in union fields.](https://github.com/rust-lang/rust/pull/106938/)
+- [Improve analysis of trait bounds for associated types.](https://github.com/rust-lang/rust/pull/103695/)
+- [Allow associated types to be used as union fields.](https://github.com/rust-lang/rust/pull/106938/)
 - [Allow `Self: Autotrait` bounds on dyn-safe trait methods.](https://github.com/rust-lang/rust/pull/107082/)
 - [Treat `str` as containing `[u8]` for auto trait purposes.](https://github.com/rust-lang/rust/pull/107941/)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -63,7 +63,7 @@ Cargo
 -----
 
 - [Added '-C' flag for changing current dir before build](https://github.com/rust-lang/cargo/pull/10952/)
-- [Cargo now suggests `cargo fix` or `cargo clippy --fix` when compilation warnings/errors are auto-fixable.](https://github.com/rust-lang/cargo/pull/11558/)
+- [Cargo now suggests `cargo fix` or `cargo clippy --fix` when compilation warnings are auto-fixable.](https://github.com/rust-lang/cargo/pull/11558/)
 - [Cargo now suggests `cargo add` if you try to install a library crate.](https://github.com/rust-lang/cargo/pull/11410/)
 - [Cargo now sets `CARGO_BIN_NAME` environment variable also for binary examples.](https://github.com/rust-lang/cargo/pull/11705/)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -77,11 +77,6 @@ Rustdoc
 - [Remove inconsistently-present sidebar tooltips.](https://github.com/rust-lang/rust/pull/107490/)
 - [Search by macro when query ends with `!`.](https://github.com/rust-lang/rust/pull/108143/)
 
-<a id="1.69.0-Misc"></a>
-
-Misc
-----
-
 <a id="1.69.0-Compatibility-Notes"></a>
 
 Compatibility Notes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -31,7 +31,6 @@ Libraries
 - [Implement the unstable `DispatchFromDyn` for cell types, allowing downstream experimentation with custom method receivers.](https://github.com/rust-lang/rust/pull/97373/)
 - [Document that `fmt::Arguments::as_str()` may return `Some(_)` in more cases after optimization, subject to change.](https://github.com/rust-lang/rust/pull/106823/)
 - [Implement `AsFd` and `AsRawFd` for `Rc`.](https://github.com/rust-lang/rust/pull/107317/)
-- [Move `IpAddr`, `SocketAddr` and V4+V6 related types to `core`](https://github.com/rust-lang/rust/pull/104265/)
 
 <a id="1.69.0-Stabilized-APIs"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -87,7 +87,7 @@ Misc
 Compatibility Notes
 -------------------
 
-- [Remove `-Zsave-analysis` from the compiler, which was primarily intended for RLS.](https://github.com/rust-lang/rust/pull/101841/) The `rust-analysis` component from `rustup` now only contains a warning placeholder.
+- [The `rust-analysis` component from `rustup` now only contains a warning placeholder.](https://github.com/rust-lang/rust/pull/101841/) This was primarily intended for RLS, and the corresponding `-Zsave-analysis` flag has been removed from the compiler as well.
 - [Unaligned references to packed fields are now a hard error.](https://github.com/rust-lang/rust/pull/102513/) This has been a warning since 1.53, and denied by default with a future-compatibility warning since 1.62.
 - [Update the minimum external LLVM to 14.](https://github.com/rust-lang/rust/pull/107573/)
 - [Cargo now emits errors on invalid alphanumeric token for crates.io.](https://github.com/rust-lang/cargo/pull/11600/)

--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -56,11 +56,12 @@ impl<'a, 'tcx: 'a> InferCtxtExt<'a, 'tcx> for InferCtxt<'tcx> {
         let ty = self.resolve_vars_if_possible(ty);
         let ty = OpportunisticRegionResolver::new(self).fold_ty(ty);
 
-        // We must avoid processing constrained lifetime variables in implied
+        // We must avoid processing unconstrained lifetime variables in implied
         // bounds. See #110161 for context.
+        assert!(!ty.has_non_region_infer());
         if ty.needs_infer() {
             self.tcx.sess.delay_span_bug(
-                self.tcx.source_span_untracked(body_id),
+                self.tcx.def_span(body_id),
                 "skipped implied_outlives_bounds due to unconstrained lifetimes",
             );
             return vec![];

--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -56,8 +56,9 @@ impl<'a, 'tcx: 'a> InferCtxtExt<'a, 'tcx> for InferCtxt<'tcx> {
         let ty = self.resolve_vars_if_possible(ty);
         let ty = OpportunisticRegionResolver::new(self).fold_ty(ty);
 
-        // We must avoid processing unconstrained lifetime variables in implied
-        // bounds. See #110161 for context.
+        // We do not expect existential variables in implied bounds.
+        // We may however encounter unconstrained lifetime variables in invalid
+        // code. See #110161 for context.
         assert!(!ty.has_non_region_infer());
         if ty.needs_infer() {
             self.tcx.sess.delay_span_bug(

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -170,7 +170,7 @@ pub fn forget_unsized<T: ?Sized>(t: T) {
 ///
 /// The following table gives the size for primitives.
 ///
-/// Type | size_of::\<Type>()
+/// Type | `size_of::<Type>()`
 /// ---- | ---------------
 /// () | 0
 /// bool | 1
@@ -190,8 +190,8 @@ pub fn forget_unsized<T: ?Sized>(t: T) {
 ///
 /// Furthermore, `usize` and `isize` have the same size.
 ///
-/// The types `*const T`, `&T`, `Box<T>`, `Option<&T>`, and `Option<Box<T>>` all have
-/// the same size. If `T` is Sized, all of those types have the same size as `usize`.
+/// The types [`*const T`], `&T`, [`Box<T>`], [`Option<&T>`], and `Option<Box<T>>` all have
+/// the same size. If `T` is `Sized`, all of those types have the same size as `usize`.
 ///
 /// The mutability of a pointer does not change its size. As such, `&T` and `&mut T`
 /// have the same size. Likewise for `*const T` and `*mut T`.
@@ -203,7 +203,7 @@ pub fn forget_unsized<T: ?Sized>(t: T) {
 ///
 /// ## Size of Structs
 ///
-/// For `structs`, the size is determined by the following algorithm.
+/// For `struct`s, the size is determined by the following algorithm.
 ///
 /// For each field in the struct ordered by declaration order:
 ///
@@ -299,6 +299,10 @@ pub fn forget_unsized<T: ?Sized>(t: T) {
 /// ```
 ///
 /// [alignment]: align_of
+/// [`*const T`]: primitive@pointer
+/// [`Box<T>`]: ../../std/boxed/struct.Box.html
+/// [`Option<&T>`]: crate::option::Option
+///
 #[inline(always)]
 #[must_use]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -311,7 +315,7 @@ pub const fn size_of<T>() -> usize {
 
 /// Returns the size of the pointed-to value in bytes.
 ///
-/// This is usually the same as `size_of::<T>()`. However, when `T` *has* no
+/// This is usually the same as [`size_of::<T>()`]. However, when `T` *has* no
 /// statically-known size, e.g., a slice [`[T]`][slice] or a [trait object],
 /// then `size_of_val` can be used to get the dynamically-known size.
 ///
@@ -328,6 +332,8 @@ pub const fn size_of<T>() -> usize {
 /// let y: &[u8] = &x;
 /// assert_eq!(13, mem::size_of_val(y));
 /// ```
+///
+/// [`size_of::<T>()`]: size_of
 #[inline]
 #[must_use]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -340,7 +346,7 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 
 /// Returns the size of the pointed-to value in bytes.
 ///
-/// This is usually the same as `size_of::<T>()`. However, when `T` *has* no
+/// This is usually the same as [`size_of::<T>()`]. However, when `T` *has* no
 /// statically-known size, e.g., a slice [`[T]`][slice] or a [trait object],
 /// then `size_of_val_raw` can be used to get the dynamically-known size.
 ///
@@ -363,6 +369,7 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 ///       [`size_of_val`] on a reference to a type with an extern type tail.
 ///     - otherwise, it is conservatively not allowed to call this function.
 ///
+/// [`size_of::<T>()`]: size_of
 /// [trait object]: ../../book/ch17-02-trait-objects.html
 /// [extern type]: ../../unstable-book/language-features/extern-types.html
 ///

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1009,7 +1009,9 @@ impl Config {
         });
         config.initial_cargo = build
             .cargo
-            .map(PathBuf::from)
+            .map(|cargo| {
+                t!(PathBuf::from(cargo).canonicalize(), "`initial_cargo` not found on disk")
+            })
             .unwrap_or_else(|| config.out.join(config.build.triple).join("stage0/bin/cargo"));
 
         // NOTE: it's important this comes *after* we set `initial_rustc` just above.

--- a/tests/ui/generics/issue-79605.rs
+++ b/tests/ui/generics/issue-79605.rs
@@ -1,0 +1,6 @@
+struct X<'a, T>(&'a T);
+
+impl X<'_, _> {}
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for implementations
+
+fn main() {}

--- a/tests/ui/generics/issue-79605.stderr
+++ b/tests/ui/generics/issue-79605.stderr
@@ -1,0 +1,14 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for implementations
+  --> $DIR/issue-79605.rs:3:12
+   |
+LL | impl X<'_, _> {}
+   |            ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL | impl<T> X<'_, T> {}
+   |     +++       ~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/implied-bounds/issue-110161.rs
+++ b/tests/ui/implied-bounds/issue-110161.rs
@@ -1,0 +1,24 @@
+// ICE regression relating to unconstrained lifetimes in implied
+// bounds. See #110161.
+
+// compile-flags: --crate-type=lib
+
+trait Trait {
+    type Ty;
+}
+
+// erroneous `Ty` impl
+impl Trait for () {
+//~^ ERROR not all trait items implemented, missing: `Ty` [E0046]
+}
+
+// `'lt` is not constrained by the erroneous `Ty`
+impl<'lt, T> Trait for Box<T>
+where
+    T: Trait<Ty = &'lt ()>,
+{
+    type Ty = &'lt ();
+}
+
+// unconstrained lifetime appears in implied bounds
+fn test(_: <Box<()> as Trait>::Ty) {}

--- a/tests/ui/implied-bounds/issue-110161.rs
+++ b/tests/ui/implied-bounds/issue-110161.rs
@@ -3,22 +3,24 @@
 
 // compile-flags: --crate-type=lib
 
-trait Trait {
+trait LtTrait {
     type Ty;
 }
 
 // erroneous `Ty` impl
-impl Trait for () {
+impl LtTrait for () {
 //~^ ERROR not all trait items implemented, missing: `Ty` [E0046]
 }
 
 // `'lt` is not constrained by the erroneous `Ty`
-impl<'lt, T> Trait for Box<T>
+impl<'lt, T> LtTrait for Box<T>
 where
-    T: Trait<Ty = &'lt ()>,
+    T: LtTrait<Ty = &'lt ()>,
 {
     type Ty = &'lt ();
 }
 
 // unconstrained lifetime appears in implied bounds
-fn test(_: <Box<()> as Trait>::Ty) {}
+fn test(_: <Box<()> as LtTrait>::Ty) {}
+
+fn test2<'x>(_: &'x <Box<()> as LtTrait>::Ty) {}

--- a/tests/ui/implied-bounds/issue-110161.stderr
+++ b/tests/ui/implied-bounds/issue-110161.stderr
@@ -1,0 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `Ty`
+  --> $DIR/issue-110161.rs:11:1
+   |
+LL |     type Ty;
+   |     ------- `Ty` from trait
+...
+LL | impl Trait for () {
+   | ^^^^^^^^^^^^^^^^^ missing `Ty` in implementation
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0046`.

--- a/tests/ui/implied-bounds/issue-110161.stderr
+++ b/tests/ui/implied-bounds/issue-110161.stderr
@@ -4,8 +4,8 @@ error[E0046]: not all trait items implemented, missing: `Ty`
 LL |     type Ty;
    |     ------- `Ty` from trait
 ...
-LL | impl Trait for () {
-   | ^^^^^^^^^^^^^^^^^ missing `Ty` in implementation
+LL | impl LtTrait for () {
+   | ^^^^^^^^^^^^^^^^^^^ missing `Ty` in implementation
 
 error: aborting due to previous error
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -11,6 +11,7 @@ allow-unauthenticated = [
     "S-*",
     "T-*",
     "WG-*",
+    "beta-nominated",
     "const-hack",
     "llvm-main",
     "needs-fcp",
@@ -470,8 +471,8 @@ cc = ["@rust-lang/style"]
 
 [mentions."Cargo.lock"]
 message = """
-These commits modify the `Cargo.lock` file. Random changes to `Cargo.lock` can be introduced when switching branches and rebasing PRs. 
-This was probably unintentional and should be reverted before this PR is merged. 
+These commits modify the `Cargo.lock` file. Random changes to `Cargo.lock` can be introduced when switching branches and rebasing PRs.
+This was probably unintentional and should be reverted before this PR is merged.
 
 If this was intentional then you can ignore this comment.
 """


### PR DESCRIPTION
Successful merges:

 - #110033 (Add 1.69.0 release notes)
 - #110272 (fix: skip implied bounds if unconstrained lifetime exists)
 - #110307 (Allow everyone to set the beta-nominated label)
 - #110347 (Add intra-doc links to size_of_* functions)
 - #110350 (Add a UI test for #79605)
 - #110356 (Fix `x test rust-installer` when `cargo` is set to a relative path)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=110033,110272,110307,110347,110350,110356)
<!-- homu-ignore:end -->