### PR TITLE
rustdoc-json: Add test for field ordering.

### DIFF
--- a/tests/rustdoc-json/enums/field_order.rs
+++ b/tests/rustdoc-json/enums/field_order.rs
@@ -1,0 +1,40 @@
+// Check that the order of fields is preserved.
+
+pub enum Whatever {
+    Foo {
+        // Important: random prefixes are used here to ensure that
+        // sorting fields by name would cause this test to fail.
+        ews_0: i32,
+        dik_1: i32,
+        hsk_2: i32,
+        djt_3: i32,
+        jnr_4: i32,
+        dfs_5: i32,
+        bja_6: i32,
+        lyc_7: i32,
+        yqd_8: i32,
+        vll_9: i32,
+    },
+}
+
+// @set 0 = '$.index[*][?(@.name == "ews_0")].id'
+// @set 1 = '$.index[*][?(@.name == "dik_1")].id'
+// @set 2 = '$.index[*][?(@.name == "hsk_2")].id'
+// @set 3 = '$.index[*][?(@.name == "djt_3")].id'
+// @set 4 = '$.index[*][?(@.name == "jnr_4")].id'
+// @set 5 = '$.index[*][?(@.name == "dfs_5")].id'
+// @set 6 = '$.index[*][?(@.name == "bja_6")].id'
+// @set 7 = '$.index[*][?(@.name == "lyc_7")].id'
+// @set 8 = '$.index[*][?(@.name == "yqd_8")].id'
+// @set 9 = '$.index[*][?(@.name == "vll_9")].id'
+
+// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[0]' $0
+// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[1]' $1
+// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[2]' $2
+// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[3]' $3
+// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[4]' $4
+// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[5]' $5
+// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[6]' $6
+// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[7]' $7
+// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[8]' $8
+// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[9]' $9

--- a/tests/rustdoc-json/enums/variant_order.rs
+++ b/tests/rustdoc-json/enums/variant_order.rs
@@ -1,0 +1,38 @@
+// Check that the order of variants is preserved.
+
+pub enum Foo {
+    // Important: random prefixes are used here to ensure that
+    // sorting fields by name would cause this test to fail.
+    Ews0,
+    Dik1,
+    Hsk2,
+    Djt3,
+    Jnr4,
+    Dfs5,
+    Bja6,
+    Lyc7,
+    Yqd8,
+    Vll9,
+}
+
+// @set 0 = '$.index[*][?(@.name == "Ews0")].id'
+// @set 1 = '$.index[*][?(@.name == "Dik1")].id'
+// @set 2 = '$.index[*][?(@.name == "Hsk2")].id'
+// @set 3 = '$.index[*][?(@.name == "Djt3")].id'
+// @set 4 = '$.index[*][?(@.name == "Jnr4")].id'
+// @set 5 = '$.index[*][?(@.name == "Dfs5")].id'
+// @set 6 = '$.index[*][?(@.name == "Bja6")].id'
+// @set 7 = '$.index[*][?(@.name == "Lyc7")].id'
+// @set 8 = '$.index[*][?(@.name == "Yqd8")].id'
+// @set 9 = '$.index[*][?(@.name == "Vll9")].id'
+
+// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[0]' $0
+// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[1]' $1
+// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[2]' $2
+// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[3]' $3
+// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[4]' $4
+// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[5]' $5
+// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[6]' $6
+// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[7]' $7
+// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[8]' $8
+// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[9]' $9

--- a/tests/rustdoc-json/structs/field_order.rs
+++ b/tests/rustdoc-json/structs/field_order.rs
@@ -1,0 +1,38 @@
+// Check that the order of fields is preserved.
+
+pub struct Foo {
+    // Important: random prefixes are used here to ensure that
+    // sorting fields by name would cause this test to fail.
+    pub ews_0: i32,
+    pub dik_1: i32,
+    pub hsk_2: i32,
+    pub djt_3: i32,
+    pub jnr_4: i32,
+    pub dfs_5: i32,
+    pub bja_6: i32,
+    pub lyc_7: i32,
+    pub yqd_8: i32,
+    pub vll_9: i32,
+}
+
+// @set 0 = '$.index[*][?(@.name == "ews_0")].id'
+// @set 1 = '$.index[*][?(@.name == "dik_1")].id'
+// @set 2 = '$.index[*][?(@.name == "hsk_2")].id'
+// @set 3 = '$.index[*][?(@.name == "djt_3")].id'
+// @set 4 = '$.index[*][?(@.name == "jnr_4")].id'
+// @set 5 = '$.index[*][?(@.name == "dfs_5")].id'
+// @set 6 = '$.index[*][?(@.name == "bja_6")].id'
+// @set 7 = '$.index[*][?(@.name == "lyc_7")].id'
+// @set 8 = '$.index[*][?(@.name == "yqd_8")].id'
+// @set 9 = '$.index[*][?(@.name == "vll_9")].id'
+
+// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[0]' $0
+// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[1]' $1
+// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[2]' $2
+// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[3]' $3
+// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[4]' $4
+// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[5]' $5
+// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[6]' $6
+// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[7]' $7
+// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[8]' $8
+// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[9]' $9

--- a/tests/rustdoc-json/unions/field_order.rs
+++ b/tests/rustdoc-json/unions/field_order.rs
@@ -1,0 +1,38 @@
+// Check that the order of fields is preserved.
+
+pub union Foo {
+    // Important: random prefixes are used here to ensure that
+    // sorting fields by name would cause this test to fail.
+    pub ews_0: i32,
+    pub dik_1: i32,
+    pub hsk_2: i32,
+    pub djt_3: i32,
+    pub jnr_4: i32,
+    pub dfs_5: i32,
+    pub bja_6: i32,
+    pub lyc_7: i32,
+    pub yqd_8: i32,
+    pub vll_9: i32,
+}
+
+// @set 0 = '$.index[*][?(@.name == "ews_0")].id'
+// @set 1 = '$.index[*][?(@.name == "dik_1")].id'
+// @set 2 = '$.index[*][?(@.name == "hsk_2")].id'
+// @set 3 = '$.index[*][?(@.name == "djt_3")].id'
+// @set 4 = '$.index[*][?(@.name == "jnr_4")].id'
+// @set 5 = '$.index[*][?(@.name == "dfs_5")].id'
+// @set 6 = '$.index[*][?(@.name == "bja_6")].id'
+// @set 7 = '$.index[*][?(@.name == "lyc_7")].id'
+// @set 8 = '$.index[*][?(@.name == "yqd_8")].id'
+// @set 9 = '$.index[*][?(@.name == "vll_9")].id'
+
+// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[0]' $0
+// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[1]' $1
+// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[2]' $2
+// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[3]' $3
+// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[4]' $4
+// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[5]' $5
+// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[6]' $6
+// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[7]' $7
+// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[8]' $8
+// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[9]' $9


### PR DESCRIPTION
Inspired by [this on twitter](https://twitter.com/PredragGruevski/status/1647705616650043392), the ordering of fields really matters, so we should test we preserve it through json.

r? rustdoc