### PR TITLE
Add `impl_tag!` macro to implement `Tag` for tagged pointer easily

### DIFF
--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -31,6 +31,7 @@
 #![feature(unwrap_infallible)]
 #![feature(strict_provenance)]
 #![feature(ptr_alignment_type)]
+#![feature(macro_metavar_expr)]
 #![allow(rustc::default_hash_types)]
 #![allow(rustc::potential_query_instability)]
 #![deny(rustc::untranslatable_diagnostic)]

--- a/compiler/rustc_data_structures/src/tagged_ptr.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr.rs
@@ -155,22 +155,12 @@ pub const fn bits_for_tags(mut tags: &[usize]) -> u32 {
     while let &[tag, ref rest @ ..] = tags {
         tags = rest;
 
-        let b = bits_for_tag(tag);
+        // bits required to represent `tag`,
+        // position of the most significant 1
+        let b = usize::BITS - tag.leading_zeros();
         if b > bits {
             bits = b;
         }
-    }
-
-    bits
-}
-
-/// Returns `(size_of::<usize>() * 8) - tag.leading_zeros()`
-const fn bits_for_tag(mut tag: usize) -> u32 {
-    let mut bits = 0;
-
-    while tag > 0 {
-        bits += 1;
-        tag >>= 1;
     }
 
     bits

--- a/compiler/rustc_data_structures/src/tagged_ptr/impl_tag.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/impl_tag.rs
@@ -100,6 +100,7 @@ macro_rules! impl_tag {
                 )*
             ]);
 
+            #[inline]
             fn into_usize(self) -> usize {
                 // This forbids use of repeating patterns (`Enum::V`&`Enum::V`, etc)
                 // (or at least it should, see <https://github.com/rust-lang/rust/issues/110613>)
@@ -112,6 +113,7 @@ macro_rules! impl_tag {
                 }
             }
 
