### PR TITLE
Missing blanket impl trait not public

### DIFF
--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -20,7 +20,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
         trace!("get_blanket_impls({:?})", ty);
         let mut impls = Vec::new();
         for trait_def_id in cx.tcx.all_traits() {
-            if !cx.cache.effective_visibilities.is_directly_public(cx.tcx, trait_def_id)
+            if !cx.cache.effective_visibilities.is_reachable(cx.tcx, trait_def_id)
                 || cx.generated_synthetics.get(&(ty.0, trait_def_id)).is_some()
             {
                 continue;

--- a/tests/rustdoc/issue-94183-blanket-impl-reexported-trait.rs
+++ b/tests/rustdoc/issue-94183-blanket-impl-reexported-trait.rs
@@ -1,0 +1,31 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/94183>.
+// This test ensures that a publicly re-exported private trait will
+// appear in the blanket impl list.
+
+#![crate_name = "foo"]
+
+// @has 'foo/struct.S.html'
+
+mod actual_sub {
+    pub trait Actual {}
+    pub trait Another {}
+
+    // `Another` is publicly re-exported so it should appear in the blanket impl list.
+    // @has - '//*[@id="blanket-implementations-list"]//*[@class="code-header"]' 'impl<T> Another for T'
+    impl<T> Another for T {}
+
+    trait Foo {}
+
+    // `Foo` is not publicly re-exported nor reachable so it shouldn't appear in the
+    // blanket impl list.
+    // @!has - '//*[@id="blanket-implementations-list"]//*[@class="code-header"]' 'impl<T> Foo for T'
+    impl<T> Foo for T {}
+}
+
+pub use actual_sub::{Actual, Another};
+
+// `Actual` is publicly re-exported so it should appear in the blanket impl list.
+// @has - '//*[@id="blanket-implementations-list"]//*[@class="code-header"]' 'impl<T> Actual for T'
+impl<T> Actual for T {}
+
+pub struct S;


### PR DESCRIPTION
Fixes #94183.

The problem was that we should have checked if the trait was reachable instead of only "directly public".

r? @notriddle 