### PR TITLE
Remove public doc(hidden) core::fmt::rt::v1

### DIFF
--- a/compiler/rustc_ast_lowering/src/format.rs
+++ b/compiler/rustc_ast_lowering/src/format.rs
@@ -220,19 +220,19 @@ fn make_argument<'hir>(
 /// Generates:
 ///
 /// ```text
-///     <core::fmt::rt::v1::Count>::Is(…)
+///     <core::fmt::rt::Count>::Is(…)
 /// ```
 ///
 /// or
 ///
 /// ```text
-///     <core::fmt::rt::v1::Count>::Param(…)
+///     <core::fmt::rt::Count>::Param(…)
 /// ```
 ///
 /// or
 ///
 /// ```text
-///     <core::fmt::rt::v1::Count>::Implied
+///     <core::fmt::rt::Count>::Implied
 /// ```
 fn make_count<'hir>(
     ctx: &mut LoweringContext<'_, 'hir>,
@@ -278,13 +278,13 @@ fn make_count<'hir>(
 /// Generates
 ///
 /// ```text
-///     <core::fmt::rt::v1::Argument::new(
+///     <core::fmt::rt::Placeholder::new(
 ///         …usize, // position
 ///         '…', // fill
-///         <core::fmt::rt::v1::Alignment>::…, // alignment
+///         <core::fmt::rt::Alignment>::…, // alignment
 ///         …u32, // flags
-///         <core::fmt::rt::v1::Count::…>, // width
-///         <core::fmt::rt::v1::Count::…>, // precision
+///         <core::fmt::rt::Count::…>, // width
+///         <core::fmt::rt::Count::…>, // precision
 ///     )
 /// ```
 fn make_format_spec<'hir>(

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -551,8 +551,6 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-#[unstable(feature = "fmt_internals", issue = "none")]
-pub use core::fmt::rt;
 #[stable(feature = "fmt_flags_align", since = "1.28.0")]
 pub use core::fmt::Alignment;
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -1277,14 +1277,14 @@ pub fn write(output: &mut dyn Write, args: Arguments<'_>) -> Result {
 }
 
 unsafe fn run(fmt: &mut Formatter<'_>, arg: &rt::Placeholder, args: &[ArgumentV1<'_>]) -> Result {
-    fmt.fill = arg.format.fill;
-    fmt.align = arg.format.align;
-    fmt.flags = arg.format.flags;
+    fmt.fill = arg.fill;
+    fmt.align = arg.align;
+    fmt.flags = arg.flags;
     // SAFETY: arg and args come from the same Arguments,
     // which guarantees the indexes are always within bounds.
     unsafe {
-        fmt.width = getcount(args, &arg.format.width);
-        fmt.precision = getcount(args, &arg.format.precision);
+        fmt.width = getcount(args, &arg.width);
+        fmt.precision = getcount(args, &arg.precision);
     }
 
     // Extract the correct argument

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -428,7 +428,7 @@ impl<'a> Arguments<'a> {
     /// An `UnsafeArg` is required because the following invariants must be held
     /// in order for this function to be safe:
     /// 1. The `pieces` slice must be at least as long as `fmt`.
-    /// 2. Every [`rt::Argument::position`] value within `fmt` must be a
+    /// 2. Every [`rt::Placeholder::position`] value within `fmt` must be a
     ///    valid index of `args`.
     /// 3. Every [`rt::Count::Param`] within `fmt` must contain a valid index of
     ///    `args`.
@@ -438,7 +438,7 @@ impl<'a> Arguments<'a> {
     pub fn new_v1_formatted(
         pieces: &'a [&'static str],
         args: &'a [ArgumentV1<'a>],
-        fmt: &'a [rt::Argument],
+        fmt: &'a [rt::Placeholder],
         _unsafe_arg: UnsafeArg,
     ) -> Arguments<'a> {
         Arguments { pieces, fmt: Some(fmt), args }
@@ -500,7 +500,7 @@ pub struct Arguments<'a> {
     pieces: &'a [&'static str],
 
     // Placeholder specs, or `None` if all specs are default (as in "{}{}").
-    fmt: Option<&'a [rt::Argument]>,
+    fmt: Option<&'a [rt::Placeholder]>,
 
     // Dynamic arguments for interpolation, to be interleaved with string
     // pieces. (Every argument is preceded by a string piece.)
@@ -1276,7 +1276,7 @@ pub fn write(output: &mut dyn Write, args: Arguments<'_>) -> Result {
     Ok(())
 }
 
