### PR TITLE
bolt: remove deprecated option value for split-functions

### DIFF
--- a/src/bootstrap/bolt.rs
+++ b/src/bootstrap/bolt.rs
@@ -40,7 +40,7 @@ pub fn optimize_with_bolt(path: &Path, profile_path: &Path, output_path: &Path) 
         // Reorder functions within the binary
         .arg("-reorder-functions=hfsort+")
         // Split function code into hot and code regions
-        .arg("-split-functions=2")
+        .arg("-split-functions")
         // Split as many basic blocks as possible
         .arg("-split-all-cold")
         // Move jump tables to a separate section


### PR DESCRIPTION
Noticed warning at https://github.com/rust-lang-ci/rust/actions/runs/4711883459/jobs/8356538964#step:26:40828, option value was removed at https://github.com/llvm/llvm-project/commit/96f6ec5090c2f7a1e4804693cbb84c29c574b3de.

bolt only running on latest supported llvm (yes?), so it's safe to apply this patch.
cc @Kobzol 