### PR TITLE
Update max_atomic_width of armv7r and armv7_sony_vita targets to 64.

### DIFF
--- a/compiler/rustc_target/src/spec/armebv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armebv7r_none_eabi.rs
@@ -16,7 +16,7 @@ pub fn target() -> Target {
             linker: Some("rust-lld".into()),
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
-            max_atomic_width: Some(32),
+            max_atomic_width: Some(64),
             emit_debug_gdb_scripts: false,
             // GCC and Clang default to 8 for arm-none here
             c_enum_min_bits: Some(8),

--- a/compiler/rustc_target/src/spec/armebv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armebv7r_none_eabihf.rs
@@ -17,7 +17,7 @@ pub fn target() -> Target {
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
             features: "+vfp3,-d32,-fp16".into(),
-            max_atomic_width: Some(32),
+            max_atomic_width: Some(64),
             emit_debug_gdb_scripts: false,
             // GCC and Clang default to 8 for arm-none here
             c_enum_min_bits: Some(8),

--- a/compiler/rustc_target/src/spec/armv7_sony_vita_newlibeabihf.rs
+++ b/compiler/rustc_target/src/spec/armv7_sony_vita_newlibeabihf.rs
@@ -33,7 +33,7 @@ pub fn target() -> Target {
             pre_link_args,
             exe_suffix: ".elf".into(),
             panic_strategy: PanicStrategy::Abort,
-            max_atomic_width: Some(32),
+            max_atomic_width: Some(64),
             ..Default::default()
         },
     }

--- a/compiler/rustc_target/src/spec/armv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv7r_none_eabi.rs
@@ -15,7 +15,7 @@ pub fn target() -> Target {
             linker: Some("rust-lld".into()),
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
-            max_atomic_width: Some(32),
+            max_atomic_width: Some(64),
             emit_debug_gdb_scripts: false,
             // GCC and Clang default to 8 for arm-none here
             c_enum_min_bits: Some(8),

--- a/compiler/rustc_target/src/spec/armv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armv7r_none_eabihf.rs
@@ -16,7 +16,7 @@ pub fn target() -> Target {
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
             features: "+vfp3,-d32,-fp16".into(),
-            max_atomic_width: Some(32),
+            max_atomic_width: Some(64),
             emit_debug_gdb_scripts: false,
             // GCC and Clang default to 8 for arm-none here
             c_enum_min_bits: Some(8),


### PR DESCRIPTION
All armv7a and armv7r implementations support `ldrexd`/`strexd`, only armv7m does not.