### PR TITLE
Spelling src etc

### DIFF
--- a/src/etc/installer/pkg/Distribution.xml
+++ b/src/etc/installer/pkg/Distribution.xml
@@ -23,7 +23,7 @@
     </choices-outline>
     <!--
     These 'selected' scripts ensure that install and uninstall can never be selected at
-    the same time. Exectly how they work is pretty mysterious, tied to the unspecified algorithm
+    the same time. Exactly how they work is pretty mysterious, tied to the unspecified algorithm
     the installer uses to traverse the options after one is toggled.
       -->
     <choice id="install" visible="true"

--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -115,4 +115,4 @@ def synthetic_lookup(valobj, dict):
     if rust_type == RustType.STD_REF_CELL:
         return StdRefSyntheticProvider(valobj, dict, is_cell=True)
 
-    return DefaultSynthteticProvider(valobj, dict)
+    return DefaultSyntheticProvider(valobj, dict)

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -69,9 +69,9 @@ def unwrap_unique_or_non_null(unique_or_nonnull):
     return ptr if ptr.TypeIsPointerType() else ptr.GetChildAtIndex(0)
 
 
-class DefaultSynthteticProvider:
+class DefaultSyntheticProvider:
     def __init__(self, valobj, dict):
-        # type: (SBValue, dict) -> DefaultSynthteticProvider
+        # type: (SBValue, dict) -> DefaultSyntheticProvider
         # logger = Logger.Logger()
         # logger >> "Default synthetic provider for " + str(valobj.GetName())
         self.valobj = valobj


### PR DESCRIPTION
The various src/* items seem slightly disparate, so I'm doing src/* individually.

split from https://github.com/rust-lang/rust/pull/110392