### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Read ["Installation"] from [The Book].
 
 The Rust build system uses a Python script called `x.py` to build the compiler,
 which manages the bootstrapping process. It lives at the root of the project.
+It also uses a file named `config.toml` to determine various configuration settings for the build.
+You can see a full list of options in `config.example.toml`.
 
 The `x.py` command can be run directly on most Unix systems in the following
 format:
@@ -85,6 +87,8 @@ See [the rustc-dev-guide for more info][sysllvm].
 
 ### Building on a Unix-like system
 
+#### Build steps
+
 1. Clone the [source] with `git`:
 
    ```sh
@@ -96,18 +100,13 @@ See [the rustc-dev-guide for more info][sysllvm].
 
 2. Configure the build settings:
 
-   The Rust build system uses a file named `config.toml` in the root of the
-   source tree to determine various configuration settings for the build.
-   Set up the defaults intended for distros to get started. You can see a full
-   list of options in `config.example.toml`.
-
    ```sh
-   printf 'profile = "user" \nchangelog-seen = 2 \n' > config.toml
+   ./configure
    ```
 
    If you plan to use `x.py install` to create an installation, it is
    recommended that you set the `prefix` value in the `[install]` section to a
-   directory.
+   directory: `./configure --set install.prefix=<path>`
 
 3. Build and install:
 
@@ -117,11 +116,24 @@ See [the rustc-dev-guide for more info][sysllvm].
 
    When complete, `./x.py install` will place several programs into
    `$PREFIX/bin`: `rustc`, the Rust compiler, and `rustdoc`, the
-   API-documentation tool. If you've set `profile = "user"` or
-   `build.extended = true`, it will also include [Cargo], Rust's package
-   manager.
+   API-documentation tool. By default, it will also include [Cargo], Rust's package manager.
+   You can disable this behavior by passing `--set build.extended=false` to `./configure`.
 
 [Cargo]: https://github.com/rust-lang/cargo
+
+#### Configure and Make
+
+This project provides a configure script and makefile (the latter of which just invokes `x.py`).
+`./configure` is the recommended way to programatically generate a `config.toml`. `make` is not
+recommended (we suggest using `x.py` directly), but it is supported and we try not to break it
+unnecessarily.
+
+```sh
+./configure
+make && sudo make install
+```
+
+`configure` generates a `config.toml` which can also be used with normal `x.py` invocations.
 
 ### Building on Windows
 
@@ -186,7 +198,7 @@ toolchain.
 4. Navigate to Rust's source code (or clone it), then build it:
 
    ```sh
-   ./x.py build && ./x.py install
+   python x.py setup user && python x.py build && python x.py install
    ```
 
 #### MSVC
@@ -204,6 +216,7 @@ With these dependencies installed, you can build the compiler in a `cmd.exe`
 shell with:
 
 ```sh
