### PR TITLE
Skip installing rustc stage 0

### DIFF
--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -247,10 +247,14 @@ install!((self, builder, _config),
         }
     };
     Rustc, path = "compiler/rustc", true, only_hosts: true, {
-        let tarball = builder.ensure(dist::Rustc {
-            compiler: builder.compiler(builder.top_stage, self.target),
-        });
-        install_sh(builder, "rustc", self.compiler.stage, Some(self.target), &tarball);
+        if builder.top_stage == 0 {
+            builder.info("skipping Install Rustc stage0");
+        } else {
+            let tarball = builder.ensure(dist::Rustc {
+                compiler: builder.compiler(builder.top_stage, self.target),
+            });
+            install_sh(builder, "rustc", self.compiler.stage, Some(self.target), &tarball);
+        }
     };
 );
 


### PR DESCRIPTION
Installing rustc stage 0 is meaningless to bootstrap but actually confusing sometimes. Currently bootstrap leaves a dir-not-found error when installing compiler/rustc with stage set to 0:

```
Building bootstrap
   Compiling bootstrap v0.0.0 (rust/src/bootstrap)
    Finished dev [unoptimized] target(s) in 1.90s
thread 'main' panicked at 'could not read dir "rust/build/aarch64-apple-darwin/stage0-sysroot/bin": Os { code: 2, kind: NotFound, message: "No such file or directory" }', lib.rs:1550:25
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Skip it proactively to avoid confusion.