+            #[inline]
             unsafe fn from_usize(tag: usize) -> Self {
                 match tag {
                     $(

--- a/compiler/rustc_data_structures/src/tagged_ptr/impl_tag.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/impl_tag.rs
@@ -1,0 +1,170 @@
+/// Implements [`Tag`] for a given type.
+///
+/// You can use `impl_tag` on structs and enums.
+/// You need to specify the type and all its possible values,
+/// which can only be paths with optional fields.
+///
+/// [`Tag`]: crate::tagged_ptr::Tag
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// use rustc_data_structures::{impl_tag, tagged_ptr::Tag};
+///
+/// #[derive(Copy, Clone, PartialEq, Debug)]
+/// enum SomeTag {
+///     A,
+///     B,
+///     X { v: bool },
+///     Y(bool, bool),
+/// }
+///
+/// impl_tag! {
+///     // The type for which the `Tag` will be implemented
+///     for SomeTag;
+///     // You need to specify the `{value_of_the_type} <=> {tag}` relationship
+///     SomeTag::A <=> 0,
+///     SomeTag::B <=> 1,
+///     // For variants with fields, you need to specify the fields:
+///     SomeTag::X { v: true  } <=> 2,
+///     SomeTag::X { v: false } <=> 3,
+///     // For tuple variants use named syntax:
+///     SomeTag::Y { 0: true,  1: true  } <=> 4,
+///     SomeTag::Y { 0: false, 1: true  } <=> 5,
+///     SomeTag::Y { 0: true,  1: false } <=> 6,
+///     SomeTag::Y { 0: false, 1: false } <=> 7,
+/// }
+///
+/// assert_eq!(SomeTag::A.into_usize(), 0);
+/// assert_eq!(SomeTag::X { v: false }.into_usize(), 3);
+/// assert_eq!(SomeTag::Y(false, true).into_usize(), 5);
+///
+/// assert_eq!(unsafe { SomeTag::from_usize(1) }, SomeTag::B);
+/// assert_eq!(unsafe { SomeTag::from_usize(2) }, SomeTag::X { v: true });
+/// assert_eq!(unsafe { SomeTag::from_usize(7) }, SomeTag::Y(false, false));
+/// ```
+///
+/// Structs are supported:
+///
+/// ```
+/// # use rustc_data_structures::impl_tag;
+/// #[derive(Copy, Clone)]
+/// struct Flags { a: bool, b: bool }
+///
+/// impl_tag! {
+///     for Flags;
+///     Flags { a: true,  b: true  } <=> 3,
+///     Flags { a: false, b: true  } <=> 2,
+///     Flags { a: true,  b: false } <=> 1,
+///     Flags { a: false, b: false } <=> 0,
+/// }
+/// ```
+///
+// This is supposed to produce a compile error, but does not,
+// see <https://github.com/rust-lang/rust/issues/110613> for more information.
+//
+// Using the same pattern twice results in a compile error:
+//
+// ```compile_fail
+// # use rustc_data_structures::impl_tag;
+// #[derive(Copy, Clone)]
+// struct Unit;
+//
+// impl_tag! {
+//     for Unit;
+//     Unit <=> 0,
+//     Unit <=> 1,
+// }
+// ```
+//
+// Using the same tag twice results in a compile error:
+//
+// ```compile_fail
+// # use rustc_data_structures::impl_tag;
+// #[derive(Copy, Clone)]
+// enum E { A, B };
+//
+// impl_tag! {
+//     for E;
+//     E::A <=> 0,
+//     E::B <=> 0,
+// }
+// ```
+//
+/// Not specifying all values results in a compile error:
+///
+/// ```compile_fail,E0004
+/// # use rustc_data_structures::impl_tag;
+/// #[derive(Copy, Clone)]
+/// enum E {
+///     A,
+///     B,
+/// }
+///
+/// impl_tag! {
+///     for E;
+///     E::A <=> 0,
+/// }
+/// ```
+#[macro_export]
+macro_rules! impl_tag {
+    (
+        for $Self:ty;
+        $(
+            $($path:ident)::* $( { $( $fields:tt )* })? <=> $tag:literal,
+        )*
+    ) => {
+        // Safety:
+        // `into_usize` only returns one of `$tag`s,
+        // `bits_for_tags` is called on all `$tag`s,
+        // thus `BITS` constant is correct.
+        unsafe impl $crate::tagged_ptr::Tag for $Self {
+            const BITS: u32 = $crate::tagged_ptr::bits_for_tags(&[
+                $( $tag, )*
+            ]);
+
+            fn into_usize(self) -> usize {
+                // This forbids use of repeating patterns (`Enum::V`&`Enum::V`, etc)
+                // (or at least it should, see <https://github.com/rust-lang/rust/issues/110613>)
+                #[forbid(unreachable_patterns)]
+                match self {
+                    // `match` is doing heavy lifting here, by requiring exhaustiveness
+                    $(
+                        $($path)::* $( { $( $fields )* } )? => $tag,
+                    )*
+                }
+            }
+
+            unsafe fn from_usize(tag: usize) -> Self {
+                // Similarly to the above, this forbids repeating tags
+                // (or at least it should, see <https://github.com/rust-lang/rust/issues/110613>)
+                #[forbid(unreachable_patterns)]
+                match tag {
+                    $(
+                        $tag => $($path)::* $( { $( $fields )* } )?,
+                    )*
+
+                    // Safety:
+                    // `into_usize` only returns one of `$tag`s,
+                    // all `$tag`s are filtered up above,
+                    // thus if this is reached, the safety contract of this
+                    // function was already breached.
+                    _ => unsafe {
+                        debug_assert!(
+                            false,
+                            "invalid tag: {tag}\
+                             (this is a bug in the caller of `from_usize`)"
+                        );
+                        std::hint::unreachable_unchecked()
+                    },
+                }
+            }
+
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests;

--- a/compiler/rustc_data_structures/src/tagged_ptr/impl_tag.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/impl_tag.rs
@@ -62,37 +62,6 @@
 /// }
 /// ```
 ///
-// This is supposed to produce a compile error, but does not,
-// see <https://github.com/rust-lang/rust/issues/110613> for more information.
-//
-// Using the same pattern twice results in a compile error:
-//
-// ```compile_fail
-// # use rustc_data_structures::impl_tag;
-// #[derive(Copy, Clone)]
-// struct Unit;
-//
-// impl_tag! {
-//     impl Tag for Unit;
-//     Unit <=> 0,
-//     Unit <=> 1,
-// }
-// ```
-//
-// Using the same tag twice results in a compile error:
-//
-// ```compile_fail
-// # use rustc_data_structures::impl_tag;
-// #[derive(Copy, Clone)]
-// enum E { A, B };
-//
-// impl_tag! {
-//     impl Tag for E;
-//     E::A <=> 0,
-//     E::B <=> 0,
-// }
-// ```
-//
 /// Not specifying all values results in a compile error:
 ///
 /// ```compile_fail,E0004

--- a/compiler/rustc_data_structures/src/tagged_ptr/impl_tag.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/impl_tag.rs
@@ -23,7 +23,7 @@
 ///
 /// impl_tag! {
 ///     // The type for which the `Tag` will be implemented
-///     for SomeTag;
+///     impl Tag for SomeTag;
 ///     // You need to specify the `{value_of_the_type} <=> {tag}` relationship
 ///     SomeTag::A <=> 0,
 ///     SomeTag::B <=> 1,
@@ -54,7 +54,7 @@
 /// struct Flags { a: bool, b: bool }
 ///
 /// impl_tag! {
-///     for Flags;
+///     impl Tag for Flags;
 ///     Flags { a: true,  b: true  } <=> 3,
 ///     Flags { a: false, b: true  } <=> 2,
 ///     Flags { a: true,  b: false } <=> 1,
@@ -73,7 +73,7 @@
 // struct Unit;
 //
 // impl_tag! {
-//     for Unit;
+//     impl Tag for Unit;
 //     Unit <=> 0,
 //     Unit <=> 1,
 // }
@@ -87,7 +87,7 @@
 // enum E { A, B };
 //
 // impl_tag! {
-//     for E;
+//     impl Tag for E;
 //     E::A <=> 0,
 //     E::B <=> 0,
 // }
@@ -104,14 +104,14 @@
 /// }
 ///
 /// impl_tag! {
-///     for E;
+///     impl Tag for E;
 ///     E::A <=> 0,
 /// }
 /// ```
 #[macro_export]
 macro_rules! impl_tag {
     (
-        for $Self:ty;
+        impl Tag for $Self:ty;
         $(
             $($path:ident)::* $( { $( $fields:tt )* })? <=> $tag:literal,
         )*

--- a/compiler/rustc_data_structures/src/tagged_ptr/impl_tag/tests.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/impl_tag/tests.rs
@@ -1,0 +1,33 @@
+#[test]
+fn bits_constant() {
+    use crate::tagged_ptr::Tag;
+
+    #[derive(Copy, Clone)]
+    struct Unit;
+    impl_tag! { for Unit; Unit <=> 0, }
+    assert_eq!(Unit::BITS, 0);
+
+    #[derive(Copy, Clone)]
+    struct Unit1;
+    impl_tag! { for Unit1; Unit1 <=> 1, }
+    assert_eq!(Unit1::BITS, 1);
+
+    #[derive(Copy, Clone)]
+    struct Unit2;
+    impl_tag! { for Unit2; Unit2 <=> 0b10, }
+    assert_eq!(Unit2::BITS, 2);
+
+    #[derive(Copy, Clone)]
+    struct Unit3;
+    impl_tag! { for Unit3; Unit3 <=> 0b100, }
+    assert_eq!(Unit3::BITS, 3);
+
+    #[derive(Copy, Clone)]
+    enum Enum {
+        A,
+        B,
+        C,
+    }
+    impl_tag! { for Enum; Enum::A <=> 0b1, Enum::B <=> 0b1000, Enum::C <=> 0b10, }
+    assert_eq!(Enum::BITS, 4);
+}

--- a/compiler/rustc_data_structures/src/tagged_ptr/impl_tag/tests.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/impl_tag/tests.rs
@@ -4,22 +4,22 @@ fn bits_constant() {
 
     #[derive(Copy, Clone)]
     struct Unit;
-    impl_tag! { for Unit; Unit <=> 0, }
+    impl_tag! { impl Tag for Unit; Unit <=> 0, }
     assert_eq!(Unit::BITS, 0);
 
     #[derive(Copy, Clone)]
     struct Unit1;
-    impl_tag! { for Unit1; Unit1 <=> 1, }
+    impl_tag! { impl Tag for Unit1; Unit1 <=> 1, }
     assert_eq!(Unit1::BITS, 1);
 
     #[derive(Copy, Clone)]
     struct Unit2;
-    impl_tag! { for Unit2; Unit2 <=> 0b10, }
+    impl_tag! { impl Tag for Unit2; Unit2 <=> 0b10, }
     assert_eq!(Unit2::BITS, 2);
 
     #[derive(Copy, Clone)]
     struct Unit3;
-    impl_tag! { for Unit3; Unit3 <=> 0b100, }
+    impl_tag! { impl Tag for Unit3; Unit3 <=> 0b100, }
     assert_eq!(Unit3::BITS, 3);
 
     #[derive(Copy, Clone)]
@@ -28,6 +28,6 @@ fn bits_constant() {
         B,
         C,
     }
-    impl_tag! { for Enum; Enum::A <=> 0b1, Enum::B <=> 0b1000, Enum::C <=> 0b10, }
+    impl_tag! { impl Tag for Enum; Enum::A <=> 0b1, Enum::B <=> 0b1000, Enum::C <=> 0b10, }
     assert_eq!(Enum::BITS, 4);
 }

--- a/compiler/rustc_data_structures/src/tagged_ptr/impl_tag/tests.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/impl_tag/tests.rs
@@ -4,30 +4,31 @@ fn bits_constant() {
 
     #[derive(Copy, Clone)]
     struct Unit;
-    impl_tag! { impl Tag for Unit; Unit <=> 0, }
+    impl_tag! { impl Tag for Unit; Unit, }
     assert_eq!(Unit::BITS, 0);
 
     #[derive(Copy, Clone)]
-    struct Unit1;
-    impl_tag! { impl Tag for Unit1; Unit1 <=> 1, }
-    assert_eq!(Unit1::BITS, 1);
-
-    #[derive(Copy, Clone)]
-    struct Unit2;
-    impl_tag! { impl Tag for Unit2; Unit2 <=> 0b10, }
-    assert_eq!(Unit2::BITS, 2);
-
-    #[derive(Copy, Clone)]
-    struct Unit3;
-    impl_tag! { impl Tag for Unit3; Unit3 <=> 0b100, }
-    assert_eq!(Unit3::BITS, 3);
-
-    #[derive(Copy, Clone)]
-    enum Enum {
+    enum Enum3 {
         A,
         B,
         C,
     }
-    impl_tag! { impl Tag for Enum; Enum::A <=> 0b1, Enum::B <=> 0b1000, Enum::C <=> 0b10, }
-    assert_eq!(Enum::BITS, 4);
+    impl_tag! { impl Tag for Enum3; Enum3::A, Enum3::B, Enum3::C, }
+    assert_eq!(Enum3::BITS, 2);
+
+    #[derive(Copy, Clone)]
+    struct Eight(bool, bool, bool);
+    impl_tag! {
+        impl Tag for Eight;
+        Eight { 0: true,  1: true,  2: true  },
+        Eight { 0: true,  1: true,  2: false },
+        Eight { 0: true,  1: false, 2: true  },
+        Eight { 0: true,  1: false, 2: false },
+        Eight { 0: false, 1: true,  2: true  },
+        Eight { 0: false, 1: true,  2: false },
+        Eight { 0: false, 1: false, 2: true  },
+        Eight { 0: false, 1: false, 2: false },
+    }
+
+    assert_eq!(Eight::BITS, 3);
 }

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -60,6 +60,7 @@
 #![feature(const_option)]
 #![feature(trait_alias)]
 #![feature(ptr_alignment_type)]
+#![feature(macro_metavar_expr)]
 #![recursion_limit = "512"]
 #![allow(rustc::potential_query_instability)]
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1626,29 +1626,12 @@ struct ParamTag {
     constness: hir::Constness,
 }
 
-unsafe impl rustc_data_structures::tagged_ptr::Tag for ParamTag {
-    const BITS: u32 = 2;
-
-    #[inline]
-    fn into_usize(self) -> usize {
-        match self {
-            Self { reveal: traits::Reveal::UserFacing, constness: hir::Constness::NotConst } => 0,
-            Self { reveal: traits::Reveal::All, constness: hir::Constness::NotConst } => 1,
-            Self { reveal: traits::Reveal::UserFacing, constness: hir::Constness::Const } => 2,
-            Self { reveal: traits::Reveal::All, constness: hir::Constness::Const } => 3,
-        }
-    }
-
-    #[inline]
-    unsafe fn from_usize(ptr: usize) -> Self {
-        match ptr {
-            0 => Self { reveal: traits::Reveal::UserFacing, constness: hir::Constness::NotConst },
-            1 => Self { reveal: traits::Reveal::All, constness: hir::Constness::NotConst },
-            2 => Self { reveal: traits::Reveal::UserFacing, constness: hir::Constness::Const },
-            3 => Self { reveal: traits::Reveal::All, constness: hir::Constness::Const },
-            _ => std::hint::unreachable_unchecked(),
-        }
-    }
+impl_tag! {
+    for ParamTag;
+    ParamTag { reveal: traits::Reveal::UserFacing, constness: hir::Constness::NotConst } <=> 0,
+    ParamTag { reveal: traits::Reveal::All,        constness: hir::Constness::NotConst } <=> 1,
+    ParamTag { reveal: traits::Reveal::UserFacing, constness: hir::Constness::Const    } <=> 2,
+    ParamTag { reveal: traits::Reveal::All,        constness: hir::Constness::Const    } <=> 3,
 }
 
 impl<'tcx> fmt::Debug for ParamEnv<'tcx> {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1627,7 +1627,7 @@ struct ParamTag {
 }
 
 impl_tag! {
-    for ParamTag;
+    impl Tag for ParamTag;
     ParamTag { reveal: traits::Reveal::UserFacing, constness: hir::Constness::NotConst } <=> 0,
     ParamTag { reveal: traits::Reveal::All,        constness: hir::Constness::NotConst } <=> 1,
     ParamTag { reveal: traits::Reveal::UserFacing, constness: hir::Constness::Const    } <=> 2,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1628,10 +1628,10 @@ struct ParamTag {
 
 impl_tag! {
     impl Tag for ParamTag;
-    ParamTag { reveal: traits::Reveal::UserFacing, constness: hir::Constness::NotConst } <=> 0,
-    ParamTag { reveal: traits::Reveal::All,        constness: hir::Constness::NotConst } <=> 1,
-    ParamTag { reveal: traits::Reveal::UserFacing, constness: hir::Constness::Const    } <=> 2,
-    ParamTag { reveal: traits::Reveal::All,        constness: hir::Constness::Const    } <=> 3,
+    ParamTag { reveal: traits::Reveal::UserFacing, constness: hir::Constness::NotConst },
+    ParamTag { reveal: traits::Reveal::All,        constness: hir::Constness::NotConst },
+    ParamTag { reveal: traits::Reveal::UserFacing, constness: hir::Constness::Const    },
+    ParamTag { reveal: traits::Reveal::All,        constness: hir::Constness::Const    },
 }
 
 impl<'tcx> fmt::Debug for ParamEnv<'tcx> {


### PR DESCRIPTION
r? @Nilstrieb 

This should also lifts the need to think about safety from the callers (`impl_tag!` is robust (ish, see the macro issue)) and removes the possibility of making a "weird" `Tag` impl.