+python x.py setup user
 python x.py build
 ```
 
@@ -232,21 +245,7 @@ Windows build triples are:
 
 The build triple can be specified by either specifying `--build=<triple>` when
 invoking `x.py` commands, or by creating a `config.toml` file (as described in
-[Installing from Source](#installing-from-source)), and modifying the `build`
-option under the `[build]` section.
-
-### Configure and Make
-
-While it's not the recommended build system, this project also provides a
-configure script and makefile (the latter of which just invokes `x.py`).
-
-```sh
-./configure
-make && sudo make install
-```
-
-`configure` generates a `config.toml` which can also be used with normal `x.py`
-invocations.
+[Building on a Unix-like system](#building-on-a-unix-like-system)), and passing `--set build.build=<triple>` to `./configure`.
 
 ## Building Documentation
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1960,7 +1960,7 @@ pub enum ExprKind<'hir> {
     Lit(&'hir Lit),
     /// A cast (e.g., `foo as f64`).
     Cast(&'hir Expr<'hir>, &'hir Ty<'hir>),
-    /// A type reference (e.g., `Foo`).
+    /// A type ascription (e.g., `x: Foo`). See RFC 3307.
     Type(&'hir Expr<'hir>, &'hir Ty<'hir>),
     /// Wraps the expression in a terminating scope.
     /// This makes it semantically equivalent to `{ let _t = expr; _t }`.

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -178,7 +178,7 @@ impl FlagComputation {
 
             &ty::Alias(ty::Projection, data) => {
                 self.add_flags(TypeFlags::HAS_TY_PROJECTION);
-                self.add_projection_ty(data);
+                self.add_alias_ty(data);
             }
 
             &ty::Alias(ty::Opaque, ty::AliasTy { substs, .. }) => {
@@ -267,7 +267,7 @@ impl FlagComputation {
                 projection_ty,
                 term,
             })) => {
-                self.add_projection_ty(projection_ty);
+                self.add_alias_ty(projection_ty);
                 self.add_term(term);
             }
             ty::PredicateKind::WellFormed(arg) => {
@@ -372,8 +372,8 @@ impl FlagComputation {
         }
     }
 
-    fn add_projection_ty(&mut self, projection_ty: ty::AliasTy<'_>) {
-        self.add_substs(projection_ty.substs);
+    fn add_alias_ty(&mut self, alias_ty: ty::AliasTy<'_>) {
+        self.add_substs(alias_ty.substs);
     }
 
     fn add_substs(&mut self, substs: &[GenericArg<'_>]) {

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -170,29 +170,20 @@ pub fn predicate_obligations<'tcx>(
         ty::PredicateKind::WellFormed(arg) => {
             wf.compute(arg);
         }
-        ty::PredicateKind::ObjectSafe(_) => {}
-        ty::PredicateKind::ClosureKind(..) => {}
-        ty::PredicateKind::Subtype(ty::SubtypePredicate { a, b, a_is_expected: _ }) => {
-            wf.compute(a.into());
-            wf.compute(b.into());
-        }
-        ty::PredicateKind::Coerce(ty::CoercePredicate { a, b }) => {
-            wf.compute(a.into());
-            wf.compute(b.into());
-        }
+
         ty::PredicateKind::ConstEvaluatable(ct) => {
             wf.compute(ct.into());
         }
-        ty::PredicateKind::ConstEquate(c1, c2) => {
-            wf.compute(c1.into());
-            wf.compute(c2.into());
-        }
-        ty::PredicateKind::Ambiguous => {}
-        ty::PredicateKind::TypeWellFormedFromEnv(..) => {
-            bug!("TypeWellFormedFromEnv is only used for Chalk")
-        }
-        ty::PredicateKind::AliasRelate(..) => {
-            bug!("We should only wf check where clauses and `AliasRelate` is not a `Clause`")
+
+        ty::PredicateKind::ObjectSafe(_)
+        | ty::PredicateKind::ClosureKind(..)
+        | ty::PredicateKind::Subtype(..)
+        | ty::PredicateKind::Coerce(..)
+        | ty::PredicateKind::ConstEquate(..)
+        | ty::PredicateKind::Ambiguous
+        | ty::PredicateKind::AliasRelate(..)
+        | ty::PredicateKind::TypeWellFormedFromEnv(..) => {
+            bug!("We should only wf check where clauses, unexpected predicate: {predicate:?}")
         }
     }
 

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -575,7 +575,7 @@ class RustBuild(object):
         ]
         patchelf_args = ["--set-rpath", ":".join(rpath_entries)]
         if not fname.endswith(".so"):
-            # Finally, set the corret .interp for binaries
+            # Finally, set the correct .interp for binaries
             with open("{}/nix-support/dynamic-linker".format(nix_deps_dir)) as dynamic_linker:
                 patchelf_args += ["--set-interpreter", dynamic_linker.read().rstrip()]
 

--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -97,6 +97,7 @@ class GenerateAndParseConfig(unittest.TestCase):
     def test_no_args(self):
         build = self.serialize_and_parse([])
         self.assertEqual(build.get_toml("changelog-seen"), '2')
+        self.assertEqual(build.get_toml("profile"), 'user')
         self.assertIsNone(build.get_toml("llvm.download-ci-llvm"))
 
     def test_set_section(self):

--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -107,10 +107,9 @@ class GenerateAndParseConfig(unittest.TestCase):
         build = self.serialize_and_parse(["--set", "target.x86_64-unknown-linux-gnu.cc=gcc"])
         self.assertEqual(build.get_toml("cc", section="target.x86_64-unknown-linux-gnu"), 'gcc')
 
-    # Uncomment when #108928 is fixed.
-    # def test_set_top_level(self):
-    #     build = self.serialize_and_parse(["--set", "profile=compiler"])
-    #     self.assertEqual(build.get_toml("profile"), 'compiler')
+    def test_set_top_level(self):
+        build = self.serialize_and_parse(["--set", "profile=compiler"])
+        self.assertEqual(build.get_toml("profile"), 'compiler')
 
 if __name__ == '__main__':
     SUITE = unittest.TestSuite()

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1384,7 +1384,7 @@ impl<'a> Builder<'a> {
 
         // Add extra cfg not defined in/by rustc
         //
-        // Note: Altrough it would seems that "-Zunstable-options" to `rustflags` is useless as
+        // Note: Although it would seems that "-Zunstable-options" to `rustflags` is useless as
         // cargo would implicitly add it, it was discover that sometimes bootstrap only use
         // `rustflags` without `cargo` making it required.
         rustflags.arg("-Zunstable-options");

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -22,7 +22,7 @@ pub enum GitInfo {
     /// If the info should be used (`omit_git_hash` is false), this will be
     /// `Some`, otherwise it will be `None`.
     Present(Option<Info>),
-    /// This is not a git repostory, but the info can be fetched from the
+    /// This is not a git repository, but the info can be fetched from the
     /// `git-commit-info` file.
     RecordedForTarball(Info),
 }

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -523,17 +523,17 @@ def write_config_toml(writer, section_order, targets, sections):
 
 def quit_if_file_exists(file):
     if os.path.isfile(file):
-        p("Existing '" + file + "' detected. EXITING")
-        quit()
+        err("Existing '" + file + "' detected.")
 
 if __name__ == "__main__":
+    # If 'config.toml' already exists, exit the script at this point
+    quit_if_file_exists('config.toml')
+
     p("processing command line")
     # Parse all known arguments into a configuration structure that reflects the
     # TOML we're going to write out
     p("")
     section_order, sections, targets = parse_args(sys.argv[1:])
-    # If 'config.toml' already exists, exit the script at this point
-    quit_if_file_exists('config.toml')
 
     # Now that we've built up our `config.toml`, write it all out in the same
     # order that we read it in.

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -417,6 +417,8 @@ def parse_example_config(known_args, config):
         # Avoid using quotes unless it's necessary.
         targets[target][0] = targets[target][0].replace("x86_64-unknown-linux-gnu", "'{}'".format(target) if "." in target else target)
 
+    if 'profile' not in config:
+        set('profile', 'user', config)
     configure_file(sections, top_level_keys, targets, config)
     return section_order, sections, targets
 

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -521,6 +521,10 @@ def write_config_toml(writer, section_order, targets, sections):
         else:
             writer = write_uncommented(sections[section], writer)
 
+def quit_if_file_exists(file):
+    if os.path.isfile(file):
+        p("Existing '" + file + "' detected. EXITING")
+        quit()
 
 if __name__ == "__main__":
     p("processing command line")
@@ -528,6 +532,8 @@ if __name__ == "__main__":
     # TOML we're going to write out
     p("")
     section_order, sections, targets = parse_args(sys.argv[1:])
+    # If 'config.toml' already exists, exit the script at this point
+    quit_if_file_exists('config.toml')
 
     # Now that we've built up our `config.toml`, write it all out in the same
     # order that we read it in.

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -475,7 +475,7 @@ def configure_section(lines, config):
 def configure_top_level_key(lines, top_level_key, value):
     for i, line in enumerate(lines):
         if line.startswith('#' + top_level_key + ' = ') or line.startswith(top_level_key + ' = '):
-            lines[i] = "{} = {}".format(top_level_key, value)
+            lines[i] = "{} = {}".format(top_level_key, to_toml(value))
             return
 
     raise RuntimeError("failed to find config line for {}".format(top_level_key))

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1965,20 +1965,6 @@ fn maybe_install_llvm(builder: &Builder<'_>, target: TargetSelection, dst_libdir
         }
     }
 
-    // FIXME: for reasons I don't understand, the LLVM so in the `rustc` component is different than the one in `rust-dev`.
-    // Only the one in `rustc` works with the downloaded compiler.
-    if builder.download_rustc() && target == builder.build.build {
-        let src_libdir = builder.ci_rustc_dir(target).join("lib");
-        for entry in t!(std::fs::read_dir(&src_libdir)) {
-            let entry = t!(entry);
-            if entry.file_name().to_str().unwrap().starts_with("libLLVM-") {
-                install_llvm_file(builder, &entry.path(), dst_libdir);
-                return !builder.config.dry_run();
-            }
-        }
-        panic!("libLLVM.so not found in src_libdir {}!", src_libdir.display());
-    }
-
     // On macOS, rustc (and LLVM tools) link to an unversioned libLLVM.dylib
     // instead of libLLVM-11-rust-....dylib, as on linux. It's not entirely
     // clear why this is the case, though. llvm-config will emit the versioned

--- a/src/bootstrap/llvm.rs
+++ b/src/bootstrap/llvm.rs
@@ -1153,7 +1153,7 @@ impl Step for Libunwind {
         run.builder.ensure(Libunwind { target: run.target });
     }
 
-    /// Build linunwind.a
+    /// Build libunwind.a
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         builder.update_submodule(&Path::new("src/llvm-project"));
 

--- a/src/bootstrap/render_tests.rs
+++ b/src/bootstrap/render_tests.rs
@@ -1,7 +1,7 @@
 //! This module renders the JSON output of libtest into a human-readable form, trying to be as
 //! similar to libtest's native output as possible.
 //!
-//! This is needed because we need to use libtest in JSON mode to extract granluar information
+//! This is needed because we need to use libtest in JSON mode to extract granular information
 //! about the executed tests. Doing so suppresses the human-readable output, and (compared to Cargo
 //! and rustc) libtest doesn't include the rendered human-readable output as a JSON field. We had
 //! to reimplement all the rendering logic in this module because of that.

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -100,7 +100,7 @@ pub fn check(build: &mut Build) {
 Couldn't find required command: cmake
 
 You should install cmake, or set `download-ci-llvm = true` in the
-`[llvm]` section section of `config.toml` to download LLVM rather
+`[llvm]` section of `config.toml` to download LLVM rather
 than building it.
 "
             );

--- a/src/ci/docker/README.md
+++ b/src/ci/docker/README.md
@@ -211,7 +211,7 @@ For targets: `armv7-unknown-linux-gnueabihf`
 (\*) These options have been selected to match the configuration of the arm
       toolchains shipped with Ubuntu 15.10
 (+) These options have been selected to match the gcc flags we use to compile C
-    libraries like jemalloc. See the mk/cfg/arm(v7)-uknown-linux-gnueabi{,hf}.mk
+    libraries like jemalloc. See the mk/cfg/arm(v7)-unknown-linux-gnueabi{,hf}.mk
     file in Rust's source code.
 
 ### `aarch64-linux-gnu.config`

--- a/src/ci/docker/host-x86_64/disabled/riscv64gc-linux/0001-Remove-stime-function-calls.patch
+++ b/src/ci/docker/host-x86_64/disabled/riscv64gc-linux/0001-Remove-stime-function-calls.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Remove stime() function calls
 
 stime() has been deprecated in glibc 2.31 and replaced with
 clock_settime(). Let's replace the stime() function calls with
-clock_settime() in preperation.
+clock_settime() in preparation.
 
 function                                             old     new   delta
 rdate_main                                           197     224     +27

--- a/src/ci/docker/host-x86_64/dist-mips-linux/mips-linux-gnu.config
+++ b/src/ci/docker/host-x86_64/dist-mips-linux/mips-linux-gnu.config
@@ -528,7 +528,7 @@ CT_CC_GCC_DEC_FLOAT_AUTO=y
 CT_CC_GCC_HAS_ARCH_OPTIONS=y
 
 #
-# archictecture-specific options
+# architecture-specific options
 #
 CT_CC_GCC_mips_llsc=m
 CT_CC_GCC_mips_synci=m

--- a/src/ci/docker/host-x86_64/dist-mips64-linux/mips64-linux-gnu.config
+++ b/src/ci/docker/host-x86_64/dist-mips64-linux/mips64-linux-gnu.config
@@ -529,7 +529,7 @@ CT_CC_GCC_DEC_FLOAT_AUTO=y
 CT_CC_GCC_HAS_ARCH_OPTIONS=y
 
 #
-# archictecture-specific options
+# architecture-specific options
 #
 CT_CC_GCC_mips_llsc=m
 CT_CC_GCC_mips_synci=m

--- a/src/ci/docker/host-x86_64/dist-mips64el-linux/mips64el-linux-gnu.config
+++ b/src/ci/docker/host-x86_64/dist-mips64el-linux/mips64el-linux-gnu.config
@@ -529,7 +529,7 @@ CT_CC_GCC_DEC_FLOAT_AUTO=y
 CT_CC_GCC_HAS_ARCH_OPTIONS=y
 
 #
-# archictecture-specific options
+# architecture-specific options
 #
 CT_CC_GCC_mips_llsc=m
 CT_CC_GCC_mips_synci=m

--- a/src/ci/docker/host-x86_64/dist-mipsel-linux/mipsel-linux-gnu.config
+++ b/src/ci/docker/host-x86_64/dist-mipsel-linux/mipsel-linux-gnu.config
@@ -528,7 +528,7 @@ CT_CC_GCC_DEC_FLOAT_AUTO=y
 CT_CC_GCC_HAS_ARCH_OPTIONS=y
 
 #
-# archictecture-specific options
+# architecture-specific options
 #
 CT_CC_GCC_mips_llsc=m
 CT_CC_GCC_mips_synci=m

--- a/src/ci/docker/host-x86_64/mingw-check/validate-toolstate.sh
+++ b/src/ci/docker/host-x86_64/mingw-check/validate-toolstate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# A quick smoke test to make sure publish_tooolstate.py works.
+# A quick smoke test to make sure publish_toolstate.py works.
 
 set -euo pipefail
 IFS=$'\n\t'

--- a/src/ci/docker/scripts/qemu-bare-bones-rcS
+++ b/src/ci/docker/scripts/qemu-bare-bones-rcS
@@ -9,7 +9,7 @@ mount -t sysfs none /sys
 /addentropy < /addentropy
 cat /dev/urandom | head -n 2048 | /addentropy
 
-# Set up IP that qemu expects. This confgures eth0 with the public IP that QEMU
+# Set up IP that qemu expects. This configures eth0 with the public IP that QEMU
 # will communicate to as well as the loopback 127.0.0.1 address.
 ifconfig eth0 10.0.2.15
 ifconfig lo up

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -20,7 +20,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
         trace!("get_blanket_impls({:?})", ty);
         let mut impls = Vec::new();
         for trait_def_id in cx.tcx.all_traits() {
-            if !cx.cache.effective_visibilities.is_directly_public(cx.tcx, trait_def_id)
+            if !cx.cache.effective_visibilities.is_reachable(cx.tcx, trait_def_id)
                 || cx.generated_synthetics.get(&(ty.0, trait_def_id)).is_some()
             {
                 continue;

--- a/src/tools/lint-docs/src/groups.rs
+++ b/src/tools/lint-docs/src/groups.rs
@@ -39,11 +39,12 @@ impl<'a> LintExtractor<'a> {
     fn collect_groups(&self) -> Result<LintGroups, Box<dyn Error>> {
         let mut result = BTreeMap::new();
         let mut cmd = Command::new(self.rustc_path);
+        cmd.env_remove("LD_LIBRARY_PATH");
         cmd.arg("-Whelp");
         let output = cmd.output().map_err(|e| format!("failed to run command {:?}\n{}", cmd, e))?;
         if !output.status.success() {
             return Err(format!(
-                "failed to collect lint info: {:?}\n--- stderr\n{}--- stdout\n{}\n",
+                "failed to collect lint info: failed to run {cmd:?}: {:?}\n--- stderr\n{}--- stdout\n{}\n",
                 output.status,
                 std::str::from_utf8(&output.stderr).unwrap(),
                 std::str::from_utf8(&output.stdout).unwrap(),

--- a/tests/run-make/translation/Makefile
+++ b/tests/run-make/translation/Makefile
@@ -46,6 +46,8 @@ sysroot: test.rs working.ftl
 	rm -f $(FAKEROOT)/lib/rustlib/src
 	mkdir $(FAKEROOT)/lib/rustlib/src
 	ln -s $(SYSROOT)/lib/rustlib/src/* $(FAKEROOT)/lib/rustlib/src
+	# When download-rustc is enabled, `$(SYSROOT)` will have a share directory. Delete the link to it.
+	rm -f $(FAKEROOT)/share
 	mkdir -p $(FAKEROOT)/share/locale/zh-CN/
 	ln -s $(CURDIR)/working.ftl $(FAKEROOT)/share/locale/zh-CN/basic-translation.ftl
 	$(RUSTC) $< --sysroot $(FAKEROOT) -Ztranslate-lang=zh-CN 2>&1 | $(CGREP) "this is a test message"

--- a/tests/rustdoc/issue-94183-blanket-impl-reexported-trait.rs
+++ b/tests/rustdoc/issue-94183-blanket-impl-reexported-trait.rs
@@ -1,0 +1,31 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/94183>.
+// This test ensures that a publicly re-exported private trait will
+// appear in the blanket impl list.
+
+#![crate_name = "foo"]
+
+// @has 'foo/struct.S.html'
+
+mod actual_sub {
+    pub trait Actual {}
+    pub trait Another {}
+
+    // `Another` is publicly re-exported so it should appear in the blanket impl list.
+    // @has - '//*[@id="blanket-implementations-list"]//*[@class="code-header"]' 'impl<T> Another for T'
+    impl<T> Another for T {}
+
+    trait Foo {}
+
+    // `Foo` is not publicly re-exported nor reachable so it shouldn't appear in the
+    // blanket impl list.
+    // @!has - '//*[@id="blanket-implementations-list"]//*[@class="code-header"]' 'impl<T> Foo for T'
+    impl<T> Foo for T {}
+}
+
+pub use actual_sub::{Actual, Another};
+
+// `Actual` is publicly re-exported so it should appear in the blanket impl list.
+// @has - '//*[@id="blanket-implementations-list"]//*[@class="code-header"]' 'impl<T> Actual for T'
+impl<T> Actual for T {}
+
+pub struct S;


### PR DESCRIPTION
Successful merges:

 - #110123 ('./configure' now checks if 'config.toml' exists before writing to that destination)
 - #110429 (Spelling src bootstrap)
 - #110430 (Spelling src ci)
 - #110515 (Don't special-case download-rustc in `maybe_install_llvm`)
 - #110521 (Fix `x test lint-docs linkchecker` when download-rustc is enabled)
 - #110525 (Fix `tests/run-make-translation` when download-rustc is enabled)
 - #110531 (small type system cleanup)
 - #110533 (Missing blanket impl trait not public)
 - #110540 (Fix wrong comment in rustc_hir/src/hir.rs)
 - #110541 (Fix various configure bugs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=110123,110429,110430,110515,110521,110525,110531,110533,110540,110541)
<!-- homu-ignore:end -->