### PR TITLE
make `non_upper_case_globals` lint not report trait impls

### DIFF
--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -494,6 +494,15 @@ impl<'tcx> LateLintPass<'tcx> for NonUpperCaseGlobals {
             hir::ItemKind::Const(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "constant", &it.ident);
             }
+            // we only want to check inherent associated consts, trait consts
+            // are linted at def-site.
+            hir::ItemKind::Impl(hir::Impl { of_trait: None, items, .. }) => {
+                for it in *items {
+                    if let hir::AssocItemKind::Const = it.kind {
+                        NonUpperCaseGlobals::check_upper_case(cx, "associated constant", &it.ident);
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -501,12 +510,6 @@ impl<'tcx> LateLintPass<'tcx> for NonUpperCaseGlobals {
     fn check_trait_item(&mut self, cx: &LateContext<'_>, ti: &hir::TraitItem<'_>) {
         if let hir::TraitItemKind::Const(..) = ti.kind {
             NonUpperCaseGlobals::check_upper_case(cx, "associated constant", &ti.ident);
-        }
-    }
-
-    fn check_impl_item(&mut self, cx: &LateContext<'_>, ii: &hir::ImplItem<'_>) {
-        if let hir::ImplItemKind::Const(..) = ii.kind {
-            NonUpperCaseGlobals::check_upper_case(cx, "associated constant", &ii.ident);
         }
     }
 

--- a/tests/ui/lint/lint-non-uppercase-trait-assoc-const.rs
+++ b/tests/ui/lint/lint-non-uppercase-trait-assoc-const.rs
@@ -1,0 +1,15 @@
+#![deny(non_upper_case_globals)]
+
+trait Trait {
+    const item: usize;
+    //~^ ERROR associated constant `item` should have an upper case name [non_upper_case_globals]
+}
+
+struct Foo;
+
+impl Trait for Foo {
+    const item: usize = 5;
+    // ^^^ there should be no error here (in the trait `impl`)
+}
+
+fn main() {}

--- a/tests/ui/lint/lint-non-uppercase-trait-assoc-const.stderr
+++ b/tests/ui/lint/lint-non-uppercase-trait-assoc-const.stderr
@@ -1,0 +1,14 @@
+error: associated constant `item` should have an upper case name
+  --> $DIR/lint-non-uppercase-trait-assoc-const.rs:4:11
+   |
+LL |     const item: usize;
+   |           ^^^^ help: convert the identifier to upper case: `ITEM`
+   |
+note: the lint level is defined here
+  --> $DIR/lint-non-uppercase-trait-assoc-const.rs:1:9
+   |
+LL | #![deny(non_upper_case_globals)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
We should not lint on trait `impl`s for `non_upper_case_globals`; the user doesn't have control over the name. This brings `non_upper_case_globals` into consistency with other `nonstandard_style` lints.