### PR TITLE
Use `matches` by None in `is_none` method on Option

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -641,7 +641,7 @@ impl<T> Option<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_option_basics", since = "1.48.0")]
     pub const fn is_none(&self) -> bool {
-        !self.is_some()
+        matches!(*self, None)
     }
 
     /////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`assume` don't understand inversion. Code like 
```rust
pub fn f(a: Option<i32>) -> i32 {
    unsafe { assume(a.is_some()) }

    return a.unwrap();
}
```
compiles into
```assembler
example::f:
        mov     eax, esi
        ret
```
but
```rust 
pub fn f(a: Option<i32>) -> i32 {
    unsafe { assume(a.is_none()) }

    return a.unwrap();
}
```
compiles into
```assembler
example::f:
        test    edi, edi
        je      .LBB0_1
        mov     eax, esi
        ret
.LBB0_1:
        push    rax
        lea     rdi, [rip + .L__unnamed_1]
        lea     rdx, [rip + .L__unnamed_2]
        mov     esi, 43
        call    qword ptr [rip + core::panicking::panic@GOTPCREL]
        ud2
```

This patch solves that problem.