### PR TITLE
Restrict `From<S>` for `{D,Subd}iagnosticMessage`.

### DIFF
--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -136,7 +136,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
         self.diagnostic().span_bug(
             p.span,
-            &format!(
+            format!(
                 "lower_qpath: no final extension segment in {}..{}",
                 proj_start,
                 p.segments.len()

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -83,7 +83,7 @@ impl<'a> PostExpansionVisitor<'a> {
                     &self,
                     const_extern_fn,
                     span,
-                    &format!("`{}` as a `const fn` ABI is unstable", abi)
+                    format!("`{}` as a `const fn` ABI is unstable", abi)
                 ),
             }
         }
@@ -104,7 +104,7 @@ impl<'a> PostExpansionVisitor<'a> {
                 if self.sess.opts.pretty.map_or(true, |ppm| ppm.needs_hir()) {
                     self.sess.parse_sess.span_diagnostic.delay_span_bug(
                         span,
-                        &format!(
+                        format!(
                             "unrecognized ABI not caught in lowering: {}",
                             symbol_unescaped.as_str()
                         ),

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -623,7 +623,7 @@ fn gate_cfg(gated_cfg: &GatedCfg, cfg_span: Span, sess: &ParseSess, features: &F
     let (cfg, feature, has_feature) = gated_cfg;
     if !has_feature(features) && !cfg_span.allows_unstable(*feature) {
         let explain = format!("`cfg({cfg})` is experimental and subject to change");
-        feature_err(sess, *feature, cfg_span, &explain).emit();
+        feature_err(sess, *feature, cfg_span, explain).emit();
     }
 }
 

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -158,7 +158,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             } else if reinits > 1 {
                 err.span_note(
                     MultiSpan::from_spans(reinit_spans),
-                    &if reinits <= 3 {
+                    if reinits <= 3 {
                         format!("these {reinits} reinitializations might get skipped")
                     } else {
                         format!(
@@ -253,7 +253,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     // We have a `&mut` ref, we need to reborrow on each iteration (#62112).
                     err.span_suggestion_verbose(
                         span.shrink_to_lo(),
-                        &format!(
+                        format!(
                             "consider creating a fresh reborrow of {} here",
                             self.describe_place(moved_place)
                                 .map(|n| format!("`{n}`"))
@@ -304,7 +304,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 ..
             } = use_spans
             {
-                err.note(&format!(
+                err.note(format!(
                     "{} occurs due to deref coercion to `{deref_target_ty}`",
                     desired_action.as_noun(),
                 ));
@@ -586,7 +586,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 //     _ => {} // We don't want to point to this.
                 // };
                 // ```
-                err.span_label(sp, &label);
+                err.span_label(sp, label);
                 shown = true;
             }
         }
@@ -1139,7 +1139,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         }
 
         if union_type_name != "" {
-            err.note(&format!(
+            err.note(format!(
                 "{} is a field of the union `{}`, so it overlaps the field {}",
                 msg_place, union_type_name, msg_borrow,
             ));
@@ -1238,14 +1238,14 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         }
         err.span_help(
             inner_call_span,
-            &format!(
+            format!(
                 "try adding a local storing this{}...",
                 if use_span.is_some() { "" } else { " argument" }
             ),
         );
         err.span_help(
             outer_call_span,
-            &format!(
+            format!(
                 "...and then using that local {}",
                 if use_span.is_some() { "here" } else { "as the argument to this call" }
             ),
@@ -2281,7 +2281,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         );
         err.span_suggestion_verbose(
             sugg_span,
-            &format!(
+            format!(
                 "to force the {} to take ownership of {} (and any \
                  other referenced variables), use the `move` keyword",
                 kind, captured_var
@@ -2293,7 +2293,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         match category {
             ConstraintCategory::Return(_) | ConstraintCategory::OpaqueType => {
                 let msg = format!("{} is returned here", kind);
-                err.span_note(constraint_span, &msg);
+                err.span_note(constraint_span, msg);
             }
             ConstraintCategory::CallArgument(_) => {
                 fr_name.highlight_region_name(&mut err);
@@ -2304,7 +2304,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     );
                 } else {
                     let msg = format!("{scope} requires argument type to outlive `{fr_name}`");
-                    err.span_note(constraint_span, &msg);
+                    err.span_note(constraint_span, msg);
                 }
             }
             _ => bug!(
@@ -2626,7 +2626,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     });
                 if let Some(Ok(instance)) = deref_target {
                     let deref_target_ty = instance.ty(tcx, self.param_env);
-                    err.note(&format!(
+                    err.note(format!(
                         "borrow occurs due to deref coercion to `{}`",
                         deref_target_ty
                     ));
@@ -3180,7 +3180,7 @@ impl<'tcx> AnnotatedBorrowFnSignature<'tcx> {
 
                 diag.span_label(*return_span, format!("also has lifetime `{}`", region_name,));
 
-                diag.help(&format!(
+                diag.help(format!(
                     "use data from the highlighted arguments which match the `{}` lifetime of \
                      the return type",
                     region_name,

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -90,7 +90,7 @@ impl<'tcx> BorrowExplanation<'tcx> {
                     {
                         err.span_label(
                             pat.span,
-                            &format!("binding `{ident}` declared here"),
+                            format!("binding `{ident}` declared here"),
                         );
                     }
                 }
@@ -323,7 +323,7 @@ impl<'tcx> BorrowExplanation<'tcx> {
 
             err.span_suggestion_verbose(
                 span.shrink_to_hi(),
-                &msg,
+                msg,
                 format!(" + {suggestable_name}"),
                 Applicability::Unspecified,
             );

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -1073,7 +1073,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                             if !is_loop_move {
                                 err.span_suggestion_verbose(
                                     move_span.shrink_to_lo(),
-                                    &format!(
+                                    format!(
                                         "consider creating a fresh reborrow of {} here",
                                         self.describe_place(moved_place.as_ref())
                                             .map(|n| format!("`{n}`"))

--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -533,7 +533,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         suggestions.sort_unstable_by_key(|&(span, _, _)| span);
         suggestions.dedup_by_key(|&mut (span, _, _)| span);
         for (span, msg, suggestion) in suggestions {
-            err.span_suggestion_verbose(span, &msg, suggestion, Applicability::MachineApplicable);
+            err.span_suggestion_verbose(span, msg, suggestion, Applicability::MachineApplicable);
         }
     }
 

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -573,7 +573,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                                 if !is_trait_sig {
                                     err.span_suggestion_verbose(
                                         err_help_span,
-                                        &format!(
+                                        format!(
                                             "consider changing this to be a mutable {pointer_desc}"
                                         ),
                                         suggested_code,
@@ -582,7 +582,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                                 } else if let Some(x) = local_trait {
                                     err.span_suggestion_verbose(
                                         x,
-                                        &format!(
+                                        format!(
                                             "consider changing that to be a mutable {pointer_desc}"
                                         ),
                                         suggested_code,
@@ -636,14 +636,14 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                                     };
                                     err.span_suggestion_verbose(
                                         span,
-                                        &format!("consider {changing} this binding's type"),
+                                        format!("consider {changing} this binding's type"),
                                         sugg,
                                         Applicability::HasPlaceholders,
                                     );
                                 } else {
                                     err.span_label(
                                         err_label_span,
-                                        &format!(
+                                        format!(
                                             "consider changing this binding's type to be: `{message}`"
                                         ),
                                     );
@@ -679,13 +679,13 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
 
                 match opt_source {
                     Some(BorrowedContentSource::OverloadedDeref(ty)) => {
-                        err.help(&format!(
+                        err.help(format!(
                             "trait `DerefMut` is required to modify through a dereference, \
                              but it is not implemented for `{ty}`",
                         ));
                     }
                     Some(BorrowedContentSource::OverloadedIndex(ty)) => {
-                        err.help(&format!(
+                        err.help(format!(
                             "trait `IndexMut` is required to modify indexed content, \
                              but it is not implemented for `{ty}`",
                         ));
@@ -736,7 +736,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                         // val[index] = rv;
                         // ---------- place
                         self.err.multipart_suggestions(
-                            &format!(
+                            format!(
                                 "to modify a `{}`, use `.get_mut()`, `.insert()` or the entry API",
                                 self.ty,
                             ),
@@ -788,7 +788,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     {
                         // val[index].path(args..);
                         self.err.multipart_suggestion(
-                            &format!("to modify a `{}` use `.get_mut()`", self.ty),
+                            format!("to modify a `{}` use `.get_mut()`", self.ty),
                             vec![
                                 (
                                     val.span.shrink_to_hi().with_hi(index.span.lo()),
@@ -822,7 +822,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             let mut v = V { assign_span, err, ty, suggested: false };
             v.visit_body(body);
             if !v.suggested {
-                err.help(&format!(
+                err.help(format!(
                     "to modify a `{ty}`, use `.get_mut()`, `.insert()` or the entry API",
                 ));
             }

--- a/compiler/rustc_borrowck/src/diagnostics/outlives_suggestion.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/outlives_suggestion.rs
@@ -171,7 +171,7 @@ impl OutlivesSuggestionBuilder {
         if let (Some(fr_name), Some(outlived_fr_name)) = (fr_name, outlived_fr_name)
             && !matches!(outlived_fr_name.source, RegionNameSource::Static)
         {
-            diag.help(&format!(
+            diag.help(format!(
                 "consider adding the following bound: `{fr_name}: {outlived_fr_name}`",
             ));
         }
@@ -207,7 +207,7 @@ impl OutlivesSuggestionBuilder {
         // If there is exactly one suggestable constraints, then just suggest it. Otherwise, emit a
         // list of diagnostics.
         let mut diag = if suggested.len() == 1 {
-            mbcx.infcx.tcx.sess.diagnostic().struct_help(&match suggested.last().unwrap() {
+            mbcx.infcx.tcx.sess.diagnostic().struct_help(match suggested.last().unwrap() {
                 SuggestedConstraint::Outlives(a, bs) => {
                     let bs: SmallVec<[String; 2]> = bs.iter().map(|r| r.to_string()).collect();
                     format!("add bound `{a}: {}`", bs.join(" + "))
@@ -232,15 +232,15 @@ impl OutlivesSuggestionBuilder {
                 match constraint {
                     SuggestedConstraint::Outlives(a, bs) => {
                         let bs: SmallVec<[String; 2]> = bs.iter().map(|r| r.to_string()).collect();
-                        diag.help(&format!("add bound `{a}: {}`", bs.join(" + ")));
+                        diag.help(format!("add bound `{a}: {}`", bs.join(" + ")));
                     }
                     SuggestedConstraint::Equal(a, b) => {
-                        diag.help(&format!(
+                        diag.help(format!(
                             "`{a}` and `{b}` must be the same: replace one with the other",
                         ));
                     }
                     SuggestedConstraint::Static(a) => {
-                        diag.help(&format!("replace `{a}` with `'static`"));
+                        diag.help(format!("replace `{a}` with `'static`"));
                     }
                 }
             }

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -533,8 +533,8 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     }
                     _ => panic!("Unexpected type {ty:?}"),
                 };
-                diag.note(&format!("requirement occurs because of {desc}",));
-                diag.note(&note);
+                diag.note(format!("requirement occurs because of {desc}",));
+                diag.note(note);
                 diag.help("see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance");
             }
         }
@@ -863,7 +863,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             }
             spans_suggs.push((alias_span.shrink_to_hi(), "<'a>".to_string()));
             diag.multipart_suggestion_verbose(
-                &format!(
+                format!(
                     "to declare that the trait object {captures}, you can add a lifetime parameter `'a` in the type alias"
                 ),
                 spans_suggs,

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -622,7 +622,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
                     // programs, so we need to use delay_span_bug here. See #82126.
                     self.infcx.tcx.sess.delay_span_bug(
                         hir_arg.span(),
-                        &format!("unmatched subst and hir arg: found {kind:?} vs {hir_arg:?}"),
+                        format!("unmatched subst and hir arg: found {kind:?} vs {hir_arg:?}"),
                     );
                 }
             }

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -2022,7 +2022,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     // been emitted (#52262).
                     self.infcx.tcx.sess.delay_span_bug(
                         span,
-                        &format!(
+                        format!(
                             "Accessing `{:?}` with the kind `{:?}` shouldn't be possible",
                             place, kind,
                         ),
@@ -2383,7 +2383,7 @@ mod error {
             }
             for (_, (mut diag, count)) in std::mem::take(&mut self.errors.buffered_mut_errors) {
                 if count > 10 {
-                    diag.note(&format!("...and {} other attempted mutable borrows", count - 10));
+                    diag.note(format!("...and {} other attempted mutable borrows", count - 10));
                 }
                 diag.buffer(&mut self.errors.buffered);
             }

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -399,7 +399,7 @@ pub(super) fn dump_annotation<'tcx>(
 
         regioncx.annotate(tcx, &mut err);
 
-        err.note(&format!(
+        err.note(format!(
             "number of external vids: {}",
             closure_region_requirements.num_external_vids
         ));
@@ -421,7 +421,7 @@ pub(super) fn dump_annotation<'tcx>(
     };
 
     if !opaque_type_values.is_empty() {
-        err.note(&format!("Inferred opaque type values:\n{:#?}", opaque_type_values));
+        err.note(format!("Inferred opaque type values:\n{:#?}", opaque_type_values));
     }
 
     errors.buffer_non_error_diag(err);

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -399,7 +399,7 @@ fn check_opaque_type_parameter_valid(
             return Err(tcx
                 .sess
                 .struct_span_err(span, "non-defining opaque type use in defining scope")
-                .span_note(spans, &format!("{} used multiple times", descr))
+                .span_note(spans, format!("{} used multiple times", descr))
                 .emit());
         }
     }

--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -249,7 +249,7 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
                         .infcx
                         .tcx
                         .sess
-                        .delay_span_bug(span, &format!("failed to normalize {:?}", ty));
+                        .delay_span_bug(span, format!("failed to normalize {:?}", ty));
                     TypeOpOutput {
                         output: self.infcx.tcx.ty_error(guar),
                         constraints: None,

--- a/compiler/rustc_borrowck/src/type_check/input_output.rs
+++ b/compiler/rustc_borrowck/src/type_check/input_output.rs
@@ -106,7 +106,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         if body.yield_ty().is_some() != universal_regions.yield_ty.is_some() {
             self.tcx().sess.delay_span_bug(
                 body.span,
-                &format!(
+                format!(
                     "Expected body to have yield_ty ({:?}) iff we have a UR yield_ty ({:?})",
                     body.yield_ty(),
                     universal_regions.yield_ty,

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -236,7 +236,7 @@ pub(crate) fn type_check<'mir, 'tcx>(
             if hidden_type.has_non_region_infer() {
                 let reported = infcx.tcx.sess.delay_span_bug(
                     decl.hidden_type.span,
-                    &format!("could not resolve {:#?}", hidden_type.ty.kind()),
+                    format!("could not resolve {:#?}", hidden_type.ty.kind()),
                 );
                 hidden_type.ty = infcx.tcx.ty_error(reported);
             }

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -335,7 +335,7 @@ impl<'tcx> UniversalRegions<'tcx> {
     pub(crate) fn annotate(&self, tcx: TyCtxt<'tcx>, err: &mut Diagnostic) {
         match self.defining_ty {
             DefiningTy::Closure(def_id, substs) => {
-                err.note(&format!(
+                err.note(format!(
                     "defining type: {} with closure substs {:#?}",
                     tcx.def_path_str_with_substs(def_id, substs),
                     &substs[tcx.generics_of(def_id).parent_count..],
@@ -347,11 +347,11 @@ impl<'tcx> UniversalRegions<'tcx> {
                 // and other things that are not stable across tests!
                 // So we just include the region-vid. Annoying.
                 for_each_late_bound_region_in_recursive_scope(tcx, def_id.expect_local(), |r| {
-                    err.note(&format!("late-bound region is {:?}", self.to_region_vid(r)));
+                    err.note(format!("late-bound region is {:?}", self.to_region_vid(r)));
                 });
             }
             DefiningTy::Generator(def_id, substs, _) => {
-                err.note(&format!(
+                err.note(format!(
                     "defining type: {} with generator substs {:#?}",
                     tcx.def_path_str_with_substs(def_id, substs),
                     &substs[tcx.generics_of(def_id).parent_count..],
@@ -361,23 +361,23 @@ impl<'tcx> UniversalRegions<'tcx> {
                 // `r` but doing so is not stable across architectures
                 // and so forth.
                 for_each_late_bound_region_in_recursive_scope(tcx, def_id.expect_local(), |r| {
-                    err.note(&format!("late-bound region is {:?}", self.to_region_vid(r)));
+                    err.note(format!("late-bound region is {:?}", self.to_region_vid(r)));
                 });
             }
             DefiningTy::FnDef(def_id, substs) => {
-                err.note(&format!(
+                err.note(format!(
                     "defining type: {}",
                     tcx.def_path_str_with_substs(def_id, substs),
                 ));
             }
             DefiningTy::Const(def_id, substs) => {
-                err.note(&format!(
+                err.note(format!(
                     "defining constant type: {}",
                     tcx.def_path_str_with_substs(def_id, substs),
                 ));
             }
             DefiningTy::InlineConst(def_id, substs) => {
-                err.note(&format!(
+                err.note(format!(
                     "defining inline constant type: {}",
                     tcx.def_path_str_with_substs(def_id, substs),
                 ));

--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -553,7 +553,7 @@ fn expand_preparsed_asm(ecx: &mut ExtCtxt<'_>, args: AsmArgs) -> Option<ast::Inl
             let mut e = ecx.struct_span_err(err_sp, msg);
             e.span_label(err_sp, err.label + " in asm template string");
             if let Some(note) = err.note {
-                e.note(&note);
+                e.note(note);
             }
             if let Some((label, span)) = err.secondary_label {
                 let err_sp = template_span.from_inner(InnerSpan::new(span.start, span.end));
@@ -600,7 +600,7 @@ fn expand_preparsed_asm(ecx: &mut ExtCtxt<'_>, args: AsmArgs) -> Option<ast::Inl
                                     1 => format!("there is 1 {}argument", positional),
                                     x => format!("there are {} {}arguments", x, positional),
                                 };
-                                err.note(&msg);
+                                err.note(msg);
 
                                 if named_pos.contains_key(&idx) {
                                     err.span_label(args.operands[idx].1, "named argument");
@@ -703,7 +703,7 @@ fn expand_preparsed_asm(ecx: &mut ExtCtxt<'_>, args: AsmArgs) -> Option<ast::Inl
             let (sp, msg) = unused_operands.into_iter().next().unwrap();
             let mut err = ecx.struct_span_err(sp, msg);
             err.span_label(sp, msg);
-            err.help(&format!(
+            err.help(format!(
                 "if this argument is intentionally unused, \
                  consider using it in an asm comment: `\"/*{} */\"`",
                 help_str
@@ -718,7 +718,7 @@ fn expand_preparsed_asm(ecx: &mut ExtCtxt<'_>, args: AsmArgs) -> Option<ast::Inl
             for (sp, msg) in unused_operands {
                 err.span_label(sp, msg);
             }
-            err.help(&format!(
+            err.help(format!(
                 "if these arguments are intentionally unused, \
                  consider using them in an asm comment: `\"/*{} */\"`",
                 help_str

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -616,14 +616,14 @@ fn report_missing_placeholders(
                         } else {
                             diag.span_note(
                                 sp,
-                                &format!("format specifiers use curly braces, and {}", trn),
+                                format!("format specifiers use curly braces, and {}", trn),
                             );
                         }
                     } else {
                         if success {
-                            diag.help(&format!("`{}` should be written as `{}`", sub, trn));
+                            diag.help(format!("`{}` should be written as `{}`", sub, trn));
                         } else {
-                            diag.note(&format!("`{}` should use curly braces, and {}", sub, trn));
+                            diag.note(format!("`{}` should use curly braces, and {}", sub, trn));
                         }
                     }
                 }
@@ -777,7 +777,7 @@ fn report_invalid_references(
                 has_precision_star = true;
                 e.span_label(
                     *span,
-                    &format!(
+                    format!(
                         "this precision flag adds an extra required argument at position {}, which is why there {} expected",
                         index,
                         if num_placeholders == 1 {

--- a/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
+++ b/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
@@ -194,7 +194,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
                     };
 
                     self.handler
-                        .struct_span_err(attr.span, &msg)
+                        .struct_span_err(attr.span, msg)
                         .span_label(prev_attr.span, "previous attribute here")
                         .emit();
 
@@ -219,7 +219,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
                 pprust::path_to_string(&attr.get_normal_item().path),
             );
 
-            self.handler.span_err(attr.span, &msg);
+            self.handler.span_err(attr.span, msg);
             return;
         }
 
@@ -233,7 +233,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
                 pprust::path_to_string(&attr.get_normal_item().path),
             );
 
-            self.handler.span_err(attr.span, &msg);
+            self.handler.span_err(attr.span, msg);
             return;
         }
 

--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -150,7 +150,7 @@ pub fn expand_include<'cx>(
                         if self.p.token != token::Eof {
                             let token = pprust::token_to_string(&self.p.token);
                             let msg = format!("expected item, found `{}`", token);
-                            self.p.struct_span_err(self.p.token.span, &msg).emit();
+                            self.p.struct_span_err(self.p.token.span, msg).emit();
                         }
 
                         break;

--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -88,10 +88,10 @@ pub(crate) fn import_function<'tcx>(
     let sig = get_function_sig(tcx, module.target_config().default_call_conv, inst);
     match module.declare_function(name, Linkage::Import, &sig) {
         Ok(func_id) => func_id,
-        Err(ModuleError::IncompatibleDeclaration(_)) => tcx.sess.fatal(&format!(
+        Err(ModuleError::IncompatibleDeclaration(_)) => tcx.sess.fatal(format!(
             "attempt to declare `{name}` as function, but it was already declared as static"
         )),
-        Err(ModuleError::IncompatibleSignature(_, prev_sig, new_sig)) => tcx.sess.fatal(&format!(
+        Err(ModuleError::IncompatibleSignature(_, prev_sig, new_sig)) => tcx.sess.fatal(format!(
             "attempt to declare `{name}` with signature {new_sig:?}, \
              but it was already declared with signature {prev_sig:?}"
         )),
@@ -548,7 +548,7 @@ pub(crate) fn codegen_terminator_call<'tcx>(
             if !matches!(fn_sig.abi(), Abi::C { .. }) {
                 fx.tcx.sess.span_fatal(
                     source_info.span,
-                    &format!("Variadic call for non-C abi {:?}", fn_sig.abi()),
+                    format!("Variadic call for non-C abi {:?}", fn_sig.abi()),
                 );
             }
             let sig_ref = fx.bcx.func.dfg.call_signature(call_inst).unwrap();
@@ -560,7 +560,7 @@ pub(crate) fn codegen_terminator_call<'tcx>(
                         // FIXME set %al to upperbound on float args once floats are supported
                         fx.tcx.sess.span_fatal(
                             source_info.span,
-                            &format!("Non int ty {:?} for variadic call", ty),
+                            format!("Non int ty {:?} for variadic call", ty),
                         );
                     }
                     AbiParam::new(ty)

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -220,13 +220,13 @@ pub(crate) fn verify_func(
         match cranelift_codegen::verify_function(&func, &flags) {
             Ok(_) => {}
             Err(err) => {
-                tcx.sess.err(&format!("{:?}", err));
+                tcx.sess.err(format!("{:?}", err));
                 let pretty_error = cranelift_codegen::print_errors::pretty_verifier_error(
                     &func,
                     Some(Box::new(writer)),
                     err,
                 );
-                tcx.sess.fatal(&format!("cranelift verify error:\n{}", pretty_error));
+                tcx.sess.fatal(format!("cranelift verify error:\n{}", pretty_error));
             }
         }
     });

--- a/compiler/rustc_codegen_cranelift/src/common.rs
+++ b/compiler/rustc_codegen_cranelift/src/common.rs
@@ -481,7 +481,7 @@ impl<'tcx> LayoutOfHelpers<'tcx> for RevealAllLayoutCx<'tcx> {
     #[inline]
     fn handle_layout_err(&self, err: LayoutError<'tcx>, span: Span, ty: Ty<'tcx>) -> ! {
         if let layout::LayoutError::SizeOverflow(_) = err {
-            self.0.sess.span_fatal(span, &err.to_string())
+            self.0.sess.span_fatal(span, err.to_string())
         } else {
             span_bug!(span, "failed to get layout for `{}`: {}", ty, err)
         }
@@ -499,7 +499,7 @@ impl<'tcx> FnAbiOfHelpers<'tcx> for RevealAllLayoutCx<'tcx> {
         fn_abi_request: FnAbiRequest<'tcx>,
     ) -> ! {
         if let FnAbiError::Layout(LayoutError::SizeOverflow(_)) = err {
-            self.0.sess.span_fatal(span, &err.to_string())
+            self.0.sess.span_fatal(span, err.to_string())
         } else {
             match fn_abi_request {
                 FnAbiRequest::OfFnPtr { sig, extra_args } => {

--- a/compiler/rustc_codegen_cranelift/src/concurrency_limiter.rs
+++ b/compiler/rustc_codegen_cranelift/src/concurrency_limiter.rs
@@ -65,7 +65,7 @@ impl ConcurrencyLimiter {
                     // Make sure to drop the mutex guard first to prevent poisoning the mutex.
                     drop(state);
                     if let Some(err) = err {
-                        handler.fatal(&err).raise();
+                        handler.fatal(err).raise();
                     } else {
                         // The error was already emitted, but compilation continued. Raise a silent
                         // fatal error.

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -308,7 +308,7 @@ fn data_id_for_static(
             attrs.flags.contains(CodegenFnAttrFlags::THREAD_LOCAL),
         ) {
             Ok(data_id) => data_id,
-            Err(ModuleError::IncompatibleDeclaration(_)) => tcx.sess.fatal(&format!(
+            Err(ModuleError::IncompatibleDeclaration(_)) => tcx.sess.fatal(format!(
                 "attempt to declare `{symbol_name}` as static, but it was already declared as function"
             )),
             Err(err) => Err::<_, _>(err).unwrap(),
@@ -356,7 +356,7 @@ fn data_id_for_static(
         attrs.flags.contains(CodegenFnAttrFlags::THREAD_LOCAL),
     ) {
         Ok(data_id) => data_id,
-        Err(ModuleError::IncompatibleDeclaration(_)) => tcx.sess.fatal(&format!(
+        Err(ModuleError::IncompatibleDeclaration(_)) => tcx.sess.fatal(format!(
             "attempt to declare `{symbol_name}` as static, but it was already declared as function"
         )),
         Err(err) => Err::<_, _>(err).unwrap(),
@@ -404,7 +404,7 @@ fn define_all_allocs(tcx: TyCtxt<'_>, module: &mut dyn Module, cx: &mut Constant
                 if let Some(names) = section_name.split_once(',') {
                     names
                 } else {
-                    tcx.sess.fatal(&format!(
+                    tcx.sess.fatal(format!(
                         "#[link_section = \"{}\"] is not valid for macos target: must be segment and section separated by comma",
                         section_name
                     ));
@@ -449,7 +449,7 @@ fn define_all_allocs(tcx: TyCtxt<'_>, module: &mut dyn Module, cx: &mut Constant
                 GlobalAlloc::Static(def_id) => {
                     if tcx.codegen_fn_attrs(def_id).flags.contains(CodegenFnAttrFlags::THREAD_LOCAL)
                     {
-                        tcx.sess.fatal(&format!(
+                        tcx.sess.fatal(format!(
                             "Allocation {:?} contains reference to TLS value {:?}",
                             alloc_id, def_id
                         ));

--- a/compiler/rustc_codegen_cranelift/src/driver/aot.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/aot.rs
@@ -69,7 +69,7 @@ impl OngoingCodegen {
 
             let module_codegen_result = match module_codegen_result {
                 Ok(module_codegen_result) => module_codegen_result,
-                Err(err) => sess.fatal(&err),
+                Err(err) => sess.fatal(err),
             };
             let ModuleCodegenResult { module_regular, module_global_asm, existing_work_product } =
                 module_codegen_result;
@@ -468,7 +468,7 @@ pub(crate) fn run_aot(
             let obj = create_compressed_metadata_file(tcx.sess, &metadata, &symbol_name);
 
             if let Err(err) = std::fs::write(&tmp_file, obj) {
-                tcx.sess.fatal(&format!("error writing metadata object file: {}", err));
+                tcx.sess.fatal(format!("error writing metadata object file: {}", err));
             }
 
             (metadata_cgu_name, tmp_file)

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/llvm.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/llvm.rs
@@ -42,7 +42,7 @@ pub(crate) fn codegen_llvm_intrinsic_call<'tcx>(
         _ => {
             fx.tcx
                 .sess
-                .warn(&format!("unsupported llvm intrinsic {}; replacing with trap", intrinsic));
+                .warn(format!("unsupported llvm intrinsic {}; replacing with trap", intrinsic));
             crate::trap::trap_unimplemented(fx, intrinsic);
             return;
         }

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/llvm_aarch64.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/llvm_aarch64.rs
@@ -207,7 +207,7 @@ pub(crate) fn codegen_aarch64_llvm_intrinsic_call<'tcx>(
         }
         */
         _ => {
-            fx.tcx.sess.warn(&format!(
+            fx.tcx.sess.warn(format!(
                 "unsupported AArch64 llvm intrinsic {}; replacing with trap",
                 intrinsic
             ));

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/llvm_x86.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/llvm_x86.rs
@@ -138,10 +138,9 @@ pub(crate) fn codegen_x86_llvm_intrinsic_call<'tcx>(
             llvm_add_sub(fx, BinOp::Sub, ret, b_in, a, b);
         }
         _ => {
-            fx.tcx.sess.warn(&format!(
-                "unsupported x86 llvm intrinsic {}; replacing with trap",
-                intrinsic
-            ));
+            fx.tcx
+                .sess
+                .warn(format!("unsupported x86 llvm intrinsic {}; replacing with trap", intrinsic));
             crate::trap::trap_unimplemented(fx, intrinsic);
             return;
         }

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -42,7 +42,7 @@ fn report_atomic_type_validation_error<'tcx>(
 ) {
     fx.tcx.sess.span_err(
         span,
-        &format!(
+        format!(
             "`{}` intrinsic: expected basic integer or raw pointer type, found `{:?}`",
             intrinsic, ty
         ),
@@ -1202,7 +1202,7 @@ fn codegen_regular_intrinsic_call<'tcx>(
         _ => {
             fx.tcx
                 .sess
-                .span_fatal(source_info.span, &format!("unsupported intrinsic {}", intrinsic));
+                .span_fatal(source_info.span, format!("unsupported intrinsic {}", intrinsic));
         }
     }
 

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
@@ -13,7 +13,7 @@ fn report_simd_type_validation_error(
     span: Span,
     ty: Ty<'_>,
 ) {
-    fx.tcx.sess.span_err(span, &format!("invalid monomorphization of `{}` intrinsic: expected SIMD input type, found non-SIMD `{}`", intrinsic, ty));
+    fx.tcx.sess.span_err(span, format!("invalid monomorphization of `{}` intrinsic: expected SIMD input type, found non-SIMD `{}`", intrinsic, ty));
     // Prevent verifier error
     fx.bcx.ins().trap(TrapCode::UnreachableCodeReached);
 }
@@ -150,7 +150,7 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
                     _ => {
                         fx.tcx.sess.span_err(
                             span,
-                            &format!(
+                            format!(
                                 "simd_shuffle index must be an array of `u32`, got `{}`",
                                 idx_ty,
                             ),
@@ -248,7 +248,7 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
             if idx >= lane_count.into() {
                 fx.tcx.sess.span_fatal(
                     fx.mir.span,
-                    &format!("[simd_insert] idx {} >= lane_count {}", idx, lane_count),
+                    format!("[simd_insert] idx {} >= lane_count {}", idx, lane_count),
                 );
             }
 
@@ -296,7 +296,7 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
             if idx >= lane_count.into() {
                 fx.tcx.sess.span_fatal(
                     fx.mir.span,
-                    &format!("[simd_extract] idx {} >= lane_count {}", idx, lane_count),
+                    format!("[simd_extract] idx {} >= lane_count {}", idx, lane_count),
                 );
             }
 
@@ -699,7 +699,7 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
                 _ => {
                     fx.tcx.sess.span_fatal(
                         span,
-                        &format!(
+                        format!(
                             "invalid monomorphization of `simd_bitmask` intrinsic: \
                             vector argument `{}`'s element type `{}`, expected integer element \
                             type",
@@ -739,7 +739,7 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
                 _ => {
                     fx.tcx.sess.span_fatal(
                         span,
-                        &format!(
+                        format!(
                             "invalid monomorphization of `simd_bitmask` intrinsic: \
                             cannot return `{}`, expected `u{}` or `[u8; {}]`",
                             ret.layout().ty,
@@ -875,7 +875,7 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
         }
 
         _ => {
-            fx.tcx.sess.span_err(span, &format!("Unknown SIMD intrinsic {}", intrinsic));
+            fx.tcx.sess.span_err(span, format!("Unknown SIMD intrinsic {}", intrinsic));
             // Prevent verifier error
             fx.bcx.ins().trap(TrapCode::UnreachableCodeReached);
         }

--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -185,7 +185,7 @@ impl CodegenBackend for CraneliftCodegenBackend {
         let mut config = self.config.borrow_mut();
         if config.is_none() {
             let new_config = BackendConfig::from_opts(&sess.opts.cg.llvm_args)
-                .unwrap_or_else(|err| sess.fatal(&err));
+                .unwrap_or_else(|err| sess.fatal(err));
             *config = Some(new_config);
         }
     }
@@ -245,7 +245,7 @@ impl CodegenBackend for CraneliftCodegenBackend {
 fn target_triple(sess: &Session) -> target_lexicon::Triple {
     match sess.target.llvm_target.parse() {
         Ok(triple) => triple,
-        Err(err) => sess.fatal(&format!("target not recognized: {}", err)),
+        Err(err) => sess.fatal(format!("target not recognized: {}", err)),
     }
 }
 
@@ -307,7 +307,7 @@ fn build_isa(sess: &Session, backend_config: &BackendConfig) -> Arc<dyn isa::Tar
         Some(value) => {
             let mut builder =
                 cranelift_codegen::isa::lookup(target_triple.clone()).unwrap_or_else(|err| {
-                    sess.fatal(&format!("can't compile for {}: {}", target_triple, err));
+                    sess.fatal(format!("can't compile for {}: {}", target_triple, err));
                 });
             if let Err(_) = builder.enable(value) {
                 sess.fatal("the specified target cpu isn't currently supported by Cranelift.");
@@ -317,7 +317,7 @@ fn build_isa(sess: &Session, backend_config: &BackendConfig) -> Arc<dyn isa::Tar
         None => {
             let mut builder =
                 cranelift_codegen::isa::lookup(target_triple.clone()).unwrap_or_else(|err| {
-                    sess.fatal(&format!("can't compile for {}: {}", target_triple, err));
+                    sess.fatal(format!("can't compile for {}: {}", target_triple, err));
                 });
             if target_triple.architecture == target_lexicon::Architecture::X86_64 {
                 // Don't use "haswell" as the default, as it implies `has_lzcnt`.
@@ -330,7 +330,7 @@ fn build_isa(sess: &Session, backend_config: &BackendConfig) -> Arc<dyn isa::Tar
 
     match isa_builder.finish(flags) {
         Ok(target_isa) => target_isa,
-        Err(err) => sess.fatal(&format!("failed to build TargetIsa: {}", err)),
+        Err(err) => sess.fatal(format!("failed to build TargetIsa: {}", err)),
     }
 }
 

--- a/compiler/rustc_codegen_cranelift/src/main_shim.rs
+++ b/compiler/rustc_codegen_cranelift/src/main_shim.rs
@@ -75,7 +75,7 @@ pub(crate) fn maybe_create_entry_wrapper(
             Ok(func_id) => func_id,
             Err(err) => {
                 tcx.sess
-                    .fatal(&format!("entry symbol `{entry_name}` declared multiple times: {err}"));
+                    .fatal(format!("entry symbol `{entry_name}` declared multiple times: {err}"));
             }
         };
 
@@ -171,7 +171,7 @@ pub(crate) fn maybe_create_entry_wrapper(
         }
 
         if let Err(err) = m.define_function(cmain_func_id, &mut ctx) {
-            tcx.sess.fatal(&format!("entry symbol `{entry_name}` defined multiple times: {err}"));
+            tcx.sess.fatal(format!("entry symbol `{entry_name}` defined multiple times: {err}"));
         }
 
         unwind_context.add_function(cmain_func_id, &ctx, m.isa());

--- a/compiler/rustc_codegen_cranelift/src/value_and_place.rs
+++ b/compiler/rustc_codegen_cranelift/src/value_and_place.rs
@@ -344,7 +344,7 @@ impl<'tcx> CPlace<'tcx> {
         if layout.size.bytes() >= u64::from(u32::MAX - 16) {
             fx.tcx
                 .sess
-                .fatal(&format!("values of type {} are too big to store on the stack", layout.ty));
+                .fatal(format!("values of type {} are too big to store on the stack", layout.ty));
         }
 
         let stack_slot = fx.bcx.create_sized_stack_slot(StackSlotData {

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -53,7 +53,7 @@ use std::{env, fmt, fs, io, mem, str};
 pub fn ensure_removed(diag_handler: &Handler, path: &Path) {
     if let Err(e) = fs::remove_file(path) {
         if e.kind() != io::ErrorKind::NotFound {
-            diag_handler.err(&format!("failed to remove {}: {}", path.display(), e));
+            diag_handler.err(format!("failed to remove {}: {}", path.display(), e));
         }
     }
 }
@@ -1405,7 +1405,7 @@ fn print_native_static_libs(sess: &Session, all_native_libs: &[NativeLib]) {
         sess.emit_note(errors::StaticLibraryNativeArtifacts);
         // Prefix for greppability
         // Note: This must not be translated as tools are allowed to depend on this exact string.
-        sess.note_without_error(&format!("native-static-libs: {}", &lib_args.join(" ")));
+        sess.note_without_error(format!("native-static-libs: {}", &lib_args.join(" ")));
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1631,7 +1631,7 @@ impl<'a> Linker for AixLinker<'a> {
             }
         };
         if let Err(e) = res {
-            self.sess.fatal(&format!("failed to write export file: {}", e));
+            self.sess.fatal(format!("failed to write export file: {}", e));
         }
         self.cmd.arg(format!("-bE:{}", path.to_str().unwrap()));
     }

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1833,7 +1833,7 @@ impl SharedEmitterMain {
                     sess.abort_if_errors();
                 }
                 Ok(SharedEmitterMessage::Fatal(msg)) => {
-                    sess.fatal(&msg);
+                    sess.fatal(msg);
                 }
                 Err(_) => {
                     break;

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -301,7 +301,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
                 if let Some(val) = attr.value_str() {
                     if val.as_str().bytes().any(|b| b == 0) {
                         let msg = format!("illegal null byte in link_section value: `{}`", &val);
-                        tcx.sess.span_err(attr.span, &msg);
+                        tcx.sess.span_err(attr.span, msg);
                     } else {
                         codegen_fn_attrs.link_section = Some(val);
                     }
@@ -631,7 +631,7 @@ fn check_link_ordinal(tcx: TyCtxt<'_>, attr: &ast::Attribute) -> Option<u16> {
         } else {
             let msg = format!("ordinal value in `link_ordinal` is too large: `{}`", &ordinal);
             tcx.sess
-                .struct_span_err(attr.span, &msg)
+                .struct_span_err(attr.span, msg)
                 .note("the value may not exceed `u16::MAX`")
                 .emit();
             None

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -94,7 +94,7 @@ fn push_debuginfo_type_name<'tcx>(
                         // Computing the layout can still fail here, e.g. if the target architecture
                         // cannot represent the type. See https://github.com/rust-lang/rust/issues/94961.
                         // FIXME: migrate once `rustc_middle::mir::interpret::InterpError` is translatable.
-                        tcx.sess.fatal(&format!("{}", e));
+                        tcx.sess.fatal(format!("{}", e));
                     }
                 }
             } else {

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -370,7 +370,7 @@ pub fn from_target_feature(
             let Some(feature_gate) = supported_target_features.get(feature) else {
                 let msg =
                     format!("the feature named `{}` is not valid for this target", feature);
-                let mut err = tcx.sess.struct_span_err(item.span(), &msg);
+                let mut err = tcx.sess.struct_span_err(item.span(), msg);
                 err.span_label(
                     item.span(),
                     format!("`{}` is not valid for this target", feature),
@@ -408,7 +408,7 @@ pub fn from_target_feature(
                     &tcx.sess.parse_sess,
                     feature_gate.unwrap(),
                     item.span(),
-                    &format!("the target feature `{}` is currently unstable", feature),
+                    format!("the target feature `{}` is currently unstable", feature),
                 )
                 .emit();
             }

--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -104,13 +104,13 @@ impl<'tcx> ConstEvalErr<'tcx> {
         // Add spans for the stacktrace. Don't print a single-line backtrace though.
         if self.stacktrace.len() > 1 {
             // Helper closure to print duplicated lines.
-            let mut flush_last_line = |last_frame, times| {
+            let mut flush_last_line = |last_frame: Option<(String, _)>, times| {
                 if let Some((line, span)) = last_frame {
-                    err.span_note(span, &line);
+                    err.span_note(span, line.clone());
                     // Don't print [... additional calls ...] if the number of lines is small
                     if times < 3 {
                         for _ in 0..times {
-                            err.span_note(span, &line);
+                            err.span_note(span, line.clone());
                         }
                     } else {
                         err.span_note(

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -368,7 +368,7 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
                         if matches!(err.error, InterpError::UndefinedBehavior(_)) {
                             diag.note(NOTE_ON_UNDEFINED_BEHAVIOR_ERROR);
                         }
-                        diag.note(&format!(
+                        diag.note(format!(
                             "the raw bytes of the constant ({}",
                             display_allocation(
                                 *ecx.tcx,

--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -83,7 +83,7 @@ pub(crate) fn eval_to_valtree<'tcx>(
                         Some(span) => {
                             tcx.sess.create_err(MaxNumNodesInConstErr { span, global_const_id })
                         }
-                        None => tcx.sess.struct_err(&msg),
+                        None => tcx.sess.struct_err(msg),
                     };
                     diag.emit();
 

--- a/compiler/rustc_const_eval/src/interpret/intern.rs
+++ b/compiler/rustc_const_eval/src/interpret/intern.rs
@@ -387,7 +387,7 @@ pub fn intern_const_alloc_recursive<
             Err(error) => {
                 ecx.tcx.sess.delay_span_bug(
                     ecx.tcx.span,
-                    &format!(
+                    format!(
                         "error during interning should later cause validation failure: {}",
                         error
                     ),

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -293,7 +293,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     // FIXME: This should be a span_bug (#80742)
                     self.tcx.sess.delay_span_bug(
                         self.frame().current_span(),
-                        &format!("{null_op:?} MIR operator called for unsized type {ty}"),
+                        format!("{null_op:?} MIR operator called for unsized type {ty}"),
                     );
                     throw_inval!(SizeOfUnsizedType(ty));
                 }

--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -77,7 +77,7 @@ impl<'tcx> NonConstOp<'tcx> for FloatingPointOp {
             &ccx.tcx.sess.parse_sess,
             sym::const_fn_floating_point_arithmetic,
             span,
-            &format!("floating point arithmetic is not allowed in {}s", ccx.const_kind()),
+            format!("floating point arithmetic is not allowed in {}s", ccx.const_kind()),
         )
     }
 }
@@ -211,13 +211,13 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
                         err.span_note(span, "function defined here, but it is not `const`");
                     }
                     FnPtr(..) => {
-                        err.note(&format!(
+                        err.note(format!(
                             "function pointers need an RFC before allowed to be called in {}s",
                             ccx.const_kind()
                         ));
                     }
                     Closure(..) => {
-                        err.note(&format!(
+                        err.note(format!(
                             "closures need an RFC before allowed to be called in {}s",
                             ccx.const_kind()
                         ));
@@ -289,7 +289,7 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
                     ccx.const_kind()
                 );
 
-                err.note(&format!("attempting to deref into `{}`", deref_target_ty));
+                err.note(format!("attempting to deref into `{}`", deref_target_ty));
 
                 // Check first whether the source is accessible (issue #87060)
                 if tcx.sess.source_map().is_span_accessible(deref_target) {
@@ -310,14 +310,14 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
             }),
         };
 
-        err.note(&format!(
+        err.note(format!(
             "calls in {}s are limited to constant functions, \
              tuple structs and tuple variants",
             ccx.const_kind(),
         ));
 
         if let Some(feature) = feature && ccx.tcx.sess.is_nightly_build() {
-            err.help(&format!(
+            err.help(format!(
                 "add `#![feature({})]` to the crate attributes to enable",
                 feature,
             ));
@@ -354,7 +354,7 @@ impl<'tcx> NonConstOp<'tcx> for FnCallUnstable {
             err.help("const-stable functions can only call other const-stable functions");
         } else if ccx.tcx.sess.is_nightly_build() {
             if let Some(feature) = feature {
-                err.help(&format!(
+                err.help(format!(
                     "add `#![feature({})]` to the crate attributes to enable",
                     feature
                 ));
@@ -637,7 +637,7 @@ impl<'tcx> NonConstOp<'tcx> for RawMutPtrDeref {
             &ccx.tcx.sess.parse_sess,
             sym::const_mut_refs,
             span,
-            &format!("dereferencing raw mutable pointers in {}s is unstable", ccx.const_kind(),),
+            format!("dereferencing raw mutable pointers in {}s is unstable", ccx.const_kind(),),
         )
     }
 }
@@ -724,7 +724,7 @@ pub mod ty {
                 &ccx.tcx.sess.parse_sess,
                 sym::const_mut_refs,
                 span,
-                &format!("mutable references are not allowed in {}s", ccx.const_kind()),
+                format!("mutable references are not allowed in {}s", ccx.const_kind()),
             )
         }
     }

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -107,7 +107,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         // occurred.
         self.tcx.sess.diagnostic().delay_span_bug(
             span,
-            &format!(
+            format!(
                 "broken MIR in {:?} ({}) at {:?}:\n{}",
                 self.body.source.instance,
                 self.when,
@@ -1094,7 +1094,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
         if self.body.source_scopes.get(scope).is_none() {
             self.tcx.sess.diagnostic().delay_span_bug(
                 self.body.span,
-                &format!(
+                format!(
                     "broken MIR in {:?} ({}):\ninvalid source scope {:?}",
                     self.body.source.instance, self.when, scope,
                 ),

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -287,11 +287,19 @@ pub enum SubdiagnosticMessage {
     FluentAttr(FluentId),
 }
 
-/// `From` impl that enables existing diagnostic calls to functions which now take
-/// `impl Into<SubdiagnosticMessage>` to continue to work as before.
-impl<S: Into<String>> From<S> for SubdiagnosticMessage {
-    fn from(s: S) -> Self {
-        SubdiagnosticMessage::Str(s.into())
+impl From<String> for SubdiagnosticMessage {
+    fn from(s: String) -> Self {
+        SubdiagnosticMessage::Str(s)
+    }
+}
+impl<'a> From<&'a str> for SubdiagnosticMessage {
+    fn from(s: &'a str) -> Self {
+        SubdiagnosticMessage::Str(s.to_string())
+    }
+}
+impl From<Cow<'static, str>> for SubdiagnosticMessage {
+    fn from(s: Cow<'static, str>) -> Self {
+        SubdiagnosticMessage::Str(s.to_string())
     }
 }
 
@@ -352,11 +360,19 @@ impl DiagnosticMessage {
     }
 }
 
-/// `From` impl that enables existing diagnostic calls to functions which now take
-/// `impl Into<DiagnosticMessage>` to continue to work as before.
-impl<S: Into<String>> From<S> for DiagnosticMessage {
-    fn from(s: S) -> Self {
-        DiagnosticMessage::Str(s.into())
+impl From<String> for DiagnosticMessage {
+    fn from(s: String) -> Self {
+        DiagnosticMessage::Str(s)
+    }
+}
+impl<'a> From<&'a str> for DiagnosticMessage {
+    fn from(s: &'a str) -> Self {
+        DiagnosticMessage::Str(s.to_string())
+    }
+}
+impl From<Cow<'static, str>> for DiagnosticMessage {
+    fn from(s: Cow<'static, str>) -> Self {
+        DiagnosticMessage::Str(s.to_string())
     }
 }
 

--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -791,7 +791,7 @@ macro_rules! struct_span_err {
     ($session:expr, $span:expr, $code:ident, $($message:tt)*) => ({
         $session.struct_span_err_with_code(
             $span,
-            &format!($($message)*),
+            format!($($message)*),
             $crate::error_code!($code),
         )
     })

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -601,7 +601,7 @@ impl Emitter for SilentEmitter {
         if d.level == Level::Fatal {
             let mut d = d.clone();
             if let Some(ref note) = self.fatal_note {
-                d.note(note);
+                d.note(note.clone());
             }
             self.fatal_handler.emit_diagnostic(&mut d);
         }

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1462,10 +1462,10 @@ impl HandlerInner {
                 DiagnosticMessage::Str(warnings),
             )),
             (_, 0) => {
-                let _ = self.fatal(&errors);
+                let _ = self.fatal(errors);
             }
             (_, _) => {
-                let _ = self.fatal(&format!("{}; {}", &errors, &warnings));
+                let _ = self.fatal(format!("{}; {}", &errors, &warnings));
             }
         }
 
@@ -1486,18 +1486,18 @@ impl HandlerInner {
                 error_codes.sort();
                 if error_codes.len() > 1 {
                     let limit = if error_codes.len() > 9 { 9 } else { error_codes.len() };
-                    self.failure(&format!(
+                    self.failure(format!(
                         "Some errors have detailed explanations: {}{}",
                         error_codes[..limit].join(", "),
                         if error_codes.len() > 9 { "..." } else { "." }
                     ));
-                    self.failure(&format!(
+                    self.failure(format!(
                         "For more information about an error, try \
                          `rustc --explain {}`.",
                         &error_codes[0]
                     ));
                 } else {
-                    self.failure(&format!(
+                    self.failure(format!(
                         "For more information about this error, try \
                          `rustc --explain {}`.",
                         &error_codes[0]
@@ -1663,7 +1663,7 @@ impl HandlerInner {
             if bug.level != Level::DelayedBug {
                 // NOTE(eddyb) not panicking here because we're already producing
                 // an ICE, and the more information the merrier.
-                bug.note(&format!(
+                bug.note(format!(
                     "`flushed_delayed` got diagnostic with level {:?}, \
                      instead of the expected `DelayedBug`",
                     bug.level,
@@ -1732,7 +1732,7 @@ impl DelayedDiagnostic {
     }
 
     fn decorate(mut self) -> Diagnostic {
-        self.inner.note(&format!("delayed at {}", self.note));
+        self.inner.note(format!("delayed at {}", self.note));
         self.inner
     }
 }
@@ -1831,7 +1831,7 @@ pub fn add_elided_lifetime_in_path_suggestion(
         if incl_angl_brckt { format!("<{}>", anon_lts) } else { format!("{}, ", anon_lts) };
     diag.span_suggestion_verbose(
         insertion_span.shrink_to_hi(),
-        &format!("indicate the anonymous lifetime{}", pluralize!(n)),
+        format!("indicate the anonymous lifetime{}", pluralize!(n)),
         suggestion,
         Applicability::MachineApplicable,
     );

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1146,7 +1146,7 @@ impl<'a> ExtCtxt<'a> {
         for (span, notes) in self.expansions.iter() {
             let mut db = self.sess.parse_sess.create_note(errors::TraceMacro { span: *span });
             for note in notes {
-                db.note(note);
+                db.note(note.clone());
             }
             db.emit();
         }

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -797,7 +797,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             &self.cx.sess.parse_sess,
             sym::proc_macro_hygiene,
             span,
-            &format!("custom attributes cannot be applied to {}", kind),
+            format!("custom attributes cannot be applied to {}", kind),
         )
         .emit();
     }

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -474,7 +474,7 @@ pub fn compile_declarative_macro(
 
                 let s = parse_failure_msg(&token);
                 let sp = token.span.substitute_dummy(def.span);
-                let mut err = sess.parse_sess.span_diagnostic.struct_span_err(sp, &s);
+                let mut err = sess.parse_sess.span_diagnostic.struct_span_err(sp, s);
                 err.span_label(sp, msg);
                 annotate_doc_comment(&mut err, sess.source_map(), sp);
                 err.emit();
@@ -483,7 +483,7 @@ pub fn compile_declarative_macro(
             Error(sp, msg) => {
                 sess.parse_sess
                     .span_diagnostic
-                    .struct_span_err(sp.substitute_dummy(def.span), &msg)
+                    .struct_span_err(sp.substitute_dummy(def.span), msg)
                     .emit();
                 return dummy_syn_ext();
             }
@@ -555,7 +555,7 @@ pub fn compile_declarative_macro(
     let (transparency, transparency_error) = attr::find_transparency(&def.attrs, macro_rules);
     match transparency_error {
         Some(TransparencyError::UnknownTransparency(value, span)) => {
-            diag.span_err(span, &format!("unknown macro transparency: `{}`", value));
+            diag.span_err(span, format!("unknown macro transparency: `{}`", value));
         }
         Some(TransparencyError::MultipleTransparencyAttrs(old_span, new_span)) => {
             diag.span_err(vec![old_span, new_span], "multiple macro transparency attributes");
@@ -1164,7 +1164,7 @@ fn check_matcher_core<'tt>(
                             let sp = next_token.span();
                             let mut err = sess.span_diagnostic.struct_span_err(
                                 sp,
-                                &format!(
+                                format!(
                                     "`${name}:{frag}` {may_be} followed by `{next}`, which \
                                      is not allowed for `{frag}` fragments",
                                     name = name,
@@ -1196,13 +1196,13 @@ fn check_matcher_core<'tt>(
                             match possible {
                                 &[] => {}
                                 &[t] => {
-                                    err.note(&format!(
+                                    err.note(format!(
                                         "only {} is allowed after `{}` fragments",
                                         t, kind,
                                     ));
                                 }
                                 ts => {
-                                    err.note(&format!(
+                                    err.note(format!(
                                         "{}{} or {}",
                                         msg,
                                         ts[..ts.len() - 1].to_vec().join(", "),

--- a/compiler/rustc_expand/src/mbe/metavar_expr.rs
+++ b/compiler/rustc_expand/src/mbe/metavar_expr.rs
@@ -78,7 +78,7 @@ fn check_trailing_token<'sess>(
     if let Some(tt) = iter.next() {
         let mut diag = sess
             .span_diagnostic
-            .struct_span_err(tt.span(), &format!("unexpected token: {}", pprust::tt_to_string(tt)));
+            .struct_span_err(tt.span(), format!("unexpected token: {}", pprust::tt_to_string(tt)));
         diag.span_note(tt.span(), "meta-variable expression must not have trailing tokens");
         Err(diag)
     } else {
@@ -137,11 +137,11 @@ fn parse_ident<'sess>(
         let token_str = pprust::token_to_string(token);
         let mut err = sess.span_diagnostic.struct_span_err(
             span,
-            &format!("expected identifier, found `{}`", &token_str)
+            format!("expected identifier, found `{}`", &token_str)
         );
         err.span_suggestion(
             token.span,
-            &format!("try removing `{}`", &token_str),
+            format!("try removing `{}`", &token_str),
             "",
             Applicability::MaybeIncorrect,
         );

--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -85,7 +85,7 @@ pub(super) fn parse(
                                                     frag.name
                                                 );
                                                 sess.span_diagnostic
-                                                    .struct_span_err(span, &msg)
+                                                    .struct_span_err(span, msg)
                                                     .help(VALID_FRAGMENT_NAMES_MSG)
                                                     .emit();
                                                 token::NonterminalKind::Ident
@@ -195,7 +195,7 @@ fn parse_tree(
                             _ => {
                                 let tok = pprust::token_kind_to_string(&token::OpenDelim(delim));
                                 let msg = format!("expected `(` or `{{`, found `{}`", tok);
-                                sess.span_diagnostic.span_err(delim_span.entire(), &msg);
+                                sess.span_diagnostic.span_err(delim_span.entire(), msg);
                             }
                         }
                     }
@@ -246,7 +246,7 @@ fn parse_tree(
                         "expected identifier, found `{}`",
                         pprust::token_to_string(&token),
                     );
-                    sess.span_diagnostic.span_err(token.span, &msg);
+                    sess.span_diagnostic.span_err(token.span, msg);
                     TokenTree::MetaVar(token.span, Ident::empty())
                 }
 
@@ -358,7 +358,7 @@ fn parse_sep_and_kleene_op(
 // For example, `macro_rules! foo { ( ${length()} ) => {} }`
 fn span_dollar_dollar_or_metavar_in_the_lhs_err(sess: &ParseSess, token: &Token) {
     sess.span_diagnostic
-        .span_err(token.span, &format!("unexpected token: {}", pprust::token_to_string(token)));
+        .span_err(token.span, format!("unexpected token: {}", pprust::token_to_string(token)));
     sess.span_diagnostic.span_note_without_error(
         token.span,
         "`$$` and meta-variable expressions are not allowed inside macro parameter definitions",

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -95,7 +95,7 @@ impl base::AttrProcMacro for AttrProcMacro {
             |e| {
                 let mut err = ecx.struct_span_err(span, "custom attribute panicked");
                 if let Some(s) = e.as_str() {
-                    err.help(&format!("message: {}", s));
+                    err.help(format!("message: {}", s));
                 }
                 err.emit()
             },
@@ -148,7 +148,7 @@ impl MultiItemModifier for DeriveProcMacro {
                 Err(e) => {
                     let mut err = ecx.struct_span_err(span, "proc-macro derive panicked");
                     if let Some(s) = e.as_str() {
-                        err.help(&format!("message: {}", s));
+                        err.help(format!("message: {}", s));
                     }
                     err.emit();
                     return ExpandResult::Ready(vec![]);

--- a/compiler/rustc_hir_analysis/src/astconv/errors.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/errors.rs
@@ -243,13 +243,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             let note = format!("{title} is defined in an impl for the type `{impl_ty}`");
 
             if let Some(span) = note_span {
-                err.span_note(span, &note);
+                err.span_note(span, note);
             } else {
-                err.note(&note);
+                err.note(note);
             }
         }
         if candidates.len() > limit {
-            err.note(&format!("and {} others", candidates.len() - limit));
+            err.note(format!("and {} others", candidates.len() - limit));
         }
     }
 
@@ -303,7 +303,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 "associated type `{name}` not found for `{self_ty}` in the current scope"
             );
             err.span_label(name.span, format!("associated item not found in `{self_ty}`"));
-            err.note(&format!(
+            err.note(format!(
                 "the associated type was found for\n{type_candidates}{additional_types}",
             ));
             add_def_label(&mut err);
@@ -390,10 +390,10 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
         let mut err = tcx.sess.struct_span_err(
             name.span,
-            &format!("the associated type `{name}` exists for `{self_ty}`, but its trait bounds were not satisfied")
+            format!("the associated type `{name}` exists for `{self_ty}`, but its trait bounds were not satisfied")
         );
         if !bounds.is_empty() {
-            err.note(&format!(
+            err.note(format!(
                 "the following trait bounds were not satisfied:\n{}",
                 bounds.join("\n")
             ));
@@ -409,7 +409,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             if !tcx.sess.source_map().is_span_accessible(span) {
                 continue;
             }
-            err.span_label(span, &msg);
+            err.span_label(span, msg);
         }
         add_def_label(&mut err);
         err.emit()
@@ -589,7 +589,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         }
         if !suggestions.is_empty() {
             err.multipart_suggestion(
-                &format!("specify the associated type{}", pluralize!(types_count)),
+                format!("specify the associated type{}", pluralize!(types_count)),
                 suggestions,
                 Applicability::HasPlaceholders,
             );

--- a/compiler/rustc_hir_analysis/src/astconv/generics.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/generics.rs
@@ -112,7 +112,7 @@ fn generic_arg_mismatch_err(
             if let rustc_hir::ExprKind::Path(rustc_hir::QPath::Resolved(_, path)) = body.value.kind
             {
                 if let Res::Def(DefKind::Fn { .. }, id) = path.res {
-                    err.help(&format!("`{}` is a function item, not a type", tcx.item_name(id)));
+                    err.help(format!("`{}` is a function item, not a type", tcx.item_name(id)));
                     err.help("function item types cannot be named directly");
                 }
             }
@@ -130,7 +130,7 @@ fn generic_arg_mismatch_err(
         } else {
             (arg.descr(), param.kind.descr())
         };
-        err.note(&format!("{} arguments must be provided before {} arguments", first, last));
+        err.note(format!("{} arguments must be provided before {} arguments", first, last));
         if let Some(help) = help {
             err.help(help);
         }

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -1168,9 +1168,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             tcx.sess
                 .struct_span_err(
                     binding.span,
-                    &format!("{} `{}` is private", assoc_item.kind, binding.item_name),
+                    format!("{} `{}` is private", assoc_item.kind, binding.item_name),
                 )
-                .span_label(binding.span, &format!("private {}", assoc_item.kind))
+                .span_label(binding.span, format!("private {}", assoc_item.kind))
                 .emit();
         }
         tcx.check_stability(assoc_item.def_id, Some(hir_ref_id), binding.span, None);
@@ -1342,11 +1342,11 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         let expected = tcx.def_descr(assoc_item_def_id);
                         let mut err = tcx.sess.struct_span_err(
                             binding.span,
-                            &format!("expected {expected} bound, found {got}"),
+                            format!("expected {expected} bound, found {got}"),
                         );
                         err.span_note(
                             tcx.def_span(assoc_item_def_id),
-                            &format!("{expected} defined here"),
+                            format!("{expected} defined here"),
                         );
 
                         if let hir::def::DefKind::AssocConst = def_kind
@@ -1508,7 +1508,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 "additional use",
             );
             first_trait.label_with_exp_info(&mut err, "first non-auto trait", "first use");
-            err.help(&format!(
+            err.help(format!(
                 "consider creating a new trait with all of these as supertraits and using that \
                  trait here instead: `trait NewTrait: {} {{}}`",
                 regular_traits
@@ -1818,7 +1818,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 ([], []) => {
                     err.span_suggestion_verbose(
                         span,
-                        &format!(
+                        format!(
                             "if there were a type named `Type` that implements a trait named \
                              `Trait` with associated type `{name}`, you could use the \
                              fully-qualified path",
@@ -1830,7 +1830,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 ([], [trait_str]) => {
                     err.span_suggestion_verbose(
                         span,
-                        &format!(
+                        format!(
                             "if there were a type named `Example` that implemented `{trait_str}`, \
                              you could use the fully-qualified path",
                         ),
@@ -1841,7 +1841,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 ([], traits) => {
                     err.span_suggestions(
                         span,
-                        &format!(
+                        format!(
                             "if there were a type named `Example` that implemented one of the \
                              traits with associated type `{name}`, you could use the \
                              fully-qualified path",
@@ -1856,7 +1856,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 ([type_str], []) => {
                     err.span_suggestion_verbose(
                         span,
-                        &format!(
+                        format!(
                             "if there were a trait named `Example` with associated type `{name}` \
                              implemented for `{type_str}`, you could use the fully-qualified path",
                         ),
@@ -1867,7 +1867,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 (types, []) => {
                     err.span_suggestions(
                         span,
-                        &format!(
+                        format!(
                             "if there were a trait named `Example` with associated type `{name}` \
                              implemented for one of the types, you could use the fully-qualified \
                              path",
@@ -2033,7 +2033,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         );
                     }
                 } else {
-                    err.note(&format!(
+                    err.note(format!(
                         "associated type `{}` could derive from `{}`",
                         ty_param_name,
                         bound.print_only_trait_path(),
@@ -2041,7 +2041,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 }
             }
             if !where_bounds.is_empty() {
-                err.help(&format!(
+                err.help(format!(
                     "consider introducing a new type parameter `T` and adding `where` constraints:\
                      \n    where\n        T: {},\n{}",
                     ty_param_name,
@@ -2109,14 +2109,14 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                 // work for the `enum`, instead of just looking if it takes *any*.
                                 err.span_suggestion_verbose(
                                     args_span,
-                                    &format!("{type_name} doesn't have generic parameters"),
+                                    format!("{type_name} doesn't have generic parameters"),
                                     "",
                                     Applicability::MachineApplicable,
                                 );
                                 return;
                             }
                             let Ok(snippet) = tcx.sess.source_map().span_to_snippet(args_span) else {
-                                err.note(&msg);
+                                err.note(msg);
                                 return;
                             };
                             let (qself_sugg_span, is_self) = if let hir::TyKind::Path(
@@ -2150,12 +2150,12 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                         kw::SelfUpper == segment.ident.name,
                                     ),
                                     _ => {
-                                        err.note(&msg);
+                                        err.note(msg);
                                         return;
                                     }
                                 }
                             } else {
-                                err.note(&msg);
+                                err.note(msg);
                                 return;
                             };
                             let suggestion = vec![
@@ -2170,7 +2170,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                 (args_span, String::new()),
                             ];
                             err.multipart_suggestion_verbose(
-                                &msg,
+                                msg,
                                 suggestion,
                                 Applicability::MaybeIncorrect,
                             );
@@ -2222,7 +2222,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 let reported = if variant_resolution.is_some() {
                     // Variant in type position
                     let msg = format!("expected type, found variant `{}`", assoc_ident);
-                    tcx.sess.span_err(span, &msg)
+                    tcx.sess.span_err(span, msg)
                 } else if qself_ty.is_enum() {
                     let mut err = struct_span_err!(
                         tcx.sess,
@@ -2293,7 +2293,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             // Assume that if it's not matched, there must be a const defined with the same name
             // but it was used in a type position.
             let msg = format!("found associated const `{assoc_ident}` when type was expected");
-            let guar = tcx.sess.struct_span_err(span, &msg).emit();
+            let guar = tcx.sess.struct_span_err(span, msg).emit();
             return Err(guar);
         };
 
@@ -2313,7 +2313,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             also,
                             tcx.def_kind_descr(kind, def_id)
                         );
-                        lint.span_note(tcx.def_span(def_id), &note_msg);
+                        lint.span_note(tcx.def_span(def_id), note_msg);
                     };
 
                     could_refer_to(DefKind::Variant, variant_def_id, "");
@@ -2510,9 +2510,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             let msg = format!("{kind} `{name}` is private");
             let def_span = tcx.def_span(item);
             tcx.sess
-                .struct_span_err_with_code(span, &msg, rustc_errors::error_code!(E0624))
-                .span_label(span, &format!("private {kind}"))
-                .span_label(def_span, &format!("{kind} defined here"))
+                .struct_span_err_with_code(span, msg, rustc_errors::error_code!(E0624))
+                .span_label(span, format!("private {kind}"))
+                .span_label(def_span, format!("{kind} defined here"))
                 .emit();
         }
         tcx.check_stability(item, Some(block), span, None);
@@ -2960,7 +2960,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 self.prohibit_generics(path.segments.iter(), |err| {
                     if let Some(span) = tcx.def_ident_span(def_id) {
                         let name = tcx.item_name(def_id);
-                        err.span_note(span, &format!("type parameter `{name}` defined here"));
+                        err.span_note(span, format!("type parameter `{name}` defined here"));
                     }
                 });
 
@@ -3021,7 +3021,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         let mut span: MultiSpan = vec![t_sp].into();
                         span.push_span_label(
                             i_sp,
-                            &format!("`Self` is on type `{type_name}` in this `impl`"),
+                            format!("`Self` is on type `{type_name}` in this `impl`"),
                         );
                         let mut postfix = "";
                         if generics == 0 {
@@ -3029,11 +3029,11 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         }
                         span.push_span_label(
                             t_sp,
-                            &format!("`Self` corresponds to this type{postfix}"),
+                            format!("`Self` corresponds to this type{postfix}"),
                         );
-                        err.span_note(span, &msg);
+                        err.span_note(span, msg);
                     } else {
-                        err.note(&msg);
+                        err.note(msg);
                     }
                     for segment in path.segments {
                         if let Some(args) = segment.args && segment.ident.name == kw::SelfUpper {
@@ -3124,7 +3124,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         if let Some(args) = segment.args {
                             err.span_suggestion_verbose(
                                 segment.ident.span.shrink_to_hi().to(args.span_ext),
-                                &format!("primitive type `{name}` doesn't have generic parameters"),
+                                format!("primitive type `{name}` doesn't have generic parameters"),
                                 "",
                                 Applicability::MaybeIncorrect,
                             );
@@ -3415,7 +3415,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
             if !infer_replacements.is_empty() {
                 diag.multipart_suggestion(
-                    &format!(
+                    format!(
                     "try replacing `_` with the type{} in the corresponding trait method signature",
                     rustc_errors::pluralize!(infer_replacements.len()),
                 ),

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -175,7 +175,7 @@ fn check_static_inhabited(tcx: TyCtxt<'_>, def_id: LocalDefId) {
         }
         // Generic statics are rejected, but we still reach this case.
         Err(e) => {
-            tcx.sess.delay_span_bug(span, &e.to_string());
+            tcx.sess.delay_span_bug(span, e.to_string());
             return;
         }
     };
@@ -334,7 +334,7 @@ pub(super) fn check_opaque_for_inheriting_lifetimes(
                 &tcx.sess.parse_sess,
                 sym::impl_trait_projections,
                 span,
-                &format!(
+                format!(
                     "`{}` return type cannot contain a projection or `Self` that references \
                     lifetimes from a parent scope",
                     if is_async { "async fn" } else { "impl Trait" },
@@ -428,7 +428,7 @@ fn check_opaque_meets_bounds<'tcx>(
             let ty_err = ty_err.to_string(tcx);
             tcx.sess.delay_span_bug(
                 span,
-                &format!("could not unify `{hidden_ty}` with revealed type:\n{ty_err}"),
+                format!("could not unify `{hidden_ty}` with revealed type:\n{ty_err}"),
             );
         }
     }
@@ -618,11 +618,11 @@ fn check_item_type(tcx: TyCtxt<'_>, id: hir::ItemId) {
                                 E0044,
                                 "foreign items may not have {kinds} parameters",
                             )
-                            .span_label(item.span, &format!("can't have {kinds} parameters"))
+                            .span_label(item.span, format!("can't have {kinds} parameters"))
                             .help(
                                 // FIXME: once we start storing spans for type arguments, turn this
                                 // into a suggestion.
-                                &format!(
+                                format!(
                                     "replace the {} parameters with concrete {}{}",
                                     kinds,
                                     kinds_pl,
@@ -985,10 +985,7 @@ pub(super) fn check_packed(tcx: TyCtxt<'_>, sp: Span, def: ty::AdtDef<'_>) {
 
                 err.span_note(
                     tcx.def_span(def_spans[0].0),
-                    &format!(
-                        "`{}` has a `#[repr(align)]` attribute",
-                        tcx.item_name(def_spans[0].0)
-                    ),
+                    format!("`{}` has a `#[repr(align)]` attribute", tcx.item_name(def_spans[0].0)),
                 );
 
                 if def_spans.len() > 2 {
@@ -997,7 +994,7 @@ pub(super) fn check_packed(tcx: TyCtxt<'_>, sp: Span, def: ty::AdtDef<'_>) {
                         let ident = tcx.item_name(*adt_def);
                         err.span_note(
                             *span,
-                            &if first {
+                            if first {
                                 format!(
                                     "`{}` contains a field of type `{}`",
                                     tcx.type_of(def.did()).subst_identity(),
@@ -1466,10 +1463,10 @@ fn opaque_type_cycle_error(
                     let ty_span = tcx.def_span(def_id);
                     if !seen.contains(&ty_span) {
                         let descr = if ty.is_impl_trait() { "opaque " } else { "" };
-                        err.span_label(ty_span, &format!("returning this {descr}type `{ty}`"));
+                        err.span_label(ty_span, format!("returning this {descr}type `{ty}`"));
                         seen.insert(ty_span);
                     }
-                    err.span_label(sp, &format!("returning here with type `{ty}`"));
+                    err.span_label(sp, format!("returning here with type `{ty}`"));
                 }
 
                 for closure_def_id in visitor.closures {

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1273,7 +1273,7 @@ fn compare_number_of_generics<'tcx>(
 
             let mut err = tcx.sess.struct_span_err_with_code(
                 spans,
-                &format!(
+                format!(
                     "{} `{}` has {} {kind} parameter{} but its trait \
                      declaration has {} {kind} parameter{}",
                     item_kind,

--- a/compiler/rustc_hir_analysis/src/check/dropck.rs
+++ b/compiler/rustc_hir_analysis/src/check/dropck.rs
@@ -52,7 +52,7 @@ pub fn check_drop_impl(tcx: TyCtxt<'_>, drop_impl_did: DefId) -> Result<(), Erro
             let span = tcx.def_span(drop_impl_did);
             let reported = tcx.sess.delay_span_bug(
                 span,
-                &format!("should have been rejected by coherence check: {dtor_self_type}"),
+                format!("should have been rejected by coherence check: {dtor_self_type}"),
             );
             Err(reported)
         }
@@ -76,15 +76,15 @@ fn ensure_drop_params_and_item_params_correspond<'tcx>(
         struct_span_err!(tcx.sess, drop_impl_span, E0366, "`Drop` impls cannot be specialized");
     match arg {
         ty::util::NotUniqueParam::DuplicateParam(arg) => {
-            err.note(&format!("`{arg}` is mentioned multiple times"))
+            err.note(format!("`{arg}` is mentioned multiple times"))
         }
         ty::util::NotUniqueParam::NotParam(arg) => {
-            err.note(&format!("`{arg}` is not a generic parameter"))
+            err.note(format!("`{arg}` is not a generic parameter"))
         }
     };
     err.span_note(
         item_span,
-        &format!(
+        format!(
             "use the same sequence of generic lifetime, type and const parameters \
                      as the {self_descr} definition",
         ),

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -547,14 +547,14 @@ pub fn check_platform_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>)
                 Err(_) => {
                     let msg =
                         format!("unrecognized platform-specific intrinsic function: `{name}`");
-                    tcx.sess.struct_span_err(it.span, &msg).emit();
+                    tcx.sess.struct_span_err(it.span, msg).emit();
                     return;
                 }
             }
         }
         _ => {
             let msg = format!("unrecognized platform-specific intrinsic function: `{name}`");
-            tcx.sess.struct_span_err(it.span, &msg).emit();
+            tcx.sess.struct_span_err(it.span, msg).emit();
             return;
         }
     };

--- a/compiler/rustc_hir_analysis/src/check/intrinsicck.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsicck.rs
@@ -130,7 +130,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
             _ => None,
         };
         let Some(asm_ty) = asm_ty else {
-            let msg = &format!("cannot use value of type `{ty}` for inline assembly");
+            let msg = format!("cannot use value of type `{ty}` for inline assembly");
             let mut err = self.tcx.sess.struct_span_err(expr.span, msg);
             err.note(
                 "only integers, floats, SIMD vectors, pointers and function pointers \
@@ -145,7 +145,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
         if !ty.is_copy_modulo_regions(self.tcx, self.param_env) {
             let msg = "arguments for inline assembly must be copyable";
             let mut err = self.tcx.sess.struct_span_err(expr.span, msg);
-            err.note(&format!("`{ty}` does not implement the Copy trait"));
+            err.note(format!("`{ty}` does not implement the Copy trait"));
             err.emit();
         }
 
@@ -164,8 +164,8 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
                 let mut err = self.tcx.sess.struct_span_err(vec![in_expr.span, expr.span], msg);
 
                 let in_expr_ty = (self.get_operand_ty)(in_expr);
-                err.span_label(in_expr.span, &format!("type `{in_expr_ty}`"));
-                err.span_label(expr.span, &format!("type `{ty}`"));
+                err.span_label(in_expr.span, format!("type `{in_expr_ty}`"));
+                err.span_label(expr.span, format!("type `{ty}`"));
                 err.note(
                     "asm inout arguments must have the same type, \
                     unless they are both pointers or integers of the same size",
@@ -184,17 +184,17 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
         let reg_class = reg.reg_class();
         let supported_tys = reg_class.supported_types(asm_arch);
         let Some((_, feature)) = supported_tys.iter().find(|&&(t, _)| t == asm_ty) else {
-            let msg = &format!("type `{ty}` cannot be used with this register class");
+            let msg = format!("type `{ty}` cannot be used with this register class");
             let mut err = self.tcx.sess.struct_span_err(expr.span, msg);
             let supported_tys: Vec<_> =
                 supported_tys.iter().map(|(t, _)| t.to_string()).collect();
-            err.note(&format!(
+            err.note(format!(
                 "register class `{}` supports these types: {}",
                 reg_class.name(),
                 supported_tys.join(", "),
             ));
             if let Some(suggest) = reg_class.suggest_class(asm_arch, asm_ty) {
-                err.help(&format!(
+                err.help(format!(
                     "consider using the `{}` register class instead",
                     suggest.name()
                 ));
@@ -215,9 +215,9 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
         // register class is usable at all.
         if let Some(feature) = feature {
             if !target_features.contains(feature) {
-                let msg = &format!("`{}` target feature is not enabled", feature);
+                let msg = format!("`{}` target feature is not enabled", feature);
                 let mut err = self.tcx.sess.struct_span_err(expr.span, msg);
-                err.note(&format!(
+                err.note(format!(
                     "this is required to use type `{}` with register class `{}`",
                     ty,
                     reg_class.name(),
@@ -252,10 +252,10 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
                     "formatting may not be suitable for sub-register argument",
                     |lint| {
                         lint.span_label(expr.span, "for this argument");
-                        lint.help(&format!(
+                        lint.help(format!(
                             "use `{{{idx}:{suggested_modifier}}}` to have the register formatted as `{suggested_result}`",
                         ));
-                        lint.help(&format!(
+                        lint.help(format!(
                             "or use `{{{idx}:{default_modifier}}}` to keep the default formatting of `{default_result}`",
                         ));
                         lint
@@ -301,7 +301,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
                         op.is_clobber(),
                     ) {
                         let msg = format!("cannot use register `{}`: {}", reg.name(), msg);
-                        self.tcx.sess.struct_span_err(*op_sp, &msg).emit();
+                        self.tcx.sess.struct_span_err(*op_sp, msg).emit();
                         continue;
                     }
                 }
@@ -340,7 +340,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
                                 reg_class.name(),
                                 feature
                             );
-                            self.tcx.sess.struct_span_err(*op_sp, &msg).emit();
+                            self.tcx.sess.struct_span_err(*op_sp, msg).emit();
                             // register isn't enabled, don't do more checks
                             continue;
                         }
@@ -354,7 +354,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
                                     .intersperse(", ")
                                     .collect::<String>(),
                             );
-                            self.tcx.sess.struct_span_err(*op_sp, &msg).emit();
+                            self.tcx.sess.struct_span_err(*op_sp, msg).emit();
                             // register isn't enabled, don't do more checks
                             continue;
                         }
@@ -436,7 +436,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
                                 self.tcx.sess.struct_span_err(*op_sp, "invalid `sym` operand");
                             err.span_label(
                                 self.tcx.def_span(anon_const.def_id),
-                                &format!("is {} `{}`", ty.kind().article(), ty),
+                                format!("is {} `{}`", ty.kind().article(), ty),
                             );
                             err.help("`sym` operands must refer to either a function or a static");
                             err.emit();

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -445,7 +445,7 @@ fn check_gat_where_clauses(tcx: TyCtxt<'_>, associated_items: &[hir::TraitItemRe
             let plural = pluralize!(unsatisfied_bounds.len());
             let mut err = tcx.sess.struct_span_err(
                 gat_item_hir.span,
-                &format!("missing required bound{} on `{}`", plural, gat_item_hir.ident),
+                format!("missing required bound{} on `{}`", plural, gat_item_hir.ident),
             );
 
             let suggestion = format!(
@@ -455,14 +455,14 @@ fn check_gat_where_clauses(tcx: TyCtxt<'_>, associated_items: &[hir::TraitItemRe
             );
             err.span_suggestion(
                 gat_item_hir.generics.tail_span_for_predicate_suggestion(),
-                &format!("add the required where clause{plural}"),
+                format!("add the required where clause{plural}"),
                 suggestion,
                 Applicability::MachineApplicable,
             );
 
             let bound =
                 if unsatisfied_bounds.len() > 1 { "these bounds are" } else { "this bound is" };
-            err.note(&format!(
+            err.note(format!(
                 "{} currently required to ensure that impls have maximum flexibility",
                 bound
             ));
@@ -916,14 +916,14 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) {
                     if is_ptr {
                         tcx.sess.span_err(
                             hir_ty.span,
-                            &format!(
+                            format!(
                                 "using {unsupported_type} as const generic parameters is forbidden",
                             ),
                         );
                     } else {
                         let mut err = tcx.sess.struct_span_err(
                             hir_ty.span,
-                            &format!(
+                            format!(
                                 "{unsupported_type} is forbidden as the type of a const generic parameter",
                             ),
                         );
@@ -1029,7 +1029,7 @@ fn check_type_defn<'tcx>(tcx: TyCtxt<'tcx>, item: &hir::Item<'tcx>, all_sized: b
                     let ty = tcx.erase_regions(ty);
                     if ty.has_infer() {
                         tcx.sess
-                            .delay_span_bug(item.span, &format!("inference variables in {:?}", ty));
+                            .delay_span_bug(item.span, format!("inference variables in {:?}", ty));
                         // Just treat unresolved type expression as if it needs drop.
                         true
                     } else {
@@ -1651,7 +1651,7 @@ fn check_method_receiver<'tcx>(
                     &tcx.sess.parse_sess,
                     sym::arbitrary_self_types,
                     span,
-                    &format!(
+                    format!(
                         "`{receiver_ty}` cannot be used as the type of `self` without \
                          the `arbitrary_self_types` feature",
                     ),
@@ -1874,10 +1874,10 @@ fn report_bivariance(
     } else {
         format!("consider removing `{param_name}` or referring to it in a field")
     };
-    err.help(&msg);
+    err.help(msg);
 
     if matches!(param.kind, hir::GenericParamKind::Type { .. }) && !has_explicit_bounds {
-        err.help(&format!(
+        err.help(format!(
             "if you intended `{0}` to be a const parameter, use `const {0}: usize` instead",
             param_name
         ));

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -213,7 +213,7 @@ fn visit_implementation_of_dispatch_from_dyn(tcx: TyCtxt<'_>, impl_did: LocalDef
                                  for structs containing the field being coerced, \
                                  ZST fields with 1 byte alignment, and nothing else",
                             )
-                            .note(&format!(
+                            .note(format!(
                                 "extra field `{}` of type `{}` is not allowed",
                                 field.name, ty_a,
                             ))
@@ -241,7 +241,7 @@ fn visit_implementation_of_dispatch_from_dyn(tcx: TyCtxt<'_>, impl_did: LocalDef
                             for a coercion between structures with a single field \
                             being coerced",
                     )
-                    .note(&format!(
+                    .note(format!(
                         "currently, {} fields need coercions: {}",
                         coerced_fields.len(),
                         coerced_fields
@@ -298,7 +298,7 @@ pub fn coerce_unsized_info<'tcx>(tcx: TyCtxt<'tcx>, impl_did: LocalDefId) -> Coe
     let coerce_unsized_trait = tcx.require_lang_item(LangItem::CoerceUnsized, Some(span));
 
     let unsize_trait = tcx.lang_items().require(LangItem::Unsize).unwrap_or_else(|err| {
-        tcx.sess.fatal(&format!("`CoerceUnsized` implementation {}", err.to_string()));
+        tcx.sess.fatal(format!("`CoerceUnsized` implementation {}", err.to_string()));
     });
 
     let source = tcx.type_of(impl_did).subst_identity();
@@ -469,7 +469,7 @@ pub fn coerce_unsized_info<'tcx>(tcx: TyCtxt<'tcx>, impl_did: LocalDefId) -> Coe
                     "`CoerceUnsized` may only be implemented for \
                           a coercion between structures with one field being coerced",
                 )
-                .note(&format!(
+                .note(format!(
                     "currently, {} fields need coercions: {}",
                     diff_fields.len(),
                     diff_fields

--- a/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
@@ -146,7 +146,7 @@ impl<'tcx> InherentCollect<'tcx> {
                 );
                 err.help("consider using an extension trait instead");
                 if let ty::Ref(_, subty, _) = ty.kind() {
-                    err.note(&format!(
+                    err.note(format!(
                         "you could also try moving the reference to \
                             uses of `{}` (such as `self`) within the implementation",
                         subty

--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -372,10 +372,10 @@ fn emit_orphan_check_error<'tcx>(
 
                 if is_target_ty {
                     // Point at `D<A>` in `impl<A, B> for C<B> in D<A>`
-                    err.span_label(self_ty_span, &msg);
+                    err.span_label(self_ty_span, msg);
                 } else {
                     // Point at `C<B>` in `impl<A, B> for C<B> in D<A>`
-                    err.span_label(trait_span, &msg);
+                    err.span_label(trait_span, msg);
                 }
             }
             err.note("define and implement a trait or new type instead");
@@ -531,15 +531,15 @@ fn lint_auto_trait_impl<'tcx>(
             let self_descr = tcx.def_descr(self_type_did);
             match arg {
                 ty::util::NotUniqueParam::DuplicateParam(arg) => {
-                    lint.note(&format!("`{}` is mentioned multiple times", arg));
+                    lint.note(format!("`{}` is mentioned multiple times", arg));
                 }
                 ty::util::NotUniqueParam::NotParam(arg) => {
-                    lint.note(&format!("`{}` is not a generic parameter", arg));
+                    lint.note(format!("`{}` is not a generic parameter", arg));
                 }
             }
             lint.span_note(
                 item_span,
-                &format!(
+                format!(
                     "try using the same sequence of generic parameters as the {} definition",
                     self_descr,
                 ),

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -987,7 +987,7 @@ impl<'a, 'tcx> Visitor<'tcx> for BoundVarContext<'a, 'tcx> {
                                         lifetime.ident
                                     ),
                                     |lint| {
-                                        let help = &format!(
+                                        let help = format!(
                                             "you can use the `'static` lifetime directly, in place of `{}`",
                                             lifetime.ident,
                                         );
@@ -1365,7 +1365,7 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
 
         self.tcx.sess.delay_span_bug(
             lifetime_ref.ident.span,
-            &format!("Could not resolve {:?} in scope {:#?}", lifetime_ref, self.scope,),
+            format!("Could not resolve {:?} in scope {:#?}", lifetime_ref, self.scope,),
         );
     }
 

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -828,14 +828,14 @@ fn infer_placeholder_type<'a>(
                 if let Some(ty) = ty.make_suggestable(tcx, false) {
                     err.span_suggestion(
                         span,
-                        &format!("provide a type for the {item}", item = kind),
+                        format!("provide a type for the {item}", item = kind),
                         format!("{colon} {ty}"),
                         Applicability::MachineApplicable,
                     );
                 } else {
                     with_forced_trimmed_paths!(err.span_note(
                         tcx.hir().body(body_id).value.span,
-                        &format!("however, the inferred type `{ty}` cannot be named"),
+                        format!("however, the inferred type `{ty}` cannot be named"),
                     ));
                 }
             }
@@ -856,7 +856,7 @@ fn infer_placeholder_type<'a>(
                 } else {
                     with_forced_trimmed_paths!(diag.span_note(
                         tcx.hir().body(body_id).value.span,
-                        &format!("however, the inferred type `{ty}` cannot be named"),
+                        format!("however, the inferred type `{ty}` cannot be named"),
                     ));
                 }
             }

--- a/compiler/rustc_hir_analysis/src/impl_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check.rs
@@ -76,7 +76,7 @@ fn enforce_impl_params_are_constrained(tcx: TyCtxt<'_>, impl_def_id: LocalDefId)
         // (#36836)
         tcx.sess.delay_span_bug(
             tcx.def_span(impl_def_id),
-            &format!(
+            format!(
                 "potentially unconstrained type parameters weren't evaluated: {:?}",
                 impl_self_ty,
             ),

--- a/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
@@ -272,7 +272,7 @@ fn check_duplicate_params<'tcx>(
     if let (_, [duplicate, ..]) = base_params.partition_dedup() {
         let param = impl1_substs[duplicate.0 as usize];
         tcx.sess
-            .struct_span_err(span, &format!("specializing impl repeats parameter `{}`", param))
+            .struct_span_err(span, format!("specializing impl repeats parameter `{}`", param))
             .emit();
     }
 }
@@ -464,7 +464,7 @@ fn check_specialization_on<'tcx>(tcx: TyCtxt<'tcx>, predicate: ty::Predicate<'tc
                 tcx.sess
                     .struct_span_err(
                         span,
-                        &format!(
+                        format!(
                             "cannot specialize on trait `{}`",
                             tcx.def_path_str(trait_ref.def_id),
                         ),
@@ -479,7 +479,7 @@ fn check_specialization_on<'tcx>(tcx: TyCtxt<'tcx>, predicate: ty::Predicate<'tc
             tcx.sess
                 .struct_span_err(
                     span,
-                    &format!("cannot specialize on associated type `{projection_ty} == {term}`",),
+                    format!("cannot specialize on associated type `{projection_ty} == {term}`",),
                 )
                 .emit();
         }
@@ -495,7 +495,7 @@ fn check_specialization_on<'tcx>(tcx: TyCtxt<'tcx>, predicate: ty::Predicate<'tc
         }
         _ => {
             tcx.sess
-                .struct_span_err(span, &format!("cannot specialize on predicate `{}`", predicate))
+                .struct_span_err(span, format!("cannot specialize on predicate `{}`", predicate))
                 .emit();
         }
     }

--- a/compiler/rustc_hir_analysis/src/outlives/mod.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/mod.rs
@@ -61,7 +61,7 @@ fn inferred_outlives_of(tcx: TyCtxt<'_>, item_def_id: LocalDefId) -> &[(ty::Clau
 
                     let span = tcx.def_span(item_def_id);
                     let mut err = tcx.sess.struct_span_err(span, "rustc_outlives");
-                    for p in &pred {
+                    for p in pred {
                         err.note(p);
                     }
                     err.emit();

--- a/compiler/rustc_hir_analysis/src/structured_errors/missing_cast_for_variadic_arg.rs
+++ b/compiler/rustc_hir_analysis/src/structured_errors/missing_cast_for_variadic_arg.rs
@@ -48,7 +48,7 @@ impl<'tcx> StructuredDiagnostic<'tcx> for MissingCastForVariadicArg<'tcx, '_> {
         &self,
         mut err: DiagnosticBuilder<'tcx, ErrorGuaranteed>,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        err.note(&format!(
+        err.note(format!(
             "certain types, like `{}`, must be casted before passing them to a \
                 variadic function, because of arcane ABI rules dictated by the C \
                 standard",

--- a/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
@@ -480,7 +480,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         let span = self.path_segment.ident.span;
         let msg = self.create_error_message();
 
-        self.tcx.sess.struct_span_err_with_code(span, &msg, self.code())
+        self.tcx.sess.struct_span_err_with_code(span, msg, self.code())
     }
 
     /// Builds the `expected 1 type argument / supplied 2 type arguments` message.
@@ -602,7 +602,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
 
                 err.span_suggestion_verbose(
                     span.shrink_to_hi(),
-                    &msg,
+                    msg,
                     sugg,
                     Applicability::HasPlaceholders,
                 );
@@ -625,7 +625,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 let sugg = format!("{}{}{}", sugg_prefix, suggested_args, sugg_suffix);
                 debug!("sugg: {:?}", sugg);
 
-                err.span_suggestion_verbose(sugg_span, &msg, sugg, Applicability::HasPlaceholders);
+                err.span_suggestion_verbose(sugg_span, msg, sugg, Applicability::HasPlaceholders);
             }
             AngleBrackets::Implied => {
                 // We never encounter missing lifetimes in situations in which lifetimes are elided
@@ -652,7 +652,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
 
                 err.span_suggestion_verbose(
                     span.shrink_to_hi(),
-                    &msg,
+                    msg,
                     sugg,
                     Applicability::HasPlaceholders,
                 );
@@ -683,7 +683,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 let sugg = format!("{}{}{}", sugg_prefix, suggested_args, sugg_suffix);
                 debug!("sugg: {:?}", sugg);
 
-                err.span_suggestion_verbose(sugg_span, &msg, sugg, Applicability::HasPlaceholders);
+                err.span_suggestion_verbose(sugg_span, msg, sugg, Applicability::HasPlaceholders);
             }
         }
     }
@@ -885,7 +885,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
 
             err.span_suggestion(
                 span_redundant_lt_args,
-                &msg_lifetimes,
+                msg_lifetimes,
                 "",
                 Applicability::MaybeIncorrect,
             );
@@ -927,7 +927,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
 
             err.span_suggestion(
                 span_redundant_type_or_const_args,
-                &msg_types_or_consts,
+                msg_types_or_consts,
                 "",
                 Applicability::MaybeIncorrect,
             );
@@ -943,7 +943,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
 
             if !suggestions.is_empty() {
                 err.multipart_suggestion_verbose(
-                    &format!(
+                    format!(
                         "replace the generic bound{s} with the associated type{s}",
                         s = pluralize!(unbound_types.len())
                     ),
@@ -969,7 +969,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 },
             );
 
-            err.span_suggestion(span, &msg, "", Applicability::MaybeIncorrect);
+            err.span_suggestion(span, msg, "", Applicability::MaybeIncorrect);
         } else if redundant_lifetime_args && redundant_type_or_const_args {
             remove_lifetime_args(err);
             remove_type_or_const_args(err);
@@ -1029,7 +1029,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
             )
         };
 
-        err.span_note(spans, &msg);
+        err.span_note(spans, msg);
     }
 
     /// Add note if `impl Trait` is explicitly specified.

--- a/compiler/rustc_hir_typeck/src/_match.rs
+++ b/compiler/rustc_hir_typeck/src/_match.rs
@@ -271,7 +271,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             &cause,
             &mut |err| {
                 if let Some((span, msg)) = &ret_reason {
-                    err.span_label(*span, msg);
+                    err.span_label(*span, msg.clone());
                 } else if let ExprKind::Block(block, _) = &then_expr.kind
                     && let Some(expr) = &block.expr
                 {

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -397,7 +397,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             .sess
                             .struct_span_err(
                                 callee_expr.span,
-                                &format!("evaluate({:?}) = {:?}", predicate, result),
+                                format!("evaluate({:?}) = {:?}", predicate, result),
                             )
                             .span_label(predicate_span, "predicate")
                             .emit();
@@ -630,7 +630,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if let Some((removal_span, kind, path)) = &unit_variant {
             err.span_suggestion_verbose(
                 *removal_span,
-                &format!(
+                format!(
                     "`{path}` is a unit {kind}, and does not take parentheses to be constructed",
                 ),
                 "",

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -146,7 +146,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let reported = self
                     .tcx
                     .sess
-                    .delay_span_bug(span, &format!("`{:?}` should be sized but is not?", t));
+                    .delay_span_bug(span, format!("`{:?}` should be sized but is not?", t));
                 return Err(reported);
             }
         })
@@ -270,7 +270,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                     fcx,
                 );
                 if self.cast_ty.is_integral() {
-                    err.help(&format!(
+                    err.help(format!(
                         "cast through {} first",
                         match e {
                             CastError::NeedViaPtr => "a raw pointer",
@@ -292,7 +292,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                     self.cast_ty,
                     fcx,
                 )
-                .help(&format!(
+                .help(format!(
                     "cast through {} first",
                     match e {
                         CastError::NeedViaInt => "an integer",
@@ -651,13 +651,13 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                             );
                         }
                         Err(_) => {
-                            let msg = &format!("did you mean `&{}{}`?", mtstr, tstr);
+                            let msg = format!("did you mean `&{}{}`?", mtstr, tstr);
                             err.span_help(self.cast_span, msg);
                         }
                     }
                 } else {
                     let msg =
-                        &format!("consider using an implicit coercion to `&{mtstr}{tstr}` instead");
+                        format!("consider using an implicit coercion to `&{mtstr}{tstr}` instead");
                     err.span_help(self.span, msg);
                 }
             }
@@ -674,7 +674,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                     Err(_) => {
                         err.span_help(
                             self.cast_span,
-                            &format!("you might have meant `Box<{tstr}>`"),
+                            format!("you might have meant `Box<{tstr}>`"),
                         );
                     }
                 }

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -707,9 +707,9 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                 &self.tcx.sess.parse_sess,
                 sym::trait_upcasting,
                 self.cause.span,
-                &format!("cannot cast `{sub}` to `{sup}`, trait upcasting coercion is experimental"),
+                format!("cannot cast `{sub}` to `{sup}`, trait upcasting coercion is experimental"),
             );
-            err.note(&format!("required when coercing `{source}` into `{target}`"));
+            err.note(format!("required when coercing `{source}` into `{target}`"));
             err.emit();
         }
 
@@ -1657,7 +1657,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
             "the function expects a value to always be returned, but loops might run zero times",
         );
         if MAXITER < ret_exprs.len() {
-            err.note(&format!(
+            err.note(format!(
                 "if the loop doesn't execute, {} other values would never get returned",
                 ret_exprs.len() - MAXITER
             ));
@@ -1767,7 +1767,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
         {
             err.span_note(
                 sp,
-                &format!(
+                format!(
                     "return type inferred to be `{}` here",
                     expected
                 ),
@@ -1864,7 +1864,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                     Applicability::MaybeIncorrect,
                 );
             } else {
-                err.help(&format!(
+                err.help(format!(
                     "if the trait `{}` were object safe, you could return a boxed trait object",
                     &snippet[5..]
                 ));

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1944,12 +1944,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         private_fields: Vec<&ty::FieldDef>,
         used_fields: &'tcx [hir::ExprField<'tcx>],
     ) {
-        let mut err = self.tcx.sess.struct_span_err(
-            span,
-            &format!(
-                "cannot construct `{adt_ty}` with struct literal syntax due to private fields",
-            ),
-        );
+        let mut err =
+            self.tcx.sess.struct_span_err(
+                span,
+                format!(
+                    "cannot construct `{adt_ty}` with struct literal syntax due to private fields",
+                ),
+            );
         let (used_private_fields, remaining_private_fields): (
             Vec<(Symbol, Span, bool)>,
             Vec<(Symbol, Span, bool)>,
@@ -2045,7 +2046,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     err.span_label(field.ident.span, "field does not exist");
                     err.span_suggestion_verbose(
                         expr_span,
-                        &format!(
+                        format!(
                             "`{adt}::{variant}` is a tuple {kind_name}, use the appropriate syntax",
                             adt = ty,
                             variant = variant.name,
@@ -2063,7 +2064,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     err.span_label(field.ident.span, "field does not exist");
                     err.span_suggestion_verbose(
                         expr_span,
-                        &format!(
+                        format!(
                             "`{adt}` is a tuple {kind_name}, use the appropriate syntax",
                             adt = ty,
                             kind_name = kind_name,
@@ -2105,7 +2106,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             let available_field_names =
                                 self.available_field_names(variant, expr_span);
                             if !available_field_names.is_empty() {
-                                err.note(&format!(
+                                err.note(format!(
                                     "available fields are: {}",
                                     self.name_series_display(available_field_names)
                                 ));
@@ -2384,7 +2385,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
         if add_label {
-            err.span_label(field_ident.span, &format!("field not found in `{ty}`"));
+            err.span_label(field_ident.span, format!("field not found in `{ty}`"));
         }
     }
 
@@ -2565,7 +2566,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let param_span = self.tcx.hir().span(param_hir_id);
         let param_name = self.tcx.hir().ty_param_name(param_def_id.expect_local());
 
-        err.span_label(param_span, &format!("type parameter '{param_name}' declared here"));
+        err.span_label(param_span, format!("type parameter '{param_name}' declared here"));
     }
 
     fn suggest_fields_on_recordish(
@@ -2589,7 +2590,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let struct_variant_def = def.non_enum_variant();
             let field_names = self.available_field_names(struct_variant_def, access_span);
             if !field_names.is_empty() {
-                err.note(&format!(
+                err.note(format!(
                     "available fields are: {}",
                     self.name_series_display(field_names),
                 ));
@@ -2630,7 +2631,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if let Ok(base) = self.tcx.sess.source_map().span_to_snippet(base.span) {
             let msg = format!("`{base}` is a raw pointer; try dereferencing it");
             let suggestion = format!("(*{base}).{field}");
-            err.span_suggestion(expr.span, &msg, suggestion, Applicability::MaybeIncorrect);
+            err.span_suggestion(expr.span, msg, suggestion, Applicability::MaybeIncorrect);
         }
     }
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -63,9 +63,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     lint::builtin::UNREACHABLE_CODE,
                     id,
                     span,
-                    &msg,
+                    msg.clone(),
                     |lint| {
-                        lint.span_label(span, &msg).span_label(
+                        lint.span_label(span, msg).span_label(
                             orig_span,
                             custom_note
                                 .unwrap_or("any code following this expression is unreachable"),
@@ -275,7 +275,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     _ => {
                         self.tcx.sess.delay_span_bug(
                             expr.span,
-                            &format!(
+                            format!(
                                 "while adjusting {:?}, can't compose {:?} and {:?}",
                                 expr,
                                 entry.get(),
@@ -1034,15 +1034,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 rcvr.span,
                 "you probably want to use this value after calling the method...",
             );
-            err.span_note(sp, &modifies_rcvr_note);
-            err.note(&format!("...instead of the `()` output of method `{}`", path_segment.ident));
+            err.span_note(sp, modifies_rcvr_note);
+            err.note(format!("...instead of the `()` output of method `{}`", path_segment.ident));
         } else if let ExprKind::MethodCall(..) = rcvr.kind {
             err.span_note(
                 sp,
                 modifies_rcvr_note.clone() + ", it is not meant to be used in method chains.",
             );
         } else {
-            err.span_note(sp, &modifies_rcvr_note);
+            err.span_note(sp, modifies_rcvr_note);
         }
     }
 
@@ -1374,7 +1374,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 Err(_) => {
                     self.tcx.sess.delay_span_bug(
                         span,
-                        &format!(
+                        format!(
                         "instantiate_value_path: (UFCS) {:?} was a subtype of {:?} but now is not?",
                         self_ty,
                         impl_ty,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -685,7 +685,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     } else {
                         err = tcx.sess.struct_span_err_with_code(
                             full_call_span,
-                            &format!(
+                            format!(
                                 "{call_name} takes {}{} but {} {} supplied",
                                 if c_variadic { "at least " } else { "" },
                                 potentially_plural_count(
@@ -828,7 +828,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         } else {
             tcx.sess.struct_span_err_with_code(
                 full_call_span,
-                &format!(
+                format!(
                     "this {} takes {}{} but {} {} supplied",
                     call_name,
                     if c_variadic { "at least " } else { "" },
@@ -1203,7 +1203,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             SuggestionText::Remove(plural) => {
                 err.multipart_suggestion(
-                    &format!("remove the extra argument{}", if plural { "s" } else { "" }),
+                    format!("remove the extra argument{}", if plural { "s" } else { "" }),
                     suggestions,
                     Applicability::HasPlaceholders,
                 );
@@ -1253,7 +1253,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             suggestion += ")";
             err.span_suggestion_verbose(
                 suggestion_span,
-                &suggestion_text,
+                suggestion_text,
                 suggestion,
                 Applicability::HasPlaceholders,
             );
@@ -1947,7 +1947,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 spans.push_span_label(param.span, "");
             }
 
-            err.span_note(spans, &format!("{} defined here", self.tcx.def_descr(def_id)));
+            err.span_note(spans, format!("{} defined here", self.tcx.def_descr(def_id)));
         } else if let Some(hir::Node::Expr(e)) = self.tcx.hir().get_if_local(def_id)
             && let hir::ExprKind::Closure(hir::Closure { body, .. }) = &e.kind
         {
@@ -1958,11 +1958,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             } else {
                 ("closure", self.tcx.def_span(def_id))
             };
-            err.span_note(span, &format!("{} defined here", kind));
+            err.span_note(span, format!("{} defined here", kind));
         } else {
             err.span_note(
                 self.tcx.def_span(def_id),
-                &format!("{} defined here", self.tcx.def_descr(def_id)),
+                format!("{} defined here", self.tcx.def_descr(def_id)),
             );
         }
     }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -278,9 +278,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.check_ref(expr, found, expected)
         {
             if verbose {
-                err.span_suggestion_verbose(sp, &msg, suggestion, applicability);
+                err.span_suggestion_verbose(sp, msg, suggestion, applicability);
             } else {
-                err.span_suggestion(sp, &msg, suggestion, applicability);
+                err.span_suggestion(sp, msg, suggestion, applicability);
             }
             if annotation {
                 let suggest_annotation = match expr.peel_drop_temps().kind {
@@ -1449,7 +1449,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         {
             diag.span_note(
                 callee_expr.span,
-                &format!(
+                format!(
                     "`{expected_ty}` does not implement `Clone`, so `{found_ty}` was cloned instead"
                 ),
             );

--- a/compiler/rustc_hir_typeck/src/generator_interior/drop_ranges/record_consumed_borrow.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/drop_ranges/record_consumed_borrow.rs
@@ -205,7 +205,7 @@ impl<'tcx> expr_use_visitor::Delegate<'tcx> for ExprUseDelegate<'tcx> {
         if ty.has_infer() {
             self.tcx.sess.delay_span_bug(
                 self.tcx.hir().span(assignee_place.hir_id),
-                &format!("inference variables in {ty}"),
+                format!("inference variables in {ty}"),
             );
         } else if ty.needs_drop(self.tcx, self.param_env) {
             self.places

--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -112,7 +112,7 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
                     self.fcx
                         .tcx
                         .sess
-                        .delay_span_bug(span, &format!("Encountered var {:?}", unresolved_term));
+                        .delay_span_bug(span, format!("Encountered var {:?}", unresolved_term));
                 } else {
                     let note = format!(
                         "the type is part of the {} because of this {}",
@@ -464,7 +464,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
                     self.fcx
                         .tcx
                         .sess
-                        .delay_span_bug(expr.span, &format!("inference variables in {ty}"));
+                        .delay_span_bug(expr.span, format!("inference variables in {ty}"));
                     true
                 } else {
                     ty.needs_drop(self.fcx.tcx, self.fcx.param_env)

--- a/compiler/rustc_hir_typeck/src/intrinsicck.rs
+++ b/compiler/rustc_hir_typeck/src/intrinsicck.rs
@@ -72,8 +72,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let from = unpack_option_like(tcx, from);
             if let (&ty::FnDef(..), SizeSkeleton::Known(size_to)) = (from.kind(), sk_to) && size_to == Pointer(dl.instruction_address_space).size(&tcx) {
                 struct_span_err!(tcx.sess, span, E0591, "can't transmute zero-sized type")
-                    .note(&format!("source type: {from}"))
-                    .note(&format!("target type: {to}"))
+                    .note(format!("source type: {from}"))
+                    .note(format!("target type: {to}"))
                     .help("cast with `as` to a pointer instead")
                     .emit();
                 return;
@@ -109,10 +109,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                         or dependently-sized types"
         );
         if from == to {
-            err.note(&format!("`{from}` does not have a fixed size"));
+            err.note(format!("`{from}` does not have a fixed size"));
         } else {
-            err.note(&format!("source type: `{}` ({})", from, skeleton_string(from, sk_from)))
-                .note(&format!("target type: `{}` ({})", to, skeleton_string(to, sk_to)));
+            err.note(format!("source type: `{}` ({})", from, skeleton_string(from, sk_from)))
+                .note(format!("target type: `{}` ({})", to, skeleton_string(to, sk_to)));
             let mut should_delay_as_bug = false;
             if let Err(LayoutError::Unknown(bad_from)) = sk_from && bad_from.references_error() {
                 should_delay_as_bug = true;

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -448,7 +448,7 @@ fn fatally_break_rust(sess: &Session) {
         "we would appreciate a joke overview: \
          https://github.com/rust-lang/rust/issues/43162#issuecomment-320764675",
     );
-    handler.note_without_error(&format!(
+    handler.note_without_error(format!(
         "rustc {} running on {}",
         option_env!("CFG_VERSION").unwrap_or("unknown_version"),
         config::host_triple(),

--- a/compiler/rustc_hir_typeck/src/method/prelude2021.rs
+++ b/compiler/rustc_hir_typeck/src/method/prelude2021.rs
@@ -118,7 +118,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         };
                         lint.span_help(
                             sp,
-                            &format!("disambiguate the method call with `({})`", self_adjusted,),
+                            format!("disambiguate the method call with `({})`", self_adjusted,),
                         );
                     }
 
@@ -180,7 +180,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     } else {
                         lint.span_help(
                             sp,
-                            &format!(
+                            format!(
                                 "disambiguate the associated function with `{}::{}(...)`",
                                 trait_name, segment.ident,
                             ),

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1396,7 +1396,7 @@ impl<'tcx> Pick<'tcx> {
                         // However `self.span` only
                         // highlights the method name, so we can't use it. Also consider reusing
                         // the code from `report_method_error()`.
-                        lint.help(&format!(
+                        lint.help(format!(
                             "call with fully qualified syntax `{}(...)` to keep using the current \
                              method",
                             tcx.def_path_str(self.item.def_id),
@@ -1420,7 +1420,7 @@ impl<'tcx> Pick<'tcx> {
                 }
                 if tcx.sess.is_nightly_build() {
                     for (candidate, feature) in &self.unstable_candidates {
-                        lint.help(&format!(
+                        lint.help(format!(
                             "add `#![feature({})]` to the crate attributes to enable `{}`",
                             feature,
                             tcx.def_path_str(candidate.item.def_id),

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -169,13 +169,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     kind,
                     item_name
                 );
-                err.span_label(item_name.span, &format!("private {}", kind));
+                err.span_label(item_name.span, format!("private {}", kind));
                 let sp = self
                     .tcx
                     .hir()
                     .span_if_local(def_id)
                     .unwrap_or_else(|| self.tcx.def_span(def_id));
-                err.span_label(sp, &format!("private {} defined here", kind));
+                err.span_label(sp, format!("private {} defined here", kind));
                 self.suggest_valid_traits(&mut err, out_of_scope_traits);
                 err.emit();
             }
@@ -188,7 +188,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 } else {
                     format!("the `{item_name}` method cannot be invoked on a trait object")
                 };
-                let mut err = self.sess().struct_span_err(span, &msg);
+                let mut err = self.sess().struct_span_err(span, msg);
                 if !needs_mut {
                     err.span_label(bound_span, "this has a `Sized` requirement");
                 }
@@ -228,12 +228,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         {
                             err.span_suggestion_verbose(
                                 mut_ty.ty.span.shrink_to_lo(),
-                                &msg,
+                                msg,
                                 "mut ",
                                 Applicability::MachineApplicable,
                             );
                         } else {
-                            err.help(&msg);
+                            err.help(msg);
                         }
                     }
                 }
@@ -374,14 +374,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ty_str
         };
         if let Some(file) = ty_file {
-            err.note(&format!("the full type name has been written to '{}'", file.display(),));
+            err.note(format!("the full type name has been written to '{}'", file.display(),));
         }
         if rcvr_ty.references_error() {
             err.downgrade_to_delayed_bug();
         }
 
         if tcx.ty_is_opaque_future(rcvr_ty) && item_name.name == sym::poll {
-            err.help(&format!(
+            err.help(format!(
                 "method `poll` found on `Pin<&mut {ty_str}>`, \
                 see documentation for `std::pin::Pin`"
             ));
@@ -510,7 +510,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             if let Some(iterator_trait) = self.tcx.get_diagnostic_item(sym::Iterator) {
                 let iterator_trait = self.tcx.def_path_str(iterator_trait);
-                err.note(&format!(
+                err.note(format!(
                     "`count` is defined on `{iterator_trait}`, which `{rcvr_ty}` does not implement"
                 ));
             }
@@ -810,7 +810,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 for (sp, label) in span_labels {
                     span.push_span_label(sp, label);
                 }
-                err.span_note(span, &msg);
+                err.span_note(span, msg);
                 unsatisfied_bounds = true;
             }
 
@@ -867,7 +867,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 obligations.sort();
                 err.span_suggestion_verbose(
                     span,
-                    &format!(
+                    format!(
                         "consider restricting the type parameter{s} to satisfy the \
                          trait bound{s}",
                         s = pluralize!(obligations.len())
@@ -912,13 +912,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                          but its trait bounds were not satisfied"
                     )
                 });
-                err.set_primary_message(&primary_message);
+                err.set_primary_message(primary_message);
                 if let Some(label) = label {
                     custom_span_label = true;
                     err.span_label(span, label);
                 }
                 if !bound_list.is_empty() {
-                    err.note(&format!(
+                    err.note(format!(
                         "the following trait bounds were not satisfied:\n{bound_list}"
                     ));
                 }
@@ -1002,7 +1002,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         } else {
                             "".to_string()
                         };
-                        err.note(&format!(
+                        err.note(format!(
                             "the {item_kind} was found for\n{}{}",
                             type_candidates, additional_types
                         ));
@@ -1049,7 +1049,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         bound_spans.sort();
         bound_spans.dedup();
         for (span, msg) in bound_spans.into_iter() {
-            err.span_label(span, &msg);
+            err.span_label(span, msg);
         }
 
         if rcvr_ty.is_numeric() && rcvr_ty.is_fresh() || restrict_type_params {
@@ -1119,7 +1119,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 } else {
                     err.span_suggestion(
                         span,
-                        &format!(
+                        format!(
                             "there is {} {} with a similar name",
                             self.tcx.def_kind_descr_article(def_kind, similar_candidate.def_id),
                             self.tcx.def_kind_descr(def_kind, similar_candidate.def_id)
@@ -1203,9 +1203,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     };
                     if let Some(note_span) = note_span {
                         // We have a span pointing to the method. Show note with snippet.
-                        err.span_note(note_span, &note_str);
+                        err.span_note(note_span, note_str);
                     } else {
-                        err.note(&note_str);
+                        err.note(note_str);
                     }
                     if let Some(sugg_span) = sugg_span
                         && let Some(trait_ref) = self.tcx.impl_trait_ref(impl_did) {
@@ -1243,7 +1243,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let Some(item) = self.associated_value(trait_did, item_name) else { continue };
                     let item_span = self.tcx.def_span(item.def_id);
                     let idx = if sources.len() > 1 {
-                        let msg = &format!(
+                        let msg = format!(
                             "candidate #{} is defined in the trait `{}`",
                             idx + 1,
                             self.tcx.def_path_str(trait_did)
@@ -1251,7 +1251,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         err.span_note(item_span, msg);
                         Some(idx + 1)
                     } else {
-                        let msg = &format!(
+                        let msg = format!(
                             "the candidate is defined in the trait `{}`",
                             self.tcx.def_path_str(trait_did)
                         );
@@ -1278,7 +1278,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
         if sources.len() > limit {
-            err.note(&format!("and {} others", sources.len() - limit));
+            err.note(format!("and {} others", sources.len() - limit));
         }
     }
 
@@ -1402,7 +1402,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 applicability,
             );
         } else {
-            err.help(&format!("try with `{}::{}`", ty_str, item_name,));
+            err.help(format!("try with `{}::{}`", ty_str, item_name,));
         }
     }
 
@@ -1436,7 +1436,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if self.is_fn_ty(field_ty, span) {
                     let expr_span = expr.span.to(item_name.span);
                     err.multipart_suggestion(
-                        &format!(
+                        format!(
                             "to call the function stored in `{}`, \
                                          surround the field access with parentheses",
                             item_name,
@@ -1612,7 +1612,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let snippet = snippet.strip_suffix('.').unwrap_or(&snippet);
                     err.span_suggestion(
                         lit.span,
-                        &format!(
+                        format!(
                             "you must specify a concrete type for this numeric value, \
                                          like `{}`",
                             concrete_type
@@ -1648,7 +1648,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     // account for `let x: _ = 42;`
                                     //                   ^^^
                                     type_span,
-                                    &msg,
+                                    msg,
                                     format!(": {concrete_type}"),
                                     Applicability::MaybeIncorrect,
                                 );
@@ -1861,7 +1861,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         let self_ty = field.ty(tcx, substs);
                         err.span_note(
                             tcx.def_span(pick.item.def_id),
-                            &format!("the method `{item_name}` exists on the type `{self_ty}`"),
+                            format!("the method `{item_name}` exists on the type `{self_ty}`"),
                         );
                         let (article, kind, variant, question) =
                             if tcx.is_diagnostic_item(sym::Result, kind.did()) {
@@ -1975,7 +1975,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                 err.span_note(
                     tcx.def_span(pick.item.def_id),
-                    &format!("the method `{item_name}` exists on the type `{ty}`"),
+                    format!("the method `{item_name}` exists on the type `{ty}`"),
                 );
             }
         }
@@ -2046,7 +2046,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     pluralize!(preds.len()),
                 )
             };
-            err.span_note(spans, &msg);
+            err.span_note(spans, msg);
         }
 
         let preds: Vec<_> = errors
@@ -2160,14 +2160,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             err.span_note(
                 span,
-                &format!("the trait{} {} must be implemented", pluralize!(len), names),
+                format!("the trait{} {} must be implemented", pluralize!(len), names),
             );
         }
 
         for (self_name, self_span, traits) in &derives_grouped {
             err.span_suggestion_verbose(
                 self_span.shrink_to_lo(),
-                &format!("consider annotating `{}` with `#[derive({})]`", self_name, traits),
+                format!("consider annotating `{}` with `#[derive({})]`", self_name, traits),
                 format!("#[derive({})]\n", traits),
                 Applicability::MaybeIncorrect,
             );
@@ -2313,7 +2313,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         err.span_suggestions(
             span,
-            &msg,
+            msg,
             path_strings.chain(glob_path_strings),
             Applicability::MaybeIncorrect,
         );
@@ -2345,7 +2345,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             self.suggest_use_candidates(err, msg, candidates);
             if let Some(did) = edition_fix {
-                err.note(&format!(
+                err.note(format!(
                     "'{}' is included in the prelude starting in Edition 2021",
                     with_crate_prefix!(self.tcx.def_path_str(did))
                 ));
@@ -2413,7 +2413,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         if pick.autoderefs == 0 && !skip {
                             err.span_label(
                                 pick.item.ident(self.tcx).span,
-                                &format!("the method is available for `{}` here", rcvr_ty),
+                                format!("the method is available for `{}` here", rcvr_ty),
                             );
                         }
                         break;
@@ -2459,7 +2459,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         if pick.autoderefs == 0 && !skip {
                             err.span_label(
                                 pick.item.ident(self.tcx).span,
-                                &format!("the method is available for `{}` here", new_rcvr_t),
+                                format!("the method is available for `{}` here", new_rcvr_t),
                             );
                             err.multipart_suggestion(
                                 "consider wrapping the receiver expression with the \
@@ -2655,7 +2655,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             if !candidates.iter().any(|t| trait_def_ids.contains(&t.def_id)) {
                                 err.span_suggestions(
                                     sp,
-                                    &message(format!(
+                                    message(format!(
                                         "restrict type parameter `{}` with",
                                         param.name.ident(),
                                     )),
@@ -2687,7 +2687,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             };
                             err.span_suggestions(
                                 sp,
-                                &message(format!("add {} supertrait for", article)),
+                                message(format!("add {} supertrait for", article)),
                                 candidates.iter().map(|t| {
                                     format!("{} {}", sep, self.tcx.def_path_str(t.def_id),)
                                 }),
@@ -2746,7 +2746,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 [trait_info] if trait_info.def_id.is_local() => {
                     err.span_note(
                         self.tcx.def_span(trait_info.def_id),
-                        &format!(
+                        format!(
                             "`{}` defines an item `{}`, perhaps you need to {} it",
                             self.tcx.def_path_str(trait_info.def_id),
                             item_name,
@@ -2763,7 +2763,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.tcx.def_path_str(trait_info.def_id),
                         ));
                     }
-                    err.note(&msg);
+                    err.note(msg);
                 }
             }
             match &explicitly_negative[..] {
@@ -2774,7 +2774,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         self.tcx.def_path_str(trait_info.def_id),
                         item_name
                     );
-                    err.note(&msg);
+                    err.note(msg);
                 }
                 trait_infos => {
                     let mut msg = format!(
@@ -2784,7 +2784,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     for trait_info in trait_infos {
                         msg.push_str(&format!("\n{}", self.tcx.def_path_str(trait_info.def_id)));
                     }
-                    err.note(&msg);
+                    err.note(msg);
                 }
             }
         }
@@ -2836,7 +2836,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 fn_args.len() == args.len() + 1 {
                 err.span_suggestion_verbose(
                     method_name.span.shrink_to_hi(),
-                    &format!("try calling `{}` instead", new_name.name.as_str()),
+                    format!("try calling `{}` instead", new_name.name.as_str()),
                     "_else",
                     Applicability::MaybeIncorrect,
                 );
@@ -2956,7 +2956,7 @@ fn print_disambiguation_help<'tcx>(
     };
     err.span_suggestion_verbose(
         span,
-        &format!(
+        format!(
             "disambiguate the {} for {}",
             def_kind_descr,
             if let Some(candidate) = candidate {

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -390,7 +390,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         )
                         .is_ok()
                     {
-                        let msg = &format!(
+                        let msg = format!(
                             "`{}{}` can be used on `{}` if you dereference the left-hand side",
                             op.node.as_str(),
                             match is_assign {
@@ -515,7 +515,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         } else {
                             // When we know that a missing bound is responsible, we don't show
                             // this note as it is redundant.
-                            err.note(&format!(
+                            err.note(format!(
                                 "the trait `{missing_trait}` is not implemented for `{lhs_ty}`"
                             ));
                         }
@@ -690,7 +690,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 {
                                     err.span_suggestion(
                                         ex.span,
-                                        &format!(
+                                        format!(
                                             "you may have meant the maximum value of `{actual}`",
                                         ),
                                         format!("{actual}::MAX"),

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -517,7 +517,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     fn endpoint_has_type(&self, err: &mut Diagnostic, span: Span, ty: Ty<'_>) {
         if !ty.references_error() {
-            err.span_label(span, &format!("this is of type `{}`", ty));
+            err.span_label(span, format!("this is of type `{}`", ty));
         }
     }
 
@@ -544,7 +544,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             format!("this is of type `{}` but it should be `char` or numeric", ty)
         };
         let mut one_side_err = |first_span, first_ty, second: Option<(bool, Ty<'tcx>, Span)>| {
-            err.span_label(first_span, &msg(first_ty));
+            err.span_label(first_span, msg(first_ty));
             if let Some((_, ty, sp)) = second {
                 let ty = self.resolve_vars_if_possible(ty);
                 self.endpoint_has_type(&mut err, sp, ty);
@@ -552,8 +552,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
         match (lhs, rhs) {
             (Some((true, lhs_ty, lhs_sp)), Some((true, rhs_ty, rhs_sp))) => {
-                err.span_label(lhs_sp, &msg(lhs_ty));
-                err.span_label(rhs_sp, &msg(rhs_ty));
+                err.span_label(lhs_sp, msg(lhs_ty));
+                err.span_label(rhs_sp, msg(rhs_ty));
             }
             (Some((true, lhs_ty, lhs_sp)), rhs) => one_side_err(lhs_sp, lhs_ty, rhs),
             (lhs, Some((true, rhs_ty, rhs_sp))) => one_side_err(rhs_sp, rhs_ty, lhs),
@@ -651,7 +651,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 )
             });
             let pre = if in_match { "in the same arm, " } else { "" };
-            err.note(&format!("{}a binding must have the same type in all alternatives", pre));
+            err.note(format!("{}a binding must have the same type in all alternatives", pre));
             self.suggest_adding_missing_ref_or_removing_ref(
                 &mut err,
                 span,
@@ -958,11 +958,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) {
         let pat_span = pat.span;
         if let Some(span) = self.tcx.hir().res_span(pat_res) {
-            e.span_label(span, &format!("{} defined here", res.descr()));
+            e.span_label(span, format!("{} defined here", res.descr()));
             if let [hir::PathSegment { ident, .. }] = &*segments {
                 e.span_label(
                     pat_span,
-                    &format!(
+                    format!(
                         "`{}` is interpreted as {} {}, not a new binding",
                         ident,
                         res.article(),
@@ -1158,7 +1158,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         );
         err.span_label(
             last_subpat_span,
-            &format!("expected {} field{}, found {}", fields.len(), fields_ending, subpats.len()),
+            format!("expected {} field{}, found {}", fields.len(), fields_ending, subpats.len()),
         );
         if self.tcx.sess.source_map().is_multiline(qpath.span().between(last_subpat_span)) {
             err.span_label(qpath.span(), "");
@@ -1171,7 +1171,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
         err.span_label(
             last_field_def_span,
-            &format!("{} has {} field{}", res.descr(), fields.len(), fields_ending),
+            format!("{} has {} field{}", res.descr(), fields.len(), fields_ending),
         );
 
         // Identify the case `Some(x, y)` where the expected type is e.g. `Option<(T, U)>`.
@@ -1641,7 +1641,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             let unmentioned_field = unmentioned_fields[0].1.name;
                             err.span_suggestion_short(
                                 pat_field.ident.span,
-                                &format!(
+                                format!(
                                     "`{}` has a field named `{}`",
                                     tcx.def_path_str(variant.def_id),
                                     unmentioned_field
@@ -1831,7 +1831,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         lint.help(
             "ensure that all fields are mentioned explicitly by adding the suggested fields",
         );
-        lint.note(&format!(
+        lint.note(format!(
             "the pattern is of type `{}` and the `non_exhaustive_omitted_patterns` attribute was found",
             ty,
         ));
@@ -1895,7 +1895,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
         err.span_suggestion(
             sp,
-            &format!(
+            format!(
                 "include the missing field{} in the pattern{}",
                 pluralize!(len),
                 if have_inaccessible_fields { " and ignore the inaccessible fields" } else { "" }
@@ -1922,7 +1922,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         );
         err.span_suggestion(
             sp,
-            &format!(
+            format!(
                 "if you don't care about {these} missing field{s}, you can explicitly ignore {them}",
                 these = pluralize!("this", len),
                 s = pluralize!(len),

--- a/compiler/rustc_hir_typeck/src/place_op.rs
+++ b/compiler/rustc_hir_typeck/src/place_op.rs
@@ -73,16 +73,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let ty = self.resolve_vars_if_possible(ty);
         let mut err = self.tcx.sess.struct_span_err(
             span,
-            &format!("negative integers cannot be used to index on a `{ty}`"),
+            format!("negative integers cannot be used to index on a `{ty}`"),
         );
-        err.span_label(span, &format!("cannot use a negative integer for indexing on `{ty}`"));
+        err.span_label(span, format!("cannot use a negative integer for indexing on `{ty}`"));
         if let (hir::ExprKind::Path(..), Ok(snippet)) =
             (&base_expr.kind, self.tcx.sess.source_map().span_to_snippet(base_expr.span))
         {
             // `foo[-1]` to `foo[foo.len() - 1]`
             err.span_suggestion_verbose(
                 span.shrink_to_lo(),
-                &format!(
+                format!(
                     "to access an element starting from the end of the `{ty}`, compute the index",
                 ),
                 format!("{snippet}.len() "),

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -713,7 +713,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                 self.tcx.sess.delay_span_bug(
                     closure_span,
-                    &format!(
+                    format!(
                         "two identical projections: ({:?}, {:?})",
                         capture1.place.projections, capture2.place.projections
                     ),
@@ -863,7 +863,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             let indent = line2.split_once(|c: char| !c.is_whitespace()).unwrap_or_default().0;
                             lint.span_suggestion(
                                 closure_body_span.with_lo(closure_body_span.lo() + BytePos::from_usize(line1.len())).shrink_to_lo(),
-                                &diagnostic_msg,
+                                diagnostic_msg,
                                 format!("\n{indent}{migration_string};"),
                                 Applicability::MachineApplicable,
                             );
@@ -874,7 +874,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             // directly after the `{`.
                             lint.span_suggestion(
                                 closure_body_span.with_lo(closure_body_span.lo() + BytePos(1)).shrink_to_lo(),
-                                &diagnostic_msg,
+                                diagnostic_msg,
                                 format!(" {migration_string};"),
                                 Applicability::MachineApplicable,
                             );
@@ -882,7 +882,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             // This is a closure without braces around the body.
                             // We add braces to add the `let` before the body.
                             lint.multipart_suggestion(
-                                &diagnostic_msg,
+                                diagnostic_msg,
                                 vec![
                                     (closure_body_span.shrink_to_lo(), format!("{{ {migration_string}; ")),
                                     (closure_body_span.shrink_to_hi(), " }".to_string()),
@@ -893,7 +893,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     } else {
                         lint.span_suggestion(
                             closure_span,
-                            &diagnostic_msg,
+                            diagnostic_msg,
                             migration_string,
                             Applicability::HasPlaceholders
                         );
@@ -1519,7 +1519,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                 let span =
                     capture_info.path_expr_id.map_or(closure_span, |e| self.tcx.hir().span(e));
-                diag.span_note(span, &output_str);
+                diag.span_note(span, output_str);
             }
             diag.emit();
         }
@@ -1560,13 +1560,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             multi_span.push_span_label(path_span, path_label);
                             multi_span.push_span_label(capture_kind_span, capture_kind_label);
 
-                            diag.span_note(multi_span, &output_str);
+                            diag.span_note(multi_span, output_str);
                         } else {
                             let span = capture_info
                                 .path_expr_id
                                 .map_or(closure_span, |e| self.tcx.hir().span(e));
 
-                            diag.span_note(span, &output_str);
+                            diag.span_note(span, output_str);
                         };
                     }
                 }

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -227,7 +227,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                 // When encountering `return [0][0]` outside of a `fn` body we can encounter a base
                 // that isn't in the type table. We assume more relevant errors have already been
                 // emitted, so we delay an ICE if none have. (#64638)
-                self.tcx().sess.delay_span_bug(e.span, &format!("bad base: `{:?}`", base));
+                self.tcx().sess.delay_span_bug(e.span, format!("bad base: `{:?}`", base));
             }
             if let Some(ty::Ref(_, base_ty, _)) = base_ty {
                 let index_ty = typeck_results.expr_ty_adjusted_opt(index).unwrap_or_else(|| {
@@ -491,7 +491,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                     let err = self
                         .tcx()
                         .sess
-                        .struct_span_err(span, &format!("user substs: {:?}", user_substs));
+                        .struct_span_err(span, format!("user substs: {:?}", user_substs));
                     err.buffer(&mut errors_buffer);
                 }
             }

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -205,7 +205,7 @@ impl CanonicalizeMode for CanonicalizeQueryResponse {
                 // `delay_span_bug` to allow type error over an ICE.
                 canonicalizer.tcx.sess.delay_span_bug(
                     rustc_span::DUMMY_SP,
-                    &format!("unexpected region in query response: `{:?}`", r),
+                    format!("unexpected region in query response: `{:?}`", r),
                 );
                 r
             }

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -192,7 +192,7 @@ impl<'tcx> InferCtxt<'tcx> {
             self.tcx.check_tys_might_be_eq(canonical).map_err(|_| {
                 self.tcx.sess.delay_span_bug(
                     DUMMY_SP,
-                    &format!("cannot relate consts of different types (a={:?}, b={:?})", a, b,),
+                    format!("cannot relate consts of different types (a={:?}, b={:?})", a, b,),
                 )
             })
         });

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -282,9 +282,9 @@ fn emit_msg_span(
     let message = format!("{}{}{}", prefix, description, suffix);
 
     if let Some(span) = span {
-        err.span_note(span, &message);
+        err.span_note(span, message);
     } else {
-        err.note(&message);
+        err.note(message);
     }
 }
 
@@ -298,9 +298,9 @@ fn label_msg_span(
     let message = format!("{}{}{}", prefix, description, suffix);
 
     if let Some(span) = span {
-        err.span_label(span, &message);
+        err.span_label(span, message);
     } else {
-        err.note(&message);
+        err.note(message);
     }
 }
 
@@ -2395,7 +2395,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 );
             } else {
                 let consider = format!("{} `{}: {}`...", msg, bound_kind, sub);
-                err.help(&consider);
+                err.help(consider);
             }
         }
 
@@ -2625,7 +2625,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             );
             err.span_note(
                 sup_trace.cause.span,
-                &format!("...so that the {}", sup_trace.cause.as_requirement_str()),
+                format!("...so that the {}", sup_trace.cause.as_requirement_str()),
             );
 
             err.note_expected_found(&"", sup_expected, &"", sup_found);

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -299,7 +299,7 @@ pub fn suggest_new_region_bound(
                     if let Some(explicit_static) = &explicit_static {
                         err.span_suggestion_verbose(
                             span,
-                            &format!("{consider} `{ty}`'s {explicit_static}"),
+                            format!("{consider} `{ty}`'s {explicit_static}"),
                             &lifetime_name,
                             Applicability::MaybeIncorrect,
                         );
@@ -367,7 +367,7 @@ pub fn suggest_new_region_bound(
                         spans_suggs
                             .push((fn_return.span.shrink_to_hi(), format!(" + {name} ")));
                         err.multipart_suggestion_verbose(
-                            &format!(
+                            format!(
                                 "{declare} `{ty}` {captures}, {use_lt}",
                             ),
                             spans_suggs,
@@ -376,7 +376,7 @@ pub fn suggest_new_region_bound(
                     } else {
                         err.span_suggestion_verbose(
                             fn_return.span.shrink_to_hi(),
-                            &format!("{declare} `{ty}` {captures}, {explicit}",),
+                            format!("{declare} `{ty}` {captures}, {explicit}",),
                             &plus_lt,
                             Applicability::MaybeIncorrect,
                         );
@@ -387,7 +387,7 @@ pub fn suggest_new_region_bound(
                 if let LifetimeName::ImplicitObjectLifetimeDefault = lt.res {
                     err.span_suggestion_verbose(
                         fn_return.span.shrink_to_hi(),
-                        &format!(
+                        format!(
                             "{declare} the trait object {captures}, {explicit}",
                             declare = declare,
                             captures = captures,
@@ -404,7 +404,7 @@ pub fn suggest_new_region_bound(
                     if let Some(explicit_static) = &explicit_static {
                         err.span_suggestion_verbose(
                             lt.ident.span,
-                            &format!("{} the trait object's {}", consider, explicit_static),
+                            format!("{} the trait object's {}", consider, explicit_static),
                             &lifetime_name,
                             Applicability::MaybeIncorrect,
                         );

--- a/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
@@ -209,7 +209,7 @@ impl<T> Trait<T> for X {
                         if !sp.contains(p_span) {
                             diag.span_label(p_span, "this type parameter");
                         }
-                        diag.help(&format!(
+                        diag.help(format!(
                             "every closure has a distinct type and so could not always match the \
                              caller-chosen type of parameter `{}`",
                             p
@@ -248,7 +248,7 @@ impl<T> Trait<T> for X {
                             proj_ty,
                             values.expected,
                         )) {
-                            diag.help(&msg);
+                            diag.help(msg);
                             diag.note(
                                 "for more information, visit \
                                 https://doc.rust-lang.org/book/ch19-03-advanced-traits.html",
@@ -415,12 +415,12 @@ impl<T> Trait<T> for X {
         if !impl_comparison {
             // Generic suggestion when we can't be more specific.
             if callable_scope {
-                diag.help(&format!(
+                diag.help(format!(
                     "{} or calling a method that returns `{}`",
                     msg, values.expected
                 ));
             } else {
-                diag.help(&msg);
+                diag.help(msg);
             }
             diag.note(
                 "for more information, visit \
@@ -536,7 +536,7 @@ fn foo(&self) -> Self::T { String::new() }
             for (sp, label) in methods.into_iter() {
                 span.push_span_label(sp, label);
             }
-            diag.span_help(span, &msg);
+            diag.span_help(span, msg);
             return true;
         }
         false

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -824,7 +824,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
         // resolution errors here; delay ICE in favor of those errors.
         self.tcx().sess.delay_span_bug(
             self.var_infos[node_idx].origin.span(),
-            &format!(
+            format!(
                 "collect_error_for_expanding_node() could not find \
                  error for var {:?} in universe {:?}, lower_bounds={:#?}, \
                  upper_bounds={:#?}",

--- a/compiler/rustc_infer/src/infer/opaque_types/table.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/table.rs
@@ -42,7 +42,7 @@ impl<'tcx> Drop for OpaqueTypeStorage<'tcx> {
     fn drop(&mut self) {
         if !self.opaque_types.is_empty() {
             ty::tls::with(|tcx| {
-                tcx.sess.delay_span_bug(DUMMY_SP, &format!("{:?}", self.opaque_types))
+                tcx.sess.delay_span_bug(DUMMY_SP, format!("{:?}", self.opaque_types))
             });
         }
     }

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -256,7 +256,7 @@ where
                     // this point it never will be
                     self.tcx.sess.delay_span_bug(
                         origin.span(),
-                        &format!("unresolved inference variable in outlives: {:?}", v),
+                        format!("unresolved inference variable in outlives: {:?}", v),
                     );
                 }
             }

--- a/compiler/rustc_infer/src/infer/outlives/verify.rs
+++ b/compiler/rustc_infer/src/infer/outlives/verify.rs
@@ -179,7 +179,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
                 // this point it never will be
                 self.tcx.sess.delay_span_bug(
                     rustc_span::DUMMY_SP,
-                    &format!("unresolved inference variable in outlives: {:?}", v),
+                    format!("unresolved inference variable in outlives: {:?}", v),
                 );
                 // add a bound that never holds
                 VerifyBound::AnyBound(vec![])

--- a/compiler/rustc_infer/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/traits/error_reporting/mod.rs
@@ -73,7 +73,7 @@ pub fn report_object_safety_error<'tcx>(
                 format!("...because {}", violation.error_msg())
             };
             if spans.is_empty() {
-                err.note(&msg);
+                err.note(msg);
             } else {
                 for span in spans {
                     multi_span.push(span);

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -616,7 +616,7 @@ pub trait LintContext: Sized {
                         1 => ("an ", ""),
                         _ => ("", "s"),
                     };
-                    db.span_label(span, &format!(
+                    db.span_label(span, format!(
                         "this comment contains {}invisible unicode text flow control codepoint{}",
                         an,
                         s,
@@ -680,12 +680,12 @@ pub trait LintContext: Sized {
                     );
                 }
                 BuiltinLintDiagnostics::UnknownCrateTypes(span, note, sugg) => {
-                    db.span_suggestion(span, &note, sugg, Applicability::MaybeIncorrect);
+                    db.span_suggestion(span, note, sugg, Applicability::MaybeIncorrect);
                 }
                 BuiltinLintDiagnostics::UnusedImports(message, replaces, in_test_module) => {
                     if !replaces.is_empty() {
                         db.tool_only_multipart_suggestion(
-                            &message,
+                            message,
                             replaces,
                             Applicability::MachineApplicable,
                         );
@@ -720,13 +720,13 @@ pub trait LintContext: Sized {
                 }
                 BuiltinLintDiagnostics::MissingAbi(span, default_abi) => {
                     db.span_label(span, "ABI should be specified here");
-                    db.help(&format!("the default ABI is {}", default_abi.name()));
+                    db.help(format!("the default ABI is {}", default_abi.name()));
                 }
                 BuiltinLintDiagnostics::LegacyDeriveHelpers(span) => {
                     db.span_label(span, "the attribute is introduced here");
                 }
                 BuiltinLintDiagnostics::ProcMacroBackCompat(note) => {
-                    db.note(&note);
+                    db.note(note);
                 }
                 BuiltinLintDiagnostics::OrPatternsBackCompat(span,suggestion) => {
                     db.span_suggestion(span, "use pat_param to preserve semantics", suggestion, Applicability::MachineApplicable);
@@ -747,13 +747,13 @@ pub trait LintContext: Sized {
                 } => {
                     db.span_note(
                         invoc_span,
-                        &format!("the built-in attribute `{attr_name}` will be ignored, since it's applied to the macro invocation `{macro_name}`")
+                        format!("the built-in attribute `{attr_name}` will be ignored, since it's applied to the macro invocation `{macro_name}`")
                     );
                 }
                 BuiltinLintDiagnostics::TrailingMacro(is_trailing, name) => {
                     if is_trailing {
                         db.note("macro invocations at the end of a block are treated as expressions");
-                        db.note(&format!("to ignore the value produced by the macro, add a semicolon after the invocation of `{name}`"));
+                        db.note(format!("to ignore the value produced by the macro, add a semicolon after the invocation of `{name}`"));
                     }
                 }
                 BuiltinLintDiagnostics::BreakWithLabelAndLoop(span) => {
@@ -765,7 +765,7 @@ pub trait LintContext: Sized {
                     );
                 }
                 BuiltinLintDiagnostics::NamedAsmLabel(help) => {
-                    db.help(&help);
+                    db.help(help);
                     db.note("see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information");
                 },
                 BuiltinLintDiagnostics::UnexpectedCfg((name, name_span), None) => {
@@ -793,7 +793,7 @@ pub trait LintContext: Sized {
                             possibilities.sort();
 
                             let possibilities = possibilities.join(", ");
-                            db.note(&format!("expected values for `{name}` are: {possibilities}"));
+                            db.note(format!("expected values for `{name}` are: {possibilities}"));
                         }
 
                         // Suggest the most probable if we found one
@@ -801,7 +801,7 @@ pub trait LintContext: Sized {
                             db.span_suggestion(value_span, "did you mean", format!("\"{best_match}\""), Applicability::MaybeIncorrect);
                         }
                     } else {
-                        db.note(&format!("no expected value for `{name}`"));
+                        db.note(format!("no expected value for `{name}`"));
                         if name != sym::feature {
                             db.span_suggestion(name_span.shrink_to_hi().to(value_span), "remove the value", "", Applicability::MaybeIncorrect);
                         }

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -428,7 +428,7 @@ pub fn check_ast_node_inner<'a, T: EarlyLintPass>(
         for early_lint in lints {
             sess.delay_span_bug(
                 early_lint.span,
-                &format!(
+                format!(
                     "failed to process buffered lint here (dummy = {})",
                     id == ast::DUMMY_NODE_ID
                 ),

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -498,7 +498,7 @@ impl IntoDiagnostic<'_> for MultipleCandidates {
         diag.code(error_code!(E0464));
         diag.set_span(self.span);
         for (i, candidate) in self.candidates.iter().enumerate() {
-            diag.note(&format!("candidate #{}: {}", i + 1, candidate.display()));
+            diag.note(format!("candidate #{}: {}", i + 1, candidate.display()));
         }
         diag
     }

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -287,7 +287,7 @@ impl<'tcx> Collector<'tcx> {
                                 &sess.parse_sess,
                                 sym::$feature,
                                 span,
-                                &format!("linking modifier `{modifier}` is unstable"),
+                                format!("linking modifier `{modifier}` is unstable"),
                             )
                             .emit();
                         }

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -231,19 +231,19 @@ pub fn explain_lint_level_source(
     let name = lint.name_lower();
     match src {
         LintLevelSource::Default => {
-            err.note_once(&format!("`#[{}({})]` on by default", level.as_str(), name));
+            err.note_once(format!("`#[{}({})]` on by default", level.as_str(), name));
         }
         LintLevelSource::CommandLine(lint_flag_val, orig_level) => {
             let flag = orig_level.to_cmd_flag();
             let hyphen_case_lint_name = name.replace('_', "-");
             if lint_flag_val.as_str() == name {
-                err.note_once(&format!(
+                err.note_once(format!(
                     "requested on the command line with `{} {}`",
                     flag, hyphen_case_lint_name
                 ));
             } else {
                 let hyphen_case_flag_val = lint_flag_val.as_str().replace('_', "-");
-                err.note_once(&format!(
+                err.note_once(format!(
                     "`{} {}` implied by `{} {}`",
                     flag, hyphen_case_lint_name, flag, hyphen_case_flag_val
                 ));
@@ -256,7 +256,7 @@ pub fn explain_lint_level_source(
             err.span_note_once(span, "the lint level is defined here");
             if lint_attr_name.as_str() != name {
                 let level_str = level.as_str();
-                err.note_once(&format!(
+                err.note_once(format!(
                     "`#[{}({})]` implied by `#[{}({})]`",
                     level_str, name, level_str, lint_attr_name
                 ));
@@ -444,12 +444,12 @@ pub fn struct_lint_level(
             };
 
             if future_incompatible.explain_reason {
-                err.warn(&explanation);
+                err.warn(explanation);
             }
             if !future_incompatible.reference.is_empty() {
                 let citation =
                     format!("for more information, see {}", future_incompatible.reference);
-                err.note(&citation);
+                err.note(citation);
             }
         }
 

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -115,8 +115,8 @@ pub fn report_unstable(
         soft_handler(SOFT_UNSTABLE, span, &msg)
     } else {
         let mut err =
-            feature_err_issue(&sess.parse_sess, feature, span, GateIssue::Library(issue), &msg);
-        if let Some((inner_types, ref msg, sugg, applicability)) = suggestion {
+            feature_err_issue(&sess.parse_sess, feature, span, GateIssue::Library(issue), msg);
+        if let Some((inner_types, msg, sugg, applicability)) = suggestion {
             err.span_suggestion(inner_types, msg, sugg, applicability);
         }
         err.emit();
@@ -170,7 +170,7 @@ pub fn deprecation_suggestion(
     if let Some(suggestion) = suggestion {
         diag.span_suggestion_verbose(
             span,
-            &format!("replace the use of the deprecated {}", kind),
+            format!("replace the use of the deprecated {}", kind),
             suggestion,
             Applicability::MachineApplicable,
         );
@@ -599,7 +599,7 @@ impl<'tcx> TyCtxt<'tcx> {
             |span, def_id| {
                 // The API could be uncallable for other reasons, for example when a private module
                 // was referenced.
-                self.sess.delay_span_bug(span, &format!("encountered unmarked API: {:?}", def_id));
+                self.sess.delay_span_bug(span, format!("encountered unmarked API: {:?}", def_id));
             },
         )
     }

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -1010,10 +1010,7 @@ impl ObjectSafetyViolation {
             ) => {
                 err.span_suggestion(
                     *span,
-                    &format!(
-                        "consider changing method `{}`'s `self` parameter to be `&self`",
-                        name
-                    ),
+                    format!("consider changing method `{}`'s `self` parameter to be `&self`", name),
                     "&Self",
                     Applicability::MachineApplicable,
                 );
@@ -1021,7 +1018,7 @@ impl ObjectSafetyViolation {
             ObjectSafetyViolation::AssocConst(name, _)
             | ObjectSafetyViolation::GAT(name, _)
             | ObjectSafetyViolation::Method(name, ..) => {
-                err.help(&format!("consider moving `{}` to another trait", name));
+                err.help(format!("consider moving `{}` to another trait", name));
             }
         }
     }

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -114,7 +114,7 @@ impl<'tcx> Const<'tcx> {
                 Err(e) => {
                     tcx.sess.delay_span_bug(
                         expr.span,
-                        &format!("Const::from_anon_const: couldn't lit_to_const {:?}", e),
+                        format!("Const::from_anon_const: couldn't lit_to_const {:?}", e),
                     );
                 }
             }

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -139,7 +139,7 @@ pub fn suggest_arbitrary_trait_bound<'tcx>(
     // Suggest a where clause bound for a non-type parameter.
     err.span_suggestion_verbose(
         generics.tail_span_for_predicate_suggestion(),
-        &format!(
+        format!(
             "consider {} `where` clause, but there might be an alternative better way to express \
              this requirement",
             if generics.where_clause_span.is_empty() { "introducing a" } else { "extending the" },
@@ -242,7 +242,7 @@ pub fn suggest_constraining_type_params<'a>(
 
                 err.span_label(
                     param.span,
-                    &format!("this type parameter needs to be `{}`", constraint),
+                    format!("this type parameter needs to be `{}`", constraint),
                 );
                 suggest_removing_unsized_bound(generics, &mut suggestions, param, def_id);
             }

--- a/compiler/rustc_middle/src/ty/opaque_types.rs
+++ b/compiler/rustc_middle/src/ty/opaque_types.rs
@@ -177,7 +177,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ReverseMapper<'tcx> {
                                 .sess
                                 .struct_span_err(
                                     self.span,
-                                    &format!(
+                                    format!(
                                         "type parameter `{}` is part of concrete type but not \
                                           used in parameter list for the `impl Trait` type alias",
                                         ty

--- a/compiler/rustc_middle/src/util/bug.rs
+++ b/compiler/rustc_middle/src/util/bug.rs
@@ -31,8 +31,8 @@ fn opt_span_bug_fmt<S: Into<MultiSpan>>(
     tls::with_opt(move |tcx| {
         let msg = format!("{}: {}", location, args);
         match (tcx, span) {
-            (Some(tcx), Some(span)) => tcx.sess.diagnostic().span_bug(span, &msg),
-            (Some(tcx), None) => tcx.sess.diagnostic().bug(&msg),
+            (Some(tcx), Some(span)) => tcx.sess.diagnostic().span_bug(span, msg),
+            (Some(tcx), None) => tcx.sess.diagnostic().bug(msg),
             (None, _) => panic_any(msg),
         }
     })

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -672,7 +672,7 @@ fn non_exhaustive_match<'p, 'tcx>(
         ty::Adt(def, _) if def.is_variant_list_non_exhaustive() && !def.did().is_local());
 
     adt_defined_here(cx, &mut err, scrut_ty, &witnesses);
-    err.note(&format!(
+    err.note(format!(
         "the matched value is of type `{}`{}",
         scrut_ty,
         if is_variant_list_non_exhaustive { ", which is marked as non-exhaustive" } else { "" }
@@ -682,13 +682,13 @@ fn non_exhaustive_match<'p, 'tcx>(
         && witnesses.len() == 1
         && matches!(witnesses[0].ctor(), Constructor::NonExhaustive)
     {
-        err.note(&format!(
+        err.note(format!(
             "`{}` does not have a fixed maximum value, so a wildcard `_` is necessary to match \
              exhaustively",
             scrut_ty,
         ));
         if cx.tcx.sess.is_nightly_build() {
-            err.help(&format!(
+            err.help(format!(
                 "add `#![feature(precise_pointer_size_matching)]` to the crate attributes to \
                  enable precise `{}` matching",
                 scrut_ty,
@@ -793,9 +793,9 @@ fn non_exhaustive_match<'p, 'tcx>(
         },
     );
     if let Some((span, sugg)) = suggestion {
-        err.span_suggestion_verbose(span, &msg, sugg, Applicability::HasPlaceholders);
+        err.span_suggestion_verbose(span, msg, sugg, Applicability::HasPlaceholders);
     } else {
-        err.help(&msg);
+        err.help(msg);
     }
     err.emit();
 }
@@ -857,7 +857,7 @@ fn adt_defined_here<'p, 'tcx>(
         for pat in spans {
             span.push_span_label(pat, "not covered");
         }
-        err.span_note(span, &format!("`{}` defined here", ty));
+        err.span_note(span, format!("`{}` defined here", ty));
     }
 }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -229,7 +229,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                         self.lower_pattern_range(ty, lc, hc, end, lo_span, lo_expr, hi_expr)
                     }
                     None => {
-                        let msg = &format!(
+                        let msg = format!(
                             "found bad range pattern `{:?}` outside of error recovery",
                             (&lo, &hi),
                         );

--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -366,7 +366,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                     if maybe_dead {
                         self.tcx.sess.delay_span_bug(
                             terminator.source_info.span,
-                            &format!(
+                            format!(
                                 "drop of untracked, uninitialized value {:?}, place {:?} ({:?})",
                                 bb, place, path
                             ),
@@ -440,7 +440,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                             ) {
                                 self.tcx.sess.delay_span_bug(
                                     terminator.source_info.span,
-                                    &format!("drop of untracked value {:?}", bb),
+                                    format!("drop of untracked value {:?}", bb),
                                 );
                             }
                             // A drop and replace behind a pointer/array/whatever.

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -865,7 +865,7 @@ fn sanitize_witness<'tcx>(
         _ => {
             tcx.sess.delay_span_bug(
                 body.span,
-                &format!("unexpected generator witness type {:?}", witness.kind()),
+                format!("unexpected generator witness type {:?}", witness.kind()),
             );
             return;
         }
@@ -1451,8 +1451,7 @@ impl<'tcx> MirPass<'tcx> for StateTransform {
                 )
             }
             _ => {
-                tcx.sess
-                    .delay_span_bug(body.span, &format!("unexpected generator type {}", gen_ty));
+                tcx.sess.delay_span_bug(body.span, format!("unexpected generator type {}", gen_ty));
                 return;
             }
         };

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -321,7 +321,7 @@ impl<'a> StringReader<'a> {
     ) -> DiagnosticBuilder<'a, !> {
         self.sess
             .span_diagnostic
-            .struct_span_fatal(self.mk_sp(from_pos, to_pos), &format!("{}: {}", m, escaped_char(c)))
+            .struct_span_fatal(self.mk_sp(from_pos, to_pos), format!("{}: {}", m, escaped_char(c)))
     }
 
     /// Detect usages of Unicode codepoints changing the direction of the text on screen and loudly
@@ -542,7 +542,7 @@ impl<'a> StringReader<'a> {
         err.span_label(self.mk_sp(start, start), "unterminated raw string");
 
         if n_hashes > 0 {
-            err.note(&format!(
+            err.note(format!(
                 "this raw string should be terminated with `\"{}`",
                 "#".repeat(n_hashes as usize)
             ));

--- a/compiler/rustc_parse/src/lexer/tokentrees.rs
+++ b/compiler/rustc_parse/src/lexer/tokentrees.rs
@@ -199,8 +199,7 @@ impl<'a> TokenTreesReader<'a> {
         // matching opening delimiter).
         let token_str = token_to_string(&self.token);
         let msg = format!("unexpected closing delimiter: `{}`", token_str);
-        let mut err =
-            self.string_reader.sess.span_diagnostic.struct_span_err(self.token.span, &msg);
+        let mut err = self.string_reader.sess.span_diagnostic.struct_span_err(self.token.span, msg);
 
         report_suspicious_mismatch_block(
             &mut err,

--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -129,7 +129,7 @@ pub(crate) fn emit_unescape_error(
             let label =
                 if mode.is_byte() { "unknown byte escape" } else { "unknown character escape" };
             let ec = escaped_char(c);
-            let mut diag = handler.struct_span_err(span, &format!("{}: `{}`", label, ec));
+            let mut diag = handler.struct_span_err(span, format!("{}: `{}`", label, ec));
             diag.span_label(span, label);
             if c == '{' || c == '}' && !mode.is_byte() {
                 diag.help(
@@ -180,13 +180,13 @@ pub(crate) fn emit_unescape_error(
             } else {
                 String::new()
             };
-            err.span_label(span, &format!("must be ASCII{}", postfix));
+            err.span_label(span, format!("must be ASCII{}", postfix));
             // Note: the \\xHH suggestions are not given for raw byte string
             // literals, because they are araw and so cannot use any escapes.
             if (c as u32) <= 0xFF && mode != Mode::RawByteStr {
                 err.span_suggestion(
                     span,
-                    &format!(
+                    format!(
                         "if you meant to use the unicode code point for {:?}, use a \\xHH escape",
                         c
                     ),
@@ -200,10 +200,7 @@ pub(crate) fn emit_unescape_error(
                 utf8.push(c);
                 err.span_suggestion(
                     span,
-                    &format!(
-                        "if you meant to use the UTF-8 encoding of {:?}, use \\xHH escapes",
-                        c
-                    ),
+                    format!("if you meant to use the UTF-8 encoding of {:?}, use \\xHH escapes", c),
                     utf8.as_bytes()
                         .iter()
                         .map(|b: &u8| format!("\\x{:X}", *b))

--- a/compiler/rustc_parse/src/lexer/unicode_chars.rs
+++ b/compiler/rustc_parse/src/lexer/unicode_chars.rs
@@ -350,7 +350,7 @@ pub(super) fn check_for_substitution(
 
     let Some((_, ascii_name, token)) = ASCII_ARRAY.iter().find(|&&(s, _, _)| s == ascii_str) else {
         let msg = format!("substitution character not found for '{}'", ch);
-        reader.sess.span_diagnostic.span_bug_no_panic(span, &msg);
+        reader.sess.span_diagnostic.span_bug_no_panic(span, msg);
         return (None, None);
     };
 

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -153,7 +153,7 @@ fn try_file_to_source_file(
 ) -> Result<Lrc<SourceFile>, Diagnostic> {
     sess.source_map().load_file(path).map_err(|e| {
         let msg = format!("couldn't read {}: {}", path.display(), e);
-        let mut diag = Diagnostic::new(Level::Fatal, &msg);
+        let mut diag = Diagnostic::new(Level::Fatal, msg);
         if let Some(sp) = spanopt {
             diag.set_span(sp);
         }
@@ -190,7 +190,7 @@ pub fn maybe_file_to_stream(
     override_span: Option<Span>,
 ) -> Result<TokenStream, Vec<Diagnostic>> {
     let src = source_file.src.as_ref().unwrap_or_else(|| {
-        sess.span_diagnostic.bug(&format!(
+        sess.span_diagnostic.bug(format!(
             "cannot lex `source_file` without source: {}",
             sess.source_map().filename_for_diagnostics(&source_file.name)
         ));
@@ -247,7 +247,7 @@ pub fn parse_cfg_attr(
             match parse_in(parse_sess, tokens.clone(), "`cfg_attr` input", |p| p.parse_cfg_attr()) {
                 Ok(r) => return Some(r),
                 Err(mut e) => {
-                    e.help(&format!("the valid syntax is `{}`", CFG_ATTR_GRAMMAR_HELP))
+                    e.help(format!("the valid syntax is `{}`", CFG_ATTR_GRAMMAR_HELP))
                         .note(CFG_ATTR_NOTE_REF)
                         .emit();
                 }

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -207,11 +207,11 @@ struct MultiSugg {
 
 impl MultiSugg {
     fn emit(self, err: &mut Diagnostic) {
-        err.multipart_suggestion(&self.msg, self.patches, self.applicability);
+        err.multipart_suggestion(self.msg, self.patches, self.applicability);
     }
 
     fn emit_verbose(self, err: &mut Diagnostic) {
-        err.multipart_suggestion_verbose(&self.msg, self.patches, self.applicability);
+        err.multipart_suggestion_verbose(self.msg, self.patches, self.applicability);
     }
 }
 
@@ -591,13 +591,13 @@ impl<'a> Parser<'a> {
         };
         self.last_unexpected_token_span = Some(self.token.span);
         // FIXME: translation requires list formatting (for `expect`)
-        let mut err = self.struct_span_err(self.token.span, &msg_exp);
+        let mut err = self.struct_span_err(self.token.span, msg_exp);
 
         if let TokenKind::Ident(symbol, _) = &self.prev_token.kind {
             if ["def", "fun", "func", "function"].contains(&symbol.as_str()) {
                 err.span_suggestion_short(
                     self.prev_token.span,
-                    &format!("write `fn` instead of `{symbol}` to declare a function"),
+                    format!("write `fn` instead of `{symbol}` to declare a function"),
                     "fn",
                     Applicability::MachineApplicable,
                 );
@@ -695,13 +695,13 @@ impl<'a> Parser<'a> {
                 err.set_span(span);
                 err.span_suggestion(
                     span,
-                    &format!("remove the extra `#`{}", pluralize!(count)),
+                    format!("remove the extra `#`{}", pluralize!(count)),
                     "",
                     Applicability::MachineApplicable,
                 );
                 err.span_label(
                     str_span,
-                    &format!("this raw string started with {n_hashes} `#`{}", pluralize!(n_hashes)),
+                    format!("this raw string started with {n_hashes} `#`{}", pluralize!(n_hashes)),
                 );
                 true
             }
@@ -1360,12 +1360,12 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, P<Expr>> {
         let mut err = self.struct_span_err(
             op_span,
-            &format!("Rust has no {} {} operator", kind.fixity, kind.op.name()),
+            format!("Rust has no {} {} operator", kind.fixity, kind.op.name()),
         );
-        err.span_label(op_span, &format!("not a valid {} operator", kind.fixity));
+        err.span_label(op_span, format!("not a valid {} operator", kind.fixity));
 
         let help_base_case = |mut err: DiagnosticBuilder<'_, _>, base| {
-            err.help(&format!("use `{}= 1` instead", kind.op.chr()));
+            err.help(format!("use `{}= 1` instead", kind.op.chr()));
             err.emit();
             Ok(base)
         };
@@ -1554,7 +1554,7 @@ impl<'a> Parser<'a> {
                 _ => this_token_str,
             },
         );
-        let mut err = self.struct_span_err(sp, &msg);
+        let mut err = self.struct_span_err(sp, msg);
         let label_exp = format!("expected `{token_str}`");
         let sm = self.sess.source_map();
         if !sm.is_multiline(prev_sp.until(sp)) {
@@ -1705,7 +1705,7 @@ impl<'a> Parser<'a> {
                     Applicability::MachineApplicable,
                 );
             }
-            err.span_suggestion(lo.shrink_to_lo(), &format!("{prefix}you can still access the deprecated `try!()` macro using the \"raw identifier\" syntax"), "r#", Applicability::MachineApplicable);
+            err.span_suggestion(lo.shrink_to_lo(), format!("{prefix}you can still access the deprecated `try!()` macro using the \"raw identifier\" syntax"), "r#", Applicability::MachineApplicable);
             err.emit();
             Ok(self.mk_expr_err(lo.to(hi)))
         } else {
@@ -2060,7 +2060,7 @@ impl<'a> Parser<'a> {
                 format!("expected expression, found {}", super::token_descr(&self.token),),
             ),
         };
-        let mut err = self.struct_span_err(span, &msg);
+        let mut err = self.struct_span_err(span, msg);
         let sp = self.sess.source_map().start_point(self.token.span);
         if let Some(sp) = self.sess.ambiguous_block_expr_parse.borrow().get(&sp) {
             err.subdiagnostic(ExprParenthesesNeeded::surrounding(*sp));
@@ -2131,7 +2131,7 @@ impl<'a> Parser<'a> {
         // arguments after a comma.
         let mut err = self.struct_span_err(
             self.token.span,
-            &format!("expected one of `,` or `>`, found {}", super::token_descr(&self.token)),
+            format!("expected one of `,` or `>`, found {}", super::token_descr(&self.token)),
         );
         err.span_label(self.token.span, "expected one of `,` or `>`");
         match self.recover_const_arg(arg.span(), err) {
@@ -2558,7 +2558,7 @@ impl<'a> Parser<'a> {
         let mut err = self.struct_span_err(comma_span, "unexpected `,` in pattern");
         if let Ok(seq_snippet) = self.span_to_snippet(seq_span) {
             err.multipart_suggestion(
-                &format!(
+                format!(
                     "try adding parentheses to match on a tuple{}",
                     if let CommaRecoveryMode::LikelyTuple = rt { "" } else { "..." },
                 ),

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -855,7 +855,7 @@ impl<'a> Parser<'a> {
                     _ => unreachable!("parse_dot_or_call_expr_with_ shouldn't produce this"),
                 }
             );
-            let mut err = self.struct_span_err(span, &msg);
+            let mut err = self.struct_span_err(span, msg);
 
             let suggest_parens = |err: &mut Diagnostic| {
                 let suggestions = vec![
@@ -1803,7 +1803,7 @@ impl<'a> Parser<'a> {
         let token = self.token.clone();
         let err = |self_: &Self| {
             let msg = format!("unexpected token: {}", super::token_descr(&token));
-            self_.struct_span_err(token.span, &msg)
+            self_.struct_span_err(token.span, msg)
         };
         // On an error path, eagerly consider a lifetime to be an unclosed character lit
         if self.token.is_lifetime() {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -71,7 +71,7 @@ impl<'a> Parser<'a> {
         if !self.eat(term) {
             let token_str = super::token_descr(&self.token);
             if !self.maybe_consume_incorrect_semicolon(&items) {
-                let msg = &format!("expected item, found {token_str}");
+                let msg = format!("expected item, found {token_str}");
                 let mut err = self.struct_span_err(self.token.span, msg);
                 let label = if self.is_kw_followed_by_ident(kw::Let) {
                     "consider using `const` or `static` instead of `let` for global variables"
@@ -1429,7 +1429,7 @@ impl<'a> Parser<'a> {
             VariantData::Struct(fields, recovered)
         } else {
             let token_str = super::token_descr(&self.token);
-            let msg = &format!("expected `where` or `{{` after union name, found {token_str}");
+            let msg = format!("expected `where` or `{{` after union name, found {token_str}");
             let mut err = self.struct_span_err(self.token.span, msg);
             err.span_label(self.token.span, "expected `where` or `{` after union name");
             return Err(err);
@@ -1465,7 +1465,7 @@ impl<'a> Parser<'a> {
             self.eat(&token::CloseDelim(Delimiter::Brace));
         } else {
             let token_str = super::token_descr(&self.token);
-            let msg = &format!(
+            let msg = format!(
                 "expected {}`{{` after struct name, found {}",
                 if parsed_where { "" } else { "`where`, or " },
                 token_str
@@ -1602,7 +1602,7 @@ impl<'a> Parser<'a> {
                 let sp = self.prev_token.span.shrink_to_hi();
                 let mut err = self.struct_span_err(
                     sp,
-                    &format!("expected `,`, or `}}`, found {}", super::token_descr(&self.token)),
+                    format!("expected `,`, or `}}`, found {}", super::token_descr(&self.token)),
                 );
 
                 // Try to recover extra trailing angle brackets
@@ -1740,7 +1740,7 @@ impl<'a> Parser<'a> {
                     Ok(_) => {
                         let mut err = self.struct_span_err(
                             lo.to(self.prev_token.span),
-                            &format!("functions are not allowed in {adt_ty} definitions"),
+                            format!("functions are not allowed in {adt_ty} definitions"),
                         );
                         err.help(
                             "unlike in C++, Java, and C#, functions are declared in `impl` blocks",
@@ -1759,7 +1759,7 @@ impl<'a> Parser<'a> {
                     Ok((ident, _)) => {
                         let mut err = self.struct_span_err(
                             lo.with_hi(ident.span.hi()),
-                            &format!("structs are not allowed in {adt_ty} definitions"),
+                            format!("structs are not allowed in {adt_ty} definitions"),
                         );
                         err.help("consider creating a new `struct` definition instead of nesting");
                         err
@@ -2228,11 +2228,11 @@ impl<'a> Parser<'a> {
 
                         err.span_suggestion(
                             self.token.uninterpolated_span(),
-                            &format!("`{original_kw}` already used earlier, remove this one"),
+                            format!("`{original_kw}` already used earlier, remove this one"),
                             "",
                             Applicability::MachineApplicable,
                         )
-                        .span_note(original_sp, &format!("`{original_kw}` first seen here"));
+                        .span_note(original_sp, format!("`{original_kw}` first seen here"));
                     }
                     // The keyword has not been seen yet, suggest correct placement in the function front matter
                     else if let Some(WrongKw::Misplaced(correct_pos_sp)) = wrong_kw {
@@ -2243,7 +2243,7 @@ impl<'a> Parser<'a> {
 
                             err.span_suggestion(
                                     correct_pos_sp.to(misplaced_qual_sp),
-                                    &format!("`{misplaced_qual}` must come before `{current_qual}`"),
+                                    format!("`{misplaced_qual}` must come before `{current_qual}`"),
                                     format!("{misplaced_qual} {current_qual}"),
                                     Applicability::MachineApplicable,
                                 ).note("keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`");
@@ -2267,7 +2267,7 @@ impl<'a> Parser<'a> {
                             if matches!(orig_vis.kind, VisibilityKind::Inherited) {
                                 err.span_suggestion(
                                     sp_start.to(self.prev_token.span),
-                                    &format!("visibility `{vs}` must come before `{snippet}`"),
+                                    format!("visibility `{vs}` must come before `{snippet}`"),
                                     format!("{vs} {snippet}"),
                                     Applicability::MachineApplicable,
                                 );

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -905,7 +905,7 @@ impl<'a> Parser<'a> {
                                 expect_err
                                     .span_suggestion_verbose(
                                         self.prev_token.span.shrink_to_hi().until(self.token.span),
-                                        &msg,
+                                        msg,
                                         " @ ",
                                         Applicability::MaybeIncorrect,
                                     )
@@ -921,7 +921,7 @@ impl<'a> Parser<'a> {
                                     expect_err
                                         .span_suggestion_short(
                                             sp,
-                                            &format!("missing `{}`", token_str),
+                                            format!("missing `{}`", token_str),
                                             token_str,
                                             Applicability::MaybeIncorrect,
                                         )

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -444,7 +444,7 @@ impl<'a> Parser<'a> {
                         super::token_descr(&self_.token)
                     );
 
-                    let mut err = self_.struct_span_err(self_.token.span, &msg);
+                    let mut err = self_.struct_span_err(self_.token.span, msg);
                     err.span_label(self_.token.span, format!("expected {}", expected));
                     err
                 });
@@ -680,7 +680,7 @@ impl<'a> Parser<'a> {
         let expected = Expected::to_string_or_fallback(expected);
         let msg = format!("expected {}, found {}", expected, super::token_descr(&self.token));
 
-        let mut err = self.struct_span_err(self.token.span, &msg);
+        let mut err = self.struct_span_err(self.token.span, msg);
         err.span_label(self.token.span, format!("expected {}", expected));
 
         let sp = self.sess.source_map().start_point(self.token.span);
@@ -978,7 +978,7 @@ impl<'a> Parser<'a> {
                     break;
                 }
                 let token_str = super::token_descr(&self.token);
-                let msg = &format!("expected `}}`, found {}", token_str);
+                let msg = format!("expected `}}`, found {}", token_str);
                 let mut err = self.struct_span_err(self.token.span, msg);
 
                 err.span_label(self.token.span, "expected `}`");

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -679,14 +679,14 @@ impl<'a> Parser<'a> {
                     );
                     err.span_suggestion(
                         eq.to(before_next),
-                        &format!("remove the `=` if `{}` is a type", ident),
+                        format!("remove the `=` if `{}` is a type", ident),
                         "",
                         Applicability::MaybeIncorrect,
                     )
                 } else {
                     err.span_label(
                         self.token.span,
-                        &format!("expected type, found {}", super::token_descr(&self.token)),
+                        format!("expected type, found {}", super::token_descr(&self.token)),
                     )
                 };
                 return Err(err);

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -634,7 +634,7 @@ impl<'a> Parser<'a> {
 
                                 e.span_suggestion(
                                     sp.with_hi(sp.lo() + BytePos(marker.len() as u32)),
-                                    &format!(
+                                    format!(
                                         "add a space before `{}` to use a regular comment",
                                         doc_comment_marker,
                                     ),

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -315,7 +315,7 @@ impl<'a> Parser<'a> {
             }
         } else {
             let msg = format!("expected type, found {}", super::token_descr(&self.token));
-            let mut err = self.struct_span_err(self.token.span, &msg);
+            let mut err = self.struct_span_err(self.token.span, msg);
             err.span_label(self.token.span, "expected type");
             return Err(err);
         };

--- a/compiler/rustc_parse/src/validate_attr.rs
+++ b/compiler/rustc_parse/src/validate_attr.rs
@@ -189,7 +189,7 @@ fn emit_malformed_attribute(
         sess.buffer_lint(&ILL_FORMED_ATTRIBUTE_INPUT, span, ast::CRATE_NODE_ID, &msg);
     } else {
         sess.span_diagnostic
-            .struct_span_err(span, &error_msg)
+            .struct_span_err(span, error_msg)
             .span_suggestions(
                 span,
                 if suggestions.len() == 1 {

--- a/compiler/rustc_passes/src/check_const.rs
+++ b/compiler/rustc_passes/src/check_const.rs
@@ -148,7 +148,7 @@ impl<'tcx> CheckConstVisitor<'tcx> {
             [missing_primary, ref missing_secondary @ ..] => {
                 let msg =
                     format!("{} is not allowed in a `{}`", expr.name(), const_kind.keyword_name());
-                let mut err = feature_err(&tcx.sess.parse_sess, *missing_primary, span, &msg);
+                let mut err = feature_err(&tcx.sess.parse_sess, *missing_primary, span, msg);
 
                 // If multiple feature gates would be required to enable this expression, include
                 // them as help messages. Don't emit a separate error for each missing feature gate.
@@ -161,7 +161,7 @@ impl<'tcx> CheckConstVisitor<'tcx> {
                             "add `#![feature({})]` to the crate attributes to enable",
                             gate,
                         );
-                        err.help(&note);
+                        err.help(note);
                     }
                 }
 

--- a/compiler/rustc_passes/src/hir_id_validator.rs
+++ b/compiler/rustc_passes/src/hir_id_validator.rs
@@ -31,7 +31,7 @@ pub fn check_crate(tcx: TyCtxt<'_>) {
 
         if !errors.is_empty() {
             let message = errors.iter().fold(String::new(), |s1, s2| s1 + "\n" + s2);
-            tcx.sess.delay_span_bug(rustc_span::DUMMY_SP, &message);
+            tcx.sess.delay_span_bug(rustc_span::DUMMY_SP, message);
         }
     }
 }

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -633,7 +633,7 @@ pub fn print_query_stack<Qcx: QueryContext>(
         };
         let mut diag = Diagnostic::new(
             Level::FailureNote,
-            &format!("#{} [{:?}] {}", i, query_info.query.dep_kind, query_info.query.description),
+            format!("#{} [{:?}] {}", i, query_info.query.dep_kind, query_info.query.description),
         );
         diag.span = query_info.job.span.into();
         handler.force_print_diagnostic(diag);

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1002,7 +1002,7 @@ impl<'a, 'b, 'tcx> BuildReducedGraphVisitor<'a, 'b, 'tcx> {
             let msg = format!("`{}` is already in scope", name);
             let note =
                 "macro-expanded `#[macro_use]`s may not shadow existing macros (see RFC 1560)";
-            self.r.tcx.sess.struct_span_err(span, &msg).note(note).emit();
+            self.r.tcx.sess.struct_span_err(span, msg).note(note).emit();
         }
     }
 

--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -418,7 +418,7 @@ impl Resolver<'_, '_> {
                 UNUSED_IMPORTS,
                 unused.use_tree_id,
                 ms,
-                &msg,
+                msg,
                 BuiltinLintDiagnostics::UnusedImports(fix_msg.into(), fixes, test_module_span),
             );
         }

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -238,7 +238,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             },
         };
 
-        err.note(&format!(
+        err.note(format!(
             "`{}` must be defined only once in the {} namespace of this {}",
             name,
             ns.descr(),
@@ -683,7 +683,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                              making the path in the pattern qualified: `path::to::ModOrType::{}`",
                             name,
                         );
-                        err.span_help(span, &help_msg);
+                        err.span_help(span, help_msg);
                     }
                     show_candidates(
                         self.tcx,
@@ -783,10 +783,10 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
                 if let Some((suggestions, msg, applicability)) = suggestion {
                     if suggestions.is_empty() {
-                        err.help(&msg);
+                        err.help(msg);
                         return err;
                     }
-                    err.multipart_suggestion(&msg, suggestions, applicability);
+                    err.multipart_suggestion(msg, suggestions, applicability);
                 }
 
                 err
@@ -930,7 +930,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             } => {
                 let mut err = self.tcx.sess.struct_span_err_with_code(
                     span,
-                    &format!(
+                    format!(
                         "item `{}` is an associated {}, which doesn't match its trait `{}`",
                         name, kind, trait_path,
                     ),
@@ -1359,7 +1359,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
         if macro_kind == MacroKind::Derive && (ident.name == sym::Send || ident.name == sym::Sync) {
             let msg = format!("unsafe traits like `{}` should be implemented explicitly", ident);
-            err.span_note(ident.span, &msg);
+            err.span_note(ident.span, msg);
             return;
         }
         if self.macro_names.contains(&ident.normalize_to_macros_2_0()) {
@@ -1419,7 +1419,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     if !import.span.is_dummy() {
                         err.span_note(
                             import.span,
-                            &format!("`{}` is imported here, but it is {}", ident, desc),
+                            format!("`{}` is imported here, but it is {}", ident, desc),
                         );
                         // Silence the 'unused import' warning we might get,
                         // since this diagnostic already covers that import.
@@ -1427,7 +1427,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         return;
                     }
                 }
-                err.note(&format!("`{}` is in scope, but it is {}", ident, desc));
+                err.note(format!("`{}` is in scope, but it is {}", ident, desc));
                 return;
             }
         }
@@ -1474,7 +1474,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
             err.span_label(
                 self.tcx.sess.source_map().guess_head_span(def_span),
-                &format!(
+                format!(
                     "{}{} `{}` defined here",
                     prefix,
                     suggestion.res.descr(),
@@ -1492,7 +1492,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 format!("maybe you meant this {}", suggestion.res.descr())
             }
         };
-        err.span_suggestion(span, &msg, suggestion.candidate, Applicability::MaybeIncorrect);
+        err.span_suggestion(span, msg, suggestion.candidate, Applicability::MaybeIncorrect);
         true
     }
 
@@ -1534,7 +1534,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
         let mut err = struct_span_err!(self.tcx.sess, ident.span, E0659, "`{ident}` is ambiguous");
         err.span_label(ident.span, "ambiguous name");
-        err.note(&format!("ambiguous because of {}", kind.descr()));
+        err.note(format!("ambiguous because of {}", kind.descr()));
 
         let mut could_refer_to = |b: &NameBinding<'_>, misc: AmbiguityErrorMisc, also: &str| {
             let what = self.binding_description(b, ident, misc == AmbiguityErrorMisc::FromPrelude);
@@ -1562,10 +1562,10 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 AmbiguityErrorMisc::FromPrelude | AmbiguityErrorMisc::None => {}
             }
 
-            err.span_note(b.span, &note_msg);
+            err.span_note(b.span, note_msg);
             for (i, help_msg) in help_msgs.iter().enumerate() {
                 let or = if i == 0 { "" } else { "or " };
-                err.help(&format!("{}{}", or, help_msg));
+                err.help(format!("{}{}", or, help_msg));
             }
         };
 
@@ -1608,7 +1608,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         let descr = get_descr(binding);
         let mut err =
             struct_span_err!(self.tcx.sess, ident.span, E0603, "{} `{}` is private", descr, ident);
-        err.span_label(ident.span, &format!("private {}", descr));
+        err.span_label(ident.span, format!("private {}", descr));
 
         let mut non_exhaustive = None;
         // If an ADT is foreign and marked as `non_exhaustive`, then that's
@@ -1623,7 +1623,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             err.span_label(span, "a constructor is private if any of the fields is private");
             if let Res::Def(_, d) = res && let Some(fields) = self.field_visibility_spans.get(&d) {
                 err.multipart_suggestion_verbose(
-                    &format!(
+                    format!(
                         "consider making the field{} publicly accessible",
                         pluralize!(fields.len())
                     ),
@@ -1676,7 +1676,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     format!("cannot be constructed because it is `#[non_exhaustive]`"),
                 );
             }
-            err.span_note(note_span, &msg);
+            err.span_note(note_span, msg);
         }
 
         err.emit();
@@ -2444,7 +2444,7 @@ fn show_candidates(
         };
 
         for note in accessible_path_strings.iter().flat_map(|cand| cand.3.as_ref()) {
-            err.note(note);
+            err.note(note.clone());
         }
 
         if let Some(span) = use_placement_span {
@@ -2452,7 +2452,7 @@ fn show_candidates(
                 DiagnosticMode::Pattern => {
                     err.span_suggestions(
                         span,
-                        &msg,
+                        msg,
                         accessible_path_strings.into_iter().map(|a| a.0),
                         Applicability::MaybeIncorrect,
                     );
@@ -2471,7 +2471,7 @@ fn show_candidates(
 
             err.span_suggestions_with_style(
                 span,
-                &msg,
+                msg,
                 accessible_path_strings.into_iter().map(|a| a.0),
                 Applicability::MaybeIncorrect,
                 SuggestionStyle::ShowAlways,
@@ -2481,7 +2481,7 @@ fn show_candidates(
                 if sp.can_be_used_for_suggestions() {
                     err.span_suggestion_verbose(
                         sp,
-                        &format!("if you import `{}`, refer to it directly", last.ident),
+                        format!("if you import `{}`, refer to it directly", last.ident),
                         "",
                         Applicability::Unspecified,
                     );
@@ -2495,7 +2495,7 @@ fn show_candidates(
                 msg.push_str(&candidate.0);
             }
 
-            err.help(&msg);
+            err.help(msg);
         }
     } else if !matches!(mode, DiagnosticMode::Import) {
         assert!(!inaccessible_path_strings.is_empty());
@@ -2520,9 +2520,9 @@ fn show_candidates(
                 let span = tcx.sess.source_map().guess_head_span(span);
                 let mut multi_span = MultiSpan::from_span(span);
                 multi_span.push_span_label(span, "not accessible");
-                err.span_note(multi_span, &msg);
+                err.span_note(multi_span, msg);
             } else {
-                err.note(&msg);
+                err.note(msg);
             }
             if let Some(note) = (*note).as_deref() {
                 err.note(note);
@@ -2566,10 +2566,10 @@ fn show_candidates(
             }
 
             for note in inaccessible_path_strings.iter().flat_map(|cand| cand.3.as_ref()) {
-                err.note(note);
+                err.note(note.clone());
             }
 
-            err.span_note(multi_span, &msg);
+            err.span_note(multi_span, msg);
         }
     }
 }

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -527,7 +527,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                         PROC_MACRO_DERIVE_RESOLUTION_FALLBACK,
                                         lint_id,
                                         orig_ident.span,
-                                        &format!(
+                                        format!(
                                             "cannot find {} `{}` in this scope",
                                             ns.descr(),
                                             ident

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -578,7 +578,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         let mut diag = struct_span_err!(self.tcx.sess, span, E0432, "{}", &msg);
 
         if let Some((_, UnresolvedImportError { note: Some(note), .. })) = errors.iter().last() {
-            diag.note(note);
+            diag.note(note.clone());
         }
 
         for (import, err) in errors.into_iter().take(MAX_LABEL_COUNT) {
@@ -588,10 +588,10 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
             if let Some((suggestions, msg, applicability)) = err.suggestion {
                 if suggestions.is_empty() {
-                    diag.help(&msg);
+                    diag.help(msg);
                     continue;
                 }
-                diag.multipart_suggestion(&msg, suggestions, applicability);
+                diag.multipart_suggestion(msg, suggestions, applicability);
             }
 
             if let Some(candidates) = &err.candidates {
@@ -1063,7 +1063,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     PUB_USE_OF_PRIVATE_EXTERN_CRATE,
                     import_id,
                     import.span,
-                    &msg,
+                    msg,
                 );
             } else {
                 let error_msg = if crate_private_reexport {
@@ -1084,7 +1084,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
                     struct_span_err!(self.tcx.sess, import.span, E0365, "{}", error_msg)
                         .span_label(import.span, label_msg)
-                        .note(&format!("consider declaring type or module `{}` with `pub`", ident))
+                        .note(format!("consider declaring type or module `{}` with `pub`", ident))
                         .emit();
                 } else {
                     let mut err =
@@ -1102,7 +1102,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         _ => {
                             err.span_note(
                                 import.span,
-                                &format!(
+                                format!(
                                     "consider marking `{ident}` as `pub` in the imported module"
                                 ),
                             );
@@ -1200,7 +1200,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 UNUSED_IMPORTS,
                 id,
                 import.span,
-                &format!("the item `{}` is imported redundantly", ident),
+                format!("the item `{}` is imported redundantly", ident),
                 BuiltinLintDiagnostics::RedundantImport(redundant_spans, ident),
             );
         }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2198,7 +2198,7 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
                     this.r
                         .tcx
                         .sess
-                        .span_err(ident.span, &format!("imports cannot refer to {}", what));
+                        .span_err(ident.span, format!("imports cannot refer to {}", what));
                 }
             };
 

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -121,7 +121,7 @@ pub(crate) fn registered_tools(tcx: TyCtxt<'_>, (): ()) -> RegisteredTools {
                     if let Some(old_ident) = registered_tools.replace(ident) {
                         let msg = format!("{} `{}` was already registered", "tool", ident);
                         tcx.sess
-                            .struct_span_err(ident.span, &msg)
+                            .struct_span_err(ident.span, msg)
                             .span_label(old_ident.span, "already registered here")
                             .emit();
                     }
@@ -130,7 +130,7 @@ pub(crate) fn registered_tools(tcx: TyCtxt<'_>, (): ()) -> RegisteredTools {
                     let msg = format!("`{}` only accepts identifiers", sym::register_tool);
                     let span = nested_meta.span();
                     tcx.sess
-                        .struct_span_err(span, &msg)
+                        .struct_span_err(span, msg)
                         .span_label(span, "not an identifier")
                         .emit();
                 }
@@ -202,7 +202,7 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
             self.tcx
                 .sess
                 .diagnostic()
-                .bug(&format!("built-in macro `{}` was already registered", name));
+                .bug(format!("built-in macro `{}` was already registered", name));
         }
     }
 
@@ -315,7 +315,7 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
                 UNUSED_MACROS,
                 node_id,
                 ident.span,
-                &format!("unused macro definition: `{}`", ident.name),
+                format!("unused macro definition: `{}`", ident.name),
             );
         }
         for (&(def_id, arm_i), &(ident, rule_span)) in self.unused_macro_rules.iter() {
@@ -328,7 +328,7 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
                 UNUSED_MACRO_RULES,
                 node_id,
                 rule_span,
-                &format!(
+                format!(
                     "{} rule of macro `{}` is never used",
                     crate::diagnostics::ordinalize(arm_i + 1),
                     ident.name
@@ -698,7 +698,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         Segment::names_to_string(path)
                     );
                     let msg_note = "import resolution is stuck, try simplifying macro imports";
-                    this.tcx.sess.struct_span_err(span, &msg).note(msg_note).emit();
+                    this.tcx.sess.struct_span_err(span, msg).note(msg_note).emit();
                 }
             }
         };
@@ -788,7 +788,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 Err(..) => {
                     let expected = kind.descr_expected();
                     let msg = format!("cannot find {} `{}` in this scope", expected, ident);
-                    let mut err = self.tcx.sess.struct_span_err(ident.span, &msg);
+                    let mut err = self.tcx.sess.struct_span_err(ident.span, msg);
                     self.unresolved_macro_suggestions(&mut err, kind, &parent_scope, ident);
                     err.emit();
                 }
@@ -866,9 +866,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             if kind != NonMacroAttrKind::Tool && binding.map_or(true, |b| b.is_import()) {
                 let msg =
                     format!("cannot use {} {} through an import", kind.article(), kind.descr());
-                let mut err = self.tcx.sess.struct_span_err(span, &msg);
+                let mut err = self.tcx.sess.struct_span_err(span, msg);
                 if let Some(binding) = binding {
-                    err.span_note(binding.span, &format!("the {} imported here", kind.descr()));
+                    err.span_note(binding.span, format!("the {} imported here", kind.descr()));
                 }
                 err.emit();
             }
@@ -883,7 +883,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             if macro_kind.is_some() && sub_namespace_match(macro_kind, Some(MacroKind::Attr)) {
                 self.tcx.sess.span_err(
                     ident.span,
-                    &format!("name `{}` is reserved in attribute namespace", ident),
+                    format!("name `{}` is reserved in attribute namespace", ident),
                 );
             }
         }
@@ -927,7 +927,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 }
             } else {
                 let msg = format!("cannot find a built-in macro with name `{}`", item.ident);
-                self.tcx.sess.span_err(item.span, &msg);
+                self.tcx.sess.span_err(item.span, msg);
             }
         }
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -271,7 +271,7 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
                 let underscores = vec!["_"; expected_args.len()].join(", ");
                 err.span_suggestion_verbose(
                     closure_arg_span.unwrap_or(found_span),
-                    &format!(
+                    format!(
                         "consider changing the closure to take and ignore the expected argument{}",
                         pluralize!(expected_args.len())
                     ),
@@ -575,7 +575,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             Limit(0) => Limit(2),
             limit => limit * 2,
         };
-        err.help(&format!(
+        err.help(format!(
             "consider increasing the recursion limit by adding a \
              `#![recursion_limit = \"{}\"]` attribute to your crate (`{}`)",
             suggested_limit,
@@ -737,7 +737,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         if is_try_conversion && let Some(ret_span) = self.return_type_span(&obligation) {
                             err.span_label(
                                 ret_span,
-                                &format!(
+                                format!(
                                     "expected `{}` because of this",
                                     trait_ref.skip_binder().self_ty()
                                 ),
@@ -780,7 +780,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             err.emit();
                             return;
                         }
-                        if let Some(ref s) = label {
+                        if let Some(s) = label {
                             // If it has a custom `#[rustc_on_unimplemented]`
                             // error message, let's display it as the label!
                             err.span_label(span, s);
@@ -788,7 +788,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                                 // When the self type is a type param We don't need to "the trait
                                 // `std::marker::Sized` is not implemented for `T`" as we will point
                                 // at the type param with a label to suggest constraining it.
-                                err.help(&explanation);
+                                err.help(explanation);
                             }
                         } else if let Some(custom_explanation) = safe_transmute_explanation {
                             err.span_label(span, custom_explanation);
@@ -811,13 +811,13 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             );
 
                         if let Some((msg, span)) = type_def {
-                            err.span_label(span, &msg);
+                            err.span_label(span, msg);
                         }
-                        if let Some(ref s) = note {
+                        if let Some(s) = note {
                             // If it has a custom `#[rustc_on_unimplemented]` note, let's display it
-                            err.note(s.as_str());
+                            err.note(s);
                         }
-                        if let Some(ref s) = parent_label {
+                        if let Some(s) = parent_label {
                             let body = obligation.cause.body_id;
                             err.span_label(tcx.def_span(body), s);
                         }
@@ -1028,7 +1028,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                                 // which bounds actually failed to hold.
                                 self.tcx.sess.struct_span_err(
                                     span,
-                                    &format!("the type `{}` is not well-formed", ty),
+                                    format!("the type `{}` is not well-formed", ty),
                                 )
                             }
                         }
@@ -1071,7 +1071,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     ty::PredicateKind::Clause(ty::Clause::ConstArgHasType(ct, ty)) => {
                         let mut diag = self.tcx.sess.struct_span_err(
                             span,
-                            &format!("the constant `{}` is not of type `{}`", ct, ty),
+                            format!("the constant `{}` is not of type `{}`", ct, ty),
                         );
                         self.note_type_err(
                             &mut diag,
@@ -1835,7 +1835,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             candidates.sort();
             candidates.dedup();
             let end = if candidates.len() <= 9 { candidates.len() } else { 8 };
-            err.help(&format!(
+            err.help(format!(
                 "the following {other}types implement trait `{}`:{}{}",
                 trait_ref.print_only_trait_path(),
                 candidates[..end].join(""),
@@ -2026,7 +2026,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 "perhaps two different versions of crate `{}` are being used?",
                 trait_crate
             );
-            err.note(&crate_msg);
+            err.note(crate_msg);
             suggested = true;
         }
         suggested
@@ -2158,7 +2158,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                                 err.cancel();
                                 return;
                             }
-                            err.note(&format!("cannot satisfy `{}`", predicate));
+                            err.note(format!("cannot satisfy `{}`", predicate));
                             let impl_candidates = self.find_similar_impl_candidates(
                                 predicate.to_opt_poly_trait_pred().unwrap(),
                             );
@@ -2178,7 +2178,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             err.cancel();
                             return;
                         }
-                        err.note(&format!("cannot satisfy `{}`", predicate));
+                        err.note(format!("cannot satisfy `{}`", predicate));
                     }
                 }
 
@@ -2223,9 +2223,9 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         err.cancel();
                         err = self.tcx.sess.struct_span_err_with_code(
                             span,
-                            &format!(
+                            format!(
                                 "cannot {verb} associated {noun} on trait without specifying the corresponding `impl` type",
-                             ),
+                            ),
                             rustc_errors::error_code!(E0790),
                         );
 
@@ -2332,7 +2332,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         ErrorCode::E0284,
                         true,
                     );
-                    err.note(&format!("cannot satisfy `{}`", predicate));
+                    err.note(format!("cannot satisfy `{}`", predicate));
                     err
                 } else {
                     // If we can't find a substitution, just print a generic error
@@ -2343,7 +2343,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         "type annotations needed: cannot satisfy `{}`",
                         predicate,
                     );
-                    err.span_label(span, &format!("cannot satisfy `{}`", predicate));
+                    err.span_label(span, format!("cannot satisfy `{}`", predicate));
                     err
                 }
             }
@@ -2371,7 +2371,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         "type annotations needed: cannot satisfy `{}`",
                         predicate,
                     );
-                    err.span_label(span, &format!("cannot satisfy `{}`", predicate));
+                    err.span_label(span, format!("cannot satisfy `{}`", predicate));
                     err
                 }
             }
@@ -2386,7 +2386,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     "type annotations needed: cannot satisfy `{}`",
                     predicate,
                 );
-                err.span_label(span, &format!("cannot satisfy `{}`", predicate));
+                err.span_label(span, format!("cannot satisfy `{}`", predicate));
                 err
             }
         };
@@ -2459,13 +2459,13 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
         match (spans.len(), crates.len(), crate_names.len()) {
             (0, 0, 0) => {
-                err.note(&format!("cannot satisfy `{}`", predicate));
+                err.note(format!("cannot satisfy `{}`", predicate));
             }
             (0, _, 1) => {
-                err.note(&format!("{} in the `{}` crate{}", msg, crates[0], post,));
+                err.note(format!("{} in the `{}` crate{}", msg, crates[0], post,));
             }
             (0, _, _) => {
-                err.note(&format!(
+                err.note(format!(
                     "{} in the following crates: {}{}",
                     msg,
                     crate_names.join(", "),
@@ -2474,19 +2474,17 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             }
             (_, 0, 0) => {
                 let span: MultiSpan = spans.into();
-                err.span_note(span, &msg);
+                err.span_note(span, msg);
             }
             (_, 1, 1) => {
                 let span: MultiSpan = spans.into();
-                err.span_note(span, &msg);
-                err.note(
-                    &format!("and another `impl` found in the `{}` crate{}", crates[0], post,),
-                );
+                err.span_note(span, msg);
+                err.note(format!("and another `impl` found in the `{}` crate{}", crates[0], post,));
             }
             _ => {
                 let span: MultiSpan = spans.into();
-                err.span_note(span, &msg);
-                err.note(&format!(
+                err.span_note(span, msg);
+                err.note(format!(
                     "and more `impl`s found in the following crates: {}{}",
                     crate_names.join(", "),
                     post,
@@ -2657,7 +2655,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         }
         err.span_help(
             multispan,
-            &format!(
+            format!(
                 "you could relax the implicit `Sized` bound on `{T}` if it were \
                 used through indirection like `&{T}` or `Box<{T}>`",
                 T = param.name.ident(),
@@ -2882,7 +2880,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             .fn_trait_kind_from_def_id(trait_ref.def_id())
             .expect("expected to map DefId to ClosureKind");
         if !implemented_kind.extends(selected_kind) {
-            err.note(&format!(
+            err.note(format!(
                 "`{}` implements `{}`, but it must implement `{}`, which is more general",
                 trait_ref.skip_binder().self_ty(),
                 implemented_kind,
@@ -2899,7 +2897,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             if expected.len() != given.len() {
                 // Note number of types that were expected and given
                 err.note(
-                    &format!(
+                    format!(
                         "expected a closure taking {} argument{}, but one taking {} argument{} was given",
                         given.len(),
                         pluralize!(given.len()),
@@ -2942,7 +2940,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 unsatisfied_const = UnsatisfiedConst(true);
                 err.span_note(
                     span,
-                    &format!(
+                    format!(
                         "the trait `{}` is implemented for `{}`, \
                         but that implementation is not `const`",
                         non_const_predicate.print_modifiers_and_trait_path(),
@@ -3171,7 +3169,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 let mut err = self.tcx.sess.struct_span_err(span, "unconstrained generic constant");
                 let const_span = self.tcx.def_span(uv.def);
                 match self.tcx.sess.source_map().span_to_snippet(const_span) {
-                    Ok(snippet) => err.help(&format!(
+                    Ok(snippet) => err.help(format!(
                         "try adding a `where` bound using this expression: `where [(); {}]:`",
                         snippet
                     )),

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -515,7 +515,7 @@ fn suggest_restriction<'tcx>(
 
         err.span_suggestion_verbose(
             sp,
-            &format!("consider further restricting {}", msg),
+            format!("consider further restricting {}", msg),
             suggestion,
             Applicability::MachineApplicable,
         );
@@ -964,7 +964,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             // a more general note.
             err.span_suggestion_verbose(
                 obligation.cause.span.shrink_to_hi(),
-                &msg,
+                msg,
                 format!("({args})"),
                 Applicability::HasPlaceholders,
             );
@@ -994,7 +994,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 }
                 _ => return false,
             };
-            err.help(&format!("{msg}: `{name}({args})`"));
+            err.help(format!("{msg}: `{name}({args})`"));
         }
         true
     }
@@ -1334,7 +1334,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
                     let msg = format!("the trait bound `{}` is not satisfied", old_pred);
                     if has_custom_message {
-                        err.note(&msg);
+                        err.note(msg);
                     } else {
                         err.message =
                             vec![(rustc_errors::DiagnosticMessage::Str(msg), Style::NoStyle)];
@@ -1358,7 +1358,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     } else {
                         let is_mut = mut_ref_self_ty_satisfies_pred || ref_inner_ty_mut;
                         let sugg_prefix = format!("&{}", if is_mut { "mut " } else { "" });
-                        let sugg_msg = &format!(
+                        let sugg_msg = format!(
                             "consider{} borrowing here",
                             if is_mut { " mutably" } else { "" }
                         );
@@ -1452,7 +1452,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
         err.span_suggestion(
             obligation.cause.span.shrink_to_lo(),
-            &format!(
+            format!(
                 "consider borrowing the value, since `&{self_ty}` can be coerced into `{object_ty}`"
             ),
             "&",
@@ -1505,7 +1505,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 };
 
                 err.multipart_suggestion_verbose(
-                    &msg,
+                    msg,
                     suggestions,
                     Applicability::MachineApplicable,
                 );
@@ -1617,7 +1617,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 if let ty::PredicateKind::Clause(ty::Clause::Trait(pred)) =
                     obligation.predicate.kind().skip_binder()
                 {
-                    err.span_label(*span, &format!("this call returns `{}`", pred.self_ty()));
+                    err.span_label(*span, format!("this call returns `{}`", pred.self_ty()));
                 }
                 if let Some(typeck_results) = &self.typeck_results
                         && let ty = typeck_results.expr_ty_adjusted(base)
@@ -1632,14 +1632,14 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         if vis_span.is_empty() {
                             err.span_suggestion_verbose(
                                 span.shrink_to_lo(),
-                                &msg,
+                                msg,
                                 "async ",
                                 Applicability::MaybeIncorrect,
                             );
                         } else {
                             err.span_suggestion_verbose(
                                 vis_span.shrink_to_hi(),
-                                &msg,
+                                msg,
                                 " async",
                                 Applicability::MaybeIncorrect,
                             );
@@ -1717,7 +1717,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             Applicability::MachineApplicable,
                         );
                     } else {
-                        err.note(&format!(
+                        err.note(format!(
                             "`{}` is implemented for `{:?}`, but not for `{:?}`",
                             trait_pred.print_modifiers_and_trait_path(),
                             suggested_ty,
@@ -1754,7 +1754,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         {
             err.span_label(
                 expr.span,
-                &format!(
+                format!(
                     "this expression has type `{}`, which implements `{}`",
                     ty,
                     trait_pred.print_modifiers_and_trait_path()
@@ -1946,7 +1946,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             // Suggest `-> impl Trait`.
             err.span_suggestion(
                 ret_ty.span,
-                &format!(
+                format!(
                     "use `impl {1}` as the return type, as all return paths are of type `{}`, \
                      which implements `{1}`",
                     last_ty, trait_obj,
@@ -1981,13 +1981,13 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             } else {
                 // This is currently not possible to trigger because E0038 takes precedence, but
                 // leave it in for completeness in case anything changes in an earlier stage.
-                err.note(&format!(
+                err.note(format!(
                     "if trait `{}` were object-safe, you could return a trait object",
                     trait_obj,
                 ));
             }
             err.note(trait_obj_msg);
-            err.note(&format!(
+            err.note(format!(
                 "if all the returned values were of the same type you could use `impl {}` as the \
                  return type",
                 trait_obj,
@@ -2027,7 +2027,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     } else {
                         err.span_label(
                             expr.span,
-                            &format!("this returned value is of type `{}`", ty),
+                            format!("this returned value is of type `{}`", ty),
                         );
                     }
                 }
@@ -2177,7 +2177,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
     ) {
         if let Some(assoc_item) = self.tcx.opt_associated_item(item_def_id) {
             if let ty::AssocKind::Const | ty::AssocKind::Type = assoc_item.kind {
-                err.note(&format!(
+                err.note(format!(
                     "{}s cannot be accessed directly on a `trait`, they can only be \
                         accessed through a specific `impl`",
                     self.tcx.def_kind_descr(assoc_item.kind.as_def_kind(), item_def_id)
@@ -2607,7 +2607,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 }
                 err.span_note(
                     span,
-                    &format!(
+                    format!(
                         "{} {} as this value is used across {}",
                         future_or_generator, trait_explanation, an_await_or_yield
                     ),
@@ -2628,7 +2628,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         );
                         err.span_note(
                             span,
-                            &format!(
+                            format!(
                                 "future {not_trait} as it awaits another future which {not_trait}",
                                 not_trait = trait_explanation
                             ),
@@ -2730,7 +2730,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
                 let mut span = MultiSpan::from_span(upvar_span);
                 span.push_span_label(upvar_span, span_label);
-                err.span_note(span, &span_note);
+                err.span_note(span, span_note);
             }
         }
 
@@ -2794,15 +2794,15 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 err.note("only the last element of a tuple may have a dynamically sized type");
             }
             ObligationCauseCode::ProjectionWf(data) => {
-                err.note(&format!("required so that the projection `{data}` is well-formed"));
+                err.note(format!("required so that the projection `{data}` is well-formed"));
             }
             ObligationCauseCode::ReferenceOutlivesReferent(ref_ty) => {
-                err.note(&format!(
+                err.note(format!(
                     "required so that reference `{ref_ty}` does not outlive its referent"
                 ));
             }
             ObligationCauseCode::ObjectTypeBound(object_ty, region) => {
-                err.note(&format!(
+                err.note(format!(
                     "required so that the lifetime bound of `{}` for `{}` is satisfied",
                     region, object_ty,
                 ));
@@ -2838,9 +2838,9 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 if span.is_visible(sm) {
                     let msg = format!("required by this bound in `{short_item_name}`");
                     multispan.push_span_label(span, msg);
-                    err.span_note(multispan, &descr);
+                    err.span_note(multispan, descr);
                 } else {
-                    err.span_note(tcx.def_span(item_def_id), &descr);
+                    err.span_note(tcx.def_span(item_def_id), descr);
                 }
             }
             ObligationCauseCode::ObjectCastObligation(concrete_ty, object_ty) => {
@@ -2848,24 +2848,24 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     self.tcx.short_ty_string(self.resolve_vars_if_possible(concrete_ty));
                 let (object_ty, object_file) =
                     self.tcx.short_ty_string(self.resolve_vars_if_possible(object_ty));
-                err.note(&with_forced_trimmed_paths!(format!(
+                err.note(with_forced_trimmed_paths!(format!(
                     "required for the cast from `{concrete_ty}` to the object type `{object_ty}`",
                 )));
                 if let Some(file) = concrete_file {
-                    err.note(&format!(
+                    err.note(format!(
                         "the full name for the casted type has been written to '{}'",
                         file.display(),
                     ));
                 }
                 if let Some(file) = object_file {
-                    err.note(&format!(
+                    err.note(format!(
                         "the full name for the object type has been written to '{}'",
                         file.display(),
                     ));
                 }
             }
             ObligationCauseCode::Coercion { source: _, target } => {
-                err.note(&format!("required by cast to type `{}`", self.ty_to_string(target)));
+                err.note(format!("required by cast to type `{}`", self.ty_to_string(target)));
             }
             ObligationCauseCode::RepeatElementCopy { is_const_fn } => {
                 err.note(
@@ -3068,8 +3068,8 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         ));
                         match ty.kind() {
                             ty::Adt(def, _) => match self.tcx.opt_item_ident(def.did()) {
-                                Some(ident) => err.span_note(ident.span, &msg),
-                                None => err.note(&msg),
+                                Some(ident) => err.span_note(ident.span, msg),
+                                None => err.note(msg),
                             },
                             ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }) => {
                                 // If the previous type is async fn, this is the future generated by the body of an async function.
@@ -3090,7 +3090,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                                 {
                                     break 'print;
                                 }
-                                err.span_note(self.tcx.def_span(def_id), &msg)
+                                err.span_note(self.tcx.def_span(def_id), msg)
                             }
                             ty::GeneratorWitness(bound_tys) => {
                                 use std::fmt::Write;
@@ -3126,7 +3126,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                                 let kind = tcx.generator_kind(def_id).unwrap().descr();
                                 err.span_note(
                                     sp,
-                                    with_forced_trimmed_paths!(&format!(
+                                    with_forced_trimmed_paths!(format!(
                                         "required because it's used within this {kind}",
                                     )),
                                 )
@@ -3136,7 +3136,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                                 "required because it's used within this closure",
                             ),
                             ty::Str => err.note("`str` is considered to contain a `[u8]` slice for auto trait purposes"),
-                            _ => err.note(&msg),
+                            _ => err.note(msg),
                         };
                     }
                 }
@@ -3190,7 +3190,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         // FIXME: we should do something else so that it works even on crate foreign
                         // auto traits.
                         is_auto_trait = matches!(is_auto, hir::IsAuto::Yes);
-                        err.span_note(ident.span, &msg);
+                        err.span_note(ident.span, msg);
                     }
                     Some(Node::Item(hir::Item {
                         kind: hir::ItemKind::Impl(hir::Impl { of_trait, self_ty, .. }),
@@ -3219,15 +3219,15 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                                 "unsatisfied trait bound introduced here",
                             );
                         }
-                        err.span_note(spans, &msg);
+                        err.span_note(spans, msg);
                     }
                     _ => {
-                        err.note(&msg);
+                        err.note(msg);
                     }
                 };
 
                 if let Some(file) = file {
-                    err.note(&format!(
+                    err.note(format!(
                         "the full type name has been written to '{}'",
                         file.display(),
                     ));
@@ -3267,19 +3267,19 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     parent_trait_pred = child_trait_pred;
                 }
                 if count > 0 {
-                    err.note(&format!(
+                    err.note(format!(
                         "{} redundant requirement{} hidden",
                         count,
                         pluralize!(count)
                     ));
                     let (self_ty, file) =
                         self.tcx.short_ty_string(parent_trait_pred.skip_binder().self_ty());
-                    err.note(&format!(
+                    err.note(format!(
                         "required for `{self_ty}` to implement `{}`",
                         parent_trait_pred.print_modifiers_and_trait_path()
                     ));
                     if let Some(file) = file {
-                        err.note(&format!(
+                        err.note(format!(
                             "the full type name has been written to '{}'",
                             file.display(),
                         ));
@@ -3360,7 +3360,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 {
                     assoc_span.push_span_label(ident.span, "in this trait");
                 }
-                err.span_note(assoc_span, &msg);
+                err.span_note(assoc_span, msg);
             }
             ObligationCauseCode::TrivialBound => {
                 err.help("see issue #48214");
@@ -3516,7 +3516,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         if can_derive {
             err.span_suggestion_verbose(
                 self.tcx.def_span(adt.did()).shrink_to_lo(),
-                &format!(
+                format!(
                     "consider annotating `{}` with `#[derive({})]`",
                     trait_pred.skip_binder().self_ty(),
                     diagnostic_name,
@@ -3903,7 +3903,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             .map(|trait_ref| trait_ref.trait_ref.self_ty())
             .find(|t| is_slice(*t))
         {
-            let msg = &format!("convert the array to a `{}` slice instead", slice_ty);
+            let msg = format!("convert the array to a `{}` slice instead", slice_ty);
 
             if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
                 let mut suggestions = vec![];
@@ -4124,7 +4124,7 @@ fn suggest_trait_object_return_type_alternatives(
 ) {
     err.span_suggestion(
         ret_ty,
-        &format!(
+        format!(
             "use `impl {}` as the return type if all return paths have the same type but you \
                 want to expose only the trait in the signature",
             trait_obj,
@@ -4134,7 +4134,7 @@ fn suggest_trait_object_return_type_alternatives(
     );
     if is_object_safe {
         err.multipart_suggestion(
-            &format!(
+            format!(
                 "use a boxed trait object if all return paths implement trait `{}`",
                 trait_obj,
             ),

--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -525,7 +525,7 @@ fn virtual_call_violation_for_method<'tcx>(
                         // #78372
                         tcx.sess.delay_span_bug(
                             tcx.def_span(method.def_id),
-                            &format!("error: {}\n while computing layout for type {:?}", err, ty),
+                            format!("error: {}\n while computing layout for type {:?}", err, ty),
                         );
                         None
                     }
@@ -541,7 +541,7 @@ fn virtual_call_violation_for_method<'tcx>(
                 abi => {
                     tcx.sess.delay_span_bug(
                         tcx.def_span(method.def_id),
-                        &format!(
+                        format!(
                             "receiver when `Self = ()` should have a Scalar ABI; found {:?}",
                             abi
                         ),
@@ -560,7 +560,7 @@ fn virtual_call_violation_for_method<'tcx>(
                 abi => {
                     tcx.sess.delay_span_bug(
                         tcx.def_span(method.def_id),
-                        &format!(
+                        format!(
                             "receiver when `Self = {}` should have a ScalarPair ABI; found {:?}",
                             trait_object_ty, abi
                         ),

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1749,7 +1749,7 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                 // These traits have no associated types.
                 selcx.tcx().sess.delay_span_bug(
                     obligation.cause.span,
-                    &format!("Cannot project an associated type from `{:?}`", impl_source),
+                    format!("Cannot project an associated type from `{:?}`", impl_source),
                 );
                 return Err(());
             }

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/custom.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/custom.rs
@@ -79,7 +79,7 @@ pub fn scrape_region_constraints<'tcx, Op: super::TypeOp<'tcx, Output = R>, R>(
     if !errors.is_empty() {
         infcx.tcx.sess.diagnostic().delay_span_bug(
             DUMMY_SP,
-            &format!("errors selecting obligation during MIR typeck: {:?}", errors),
+            format!("errors selecting obligation during MIR typeck: {:?}", errors),
         );
     }
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -67,7 +67,7 @@ impl IntercrateAmbiguityCause {
     /// Emits notes when the overlap is caused by complex intercrate ambiguities.
     /// See #23980 for details.
     pub fn add_intercrate_ambiguity_hint(&self, err: &mut Diagnostic) {
-        err.note(&self.intercrate_ambiguity_hint());
+        err.note(self.intercrate_ambiguity_hint());
     }
 
     pub fn intercrate_ambiguity_hint(&self) -> String {
@@ -2449,7 +2449,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
                 // for a variable being generalized...
                 let guar = self.infcx.tcx.sess.delay_span_bug(
                     obligation.cause.span,
-                    &format!(
+                    format!(
                         "Impl {:?} was matchable against {:?} but now is not",
                         impl_def_id, obligation
                     ),

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -373,7 +373,7 @@ fn report_conflicting_impls<'tcx>(
                     }
                     None => format!("conflicting implementation in crate `{}`", cname),
                 };
-                err.note(&msg);
+                err.note(msg);
             }
         }
 

--- a/compiler/rustc_traits/src/dropck_outlives.rs
+++ b/compiler/rustc_traits/src/dropck_outlives.rs
@@ -190,7 +190,7 @@ fn dtorck_constraint_for_ty<'tcx>(
 
                 tcx.sess.delay_span_bug(
                     span,
-                    &format!("upvar_tys for closure not found. Expected capture information for closure {ty}",),
+                    format!("upvar_tys for closure not found. Expected capture information for closure {ty}",),
                 );
                 return Err(NoSolution);
             }
@@ -232,7 +232,7 @@ fn dtorck_constraint_for_ty<'tcx>(
                 // be fully resolved.
                 tcx.sess.delay_span_bug(
                     span,
-                    &format!("upvar_tys for generator not found. Expected capture information for generator {ty}",),
+                    format!("upvar_tys for generator not found. Expected capture information for generator {ty}",),
                 );
                 return Err(NoSolution);
             }

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -85,7 +85,7 @@ fn resolve_associated_item<'tcx>(
         Err(CodegenObligationError::Ambiguity) => {
             let reported = tcx.sess.delay_span_bug(
                 tcx.def_span(trait_item_id),
-                &format!(
+                format!(
                     "encountered ambiguity selecting `{trait_ref:?}` during codegen, presuming due to \
                      overflow or prior type error",
                 ),

--- a/compiler/rustc_ty_utils/src/needs_drop.rs
+++ b/compiler/rustc_ty_utils/src/needs_drop.rs
@@ -132,7 +132,7 @@ where
                             _ => {
                                 tcx.sess.delay_span_bug(
                                     tcx.hir().span_if_local(def_id).unwrap_or(DUMMY_SP),
-                                    &format!("unexpected generator witness type {:?}", witness),
+                                    format!("unexpected generator witness type {:?}", witness),
                                 );
                                 return Some(Err(AlwaysRequiresDrop));
                             }

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -382,7 +382,7 @@ impl Options {
                 match kind.parse() {
                     Ok(kind) => emit.push(kind),
                     Err(()) => {
-                        diag.err(&format!("unrecognized emission type: {}", kind));
+                        diag.err(format!("unrecognized emission type: {}", kind));
                         return Err(1);
                     }
                 }
@@ -559,28 +559,28 @@ impl Options {
                 matches.opt_strs("theme").iter().map(|s| (PathBuf::from(&s), s.to_owned()))
             {
                 if !theme_file.is_file() {
-                    diag.struct_err(&format!("invalid argument: \"{}\"", theme_s))
+                    diag.struct_err(format!("invalid argument: \"{}\"", theme_s))
                         .help("arguments to --theme must be files")
                         .emit();
                     return Err(1);
                 }
                 if theme_file.extension() != Some(OsStr::new("css")) {
-                    diag.struct_err(&format!("invalid argument: \"{}\"", theme_s))
+                    diag.struct_err(format!("invalid argument: \"{}\"", theme_s))
                         .help("arguments to --theme must have a .css extension")
                         .emit();
                     return Err(1);
                 }
                 let (success, ret) = theme::test_theme_against(&theme_file, &paths, &diag);
                 if !success {
-                    diag.struct_err(&format!("error loading theme file: \"{}\"", theme_s)).emit();
+                    diag.struct_err(format!("error loading theme file: \"{}\"", theme_s)).emit();
                     return Err(1);
                 } else if !ret.is_empty() {
-                    diag.struct_warn(&format!(
+                    diag.struct_warn(format!(
                         "theme file \"{}\" is missing CSS rules from the default theme",
                         theme_s
                     ))
                     .warn("the theme may appear incorrect when loaded")
-                    .help(&format!(
+                    .help(format!(
                         "to see what rules are missing, call `rustdoc --check-theme \"{}\"`",
                         theme_s
                     ))
@@ -611,7 +611,7 @@ impl Options {
         match matches.opt_str("r").as_deref() {
             Some("rust") | None => {}
             Some(s) => {
-                diag.struct_err(&format!("unknown input format: {}", s)).emit();
+                diag.struct_err(format!("unknown input format: {}", s)).emit();
                 return Err(1);
             }
         }
@@ -631,7 +631,7 @@ impl Options {
         let crate_types = match parse_crate_types_from_list(matches.opt_strs("crate-type")) {
             Ok(types) => types,
             Err(e) => {
-                diag.struct_err(&format!("unknown crate type: {}", e)).emit();
+                diag.struct_err(format!("unknown crate type: {}", e)).emit();
                 return Err(1);
             }
         };
@@ -649,7 +649,7 @@ impl Options {
                     out_fmt
                 }
                 Err(e) => {
-                    diag.struct_err(&e).emit();
+                    diag.struct_err(e).emit();
                     return Err(1);
                 }
             },
@@ -790,7 +790,7 @@ fn check_deprecated_options(matches: &getopts::Matches, diag: &rustc_errors::Han
 
     for &flag in deprecated_flags.iter() {
         if matches.opt_present(flag) {
-            diag.struct_warn(&format!("the `{}` flag is deprecated", flag))
+            diag.struct_warn(format!("the `{}` flag is deprecated", flag))
                 .note(
                     "see issue #44136 <https://github.com/rust-lang/rust/issues/44136> \
                     for more information",
@@ -803,7 +803,7 @@ fn check_deprecated_options(matches: &getopts::Matches, diag: &rustc_errors::Han
 
     for &flag in removed_flags.iter() {
         if matches.opt_present(flag) {
-            let mut err = diag.struct_warn(&format!("the `{}` flag no longer functions", flag));
+            let mut err = diag.struct_warn(format!("the `{}` flag no longer functions", flag));
             err.note(
                 "see issue #44136 <https://github.com/rust-lang/rust/issues/44136> \
                 for more information",

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -383,7 +383,7 @@ pub(crate) fn run_global_ctxt(
 
     fn report_deprecated_attr(name: &str, diag: &rustc_errors::Handler, sp: Span) {
         let mut msg =
-            diag.struct_span_warn(sp, &format!("the `#![doc({})]` attribute is deprecated", name));
+            diag.struct_span_warn(sp, format!("the `#![doc({})]` attribute is deprecated", name));
         msg.note(
             "see issue #44136 <https://github.com/rust-lang/rust/issues/44136> \
             for more information",

--- a/src/librustdoc/externalfiles.rs
+++ b/src/librustdoc/externalfiles.rs
@@ -83,14 +83,14 @@ pub(crate) fn load_string<P: AsRef<Path>>(
     let contents = match fs::read(file_path) {
         Ok(bytes) => bytes,
         Err(e) => {
-            diag.struct_err(&format!("error reading `{}`: {}", file_path.display(), e)).emit();
+            diag.struct_err(format!("error reading `{}`: {}", file_path.display(), e)).emit();
             return Err(LoadStringError::ReadFail);
         }
     };
     match str::from_utf8(&contents) {
         Ok(s) => Ok(s.to_string()),
         Err(_) => {
-            diag.struct_err(&format!("error reading `{}`: not UTF-8", file_path.display())).emit();
+            diag.struct_err(format!("error reading `{}`: not UTF-8", file_path.display())).emit();
             Err(LoadStringError::BadUtf8)
         }
     }

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -746,7 +746,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
         // Flush pending errors.
         Rc::get_mut(&mut self.shared).unwrap().fs.close();
         let nb_errors =
-            self.shared.errors.iter().map(|err| self.tcx().sess.struct_err(&err).emit()).count();
+            self.shared.errors.iter().map(|err| self.tcx().sess.struct_err(err).emit()).count();
         if nb_errors > 0 {
             Err(Error::new(io::Error::new(io::ErrorKind::Other, "I/O error"), ""))
         } else {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2256,8 +2256,7 @@ fn render_call_locations<W: fmt::Write>(mut w: W, cx: &mut Context<'_>, item: &c
             Ok(contents) => contents,
             Err(err) => {
                 let span = item.span(tcx).map_or(rustc_span::DUMMY_SP, |span| span.inner());
-                tcx.sess
-                    .span_err(span, &format!("failed to read file {}: {}", path.display(), err));
+                tcx.sess.span_err(span, format!("failed to read file {}: {}", path.display(), err));
                 return false;
             }
         };

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -145,7 +145,7 @@ impl DocVisitor for SourceCollector<'_, '_> {
                 Err(e) => {
                     self.cx.shared.tcx.sess.span_err(
                         span,
-                        &format!(
+                        format!(
                             "failed to render source code for `{}`: {}",
                             filename.prefer_local(),
                             e,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -677,7 +677,7 @@ fn wrap_return(diag: &rustc_errors::Handler, res: Result<(), String>) -> MainRes
     match res {
         Ok(()) => diag.has_errors().map_or(Ok(()), Err),
         Err(err) => {
-            let reported = diag.struct_err(&err).emit();
+            let reported = diag.struct_err(err).emit();
             Err(reported)
         }
     }
@@ -693,10 +693,10 @@ fn run_renderer<'tcx, T: formats::FormatRenderer<'tcx>>(
         Ok(_) => tcx.sess.has_errors().map_or(Ok(()), Err),
         Err(e) => {
             let mut msg =
-                tcx.sess.struct_err(&format!("couldn't generate documentation: {}", e.error));
+                tcx.sess.struct_err(format!("couldn't generate documentation: {}", e.error));
             let file = e.file.display().to_string();
             if !file.is_empty() {
-                msg.note(&format!("failed to create or modify \"{}\"", file));
+                msg.note(format!("failed to create or modify \"{}\"", file));
             }
             Err(msg.emit())
         }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1179,9 +1179,9 @@ impl LinkCollector<'_, '_> {
                 specified.descr(),
             );
             if let Some(sp) = sp {
-                diag.span_label(sp, &note);
+                diag.span_label(sp, note);
             } else {
-                diag.note(&note);
+                diag.note(note);
             }
             suggest_disambiguator(resolved, diag, path_str, &ori_link.link, sp);
         };
@@ -1617,7 +1617,7 @@ fn report_diagnostic(
             let line = dox[last_new_line_offset..].lines().next().unwrap_or("");
 
             // Print the line containing the `link_range` and manually mark it with '^'s.
-            lint.note(&format!(
+            lint.note(format!(
                 "the link appears in this line:\n\n{line}\n\
                      {indicator: <before$}{indicator:^<found$}",
                 line = line,
@@ -1730,9 +1730,9 @@ fn resolution_failure(
                             format!("no item named `{}` in scope", unresolved)
                         };
                         if let Some(span) = sp {
-                            diag.span_label(span, &note);
+                            diag.span_label(span, note);
                         } else {
-                            diag.note(&note);
+                            diag.note(note);
                         }
 
                         if !path_str.contains("::") {
@@ -1787,9 +1787,9 @@ fn resolution_failure(
                                 let variant = res.name(tcx);
                                 let note = format!("variant `{variant}` has no such field");
                                 if let Some(span) = sp {
-                                    diag.span_label(span, &note);
+                                    diag.span_label(span, note);
                                 } else {
-                                    diag.note(&note);
+                                    diag.note(note);
                                 }
                                 return;
                             }
@@ -1812,9 +1812,9 @@ fn resolution_failure(
                             | InlineConst => {
                                 let note = assoc_item_not_allowed(res);
                                 if let Some(span) = sp {
-                                    diag.span_label(span, &note);
+                                    diag.span_label(span, note);
                                 } else {
-                                    diag.note(&note);
+                                    diag.note(note);
                                 }
                                 return;
                             }
@@ -1834,9 +1834,9 @@ fn resolution_failure(
                         unresolved,
                     );
                     if let Some(span) = sp {
-                        diag.span_label(span, &note);
+                        diag.span_label(span, note);
                     } else {
-                        diag.note(&note);
+                        diag.note(note);
                     }
 
                     continue;
@@ -1854,9 +1854,9 @@ fn resolution_failure(
                     }
                 };
                 if let Some(span) = sp {
-                    diag.span_label(span, &note);
+                    diag.span_label(span, note);
                 } else {
-                    diag.note(&note);
+                    diag.note(note);
                 }
             }
         },
@@ -1906,7 +1906,7 @@ fn disambiguator_error(
             "see {}/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators",
             crate::DOC_RUST_LANG_ORG_CHANNEL
         );
-        diag.note(&msg);
+        diag.note(msg);
     });
 }
 
@@ -2023,13 +2023,13 @@ fn suggest_disambiguator(
     if let Some(sp) = sp {
         let mut spans = suggestion.as_help_span(path_str, ori_link, sp);
         if spans.len() > 1 {
-            diag.multipart_suggestion(&help, spans, Applicability::MaybeIncorrect);
+            diag.multipart_suggestion(help, spans, Applicability::MaybeIncorrect);
         } else {
             let (sp, suggestion_text) = spans.pop().unwrap();
-            diag.span_suggestion_verbose(sp, &help, suggestion_text, Applicability::MaybeIncorrect);
+            diag.span_suggestion_verbose(sp, help, suggestion_text, Applicability::MaybeIncorrect);
         }
     } else {
-        diag.help(&format!("{}: {}", help, suggestion.as_help(path_str)));
+        diag.help(format!("{}: {}", help, suggestion.as_help(path_str)));
     }
 }
 

--- a/src/librustdoc/passes/lint/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/lint/check_code_block_syntax.rs
@@ -108,7 +108,7 @@ fn check_rust_syntax(
                 // just give a `help` instead.
                 lint.span_help(
                     sp.from_inner(InnerSpan::new(0, 3)),
-                    &format!("{}: ```text", explanation),
+                    format!("{}: ```text", explanation),
                 );
             } else if empty_block {
                 lint.span_suggestion(
@@ -119,12 +119,12 @@ fn check_rust_syntax(
                 );
             }
         } else if empty_block || is_ignore {
-            lint.help(&format!("{}: ```text", explanation));
+            lint.help(format!("{}: ```text", explanation));
         }
 
         // FIXME(#67563): Provide more context for these errors by displaying the spans inline.
         for message in buffer.messages.iter() {
-            lint.note(message);
+            lint.note(message.clone());
         }
 
         lint

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -331,7 +331,7 @@ pub(crate) fn run(
     };
 
     if let Err(e) = inner() {
-        tcx.sess.fatal(&e);
+        tcx.sess.fatal(e);
     }
 
     Ok(())
@@ -358,7 +358,7 @@ pub(crate) fn load_call_locations(
     };
 
     inner().map_err(|e: String| {
-        diag.err(&format!("failed to load examples: {}", e));
+        diag.err(format!("failed to load examples: {}", e));
         1
     })
 }

--- a/src/librustdoc/theme.rs
+++ b/src/librustdoc/theme.rs
@@ -241,7 +241,7 @@ pub(crate) fn test_theme_against<P: AsRef<Path>>(
     {
         Ok(c) => c,
         Err(e) => {
-            diag.struct_err(&e).emit();
+            diag.struct_err(e).emit();
             return (false, vec![]);
         }
     };

--- a/src/tools/clippy/clippy_lints/src/future_not_send.rs
+++ b/src/tools/clippy/clippy_lints/src/future_not_send.rs
@@ -96,7 +96,7 @@ impl<'tcx> LateLintPass<'tcx> for FutureNotSend {
                                 if let PredicateKind::Clause(Clause::Trait(trait_pred)) =
                                     obligation.predicate.kind().skip_binder()
                                 {
-                                    db.note(&format!(
+                                    db.note(format!(
                                         "`{}` doesn't implement `{}`",
                                         trait_pred.self_ty(),
                                         trait_pred.trait_ref.print_only_trait_path(),

--- a/src/tools/clippy/clippy_lints/src/lib.rs
+++ b/src/tools/clippy/clippy_lints/src/lib.rs
@@ -353,7 +353,7 @@ pub fn register_pre_expansion_lints(store: &mut rustc_lint::LintStore, sess: &Se
 pub fn read_conf(sess: &Session, path: &io::Result<(Option<PathBuf>, Vec<String>)>) -> Conf {
     if let Ok((_, warnings)) = path {
         for warning in warnings {
-            sess.warn(warning);
+            sess.warn(warning.clone());
         }
     }
     let file_name = match path {

--- a/src/tools/clippy/clippy_lints/src/methods/str_splitn.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/str_splitn.rs
@@ -175,13 +175,13 @@ fn check_manual_split_once_indirect(
             let remove_msg = format!("remove the `{iter_ident}` usages");
             diag.span_suggestion(
                 first.span,
-                &remove_msg,
+                remove_msg.clone(),
                 "",
                 app,
             );
             diag.span_suggestion(
                 second.span,
-                &remove_msg,
+                remove_msg,
                 "",
                 app,
             );

--- a/src/tools/clippy/clippy_lints/src/non_send_fields_in_send_ty.rs
+++ b/src/tools/clippy/clippy_lints/src/non_send_fields_in_send_ty.rs
@@ -131,13 +131,13 @@ impl<'tcx> LateLintPass<'tcx> for NonSendFieldInSendTy {
                             for field in non_send_fields {
                                 diag.span_note(
                                     field.def.span,
-                                    &format!("it is not safe to send field `{}` to another thread", field.def.ident.name),
+                                    format!("it is not safe to send field `{}` to another thread", field.def.ident.name),
                                 );
 
                                 match field.generic_params.len() {
                                     0 => diag.help("use a thread-safe type that implements `Send`"),
-                                    1 if is_ty_param(field.ty) => diag.help(&format!("add `{}: Send` bound in `Send` impl", field.ty)),
-                                    _ => diag.help(&format!(
+                                    1 if is_ty_param(field.ty) => diag.help(format!("add `{}: Send` bound in `Send` impl", field.ty)),
+                                    _ => diag.help(format!(
                                         "add bounds on type parameter{} `{}` that satisfy `{}: Send`",
                                         if field.generic_params.len() > 1 { "s" } else { "" },
                                         field.generic_params_string(),

--- a/src/tools/clippy/clippy_utils/src/attrs.rs
+++ b/src/tools/clippy/clippy_utils/src/attrs.rs
@@ -133,7 +133,7 @@ pub fn get_unique_attr<'a>(
     let mut unique_attr: Option<&ast::Attribute> = None;
     for attr in get_attr(sess, attrs, name) {
         if let Some(duplicate) = unique_attr {
-            sess.struct_span_err(attr.span, &format!("`{name}` is defined multiple times"))
+            sess.struct_span_err(attr.span, format!("`{name}` is defined multiple times"))
                 .span_note(duplicate.span, "first definition found here")
                 .emit();
         } else {

--- a/src/tools/miri/src/diagnostics.rs
+++ b/src/tools/miri/src/diagnostics.rs
@@ -409,14 +409,15 @@ pub fn report_msg<'tcx>(
     } else {
         // Make sure we show the message even when it is a dummy span.
         for line in span_msg {
-            err.note(&line);
+            err.note(line);
         }
         err.note("(no span available)");
     }
 
     // Show note and help messages.
     let mut extra_span = false;
-    for (span_data, note) in &notes {
+    let notes_len = notes.len();
+    for (span_data, note) in notes {
         if let Some(span_data) = span_data {
             err.span_note(span_data.span(), note);
             extra_span = true;
@@ -424,7 +425,8 @@ pub fn report_msg<'tcx>(
             err.note(note);
         }
     }
-    for (span_data, help) in &helps {
+    let helps_len = helps.len();
+    for (span_data, help) in helps {
         if let Some(span_data) = span_data {
             err.span_help(span_data.span(), help);
             extra_span = true;
@@ -432,7 +434,7 @@ pub fn report_msg<'tcx>(
             err.help(help);
         }
     }
-    if notes.len() + helps.len() > 0 {
+    if notes_len + helps_len > 0 {
         // Add visual separator before backtrace.
         err.note(if extra_span { "BACKTRACE (of the first span):" } else { "BACKTRACE:" });
     }
@@ -441,7 +443,7 @@ pub fn report_msg<'tcx>(
         let is_local = machine.is_local(frame_info);
         // No span for non-local frames and the first frame (which is the error site).
         if is_local && idx > 0 {
-            err.span_note(frame_info.span, &frame_info.to_string());
+            err.span_note(frame_info.span, frame_info.to_string());
         } else {
             let sm = sess.source_map();
             let span = sm.span_to_embeddable_string(frame_info.span);

--- a/tests/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
+++ b/tests/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
@@ -67,7 +67,7 @@ impl CodegenBackend for TheBackend {
         let crate_name = codegen_results.crate_info.local_crate_name;
         for &crate_type in sess.opts.crate_types.iter() {
             if crate_type != CrateType::Rlib {
-                sess.fatal(&format!("Crate type is {:?}", crate_type));
+                sess.fatal(format!("Crate type is {:?}", crate_type));
             }
             let output_name = out_filename(sess, crate_type, &outputs, crate_name);
             let mut out_file = ::std::fs::File::create(output_name).unwrap();


### PR DESCRIPTION
Currently a `{D,Subd}iagnosticMessage` can be created from any type that impls `Into<String>`. That includes `&str`, `String`, and `Cow<'static, str>`, which are reasonable. It also includes `&String`, which is pretty weird, and results in many places making unnecessary allocations for patterns like this:
```
self.fatal(&format!(...))
```
This creates a string with `format!`, takes a reference, passes the reference to `fatal`, which does an `into()`, which clones the reference, doing a second allocation. Two allocations for a single string, bleh.

This commit changes the `From` impls so that you can only create a `{D,Subd}iagnosticMessage` from `&str`, `String`, or `Cow<'static, str>`. This requires changing all the places that currently create one from a `&String`. Most of these are of the `&format!(...)` form described above; each one removes an unnecessary static `&`, plus an allocation when executed. There are also a few places where the existing use of `&String` was more reasonable; these now just use `clone()` at the call site.

As well as making the code nicer and more efficient, this is a step towards possibly using `Cow<'static, str>` in
`{D,Subd}iagnosticMessage::{Str,Eager}`. That would require changing the `From<&'a str>` impls to `From<&'static str>`, which is doable, but I'm not yet sure if it's worthwhile.

r? @davidtwco