### PR TITLE
Use the LLVM option NoTrapAfterNoreturn

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -480,6 +480,14 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
     // it prevents control flow from "falling through" into whatever code
     // happens to be laid out next in memory.
     Options.TrapUnreachable = true;
+    // But don't emit traps after other traps or no-returns unnecessarily.
+    // ...except for when targeting WebAssembly, because the NoTrapAfterNoreturn
+    // option causes bugs in the LLVM WebAssembly backend. You should be able to
+    // remove this check when Rust's minimum supported LLVM version is >= 18
+    // https://github.com/llvm/llvm-project/pull/65876
+    if (!Trip.isWasm()) {
+      Options.NoTrapAfterNoreturn = true;
+    }
   }
 
   if (Singlethread) {


### PR DESCRIPTION
Use this LLVM option: https://llvm.org/doxygen/classllvm_1_1TargetOptions.html#acd83fce25de1ac9f6c975135a8235c22 when TrapUnreachable is enabled. This prevents codegenning unnecessary double-traps in some situations.

See further discussion here: https://github.com/rust-lang/compiler-team/issues/618