### PR TITLE
Add Call terminator to SMIR

### DIFF
--- a/compiler/rustc_smir/src/stable_mir/mir/body.rs
+++ b/compiler/rustc_smir/src/stable_mir/mir/body.rs
@@ -33,7 +33,7 @@ pub enum Terminator {
         args: Vec<Operand>,
         destination: Place,
         target: Option<usize>,
-        cleanup: Option<usize>,
+        unwind: UnwindAction,
     },
     Assert {
         cond: Operand,
@@ -42,6 +42,14 @@ pub enum Terminator {
         target: usize,
         cleanup: Option<usize>,
     },
+}
+
+#[derive(Clone, Debug)]
+pub enum UnwindAction {
+    Continue,
+    Unreachable,
+    Terminate,
+    Cleanup(usize),
 }
 
 #[derive(Clone, Debug)]

--- a/tests/ui-fulldeps/stable-mir/crate-info.rs
+++ b/tests/ui-fulldeps/stable-mir/crate-info.rs
@@ -33,7 +33,6 @@ fn test_stable_mir(tcx: TyCtxt<'_>) {
 
     // Find items in the local crate.
     let items = stable_mir::all_local_items();
-    assert!(get_item(tcx, &items, (DefKind::Fn, "foo_bar")).is_some());
     assert!(get_item(tcx, &items, (DefKind::Fn, "foo::bar")).is_some());
 
     // Find the `std` crate.
@@ -50,6 +49,15 @@ fn test_stable_mir(tcx: TyCtxt<'_>) {
     }
     match &block.terminator {
         stable_mir::mir::Terminator::Return => {}
+        other => panic!("{other:?}"),
+    }
+
+    let foo_bar = get_item(tcx, &items, (DefKind::Fn, "foo_bar")).unwrap();
+    let body = foo_bar.body();
+    assert_eq!(body.blocks.len(), 4);
+    let block = &body.blocks[0];
+    match &block.terminator {
+        stable_mir::mir::Terminator::Call { .. } => {}
         other => panic!("{other:?}"),
     }
 }


### PR DESCRIPTION
This adds internal MIR `TerminatorKind::Call` to SMIR `Terminator::Call` conversion.

r? @oli-obk 