### PR TITLE
Perf: Mir inlining: Experiment with adding a query to improve incremental mode

### DIFF
--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -486,6 +486,14 @@ impl Key for (Symbol, u32, u32) {
     }
 }
 
+impl<'tcx> Key for (ty::Instance<'tcx>, ty::ParamEnv<'tcx>, usize) {
+    type CacheSelector = DefaultCacheSelector<Self>;
+
+    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+        tcx.def_span(self.0.def_id())
+    }
+}
+
 impl<'tcx> Key for (DefId, Ty<'tcx>, SubstsRef<'tcx>, ty::ParamEnv<'tcx>) {
     type CacheSelector = DefaultCacheSelector<Self>;
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1042,6 +1042,16 @@ rustc_queries! {
         }
     }
 
+    /// Check if the inlining threshold for the instance's mir is at most the given balue
+    query mir_should_inline_at(key: (ty::Instance<'tcx>, ty::ParamEnv<'tcx>, usize)) -> bool {
+        fatal_cycle
+        desc { |tcx|
+            "checking whether {} should be inlined at threshold {}",
+            tcx.def_path_str(key.0.def_id()),
+            key.2,
+        }
+    }
+
     /// Evaluates a constant and returns the computed allocation.
     ///
     /// **Do not use this** directly, use the `tcx.eval_static_initializer` wrapper.

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -131,6 +131,7 @@ pub fn provide(providers: &mut Providers) {
         is_ctfe_mir_available: |tcx, did| is_mir_available(tcx, did),
         mir_callgraph_reachable: inline::cycle::mir_callgraph_reachable,
         mir_inliner_callees: inline::cycle::mir_inliner_callees,
+        mir_should_inline_at: |tcx, args| inline::Inliner::check_inline_mir_at_threshold(tcx, args),
         promoted_mir: |tcx, def_id| {
             if let Some(def) = ty::WithOptConstParam::try_lookup(def_id, tcx) {
                 tcx.promoted_mir_of_const_arg(def)


### PR DESCRIPTION
This commit experiments with adding a query for the question "should this body be inlined at this threshold." The idea is this: Consider the `optimized_mir` query for body A, with a callsite to body B. In the case where the decision is not to inline B into A, there should be no dependency edge between `optimized_mir` for B and `optimized_mir` for A. This means that we can change B, but all of the query inputs to A will not change, and so A will be marked green without having to re-optimize it.

This commit is pretty rough and will fail some tests. For now I'm just looking to get perf numbers.

r? ghost