### PR TITLE
Remove some suspicious cast truncations

### DIFF
--- a/compiler/rustc_data_structures/src/svh.rs
+++ b/compiler/rustc_data_structures/src/svh.rs
@@ -5,58 +5,36 @@
 //! mismatches where we have two versions of the same crate that were
 //! compiled from distinct sources.
 
-use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+use crate::fingerprint::Fingerprint;
 use std::fmt;
-use std::hash::{Hash, Hasher};
 
 use crate::stable_hasher;
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Encodable, Decodable, Hash)]
 pub struct Svh {
-    hash: u64,
+    hash: Fingerprint,
 }
 
 impl Svh {
     /// Creates a new `Svh` given the hash. If you actually want to
     /// compute the SVH from some HIR, you want the `calculate_svh`
     /// function found in `rustc_incremental`.
-    pub fn new(hash: u64) -> Svh {
+    pub fn new(hash: Fingerprint) -> Svh {
         Svh { hash }
     }
 
     pub fn as_u64(&self) -> u64 {
-        self.hash
+        self.hash.to_smaller_hash()
     }
 
     pub fn to_string(&self) -> String {
-        format!("{:016x}", self.hash)
-    }
-}
-
-impl Hash for Svh {
-    fn hash<H>(&self, state: &mut H)
-    where
-        H: Hasher,
-    {
-        self.hash.to_le().hash(state);
+        format!("{:016x}", self.hash.to_smaller_hash())
     }
 }
 
 impl fmt::Display for Svh {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad(&self.to_string())
-    }
-}
-
-impl<S: Encoder> Encodable<S> for Svh {
-    fn encode(&self, s: &mut S) {
-        s.emit_u64(self.as_u64().to_le());
-    }
-}
-
-impl<D: Decoder> Decodable<D> for Svh {
-    fn decode(d: &mut D) -> Svh {
-        Svh::new(u64::from_le(d.read_u64()))
     }
 }
 

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -1199,7 +1199,7 @@ pub(super) fn crate_hash(tcx: TyCtxt<'_>, _: LocalCrate) -> Svh {
         stable_hasher.finish()
     });
 
-    Svh::new(crate_hash.to_smaller_hash())
+    Svh::new(crate_hash)
 }
 
 fn upstream_crates(tcx: TyCtxt<'_>) -> Vec<(StableCrateId, Svh)> {

--- a/compiler/rustc_query_system/src/ich/impls_syntax.rs
+++ b/compiler/rustc_query_system/src/ich/impls_syntax.rs
@@ -75,7 +75,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for SourceFile {
             ref normalized_pos,
         } = *self;
 
-        (name_hash as u64).hash_stable(hcx, hasher);
+        name_hash.hash_stable(hcx, hasher);
 
         src_hash.hash_stable(hcx, hasher);
 

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -2159,9 +2159,7 @@ where
         };
 
         Hash::hash(&TAG_VALID_SPAN, hasher);
-        // We truncate the stable ID hash and line and column numbers. The chances
-        // of causing a collision this way should be minimal.
-        Hash::hash(&(file.name_hash as u64), hasher);
+        Hash::hash(&file.name_hash, hasher);
 
         // Hash both the length and the end location (line/column) of a span. If we
         // hash only the length, for example, then two otherwise equal spans with


### PR DESCRIPTION
These truncations were added a long time ago, and as best I can tell without a perf justification. And with rust-lang/rust#110410 it has become perf-neutral to not truncate anymore. We worked hard for all these bits, let's use them.