### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -7,7 +7,7 @@
 use crate::ty::error::{ExpectedFound, TypeError};
 use crate::ty::{self, Expr, ImplSubject, Term, TermKind, Ty, TyCtxt, TypeFoldable};
 use crate::ty::{GenericArg, GenericArgKind, SubstsRef};
-use rustc_hir as ast;
+use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_target::spec::abi;
 use std::iter;
@@ -123,8 +123,8 @@ pub fn relate_type_and_mut<'tcx, R: TypeRelation<'tcx>>(
     } else {
         let mutbl = a.mutbl;
         let (variance, info) = match mutbl {
-            ast::Mutability::Not => (ty::Covariant, ty::VarianceDiagInfo::None),
-            ast::Mutability::Mut => {
+            hir::Mutability::Not => (ty::Covariant, ty::VarianceDiagInfo::None),
+            hir::Mutability::Mut => {
                 (ty::Invariant, ty::VarianceDiagInfo::Invariant { ty: base_ty, param_index: 0 })
             }
         };
@@ -239,12 +239,12 @@ impl<'tcx> Relate<'tcx> for ty::BoundConstness {
     }
 }
 
-impl<'tcx> Relate<'tcx> for ast::Unsafety {
+impl<'tcx> Relate<'tcx> for hir::Unsafety {
     fn relate<R: TypeRelation<'tcx>>(
         relation: &mut R,
-        a: ast::Unsafety,
-        b: ast::Unsafety,
-    ) -> RelateResult<'tcx, ast::Unsafety> {
+        a: hir::Unsafety,
+        b: hir::Unsafety,
+    ) -> RelateResult<'tcx, hir::Unsafety> {
         if a != b {
             Err(TypeError::UnsafetyMismatch(expected_found(relation, a, b)))
         } else {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1986,8 +1986,9 @@ impl Interner {
         name
     }
 
-    // Get the symbol as a string. `Symbol::as_str()` should be used in
-    // preference to this function.
+    /// Get the symbol as a string.
+    ///
+    /// [`Symbol::as_str()`] should be used in preference to this function.
     fn get(&self, symbol: Symbol) -> &str {
         self.0.lock().strings[symbol.0.as_usize()]
     }

--- a/tests/mir-opt/simplify_arm.rs
+++ b/tests/mir-opt/simplify_arm.rs
@@ -6,8 +6,7 @@
 // EMIT_MIR simplify_arm.id_try.SimplifyArmIdentity.diff
 // EMIT_MIR simplify_arm.id_try.SimplifyBranchSame.diff
 
-// This pass is broken since deaggregation changed
-// ignore-test
+// ignore-test This pass is broken since deaggregation changed
 
 fn id(o: Option<u8>) -> Option<u8> {
     match o {

--- a/tests/mir-opt/simplify_arm_identity.rs
+++ b/tests/mir-opt/simplify_arm_identity.rs
@@ -4,8 +4,7 @@
 // compile-flags: -Zmir-opt-level=3
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
-// This pass is broken since deaggregation changed
-// ignore-test
+// ignore-test This pass is broken since deaggregation changed
 
 enum Src {
     Foo(u8),

--- a/tests/ui/borrowck/move-error-snippets-ext.rs
+++ b/tests/ui/borrowck/move-error-snippets-ext.rs
@@ -1,4 +1,4 @@
-// ignore-test
+// ignore-test (auxiliary, used by other tests)
 
 macro_rules! aaa {
     ($c:ident) => {{

--- a/tests/ui/codemap_tests/two_files_data.rs
+++ b/tests/ui/codemap_tests/two_files_data.rs
@@ -1,4 +1,4 @@
-// ignore-test
+// ignore-test (auxiliary, used by other tests)
 
 trait Foo { }
 

--- a/tests/ui/conditional-compilation/module_with_cfg.rs
+++ b/tests/ui/conditional-compilation/module_with_cfg.rs
@@ -1,3 +1,3 @@
-// ignore-test
+// ignore-test (auxiliary, used by other tests)
 
 #![cfg_attr(all(), cfg(FALSE))]

--- a/tests/ui/cross/cross-file-errors/main.stderr
+++ b/tests/ui/cross/cross-file-errors/main.stderr
@@ -1,5 +1,5 @@
 error: in expressions, `_` can only be used on the left-hand side of an assignment
-  --> $DIR/underscore.rs:8:9
+  --> $DIR/underscore.rs:6:9
    |
 LL |         _
    |         ^ `_` not allowed here

--- a/tests/ui/cross/cross-file-errors/underscore.rs
+++ b/tests/ui/cross/cross-file-errors/underscore.rs
@@ -1,6 +1,4 @@
-// We want this file only so we can test cross-file error
-// messages, but we don't want it in an external crate.
-// ignore-test
+// ignore-test (auxiliary, used by other tests)
 #![crate_type = "lib"]
 
 macro_rules! underscore {

--- a/tests/ui/inline-const/const-match-pat-lifetime-err.rs
+++ b/tests/ui/inline-const/const-match-pat-lifetime-err.rs
@@ -1,4 +1,4 @@
-// ignore-test
+// ignore-test (This is currently broken)
 
 #![allow(incomplete_features)]
 #![feature(const_mut_refs)]

--- a/tests/ui/issues/issue-49298.rs
+++ b/tests/ui/issues/issue-49298.rs
@@ -6,7 +6,7 @@
 // where #54986 is implemented and #54987 is *not* implemented. For
 // now: just ignore it
 //
-// ignore-test
+// ignore-test (#54987)
 
 // This test is checking that the space allocated for `x.1` does not
 // overlap with `y`. (The reason why such a thing happened at one

--- a/tests/ui/issues/issue-59756.rs
+++ b/tests/ui/issues/issue-59756.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-// ignore-test
+// ignore-test (rustfix needs multiple suggestions)
 //
 // FIXME: Re-enable this test once we support choosing
 // between multiple mutually exclusive suggestions for the same span

--- a/tests/ui/lint/dead-code/closure-bang.rs
+++ b/tests/ui/lint/dead-code/closure-bang.rs
@@ -1,9 +1,7 @@
-// ignore-test FIXME(#20574)
-
 #![deny(unreachable_code)]
 
 fn main() {
-    let x = || panic!();
+    let x = || -> ! { panic!() };
     x();
     println!("Foo bar"); //~ ERROR: unreachable statement
 }

--- a/tests/ui/lint/dead-code/closure-bang.stderr
+++ b/tests/ui/lint/dead-code/closure-bang.stderr
@@ -1,0 +1,17 @@
+error: unreachable statement
+  --> $DIR/closure-bang.rs:6:5
+   |
+LL |     x();
+   |     --- any code following this expression is unreachable
+LL |     println!("Foo bar");
+   |     ^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |
+note: the lint level is defined here
+  --> $DIR/closure-bang.rs:1:9
+   |
+LL | #![deny(unreachable_code)]
+   |         ^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/tests/ui/macros/macro-expanded-include/foo/mod.rs
+++ b/tests/ui/macros/macro-expanded-include/foo/mod.rs
@@ -1,4 +1,4 @@
-// ignore-test
+// ignore-test (auxiliary, used by other tests)
 
 macro_rules! m {
     () => { include!("file.txt"); }

--- a/tests/ui/match/issue-26996.rs
+++ b/tests/ui/match/issue-26996.rs
@@ -4,7 +4,7 @@
 // where #54986 is implemented and #54987 is *not* implemented. For
 // now: just ignore it
 //
-// ignore-test
+// ignore-test (#54987)
 
 // This test is checking that the write to `c.0` (which has been moved out of)
 // won't overwrite the state in `c2`.

--- a/tests/ui/match/issue-27021.rs
+++ b/tests/ui/match/issue-27021.rs
@@ -4,7 +4,7 @@
 // where #54986 is implemented and #54987 is *not* implemented. For
 // now: just ignore it
 //
-// ignore-test
+// ignore-test (#54987)
 
 // These are variants of issue-26996.rs. In all cases we are writing
 // into a record field that has been moved out of, and ensuring that

--- a/tests/ui/numbers-arithmetic/saturating-float-casts-impl.rs
+++ b/tests/ui/numbers-arithmetic/saturating-float-casts-impl.rs
@@ -1,4 +1,4 @@
-// ignore-test
+// ignore-test (auxiliary, used by other tests)
 
 // Tests saturating float->int casts. See u128-as-f32.rs for the opposite direction.
 //

--- a/tests/ui/panics/panic-short-backtrace-windows-x86_64.rs
+++ b/tests/ui/panics/panic-short-backtrace-windows-x86_64.rs
@@ -1,6 +1,6 @@
 // This test has been spuriously failing a lot recently (#92000).
 // Ignore it until the underlying issue is fixed.
-// ignore-test
+// ignore-test (#92000)
 
 // Regression test for #87481: short backtrace formatting cut off the entire stack trace.
 

--- a/tests/ui/proc-macro/module.rs
+++ b/tests/ui/proc-macro/module.rs
@@ -1,1 +1,1 @@
-// ignore-test
+// ignore-test (auxiliary, used by other tests)

--- a/tests/ui/proc-macro/module_with_attrs.rs
+++ b/tests/ui/proc-macro/module_with_attrs.rs
@@ -1,4 +1,4 @@
-// ignore-test
+// ignore-test (auxiliary, used by other tests)
 
 #![rustfmt::skip]
 #![print_attr]

--- a/tests/ui/proc-macro/outer/inner.rs
+++ b/tests/ui/proc-macro/outer/inner.rs
@@ -1,1 +1,1 @@
-// ignore-test
+// ignore-test (auxiliary, used by other tests)

--- a/tests/ui/proc-macro/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs
+++ b/tests/ui/proc-macro/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs
@@ -1,4 +1,4 @@
-// ignore-test
+// ignore-test (auxiliary, used by other tests)
 
 #[derive(Print)]
 enum ProceduralMasqueradeDummyType {

--- a/tests/ui/proc-macro/pretty-print-hack/rental-0.5.5/src/lib.rs
+++ b/tests/ui/proc-macro/pretty-print-hack/rental-0.5.5/src/lib.rs
@@ -1,4 +1,4 @@
-// ignore-test
+// ignore-test (auxiliary, used by other tests)
 
 #[derive(Print)]
 enum ProceduralMasqueradeDummyType {

--- a/tests/ui/proc-macro/pretty-print-hack/rental-0.5.6/src/lib.rs
+++ b/tests/ui/proc-macro/pretty-print-hack/rental-0.5.6/src/lib.rs
@@ -1,4 +1,4 @@
-// ignore-test
+// ignore-test (auxiliary, used by other tests)
 
 #[derive(Print)]
 enum ProceduralMasqueradeDummyType {

--- a/tests/ui/type-alias-impl-trait/issue-65918.rs
+++ b/tests/ui/type-alias-impl-trait/issue-65918.rs
@@ -1,5 +1,3 @@
-// ignore-test: This now ICEs again.
-
 // build-pass
 
 #![feature(type_alias_impl_trait)]


### PR DESCRIPTION
Successful merges:

 - #110376 (Convert comment to doc comment on `Interner::get`.)
 - #110379 (Update some ignored tests.)
 - #110387 (Don't `use rustc_hir as ast`(!))

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=110376,110379,110387)
<!-- homu-ignore:end -->