### PR TITLE
Check freeze with right param-env in `deduced_param_attrs`

### DIFF
--- a/tests/ui/codegen/freeze-on-polymorphic-projection.rs
+++ b/tests/ui/codegen/freeze-on-polymorphic-projection.rs
@@ -1,0 +1,19 @@
+// build-pass
+// compile-flags: -Copt-level=1 --crate-type=lib
+
+#![feature(specialization)]
+//~^ WARN the feature `specialization` is incomplete
+
+pub unsafe trait Storage {
+    type Handle;
+}
+
+pub unsafe trait MultipleStorage: Storage {}
+
+default unsafe impl<S> Storage for S where S: MultipleStorage {}
+
+// Make sure that we call is_freeze on `(S::Handle,)` in the param-env of `ice`,
+// instead of in an empty, reveal-all param-env.
+pub fn ice<S: Storage>(boxed: (S::Handle,)) -> (S::Handle,) {
+    boxed
+}

--- a/tests/ui/codegen/freeze-on-polymorphic-projection.stderr
+++ b/tests/ui/codegen/freeze-on-polymorphic-projection.stderr
@@ -1,0 +1,12 @@
+warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/freeze-on-polymorphic-projection.rs:4:12
+   |
+LL | #![feature(specialization)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
+   = help: consider using `min_specialization` instead, which is more stable and complete
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
We're checking if a trait (`Freeze`) holds in a polymorphic function, but not using that function's own (reveal-all) param-env. This causes us to try to eagerly normalize a specializable projection type that has no default value, which causes an ICE.

Fixes #110171