### PR TITLE
Avoid including dry run steps in the build metrics

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -2010,7 +2010,7 @@ impl<'a> Builder<'a> {
         }
 
         #[cfg(feature = "build-metrics")]
-        self.metrics.enter_step(&step);
+        self.metrics.enter_step(&step, self);
 
         let (out, dur) = {
             let start = Instant::now();
@@ -2036,7 +2036,7 @@ impl<'a> Builder<'a> {
         }
 
         #[cfg(feature = "build-metrics")]
-        self.metrics.exit_step();
+        self.metrics.exit_step(self);
 
         {
             let mut stack = self.stack.borrow_mut();

--- a/src/bootstrap/render_tests.rs
+++ b/src/bootstrap/render_tests.rs
@@ -124,6 +124,7 @@ impl<'a> Renderer<'a> {
                     ignore_reason: reason.map(|s| s.to_string()),
                 },
             },
+            self.builder,
         );
 
         if self.builder.config.verbose_tests {


### PR DESCRIPTION
Including steps executed during the dry run will result in a duplication of all the steps in the build metrics, which just adds noise.