### PR TITLE
Bump `download-ci-llvm-stamp` for loong support

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/109373
+Last change is for: https://github.com/rust-lang/rust/pull/96971


### PR DESCRIPTION
This was missed in https://github.com/rust-lang/rust/pull/96971 and resulted in the LLVM we cache in CI being different from the one built locally. We didn't catch it because nothing tested the loong support.

Fixes https://github.com/rust-lang/rust/issues/110474.

r? @nikic