### PR TITLE
Kill moved locals in borrowed locals analysis

### DIFF
--- a/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
@@ -91,6 +91,12 @@ where
                 }
             }
 
+            mir::Rvalue::Use(mir::Operand::Move(place)) => {
+                if place.projection.len() == 0 {
+                    self.trans.kill(place.local)
+                }
+            }
+
             mir::Rvalue::Cast(..)
             | mir::Rvalue::ShallowInitBox(..)
             | mir::Rvalue::Use(..)

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -717,6 +717,7 @@ impl GeneratorSavedLocals {
                 out.insert(saved_local);
             }
         }
+
         out
     }
 

--- a/tests/ui/async-await/drop-track-field-assign-nonsend.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/drop-track-field-assign-nonsend.drop_tracking_mir.stderr
@@ -5,14 +5,11 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-note: future is not `Send` as this value is used across an await
-  --> $DIR/drop-track-field-assign-nonsend.rs:23:38
+note: captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
+  --> $DIR/drop-track-field-assign-nonsend.rs:19:21
    |
-LL |         let mut info = self.info_result.clone();
-   |             -------- has type `InfoResult` which is not `Send`
-...
-LL |         let _ = send_element(element).await;
-   |                                      ^^^^^^ await occurs here, with `mut info` maybe used later
+LL |     async fn handle(&mut self) {
+   |                     ^^^^^^^^^ has type `&mut Agent` which is not `Send`, because `Agent` is not `Send`
 note: required by a bound in `assert_send`
   --> $DIR/drop-track-field-assign-nonsend.rs:40:19
    |

--- a/tests/ui/async-await/field-assign-nonsend.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/field-assign-nonsend.drop_tracking_mir.stderr
@@ -5,14 +5,11 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-note: future is not `Send` as this value is used across an await
-  --> $DIR/field-assign-nonsend.rs:23:38
+note: captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
+  --> $DIR/field-assign-nonsend.rs:19:21
    |
-LL |         let mut info = self.info_result.clone();
-   |             -------- has type `InfoResult` which is not `Send`
-...
-LL |         let _ = send_element(element).await;
-   |                                      ^^^^^^ await occurs here, with `mut info` maybe used later
+LL |     async fn handle(&mut self) {
+   |                     ^^^^^^^^^ has type `&mut Agent` which is not `Send`, because `Agent` is not `Send`
 note: required by a bound in `assert_send`
   --> $DIR/field-assign-nonsend.rs:40:19
    |

--- a/tests/ui/async-await/issue-96084.rs
+++ b/tests/ui/async-await/issue-96084.rs
@@ -1,0 +1,33 @@
+// run-pass
+// edition:2018
+
+use std::mem;
+
+async fn foo() {
+    let x = [0u8; 100];
+    async {}.await;
+    println!("{}", x.len());
+}
+
+async fn a() {
+    let fut = foo();
+    let fut = fut;
+    fut.await;
+}
+
+async fn b() {
+    let fut = foo();
+    println!("{}", mem::size_of_val(&fut));
+    let fut = fut;
+    fut.await;
+}
+
+fn main() {
+    assert_eq!(mem::size_of_val(&foo()), 102);
+
+    // 1 + sizeof(foo)
+    assert_eq!(mem::size_of_val(&a()), 103);
+
+    // 1 + (sizeof(foo) * 2)
+    assert_eq!(mem::size_of_val(&b()), 103);
+}

--- a/tests/ui/generator/size-moved-locals.rs
+++ b/tests/ui/generator/size-moved-locals.rs
@@ -73,6 +73,6 @@ fn overlap_x_and_y() -> impl Generator<Yield = (), Return = ()> {
 fn main() {
     assert_eq!(1025, std::mem::size_of_val(&move_before_yield()));
     assert_eq!(1026, std::mem::size_of_val(&move_before_yield_with_noop()));
-    assert_eq!(2051, std::mem::size_of_val(&overlap_move_points()));
+    assert_eq!(1027, std::mem::size_of_val(&overlap_move_points()));
     assert_eq!(1026, std::mem::size_of_val(&overlap_x_and_y()));
 }


### PR DESCRIPTION
We currently solely rely on `StorageDead` statements when killing locals in the borrowed locals analysis. Killing locals when they're moved should be fine since the borrow checker guarantees that there aren't any used borrows after the move. Currently this change only kills locals corresponding to `Place`s that don't have any projections, though we could in principle also track moves of projections here. Not sure whether this is worth it given that we will be move to `drop-tracking` and `mir-drop-tracking` at some point. Still, the current change seems like an improvement to me until then.

Fixes https://github.com/rust-lang/rust/issues/96084
Fixes https://github.com/rust-lang/rust/issues/94067 (I think? I believe the example by @eholk was missing a `Send` impl on `Agent`)

r? @tmandry maybe?