### PR TITLE
rustdoc-json: Add test for #[automatically_derived] attribute

### DIFF
--- a/tests/rustdoc-json/attrs/automatically_derived.rs
+++ b/tests/rustdoc-json/attrs/automatically_derived.rs
@@ -1,0 +1,13 @@
+#[derive(Default)]
+pub struct Derive;
+
+pub struct Manual;
+
+impl Default for Manual {
+    fn default() -> Self {
+        Self
+    }
+}
+
+//@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Derive" && @.inner.impl.trait.path == "Default")].attrs' '["#[automatically_derived]"]'
+//@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Manual" && @.inner.impl.trait.path == "Default")].attrs' '[]'


### PR DESCRIPTION
~~Will fail CI due to https://github.com/freestrings/jsonpath/issues/91, but I wrote the test and don't want to forget it.~~

~~We should look into fixing the freestrings impl, or moving to a different one, so we can test things like this. [Zulip Disussion](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/jsonpath-plus.20integration)~~

FIXED!!! By #138763

r? @ghost

@rustbot blocked