### PR TITLE
Require Python 3 in bootstrap.py

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -19,6 +19,8 @@ try:
 except ImportError:
     lzma = None
 
+assert sys.version_info.major == 3
+
 if sys.platform == 'win32':
     EXE_SUFFIX = ".exe"
 else:

--- a/x.py
+++ b/x.py
@@ -19,7 +19,9 @@ if sys.version_info.major < 3:
             os.execvp("python3", ["python3"] + sys.argv)
         except OSError:
             # Python 3 isn't available, fall back to python 2
-            pass
+            sys.stderr.write("Could not find Python 3. If you have Python 3 available, use it to invoke x.py.")
+            sys.stderr.write("If no Python 3 is available, consider installing it: https://www.python.org/downloads/")
+            exit(1)
 
 rust_dir = os.path.dirname(os.path.abspath(__file__))
 # For the import below, have Python search in src/bootstrap first.


### PR DESCRIPTION
If x.py was executed with Python 2, it tries to reexecute itself with Python 3 if that is available. If it isn't, we now raise an error.

This may break people who have Python 3 in a nonstandard location under a nonstandard name. These people will now be forced to use `their-python3 x.py` instead of `./x.py`.

https://github.com/rust-lang/rust/pull/110427#issuecomment-1510479486