### PR TITLE
Fix `tests/run-make-translation` when download-rustc is enabled

### DIFF
--- a/tests/run-make/translation/Makefile
+++ b/tests/run-make/translation/Makefile
@@ -46,6 +46,8 @@ sysroot: test.rs working.ftl
 	rm -f $(FAKEROOT)/lib/rustlib/src
 	mkdir $(FAKEROOT)/lib/rustlib/src
 	ln -s $(SYSROOT)/lib/rustlib/src/* $(FAKEROOT)/lib/rustlib/src
+	# When download-rustc is enabled, `$(SYSROOT)` will have a share directory. Delete the link to it.
+	rm -f $(FAKEROOT)/share
 	mkdir -p $(FAKEROOT)/share/locale/zh-CN/
 	ln -s $(CURDIR)/working.ftl $(FAKEROOT)/share/locale/zh-CN/basic-translation.ftl
 	$(RUSTC) $< --sysroot $(FAKEROOT) -Ztranslate-lang=zh-CN 2>&1 | $(CGREP) "this is a test message"


### PR DESCRIPTION
When building locally, we never generate a `share` directory in the local sysroot. However, when we download the `rustc` component from ci, it includes a `share/man` directory in the sysroot. The `run-make/translation` test assumed that it didn't exist, and would create a link from `fakeroot` to the real share directory, and write symbolic links into it. Change it not to create the link, so that rustc doesn't try to load multiple copies of the same `.ftl` file.

Fixes https://github.com/rust-lang/rust/issues/110357.