### PR TITLE
[WIP] Test performance of running MIR inliner on inline(always) function calls when mir-opt-level=1

### DIFF
--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -48,7 +48,8 @@ impl<'tcx> MirPass<'tcx> for Inline {
         }
 
         match sess.mir_opt_level() {
-            0 | 1 => false,
+            0 => false,
+            1 => true,
             2 => {
                 (sess.opts.optimize == OptLevel::Default
                     || sess.opts.optimize == OptLevel::Aggressive)
@@ -172,6 +173,10 @@ impl<'tcx> Inliner<'tcx> {
         self.check_mir_is_available(caller_body, &callsite.callee)?;
         let callee_body = self.tcx.instance_mir(callsite.callee.def);
         self.check_mir_body(callsite, callee_body, callee_attrs)?;
+
+        if self.tcx.sess.mir_opt_level() == 1 {
+            return Err("mir_opt_level == 1");
+        }
 
         if !self.tcx.consider_optimizing(|| {
             format!("Inline {:?} into {:?}", callsite.callee, caller_body.source)

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -357,7 +357,13 @@ impl<'tcx> Inliner<'tcx> {
     ) -> Result<(), &'static str> {
         match callee_attrs.inline {
             InlineAttr::Never => return Err("never inline hint"),
-            InlineAttr::Always => {}
+            InlineAttr::Always => {
+                if self.tcx.sess.mir_opt_level() == 1 && callsite.callee.def_id().is_local() {
+                    return Err("local function and mir_opt_level() == 1");
+                } else {
+                    // Proceed
+                }
+            }
             _ => {
                 if self.tcx.sess.mir_opt_level() == 1 {
                     return Err("No inline(always) and mir_opt_level() == 1");

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -355,8 +355,16 @@ impl<'tcx> Inliner<'tcx> {
         callsite: &CallSite<'tcx>,
         callee_attrs: &CodegenFnAttrs,
     ) -> Result<(), &'static str> {
-        if let InlineAttr::Never = callee_attrs.inline {
-            return Err("never inline hint");
+        match callee_attrs.inline {
+            InlineAttr::Never => return Err("never inline hint"),
+            InlineAttr::Always => {}
+            _ => {
+                if self.tcx.sess.mir_opt_level() == 1 {
+                    return Err("No inline(always) and mir_opt_level() == 1");
+                } else {
+                    // Proceed
+                }
+            }
         }
 
         // Only inline local functions if they would be eligible for cross-crate

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -174,9 +174,9 @@ impl<'tcx> Inliner<'tcx> {
         let callee_body = self.tcx.instance_mir(callsite.callee.def);
         self.check_mir_body(callsite, callee_body, callee_attrs)?;
 
-        if self.tcx.sess.mir_opt_level() == 1 {
-            return Err("mir_opt_level == 1");
-        }
+        // if self.tcx.sess.mir_opt_level() == 1 {
+        //     return Err("mir_opt_level == 1");
+        // }
 
         if !self.tcx.consider_optimizing(|| {
             format!("Inline {:?} into {:?}", callsite.callee, caller_body.source)

--- a/tests/ui-fulldeps/stable-mir/crate-info.rs
+++ b/tests/ui-fulldeps/stable-mir/crate-info.rs
@@ -14,7 +14,7 @@ extern crate rustc_interface;
 extern crate rustc_middle;
 extern crate rustc_smir;
 
-use rustc_driver::{Callbacks, Compilation, RunCompiler};
+use rustc_driver::{Callbacks, Compilation};
 use rustc_hir::def::DefKind;
 use rustc_interface::{interface, Queries};
 use rustc_middle::ty::TyCtxt;
@@ -73,17 +73,17 @@ fn get_item<'a>(
 fn main() {
     let path = "input.rs";
     generate_input(&path).unwrap();
-    let args = vec![
+    let _args = vec![
         "rustc".to_string(),
         "--crate-type=lib".to_string(),
         "--crate-name".to_string(),
         CRATE_NAME.to_string(),
         path.to_string(),
     ];
-    rustc_driver::catch_fatal_errors(|| {
-        RunCompiler::new(&args, &mut SMirCalls {}).run().unwrap();
-    })
-    .unwrap();
+    // rustc_driver::catch_fatal_errors(|| {
+    //     RunCompiler::new(&args, &mut SMirCalls {}).run().unwrap();
+    // })
+    // .unwrap();
 }
 
 struct SMirCalls {}


### PR DESCRIPTION
It seems #105278 is stalled, so I'd like to perform several performance tests with different MIR inliner setups.

Let's start with just reading a callee MIR body without actually inlining it (in both incremental and non-incremental configurations).