### PR TITLE
rustdoc: Render private fields in tuple struct as `/* private fields */`

### DIFF
--- a/tests/rustdoc/const-generics/const-generic-defaults.rs
+++ b/tests/rustdoc/const-generics/const-generic-defaults.rs
@@ -1,5 +1,5 @@
 #![crate_name = "foo"]
 
 // @has foo/struct.Foo.html '//pre[@class="rust item-decl"]' \
-//      'pub struct Foo<const M: usize = 10, const N: usize = M, T = i32>(_);'
+//      'pub struct Foo<const M: usize = 10, const N: usize = M, T = i32>('
 pub struct Foo<const M: usize = 10, const N: usize = M, T = i32>(T);

--- a/tests/rustdoc/const-generics/const-generics-docs.rs
+++ b/tests/rustdoc/const-generics/const-generics-docs.rs
@@ -33,7 +33,7 @@ impl<const N: usize> Trait<N> for [u8; N] {}
 // @has foo/struct.Foo.html '//pre[@class="rust item-decl"]' \
 //      'pub struct Foo<const N: usize> where u8: Trait<N>'
 pub struct Foo<const N: usize> where u8: Trait<N>;
-// @has foo/struct.Bar.html '//pre[@class="rust item-decl"]' 'pub struct Bar<T, const N: usize>(_)'
+// @has foo/struct.Bar.html '//pre[@class="rust item-decl"]' 'pub struct Bar<T, const N: usize>('
 pub struct Bar<T, const N: usize>([T; N]);
 
 // @has foo/struct.Foo.html '//*[@id="impl-Foo%3CM%3E"]/h3[@class="code-header"]' 'impl<const M: usize> Foo<M>where u8: Trait<M>'
@@ -92,7 +92,7 @@ macro_rules! define_me {
 }
 
 // @has foo/struct.Foz.html '//pre[@class="rust item-decl"]' \
-//      'pub struct Foz<const N: usize>(_);'
+//      'pub struct Foz<const N: usize>(/* private fields */);'
 define_me!(Foz<N>);
 
 trait Q {

--- a/tests/rustdoc/issue-88600.rs
+++ b/tests/rustdoc/issue-88600.rs
@@ -8,10 +8,10 @@ pub struct S;
 
 // @has issue_88600/enum.FooEnum.html
 pub enum FooEnum {
-    // @has - '//*[@id="variant.HiddenTupleItem"]//h3' 'HiddenTupleItem(_)'
+    // @has - '//*[@id="variant.HiddenTupleItem"]//h3' 'HiddenTupleItem(/* private fields */)'
     // @count - '//*[@id="variant.HiddenTupleItem.field.0"]' 0
     HiddenTupleItem(#[doc(hidden)] H),
-    // @has - '//*[@id="variant.MultipleHidden"]//h3' 'MultipleHidden(_, _)'
+    // @has - '//*[@id="variant.MultipleHidden"]//h3' 'MultipleHidden(/* private fields */)'
     // @count - '//*[@id="variant.MultipleHidden.field.0"]' 0
     // @count - '//*[@id="variant.MultipleHidden.field.1"]' 0
     MultipleHidden(#[doc(hidden)] H, #[doc(hidden)] H),

--- a/tests/rustdoc/where.SWhere_Simd_item-decl.html
+++ b/tests/rustdoc/where.SWhere_Simd_item-decl.html
@@ -1,3 +1,3 @@
-<pre class="rust item-decl"><code>pub struct Simd&lt;T&gt;(_)
+<pre class="rust item-decl"><code>pub struct Simd&lt;T&gt;(/* private fields */)
 <span class="where">where
          T: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a></span>;</code></pre>

--- a/tests/rustdoc/where.rs
+++ b/tests/rustdoc/where.rs
@@ -4,8 +4,8 @@ use std::io::Lines;
 
 pub trait MyTrait { fn dummy(&self) { } }
 
-// @has foo/struct.Alpha.html '//pre' "pub struct Alpha<A>(_) where A: MyTrait"
-pub struct Alpha<A>(A) where A: MyTrait;
+// @has foo/struct.Alpha.html '//pre' "pub struct Alpha<A>where A: MyTrait"
+pub struct Alpha<A> where A: MyTrait { a: A }
 // @has foo/trait.Bravo.html '//pre' "pub trait Bravo<B>where B: MyTrait"
 pub trait Bravo<B> where B: MyTrait { fn get(&self, B: B); }
 // @has foo/fn.charlie.html '//pre' "pub fn charlie<C>()where C: MyTrait"


### PR DESCRIPTION
I've gotten some feedback that the current rustdoc rendering of...

```
struct HasPrivateFields(_);
```

...is confusing, and I agree with that feedback, especially compared to the field struct case:

```
struct HasPrivateFields { /* private fields */ }
```

So this PR makes it so that when all of the fields of a tuple variant are private, just render it with the `/* private fields */` comment. We can't *always* render it like that, for example when there's a mix of private and public fields.

---

Not sure if this is a worthwhile change, so opening it up for discussion :)