### PR TITLE
Fix `std` compilation error for wasi+atomics

### DIFF
--- a/library/std/src/sys/wasi/mod.rs
+++ b/library/std/src/sys/wasi/mod.rs
@@ -32,8 +32,6 @@ pub mod io;
 #[path = "../unsupported/locks/mod.rs"]
 pub mod locks;
 pub mod net;
-#[path = "../unsupported/once.rs"]
-pub mod once;
 pub mod os;
 #[path = "../unix/os_str.rs"]
 pub mod os_str;
@@ -50,6 +48,13 @@ pub mod thread_local_dtor;
 #[path = "../unsupported/thread_local_key.rs"]
 pub mod thread_local_key;
 pub mod time;
+
+cfg_if::cfg_if! {
+    if #[cfg(not(target_feature = "atomics"))] {
+        #[path = "../unsupported/once.rs"]
+        pub mod once;
+    }
+}
 
 #[path = "../unsupported/common.rs"]
 #[deny(unsafe_op_in_unsafe_fn)]


### PR DESCRIPTION
Fix https://github.com/rust-lang/rust/issues/109727

It seems that the `unsupported/once.rs` module isn't meant to exist at the same time as the `futex` module, as they have conflicting definitions.

I've solved this by defining the `once` module only if `not(target_feature = "atomics")`.
The `wasm32-unknown-unknown` target [similarly only defines the `once` module if `not(target_feature = "atomics")`](https://github.com/tomaka/rust/blob/01c4f319276da912dd2be768ae0ce9857ad6bb63/library/std/src/sys/wasm/mod.rs#L69-L70).

As show in [this block of code](https://github.com/tomaka/rust/blob/01c4f319276da912dd2be768ae0ce9857ad6bb63/library/std/src/sys_common/once/mod.rs#L10-L34), the `sys::once` module doesn't need to exist if `all(target_arch = "wasm32", target_feature = "atomics")`.
