### PR TITLE
tweak "make mut" spans when assigning to locals

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -1268,9 +1268,9 @@ fn suggest_ampmut<'tcx>(
         // shrink the span to just after the `&` in `&variable`
         let span = span.with_lo(span.lo() + BytePos(1)).shrink_to_lo();
         (true, span, "mut ".to_owned())
-    // otherwise, suggest that the user annotates the binding; we provide the
-    // type of the local.
     } else {
+        // otherwise, suggest that the user annotates the binding; we provide the
+        // type of the local.
         let ty_mut = local_decl.ty.builtin_deref(true).unwrap();
         assert_eq!(ty_mut.mutbl, hir::Mutability::Not);
 

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -1263,6 +1263,10 @@ fn suggest_ampmut<'tcx>(
     {
         let span = span.with_lo(span.lo() + BytePos(ws_pos as u32)).shrink_to_lo();
         (true, span, " mut".to_owned())
+    } else if binding_exists {
+        // shrink the span to just after the `&` in `&variable`
+        let span = span.with_lo(span.lo() + BytePos(1)).shrink_to_lo();
+        (true, span, "mut ".to_owned())
     } else {
         let ty_mut = local_decl.ty.builtin_deref(true).unwrap();
         assert_eq!(ty_mut.mutbl, hir::Mutability::Not);

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -1263,21 +1263,21 @@ fn suggest_ampmut<'tcx>(
     {
         let span = span.with_lo(span.lo() + BytePos(ws_pos as u32)).shrink_to_lo();
         (true, span, " mut".to_owned())
+    // if there is already a binding, we modify it to be `mut`
     } else if binding_exists {
         // shrink the span to just after the `&` in `&variable`
         let span = span.with_lo(span.lo() + BytePos(1)).shrink_to_lo();
         (true, span, "mut ".to_owned())
+    // otherwise, suggest that the user annotates the binding; we provide the
+    // type of the local.
     } else {
         let ty_mut = local_decl.ty.builtin_deref(true).unwrap();
         assert_eq!(ty_mut.mutbl, hir::Mutability::Not);
+
         (
-            binding_exists,
+            false,
             span,
-            if local_decl.ty.is_ref() {
-                format!("&mut {}", ty_mut.ty)
-            } else {
-                format!("*mut {}", ty_mut.ty)
-            },
+            format!("{}mut {}", if local_decl.ty.is_ref() {"&"} else {"*"}, ty_mut.ty)
         )
     }
 }

--- a/tests/ui/array-slice-vec/slice-mut-2.stderr
+++ b/tests/ui/array-slice-vec/slice-mut-2.stderr
@@ -7,7 +7,7 @@ LL |     let _ = &mut x[2..4];
 help: consider changing this to be a mutable reference
    |
 LL |     let x: &[isize] = &mut [1, 2, 3, 4, 5];
-   |                       ~~~~~~~~~~~~~~~~~~~~
+   |                        +++
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
+++ b/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
@@ -7,7 +7,7 @@ LL |     let q = &raw mut *x;
 help: consider changing this to be a mutable reference
    |
 LL |     let x = &mut 0;
-   |             ~~~~~~
+   |              +++
 
 error[E0596]: cannot borrow `*x` as mutable, as it is behind a `*const` pointer
   --> $DIR/borrow-raw-address-of-deref-mutability.rs:14:13
@@ -18,7 +18,7 @@ LL |     let q = &raw mut *x;
 help: consider changing this to be a mutable pointer
    |
 LL |     let x = &mut 0 as *const i32;
-   |             ~~~~~~
+   |              +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/borrowck-access-permissions.stderr
+++ b/tests/ui/borrowck/borrowck-access-permissions.stderr
@@ -35,7 +35,7 @@ LL |         let _y1 = &mut *ref_x;
 help: consider changing this to be a mutable reference
    |
 LL |         let ref_x = &mut x;
-   |                     ~~~~~~
+   |                      +++
 
 error[E0596]: cannot borrow `*ptr_x` as mutable, as it is behind a `*const` pointer
   --> $DIR/borrowck-access-permissions.rs:39:23
@@ -46,7 +46,7 @@ LL |             let _y1 = &mut *ptr_x;
 help: consider changing this to be a mutable pointer
    |
 LL |         let ptr_x : *const _ = &mut x;
-   |                                ~~~~~~
+   |                                 +++
 
 error[E0596]: cannot borrow `*foo_ref.f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-access-permissions.rs:48:18
@@ -57,7 +57,7 @@ LL |         let _y = &mut *foo_ref.f;
 help: consider changing this to be a mutable reference
    |
 LL |         let foo_ref = &mut foo;
-   |                       ~~~~~~~~
+   |                        +++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
@@ -6,8 +6,8 @@ LL |     *s.pointer += 1;
    |
 help: consider changing this to be a mutable reference
    |
-LL | fn a(s: &mut S<'_>) {
-   |         ~~~~~~~~~~
+LL | fn a(s: &mut S) {
+   |          +++
 
 error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:17:5
@@ -17,8 +17,8 @@ LL |     *s.pointer += 1;
    |
 help: consider changing this to be a mutable reference
    |
-LL | fn c(s: &mut &mut S<'_>) {
-   |         ~~~~~~~~~~~~~~~
+LL | fn c(s: &mut  &mut S) {
+   |          +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
@@ -27,8 +27,8 @@ LL |     let x:  &mut isize = &mut **t0;
    |
 help: consider changing this to be a mutable reference
    |
-LL | fn foo4(t0: &mut &mut isize) {
-   |             ~~~~~~~~~~~~~~~
+LL | fn foo4(t0: &mut  &mut isize) {
+   |              +++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/borrowck/borrowck-issue-14498.stderr
+++ b/tests/ui/borrowck/borrowck-issue-14498.stderr
@@ -7,7 +7,7 @@ LL |     ***p = 2;
 help: consider changing this to be a mutable reference
    |
 LL |     let p = &mut y;
-   |             ~~~~~~
+   |              +++
 
 error[E0506]: cannot assign to `**y` because it is borrowed
   --> $DIR/borrowck-issue-14498.rs:25:5

--- a/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
+++ b/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
@@ -111,7 +111,7 @@ LL |     let _bar1 = &mut foo.bar1;
 help: consider changing this to be a mutable reference
    |
 LL | fn borrow_mut_from_imm(foo: &mut Foo) {
-   |                             ~~~~~~~~
+   |                              +++
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/borrowck/issue-85765.stderr
+++ b/tests/ui/borrowck/issue-85765.stderr
@@ -18,7 +18,7 @@ LL |     *r = 0;
 help: consider changing this to be a mutable reference
    |
 LL |     let r = &mut mutvar;
-   |             ~~~~~~~~~~~
+   |              +++
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:19:5

--- a/tests/ui/borrowck/mutability-errors.stderr
+++ b/tests/ui/borrowck/mutability-errors.stderr
@@ -7,7 +7,7 @@ LL |     *x = (1,);
 help: consider changing this to be a mutable reference
    |
 LL | fn named_ref(x: &mut (i32,)) {
-   |                 ~~~~~~~~~~~
+   |                  +++
 
 error[E0594]: cannot assign to `x.0`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:10:5
@@ -18,7 +18,7 @@ LL |     x.0 = 1;
 help: consider changing this to be a mutable reference
    |
 LL | fn named_ref(x: &mut (i32,)) {
-   |                 ~~~~~~~~~~~
+   |                  +++
 
 error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/mutability-errors.rs:11:5
@@ -29,7 +29,7 @@ LL |     &mut *x;
 help: consider changing this to be a mutable reference
    |
 LL | fn named_ref(x: &mut (i32,)) {
-   |                 ~~~~~~~~~~~
+   |                  +++
 
 error[E0596]: cannot borrow `x.0` as mutable, as it is behind a `&` reference
   --> $DIR/mutability-errors.rs:12:5
@@ -40,7 +40,7 @@ LL |     &mut x.0;
 help: consider changing this to be a mutable reference
    |
 LL | fn named_ref(x: &mut (i32,)) {
-   |                 ~~~~~~~~~~~
+   |                  +++
 
 error[E0594]: cannot assign to data in a `&` reference
   --> $DIR/mutability-errors.rs:16:5
@@ -74,8 +74,8 @@ LL |     *x = (1,);
    |
 help: consider changing this to be a mutable pointer
    |
-LL | unsafe fn named_ptr(x: *mut (i32,)) {
-   |                        ~~~~~~~~~~~
+LL | unsafe fn named_ptr(x: *mut const (i32,)) {
+   |                         +++
 
 error[E0594]: cannot assign to `x.0`, which is behind a `*const` pointer
   --> $DIR/mutability-errors.rs:24:5
@@ -85,8 +85,8 @@ LL |     (*x).0 = 1;
    |
 help: consider changing this to be a mutable pointer
    |
-LL | unsafe fn named_ptr(x: *mut (i32,)) {
-   |                        ~~~~~~~~~~~
+LL | unsafe fn named_ptr(x: *mut const (i32,)) {
+   |                         +++
 
 error[E0596]: cannot borrow `*x` as mutable, as it is behind a `*const` pointer
   --> $DIR/mutability-errors.rs:25:5
@@ -96,8 +96,8 @@ LL |     &mut *x;
    |
 help: consider changing this to be a mutable pointer
    |
-LL | unsafe fn named_ptr(x: *mut (i32,)) {
-   |                        ~~~~~~~~~~~
+LL | unsafe fn named_ptr(x: *mut const (i32,)) {
+   |                         +++
 
 error[E0596]: cannot borrow `x.0` as mutable, as it is behind a `*const` pointer
   --> $DIR/mutability-errors.rs:26:5
@@ -107,8 +107,8 @@ LL |     &mut (*x).0;
    |
 help: consider changing this to be a mutable pointer
    |
-LL | unsafe fn named_ptr(x: *mut (i32,)) {
-   |                        ~~~~~~~~~~~
+LL | unsafe fn named_ptr(x: *mut const (i32,)) {
+   |                         +++
 
 error[E0594]: cannot assign to data in a `*const` pointer
   --> $DIR/mutability-errors.rs:30:5

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
@@ -10,7 +10,7 @@ LL |         **ref_mref_x = y;
 help: consider changing this to be a mutable reference
    |
 LL |     let ref_mref_x = &mut mref_x;
-   |                      ~~~~~~~~~~~
+   |                       +++
 
 error[E0596]: cannot borrow `**mref_ref_x` as mutable, as it is behind a `&` reference
   --> $DIR/mut_ref.rs:26:13

--- a/tests/ui/did_you_mean/issue-38147-4.stderr
+++ b/tests/ui/did_you_mean/issue-38147-4.stderr
@@ -6,8 +6,8 @@ LL |     f.s.push('x');
    |
 help: consider changing this to be a mutable reference
    |
-LL | fn f(x: usize, f: &mut Foo<'_>) {
-   |                   ~~~~~~~~~~~~
+LL | fn f(x: usize, f: &mut Foo) {
+   |                    +++
 
 error: aborting due to previous error
 

--- a/tests/ui/did_you_mean/issue-39544.stderr
+++ b/tests/ui/did_you_mean/issue-39544.stderr
@@ -40,7 +40,7 @@ LL |         let _ = &mut other.x;
 help: consider changing this to be a mutable reference
    |
 LL |     fn foo1(&self, other: &mut Z) {
-   |                           ~~~~~~
+   |                            +++
 
 error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:25:17
@@ -62,7 +62,7 @@ LL |         let _ = &mut other.x;
 help: consider changing this to be a mutable reference
    |
 LL |     fn foo2<'a>(&'a self, other: &mut Z) {
-   |                                  ~~~~~~
+   |                                   +++
 
 error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:30:17
@@ -84,7 +84,7 @@ LL |         let _ = &mut other.x;
 help: consider changing this to be a mutable reference
    |
 LL |     fn foo3<'a>(self: &'a Self, other: &mut Z) {
-   |                                        ~~~~~~
+   |                                         +++
 
 error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:35:17
@@ -95,7 +95,7 @@ LL |         let _ = &mut other.x;
 help: consider changing this to be a mutable reference
    |
 LL |     fn foo4(other: &mut Z) {
-   |                    ~~~~~~
+   |                     +++
 
 error[E0596]: cannot borrow `z.x` as mutable, as `z` is not declared as mutable
   --> $DIR/issue-39544.rs:41:13
@@ -117,7 +117,7 @@ LL |     let _ = &mut w.x;
 help: consider changing this to be a mutable reference
    |
 LL | pub fn with_arg(z: Z, w: &mut Z) {
-   |                          ~~~~~~
+   |                           +++
 
 error[E0594]: cannot assign to `*x.0`, which is behind a `&` reference
   --> $DIR/issue-39544.rs:48:5

--- a/tests/ui/did_you_mean/issue-39544.stderr
+++ b/tests/ui/did_you_mean/issue-39544.stderr
@@ -73,7 +73,7 @@ LL |         let _ = &mut self.x;
 help: consider changing this to be a mutable reference
    |
 LL |     fn foo3<'a>(self: &'a mut Self, other: &Z) {
-   |                       ~~~~~~~~~~~~
+   |                           +++
 
 error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:31:17

--- a/tests/ui/did_you_mean/issue-40823.stderr
+++ b/tests/ui/did_you_mean/issue-40823.stderr
@@ -7,7 +7,7 @@ LL |     buf.iter_mut();
 help: consider changing this to be a mutable reference
    |
 LL |     let mut buf = &mut [1, 2, 3, 4];
-   |                   ~~~~~~~~~~~~~~~~~
+   |                    +++
 
 error: aborting due to previous error
 

--- a/tests/ui/error-codes/E0389.stderr
+++ b/tests/ui/error-codes/E0389.stderr
@@ -7,7 +7,7 @@ LL |     fancy_ref.num = 6;
 help: consider changing this to be a mutable reference
    |
 LL |     let fancy_ref = &mut (&mut fancy);
-   |                     ~~~~~~~~~~~~~~~~~
+   |                      +++
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-51515.rs
+++ b/tests/ui/issues/issue-51515.rs
@@ -1,7 +1,6 @@
 fn main() {
     let foo = &16;
     //~^ HELP consider changing this to be a mutable reference
-    //~| SUGGESTION &mut 16
     *foo = 32;
     //~^ ERROR cannot assign to `*foo`, which is behind a `&` reference
     let bar = foo;

--- a/tests/ui/issues/issue-51515.stderr
+++ b/tests/ui/issues/issue-51515.stderr
@@ -1,5 +1,5 @@
 error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
-  --> $DIR/issue-51515.rs:5:5
+  --> $DIR/issue-51515.rs:4:5
    |
 LL |     *foo = 32;
    |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
@@ -7,10 +7,10 @@ LL |     *foo = 32;
 help: consider changing this to be a mutable reference
    |
 LL |     let foo = &mut 16;
-   |               ~~~~~~~
+   |                +++
 
 error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
-  --> $DIR/issue-51515.rs:9:5
+  --> $DIR/issue-51515.rs:8:5
    |
 LL |     *bar = 64;
    |     ^^^^^^^^^ `bar` is a `&` reference, so the data it refers to cannot be written

--- a/tests/ui/issues/issue-61623.stderr
+++ b/tests/ui/issues/issue-61623.stderr
@@ -7,7 +7,7 @@ LL |     f2(|| x.0, f1(x.1))
 help: consider changing this to be a mutable reference
    |
 LL | fn f3<'a>(x: &'a mut ((), &'a mut ())) {
-   |              ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                  +++
 
 error: aborting due to previous error
 

--- a/tests/ui/nll/issue-47388.stderr
+++ b/tests/ui/nll/issue-47388.stderr
@@ -7,7 +7,7 @@ LL |     fancy_ref.num = 6;
 help: consider changing this to be a mutable reference
    |
 LL |     let fancy_ref = &mut (&mut fancy);
-   |                     ~~~~~~~~~~~~~~~~~
+   |                      +++
 
 error: aborting due to previous error
 

--- a/tests/ui/nll/issue-51244.stderr
+++ b/tests/ui/nll/issue-51244.stderr
@@ -7,7 +7,7 @@ LL |     *my_ref = 0;
 help: consider changing this to be a mutable reference
    |
 LL |     let ref mut my_ref @ _ = 0;
-   |         ~~~~~~~~~~~~~~
+   |             +++
 
 error: aborting due to previous error
 

--- a/tests/ui/nll/issue-57989.stderr
+++ b/tests/ui/nll/issue-57989.stderr
@@ -7,7 +7,7 @@ LL |     *x = 0;
 help: consider changing this to be a mutable reference
    |
 LL | fn f(x: &mut i32) {
-   |         ~~~~~~~~
+   |          +++
 
 error[E0506]: cannot assign to `*x` because it is borrowed
   --> $DIR/issue-57989.rs:5:5

--- a/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
+++ b/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
@@ -112,7 +112,7 @@ LL |     *_x0 = U;
 help: consider changing this to be a mutable reference
    |
 LL |     let (ref mut _x0, _x1, ref _x2, ..) = tup;
-   |          ~~~~~~~~~~~
+   |              +++
 
 error[E0594]: cannot assign to `*_x2`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:27:5
@@ -123,7 +123,7 @@ LL |     *_x2 = U;
 help: consider changing this to be a mutable reference
    |
 LL |     let (ref _x0, _x1, ref mut _x2, ..) = tup;
-   |                        ~~~~~~~~~~~
+   |                            +++
 
 error[E0382]: use of moved value: `tup.1`
   --> $DIR/borrowck-move-ref-pattern.rs:28:10

--- a/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
@@ -50,7 +50,7 @@ LL |     x.y = 3;
 help: consider changing this to be a mutable reference
    |
 LL | fn assign_field2<'a>(x: &'a mut Own<Point>) {
-   |                         ~~~~~~~~~~~~~~~~~~
+   |                             +++
 
 error[E0499]: cannot borrow `*x` as mutable more than once at a time
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:101:5
@@ -104,7 +104,7 @@ LL |     *x.y_mut() = 3;
 help: consider changing this to be a mutable reference
    |
 LL | fn assign_method2<'a>(x: &'a mut Own<Point>) {
-   |                          ~~~~~~~~~~~~~~~~~~
+   |                              +++
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
@@ -18,7 +18,7 @@ LL |     &mut x.y
 help: consider changing this to be a mutable reference
    |
 LL | fn deref_extend_mut_field1(x: &mut Own<Point>) -> &mut isize {
-   |                               ~~~~~~~~~~~~~~~
+   |                                +++
 
 error[E0499]: cannot borrow `*x` as mutable more than once at a time
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:78:19
@@ -82,7 +82,7 @@ LL |     x.y_mut()
 help: consider changing this to be a mutable reference
    |
 LL | fn deref_extend_mut_method1(x: &mut Own<Point>) -> &mut isize {
-   |                                ~~~~~~~~~~~~~~~
+   |                                 +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:129:6

--- a/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
@@ -18,7 +18,7 @@ LL |     &mut **x
 help: consider changing this to be a mutable reference
    |
 LL | fn deref_extend_mut1<'a>(x: &'a mut Own<isize>) -> &'a mut isize {
-   |                             ~~~~~~~~~~~~~~~~~~
+   |                                 +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:49:6
@@ -40,7 +40,7 @@ LL |     **x = 3;
 help: consider changing this to be a mutable reference
    |
 LL | fn assign2<'a>(x: &'a mut Own<isize>) {
-   |                   ~~~~~~~~~~~~~~~~~~
+   |                       +++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
+++ b/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
@@ -19,7 +19,7 @@ LL |     (*f)();
 help: consider changing this to be a mutable reference
    |
 LL | fn test2<F>(f: &mut F) where F: FnMut() {
-   |                ~~~~~~
+   |                 +++
 
 error[E0596]: cannot borrow `f.f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:34:5
@@ -29,8 +29,8 @@ LL |     f.f.call_mut(())
    |
 help: consider changing this to be a mutable reference
    |
-LL | fn test4(f: &mut Test<'_>) {
-   |             ~~~~~~~~~~~~~
+LL | fn test4(f: &mut Test) {
+   |              +++
 
 error[E0507]: cannot move out of `f`, a captured variable in an `FnMut` closure
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:57:13

--- a/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
+++ b/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
@@ -7,7 +7,7 @@ LL |     x.h();
 help: consider changing this to be a mutable reference
    |
 LL | fn b(x: &mut Foo) {
-   |         ~~~~~~~~
+   |          +++
 
 error: aborting due to previous error
 

--- a/tests/ui/span/borrowck-fn-in-const-b.stderr
+++ b/tests/ui/span/borrowck-fn-in-const-b.stderr
@@ -7,7 +7,7 @@ LL |         x.push(format!("this is broken"));
 help: consider changing this to be a mutable reference
    |
 LL |     fn broken(x: &mut Vec<String>) {
-   |                  ~~~~~~~~~~~~~~~~
+   |                   +++
 
 error: aborting due to previous error
 

--- a/tests/ui/span/borrowck-object-mutability.stderr
+++ b/tests/ui/span/borrowck-object-mutability.stderr
@@ -7,7 +7,7 @@ LL |     x.borrowed_mut();
 help: consider changing this to be a mutable reference
    |
 LL | fn borrowed_receiver(x: &mut dyn Foo) {
-   |                         ~~~~~~~~~~~~
+   |                          +++
 
 error[E0596]: cannot borrow `*x` as mutable, as `x` is not declared as mutable
   --> $DIR/borrowck-object-mutability.rs:18:5

--- a/tests/ui/span/mut-arg-hint.stderr
+++ b/tests/ui/span/mut-arg-hint.stderr
@@ -7,7 +7,7 @@ LL |         a.push_str("bar");
 help: consider changing this to be a mutable reference
    |
 LL |     fn foo(mut a: &mut String) {
-   |                   ~~~~~~~~~~~
+   |                    +++
 
 error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:8:5
@@ -29,7 +29,7 @@ LL |         a.push_str("foo");
 help: consider changing this to be a mutable reference
    |
 LL |     pub fn foo(mut a: &mut String) {
-   |                       ~~~~~~~~~~~
+   |                        +++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/span/mut-arg-hint.stderr
+++ b/tests/ui/span/mut-arg-hint.stderr
@@ -18,7 +18,7 @@ LL |     a.push_str("foo");
 help: consider changing this to be a mutable reference
    |
 LL | pub fn foo<'a>(mut a: &'a mut String) {
-   |                       ~~~~~~~~~~~~~~
+   |                           +++
 
 error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:15:9

--- a/tests/ui/suggestions/issue-68049-2.stderr
+++ b/tests/ui/suggestions/issue-68049-2.stderr
@@ -6,8 +6,8 @@ LL |       *input = self.0;
    |
 help: consider changing that to be a mutable reference
    |
-LL |   fn example(&self, input: &mut i32); // should suggest here
-   |                            ~~~~~~~~
+LL |   fn example(&self, input: mut ); // should suggest here
+   |                            ~~~
 
 error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:17:5

--- a/tests/ui/suggestions/issue-68049-2.stderr
+++ b/tests/ui/suggestions/issue-68049-2.stderr
@@ -4,10 +4,10 @@ error[E0594]: cannot assign to `*input`, which is behind a `&` reference
 LL |       *input = self.0;
    |       ^^^^^^^^^^^^^^^ `input` is a `&` reference, so the data it refers to cannot be written
    |
-help: consider changing that to be a mutable reference
+help: consider changing this to be a mutable reference
    |
-LL |   fn example(&self, input: mut ); // should suggest here
-   |                            ~~~
+LL |   fn example(&self, input: &mut i32) { // should not suggest here
+   |                             +++
 
 error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:17:5
@@ -15,7 +15,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
 LL |     self.0 += *input;
    |     ^^^^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
    |
-help: consider changing that to be a mutable reference
+help: consider changing this to be a mutable reference
    |
 LL |   fn example(&mut self, input: &i32); // should suggest here
    |              ~~~~~~~~~

--- a/tests/ui/suggestions/suggest-ref-mut.rs
+++ b/tests/ui/suggestions/suggest-ref-mut.rs
@@ -12,12 +12,10 @@ impl X {
 fn main() {
     let ref foo = 16;
     //~^ HELP
-    //~| SUGGESTION ref mut foo
     *foo = 32;
     //~^ ERROR
     if let Some(ref bar) = Some(16) {
         //~^ HELP
-        //~| SUGGESTION ref mut bar
         *bar = 32;
         //~^ ERROR
     }
@@ -25,6 +23,5 @@ fn main() {
         ref quo => { *quo = 32; },
         //~^ ERROR
         //~| HELP
-        //~| SUGGESTION ref mut quo
     }
 }

--- a/tests/ui/suggestions/suggest-ref-mut.stderr
+++ b/tests/ui/suggestions/suggest-ref-mut.stderr
@@ -10,7 +10,7 @@ LL |     fn zap(&mut self) {
    |            ~~~~~~~~~
 
 error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
-  --> $DIR/suggest-ref-mut.rs:16:5
+  --> $DIR/suggest-ref-mut.rs:15:5
    |
 LL |     *foo = 32;
    |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
@@ -18,10 +18,10 @@ LL |     *foo = 32;
 help: consider changing this to be a mutable reference
    |
 LL |     let ref mut foo = 16;
-   |         ~~~~~~~~~~~
+   |             +++
 
 error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
-  --> $DIR/suggest-ref-mut.rs:21:9
+  --> $DIR/suggest-ref-mut.rs:19:9
    |
 LL |         *bar = 32;
    |         ^^^^^^^^^ `bar` is a `&` reference, so the data it refers to cannot be written
@@ -29,10 +29,10 @@ LL |         *bar = 32;
 help: consider changing this to be a mutable reference
    |
 LL |     if let Some(ref mut bar) = Some(16) {
-   |                 ~~~~~~~~~~~
+   |                     +++
 
 error[E0594]: cannot assign to `*quo`, which is behind a `&` reference
-  --> $DIR/suggest-ref-mut.rs:25:22
+  --> $DIR/suggest-ref-mut.rs:23:22
    |
 LL |         ref quo => { *quo = 32; },
    |                      ^^^^^^^^^ `quo` is a `&` reference, so the data it refers to cannot be written
@@ -40,7 +40,7 @@ LL |         ref quo => { *quo = 32; },
 help: consider changing this to be a mutable reference
    |
 LL |         ref mut quo => { *quo = 32; },
-   |         ~~~~~~~~~~~
+   |             +++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
+++ b/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
@@ -7,7 +7,7 @@ LL |     *t
 help: consider changing this to be a mutable reference
    |
 LL | fn reborrow_mut<'a>(t: &'a mut &'a mut i32) -> &'a mut i32 where &'a mut i32: Copy {
-   |                        ~~~~~~~~~~~~~~~~~~~
+   |                            +++
 
 error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:10:6
@@ -18,7 +18,7 @@ LL |     {*t}
 help: consider changing this to be a mutable reference
    |
 LL | fn copy_reborrow_mut<'a>(t: &'a mut &'a mut i32) -> &'a mut i32 where &'a mut i32: Copy {
-   |                             ~~~~~~~~~~~~~~~~~~~
+   |                                 +++
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Work towards fixing #106857

This PR just cleans up a lot of spans which is helpful before properly fixing the issues. Best reviewed commit-by-commit.

r? @estebank