### PR TITLE
Support loading version information from xz tarballs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "sha2",
  "tar",
  "toml",
+ "xz2",
 ]
 
 [[package]]
@@ -1939,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "lzma-sys"
-version = "0.1.16"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f24f76ec44a8ac23a31915d6e326bca17ce88da03096f1ff194925dc714dac99"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
 dependencies = [
  "cc",
  "libc",
@@ -5386,9 +5387,9 @@ dependencies = [
 
 [[package]]
 name = "xz2"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
 ]

--- a/src/tools/build-manifest/Cargo.toml
+++ b/src/tools/build-manifest/Cargo.toml
@@ -9,6 +9,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0.32"
 flate2 = "1.0.16"
+xz2 = "0.1.7"
 tar = "0.4.29"
 sha2 = "0.10.1"
 rayon = "1.5.1"

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -5,6 +5,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use tar::Archive;
+use xz2::read::XzDecoder;
 
 const DEFAULT_TARGET: &str = "x86_64-unknown-linux-gnu";
 
@@ -175,9 +176,23 @@ impl Versions {
     }
 
     fn load_version_from_tarball(&mut self, package: &PkgType) -> Result<VersionInfo, Error> {
-        let tarball_name = self.tarball_name(package, DEFAULT_TARGET)?;
-        let tarball = self.dist_path.join(tarball_name);
+        for ext in ["xz", "gz"] {
+            let info =
+                self.load_version_from_tarball_inner(&self.dist_path.join(self.archive_name(
+                    package,
+                    DEFAULT_TARGET,
+                    &format!("tar.{}", ext),
+                )?))?;
+            if info.present {
+                return Ok(info);
+            }
+        }
 
+        // If neither tarball is present, we fallback to returning the non-present info.
+        Ok(VersionInfo::default())
+    }
+
+    fn load_version_from_tarball_inner(&mut self, tarball: &Path) -> Result<VersionInfo, Error> {
         let file = match File::open(&tarball) {
             Ok(file) => file,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
@@ -187,7 +202,14 @@ impl Versions {
             }
             Err(err) => return Err(err.into()),
         };
-        let mut tar = Archive::new(GzDecoder::new(file));
+        let mut tar: Archive<Box<dyn std::io::Read>> =
+            Archive::new(if tarball.extension().map_or(false, |e| e == "gz") {
+                Box::new(GzDecoder::new(file))
+            } else if tarball.extension().map_or(false, |e| e == "xz") {
+                Box::new(XzDecoder::new(file))
+            } else {
+                unimplemented!("tarball extension not recognized: {}", tarball.display())
+            });
 
         let mut version = None;
         let mut git_commit = None;


### PR DESCRIPTION
This is intended to allow us to move recompression from xz (produced in CI) to gz after an initial manifest run, which produces a list of actually required artifacts. The rest are then deleted, which means that we can avoid recompressing them, saving a bunch of time.

This is essentially untested and more might be needed, will run a patched promote-release against try artifacts from this PR. If we do go ahead with this we'll either need to backport this patch to beta/stable, wait for it to propagate, or temporarily recompress to gzip but not xz tarballs (or similar).

r? @pietroalbini 