### PR TITLE
Allow overwriting the sysroot compile flag in compile tests

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1900,8 +1900,11 @@ impl<'test> TestCx<'test> {
         // Use a single thread for efficiency and a deterministic error message order
         rustc.arg("-Zthreads=1");
 
-        // In stage 0, make sure we use `stage0-sysroot` instead of the bootstrap sysroot.
-        rustc.arg("--sysroot").arg(&self.config.sysroot_base);
+        // Optionally prevent default --sysroot if specified in test compile-flags.
+        if !self.props.compile_flags.iter().any(|flag| flag.starts_with("--sysroot")) {
+            // In stage 0, make sure we use `stage0-sysroot` instead of the bootstrap sysroot.
+            rustc.arg("--sysroot").arg(&self.config.sysroot_base);
+        }
 
         // Optionally prevent default --target if specified in test compile-flags.
         let custom_target = self.props.compile_flags.iter().any(|x| x.starts_with("--target"));


### PR DESCRIPTION
This was added in https://github.com/rust-lang/rust/pull/110478/files#diff-03a0567fa80ca04ed5a55f9ac5c711b4f84659be2d0ac4a984196d581c04f76b, unconditionally passing the `sysroot` flag to the compile test invocations. In our ferrocene fork we have a few tests that test the `sysroot` flag specifically which fail due to the flag being passed multiple times now.

We believe upstreaming this small change could be beneficial should rust-lang/rust also want to test certain sysroot setups in the future.