### PR TITLE
Delay a good path bug on drop for `TypeErrCtxt` (instead of a regular delayed bug)

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -74,7 +74,6 @@ use rustc_middle::ty::{
     self, error::TypeError, List, Region, Ty, TyCtxt, TypeFoldable, TypeSuperVisitable,
     TypeVisitable, TypeVisitableExt,
 };
-use rustc_span::DUMMY_SP;
 use rustc_span::{sym, symbol::kw, BytePos, DesugaringKind, Pos, Span};
 use rustc_target::spec::abi;
 use std::ops::{ControlFlow, Deref};
@@ -138,7 +137,7 @@ impl Drop for TypeErrCtxt<'_, '_> {
             self.infcx
                 .tcx
                 .sess
-                .delay_span_bug(DUMMY_SP, "used a `TypeErrCtxt` without failing compilation");
+                .delay_good_path_bug("used a `TypeErrCtxt` without raising an error or lint");
         }
     }
 }

--- a/src/tools/clippy/tests/ui/crashes/ice-5207.rs
+++ b/src/tools/clippy/tests/ui/crashes/ice-5207.rs
@@ -1,5 +1,8 @@
-// Regression test for https://github.com/rust-lang/rust-clippy/issues/5207
+// compile-flags: --cap-lints=warn
+// ^ for https://github.com/rust-lang/rust-clippy/issues/10645
 
+// Regression test for https://github.com/rust-lang/rust-clippy/issues/5207
+#![warn(clippy::future_not_send)]
 pub async fn bar<'a, T: 'a>(_: T) {}
 
 fn main() {}

--- a/src/tools/clippy/tests/ui/crashes/ice-5207.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-5207.stderr
@@ -1,0 +1,16 @@
+warning: future cannot be sent between threads safely
+  --> $DIR/ice-5207.rs:6:35
+   |
+LL | pub async fn bar<'a, T: 'a>(_: T) {}
+   |                                   ^ future returned by `bar` is not `Send`
+   |
+note: captured value is not `Send`
+  --> $DIR/ice-5207.rs:6:29
+   |
+LL | pub async fn bar<'a, T: 'a>(_: T) {}
+   |                             ^ has type `T` which is not `Send`
+   = note: `T` doesn't implement `std::marker::Send`
+   = note: `-D clippy::future-not-send` implied by `-D warnings`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
r? @lcnr
Perhaps we should just delete the `Drop` impl altogether though?

Fixes rust-lang/rust-clippy#10645

@matthiaskrgr: I don't know how to make a clippy test for this. Any idea? Clippy's UI tests run with `-D warnings` and I have no idea how to switch it off to make a test that triggers this ICE in the clippy test suite 🤣 