### PR TITLE
Add shortcut for Grisu3 algorithm.

### DIFF
--- a/library/core/benches/num/flt2dec/strategy/grisu.rs
+++ b/library/core/benches/num/flt2dec/strategy/grisu.rs
@@ -81,3 +81,30 @@ fn bench_big_exact_inf(b: &mut Bencher) {
         format_exact(black_box(&decoded), &mut buf, i16::MIN);
     });
 }
+
+#[bench]
+fn bench_one_exact_inf(b: &mut Bencher) {
+    let decoded = decode_finite(1.0);
+    let mut buf = [MaybeUninit::new(0); 1024];
+    b.iter(|| {
+        format_exact(black_box(&decoded), &mut buf, i16::MIN);
+    });
+}
+
+#[bench]
+fn bench_trailing_zero_exact_inf(b: &mut Bencher) {
+    let decoded = decode_finite(250.000000000000000000000000);
+    let mut buf = [MaybeUninit::new(0); 1024];
+    b.iter(|| {
+        format_exact(black_box(&decoded), &mut buf, i16::MIN);
+    });
+}
+
+#[bench]
+fn bench_halfway_point_exact_inf(b: &mut Bencher) {
+    let decoded = decode_finite(1.00000000000000011102230246251565404236316680908203125);
+    let mut buf = [MaybeUninit::new(0); 1024];
+    b.iter(|| {
+        format_exact(black_box(&decoded), &mut buf, i16::MIN);
+    });
+}


### PR DESCRIPTION
While Grisu3 is way more faster for most numbers compare to Dragon4, the fall back to Dragon4 procedure for certain numbers could cause some performance regressions compare to use Dragon4 directly. Mitigating the regression caused by falling back is important for a largely used core library.

In Grisu3 algorithm implementation, there's a shortcut to jump out earlier when the fractional or integrals cannot meet the requirement of requested digits. This could significantly improve the performance of converting floating number to string as it falls back even without starting trying the algorithm.

The original idea is from the [.NET implementation](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Number.Grisu3.cs#L602-L615) and the code was originally added in [this PR](https://github.com/dotnet/coreclr/pull/14646#issuecomment-350942050). This shortcut has been shipped long time ago and has been proved working.

Fix #110129