### PR TITLE
[beta] Prepare Rust 1.70.0

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -239,7 +239,7 @@ declare_features! (
     /// Allows using `Self` and associated types in struct expressions and patterns.
     (accepted, more_struct_aliases, "1.16.0", Some(37544), None),
     /// Allows using the MOVBE target feature.
-    (accepted, movbe_target_feature, "CURRENT_RUSTC_VERSION", Some(44839), None),
+    (accepted, movbe_target_feature, "1.70.0", Some(44839), None),
     /// Allows patterns with concurrent by-move and by-ref bindings.
     /// For example, you can write `Foo(a, ref b)` where `a` is by-move and `b` is by-ref.
     (accepted, move_ref_pattern, "1.49.0", Some(68354), None),

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -417,7 +417,7 @@ declare_features! (
     /// Allows `if let` guard in match arms.
     (active, if_let_guard, "1.47.0", Some(51114), None),
     /// Allows `impl Trait` to be used inside associated types (RFC 2515).
-    (active, impl_trait_in_assoc_type, "CURRENT_RUSTC_VERSION", Some(63063), None),
+    (active, impl_trait_in_assoc_type, "1.70.0", Some(63063), None),
     /// Allows `impl Trait` as output type in `Fn` traits in return position of functions.
     (active, impl_trait_in_fn_trait_return, "1.64.0", Some(99697), None),
     /// Allows referencing `Self` and projections in impl-trait.
@@ -498,7 +498,7 @@ declare_features! (
     /// Allows return-position `impl Trait` in traits.
     (incomplete, return_position_impl_trait_in_trait, "1.65.0", Some(91611), None),
     /// Allows bounding the return type of AFIT/RPITIT.
-    (incomplete, return_type_notation, "CURRENT_RUSTC_VERSION", Some(109417), None),
+    (incomplete, return_type_notation, "1.70.0", Some(109417), None),
     /// Allows `extern "rust-cold"`.
     (active, rust_cold_cc, "1.63.0", Some(97544), None),
     /// Allows the use of SIMD types in functions declared in `extern` blocks.
@@ -521,7 +521,7 @@ declare_features! (
     /// Dyn upcasting is casting, e.g., `dyn Foo -> dyn Bar` where `Foo: Bar`.
     (active, trait_upcasting, "1.56.0", Some(65991), None),
     /// Allows for transmuting between arrays with sizes that contain generic consts.
-    (active, transmute_generic_consts, "CURRENT_RUSTC_VERSION", Some(109929), None),
+    (active, transmute_generic_consts, "1.70.0", Some(109929), None),
     /// Allows #[repr(transparent)] on unions (RFC 2645).
     (active, transparent_unions, "1.37.0", Some(60405), None),
     /// Allows inconsistent bounds in where clauses.

--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -53,7 +53,7 @@ declare_features! (
     (removed, await_macro, "1.38.0", Some(50547), None,
      Some("subsumed by `.await` syntax")),
     /// Allows using the `box $expr` syntax.
-    (removed, box_syntax, "CURRENT_RUSTC_VERSION", Some(49733), None, Some("replaced with `#[rustc_box]`")),
+    (removed, box_syntax, "1.70.0", Some(49733), None, Some("replaced with `#[rustc_box]`")),
     /// Allows capturing disjoint fields in a closure/generator (RFC 2229).
     (removed, capture_disjoint_fields, "1.49.0", Some(53488), None, Some("stabilized in Rust 2021")),
     /// Allows comparing raw pointers during const eval.

--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -853,7 +853,7 @@ impl<T: Ord> BinaryHeap<T> {
     ///
     /// assert_eq!(heap.into_sorted_vec(), [-10, 2, 4])
     /// ```
-    #[stable(feature = "binary_heap_retain", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "binary_heap_retain", since = "1.70.0")]
     pub fn retain<F>(&mut self, mut f: F)
     where
         F: FnMut(&T) -> bool,
@@ -1463,7 +1463,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IntoIter<T> {}
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<T> Default for IntoIter<T> {
     /// Creates an empty `binary_heap::IntoIter`.
     ///

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -362,7 +362,7 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Iter<'_, K, V> {
     }
 }
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<'a, K: 'a, V: 'a> Default for Iter<'a, K, V> {
     /// Creates an empty `btree_map::Iter`.
     ///
@@ -400,7 +400,7 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for IterMut<'_, K, V> {
     }
 }
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<'a, K: 'a, V: 'a> Default for IterMut<'a, K, V> {
     /// Creates an empty `btree_map::IterMut`.
     ///
@@ -448,7 +448,7 @@ impl<K: Debug, V: Debug, A: Allocator + Clone> Debug for IntoIter<K, V, A> {
     }
 }
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<K, V, A> Default for IntoIter<K, V, A>
 where
     A: Allocator + Default + Clone,
@@ -1812,7 +1812,7 @@ impl<K, V> Clone for Keys<'_, K, V> {
     }
 }
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<K, V> Default for Keys<'_, K, V> {
     /// Creates an empty `btree_map::Keys`.
     ///
@@ -1867,7 +1867,7 @@ impl<K, V> Clone for Values<'_, K, V> {
     }
 }
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<K, V> Default for Values<'_, K, V> {
     /// Creates an empty `btree_map::Values`.
     ///
