### PR TITLE
Style fix for loongarch-linux.md

### DIFF
--- a/src/doc/rustc/src/platform-support/loongarch-linux.md
+++ b/src/doc/rustc/src/platform-support/loongarch-linux.md
@@ -15,6 +15,8 @@ While the integer base ABI is implied by the machine field, the floating po
 |          f32           | The base ABI uses 32-bit FPRs for parameter passing. (lp64f)|
 |          sf            | The base ABI uses no FPR for parameter passing. (lp64s)     |
 
+<br>
+
 |`ABI type(Base ABI/ABI extension)`| `C library` | `kernel` |          `target tuple`          |
 |----------------------------------|-------------|----------|----------------------------------|
 |           lp64d/base             |   glibc     |  linux   | loongarch64-unknown-linux-gnu |


### PR DESCRIPTION
Currently the render result by mdbook has some problems.
![]()
![Screenshot_2023-04-20-13-59-53-024_com android chrome-edit](https://user-images.githubusercontent.com/10987206/233272178-5850ae44-cb5e-4bc1-af3e-ed67f3fdb41f.jpg)
