### PR TITLE
Don't use `serde_json` to serialize a simple JSON object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4587,7 +4587,6 @@ dependencies = [
  "rustc_index",
  "rustc_macros",
  "rustc_serialize",
- "serde_json",
  "smallvec",
  "stable_deref_trait",
  "stacker",

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -21,7 +21,6 @@ rustc-hash = "1.1.0"
 rustc_index = { path = "../rustc_index", package = "rustc_index" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_serialize = { path = "../rustc_serialize" }
-serde_json = "1.0.59"
 smallvec = { version = "1.8.1", features = [
     "const_generics",
     "union",

--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -87,6 +87,7 @@ use crate::fx::FxHashMap;
 use std::borrow::Borrow;
 use std::collections::hash_map::Entry;
 use std::error::Error;
+use std::fmt::Display;
 use std::fs;
 use std::intrinsics::unlikely;
 use std::path::Path;
@@ -97,7 +98,6 @@ use std::time::{Duration, Instant};
 pub use measureme::EventId;
 use measureme::{EventIdBuilder, Profiler, SerializableString, StringId};
 use parking_lot::RwLock;
-use serde_json::json;
 use smallvec::SmallVec;
 
 bitflags::bitflags! {
@@ -763,6 +763,31 @@ impl Drop for VerboseTimingGuard<'_> {
     }
 }
 
+struct JsonTimePassesEntry<'a> {
+    pass: &'a str,
+    time: f64,
+    start_rss: Option<usize>,
+    end_rss: Option<usize>,
+}
+
+impl Display for JsonTimePassesEntry<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { pass: what, time, start_rss, end_rss } = self;
+        write!(f, r#"{{"pass":"{what}","time":{time},"rss_start":"#).unwrap();
+        match start_rss {
+            Some(rss) => write!(f, "{rss}")?,
+            None => write!(f, "null")?,
+        }
+        write!(f, r#","rss_end":"#)?;
+        match end_rss {
+            Some(rss) => write!(f, "{rss}")?,
+            None => write!(f, "null")?,
+        }
+        write!(f, "}}")?;
+        Ok(())
+    }
+}
+
 pub fn print_time_passes_entry(
     what: &str,
     dur: Duration,
@@ -772,13 +797,10 @@ pub fn print_time_passes_entry(
 ) {
     match format {
         TimePassesFormat::Json => {
-            let json = json!({
-                "pass": what,
-                "time": dur.as_secs_f64(),
-                "rss_start": start_rss,
-                "rss_end": end_rss,
-            });
-            eprintln!("time: {json}");
+            let entry =
+                JsonTimePassesEntry { pass: what, time: dur.as_secs_f64(), start_rss, end_rss };
+
+            eprintln!(r#"time: {entry}"#);
             return;
         }
         TimePassesFormat::Text => (),
@@ -894,3 +916,6 @@ cfg_if! {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/compiler/rustc_data_structures/src/profiling/tests.rs
+++ b/compiler/rustc_data_structures/src/profiling/tests.rs
@@ -1,0 +1,19 @@
+use super::JsonTimePassesEntry;
+
+#[test]
+fn with_rss() {
+    let entry =
+        JsonTimePassesEntry { pass: "typeck", time: 56.1, start_rss: Some(10), end_rss: Some(20) };
+
+    assert_eq!(entry.to_string(), r#"{"pass":"typeck","time":56.1,"rss_start":10,"rss_end":20}"#)
+}
+
+#[test]
+fn no_rss() {
+    let entry = JsonTimePassesEntry { pass: "typeck", time: 56.1, start_rss: None, end_rss: None };
+
+    assert_eq!(
+        entry.to_string(),
+        r#"{"pass":"typeck","time":56.1,"rss_start":null,"rss_end":null}"#
+    )
+}


### PR DESCRIPTION
This avoids `rustc_data_structures` depending on `serde_json` which allows it to be compiled much earlier, unlocking most of rustc.

This used to not matter, but after #110407 we're not blocked on fluent anymore, which means that it's now a blocking edge.
![image](https://user-images.githubusercontent.com/48135649/232313178-e0150420-3020-4eb6-98d3-fe5294a8f947.png)

This saves a few more seconds.

cc @Zoxc who added it recently