### PR TITLE
Fix Unreadable non-UTF-8 output on localized MSVC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,6 +3250,7 @@ dependencies = [
  "tempfile",
  "thorin-dwp",
  "tracing",
+ "windows 0.46.0",
 ]
 
 [[package]]

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -49,3 +49,7 @@ libc = "0.2.50"
 version = "0.30.1"
 default-features = false
 features = ["read_core", "elf", "macho", "pe", "unaligned", "archive", "write"]
+
+[target.'cfg(windows)'.dependencies.windows]
+version = "0.46.0"
+features = ["Win32_Globalization"]

--- a/tests/ui/native-library-link-flags/msvc-non-utf8-output.rs
+++ b/tests/ui/native-library-link-flags/msvc-non-utf8-output.rs
@@ -1,0 +1,6 @@
+// build-fail
+// compile-flags:-C link-arg=märchenhaft
+// only-msvc
+// error-pattern:= note: LINK : fatal error LNK1181:
+// normalize-stderr-test "(\s*\|\n)\s*= note: .*\n" -> "$1"
+pub fn main() {}

--- a/tests/ui/native-library-link-flags/msvc-non-utf8-output.stderr
+++ b/tests/ui/native-library-link-flags/msvc-non-utf8-output.stderr
@@ -1,0 +1,7 @@
+error: linking with `link.exe` failed: exit code: 1181
+   |
+   = note: LINK : fatal error LNK1181: cannot open input file 'märchenhaft.obj'
+           
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #35785 by converting non UTF-8 linker output to Unicode using the OEM code page.

Before:

```text
  = note: Non-UTF-8 output: LINK : fatal error LNK1181: cannot open input file \'m\x84rchenhaft.obj\'\r\n
```

After:

```text
   = note: LINK : fatal error LNK1181: cannot open input file 'märchenhaft.obj'
```

The difference is more dramatic if using a non-ascii language pack for Windows.