### PR TITLE
Allow relaxable (x86) ELF relocations by default.

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1684,7 +1684,7 @@ pub struct TargetOptions {
     /// LLVM ABI name, corresponds to the '-mabi' parameter available in multilib C compilers
     pub llvm_abiname: StaticCow<str>,
 
-    /// Whether or not RelaxElfRelocation flag will be passed to the linker
+    /// Whether to allow LLVM to generate relaxable X86 relocations.
     pub relax_elf_relocations: bool,
 
     /// Additional arguments to pass to LLVM, similar to the `-C llvm-args` codegen option.
@@ -1948,7 +1948,7 @@ impl Default for TargetOptions {
             merge_functions: MergeFunctions::Aliases,
             mcount: "mcount".into(),
             llvm_abiname: "".into(),
-            relax_elf_relocations: false,
+            relax_elf_relocations: true,
             llvm_args: cvs![],
             use_ctors_section: false,
             eh_frame_header: true,

--- a/compiler/rustc_target/src/spec/x86_64_fortanix_unknown_sgx.rs
+++ b/compiler/rustc_target/src/spec/x86_64_fortanix_unknown_sgx.rs
@@ -68,7 +68,6 @@ pub fn target() -> Target {
         position_independent_executables: true,
         pre_link_args,
         override_export_symbols: Some(EXPORT_SYMBOLS.iter().cloned().map(Cow::from).collect()),
-        relax_elf_relocations: true,
         ..Default::default()
     };
     Target {


### PR DESCRIPTION
Flip relax_elf_relocations to true by default. The practical effect of this is to allow modern linkers to eliminate a pointless trip through the GOT for calls in PIE binaries on x86.

These relaxations were introduced in bintuils 2.26 in 2016. LLVM (llvm/llvm-project@f5e7d63add038d984fa1dca40efd5da4275c142b) and Clang (llvm/llvm-project@c41a18cf61790fc898dcda1055c3efbf442c14c0, llvm/llvm-project@83cec143c76f4c76fe8ae28d6d836e8f7bd67891) have changed their defaults in recent years.
