### PR TITLE
Fix ICE for transmutability in candidate assembly

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -775,7 +775,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         obligation: &TraitObligation<'tcx>,
         candidates: &mut SelectionCandidateSet<'tcx>,
     ) {
-        if obligation.has_non_region_param() {
+        if obligation.predicate.has_non_region_param() {
             return;
         }
 

--- a/tests/ui/transmutability/issue-110467.rs
+++ b/tests/ui/transmutability/issue-110467.rs
@@ -1,0 +1,17 @@
+// check-pass
+#![crate_type = "lib"]
+#![feature(transmutability)]
+use std::mem::BikeshedIntrinsicFrom;
+pub struct Context;
+
+pub fn is_maybe_transmutable<Src, Dst>()
+where
+    Dst: BikeshedIntrinsicFrom<Src, Context>,
+{
+}
+
+// The `T` here should not have any effect on checking
+// if transmutability is allowed or not.
+fn function_with_generic<T>() {
+    is_maybe_transmutable::<(), ()>();
+}


### PR DESCRIPTION
Don't skip transmutability check just because there may be generics in the ParamEnv.

Fixes #110467