-unsafe fn run(fmt: &mut Formatter<'_>, arg: &rt::Argument, args: &[ArgumentV1<'_>]) -> Result {
+unsafe fn run(fmt: &mut Formatter<'_>, arg: &rt::Placeholder, args: &[ArgumentV1<'_>]) -> Result {
     fmt.fill = arg.format.fill;
     fmt.align = arg.format.align;
     fmt.flags = arg.format.flags;

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -428,10 +428,8 @@ impl<'a> Arguments<'a> {
     /// An `UnsafeArg` is required because the following invariants must be held
     /// in order for this function to be safe:
     /// 1. The `pieces` slice must be at least as long as `fmt`.
-    /// 2. Every [`rt::Placeholder::position`] value within `fmt` must be a
-    ///    valid index of `args`.
-    /// 3. Every [`rt::Count::Param`] within `fmt` must contain a valid index of
-    ///    `args`.
+    /// 2. Every `rt::Placeholder::position` value within `fmt` must be a valid index of `args`.
+    /// 3. Every `rt::Count::Param` within `fmt` must contain a valid index of `args`.
     #[doc(hidden)]
     #[inline]
     #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "none")]

--- a/library/core/src/fmt/rt.rs
+++ b/library/core/src/fmt/rt.rs
@@ -7,11 +7,6 @@
 #[derive(Copy, Clone)]
 pub struct Placeholder {
     pub position: usize,
-    pub format: FormatSpec,
-}
-
-#[derive(Copy, Clone)]
-pub struct FormatSpec {
     pub fill: char,
     pub align: Alignment,
     pub flags: u32,
@@ -29,7 +24,7 @@ impl Placeholder {
         precision: Count,
         width: Count,
     ) -> Self {
-        Self { position, format: FormatSpec { fill, align, flags, precision, width } }
+        Self { position, fill, align, flags, precision, width }
     }
 }
 

--- a/library/core/src/fmt/rt.rs
+++ b/library/core/src/fmt/rt.rs
@@ -5,8 +5,7 @@
 
 #[lang = "format_placeholder"]
 #[derive(Copy, Clone)]
-// FIXME: Rename this to Placeholder
-pub struct Argument {
+pub struct Placeholder {
     pub position: usize,
     pub format: FormatSpec,
 }
@@ -20,7 +19,7 @@ pub struct FormatSpec {
     pub width: Count,
 }
 
-impl Argument {
+impl Placeholder {
     #[inline(always)]
     pub const fn new(
         position: usize,

--- a/library/core/src/fmt/rt.rs
+++ b/library/core/src/fmt/rt.rs
@@ -1,9 +1,7 @@
-//! This is an internal module used by the ifmt! runtime. These structures are
-//! emitted to static arrays to precompile format strings ahead of time.
-//!
-//! These definitions are similar to their `ct` equivalents, but differ in that
-//! these can be statically allocated and are slightly optimized for the runtime
 #![allow(missing_debug_implementations)]
+#![unstable(feature = "fmt_internals", issue = "none")]
+
+//! These are the lang items used by format_args!().
 
 #[lang = "format_placeholder"]
 #[derive(Copy, Clone)]

--- a/library/core/src/fmt/rt.rs
+++ b/library/core/src/fmt/rt.rs
@@ -1,5 +1,5 @@
 #![allow(missing_debug_implementations)]
-#![unstable(feature = "fmt_internals", issue = "none")]
+#![unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "none")]
 
 //! These are the lang items used by format_args!().
 

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -1172,7 +1172,7 @@ impl fmt::Debug for Duration {
                         emit_without_padding(f)
                     } else {
                         // We need to add padding. Use the `Formatter::padding` helper function.
-                        let default_align = crate::fmt::rt::v1::Alignment::Left;
+                        let default_align = fmt::Alignment::Left;
                         let post_padding = f.padding(requested_w - actual_w, default_align)?;
                         emit_without_padding(f)?;
                         post_padding.write(f)


### PR DESCRIPTION
All the types used by format_arg!() are now lang items, so they are no longer required as publicly exported items.

Part of #99012

After this change, the `rt` module is private, and contains only three lang items used by format_args (`Placeholder`, `Alignment`, and `Count`): https://github.com/rust-lang/rust/blob/441682cca9a32314835a88fa981a3bf13ffb0aa8/library/core/src/fmt/rt.rs