### PR TITLE
 fix out-of-date comment about rpath in bootstrap

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1589,8 +1589,8 @@ impl<'a> Builder<'a> {
         // which adds to the runtime dynamic loader path when looking for
         // dynamic libraries. We use this by default on Unix platforms to ensure
         // that our nightlies behave the same on Windows, that is they work out
-        // of the box. This can be disabled, of course, but basically that's why
-        // we're gated on RUSTC_RPATH here.
+        // of the box. This can be disabled by setting `rpath = false` in `[rust]`
+        // table of `config.toml`
         //
         // Ok, so the astute might be wondering "why isn't `-C rpath` used
         // here?" and that is indeed a good question to ask. This codegen


### PR DESCRIPTION
in #64316   (https://github.com/rust-lang/rust/pull/64316/commits/1bec962f4687eacb09bf12955c93f6edfd6efee8),  the `RUSTC_RPATH`  enviroment variables had been removed , but the comments about the rpath still keep it 
this PR fix it  to avoid misunstanding