### PR TITLE
Fix various configure bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Read ["Installation"] from [The Book].
 
 The Rust build system uses a Python script called `x.py` to build the compiler,
 which manages the bootstrapping process. It lives at the root of the project.
+It also uses a file named `config.toml` to determine various configuration settings for the build.
+You can see a full list of options in `config.example.toml`.
 
 The `x.py` command can be run directly on most Unix systems in the following
 format:
@@ -85,6 +87,8 @@ See [the rustc-dev-guide for more info][sysllvm].
 
 ### Building on a Unix-like system
 
+#### Build steps
+
 1. Clone the [source] with `git`:
 
    ```sh
@@ -96,18 +100,13 @@ See [the rustc-dev-guide for more info][sysllvm].
 
 2. Configure the build settings:
 
-   The Rust build system uses a file named `config.toml` in the root of the
-   source tree to determine various configuration settings for the build.
-   Set up the defaults intended for distros to get started. You can see a full
-   list of options in `config.example.toml`.
-
    ```sh
-   printf 'profile = "user" \nchangelog-seen = 2 \n' > config.toml
+   ./configure
    ```
 
    If you plan to use `x.py install` to create an installation, it is
    recommended that you set the `prefix` value in the `[install]` section to a
-   directory.
+   directory: `./configure --set install.prefix=<path>`
 
 3. Build and install:
 
@@ -117,11 +116,24 @@ See [the rustc-dev-guide for more info][sysllvm].
 
    When complete, `./x.py install` will place several programs into
    `$PREFIX/bin`: `rustc`, the Rust compiler, and `rustdoc`, the
-   API-documentation tool. If you've set `profile = "user"` or
-   `build.extended = true`, it will also include [Cargo], Rust's package
-   manager.
+   API-documentation tool. By default, it will also include [Cargo], Rust's package manager.
+   You can disable this behavior by passing `--set build.extended=false` to `./configure`.
 
 [Cargo]: https://github.com/rust-lang/cargo
+
+#### Configure and Make
+
+This project provides a configure script and makefile (the latter of which just invokes `x.py`).
+`./configure` is the recommended way to programatically generate a `config.toml`. `make` is not
+recommended (we suggest using `x.py` directly), but it is supported and we try not to break it
+unnecessarily.
+
+```sh
+./configure
+make && sudo make install
+```
+
+`configure` generates a `config.toml` which can also be used with normal `x.py` invocations.
 
 ### Building on Windows
 
@@ -186,7 +198,7 @@ toolchain.
 4. Navigate to Rust's source code (or clone it), then build it:
 
    ```sh
-   ./x.py build && ./x.py install
+   python x.py setup user && python x.py build && python x.py install
    ```
 
 #### MSVC
@@ -204,6 +216,7 @@ With these dependencies installed, you can build the compiler in a `cmd.exe`
 shell with:
 
 ```sh
+python x.py setup user
 python x.py build
 ```
 
@@ -232,21 +245,7 @@ Windows build triples are:
 
 The build triple can be specified by either specifying `--build=<triple>` when
 invoking `x.py` commands, or by creating a `config.toml` file (as described in
-[Installing from Source](#installing-from-source)), and modifying the `build`
-option under the `[build]` section.
-
-### Configure and Make
-
-While it's not the recommended build system, this project also provides a
-configure script and makefile (the latter of which just invokes `x.py`).
-
-```sh
-./configure
-make && sudo make install
-```
-
-`configure` generates a `config.toml` which can also be used with normal `x.py`
-invocations.
+[Building on a Unix-like system](#building-on-a-unix-like-system)), and passing `--set build.build=<triple>` to `./configure`.
 
 ## Building Documentation
 

--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -97,6 +97,7 @@ class GenerateAndParseConfig(unittest.TestCase):
     def test_no_args(self):
         build = self.serialize_and_parse([])
         self.assertEqual(build.get_toml("changelog-seen"), '2')
+        self.assertEqual(build.get_toml("profile"), 'user')
         self.assertIsNone(build.get_toml("llvm.download-ci-llvm"))
 
     def test_set_section(self):

--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -107,10 +107,9 @@ class GenerateAndParseConfig(unittest.TestCase):
         build = self.serialize_and_parse(["--set", "target.x86_64-unknown-linux-gnu.cc=gcc"])
         self.assertEqual(build.get_toml("cc", section="target.x86_64-unknown-linux-gnu"), 'gcc')
 
-    # Uncomment when #108928 is fixed.
-    # def test_set_top_level(self):
-    #     build = self.serialize_and_parse(["--set", "profile=compiler"])
-    #     self.assertEqual(build.get_toml("profile"), 'compiler')
+    def test_set_top_level(self):
+        build = self.serialize_and_parse(["--set", "profile=compiler"])
+        self.assertEqual(build.get_toml("profile"), 'compiler')
 
 if __name__ == '__main__':
     SUITE = unittest.TestSuite()

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -417,6 +417,8 @@ def parse_example_config(known_args, config):
         # Avoid using quotes unless it's necessary.
         targets[target][0] = targets[target][0].replace("x86_64-unknown-linux-gnu", "'{}'".format(target) if "." in target else target)
 
+    if 'profile' not in config:
+        set('profile', 'user', config)
     configure_file(sections, top_level_keys, targets, config)
     return section_order, sections, targets
 

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -475,7 +475,7 @@ def configure_section(lines, config):
 def configure_top_level_key(lines, top_level_key, value):
     for i, line in enumerate(lines):
         if line.startswith('#' + top_level_key + ' = ') or line.startswith(top_level_key + ' = '):
-            lines[i] = "{} = {}".format(top_level_key, value)
+            lines[i] = "{} = {}".format(top_level_key, to_toml(value))
             return
 
     raise RuntimeError("failed to find config line for {}".format(top_level_key))


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/107050. Fixes https://github.com/rust-lang/rust/issues/108928. Closes https://github.com/rust-lang/rust/pull/108641.

I recommend reading this commit-by-commit to see the commit descriptions, but the code changes are small.

This also changes the README to suggest `configure` instead of `printf`, as well as a few other cleanups described in the commit message.