### PR TITLE
[RFC-2011] Expand `matches!`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1291,6 +1291,7 @@ impl Expr {
             ExprKind::Struct(..) => ExprPrecedence::Struct,
             ExprKind::Repeat(..) => ExprPrecedence::Repeat,
             ExprKind::Paren(..) => ExprPrecedence::Paren,
+            ExprKind::Matches(..) => ExprPrecedence::Matches,
             ExprKind::Try(..) => ExprPrecedence::Try,
             ExprKind::Yield(..) => ExprPrecedence::Yield,
             ExprKind::Yeet(..) => ExprPrecedence::Yeet,
@@ -1487,6 +1488,9 @@ pub enum ExprKind {
 
     /// Output of the `offset_of!()` macro.
     OffsetOf(P<Ty>, P<[Ident]>),
+
+    /// Output of the `matches!()` macro.
+    Matches(P<Expr>, P<Arm>, P<Arm>),
 
     /// A macro invocation; pre-expansion.
     MacCall(P<MacCall>),

--- a/compiler/rustc_ast/src/util/parser.rs
+++ b/compiler/rustc_ast/src/util/parser.rs
@@ -267,6 +267,7 @@ pub enum ExprPrecedence {
     InlineAsm,
     OffsetOf,
     Mac,
+    Matches,
     FormatArgs,
 
     Array,
@@ -329,6 +330,7 @@ impl ExprPrecedence {
             | ExprPrecedence::Field
             | ExprPrecedence::Index
             | ExprPrecedence::Try
+            | ExprPrecedence::Matches
             | ExprPrecedence::InlineAsm
             | ExprPrecedence::Mac
             | ExprPrecedence::FormatArgs

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -803,6 +803,11 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
             visitor.visit_expr(callee_expression);
             walk_list!(visitor, visit_expr, arguments);
         }
+        ExprKind::Matches(expr, true_arm, false_arm) => {
+            visitor.visit_expr(expr);
+            visitor.visit_arm(true_arm);
+            visitor.visit_arm(false_arm);
+        }
         ExprKind::MethodCall(box MethodCall { seg, receiver, args, span: _ }) => {
             visitor.visit_path_segment(seg);
             visitor.visit_expr(receiver);

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -274,6 +274,13 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 ExprKind::InlineAsm(asm) => {
                     hir::ExprKind::InlineAsm(self.lower_inline_asm(e.span, asm))
                 }
+                ExprKind::Matches(expr, true_arm, false_arm) => hir::ExprKind::Match(
+                    self.lower_expr(expr),
+                    self.arena.alloc_from_iter(
+                        [true_arm, false_arm].iter().map(|elem| self.lower_arm(elem)),
+                    ),
+                    hir::MatchSource::Normal,
+                ),
                 ExprKind::FormatArgs(fmt) => self.lower_format_args(e.span, fmt),
                 ExprKind::OffsetOf(container, fields) => hir::ExprKind::OffsetOf(
                     self.lower_ty(

--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -555,6 +555,20 @@ impl<'a> State<'a> {
                 self.end();
                 self.pclose();
             }
+            ast::ExprKind::Matches(expr, true_arm, _) => {
+                self.word("builtin # matches");
+                self.popen();
+                self.rbox(0, Inconsistent);
+                self.print_expr(expr);
+                self.word(", ");
+                self.print_pat(&true_arm.pat);
+                if let Some(elem) = &true_arm.guard {
+                    self.word("if");
+                    self.print_expr(elem);
+                }
+                self.pclose();
+                self.end();
+            }
             ast::ExprKind::OffsetOf(container, fields) => {
                 self.word("builtin # offset_of");
                 self.popen();

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3377,7 +3377,7 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, P<Expr>> {
         self.collect_tokens_trailing_token(attrs, ForceCollect::No, |this, attrs| {
             let res = f(this, attrs)?;
-            let trailing = if this.restrictions.contains(Restrictions::STMT_EXPRPAr)
+            let trailing = if this.restrictions.contains(Restrictions::STMT_EXPR)
                 && this.token.kind == token::Semi
             {
                 TrailingToken::Semi

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -569,7 +569,8 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
                 Array, ConstBlock, Call, MethodCall, Tup, Binary, Unary, Lit, Cast, Type, Let,
                 If, While, ForLoop, Loop, Match, Closure, Block, Async, Await, TryBlock, Assign,
                 AssignOp, Field, Index, Range, Underscore, Path, AddrOf, Break, Continue, Ret,
-                InlineAsm, FormatArgs, OffsetOf, MacCall, Struct, Repeat, Paren, Try, Yield, Yeet, IncludedBytes, Err
+                InlineAsm, FormatArgs, OffsetOf, MacCall, Struct, Repeat, Paren, Try, Yield, Yeet, IncludedBytes, Err,
+                Matches
             ]
         );
         ast_visit::walk_expr(self, e)

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -923,6 +923,7 @@ symbols! {
         masked,
         match_beginning_vert,
         match_default_bindings,
+        matches,
         matches_macro,
         maxnumf32,
         maxnumf64,

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -336,15 +336,41 @@ pub macro debug_assert_matches($($arg:tt)*) {
 /// let bar = Some(4);
 /// assert!(matches!(bar, Some(x) if x > 2));
 /// ```
+#[cfg(bootstrap)]
+#[cfg_attr(not(test), rustc_diagnostic_item = "matches_macro")]
 #[macro_export]
 #[stable(feature = "matches_macro", since = "1.42.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "matches_macro")]
 macro_rules! matches {
     ($expression:expr, $pattern:pat $(if $guard:expr)? $(,)?) => {
         match $expression {
             $pattern $(if $guard)? => true,
             _ => false
         }
+    };
+}
+
+/// Returns whether the given expression matches any of the given patterns.
+///
+/// Like in a `match` expression, the pattern can be optionally followed by `if`
+/// and a guard expression that has access to names bound by the pattern.
+///
+/// # Examples
+///
+/// ```
+/// let foo = 'f';
+/// assert!(matches!(foo, 'A'..='Z' | 'a'..='z'));
+///
+/// let bar = Some(4);
+/// assert!(matches!(bar, Some(x) if x > 2));
+/// ```
+#[allow_internal_unstable(builtin_syntax)]
+#[cfg(not(bootstrap))]
+#[cfg_attr(not(test), rustc_diagnostic_item = "matches_macro")]
+#[macro_export]
+#[stable(feature = "matches_macro", since = "1.42.0")]
+macro_rules! matches {
+    ($expression:expr, $pattern:pat $(if $guard:expr)? $(,)?) => {
+        builtin # matches($expression, $pattern $(if $guard)?)
     };
 }
 
@@ -782,7 +808,6 @@ macro_rules! todo {
 /// with exception of expansion functions transforming macro inputs into outputs,
 /// those functions are provided by the compiler.
 pub(crate) mod builtin {
-
     /// Causes compilation to fail with the given error message when encountered.
     ///
     /// This macro should be used when a crate uses a conditional compilation strategy to provide

--- a/src/tools/clippy/clippy_utils/src/sugg.rs
+++ b/src/tools/clippy/clippy_utils/src/sugg.rs
@@ -217,6 +217,7 @@ impl<'a> Sugg<'a> {
             | ast::ExprKind::Try(..)
             | ast::ExprKind::TryBlock(..)
             | ast::ExprKind::Tup(..)
+            | ast::ExprKind::Matches(..)
             | ast::ExprKind::Array(..)
             | ast::ExprKind::While(..)
             | ast::ExprKind::Await(..)

--- a/src/tools/rustfmt/src/expr.rs
+++ b/src/tools/rustfmt/src/expr.rs
@@ -401,6 +401,7 @@ pub(crate) fn format_expr(
         ast::ExprKind::Underscore => Some("_".to_owned()),
         ast::ExprKind::FormatArgs(..)
         | ast::ExprKind::IncludedBytes(..)
+        | ast::ExprKind::Matches(..)
         | ast::ExprKind::OffsetOf(..) => {
             // These do not occur in the AST because macros aren't expanded.
             unreachable!()

--- a/src/tools/rustfmt/src/utils.rs
+++ b/src/tools/rustfmt/src/utils.rs
@@ -500,6 +500,7 @@ pub(crate) fn is_block_expr(context: &RewriteContext<'_>, expr: &ast::Expr, repr
         | ast::ExprKind::IncludedBytes(..)
         | ast::ExprKind::InlineAsm(..)
         | ast::ExprKind::OffsetOf(..)
+        | ast::ExprKind::Matches(..)
         | ast::ExprKind::Let(..)
         | ast::ExprKind::Path(..)
         | ast::ExprKind::Range(..)

--- a/tests/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
+++ b/tests/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
@@ -4,32 +4,32 @@
   fn issue_77355_opt(_1: Foo) -> u64 {
       debug num => _1;                     // in scope 0 at $DIR/const_goto.rs:+0:20: +0:23
       let mut _0: u64;                     // return place in scope 0 at $DIR/const_goto.rs:+0:33: +0:36
--     let mut _2: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-     let mut _2: bool;                    // in scope 0 at $DIR/const_goto.rs:+1:8: +1:37
 -     let mut _3: isize;                   // in scope 0 at $DIR/const_goto.rs:+1:22: +1:28
 +     let mut _2: isize;                   // in scope 0 at $DIR/const_goto.rs:+1:22: +1:28
   
       bb0: {
--         StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         StorageLive(_2);                 // scope 0 at $DIR/const_goto.rs:+1:8: +1:37
 -         _3 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:+1:17: +1:20
--         switchInt(move _3) -> [1: bb2, 2: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         switchInt(move _3) -> [1: bb2, 2: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto.rs:+1:8: +1:20
 +         _2 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:+1:17: +1:20
-+         switchInt(move _2) -> [1: bb2, 2: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
++         switchInt(move _2) -> [1: bb2, 2: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto.rs:+1:8: +1:20
       }
   
       bb1: {
--         _2 = const false;                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         _2 = const false;                // scope 0 at $DIR/const_goto.rs:+1:8: +1:37
+-         goto -> bb3;                     // scope 0 at $DIR/const_goto.rs:+1:8: +1:37
 +         _0 = const 42_u64;               // scope 0 at $DIR/const_goto.rs:+1:53: +1:55
 +         goto -> bb3;                     // scope 0 at $DIR/const_goto.rs:+1:5: +1:57
       }
   
       bb2: {
--         _2 = const true;                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         _2 = const true;                 // scope 0 at $DIR/const_goto.rs:+1:8: +1:37
+-         goto -> bb3;                     // scope 0 at $DIR/const_goto.rs:+1:8: +1:37
 -     }
 - 
 -     bb3: {
--         switchInt(move _2) -> [0: bb5, otherwise: bb4]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         switchInt(move _2) -> [0: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto.rs:+1:8: +1:37
 -     }
 - 
 -     bb4: {

--- a/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.diff
+++ b/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.diff
@@ -22,17 +22,17 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/offset_of.rs:+1:9: +1:10
--         _1 = OffsetOf(Alpha, [0]);       // scope 0 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-+         _1 = const 4_usize;              // scope 0 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+-         _1 = OffsetOf(Alpha, [0]);       // scope 0 at $DIR/offset_of.rs:+1:13: +1:32
++         _1 = const 4_usize;              // scope 0 at $DIR/offset_of.rs:+1:13: +1:32
           StorageLive(_2);                 // scope 1 at $DIR/offset_of.rs:+2:9: +2:10
--         _2 = OffsetOf(Alpha, [1]);       // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-+         _2 = const 0_usize;              // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+-         _2 = OffsetOf(Alpha, [1]);       // scope 1 at $DIR/offset_of.rs:+2:13: +2:32
++         _2 = const 0_usize;              // scope 1 at $DIR/offset_of.rs:+2:13: +2:32
           StorageLive(_3);                 // scope 2 at $DIR/offset_of.rs:+3:9: +3:11
--         _3 = OffsetOf(Alpha, [2, 0]);    // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-+         _3 = const 2_usize;              // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+-         _3 = OffsetOf(Alpha, [2, 0]);    // scope 2 at $DIR/offset_of.rs:+3:14: +3:35
++         _3 = const 2_usize;              // scope 2 at $DIR/offset_of.rs:+3:14: +3:35
           StorageLive(_4);                 // scope 3 at $DIR/offset_of.rs:+4:9: +4:11
--         _4 = OffsetOf(Alpha, [2, 1]);    // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-+         _4 = const 3_usize;              // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+-         _4 = OffsetOf(Alpha, [2, 1]);    // scope 3 at $DIR/offset_of.rs:+4:14: +4:35
++         _4 = const 3_usize;              // scope 3 at $DIR/offset_of.rs:+4:14: +4:35
           _0 = const ();                   // scope 0 at $DIR/offset_of.rs:+0:15: +5:2
           StorageDead(_4);                 // scope 3 at $DIR/offset_of.rs:+5:1: +5:2
           StorageDead(_3);                 // scope 2 at $DIR/offset_of.rs:+5:1: +5:2

--- a/tests/mir-opt/const_prop/offset_of.generic.ConstProp.diff
+++ b/tests/mir-opt/const_prop/offset_of.generic.ConstProp.diff
@@ -22,13 +22,13 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/offset_of.rs:+1:9: +1:11
-          _1 = OffsetOf(Gamma<T>, [0]);    // scope 0 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          _1 = OffsetOf(Gamma<T>, [0]);    // scope 0 at $DIR/offset_of.rs:+1:14: +1:36
           StorageLive(_2);                 // scope 1 at $DIR/offset_of.rs:+2:9: +2:11
-          _2 = OffsetOf(Gamma<T>, [1]);    // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          _2 = OffsetOf(Gamma<T>, [1]);    // scope 1 at $DIR/offset_of.rs:+2:14: +2:36
           StorageLive(_3);                 // scope 2 at $DIR/offset_of.rs:+3:9: +3:11
-          _3 = OffsetOf(Delta<T>, [1]);    // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          _3 = OffsetOf(Delta<T>, [1]);    // scope 2 at $DIR/offset_of.rs:+3:14: +3:36
           StorageLive(_4);                 // scope 3 at $DIR/offset_of.rs:+4:9: +4:11
-          _4 = OffsetOf(Delta<T>, [2]);    // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          _4 = OffsetOf(Delta<T>, [2]);    // scope 3 at $DIR/offset_of.rs:+4:14: +4:36
           _0 = const ();                   // scope 0 at $DIR/offset_of.rs:+0:17: +5:2
           StorageDead(_4);                 // scope 3 at $DIR/offset_of.rs:+5:1: +5:2
           StorageDead(_3);                 // scope 2 at $DIR/offset_of.rs:+5:1: +5:2

--- a/tests/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.diff
@@ -4,33 +4,33 @@
   fn foo(_1: Option<()>) -> () {
       debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:+0:8: +0:11
       let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:+0:25: +0:25
-      let mut _2: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _2: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:26
       let mut _3: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:+1:22: +1:26
-+     let mut _4: isize;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
++     let mut _4: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:20
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:26
           _3 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:+1:17: +1:20
--         switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         StorageLive(_4);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         _4 = move _3;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         _2 = Eq(_4, const 0_isize);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         StorageDead(_4);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:20
++         StorageLive(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:20
++         _4 = move _3;                    // scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:20
++         _2 = Eq(_4, const 0_isize);      // scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:26
++         StorageDead(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:20
++         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:26
       }
   
       bb1: {
--         _2 = const false;                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         _2 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:26
+-         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:26
 -     }
 - 
 -     bb2: {
--         _2 = const true;                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         _2 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:26
+-         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:26
 -     }
 - 
 -     bb3: {
--         switchInt(move _2) -> [0: bb5, otherwise: bb4]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         switchInt(move _2) -> [0: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:+1:8: +1:26
 -     }
 - 
 -     bb4: {

--- a/tests/ui/macros/rfc-2011-nicer-assert-messages/all-expr-kinds.rs
+++ b/tests/ui/macros/rfc-2011-nicer-assert-messages/all-expr-kinds.rs
@@ -86,6 +86,9 @@ fn main() {
     // index
     [ [1i32, 1][elem as usize] == 3 ] => "Assertion failed: [1i32, 1][elem as usize] == 3\nWith captures:\n  elem = 1\n"
 
+    // matches
+    [ matches!(Some(elem == 1i32), None) ] => "Assertion failed: builtin # matches(Some(elem == 1i32), None)\nWith captures:\n  elem = 1\n"
+
     // method call
     [ FOO.add(elem, elem) == 3 ] => "Assertion failed: FOO.add(elem, elem) == 3\nWith captures:\n  elem = 1\n"
 

--- a/tests/ui/stdlib-unit-tests/matches2021.rs
+++ b/tests/ui/stdlib-unit-tests/matches2021.rs
@@ -1,3 +1,5 @@
+#![allow(unreachable_patterns)]
+
 // run-pass
 // edition:2021
 


### PR DESCRIPTION
cc #44838

I really thought for months how to expand `matches` and the best approach I could find was the introduction of a new `ExprKind` variant as well as turning `matches!` into a built-in macro. Please, let me known if there is a better method.

```rust
fn fun(a: Option<i32>, b: Option<i32>, c: Option<i32>) {
  assert!(
    [matches!(a, None), matches!(b, Some(1)] == [true, true] && matches!(c, Some(x) if x == 2)
  );
}

fn main() {
  fun(Some(1), None, Some(2));
}

// Assertion failed: [matches!(a, None), matches!(b, Some(1)] == [true, true] && matches!(c, Some(x) if x == 2)
//
// With captures:
//   a = Some(1)
//   b = None
//   c = Some(2)
```

cc @oli-obk Reviewed the last PRs
cc @petrochenkov We talked a bit about this subject