### PR TITLE
Assert that global cache values are stable on insertion

### DIFF
--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -569,7 +569,7 @@ pub struct DerivedObligationCause<'tcx> {
     pub parent_code: InternedObligationCauseCode<'tcx>,
 }
 
-#[derive(Clone, Debug, TypeFoldable, TypeVisitable, Lift)]
+#[derive(PartialEq, Eq, Clone, Debug, TypeFoldable, TypeVisitable, Lift)]
 pub enum SelectionError<'tcx> {
     /// The trait is not implemented.
     Unimplemented,

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1333,10 +1333,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         if self.can_use_global_caches(param_env) {
             if !trait_pred.needs_infer() {
                 debug!(?trait_pred, ?result, "insert_evaluation_cache global");
-                // This may overwrite the cache with the same value
-                // FIXME: Due to #50507 this overwrites the different values
-                // This should be changed to use HashMapExt::insert_same
-                // when that is fixed
                 self.tcx().evaluation_cache.insert((param_env, trait_pred), dep_node, result);
                 return;
             }


### PR DESCRIPTION
Let's make sure not to overwrite cache values with new values in, e.g., the evaluation cache and selection cache. I haven't found this being triggered in practice, but if we ever did, that'd be incredibly interesting to study.

There was a FIXME that says that we should be using `HashMapExt::insert_same`, but it turns out that we can't (cc @Zoxc in https://github.com/rust-lang/rust/issues/50507), because it turns out that these cache entries are only equal modulo dep node index. But we don't *need* to use that particular method to protect against collisions in these caches, since we can just ignore the dep node. So instead of using that, let's just check that the *values* are the same.