### PR TITLE
Add some tests around (lack of) object safety of associated types and consts

### DIFF
--- a/tests/ui/object-safety/assoc_const_bounds.rs
+++ b/tests/ui/object-safety/assoc_const_bounds.rs
@@ -1,0 +1,13 @@
+trait Foo<T> {
+    const BAR: bool
+        where //~ ERROR: expected one of `!`, `(`, `+`, `::`, `;`, `<`, or `=`, found keyword `where`
+            Self: Sized;
+}
+
+trait Cake {}
+impl Cake for () {}
+
+fn foo(_: &dyn Foo<()>) {}
+fn bar(_: &dyn Foo<i32>) {}
+
+fn main() {}

--- a/tests/ui/object-safety/assoc_const_bounds.stderr
+++ b/tests/ui/object-safety/assoc_const_bounds.stderr
@@ -1,0 +1,15 @@
+error: expected one of `!`, `(`, `+`, `::`, `;`, `<`, or `=`, found keyword `where`
+  --> $DIR/assoc_const_bounds.rs:3:9
+   |
+LL | trait Foo<T> {
+   |              - while parsing this item list starting here
+LL |     const BAR: bool
+   |                    - expected one of 7 possible tokens
+LL |         where
+   |         ^^^^^ unexpected token
+LL |             Self: Sized;
+LL | }
+   | - the item list ends here
+
+error: aborting due to previous error
+

--- a/tests/ui/object-safety/assoc_const_bounds_sized.rs
+++ b/tests/ui/object-safety/assoc_const_bounds_sized.rs
@@ -1,0 +1,9 @@
+trait Foo {
+    const BAR: bool
+        where //~ ERROR: expected one of `!`, `(`, `+`, `::`, `;`, `<`, or `=`, found keyword `where`
+            Self: Sized;
+}
+
+fn foo(_: &dyn Foo) {}
+
+fn main() {}

--- a/tests/ui/object-safety/assoc_const_bounds_sized.stderr
+++ b/tests/ui/object-safety/assoc_const_bounds_sized.stderr
@@ -1,0 +1,15 @@
+error: expected one of `!`, `(`, `+`, `::`, `;`, `<`, or `=`, found keyword `where`
+  --> $DIR/assoc_const_bounds_sized.rs:3:9
+   |
+LL | trait Foo {
+   |           - while parsing this item list starting here
+LL |     const BAR: bool
+   |                    - expected one of 7 possible tokens
+LL |         where
+   |         ^^^^^ unexpected token
+LL |             Self: Sized;
+LL | }
+   | - the item list ends here
+
+error: aborting due to previous error
+

--- a/tests/ui/object-safety/assoc_type_bounds.rs
+++ b/tests/ui/object-safety/assoc_type_bounds.rs
@@ -1,0 +1,13 @@
+trait Foo<T> {
+    type Bar
+    where
+        T: Cake;
+}
+
+trait Cake {}
+impl Cake for () {}
+
+fn foo(_: &dyn Foo<()>) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
+fn bar(_: &dyn Foo<i32>) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
+
+fn main() {}

--- a/tests/ui/object-safety/assoc_type_bounds.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds.stderr
@@ -1,0 +1,21 @@
+error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+  --> $DIR/assoc_type_bounds.rs:10:16
+   |
+LL |     type Bar
+   |     -------- `Bar` defined here
+...
+LL | fn foo(_: &dyn Foo<()>) {}
+   |                ^^^^^^^ help: specify the associated type: `Foo<(), Bar = Type>`
+
+error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+  --> $DIR/assoc_type_bounds.rs:11:16
+   |
+LL |     type Bar
+   |     -------- `Bar` defined here
+...
+LL | fn bar(_: &dyn Foo<i32>) {}
+   |                ^^^^^^^^ help: specify the associated type: `Foo<i32, Bar = Type>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/object-safety/assoc_type_bounds2.rs
+++ b/tests/ui/object-safety/assoc_type_bounds2.rs
@@ -1,0 +1,13 @@
+trait Foo<T> {
+    type Bar
+    where
+        Self: Foo<()>;
+}
+
+trait Cake {}
+impl Cake for () {}
+
+fn foo(_: &dyn Foo<()>) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
+fn bar(_: &dyn Foo<i32>) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
+
+fn main() {}

--- a/tests/ui/object-safety/assoc_type_bounds2.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds2.stderr
@@ -1,0 +1,21 @@
+error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+  --> $DIR/assoc_type_bounds2.rs:10:16
+   |
+LL |     type Bar
+   |     -------- `Bar` defined here
+...
+LL | fn foo(_: &dyn Foo<()>) {}
+   |                ^^^^^^^ help: specify the associated type: `Foo<(), Bar = Type>`
+
+error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+  --> $DIR/assoc_type_bounds2.rs:11:16
+   |
+LL |     type Bar
+   |     -------- `Bar` defined here
+...
+LL | fn bar(_: &dyn Foo<i32>) {}
+   |                ^^^^^^^^ help: specify the associated type: `Foo<i32, Bar = Type>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/object-safety/assoc_type_bounds_sized.rs
+++ b/tests/ui/object-safety/assoc_type_bounds_sized.rs
@@ -1,0 +1,9 @@
+trait Foo {
+    type Bar
+    where
+        Self: Sized;
+}
+
+fn foo(_: &dyn Foo) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
+
+fn main() {}

--- a/tests/ui/object-safety/assoc_type_bounds_sized.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds_sized.stderr
@@ -1,0 +1,12 @@
+error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+  --> $DIR/assoc_type_bounds_sized.rs:7:16
+   |
+LL |     type Bar
+   |     -------- `Bar` defined here
+...
+LL | fn foo(_: &dyn Foo) {}
+   |                ^^^ help: specify the associated type: `Foo<Bar = Type>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0191`.


### PR DESCRIPTION
See https://rust-lang.zulipchat.com/#narrow/stream/144729-t-types/topic/.60where.20Self.3ASized.60.20on.20assoc.20types/near/351260928 for some discussion around why this isn't allowed.

We didn't have any tests for these, so I decided to add them now, even if we don't end up doing anything about it.