### PR TITLE
Deduplicate unreachable blocks, for real this time

### DIFF
--- a/compiler/rustc_mir_transform/src/instcombine.rs
+++ b/compiler/rustc_mir_transform/src/instcombine.rs
@@ -1,11 +1,9 @@
 //! Performs various peephole optimizations.
 
+use crate::simplify::combine_duplicate_switch_targets;
 use crate::MirPass;
 use rustc_hir::Mutability;
-use rustc_middle::mir::{
-    BinOp, Body, CastKind, Constant, ConstantKind, LocalDecls, Operand, Place, ProjectionElem,
-    Rvalue, SourceInfo, Statement, StatementKind, SwitchTargets, Terminator, TerminatorKind, UnOp,
-};
+use rustc_middle::mir::*;
 use rustc_middle::ty::layout::ValidityRequirement;
 use rustc_middle::ty::util::IntTypeExt;
 use rustc_middle::ty::{self, ParamEnv, SubstsRef, Ty, TyCtxt};
@@ -46,7 +44,7 @@ impl<'tcx> MirPass<'tcx> for InstCombine {
                 &mut block.terminator.as_mut().unwrap(),
                 &mut block.statements,
             );
-            ctx.combine_duplicate_switch_targets(&mut block.terminator.as_mut().unwrap());
+            combine_duplicate_switch_targets(block.terminator.as_mut().unwrap());
         }
     }
 }
@@ -262,19 +260,6 @@ impl<'tcx> InstCombineContext<'tcx, '_> {
             ))),
         });
         terminator.kind = TerminatorKind::Goto { target: destination_block };
-    }
-
-    fn combine_duplicate_switch_targets(&self, terminator: &mut Terminator<'tcx>) {
-        let TerminatorKind::SwitchInt { targets, .. } = &mut terminator.kind
-        else { return };
-
-        let otherwise = targets.otherwise();
-        if targets.iter().any(|t| t.1 == otherwise) {
-            *targets = SwitchTargets::new(
-                targets.iter().filter(|t| t.1 != otherwise),
-                targets.otherwise(),
-            );
-        }
     }
 
     fn combine_intrinsic_assert(

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.diff
@@ -34,7 +34,7 @@
 -                                          // + literal: Const { ty: unsafe fn(Option<T>) -> T {Option::<T>::unwrap_unchecked}, val: Value(<ZST>) }
 +         StorageLive(_3);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:9: +1:27
 +         _4 = discriminant(_2);           // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
-+         switchInt(move _4) -> [0: bb1, 1: bb2, otherwise: bb1]; // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
++         switchInt(move _4) -> [1: bb2, otherwise: bb1]; // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
       }
   
       bb1: {

--- a/tests/mir-opt/instcombine_duplicate_switch_targets_e2e.rs
+++ b/tests/mir-opt/instcombine_duplicate_switch_targets_e2e.rs
@@ -1,0 +1,16 @@
+// compile-flags: -Zmir-opt-level=2 -Zinline-mir
+// ignore-debug: standard library debug assertions add a panic that breaks this optimization
+#![crate_type = "lib"]
+
+pub enum Thing {
+    A,
+    B,
+}
+
+// EMIT_MIR instcombine_duplicate_switch_targets_e2e.ub_if_b.PreCodegen.after.mir
+pub unsafe fn ub_if_b(t: Thing) -> Thing {
+    match t {
+        Thing::A => t,
+        Thing::B => std::hint::unreachable_unchecked(),
+    }
+}

--- a/tests/mir-opt/instcombine_duplicate_switch_targets_e2e.ub_if_b.PreCodegen.after.mir
+++ b/tests/mir-opt/instcombine_duplicate_switch_targets_e2e.ub_if_b.PreCodegen.after.mir
@@ -13,7 +13,7 @@ fn ub_if_b(_1: Thing) -> Thing {
 
     bb0: {
         _2 = discriminant(_1);           // scope 0 at $DIR/instcombine_duplicate_switch_targets_e2e.rs:+1:11: +1:12
-        switchInt(move _2) -> [0: bb2, 1: bb1, otherwise: bb1]; // scope 0 at $DIR/instcombine_duplicate_switch_targets_e2e.rs:+1:5: +1:12
+        switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/instcombine_duplicate_switch_targets_e2e.rs:+1:5: +1:12
     }
 
     bb1: {

--- a/tests/mir-opt/instcombine_duplicate_switch_targets_e2e.ub_if_b.PreCodegen.after.mir
+++ b/tests/mir-opt/instcombine_duplicate_switch_targets_e2e.ub_if_b.PreCodegen.after.mir
@@ -1,0 +1,27 @@
+// MIR for `ub_if_b` after PreCodegen
+
+fn ub_if_b(_1: Thing) -> Thing {
+    debug t => _1;                       // in scope 0 at $DIR/instcombine_duplicate_switch_targets_e2e.rs:+0:23: +0:24
+    let mut _0: Thing;                   // return place in scope 0 at $DIR/instcombine_duplicate_switch_targets_e2e.rs:+0:36: +0:41
+    let mut _2: isize;                   // in scope 0 at $DIR/instcombine_duplicate_switch_targets_e2e.rs:+2:9: +2:17
+    scope 1 (inlined unreachable_unchecked) { // at $DIR/instcombine_duplicate_switch_targets_e2e.rs:14:21: 14:55
+        scope 2 {
+            scope 3 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+            }
+        }
+    }
+
+    bb0: {
+        _2 = discriminant(_1);           // scope 0 at $DIR/instcombine_duplicate_switch_targets_e2e.rs:+1:11: +1:12
+        switchInt(move _2) -> [0: bb2, 1: bb1, otherwise: bb1]; // scope 0 at $DIR/instcombine_duplicate_switch_targets_e2e.rs:+1:5: +1:12
+    }
+
+    bb1: {
+        unreachable;                     // scope 2 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+    }
+
+    bb2: {
+        _0 = move _1;                    // scope 0 at $DIR/instcombine_duplicate_switch_targets_e2e.rs:+2:21: +2:22
+        return;                          // scope 0 at $DIR/instcombine_duplicate_switch_targets_e2e.rs:+5:2: +5:2
+    }
+}


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/106428 (in particular https://github.com/rust-lang/rust/pull/106428/commits/41eda69516dd3ee217ae07c0efa369d31f630405) we noticed that inlining `unreachable_unchecked` can produce duplicate unreachable blocks. So we improved two MIR optimizations: `SimplifyCfg` was given a simplify to deduplicate unreachable blocks, then `InstCombine` was given a combiner to deduplicate switch targets that point at the same block. The problem is that change doesn't actually work.

Our current pass order is
```
SimplifyCfg (does nothing relevant to this situation)
Inline (produces multiple unreachable blocks)
InstCombine (doesn't do anything here, oops)
SimplifyCfg (produces the duplicate SwitchTargets that InstCombine is looking for)
```

So in here, I have factored out the specific function from `InstCombine` and placed it inside the simplify that produces the case it is looking for. This should ensure that it runs in the scenario it was designed for.

Fixes https://github.com/rust-lang/rust/issues/110551
r? @cjgillot 