@@ -2017,7 +2017,7 @@ impl<'a, K, V> Iterator for Range<'a, K, V> {
     }
 }
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<K, V> Default for Range<'_, K, V> {
     /// Creates an empty `btree_map::Range`.
     ///
@@ -2107,7 +2107,7 @@ impl<K, V, A: Allocator + Clone> ExactSizeIterator for IntoKeys<K, V, A> {
 #[stable(feature = "map_into_keys_values", since = "1.54.0")]
 impl<K, V, A: Allocator + Clone> FusedIterator for IntoKeys<K, V, A> {}
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<K, V, A> Default for IntoKeys<K, V, A>
 where
     A: Allocator + Default + Clone,
@@ -2158,7 +2158,7 @@ impl<K, V, A: Allocator + Clone> ExactSizeIterator for IntoValues<K, V, A> {
 #[stable(feature = "map_into_keys_values", since = "1.54.0")]
 impl<K, V, A: Allocator + Clone> FusedIterator for IntoValues<K, V, A> {}
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<K, V, A> Default for IntoValues<K, V, A>
 where
     A: Allocator + Default + Clone,

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -1538,7 +1538,7 @@ impl<T, A: Allocator + Clone> Iterator for IntoIter<T, A> {
     }
 }
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<T> Default for Iter<'_, T> {
     /// Creates an empty `btree_set::Iter`.
     ///
@@ -1568,7 +1568,7 @@ impl<T, A: Allocator + Clone> ExactSizeIterator for IntoIter<T, A> {
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T, A: Allocator + Clone> FusedIterator for IntoIter<T, A> {}
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<T, A> Default for IntoIter<T, A>
 where
     A: Allocator + Default + Clone,
@@ -1623,7 +1623,7 @@ impl<'a, T> DoubleEndedIterator for Range<'a, T> {
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for Range<'_, T> {}
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<T> Default for Range<'_, T> {
     /// Creates an empty `btree_set::Range`.
     ///

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -1074,7 +1074,7 @@ impl<T> ExactSizeIterator for Iter<'_, T> {}
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for Iter<'_, T> {}
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<T> Default for Iter<'_, T> {
     /// Creates an empty `linked_list::Iter`.
     ///
@@ -1142,7 +1142,7 @@ impl<T> ExactSizeIterator for IterMut<'_, T> {}
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IterMut<'_, T> {}
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<T> Default for IterMut<'_, T> {
     fn default() -> Self {
         IterMut { head: None, tail: None, len: 0, marker: Default::default() }
@@ -1828,7 +1828,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {}
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IntoIter<T> {}
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<T> Default for IntoIter<T> {
     /// Creates an empty `linked_list::IntoIter`.
     ///

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -693,7 +693,7 @@ impl<T> Rc<T> {
     /// This is equivalent to `Rc::try_unwrap(this).ok()`. (Note that these are not equivalent for
     /// [`Arc`](crate::sync::Arc), due to race conditions that do not apply to `Rc`.)
     #[inline]
-    #[stable(feature = "rc_into_inner", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "rc_into_inner", since = "1.70.0")]
     pub fn into_inner(this: Self) -> Option<T> {
         Rc::try_unwrap(this).ok()
     }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -793,7 +793,7 @@ impl<T> Arc<T> {
     /// y_thread.join().unwrap();
     /// ```
     #[inline]
-    #[stable(feature = "arc_into_inner", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "arc_into_inner", since = "1.70.0")]
     pub fn into_inner(this: Self) -> Option<T> {
         // Make sure that the ordinary `Drop` implementation isn’t called as well
         let mut this = mem::ManuallyDrop::new(this);

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -342,7 +342,7 @@ impl<T, A: Allocator> FusedIterator for IntoIter<T, A> {}
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<T, A: Allocator> TrustedLen for IntoIter<T, A> {}
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<T, A> Default for IntoIter<T, A>
 where
     A: Allocator + Default,

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -247,7 +247,7 @@ mod once;
 
 #[unstable(feature = "lazy_cell", issue = "109736")]
 pub use lazy::LazyCell;
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 pub use once::OnceCell;
 
 /// A mutable memory location.

--- a/library/core/src/cell/once.rs
+++ b/library/core/src/cell/once.rs
@@ -29,7 +29,7 @@ use crate::mem;
 /// assert_eq!(value, "Hello, World!");
 /// assert!(cell.get().is_some());
 /// ```
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 pub struct OnceCell<T> {
     // Invariant: written to at most once.
     inner: UnsafeCell<Option<T>>,
@@ -39,8 +39,8 @@ impl<T> OnceCell<T> {
     /// Creates a new empty cell.
     #[inline]
     #[must_use]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
+    #[rustc_const_stable(feature = "once_cell", since = "1.70.0")]
     pub const fn new() -> OnceCell<T> {
         OnceCell { inner: UnsafeCell::new(None) }
     }
@@ -49,7 +49,7 @@ impl<T> OnceCell<T> {
     ///
     /// Returns `None` if the cell is empty.
     #[inline]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
     pub fn get(&self) -> Option<&T> {
         // SAFETY: Safe due to `inner`'s invariant
         unsafe { &*self.inner.get() }.as_ref()
@@ -59,7 +59,7 @@ impl<T> OnceCell<T> {
     ///
     /// Returns `None` if the cell is empty.
     #[inline]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
     pub fn get_mut(&mut self) -> Option<&mut T> {
         self.inner.get_mut().as_mut()
     }
@@ -85,7 +85,7 @@ impl<T> OnceCell<T> {
     /// assert!(cell.get().is_some());
     /// ```
     #[inline]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
     pub fn set(&self, value: T) -> Result<(), T> {
         // SAFETY: Safe because we cannot have overlapping mutable borrows
         let slot = unsafe { &*self.inner.get() };
@@ -125,7 +125,7 @@ impl<T> OnceCell<T> {
     /// assert_eq!(value, &92);
     /// ```
     #[inline]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
     pub fn get_or_init<F>(&self, f: F) -> &T
     where
         F: FnOnce() -> T,
@@ -206,7 +206,7 @@ impl<T> OnceCell<T> {
     /// assert_eq!(cell.into_inner(), Some("hello".to_string()));
     /// ```
     #[inline]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
     pub fn into_inner(self) -> Option<T> {
         // Because `into_inner` takes `self` by value, the compiler statically verifies
         // that it is not currently borrowed. So it is safe to move out `Option<T>`.
@@ -233,13 +233,13 @@ impl<T> OnceCell<T> {
     /// assert_eq!(cell.get(), None);
     /// ```
     #[inline]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
     pub fn take(&mut self) -> Option<T> {
         mem::take(self).into_inner()
     }
 }
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T> Default for OnceCell<T> {
     #[inline]
     fn default() -> Self {
@@ -247,7 +247,7 @@ impl<T> Default for OnceCell<T> {
     }
 }
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T: fmt::Debug> fmt::Debug for OnceCell<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.get() {
@@ -257,7 +257,7 @@ impl<T: fmt::Debug> fmt::Debug for OnceCell<T> {
     }
 }
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T: Clone> Clone for OnceCell<T> {
     #[inline]
     fn clone(&self) -> OnceCell<T> {
@@ -272,7 +272,7 @@ impl<T: Clone> Clone for OnceCell<T> {
     }
 }
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T: PartialEq> PartialEq for OnceCell<T> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -280,10 +280,10 @@ impl<T: PartialEq> PartialEq for OnceCell<T> {
     }
 }
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T: Eq> Eq for OnceCell<T> {}
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 #[rustc_const_unstable(feature = "const_convert", issue = "88674")]
 impl<T> const From<T> for OnceCell<T> {
     /// Creates a new `OnceCell<T>` which already contains the given `value`.
@@ -294,5 +294,5 @@ impl<T> const From<T> for OnceCell<T> {
 }
 
 // Just like for `Cell<T>` this isn't needed, but results in nicer error messages.
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T> !Sync for OnceCell<T> {}

--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -273,7 +273,7 @@ where
 {
 }
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<A: Default, B: Default> Default for Chain<A, B> {
     /// Creates a `Chain` from the default values for `A` and `B`.
     ///

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -154,7 +154,7 @@ where
     }
 }
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<I: Default> Default for Cloned<I> {
     /// Creates a `Cloned` iterator from the default value of `I`
     /// ```

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -242,7 +242,7 @@ where
     }
 }
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<I: Default> Default for Copied<I> {
     /// Creates a `Copied` iterator from the default value of `I`
     /// ```

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -263,7 +263,7 @@ where
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable> InPlaceIterable for Enumerate<I> {}
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<I: Default> Default for Enumerate<I> {
     /// Creates an `Enumerate` iterator from the default value of `I`
     /// ```

--- a/library/core/src/iter/adapters/flatten.rs
+++ b/library/core/src/iter/adapters/flatten.rs
@@ -303,7 +303,7 @@ where
 {
 }
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<I> Default for Flatten<I>
 where
     I: Default + Iterator<Item: IntoIterator>,

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -181,7 +181,7 @@ where
     }
 }
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<I: Default> Default for Fuse<I> {
     /// Creates a `Fuse` iterator from the default value of `I`.
     ///

--- a/library/core/src/iter/adapters/rev.rs
+++ b/library/core/src/iter/adapters/rev.rs
@@ -137,7 +137,7 @@ impl<I> FusedIterator for Rev<I> where I: FusedIterator + DoubleEndedIterator {}
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<I> TrustedLen for Rev<I> where I: TrustedLen + DoubleEndedIterator {}
 
-#[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "default_iters", since = "1.70.0")]
 impl<I: Default> Default for Rev<I> {
     /// Creates a `Rev` iterator from the default value of `I`
     /// ```

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1157,7 +1157,7 @@ macro_rules! nonzero_min_max_unsigned {
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN.get(), 1", stringify!($Int), ");")]
                 /// ```
-                #[stable(feature = "nonzero_min_max", since = "CURRENT_RUSTC_VERSION")]
+                #[stable(feature = "nonzero_min_max", since = "1.70.0")]
                 pub const MIN: Self = Self::new(1).unwrap();
 
                 /// The largest value that can be represented by this non-zero
@@ -1170,7 +1170,7 @@ macro_rules! nonzero_min_max_unsigned {
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX.get(), ", stringify!($Int), "::MAX);")]
                 /// ```
-                #[stable(feature = "nonzero_min_max", since = "CURRENT_RUSTC_VERSION")]
+                #[stable(feature = "nonzero_min_max", since = "1.70.0")]
                 pub const MAX: Self = Self::new(<$Int>::MAX).unwrap();
             }
         )+
@@ -1195,7 +1195,7 @@ macro_rules! nonzero_min_max_signed {
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN.get(), ", stringify!($Int), "::MIN);")]
                 /// ```
-                #[stable(feature = "nonzero_min_max", since = "CURRENT_RUSTC_VERSION")]
+                #[stable(feature = "nonzero_min_max", since = "1.70.0")]
                 pub const MIN: Self = Self::new(<$Int>::MIN).unwrap();
 
                 /// The largest value that can be represented by this non-zero
@@ -1212,7 +1212,7 @@ macro_rules! nonzero_min_max_signed {
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX.get(), ", stringify!($Int), "::MAX);")]
                 /// ```
-                #[stable(feature = "nonzero_min_max", since = "CURRENT_RUSTC_VERSION")]
+                #[stable(feature = "nonzero_min_max", since = "1.70.0")]
                 pub const MAX: Self = Self::new(<$Int>::MAX).unwrap();
             }
         )+

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -616,7 +616,7 @@ impl<T> Option<T> {
     /// ```
     #[must_use]
     #[inline]
-    #[stable(feature = "is_some_and", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "is_some_and", since = "1.70.0")]
     pub fn is_some_and(self, f: impl FnOnce(T) -> bool) -> bool {
         match self {
             None => false,

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -473,7 +473,7 @@ impl<T> NonNull<[T]> {
     ///
     /// (Note that this example artificially demonstrates a use of this method,
     /// but `let slice = NonNull::from(&x[..]);` would be a better way to write code like this.)
-    #[stable(feature = "nonnull_slice_from_raw_parts", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "nonnull_slice_from_raw_parts", since = "1.70.0")]
     #[rustc_const_unstable(feature = "const_slice_from_raw_parts_mut", issue = "67456")]
     #[must_use]
     #[inline]

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -556,7 +556,7 @@ impl<T, E> Result<T, E> {
     /// ```
     #[must_use]
     #[inline]
-    #[stable(feature = "is_some_and", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "is_some_and", since = "1.70.0")]
     pub fn is_ok_and(self, f: impl FnOnce(T) -> bool) -> bool {
         match self {
             Err(_) => false,
@@ -601,7 +601,7 @@ impl<T, E> Result<T, E> {
     /// ```
     #[must_use]
     #[inline]
-    #[stable(feature = "is_some_and", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "is_some_and", since = "1.70.0")]
     pub fn is_err_and(self, f: impl FnOnce(E) -> bool) -> bool {
         match self {
             Ok(_) => false,

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -394,7 +394,7 @@ macro_rules! iterator {
             }
         }
 
-        #[stable(feature = "default_iters", since = "CURRENT_RUSTC_VERSION")]
+        #[stable(feature = "default_iters", since = "1.70.0")]
         impl<T> Default for $name<'_, T> {
             /// Creates an empty slice iterator.
             ///

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -972,8 +972,8 @@ impl AtomicBool {
     /// # }
     /// ```
     #[inline]
-    #[stable(feature = "atomic_as_ptr", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "atomic_as_ptr", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "atomic_as_ptr", since = "1.70.0")]
+    #[rustc_const_stable(feature = "atomic_as_ptr", since = "1.70.0")]
     pub const fn as_ptr(&self) -> *mut bool {
         self.v.get().cast()
     }
@@ -1907,8 +1907,8 @@ impl<T> AtomicPtr<T> {
     /// }
     /// ```
     #[inline]
-    #[stable(feature = "atomic_as_ptr", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "atomic_as_ptr", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "atomic_as_ptr", since = "1.70.0")]
+    #[rustc_const_stable(feature = "atomic_as_ptr", since = "1.70.0")]
     pub const fn as_ptr(&self) -> *mut *mut T {
         self.p.get()
     }
@@ -2860,8 +2860,8 @@ macro_rules! atomic_int {
             /// # }
             /// ```
             #[inline]
-            #[stable(feature = "atomic_as_ptr", since = "CURRENT_RUSTC_VERSION")]
-            #[rustc_const_stable(feature = "atomic_as_ptr", since = "CURRENT_RUSTC_VERSION")]
+            #[stable(feature = "atomic_as_ptr", since = "1.70.0")]
+            #[rustc_const_stable(feature = "atomic_as_ptr", since = "1.70.0")]
             pub const fn as_ptr(&self) -> *mut $int_type {
                 self.v.get()
             }

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -268,7 +268,7 @@ pub(crate) use self::stdio::attempt_print_to_stderr;
 #[unstable(feature = "internal_output_capture", issue = "none")]
 #[doc(no_inline, hidden)]
 pub use self::stdio::set_output_capture;
-#[stable(feature = "is_terminal", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "is_terminal", since = "1.70.0")]
 pub use self::stdio::IsTerminal;
 #[unstable(feature = "print_internals", issue = "none")]
 pub use self::stdio::{_eprint, _print};

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -1047,7 +1047,7 @@ pub(crate) fn attempt_print_to_stderr(args: fmt::Arguments<'_>) {
 }
 
 /// Trait to determine if a descriptor/handle refers to a terminal/tty.
-#[stable(feature = "is_terminal", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "is_terminal", since = "1.70.0")]
 pub trait IsTerminal: crate::sealed::Sealed {
     /// Returns `true` if the descriptor/handle refers to a terminal/tty.
     ///
@@ -1063,7 +1063,7 @@ pub trait IsTerminal: crate::sealed::Sealed {
     /// Note that this [may change in the future][changes].
     ///
     /// [changes]: io#platform-specific-behavior
-    #[stable(feature = "is_terminal", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "is_terminal", since = "1.70.0")]
     fn is_terminal(&self) -> bool;
 }
 
@@ -1072,7 +1072,7 @@ macro_rules! impl_is_terminal {
         #[unstable(feature = "sealed", issue = "none")]
         impl crate::sealed::Sealed for $t {}
 
-        #[stable(feature = "is_terminal", since = "CURRENT_RUSTC_VERSION")]
+        #[stable(feature = "is_terminal", since = "1.70.0")]
         impl IsTerminal for $t {
             #[inline]
             fn is_terminal(&self) -> bool {

--- a/library/std/src/os/android/net.rs
+++ b/library/std/src/os/android/net.rs
@@ -1,8 +1,8 @@
 //! Android-specific networking functionality.
 
-#![stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+#![stable(feature = "unix_socket_abstract", since = "1.70.0")]
 
-#[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "unix_socket_abstract", since = "1.70.0")]
 pub use crate::os::net::linux_ext::addr::SocketAddrExt;
 
 #[unstable(feature = "tcp_quickack", issue = "96256")]

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -201,7 +201,7 @@ macro_rules! impl_is_terminal {
         #[unstable(feature = "sealed", issue = "none")]
         impl crate::sealed::Sealed for $t {}
 
-        #[stable(feature = "is_terminal", since = "CURRENT_RUSTC_VERSION")]
+        #[stable(feature = "is_terminal", since = "1.70.0")]
         impl crate::io::IsTerminal for $t {
             #[inline]
             fn is_terminal(&self) -> bool {

--- a/library/std/src/os/linux/net.rs
+++ b/library/std/src/os/linux/net.rs
@@ -1,8 +1,8 @@
 //! Linux-specific networking functionality.
 
-#![stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+#![stable(feature = "unix_socket_abstract", since = "1.70.0")]
 
-#[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "unix_socket_abstract", since = "1.70.0")]
 pub use crate::os::net::linux_ext::addr::SocketAddrExt;
 
 #[unstable(feature = "tcp_quickack", issue = "96256")]

--- a/library/std/src/os/net/linux_ext/addr.rs
+++ b/library/std/src/os/net/linux_ext/addr.rs
@@ -4,7 +4,7 @@ use crate::os::unix::net::SocketAddr;
 use crate::sealed::Sealed;
 
 /// Platform-specific extensions to [`SocketAddr`].
-#[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "unix_socket_abstract", since = "1.70.0")]
 pub trait SocketAddrExt: Sealed {
     /// Creates a Unix socket address in the abstract namespace.
     ///
@@ -37,7 +37,7 @@ pub trait SocketAddrExt: Sealed {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "unix_socket_abstract", since = "1.70.0")]
     fn from_abstract_name<N>(name: N) -> crate::io::Result<SocketAddr>
     where
         N: AsRef<[u8]>;
@@ -59,6 +59,6 @@ pub trait SocketAddrExt: Sealed {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "unix_socket_abstract", since = "1.70.0")]
     fn as_abstract_name(&self) -> Option<&[u8]>;
 }

--- a/library/std/src/os/net/linux_ext/mod.rs
+++ b/library/std/src/os/net/linux_ext/mod.rs
@@ -2,7 +2,7 @@
 
 #![doc(cfg(any(target_os = "linux", target_os = "android")))]
 
-#[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "unix_socket_abstract", since = "1.70.0")]
 pub(crate) mod addr;
 
 #[unstable(feature = "tcp_quickack", issue = "96256")]

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -245,12 +245,12 @@ impl SocketAddr {
     }
 }
 
-#[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "unix_socket_abstract", since = "1.70.0")]
 impl Sealed for SocketAddr {}
 
 #[doc(cfg(any(target_os = "android", target_os = "linux")))]
 #[cfg(any(doc, target_os = "android", target_os = "linux"))]
-#[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "unix_socket_abstract", since = "1.70.0")]
 impl linux_ext::addr::SocketAddrExt for SocketAddr {
     fn as_abstract_name(&self) -> Option<&[u8]> {
         if let AddressKind::Abstract(name) = self.address() { Some(name) } else { None }

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -118,7 +118,7 @@ impl UnixDatagram {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "unix_socket_abstract", since = "1.70.0")]
     pub fn bind_addr(socket_addr: &SocketAddr) -> io::Result<UnixDatagram> {
         unsafe {
             let socket = UnixDatagram::unbound()?;
@@ -233,7 +233,7 @@ impl UnixDatagram {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "unix_socket_abstract", since = "1.70.0")]
     pub fn connect_addr(&self, socket_addr: &SocketAddr) -> io::Result<()> {
         unsafe {
             cvt(libc::connect(
@@ -532,7 +532,7 @@ impl UnixDatagram {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "unix_socket_abstract", since = "1.70.0")]
     pub fn send_to_addr(&self, buf: &[u8], socket_addr: &SocketAddr) -> io::Result<usize> {
         unsafe {
             let count = cvt(libc::sendto(

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -106,7 +106,7 @@ impl UnixListener {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "unix_socket_abstract", since = "1.70.0")]
     pub fn bind_addr(socket_addr: &SocketAddr) -> io::Result<UnixListener> {
         unsafe {
             let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -122,7 +122,7 @@ impl UnixStream {
     ///     Ok(())
     /// }
     /// ````
-    #[stable(feature = "unix_socket_abstract", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "unix_socket_abstract", since = "1.70.0")]
     pub fn connect_addr(socket_addr: &SocketAddr) -> io::Result<UnixStream> {
         unsafe {
             let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -389,7 +389,7 @@ macro_rules! impl_is_terminal {
         #[unstable(feature = "sealed", issue = "none")]
         impl crate::sealed::Sealed for $t {}
 
-        #[stable(feature = "is_terminal", since = "CURRENT_RUSTC_VERSION")]
+        #[stable(feature = "is_terminal", since = "1.70.0")]
         impl crate::io::IsTerminal for $t {
             #[inline]
             fn is_terminal(&self) -> bool {

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1509,7 +1509,7 @@ impl PathBuf {
     /// path.as_mut_os_string().push("baz");
     /// assert_eq!(path, Path::new("/foo/barbaz"));
     /// ```
-    #[stable(feature = "path_as_mut_os_str", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "path_as_mut_os_str", since = "1.70.0")]
     #[must_use]
     #[inline]
     pub fn as_mut_os_string(&mut self) -> &mut OsString {
@@ -2074,7 +2074,7 @@ impl Path {
     /// path.as_mut_os_str().make_ascii_lowercase();
     /// assert_eq!(path, Path::new("foo.txt"));
     /// ```
-    #[stable(feature = "path_as_mut_os_str", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "path_as_mut_os_str", since = "1.70.0")]
     #[must_use]
     #[inline]
     pub fn as_mut_os_str(&mut self) -> &mut OsStr {

--- a/library/std/src/sync/mod.rs
+++ b/library/std/src/sync/mod.rs
@@ -177,7 +177,7 @@ pub use self::rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 #[unstable(feature = "lazy_cell", issue = "109736")]
 pub use self::lazy_lock::LazyLock;
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 pub use self::once_lock::OnceLock;
 
 pub(crate) use self::remutex::{ReentrantMutex, ReentrantMutexGuard};

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -30,7 +30,7 @@ use crate::sync::Once;
 /// assert!(value.is_some());
 /// assert_eq!(value.unwrap().as_str(), "Hello, World!");
 /// ```
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 pub struct OnceLock<T> {
     once: Once,
     // Whether or not the value is initialized is tracked by `once.is_completed()`.
@@ -59,8 +59,8 @@ impl<T> OnceLock<T> {
     /// Creates a new empty cell.
     #[inline]
     #[must_use]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
+    #[rustc_const_stable(feature = "once_cell", since = "1.70.0")]
     pub const fn new() -> OnceLock<T> {
         OnceLock {
             once: Once::new(),
@@ -74,7 +74,7 @@ impl<T> OnceLock<T> {
     /// Returns `None` if the cell is empty, or being initialized. This
     /// method never blocks.
     #[inline]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
     pub fn get(&self) -> Option<&T> {
         if self.is_initialized() {
             // Safe b/c checked is_initialized
@@ -88,7 +88,7 @@ impl<T> OnceLock<T> {
     ///
     /// Returns `None` if the cell is empty. This method never blocks.
     #[inline]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
     pub fn get_mut(&mut self) -> Option<&mut T> {
         if self.is_initialized() {
             // Safe b/c checked is_initialized and we have a unique access
@@ -124,7 +124,7 @@ impl<T> OnceLock<T> {
     /// }
     /// ```
     #[inline]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
     pub fn set(&self, value: T) -> Result<(), T> {
         let mut value = Some(value);
         self.get_or_init(|| value.take().unwrap());
@@ -162,7 +162,7 @@ impl<T> OnceLock<T> {
     /// assert_eq!(value, &92);
     /// ```
     #[inline]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
     pub fn get_or_init<F>(&self, f: F) -> &T
     where
         F: FnOnce() -> T,
@@ -239,7 +239,7 @@ impl<T> OnceLock<T> {
     /// assert_eq!(cell.into_inner(), Some("hello".to_string()));
     /// ```
     #[inline]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
     pub fn into_inner(mut self) -> Option<T> {
         self.take()
     }
@@ -264,7 +264,7 @@ impl<T> OnceLock<T> {
     /// assert_eq!(cell.get(), None);
     /// ```
     #[inline]
-    #[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_cell", since = "1.70.0")]
     pub fn take(&mut self) -> Option<T> {
         if self.is_initialized() {
             self.once = Once::new();
@@ -333,17 +333,17 @@ impl<T> OnceLock<T> {
 // scoped thread B, which fills the cell, which is
 // then destroyed by A. That is, destructor observes
 // a sent value.
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 unsafe impl<T: Sync + Send> Sync for OnceLock<T> {}
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 unsafe impl<T: Send> Send for OnceLock<T> {}
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T: RefUnwindSafe + UnwindSafe> RefUnwindSafe for OnceLock<T> {}
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T: UnwindSafe> UnwindSafe for OnceLock<T> {}
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 #[rustc_const_unstable(feature = "const_default_impls", issue = "87864")]
 impl<T> const Default for OnceLock<T> {
     /// Creates a new empty cell.
@@ -363,7 +363,7 @@ impl<T> const Default for OnceLock<T> {
     }
 }
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T: fmt::Debug> fmt::Debug for OnceLock<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.get() {
@@ -373,7 +373,7 @@ impl<T: fmt::Debug> fmt::Debug for OnceLock<T> {
     }
 }
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T: Clone> Clone for OnceLock<T> {
     #[inline]
     fn clone(&self) -> OnceLock<T> {
@@ -388,7 +388,7 @@ impl<T: Clone> Clone for OnceLock<T> {
     }
 }
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T> From<T> for OnceLock<T> {
     /// Create a new cell with its contents set to `value`.
     ///
@@ -415,7 +415,7 @@ impl<T> From<T> for OnceLock<T> {
     }
 }
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T: PartialEq> PartialEq for OnceLock<T> {
     #[inline]
     fn eq(&self, other: &OnceLock<T>) -> bool {
@@ -423,10 +423,10 @@ impl<T: PartialEq> PartialEq for OnceLock<T> {
     }
 }
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 impl<T: Eq> Eq for OnceLock<T> {}
 
-#[stable(feature = "once_cell", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "once_cell", since = "1.70.0")]
 unsafe impl<#[may_dangle] T> Drop for OnceLock<T> {
     #[inline]
     fn drop(&mut self) {

--- a/src/ci/channel
+++ b/src/ci/channel
@@ -1,1 +1,1 @@
-nightly
+beta

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -79,6 +79,9 @@ pub struct TestProps {
     pub unset_rustc_env: Vec<String>,
     // Environment settings to use during execution
     pub exec_env: Vec<(String, String)>,
+    // Environment variables to unset prior to execution.
+    // Variables are unset before applying 'exec_env'
+    pub unset_exec_env: Vec<String>,
     // Build documentation for all specified aux-builds as well
     pub build_aux_docs: bool,
     // Flag to force a crate to be built with the host architecture
@@ -184,6 +187,7 @@ mod directives {
     pub const AUX_CRATE: &'static str = "aux-crate";
     pub const EXEC_ENV: &'static str = "exec-env";
     pub const RUSTC_ENV: &'static str = "rustc-env";
+    pub const UNSET_EXEC_ENV: &'static str = "unset-exec-env";
     pub const UNSET_RUSTC_ENV: &'static str = "unset-rustc-env";
     pub const FORBID_OUTPUT: &'static str = "forbid-output";
     pub const CHECK_TEST_LINE_NUMBERS_MATCH: &'static str = "check-test-line-numbers-match";
@@ -216,6 +220,7 @@ impl TestProps {
             rustc_env: vec![],
             unset_rustc_env: vec![],
             exec_env: vec![],
+            unset_exec_env: vec![],
             build_aux_docs: false,
             force_host: false,
             check_stdout: false,
@@ -365,6 +370,12 @@ impl TestProps {
                     EXEC_ENV,
                     &mut self.exec_env,
                     Config::parse_env,
+                );
+                config.push_name_value_directive(
+                    ln,
+                    UNSET_EXEC_ENV,
+                    &mut self.unset_exec_env,
+                    |r| r,
                 );
                 config.push_name_value_directive(
                     ln,

--- a/src/tools/compiletest/src/header/cfg.rs
+++ b/src/tools/compiletest/src/header/cfg.rs
@@ -130,11 +130,15 @@ pub(super) fn parse_cfg_name_directive<'a>(
         message: "when the architecture is part of the Thumb family"
     }
 
+    // Technically the locally built compiler uses the "dev" channel rather than the "nightly"
+    // channel, even though most people don't know or won't care about it. To avoid confusion, we
+    // treat the "dev" channel as the "nightly" channel when processing the directive.
     condition! {
-        name: &config.channel,
+        name: if config.channel == "dev" { "nightly" } else { &config.channel },
         allowed_names: &["stable", "beta", "nightly"],
         message: "when the release channel is {name}",
     }
+
     condition! {
         name: "cross-compile",
         condition: config.target != config.host,

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1613,8 +1613,13 @@ impl<'test> TestCx<'test> {
                 test_client
                     .args(&["run", &support_libs.len().to_string(), &prog])
                     .args(support_libs)
-                    .args(args)
-                    .envs(env.clone());
+                    .args(args);
+
+                for key in &self.props.unset_exec_env {
+                    test_client.env_remove(key);
+                }
+                test_client.envs(env.clone());
+
                 self.compose_and_run(
                     test_client,
                     self.config.run_lib_path.to_str().unwrap(),
@@ -1626,7 +1631,13 @@ impl<'test> TestCx<'test> {
                 let aux_dir = self.aux_output_dir_name();
                 let ProcArgs { prog, args } = self.make_run_args();
                 let mut wr_run = Command::new("wr-run");
-                wr_run.args(&[&prog]).args(args).envs(env.clone());
+                wr_run.args(&[&prog]).args(args);
+
+                for key in &self.props.unset_exec_env {
+                    wr_run.env_remove(key);
+                }
+                wr_run.envs(env.clone());
+
                 self.compose_and_run(
                     wr_run,
                     self.config.run_lib_path.to_str().unwrap(),
@@ -1638,7 +1649,13 @@ impl<'test> TestCx<'test> {
                 let aux_dir = self.aux_output_dir_name();
                 let ProcArgs { prog, args } = self.make_run_args();
                 let mut program = Command::new(&prog);
-                program.args(args).current_dir(&self.output_base_dir()).envs(env.clone());
+                program.args(args).current_dir(&self.output_base_dir());
+
+                for key in &self.props.unset_exec_env {
+                    program.env_remove(key);
+                }
+                program.envs(env.clone());
+
                 self.compose_and_run(
                     program,
                     self.config.run_lib_path.to_str().unwrap(),

--- a/tests/ui/feature-gates/test-listing-format-json.rs
+++ b/tests/ui/feature-gates/test-listing-format-json.rs
@@ -1,13 +1,10 @@
 // no-prefer-dynamic
 // compile-flags: --test
 // run-flags: --list --format json -Zunstable-options
-// run-pass
+// run-fail
 // check-run-results
-// only-nightly
-// normalize-stdout-test: "fake-test-src-base/test-attrs/" -> "$$DIR/"
-// normalize-stdout-test: "fake-test-src-base\\test-attrs\\" -> "$$DIR/"
-
-// Checks the listing of tests with --format json.
+// ignore-nightly
+// unset-exec-env:RUSTC_BOOTSTRAP
 
 #![cfg(test)]
 #[test]

--- a/tests/ui/feature-gates/test-listing-format-json.run.stderr
+++ b/tests/ui/feature-gates/test-listing-format-json.run.stderr
@@ -1,0 +1,1 @@
+error: the option `Z` is only accepted on the nightly compiler


### PR DESCRIPTION
This PR replaces the version placeholders, and changes the channel to `beta`.

r? @ghost
cc @rust-lang/release