### PR TITLE
Allow `transmute`-ing for tuples with `[u8; <const N: usize>]`

### DIFF
--- a/tests/ui/const-generics/transmute.rs
+++ b/tests/ui/const-generics/transmute.rs
@@ -67,10 +67,20 @@ fn transpose_with_const<const W: usize, const H: usize>(
   unsafe {
     std::mem::transmute(v)
   }
+
+}
+
+fn concat_tuple<const W: usize, const H: usize>(
+  v: ([u8; W], [u8; H]),
+) -> [u8; W + H] {
+  unsafe {
+    std::mem::transmute(v)
+  }
 }
 
 fn main() {
   let _ = transpose([[0; 8]; 16]);
+  let _ = concat_tuple(([0; 10], [0; 16]));
   let _ = transpose_with_const::<8,4>([[0; 8]; 16]);
   let _ = ident([[0; 8]; 16]);
   let _ = flatten([[0; 13]; 5]);

--- a/tests/ui/const-generics/transmute_no_gate.rs
+++ b/tests/ui/const-generics/transmute_no_gate.rs
@@ -77,8 +77,18 @@ fn transpose_with_const<const W: usize, const H: usize>(
   }
 }
 
+fn concat_tuple<const W: usize, const H: usize>(
+  v: ([u8; W], [u8; H]),
+) -> [u8; W + H] {
+  unsafe {
+    std::mem::transmute(v)
+    //~^ ERROR cannot transmute
+  }
+}
+
 fn main() {
   let _ = transpose([[0; 8]; 16]);
+  let _ = concat_tuple(([0; 10], [0; 16]));
   let _ = transpose_with_const::<8,4>([[0; 8]; 16]);
   let _ = ident([[0; 8]; 16]);
   let _ = flatten([[0; 13]; 5]);

--- a/tests/ui/const-generics/transmute_no_gate.stderr
+++ b/tests/ui/const-generics/transmute_no_gate.stderr
@@ -79,6 +79,15 @@ LL |     std::mem::transmute(v)
    = note: source type: `[[u32; 2 * H]; W + W]` (this type does not have a fixed size)
    = note: target type: `[[u32; W + W]; 2 * H]` (this type does not have a fixed size)
 
-error: aborting due to 9 previous errors
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/transmute_no_gate.rs:84:5
+   |
+LL |     std::mem::transmute(v)
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `([u8; W], [u8; H])` (size can vary because of [u8; W])
+   = note: target type: `[u8; W + H]` (this type does not have a fixed size)
+
+error: aborting due to 10 previous errors
 
 For more information about this error, try `rustc --explain E0512`.


### PR DESCRIPTION
This allows transmuting tuples, but currently only supports `u8` or other single byte types, because I did not add any way to factor additions.

Why this is desired is it will allow for concatenation of arrays "without copying", (although likely they will have to be copied to be adjacent in memory?). As opposed to before which handled multiplication of layouts within arrays which can be thought of as reshaping, this allows for stacking arrays.

For example, if I have:
`transmute( ( [u32; N], [u32; M] ) ) == [u32; N + M]`, it is equivalent to `4N + 4M = 4 (N + M)`. I do not currently factor the `4` out.

This also doesn't handle subtractions, since I didn't want to have to think about underflow (not sure if that would be desired in the future. It is also unclear how to handle `N + N = 2N`, which I suspect likely wouldn't be handled.

I think this PR still lacks what I hope would be complete functionality, but is enough to ask for feedback on how to implement the missing pieces.