### PR TITLE
Fix LLVM compile warning message for deprecated-declarations

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -523,13 +523,13 @@ extern "C" typedef void (*LLVMRustSelfProfileBeforePassCallback)(void*, // LlvmS
 extern "C" typedef void (*LLVMRustSelfProfileAfterPassCallback)(void*); // LlvmSelfProfiler
 
 std::string LLVMRustwrappedIrGetName(const llvm::Any &WrappedIr) {
-  if (any_isa<const Module *>(WrappedIr))
+  if (any_cast<const Module *>(WrappedIr) != nullptr)
     return any_cast<const Module *>(WrappedIr)->getName().str();
-  if (any_isa<const Function *>(WrappedIr))
+  if (any_cast<const Function *>(WrappedIr) != nullptr)
     return any_cast<const Function *>(WrappedIr)->getName().str();
-  if (any_isa<const Loop *>(WrappedIr))
+  if (any_cast<const Loop *>(WrappedIr) != nullptr)
     return any_cast<const Loop *>(WrappedIr)->getName().str();
-  if (any_isa<const LazyCallGraph::SCC *>(WrappedIr))
+  if (any_cast<const LazyCallGraph::SCC *>(WrappedIr) != nullptr)
     return any_cast<const LazyCallGraph::SCC *>(WrappedIr)->getName();
   return "<UNKNOWN>";
 }


### PR DESCRIPTION
llvm-wrapper is giving this kind of warning messages when `x b`, this PR will fix it:

```console
warning: llvm-wrapper/PassWrapper.cpp:526:7: warning: 'any_isa<const llvm::Module *>' is deprecated: Use any_cast(Any*) != nullptr instead [-Wdeprecated-declarations]
warning:   if (any_isa<const Module *>(WrappedIr))
warning:       ^~~~~~~
warning:       any_cast
warning: /Users/yukang/rust/build/aarch64-apple-darwin/ci-llvm/include/llvm/ADT/Any.h:130:1: note: 'any_isa<const llvm::Module *>' has been explicitly marked deprecated here
warning: LLVM_DEPRECATED("Use any_cast(Any*) != nullptr instead", "any_cast")
warning: ^
warning: /Users/yukang/rust/build/aarch64-apple-darwin/ci-llvm/include/llvm/Support/Compiler.h:143:50: note: expanded from macro 'LLVM_DEPRECATED'
warning: #define LLVM_DEPRECATED(MSG, FIX) __attribute__((deprecated(MSG, FIX)))
warning:                                                  ^
warning: llvm-wrapper/PassWrapper.cpp:528:7: warning: 'any_isa<const llvm::Function *>' is deprecated: Use any_cast(Any*) != nullptr instead [-Wdeprecated-declarations]
warning:   if (any_isa<const Function *>(WrappedIr))
warning:       ^~~~~~~
warning:       any_cast
```
