### PR TITLE
(More) consistently use "region" terminology in `rustc_middle`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -1047,7 +1047,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                 type_known_to_meet_bound_modulo_regions(
                                     &infcx,
                                     self.param_env,
-                                    tcx.mk_imm_ref(tcx.lifetimes.re_erased, tcx.erase_regions(ty)),
+                                    tcx.mk_imm_ref(tcx.regions.erased, tcx.erase_regions(ty)),
                                     def_id,
                                 )
                             }

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -597,7 +597,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
     ) -> Option<&'hir hir::Lifetime> {
         for (kind, hir_arg) in iter::zip(substs, args.args) {
             match (kind.unpack(), hir_arg) {
-                (GenericArgKind::Lifetime(r), hir::GenericArg::Lifetime(lt)) => {
+                (GenericArgKind::Region(r), hir::GenericArg::Lifetime(lt)) => {
                     if r.as_var() == needle_fr {
                         return Some(lt);
                     }
@@ -613,9 +613,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
                 }
 
                 (
-                    GenericArgKind::Lifetime(_)
-                    | GenericArgKind::Type(_)
-                    | GenericArgKind::Const(_),
+                    GenericArgKind::Region(_) | GenericArgKind::Type(_) | GenericArgKind::Const(_),
                     _,
                 ) => {
                     // HIR lowering sometimes doesn't catch this in erroneous

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1115,7 +1115,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                     std::iter::zip(substs, tcx.variances_of(def_id)).map(|(arg, v)| {
                         match (arg.unpack(), v) {
                             (ty::GenericArgKind::Region(_), ty::Bivariant) => {
-                                tcx.lifetimes.re_static.into()
+                                tcx.regions.re_static.into()
                             }
                             _ => arg.fold_with(self),
                         }
@@ -1142,7 +1142,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 .map(|u_r| tcx.mk_re_var(u_r))
                 // In the case of a failure, use `ReErased`. We will eventually
                 // return `None` in this case.
-                .unwrap_or(tcx.lifetimes.re_erased)
+                .unwrap_or(tcx.regions.erased)
         });
 
         debug!("try_promote_type_test_subject: folded ty = {:?}", ty);

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1114,7 +1114,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 let substs =
                     std::iter::zip(substs, tcx.variances_of(def_id)).map(|(arg, v)| {
                         match (arg.unpack(), v) {
-                            (ty::GenericArgKind::Lifetime(_), ty::Bivariant) => {
+                            (ty::GenericArgKind::Region(_), ty::Bivariant) => {
                                 tcx.lifetimes.re_static.into()
                             }
                             _ => arg.fold_with(self),

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -131,7 +131,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                         .iter()
                         .find(|ur_vid| self.eval_equal(vid, **ur_vid))
                         .and_then(|ur_vid| self.definitions[*ur_vid].external_name)
-                        .unwrap_or(infcx.tcx.lifetimes.re_erased),
+                        .unwrap_or(infcx.tcx.regions.erased),
                     _ => region,
                 });
             debug!(?universal_concrete_type);

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -367,8 +367,8 @@ fn check_opaque_type_parameter_valid(
     for (i, arg) in opaque_type_key.substs.iter().enumerate() {
         let arg_is_param = match arg.unpack() {
             GenericArgKind::Type(ty) => matches!(ty.kind(), ty::Param(_)),
-            GenericArgKind::Lifetime(lt) => {
-                matches!(*lt, ty::ReEarlyBound(_) | ty::ReFree(_))
+            GenericArgKind::Region(re) => {
+                matches!(*re, ty::ReEarlyBound(_) | ty::ReFree(_))
             }
             GenericArgKind::Const(ct) => matches!(ct.kind(), ty::ConstKind::Param(_)),
         };

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -141,7 +141,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
 
         let ty::OutlivesPredicate(k1, r2) = predicate;
         match k1.unpack() {
-            GenericArgKind::Lifetime(r1) => {
+            GenericArgKind::Region(r1) => {
                 let r1_vid = self.to_region_vid(r1);
                 let r2_vid = self.to_region_vid(r2);
                 self.add_outlives(r1_vid, r2_vid, constraint_category);

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -248,7 +248,7 @@ impl<'tcx> UniversalRegions<'tcx> {
         closure_def_id: LocalDefId,
     ) -> IndexVec<RegionVid, ty::Region<'tcx>> {
         let mut region_mapping = IndexVec::with_capacity(expected_num_vars);
-        region_mapping.push(tcx.lifetimes.re_static);
+        region_mapping.push(tcx.regions.re_static);
         tcx.for_each_free_region(&closure_substs, |fr| {
             region_mapping.push(fr);
         });
@@ -632,7 +632,7 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
             DefiningTy::FnDef(_, substs) | DefiningTy::Const(_, substs) => substs,
         };
 
-        let global_mapping = iter::once((tcx.lifetimes.re_static, fr_static));
+        let global_mapping = iter::once((tcx.regions.re_static, fr_static));
         let subst_mapping =
             iter::zip(identity_substs.regions(), fr_substs.regions().map(|r| r.as_var()));
 

--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -668,7 +668,7 @@ pub(crate) fn codegen_drop<'tcx>(
                 let arg_value = drop_place.place_ref(
                     fx,
                     fx.layout_of(fx.tcx.mk_ref(
-                        fx.tcx.lifetimes.re_erased,
+                        fx.tcx.regions.erased,
                         TypeAndMut { ty, mutbl: crate::rustc_hir::Mutability::Mut },
                     )),
                 );

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
@@ -187,7 +187,7 @@ fn declare_unused_fn<'tcx>(cx: &CodegenCx<'_, 'tcx>, def_id: DefId) -> Instance<
     let instance = Instance::new(
         def_id,
         InternalSubsts::for_item(tcx, def_id, |param, _| {
-            if let ty::GenericParamDefKind::Lifetime = param.kind {
+            if let ty::GenericParamDefKind::Region = param.kind {
                 tcx.lifetimes.re_erased.into()
             } else {
                 tcx.mk_param_from_def(param)

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
@@ -188,7 +188,7 @@ fn declare_unused_fn<'tcx>(cx: &CodegenCx<'_, 'tcx>, def_id: DefId) -> Instance<
         def_id,
         InternalSubsts::for_item(tcx, def_id, |param, _| {
             if let ty::GenericParamDefKind::Region = param.kind {
-                tcx.lifetimes.re_erased.into()
+                tcx.regions.erased.into()
             } else {
                 tcx.mk_param_from_def(param)
             }

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -573,7 +573,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             mir::Rvalue::Ref(_, bk, place) => {
                 let mk_ref = move |tcx: TyCtxt<'tcx>, ty: Ty<'tcx>| {
                     tcx.mk_ref(
-                        tcx.lifetimes.re_erased,
+                        tcx.regions.erased,
                         ty::TypeAndMut { ty, mutbl: bk.to_mutbl_lossy() },
                     )
                 };

--- a/compiler/rustc_const_eval/src/interpret/intrinsics/caller_location.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/caller_location.rs
@@ -96,7 +96,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let loc_ty = self
             .tcx
             .type_of(self.tcx.require_lang_item(LangItem::PanicLocation, None))
-            .subst(*self.tcx, self.tcx.mk_substs(&[self.tcx.lifetimes.re_erased.into()]));
+            .subst(*self.tcx, self.tcx.mk_substs(&[self.tcx.regions.erased.into()]));
         let loc_layout = self.layout_of(loc_ty).unwrap();
         let location = self.allocate(loc_layout, MemoryKind::CallerLocation).unwrap();
 

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -775,10 +775,9 @@ where
         let meta = Scalar::from_target_usize(u64::try_from(str.len()).unwrap(), self);
         let mplace = MemPlace { ptr: ptr.into(), meta: MemPlaceMeta::Meta(meta) };
 
-        let ty = self.tcx.mk_ref(
-            self.tcx.lifetimes.re_static,
-            ty::TypeAndMut { ty: self.tcx.types.str_, mutbl },
-        );
+        let ty = self
+            .tcx
+            .mk_ref(self.tcx.regions.re_static, ty::TypeAndMut { ty: self.tcx.types.str_, mutbl });
         let layout = self.layout_of(ty).unwrap();
         Ok(MPlaceTy { mplace, layout, align: layout.align.abi })
     }

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -346,7 +346,7 @@ impl<'mir, 'tcx> Checker<'mir, 'tcx> {
 
                 // No constraints on lifetimes or constants, except potentially
                 // constants' types, but `walk` will get to them as well.
-                GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => continue,
+                GenericArgKind::Region(_) | GenericArgKind::Const(_) => continue,
             };
 
             match *ty.kind() {

--- a/compiler/rustc_const_eval/src/transform/promote_consts.rs
+++ b/compiler/rustc_const_eval/src/transform/promote_consts.rs
@@ -859,11 +859,11 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
             let span = statement.source_info.span;
 
             let ref_ty = tcx.mk_ref(
-                tcx.lifetimes.re_erased,
+                tcx.regions.erased,
                 ty::TypeAndMut { ty, mutbl: borrow_kind.to_mutbl_lossy() },
             );
 
-            *region = tcx.lifetimes.re_erased;
+            *region = tcx.regions.erased;
 
             let mut projection = vec![PlaceElem::Deref];
             projection.extend(place.projection);
@@ -887,7 +887,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
             self.extra_statements.push((loc, promoted_ref_statement));
 
             Rvalue::Ref(
-                tcx.lifetimes.re_erased,
+                tcx.regions.erased,
                 *borrow_kind,
                 Place {
                     local: mem::replace(&mut place.local, promoted_ref),

--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -131,7 +131,7 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
     ) -> Result<Self::Path, Self::Error> {
         self = print_prefix(self)?;
         let args =
-            args.iter().cloned().filter(|arg| !matches!(arg.unpack(), GenericArgKind::Lifetime(_)));
+            args.iter().cloned().filter(|arg| !matches!(arg.unpack(), GenericArgKind::Region(_)));
         if args.clone().next().is_some() {
             self.generic_delimiters(|cx| cx.comma_sep(args))
         } else {

--- a/compiler/rustc_hir_analysis/src/astconv/generics.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/generics.rs
@@ -242,7 +242,7 @@ pub fn create_substs_for_generic_args<'tcx, 'a>(
             match (args.peek(), params.peek()) {
                 (Some(&arg), Some(&param)) => {
                     match (arg, &param.kind, arg_count.explicit_late_bound) {
-                        (GenericArg::Lifetime(_), GenericParamDefKind::Lifetime, _)
+                        (GenericArg::Lifetime(_), GenericParamDefKind::Region, _)
                         | (
                             GenericArg::Type(_) | GenericArg::Infer(_),
                             GenericParamDefKind::Type { .. },
@@ -259,7 +259,7 @@ pub fn create_substs_for_generic_args<'tcx, 'a>(
                         }
                         (
                             GenericArg::Infer(_) | GenericArg::Type(_) | GenericArg::Const(_),
-                            GenericParamDefKind::Lifetime,
+                            GenericParamDefKind::Region,
                             _,
                         ) => {
                             // We expected a lifetime argument, but got a type or const

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -437,7 +437,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 };
 
                 match (&param.kind, arg) {
-                    (GenericParamDefKind::Lifetime, GenericArg::Lifetime(lt)) => {
+                    (GenericParamDefKind::Region, GenericArg::Lifetime(lt)) => {
                         self.astconv.ast_region_to_region(lt, Some(param)).into()
                     }
                     (&GenericParamDefKind::Type { has_default, .. }, GenericArg::Type(ty)) => {
@@ -481,7 +481,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             ) -> subst::GenericArg<'tcx> {
                 let tcx = self.astconv.tcx();
                 match param.kind {
-                    GenericParamDefKind::Lifetime => self
+                    GenericParamDefKind::Region => self
                         .astconv
                         .re_infer(Some(param), self.span)
                         .unwrap_or_else(|| {
@@ -1175,7 +1175,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             let substs =
                 candidate.skip_binder().substs.extend_to(tcx, assoc_item.def_id, |param, _| {
                     let subst = match param.kind {
-                        GenericParamDefKind::Lifetime => tcx
+                        GenericParamDefKind::Region => tcx
                             .mk_re_late_bound(
                                 ty::INNERMOST,
                                 ty::BoundRegion {
@@ -3274,7 +3274,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             if let Some(i) = (param.index as usize).checked_sub(generics.count() - lifetimes.len())
             {
                 // Resolve our own lifetime parameters.
-                let GenericParamDefKind::Lifetime { .. } = param.kind else { bug!() };
+                let GenericParamDefKind::Region { .. } = param.kind else { bug!() };
                 let hir::GenericArg::Lifetime(lifetime) = &lifetimes[i] else { bug!() };
                 self.ast_region_to_region(lifetime, None).into()
             } else {
@@ -3651,7 +3651,7 @@ pub trait InferCtxtExt<'tcx> {
 impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
     fn fresh_item_substs(&self, def_id: DefId) -> SubstsRef<'tcx> {
         InternalSubsts::for_item(self.tcx, def_id, |param, _| match param.kind {
-            GenericParamDefKind::Lifetime => self.tcx.lifetimes.re_erased.into(),
+            GenericParamDefKind::Region => self.tcx.lifetimes.re_erased.into(),
             GenericParamDefKind::Type { .. } => self
                 .next_ty_var(TypeVariableOrigin {
                     kind: TypeVariableOriginKind::SubstitutionPlaceholder,

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1429,11 +1429,11 @@ fn compare_synthetic_generics<'tcx>(
     let trait_m_generics = tcx.generics_of(trait_m.def_id);
     let impl_m_type_params = impl_m_generics.params.iter().filter_map(|param| match param.kind {
         GenericParamDefKind::Type { synthetic, .. } => Some((param.def_id, synthetic)),
-        GenericParamDefKind::Lifetime | GenericParamDefKind::Const { .. } => None,
+        GenericParamDefKind::Region | GenericParamDefKind::Const { .. } => None,
     });
     let trait_m_type_params = trait_m_generics.params.iter().filter_map(|param| match param.kind {
         GenericParamDefKind::Type { synthetic, .. } => Some((param.def_id, synthetic)),
-        GenericParamDefKind::Lifetime | GenericParamDefKind::Const { .. } => None,
+        GenericParamDefKind::Region | GenericParamDefKind::Const { .. } => None,
     });
     for ((impl_def_id, impl_synthetic), (trait_def_id, trait_synthetic)) in
         iter::zip(impl_m_type_params, trait_m_type_params)
@@ -1599,7 +1599,7 @@ fn compare_generic_param_kinds<'tcx>(
             // this is exhaustive so that anyone adding new generic param kinds knows
             // to make sure this error is reported for them.
             (Const { .. }, Const { .. }) | (Type { .. }, Type { .. }) => false,
-            (Lifetime { .. }, _) | (_, Lifetime { .. }) => unreachable!(),
+            (Region { .. }, _) | (_, Region { .. }) => unreachable!(),
         } {
             let param_impl_span = tcx.def_span(param_impl.def_id);
             let param_trait_span = tcx.def_span(param_trait.def_id);
@@ -1623,7 +1623,7 @@ fn compare_generic_param_kinds<'tcx>(
                     )
                 }
                 Type { .. } => format!("{} type parameter", prefix),
-                Lifetime { .. } => unreachable!(),
+                Region { .. } => unreachable!(),
             };
 
             let trait_header_span = tcx.def_ident_span(tcx.parent(trait_item.def_id)).unwrap();
@@ -1916,7 +1916,7 @@ pub(super) fn check_type_bounds<'tcx>(
                 )
                 .into()
             }
-            GenericParamDefKind::Lifetime => {
+            GenericParamDefKind::Region => {
                 let kind = ty::BoundRegionKind::BrNamed(param.def_id, param.name);
                 let bound_var = ty::BoundVariableKind::Region(kind);
                 bound_vars.push(bound_var);

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -718,8 +718,8 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for GATSubstCollector<'tcx> {
             ty::Alias(ty::Projection, p) if p.def_id == self.gat => {
                 for (idx, subst) in p.substs.iter().enumerate() {
                     match subst.unpack() {
-                        GenericArgKind::Lifetime(lt) if !lt.is_late_bound() => {
-                            self.regions.insert((lt, idx));
+                        GenericArgKind::Region(re) if !re.is_late_bound() => {
+                            self.regions.insert((re, idx));
                         }
                         GenericArgKind::Type(t) => {
                             self.types.insert((t, idx));

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1273,7 +1273,7 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
         | GenericParamDefKind::Const { has_default } => {
             has_default && def.index >= generics.parent_count as u32
         }
-        GenericParamDefKind::Lifetime => unreachable!(),
+        GenericParamDefKind::Region => unreachable!(),
     };
 
     // Check that concrete defaults are well-formed. See test `type-check-defaults.rs`.
@@ -1316,7 +1316,7 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
                 }
             }
             // Doesn't have defaults.
-            GenericParamDefKind::Lifetime => {}
+            GenericParamDefKind::Region => {}
         }
     }
 
@@ -1330,7 +1330,7 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
     // First we build the defaulted substitution.
     let substs = InternalSubsts::for_item(tcx, def_id.to_def_id(), |param, _| {
         match param.kind {
-            GenericParamDefKind::Lifetime => {
+            GenericParamDefKind::Region => {
                 // All regions are identity.
                 tcx.mk_param_from_def(param)
             }

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -387,7 +387,7 @@ impl<'tcx> AstConv<'tcx> for ItemCtxt<'tcx> {
 
     fn ct_infer(&self, ty: Ty<'tcx>, _: Option<&ty::GenericParamDef>, span: Span) -> Const<'tcx> {
         let ty = self.tcx.fold_regions(ty, |r, _| match *r {
-            ty::ReErased => self.tcx.lifetimes.re_static,
+            ty::ReErased => self.tcx.regions.re_static,
             _ => r,
         });
         self.tcx().const_error_with_message(ty, span, "bad placeholder constant")
@@ -1141,7 +1141,7 @@ fn infer_return_ty_for_fn_sig<'tcx>(
             let fn_sig = tcx.typeck(def_id).liberated_fn_sigs()[hir_id];
             // Typeck doesn't expect erased regions to be returned from `type_of`.
             let fn_sig = tcx.fold_regions(fn_sig, |r, _| match *r {
-                ty::ReErased => tcx.lifetimes.re_static,
+                ty::ReErased => tcx.regions.re_static,
                 _ => r,
             });
 

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -242,7 +242,7 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
         index: own_start + i as u32,
         def_id: param.def_id.to_def_id(),
         pure_wrt_drop: param.pure_wrt_drop,
-        kind: ty::GenericParamDefKind::Lifetime,
+        kind: ty::GenericParamDefKind::Region,
     }));
 
     // Now create the real type and const parameters.

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -1667,7 +1667,7 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
                         .params
                         .iter()
                         .map(|param| match param.kind {
-                            ty::GenericParamDefKind::Lifetime => ty::BoundVariableKind::Region(
+                            ty::GenericParamDefKind::Region => ty::BoundVariableKind::Region(
                                 ty::BoundRegionKind::BrNamed(param.def_id, param.name),
                             ),
                             ty::GenericParamDefKind::Type { .. } => ty::BoundVariableKind::Ty(

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -932,7 +932,7 @@ fn infer_placeholder_type<'a>(
 
     // Typeck doesn't expect erased regions to be returned from `type_of`.
     tcx.fold_regions(ty, |r, _| match *r {
-        ty::ReErased => tcx.lifetimes.re_static,
+        ty::ReErased => tcx.regions.re_static,
         _ => r,
     })
 }

--- a/compiler/rustc_hir_analysis/src/hir_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/hir_wf_check.rs
@@ -194,6 +194,6 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for EraseAllBoundRegions<'tcx> {
         self.tcx
     }
     fn fold_region(&mut self, r: Region<'tcx>) -> Region<'tcx> {
-        if r.is_late_bound() { self.tcx.lifetimes.re_erased } else { r }
+        if r.is_late_bound() { self.tcx.regions.erased } else { r }
     }
 }

--- a/compiler/rustc_hir_analysis/src/impl_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check.rs
@@ -123,7 +123,7 @@ fn enforce_impl_params_are_constrained(tcx: TyCtxt<'_>, impl_def_id: LocalDefId)
                     report_unused_parameter(tcx, tcx.def_span(param.def_id), "type", param_ty.name);
                 }
             }
-            ty::GenericParamDefKind::Lifetime => {
+            ty::GenericParamDefKind::Region => {
                 let param_lt = cgp::Parameter::from(param.to_early_bound_region_data());
                 if lifetimes_in_associated_types.contains(&param_lt) && // (*)
                     !input_parameters.contains(&param_lt)

--- a/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
@@ -99,7 +99,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
 
             // No predicates from lifetimes or constants, except potentially
             // constants' types, but `walk` will get to them as well.
-            GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => continue,
+            GenericArgKind::Region(_) | GenericArgKind::Const(_) => continue,
         };
 
         match *ty.kind() {

--- a/compiler/rustc_hir_analysis/src/outlives/mod.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/mod.rs
@@ -105,7 +105,7 @@ fn inferred_outlives_crate(tcx: TyCtxt<'_>, (): ()) -> CratePredicatesMap<'_> {
                             ty::Clause::TypeOutlives(ty::OutlivesPredicate(ty1, *region2)),
                             span,
                         )),
-                        GenericArgKind::Lifetime(region1) => Some((
+                        GenericArgKind::Region(region1) => Some((
                             ty::Clause::RegionOutlives(ty::OutlivesPredicate(region1, *region2)),
                             span,
                         )),

--- a/compiler/rustc_hir_analysis/src/outlives/utils.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/utils.rs
@@ -127,7 +127,7 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
             }
         }
 
-        GenericArgKind::Lifetime(r) => {
+        GenericArgKind::Region(r) => {
             if !is_free_region(r) {
                 return;
             }

--- a/compiler/rustc_hir_analysis/src/variance/constraints.rs
+++ b/compiler/rustc_hir_analysis/src/variance/constraints.rs
@@ -186,12 +186,12 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
 
         for k in substs {
             match k.unpack() {
-                GenericArgKind::Lifetime(lt) => {
-                    self.add_constraints_from_region(current, lt, variance_i)
+                GenericArgKind::Region(re) => {
+                    self.add_constraints_from_region(current, re, variance_i)
                 }
                 GenericArgKind::Type(ty) => self.add_constraints_from_ty(current, ty, variance_i),
-                GenericArgKind::Const(val) => {
-                    self.add_constraints_from_const(current, val, variance_i)
+                GenericArgKind::Const(ct) => {
+                    self.add_constraints_from_const(current, ct, variance_i)
                 }
             }
         }
@@ -345,13 +345,11 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 variance_decl, variance_i
             );
             match k.unpack() {
-                GenericArgKind::Lifetime(lt) => {
-                    self.add_constraints_from_region(current, lt, variance_i)
+                GenericArgKind::Region(re) => {
+                    self.add_constraints_from_region(current, re, variance_i)
                 }
                 GenericArgKind::Type(ty) => self.add_constraints_from_ty(current, ty, variance_i),
-                GenericArgKind::Const(val) => {
-                    self.add_constraints_from_const(current, val, variance)
-                }
+                GenericArgKind::Const(ct) => self.add_constraints_from_const(current, ct, variance),
             }
         }
     }

--- a/compiler/rustc_hir_analysis/src/variance/mod.rs
+++ b/compiler/rustc_hir_analysis/src/variance/mod.rs
@@ -140,7 +140,7 @@ fn variance_of_opaque(tcx: TyCtxt<'_>, item_def_id: LocalDefId) -> &[ty::Varianc
             generics = tcx.generics_of(def_id);
             for param in &generics.params {
                 match param.kind {
-                    ty::GenericParamDefKind::Lifetime => {
+                    ty::GenericParamDefKind::Region => {
                         variances[param.index as usize] = ty::Bivariant;
                     }
                     ty::GenericParamDefKind::Type { .. }

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -394,7 +394,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                             .try_coerce(
                                 self.expr,
                                 fcx.tcx.mk_ref(
-                                    fcx.tcx.lifetimes.re_erased,
+                                    fcx.tcx.regions.erased,
                                     TypeAndMut { ty: expr_ty, mutbl },
                                 ),
                                 self.cast_ty,
@@ -442,7 +442,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                         .try_coerce(
                             self.expr,
                             fcx.tcx.mk_ref(
-                                fcx.tcx.lifetimes.re_erased,
+                                fcx.tcx.regions.erased,
                                 TypeAndMut { ty: self.expr_ty, mutbl },
                             ),
                             self.cast_ty,

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -282,7 +282,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ty
                 }
             },
-            lt_op: |_| self.tcx.lifetimes.re_erased,
+            lt_op: |_| self.tcx.regions.erased,
             ct_op: |ct| {
                 if let ty::ConstKind::Infer(_) = ct.kind() {
                     self.next_const_var(
@@ -1293,10 +1293,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // ```
                 let ref_ty = match mutability {
                     hir::Mutability::Mut => {
-                        self.tcx.mk_mut_ref(self.tcx.lifetimes.re_static, checked_ty)
+                        self.tcx.mk_mut_ref(self.tcx.regions.re_static, checked_ty)
                     }
                     hir::Mutability::Not => {
-                        self.tcx.mk_imm_ref(self.tcx.lifetimes.re_static, checked_ty)
+                        self.tcx.mk_imm_ref(self.tcx.regions.re_static, checked_ty)
                     }
                 };
                 if self.can_coerce(ref_ty, expected) {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1260,7 +1260,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 arg: &GenericArg<'_>,
             ) -> ty::GenericArg<'tcx> {
                 match (&param.kind, arg) {
-                    (GenericParamDefKind::Lifetime, GenericArg::Lifetime(lt)) => {
+                    (GenericParamDefKind::Region, GenericArg::Lifetime(lt)) => {
                         self.fcx.astconv().ast_region_to_region(lt, Some(param)).into()
                     }
                     (GenericParamDefKind::Type { .. }, GenericArg::Type(ty)) => {
@@ -1296,7 +1296,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ) -> ty::GenericArg<'tcx> {
                 let tcx = self.fcx.tcx();
                 match param.kind {
-                    GenericParamDefKind::Lifetime => {
+                    GenericParamDefKind::Region => {
                         self.fcx.re_infer(Some(param), self.span).unwrap().into()
                     }
                     GenericParamDefKind::Type { has_default, .. } => {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1289,7 +1289,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         match lit.node {
             ast::LitKind::Str(..) => tcx.mk_static_str(),
             ast::LitKind::ByteStr(ref v, _) => {
-                tcx.mk_imm_ref(tcx.lifetimes.re_static, tcx.mk_array(tcx.types.u8, v.len() as u64))
+                tcx.mk_imm_ref(tcx.regions.re_static, tcx.mk_array(tcx.types.u8, v.len() as u64))
             }
             ast::LitKind::Byte(_) => tcx.types.u8,
             ast::LitKind::Char(_) => tcx.types.char,

--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -360,7 +360,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
                             let ty = tcx.mk_ref(
                                 // Use `ReErased` as `resolve_interior` is going to replace all the
                                 // regions anyway.
-                                tcx.lifetimes.re_erased,
+                                tcx.regions.erased,
                                 ty::TypeAndMut { ty, mutbl: hir::Mutability::Not },
                             );
                             self.interior_visitor.record(

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -370,7 +370,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                 arg: &GenericArg<'_>,
             ) -> subst::GenericArg<'tcx> {
                 match (&param.kind, arg) {
-                    (GenericParamDefKind::Lifetime, GenericArg::Lifetime(lt)) => {
+                    (GenericParamDefKind::Region, GenericArg::Lifetime(lt)) => {
                         self.cfcx.fcx.astconv().ast_region_to_region(lt, Some(param)).into()
                     }
                     (GenericParamDefKind::Type { .. }, GenericArg::Type(ty)) => {

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -305,7 +305,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Construct a trait-reference `self_ty : Trait<input_tys>`
         let substs = InternalSubsts::for_item(self.tcx, trait_def_id, |param, _| {
             match param.kind {
-                GenericParamDefKind::Lifetime | GenericParamDefKind::Const { .. } => {}
+                GenericParamDefKind::Region | GenericParamDefKind::Const { .. } => {}
                 GenericParamDefKind::Type { .. } => {
                     if param.index == 0 {
                         return self_ty.into();

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1877,7 +1877,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     substs[i]
                 } else {
                     match param.kind {
-                        GenericParamDefKind::Lifetime => {
+                        GenericParamDefKind::Region => {
                             // In general, during probe we erase regions.
                             self.tcx.lifetimes.re_erased.into()
                         }

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1212,7 +1212,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         let tcx = self.tcx;
 
         // In general, during probing we erase regions.
-        let region = tcx.lifetimes.re_erased;
+        let region = tcx.regions.erased;
 
         let autoref_ty = tcx.mk_ref(region, ty::TypeAndMut { ty: self_ty, mutbl });
         self.pick_method(autoref_ty, unstable_candidates).map(|r| {
@@ -1879,7 +1879,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     match param.kind {
                         GenericParamDefKind::Region => {
                             // In general, during probe we erase regions.
-                            self.tcx.lifetimes.re_erased.into()
+                            self.tcx.regions.erased.into()
                         }
                         GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {
                             self.var_for_def(self.span, param)

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1315,7 +1315,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     if !arg.is_suggestable(self.tcx, true) {
                         has_unsuggestable_args = true;
                         match arg.unpack() {
-                            GenericArgKind::Lifetime(_) => self
+                            GenericArgKind::Region(_) => self
                                 .next_region_var(RegionVariableOrigin::MiscVariable(
                                     rustc_span::DUMMY_SP,
                                 ))

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2380,8 +2380,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // just this list.
             for (rcvr_ty, post) in &[
                 (rcvr_ty, ""),
-                (self.tcx.mk_mut_ref(self.tcx.lifetimes.re_erased, rcvr_ty), "&mut "),
-                (self.tcx.mk_imm_ref(self.tcx.lifetimes.re_erased, rcvr_ty), "&"),
+                (self.tcx.mk_mut_ref(self.tcx.regions.erased, rcvr_ty), "&mut "),
+                (self.tcx.mk_imm_ref(self.tcx.regions.erased, rcvr_ty), "&"),
             ] {
                 match self.lookup_probe_for_diagnostic(
                     item_name,

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -403,7 +403,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .borrow_mut()
                     .treat_byte_string_as_slice
                     .insert(lt.hir_id.local_id);
-                pat_ty = tcx.mk_imm_ref(tcx.lifetimes.re_static, tcx.mk_slice(tcx.types.u8));
+                pat_ty = tcx.mk_imm_ref(tcx.regions.re_static, tcx.mk_slice(tcx.types.u8));
             }
         }
 

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -964,7 +964,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.tcx,
                     ty,
                     max_capture_info.capture_kind,
-                    Some(self.tcx.lifetimes.re_erased),
+                    Some(self.tcx.regions.erased),
                 )
             }
         };
@@ -990,7 +990,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.tcx,
                 capture.place.ty(),
                 capture.info.capture_kind,
-                Some(self.tcx.lifetimes.re_erased),
+                Some(self.tcx.regions.erased),
             );
 
             // Checks if a capture implements any of the auto traits

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -774,7 +774,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for EraseEarlyRegions<'tcx> {
         }
     }
     fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
-        if r.is_late_bound() { r } else { self.tcx.lifetimes.re_erased }
+        if r.is_late_bound() { r } else { self.tcx.regions.erased }
     }
 }
 
@@ -803,7 +803,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Resolver<'cx, 'tcx> {
 
     fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
         debug_assert!(!r.is_late_bound(), "Should not be resolving bound region.");
-        self.tcx.lifetimes.re_erased
+        self.tcx.regions.erased
     }
 
     fn fold_const(&mut self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -407,15 +407,15 @@ impl<'tcx> ToTrace<'tcx> for ty::GenericArg<'tcx> {
         TypeTrace {
             cause: cause.clone(),
             values: match (a.unpack(), b.unpack()) {
-                (Lifetime(a), Lifetime(b)) => Regions(ExpectedFound::new(a_is_expected, a, b)),
+                (Region(a), Region(b)) => Regions(ExpectedFound::new(a_is_expected, a, b)),
                 (Type(a), Type(b)) => Terms(ExpectedFound::new(a_is_expected, a.into(), b.into())),
                 (Const(a), Const(b)) => {
                     Terms(ExpectedFound::new(a_is_expected, a.into(), b.into()))
                 }
 
-                (Lifetime(_), Type(_) | Const(_))
-                | (Type(_), Lifetime(_) | Const(_))
-                | (Const(_), Lifetime(_) | Type(_)) => {
+                (Region(_), Type(_) | Const(_))
+                | (Type(_), Region(_) | Const(_))
+                | (Const(_), Region(_) | Type(_)) => {
                     bug!("relating different kinds: {a:?} {b:?}")
                 }
             },

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -267,13 +267,13 @@ impl<'tcx> InferCtxt<'tcx> {
                 v.var_values[BoundVar::new(index)]
             });
             match (original_value.unpack(), result_value.unpack()) {
-                (GenericArgKind::Lifetime(re1), GenericArgKind::Lifetime(re2))
+                (GenericArgKind::Region(re1), GenericArgKind::Region(re2))
                     if re1.is_erased() && re2.is_erased() =>
                 {
                     // No action needed.
                 }
 
-                (GenericArgKind::Lifetime(v_o), GenericArgKind::Lifetime(v_r)) => {
+                (GenericArgKind::Region(v_o), GenericArgKind::Region(v_r)) => {
                     // To make `v_o = v_r`, we emit `v_o: v_r` and `v_r: v_o`.
                     if v_o != v_r {
                         output_query_region_constraints
@@ -456,7 +456,7 @@ impl<'tcx> InferCtxt<'tcx> {
                         opt_values[b.var] = Some(*original_value);
                     }
                 }
-                GenericArgKind::Lifetime(result_value) => {
+                GenericArgKind::Region(result_value) => {
                     // e.g., here `result_value` might be `'?1` in the example above...
                     if let ty::ReLateBound(debruijn, br) = *result_value {
                         // ... in which case we would set `canonical_vars[0]` to `Some('static)`.
@@ -568,7 +568,7 @@ impl<'tcx> InferCtxt<'tcx> {
         let ty::OutlivesPredicate(k1, r2) = predicate;
 
         let atom = match k1.unpack() {
-            GenericArgKind::Lifetime(r1) => {
+            GenericArgKind::Region(r1) => {
                 ty::PredicateKind::Clause(ty::Clause::RegionOutlives(ty::OutlivesPredicate(r1, r2)))
             }
             GenericArgKind::Type(t1) => {
@@ -607,12 +607,12 @@ impl<'tcx> InferCtxt<'tcx> {
                                 .into_obligations(),
                         );
                     }
-                    (GenericArgKind::Lifetime(re1), GenericArgKind::Lifetime(re2))
+                    (GenericArgKind::Region(re1), GenericArgKind::Region(re2))
                         if re1.is_erased() && re2.is_erased() =>
                     {
                         // no action needed
                     }
-                    (GenericArgKind::Lifetime(v1), GenericArgKind::Lifetime(v2)) => {
+                    (GenericArgKind::Region(v1), GenericArgKind::Region(v2)) => {
                         obligations.extend(
                             self.at(cause, param_env)
                                 .eq(DefineOpaqueTypes::Yes, v1, v2)?

--- a/compiler/rustc_infer/src/infer/canonical/substitute.rs
+++ b/compiler/rustc_infer/src/infer/canonical/substitute.rs
@@ -74,17 +74,17 @@ where
         value
     } else {
         let delegate = FnMutDelegate {
-            regions: &mut |br: ty::BoundRegion| match var_values[br.var].unpack() {
-                GenericArgKind::Lifetime(l) => l,
-                r => bug!("{:?} is a region but value is {:?}", br, r),
+            regions: &mut |bound_re: ty::BoundRegion| match var_values[bound_re.var].unpack() {
+                GenericArgKind::Region(re) => re,
+                v => bug!("{bound_re:?} is a region but value is {v:?}"),
             },
             types: &mut |bound_ty: ty::BoundTy| match var_values[bound_ty.var].unpack() {
                 GenericArgKind::Type(ty) => ty,
-                r => bug!("{:?} is a type but value is {:?}", bound_ty, r),
+                v => bug!("{bound_ty:?} is a type but value is {v:?}"),
             },
             consts: &mut |bound_ct: ty::BoundVar, _| match var_values[bound_ct].unpack() {
                 GenericArgKind::Const(ct) => ct,
-                c => bug!("{:?} is a const but value is {:?}", bound_ct, c),
+                v => bug!("{bound_ct:?} is a const but value is {v:?}"),
             },
         };
 

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -503,7 +503,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         // placeholder. In practice, we expect more
                         // tailored errors that don't really use this
                         // value.
-                        let sub_r = self.tcx.lifetimes.re_erased;
+                        let sub_r = self.tcx.regions.erased;
 
                         self.report_placeholder_failure(sup_origin, sub_r, sup_r).emit();
                     }

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2284,7 +2284,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             let lts_names =
                 iter::successors(Some(generics), |g| g.parent.map(|p| self.tcx.generics_of(p)))
                     .flat_map(|g| &g.params)
-                    .filter(|p| matches!(p.kind, ty::GenericParamDefKind::Lifetime))
+                    .filter(|p| matches!(p.kind, ty::GenericParamDefKind::Region))
                     .map(|p| p.name.as_str())
                     .collect::<Vec<_>>();
             possible

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -329,7 +329,7 @@ impl<'tcx> InferCtxt<'tcx> {
                     }
                 }
             }
-            GenericArgKind::Lifetime(_) => bug!("unexpected lifetime"),
+            GenericArgKind::Region(_) => bug!("unexpected region"),
         }
     }
 
@@ -486,7 +486,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             }
 
                             match arg.unpack() {
-                                GenericArgKind::Lifetime(_) => bug!("unexpected lifetime"),
+                                GenericArgKind::Region(_) => bug!("unexpected region"),
                                 GenericArgKind::Type(_) => self
                                     .next_ty_var(TypeVariableOrigin {
                                         span: rustc_span::DUMMY_SP,
@@ -756,7 +756,7 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
         impl<'tcx> CostCtxt<'tcx> {
             fn arg_cost(self, arg: GenericArg<'tcx>) -> usize {
                 match arg.unpack() {
-                    GenericArgKind::Lifetime(_) => 0, // erased
+                    GenericArgKind::Region(_) => 0, // erased
                     GenericArgKind::Type(ty) => self.ty_cost(ty),
                     GenericArgKind::Const(_) => 3, // some non-zero value
                 }
@@ -884,7 +884,7 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
                 return true;
             }
             match inner.unpack() {
-                GenericArgKind::Lifetime(_) => {}
+                GenericArgKind::Region(_) => {}
                 GenericArgKind::Type(ty) => {
                     if matches!(
                         ty.kind(),

--- a/compiler/rustc_infer/src/infer/free_regions.rs
+++ b/compiler/rustc_infer/src/infer/free_regions.rs
@@ -60,7 +60,7 @@ impl<'tcx> FreeRegionMap<'tcx> {
         r_b: Region<'tcx>,
     ) -> bool {
         assert!(r_a.is_free_or_static() && r_b.is_free_or_static());
-        let re_static = tcx.lifetimes.re_static;
+        let re_static = tcx.regions.re_static;
         if self.check_relation(re_static, r_b) {
             // `'a <= 'static` is always true, and not stored in the
             // relation explicitly, so check if `'b` is `'static` (or
@@ -93,7 +93,7 @@ impl<'tcx> FreeRegionMap<'tcx> {
             r_a
         } else {
             match self.relation.postdom_upper_bound(r_a, r_b) {
-                None => tcx.lifetimes.re_static,
+                None => tcx.regions.re_static,
                 Some(r) => r,
             }
         };

--- a/compiler/rustc_infer/src/infer/freshen.rs
+++ b/compiler/rustc_infer/src/infer/freshen.rs
@@ -121,7 +121,7 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for TypeFreshener<'a, 'tcx> {
             | ty::RePlaceholder(..)
             | ty::ReStatic
             | ty::ReError(_)
-            | ty::ReErased => self.interner().lifetimes.re_erased,
+            | ty::ReErased => self.interner().regions.erased,
         }
     }
 

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -179,7 +179,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
 
             ReStatic => {
                 // nothing lives longer than `'static`
-                Ok(self.tcx().lifetimes.re_static)
+                Ok(self.tcx().regions.re_static)
             }
 
             ReError(_) => Ok(a_region),
@@ -244,7 +244,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                                     Err(placeholder) if a_universe == placeholder.universe => {
                                         cur_region
                                     }
-                                    Err(_) => self.tcx().lifetimes.re_static,
+                                    Err(_) => self.tcx().regions.re_static,
                                 };
 
                                 if lub == cur_region {
@@ -338,7 +338,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                     Err(placeholder) if empty_ui.can_name(placeholder.universe) => {
                         self.tcx().mk_re_placeholder(placeholder)
                     }
-                    Err(_) => self.tcx().lifetimes.re_static,
+                    Err(_) => self.tcx().regions.re_static,
                 };
 
                 debug!("Expanding value of {:?} from empty lifetime to {:?}", b_vid, lub);
@@ -367,7 +367,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                 //
                 // (This might e.g. arise from being asked to prove `for<'a> { 'b: 'a }`.)
                 if let ty::RePlaceholder(p) = *lub && b_universe.cannot_name(p.universe) {
-                    lub = self.tcx().lifetimes.re_static;
+                    lub = self.tcx().regions.re_static;
                 }
 
                 debug!("Expanding value of {:?} from {:?} to {:?}", b_vid, cur_region, lub);
@@ -469,7 +469,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
         // Check for the case where we know that `'b: 'static` -- in that case,
         // `a <= b` for all `a`.
         let b_free_or_static = b.is_free_or_static();
-        if b_free_or_static && sub_free_regions(tcx.lifetimes.re_static, b) {
+        if b_free_or_static && sub_free_regions(tcx.regions.re_static, b) {
             return true;
         }
 
@@ -516,7 +516,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
 
             (ReStatic, _) | (_, ReStatic) => {
                 // nothing lives longer than `'static`
-                self.tcx().lifetimes.re_static
+                self.tcx().regions.re_static
             }
 
             (ReEarlyBound(_) | ReFree(_), ReEarlyBound(_) | ReFree(_)) => {
@@ -529,7 +529,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                 if a == b {
                     a
                 } else {
-                    self.tcx().lifetimes.re_static
+                    self.tcx().regions.re_static
                 }
             }
         }
@@ -759,7 +759,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
         for lower_bound in &lower_bounds {
             let effective_lower_bound = if let ty::RePlaceholder(p) = *lower_bound.region {
                 if node_universe.cannot_name(p.universe) {
-                    self.tcx().lifetimes.re_static
+                    self.tcx().regions.re_static
                 } else {
                     lower_bound.region
                 }
@@ -1012,7 +1012,7 @@ impl<'tcx> LexicalRegionResolutions<'tcx> {
             ty::ReVar(rid) => match self.values[rid] {
                 VarValue::Empty(_) => r,
                 VarValue::Value(r) => r,
-                VarValue::ErrorValue => tcx.lifetimes.re_static,
+                VarValue::ErrorValue => tcx.regions.re_static,
             },
             _ => r,
         };

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1117,7 +1117,7 @@ impl<'tcx> InferCtxt<'tcx> {
 
     pub fn var_for_def(&self, span: Span, param: &ty::GenericParamDef) -> GenericArg<'tcx> {
         match param.kind {
-            GenericParamDefKind::Lifetime => {
+            GenericParamDefKind::Region => {
                 // Create a region inference variable for the given
                 // region parameter definition.
                 self.next_region_var(EarlyBoundRegion(span, param.name)).into()

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1740,7 +1740,7 @@ impl<'tcx> TyOrConstInferVar<'tcx> {
         match arg.unpack() {
             GenericArgKind::Type(ty) => Self::maybe_from_ty(ty),
             GenericArgKind::Const(ct) => Self::maybe_from_const(ct),
-            GenericArgKind::Lifetime(_) => None,
+            GenericArgKind::Region(_) => None,
         }
     }
 

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -351,7 +351,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 .enumerate()
                 .filter(|(i, _)| variances[*i] == ty::Variance::Invariant)
                 .filter_map(|(_, arg)| match arg.unpack() {
-                    GenericArgKind::Lifetime(r) => Some(r),
+                    GenericArgKind::Region(r) => Some(r),
                     GenericArgKind::Type(_) | GenericArgKind::Const(_) => None,
                 })
                 .chain(std::iter::once(self.tcx.lifetimes.re_static))

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -354,7 +354,7 @@ impl<'tcx> InferCtxt<'tcx> {
                     GenericArgKind::Region(r) => Some(r),
                     GenericArgKind::Type(_) | GenericArgKind::Const(_) => None,
                 })
-                .chain(std::iter::once(self.tcx.lifetimes.re_static))
+                .chain(std::iter::once(self.tcx.regions.re_static))
                 .collect(),
         );
 

--- a/compiler/rustc_infer/src/infer/outlives/components.rs
+++ b/compiler/rustc_infer/src/infer/outlives/components.rs
@@ -84,7 +84,7 @@ fn compute_components<'tcx>(
                         GenericArgKind::Type(ty) => {
                             compute_components(tcx, ty, out, visited);
                         }
-                        GenericArgKind::Lifetime(_) => {}
+                        GenericArgKind::Region(_) => {}
                         GenericArgKind::Const(_) => {
                             compute_components_recursive(tcx, child, out, visited);
                         }
@@ -212,10 +212,10 @@ pub(super) fn compute_alias_components_recursive<'tcx>(
             GenericArgKind::Type(ty) => {
                 compute_components(tcx, ty, out, visited);
             }
-            GenericArgKind::Lifetime(lt) => {
+            GenericArgKind::Region(re) => {
                 // Ignore late-bound regions.
-                if !lt.is_late_bound() {
-                    out.push(Component::Region(lt));
+                if !re.is_late_bound() {
+                    out.push(Component::Region(re));
                 }
             }
             GenericArgKind::Const(_) => {
@@ -240,10 +240,10 @@ fn compute_components_recursive<'tcx>(
             GenericArgKind::Type(ty) => {
                 compute_components(tcx, ty, out, visited);
             }
-            GenericArgKind::Lifetime(lt) => {
+            GenericArgKind::Region(re) => {
                 // Ignore late-bound regions.
-                if !lt.is_late_bound() {
-                    out.push(Component::Region(lt));
+                if !re.is_late_bound() {
+                    out.push(Component::Region(re));
                 }
             }
             GenericArgKind::Const(_) => {

--- a/compiler/rustc_infer/src/infer/outlives/mod.rs
+++ b/compiler/rustc_infer/src/infer/outlives/mod.rs
@@ -62,7 +62,7 @@ impl<'tcx> InferCtxt<'tcx> {
 
         let lexical_region_resolutions = LexicalRegionResolutions {
             values: rustc_index::vec::IndexVec::from_elem_n(
-                crate::infer::lexical_region_resolve::VarValue::Value(self.tcx.lifetimes.re_erased),
+                crate::infer::lexical_region_resolve::VarValue::Value(self.tcx.regions.erased),
                 var_infos.len(),
             ),
         };

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -408,7 +408,7 @@ where
         let constraint = origin.to_constraint_category();
         for (index, k) in substs.iter().enumerate() {
             match k.unpack() {
-                GenericArgKind::Lifetime(lt) => {
+                GenericArgKind::Region(re) => {
                     let variance = if let Some(variances) = opt_variances {
                         variances[index]
                     } else {
@@ -418,7 +418,7 @@ where
                         self.delegate.push_sub_region_constraint(
                             origin.clone(),
                             region,
-                            lt,
+                            re,
                             constraint,
                         );
                     }

--- a/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
+++ b/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
@@ -53,7 +53,7 @@ pub fn extract_verify_if_eq<'tcx>(
             None => {
                 // If there is no mapping, then this region is unconstrained.
                 // In that case, we escalate to `'static`.
-                Some(tcx.lifetimes.re_static)
+                Some(tcx.regions.re_static)
             }
         }
     } else {

--- a/compiler/rustc_middle/src/infer/canonical.rs
+++ b/compiler/rustc_middle/src/infer/canonical.rs
@@ -69,7 +69,7 @@ pub struct CanonicalVarValues<'tcx> {
 impl CanonicalVarValues<'_> {
     pub fn is_identity(&self) -> bool {
         self.var_values.iter().enumerate().all(|(bv, arg)| match arg.unpack() {
-            ty::GenericArgKind::Lifetime(r) => {
+            ty::GenericArgKind::Region(r) => {
                 matches!(*r, ty::ReLateBound(ty::INNERMOST, br) if br.var.as_usize() == bv)
             }
             ty::GenericArgKind::Type(ty) => {
@@ -83,7 +83,7 @@ impl CanonicalVarValues<'_> {
 
     pub fn is_identity_modulo_regions(&self) -> bool {
         self.var_values.iter().enumerate().all(|(bv, arg)| match arg.unpack() {
-            ty::GenericArgKind::Lifetime(_) => true,
+            ty::GenericArgKind::Region(_) => true,
             ty::GenericArgKind::Type(ty) => {
                 matches!(*ty.kind(), ty::Bound(ty::INNERMOST, bt) if bt.var.as_usize() == bv)
             }

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -534,7 +534,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let is_generic = instance
             .substs
             .into_iter()
-            .any(|kind| !matches!(kind.unpack(), GenericArgKind::Lifetime(_)));
+            .any(|kind| !matches!(kind.unpack(), GenericArgKind::Region(_)));
         if is_generic {
             // Get a fresh ID.
             let mut alloc_map = self.alloc_map.lock();

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1749,7 +1749,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let adt_def = self.adt_def(wrapper_def_id);
         let substs =
             InternalSubsts::for_item(self, wrapper_def_id, |param, substs| match param.kind {
-                GenericParamDefKind::Lifetime | GenericParamDefKind::Const { .. } => bug!(),
+                GenericParamDefKind::Region | GenericParamDefKind::Const { .. } => bug!(),
                 GenericParamDefKind::Type { has_default, .. } => {
                     if param.index == 0 {
                         ty_param.into()
@@ -2008,7 +2008,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
     pub fn mk_param_from_def(self, param: &ty::GenericParamDef) -> GenericArg<'tcx> {
         match param.kind {
-            GenericParamDefKind::Lifetime => {
+            GenericParamDefKind::Region => {
                 self.mk_re_early_bound(param.to_early_bound_region_data()).into()
             }
             GenericParamDefKind::Type { .. } => self.mk_ty_param(param.index, param.name).into(),

--- a/compiler/rustc_middle/src/ty/erase_regions.rs
+++ b/compiler/rustc_middle/src/ty/erase_regions.rs
@@ -62,7 +62,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for RegionEraserVisitor<'tcx> {
         // whenever a substitution occurs.
         match *r {
             ty::ReLateBound(..) => r,
-            _ => self.tcx.lifetimes.re_erased,
+            _ => self.tcx.regions.erased,
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/fast_reject.rs
+++ b/compiler/rustc_middle/src/ty/fast_reject.rs
@@ -196,7 +196,7 @@ impl DeepRejectCtxt {
         iter::zip(obligation_substs, impl_substs).all(|(obl, imp)| {
             match (obl.unpack(), imp.unpack()) {
                 // We don't fast reject based on regions for now.
-                (GenericArgKind::Lifetime(_), GenericArgKind::Lifetime(_)) => true,
+                (GenericArgKind::Region(_), GenericArgKind::Region(_)) => true,
                 (GenericArgKind::Type(obl), GenericArgKind::Type(imp)) => {
                     self.types_may_unify(obl, imp)
                 }

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -380,7 +380,7 @@ impl FlagComputation {
         for kind in substs {
             match kind.unpack() {
                 GenericArgKind::Type(ty) => self.add_ty(ty),
-                GenericArgKind::Lifetime(lt) => self.add_region(lt),
+                GenericArgKind::Region(re) => self.add_region(re),
                 GenericArgKind::Const(ct) => self.add_const(ct),
             }
         }

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -362,7 +362,7 @@ impl<'tcx> TyCtxt<'tcx> {
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
     {
-        self.replace_late_bound_regions(value, |_| self.lifetimes.re_erased).0
+        self.replace_late_bound_regions(value, |_| self.regions.erased).0
     }
 
     /// Anonymize all bound variables in `value`, this is mostly used to improve caching.

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -10,7 +10,7 @@ use super::{EarlyBoundRegion, InstantiatedPredicates, ParamConst, ParamTy, Predi
 
 #[derive(Clone, Debug, TyEncodable, TyDecodable, HashStable)]
 pub enum GenericParamDefKind {
-    Lifetime,
+    Region,
     Type { has_default: bool, synthetic: bool },
     Const { has_default: bool },
 }
@@ -18,14 +18,14 @@ pub enum GenericParamDefKind {
 impl GenericParamDefKind {
     pub fn descr(&self) -> &'static str {
         match self {
-            GenericParamDefKind::Lifetime => "lifetime",
+            GenericParamDefKind::Region => "lifetime",
             GenericParamDefKind::Type { .. } => "type",
             GenericParamDefKind::Const { .. } => "constant",
         }
     }
     pub fn to_ord(&self) -> ast::ParamKindOrd {
         match self {
-            GenericParamDefKind::Lifetime => ast::ParamKindOrd::Lifetime,
+            GenericParamDefKind::Region => ast::ParamKindOrd::Lifetime,
             GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {
                 ast::ParamKindOrd::TypeOrConst
             }
@@ -34,7 +34,7 @@ impl GenericParamDefKind {
 
     pub fn is_ty_or_const(&self) -> bool {
         match self {
-            GenericParamDefKind::Lifetime => false,
+            GenericParamDefKind::Region => false,
             GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => true,
         }
     }
@@ -63,7 +63,7 @@ pub struct GenericParamDef {
 
 impl GenericParamDef {
     pub fn to_early_bound_region_data(&self) -> ty::EarlyBoundRegion {
-        if let GenericParamDefKind::Lifetime = self.kind {
+        if let GenericParamDefKind::Region = self.kind {
             ty::EarlyBoundRegion { def_id: self.def_id, index: self.index, name: self.name }
         } else {
             bug!("cannot convert a non-lifetime parameter def to an early bound region")
@@ -72,7 +72,7 @@ impl GenericParamDef {
 
     pub fn is_anonymous_lifetime(&self) -> bool {
         match self.kind {
-            GenericParamDefKind::Lifetime => {
+            GenericParamDefKind::Region => {
                 self.name == kw::UnderscoreLifetime || self.name == kw::Empty
             }
             _ => false,
@@ -100,7 +100,7 @@ impl GenericParamDef {
         preceding_substs: &[ty::GenericArg<'tcx>],
     ) -> ty::GenericArg<'tcx> {
         match &self.kind {
-            ty::GenericParamDefKind::Lifetime => tcx.mk_re_error_misc().into(),
+            ty::GenericParamDefKind::Region => tcx.mk_re_error_misc().into(),
             ty::GenericParamDefKind::Type { .. } => tcx.ty_error_misc().into(),
             ty::GenericParamDefKind::Const { .. } => {
                 tcx.const_error(tcx.type_of(self.def_id).subst(tcx, preceding_substs)).into()
@@ -164,7 +164,7 @@ impl<'tcx> Generics {
 
         for param in &self.params {
             match param.kind {
-                GenericParamDefKind::Lifetime => own_counts.lifetimes += 1,
+                GenericParamDefKind::Region => own_counts.lifetimes += 1,
                 GenericParamDefKind::Type { .. } => own_counts.types += 1,
                 GenericParamDefKind::Const { .. } => own_counts.consts += 1,
             }
@@ -178,7 +178,7 @@ impl<'tcx> Generics {
 
         for param in &self.params {
             match param.kind {
-                GenericParamDefKind::Lifetime => (),
+                GenericParamDefKind::Region => (),
                 GenericParamDefKind::Type { has_default, .. } => {
                     own_defaults.types += has_default as usize;
                 }
@@ -210,7 +210,7 @@ impl<'tcx> Generics {
                 GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {
                     return true;
                 }
-                GenericParamDefKind::Lifetime => {}
+                GenericParamDefKind::Region => {}
             }
         }
         false
@@ -243,7 +243,7 @@ impl<'tcx> Generics {
     ) -> &'tcx GenericParamDef {
         let param = self.param_at(param.index as usize, tcx);
         match param.kind {
-            GenericParamDefKind::Lifetime => param,
+            GenericParamDefKind::Region => param,
             _ => bug!("expected lifetime parameter, but found another generic parameter"),
         }
     }

--- a/compiler/rustc_middle/src/ty/impls_ty.rs
+++ b/compiler/rustc_middle/src/ty/impls_ty.rs
@@ -93,9 +93,9 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ty::subst::GenericArgKin
                 0xF3u8.hash_stable(hcx, hasher);
                 ct.hash_stable(hcx, hasher);
             }
-            ty::subst::GenericArgKind::Lifetime(lt) => {
+            ty::subst::GenericArgKind::Region(re) => {
                 0xF5u8.hash_stable(hcx, hasher);
-                lt.hash_stable(hcx, hasher);
+                re.hash_stable(hcx, hasher);
             }
         }
     }

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -363,7 +363,7 @@ impl<'tcx> Instance<'tcx> {
 
     pub fn mono(tcx: TyCtxt<'tcx>, def_id: DefId) -> Instance<'tcx> {
         let substs = InternalSubsts::for_item(tcx, def_id, |param, _| match param.kind {
-            ty::GenericParamDefKind::Lifetime => tcx.lifetimes.re_erased.into(),
+            ty::GenericParamDefKind::Region => tcx.lifetimes.re_erased.into(),
             ty::GenericParamDefKind::Type { .. } => {
                 bug!("Instance::mono: {:?} has type parameters", def_id)
             }

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -363,7 +363,7 @@ impl<'tcx> Instance<'tcx> {
 
     pub fn mono(tcx: TyCtxt<'tcx>, def_id: DefId) -> Instance<'tcx> {
         let substs = InternalSubsts::for_item(tcx, def_id, |param, _| match param.kind {
-            ty::GenericParamDefKind::Region => tcx.lifetimes.re_erased.into(),
+            ty::GenericParamDefKind::Region => tcx.regions.erased.into(),
             ty::GenericParamDefKind::Type { .. } => {
                 bug!("Instance::mono: {:?} has type parameters", def_id)
             }

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -796,7 +796,7 @@ where
                         let unit_ptr_ty = if this.ty.is_unsafe_ptr() {
                             tcx.mk_mut_ptr(nil)
                         } else {
-                            tcx.mk_mut_ref(tcx.lifetimes.re_static, nil)
+                            tcx.mk_mut_ref(tcx.regions.re_static, nil)
                         };
 
                         // NOTE(eddyb) using an empty `ParamEnv`, and `unwrap`-ing
@@ -809,7 +809,7 @@ where
                     }
 
                     let mk_dyn_vtable = || {
-                        tcx.mk_imm_ref(tcx.lifetimes.re_static, tcx.mk_array(tcx.types.usize, 3))
+                        tcx.mk_imm_ref(tcx.regions.re_static, tcx.mk_array(tcx.types.usize, 3))
                         /* FIXME: use actual fn pointers
                         Warning: naively computing the number of entries in the
                         vtable by counting the methods on the trait + methods on
@@ -911,10 +911,7 @@ where
                     } else if i == 1 {
                         // FIXME(dyn-star) same FIXME as above applies here too
                         TyMaybeWithLayout::Ty(
-                            tcx.mk_imm_ref(
-                                tcx.lifetimes.re_static,
-                                tcx.mk_array(tcx.types.usize, 3),
-                            ),
+                            tcx.mk_imm_ref(tcx.regions.re_static, tcx.mk_array(tcx.types.usize, 3)),
                         )
                     } else {
                         bug!("no field {i} on dyn*")

--- a/compiler/rustc_middle/src/ty/opaque_types.rs
+++ b/compiler/rustc_middle/src/ty/opaque_types.rs
@@ -123,7 +123,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ReverseMapper<'tcx> {
         }
 
         match self.map.get(&r.into()).map(|k| k.unpack()) {
-            Some(GenericArgKind::Lifetime(r1)) => r1,
+            Some(GenericArgKind::Region(r1)) => r1,
             Some(u) => panic!("region mapped to unexpected kind: {:?}", u),
             None if self.do_not_error => self.tcx.lifetimes.re_static,
             None => {

--- a/compiler/rustc_middle/src/ty/opaque_types.rs
+++ b/compiler/rustc_middle/src/ty/opaque_types.rs
@@ -125,7 +125,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ReverseMapper<'tcx> {
         match self.map.get(&r.into()).map(|k| k.unpack()) {
             Some(GenericArgKind::Region(r1)) => r1,
             Some(u) => panic!("region mapped to unexpected kind: {:?}", u),
-            None if self.do_not_error => self.tcx.lifetimes.re_static,
+            None if self.do_not_error => self.tcx.regions.re_static,
             None => {
                 let e = self
                     .tcx

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2862,7 +2862,7 @@ define_print_and_forward_display! {
 
     GenericArg<'tcx> {
         match self.unpack() {
-            GenericArgKind::Lifetime(lt) => p!(print(lt)),
+            GenericArgKind::Region(re) => p!(print(re)),
             GenericArgKind::Type(ty) => p!(print(ty)),
             GenericArgKind::Const(ct) => p!(print(ct)),
         }

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -782,8 +782,8 @@ impl<'tcx> Relate<'tcx> for GenericArg<'tcx> {
         b: GenericArg<'tcx>,
     ) -> RelateResult<'tcx, GenericArg<'tcx>> {
         match (a.unpack(), b.unpack()) {
-            (GenericArgKind::Lifetime(a_lt), GenericArgKind::Lifetime(b_lt)) => {
-                Ok(relation.relate(a_lt, b_lt)?.into())
+            (GenericArgKind::Region(a_re), GenericArgKind::Region(b_re)) => {
+                Ok(relation.relate(a_re, b_re)?.into())
             }
             (GenericArgKind::Type(a_ty), GenericArgKind::Type(b_ty)) => {
                 Ok(relation.relate(a_ty, b_ty)?.into())
@@ -791,7 +791,7 @@ impl<'tcx> Relate<'tcx> for GenericArg<'tcx> {
             (GenericArgKind::Const(a_ct), GenericArgKind::Const(b_ct)) => {
                 Ok(relation.relate(a_ct, b_ct)?.into())
             }
-            (GenericArgKind::Lifetime(unpacked), x) => {
+            (GenericArgKind::Region(unpacked), x) => {
                 bug!("impossible case reached: can't relate: {:?} with {:?}", unpacked, x)
             }
             (GenericArgKind::Type(unpacked), x) => {

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -675,7 +675,7 @@ impl<'tcx> CanonicalUserType<'tcx> {
                             _ => false,
                         },
 
-                        GenericArgKind::Lifetime(r) => match *r {
+                        GenericArgKind::Region(r) => match *r {
                             ty::ReLateBound(debruijn, br) => {
                                 // We only allow a `ty::INNERMOST` index in substitutions.
                                 assert_eq!(debruijn, ty::INNERMOST);

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -619,7 +619,7 @@ impl<'tcx> TyCtxt<'tcx> {
             self.mk_imm_ptr(static_ty)
         } else {
             // FIXME: These things don't *really* have 'static lifetime.
-            self.mk_imm_ref(self.lifetimes.re_static, static_ty)
+            self.mk_imm_ref(self.regions.re_static, static_ty)
         }
     }
 
@@ -638,7 +638,7 @@ impl<'tcx> TyCtxt<'tcx> {
         } else if self.is_foreign_item(def_id) {
             self.mk_imm_ptr(static_ty)
         } else {
-            self.mk_imm_ref(self.lifetimes.re_erased, static_ty)
+            self.mk_imm_ref(self.regions.erased, static_ty)
         }
     }
 

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -430,7 +430,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let result = iter::zip(item_substs, impl_substs)
             .filter(|&(_, k)| {
                 match k.unpack() {
-                    GenericArgKind::Lifetime(region) => match region.kind() {
+                    GenericArgKind::Region(region) => match region.kind() {
                         ty::ReEarlyBound(ref ebr) => {
                             !impl_generics.region_param(ebr, self).pure_wrt_drop
                         }
@@ -466,13 +466,13 @@ impl<'tcx> TyCtxt<'tcx> {
         let mut seen = GrowableBitSet::default();
         for arg in substs {
             match arg.unpack() {
-                GenericArgKind::Lifetime(lt) => {
+                GenericArgKind::Region(re) => {
                     if ignore_regions == IgnoreRegions::No {
-                        let ty::ReEarlyBound(p) = lt.kind() else {
-                            return Err(NotUniqueParam::NotParam(lt.into()))
+                        let ty::ReEarlyBound(p) = re.kind() else {
+                            return Err(NotUniqueParam::NotParam(re.into()))
                         };
                         if !seen.insert(p.index) {
-                            return Err(NotUniqueParam::DuplicateParam(lt.into()));
+                            return Err(NotUniqueParam::DuplicateParam(re.into()));
                         }
                     }
                 }

--- a/compiler/rustc_middle/src/ty/walk.rs
+++ b/compiler/rustc_middle/src/ty/walk.rs
@@ -203,7 +203,7 @@ fn push_inner<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent: GenericArg<'tcx>)
                 stack.extend(sig.skip_binder().inputs().iter().copied().rev().map(|ty| ty.into()));
             }
         },
-        GenericArgKind::Lifetime(_) => {}
+        GenericArgKind::Region(_) => {}
         GenericArgKind::Const(parent_ct) => {
             stack.push(parent_ct.ty().into());
             match parent_ct.kind() {

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -155,7 +155,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
             },
             @call("mir_len", args) => Ok(Rvalue::Len(self.parse_place(args[0])?)),
             ExprKind::Borrow { borrow_kind, arg } => Ok(
-                Rvalue::Ref(self.tcx.lifetimes.re_erased, *borrow_kind, self.parse_place(*arg)?)
+                Rvalue::Ref(self.tcx.regions.erased, *borrow_kind, self.parse_place(*arg)?)
             ),
             ExprKind::AddressOf { mutability, arg } => Ok(
                 Rvalue::AddressOf(*mutability, self.parse_place(*arg)?)

--- a/compiler/rustc_mir_build/src/build/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_place.rs
@@ -687,7 +687,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         )
                         .ty;
                         let fake_borrow_ty =
-                            tcx.mk_imm_ref(tcx.lifetimes.re_erased, fake_borrow_deref_ty);
+                            tcx.mk_imm_ref(tcx.regions.erased, fake_borrow_deref_ty);
                         let fake_borrow_temp =
                             self.local_decls.push(LocalDecl::new(fake_borrow_ty, expr_span));
                         let projection = tcx.mk_place_elems(&base_place.projection[..idx]);
@@ -696,7 +696,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             source_info,
                             fake_borrow_temp.into(),
                             Rvalue::Ref(
-                                tcx.lifetimes.re_erased,
+                                tcx.regions.erased,
                                 BorrowKind::Shallow,
                                 Place { local: base_place.local, projection },
                             ),

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -785,7 +785,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             block,
             source_info,
             Place::from(temp),
-            Rvalue::Ref(this.tcx.lifetimes.re_erased, borrow_kind, arg_place),
+            Rvalue::Ref(this.tcx.regions.erased, borrow_kind, arg_place),
         );
 
         // See the comment in `expr_as_temp` and on the `rvalue_scopes` field for why

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -296,7 +296,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     BorrowKind::Shared => unpack!(block = this.as_read_only_place(block, arg)),
                     _ => unpack!(block = this.as_place(block, arg)),
                 };
-                let borrow = Rvalue::Ref(this.tcx.lifetimes.re_erased, borrow_kind, arg_place);
+                let borrow = Rvalue::Ref(this.tcx.regions.erased, borrow_kind, arg_place);
                 this.cfg.push_assign(block, source_info, destination, borrow);
                 block.unit()
             }

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -1751,7 +1751,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     projection: tcx.mk_place_elems(matched_place_ref.projection),
                 };
                 let fake_borrow_deref_ty = matched_place.ty(&self.local_decls, tcx).ty;
-                let fake_borrow_ty = tcx.mk_imm_ref(tcx.lifetimes.re_erased, fake_borrow_deref_ty);
+                let fake_borrow_ty = tcx.mk_imm_ref(tcx.regions.erased, fake_borrow_deref_ty);
                 let mut fake_borrow_temp = LocalDecl::new(fake_borrow_ty, temp_span);
                 fake_borrow_temp.internal = self.local_decls[matched_place.local].internal;
                 fake_borrow_temp.local_info = ClearCrossCrate::Set(Box::new(LocalInfo::FakeBorrow));
@@ -1956,7 +1956,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             debug!("entering guard building context: {:?}", guard_frame);
             self.guard_context.push(guard_frame);
 
-            let re_erased = tcx.lifetimes.re_erased;
+            let re_erased = tcx.regions.erased;
             let scrutinee_source_info = self.source_info(scrutinee_span);
             for &(place, temp) in fake_borrows {
                 let borrow = Rvalue::Ref(re_erased, BorrowKind::Shallow, place);
@@ -2111,7 +2111,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // Assign each of the bindings. Since we are binding for a
         // guard expression, this will never trigger moves out of the
         // candidate.
-        let re_erased = self.tcx.lifetimes.re_erased;
+        let re_erased = self.tcx.regions.erased;
         for binding in bindings {
             debug!("bind_matched_candidate_for_guard(binding={:?})", binding);
             let source_info = self.source_info(binding.span);
@@ -2161,7 +2161,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     {
         debug!("bind_matched_candidate_for_arm_body(block={:?})", block);
 
-        let re_erased = self.tcx.lifetimes.re_erased;
+        let re_erased = self.tcx.regions.erased;
         // Assign each of the bindings. This may trigger moves out of the candidate.
         for binding in bindings {
             let source_info = self.source_info(binding.span);
@@ -2249,7 +2249,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // This variable isn't mutated but has a name, so has to be
                 // immutable to avoid the unused mut lint.
                 mutability: Mutability::Not,
-                ty: tcx.mk_imm_ref(tcx.lifetimes.re_erased, var_ty),
+                ty: tcx.mk_imm_ref(tcx.regions.erased, var_ty),
                 user_ty: None,
                 source_info,
                 internal: false,

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -243,7 +243,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     if !tcx.features().string_deref_patterns {
                         bug!("matching on `String` went through without enabling string_deref_patterns");
                     }
-                    let re_erased = tcx.lifetimes.re_erased;
+                    let re_erased = tcx.regions.erased;
                     let ref_string = self.temp(tcx.mk_imm_ref(re_erased, ty), test.span);
                     let ref_str_ty = tcx.mk_imm_ref(re_erased, tcx.types.str_);
                     let ref_str = self.temp(ref_str_ty, test.span);

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -195,9 +195,7 @@ impl<'tcx> Cx<'tcx> {
             let ty = if fn_decl.c_variadic && index == fn_decl.inputs.len() {
                 let va_list_did = self.tcx.require_lang_item(LangItem::VaList, Some(param.span));
 
-                self.tcx
-                    .type_of(va_list_did)
-                    .subst(self.tcx, &[self.tcx.lifetimes.re_erased.into()])
+                self.tcx.type_of(va_list_did).subst(self.tcx, &[self.tcx.regions.erased.into()])
             } else {
                 fn_sig.inputs()[index]
             };

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -204,7 +204,7 @@ impl<'tcx> ConstToPat<'tcx> {
         // not *yet* implement `PartialEq`. So for now we leave this here.
         has_impl
             || ty.walk().any(|t| match t.unpack() {
-                ty::subst::GenericArgKind::Lifetime(_) => false,
+                ty::subst::GenericArgKind::Region(_) => false,
                 ty::subst::GenericArgKind::Type(t) => t.is_fn_ptr(),
                 ty::subst::GenericArgKind::Const(_) => false,
             })

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -616,7 +616,7 @@ where
         let ty = self.place_ty(self.place);
 
         let ref_ty =
-            tcx.mk_ref(tcx.lifetimes.re_erased, ty::TypeAndMut { ty, mutbl: hir::Mutability::Mut });
+            tcx.mk_ref(tcx.regions.erased, ty::TypeAndMut { ty, mutbl: hir::Mutability::Mut });
         let ref_place = self.new_temp(ref_ty);
         let unit_temp = Place::from(self.new_temp(tcx.mk_unit()));
 
@@ -624,7 +624,7 @@ where
             statements: vec![self.assign(
                 Place::from(ref_place),
                 Rvalue::Ref(
-                    tcx.lifetimes.re_erased,
+                    tcx.regions.erased,
                     BorrowKind::Mut { allow_two_phase_borrow: false },
                     self.place,
                 ),

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -413,7 +413,7 @@ fn make_generator_state_argument_indirect<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Bo
     let gen_ty = body.local_decls.raw[1].ty;
 
     let ref_gen_ty =
-        tcx.mk_ref(tcx.lifetimes.re_erased, ty::TypeAndMut { ty: gen_ty, mutbl: Mutability::Mut });
+        tcx.mk_ref(tcx.regions.erased, ty::TypeAndMut { ty: gen_ty, mutbl: Mutability::Mut });
 
     // Replace the by value generator argument
     body.local_decls.raw[1].ty = ref_gen_ty;

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -514,7 +514,7 @@ impl<'tcx> Inliner<'tcx> {
                 let dest = if dest_needs_borrow(destination) {
                     trace!("creating temp for return destination");
                     let dest = Rvalue::Ref(
-                        self.tcx.lifetimes.re_erased,
+                        self.tcx.regions.erased,
                         BorrowKind::Mut { allow_two_phase_borrow: false },
                         destination,
                     );

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -187,7 +187,7 @@ fn build_drop_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, ty: Option<Ty<'tcx>>)
         // It's important that we do this first, before anything that depends on `dropee_ptr`
         // has been put into the body.
         let reborrow = Rvalue::Ref(
-            tcx.lifetimes.re_erased,
+            tcx.regions.erased,
             BorrowKind::Mut { allow_two_phase_borrow: false },
             tcx.mk_place_deref(dropee_ptr),
         );
@@ -482,13 +482,13 @@ impl<'tcx> CloneShimBuilder<'tcx> {
 
         let ref_loc = self.make_place(
             Mutability::Not,
-            tcx.mk_ref(tcx.lifetimes.re_erased, ty::TypeAndMut { ty, mutbl: hir::Mutability::Not }),
+            tcx.mk_ref(tcx.regions.erased, ty::TypeAndMut { ty, mutbl: hir::Mutability::Not }),
         );
 
         // `let ref_loc: &ty = &src;`
         let statement = self.make_statement(StatementKind::Assign(Box::new((
             ref_loc,
-            Rvalue::Ref(tcx.lifetimes.re_erased, BorrowKind::Shared, src),
+            Rvalue::Ref(tcx.regions.erased, BorrowKind::Shared, src),
         ))));
 
         // `let loc = Clone::clone(ref_loc);`
@@ -701,7 +701,7 @@ fn build_call_shim<'tcx>(
             let ref_rcvr = local_decls.push(
                 LocalDecl::new(
                     tcx.mk_ref(
-                        tcx.lifetimes.re_erased,
+                        tcx.regions.erased,
                         ty::TypeAndMut { ty: sig.inputs()[0], mutbl: hir::Mutability::Mut },
                     ),
                     span,
@@ -713,7 +713,7 @@ fn build_call_shim<'tcx>(
                 source_info,
                 kind: StatementKind::Assign(Box::new((
                     Place::from(ref_rcvr),
-                    Rvalue::Ref(tcx.lifetimes.re_erased, borrow_kind, rcvr_place()),
+                    Rvalue::Ref(tcx.regions.erased, borrow_kind, rcvr_place()),
                 ))),
             });
             Operand::Move(Place::from(ref_rcvr))

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1360,7 +1360,7 @@ fn create_mono_items_for_default_impls<'tcx>(
     // we use the ReErased, which has no lifetime information associated with
     // it, to validate whether or not the impl is legal to instantiate at all.
     let only_region_params = |param: &ty::GenericParamDef, _: &_| match param.kind {
-        GenericParamDefKind::Region => tcx.lifetimes.re_erased.into(),
+        GenericParamDefKind::Region => tcx.regions.erased.into(),
         GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {
             unreachable!(
                 "`own_requires_monomorphization` check means that \

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -636,7 +636,7 @@ fn check_type_length_limit<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) {
         .flat_map(|arg| arg.walk())
         .filter(|arg| match arg.unpack() {
             GenericArgKind::Type(_) | GenericArgKind::Const(_) => true,
-            GenericArgKind::Lifetime(_) => false,
+            GenericArgKind::Region(_) => false,
         })
         .count();
     debug!(" => type length={}", type_length);

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1360,7 +1360,7 @@ fn create_mono_items_for_default_impls<'tcx>(
     // we use the ReErased, which has no lifetime information associated with
     // it, to validate whether or not the impl is legal to instantiate at all.
     let only_region_params = |param: &ty::GenericParamDef, _: &_| match param.kind {
-        GenericParamDefKind::Lifetime => tcx.lifetimes.re_erased.into(),
+        GenericParamDefKind::Region => tcx.lifetimes.re_erased.into(),
         GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {
             unreachable!(
                 "`own_requires_monomorphization` check means that \

--- a/compiler/rustc_monomorphize/src/polymorphize.rs
+++ b/compiler/rustc_monomorphize/src/polymorphize.rs
@@ -170,7 +170,7 @@ fn mark_used_by_default_parameters<'tcx>(
         | DefKind::Impl { .. } => {
             for param in &generics.params {
                 debug!(?param, "(other)");
-                if let ty::GenericParamDefKind::Lifetime = param.kind {
+                if let ty::GenericParamDefKind::Region = param.kind {
                     unused_parameters.mark_used(param.index);
                 }
             }

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -850,7 +850,7 @@ impl ReachEverythingInTheInterfaceVisitor<'_, '_> {
     fn generics(&mut self) -> &mut Self {
         for param in &self.ev.tcx.generics_of(self.item_def_id).params {
             match param.kind {
-                GenericParamDefKind::Lifetime => {}
+                GenericParamDefKind::Region => {}
                 GenericParamDefKind::Type { has_default, .. } => {
                     if has_default {
                         self.visit(self.ev.tcx.type_of(param.def_id).subst_identity());
@@ -1755,7 +1755,7 @@ impl SearchInterfaceForPrivateItemsVisitor<'_> {
     fn generics(&mut self) -> &mut Self {
         for param in &self.tcx.generics_of(self.item_def_id).params {
             match param.kind {
-                GenericParamDefKind::Lifetime => {}
+                GenericParamDefKind::Region => {}
                 GenericParamDefKind::Type { has_default, .. } => {
                     if has_default {
                         self.visit(self.tcx.type_of(param.def_id).subst_identity());

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -107,7 +107,7 @@ impl QueryContext for QueryCtxt<'_> {
         compute: impl FnOnce() -> R,
     ) -> R {
         // The `TyCtxt` stored in TLS has the same global interner lifetime
-        // as `self`, so we use `with_related_context` to relate the 'tcx lifetimes
+        // as `self`, so we use `with_related_context` to relate the 'tcx.regions
         // when accessing the `ImplicitCtxt`.
         tls::with_related_context(*self, move |current_icx| {
             if depth_limit && !self.recursion_limit().value_within_limit(current_icx.query_depth) {

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -355,7 +355,7 @@ impl<'tcx> Printer<'tcx> for &mut SymbolPrinter<'tcx> {
         self = print_prefix(self)?;
 
         let args =
-            args.iter().cloned().filter(|arg| !matches!(arg.unpack(), GenericArgKind::Lifetime(_)));
+            args.iter().cloned().filter(|arg| !matches!(arg.unpack(), GenericArgKind::Region(_)));
 
         if args.clone().next().is_some() {
             self.generic_delimiters(|cx| cx.comma_sep(args))

--- a/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
+++ b/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
@@ -323,7 +323,7 @@ fn encode_substs<'tcx>(
         s.push('I');
         for subst in substs {
             match subst.unpack() {
-                GenericArgKind::Lifetime(region) => {
+                GenericArgKind::Region(region) => {
                     s.push_str(&encode_region(tcx, region, dict, options));
                 }
                 GenericArgKind::Type(ty) => {

--- a/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
+++ b/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
@@ -740,9 +740,9 @@ fn transform_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, options: TransformTyOptio
         ty::Ref(region, ty0, ..) => {
             if options.contains(TransformTyOptions::GENERALIZE_POINTERS) {
                 if ty.is_mutable_ptr() {
-                    ty = tcx.mk_mut_ref(tcx.lifetimes.re_static, tcx.mk_unit());
+                    ty = tcx.mk_mut_ref(tcx.regions.re_static, tcx.mk_unit());
                 } else {
-                    ty = tcx.mk_imm_ref(tcx.lifetimes.re_static, tcx.mk_unit());
+                    ty = tcx.mk_imm_ref(tcx.regions.re_static, tcx.mk_unit());
                 }
             } else {
                 if ty.is_mutable_ptr() {

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -808,11 +808,11 @@ impl<'tcx> Printer<'tcx> for &mut SymbolMangler<'tcx> {
     ) -> Result<Self::Path, Self::Error> {
         // Don't print any regions if they're all erased.
         let print_regions = args.iter().any(|arg| match arg.unpack() {
-            GenericArgKind::Lifetime(r) => !r.is_erased(),
+            GenericArgKind::Region(r) => !r.is_erased(),
             _ => false,
         });
         let args = args.iter().cloned().filter(|arg| match arg.unpack() {
-            GenericArgKind::Lifetime(_) => print_regions,
+            GenericArgKind::Region(_) => print_regions,
             _ => true,
         });
 
@@ -824,8 +824,8 @@ impl<'tcx> Printer<'tcx> for &mut SymbolMangler<'tcx> {
         self = print_prefix(self)?;
         for arg in args {
             match arg.unpack() {
-                GenericArgKind::Lifetime(lt) => {
-                    self = lt.print(self)?;
+                GenericArgKind::Region(re) => {
+                    self = re.print(self)?;
                 }
                 GenericArgKind::Type(ty) => {
                     self = ty.print(self)?;

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
@@ -149,7 +149,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
                         opt_values[b.var] = Some(*original_value);
                     }
                 }
-                GenericArgKind::Lifetime(r) => {
+                GenericArgKind::Region(r) => {
                     if let ty::ReLateBound(debruijn, br) = *r {
                         assert_eq!(debruijn, ty::INNERMOST);
                         opt_values[br.var] = Some(*original_value);
@@ -217,7 +217,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
     fn register_region_constraints(&mut self, region_constraints: &QueryRegionConstraints<'tcx>) {
         for &(ty::OutlivesPredicate(lhs, rhs), _) in &region_constraints.outlives {
             match lhs.unpack() {
-                GenericArgKind::Lifetime(lhs) => self.register_region_outlives(lhs, rhs),
+                GenericArgKind::Region(lhs) => self.register_region_outlives(lhs, rhs),
                 GenericArgKind::Type(lhs) => self.register_ty_outlives(lhs, rhs),
                 GenericArgKind::Const(_) => bug!("const outlives: {lhs:?}: {rhs:?}"),
             }

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -771,7 +771,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                         (None, Some(t_a)) => {
                             selcx.infcx.register_region_obligation_with_cause(
                                 t_a,
-                                selcx.infcx.tcx.lifetimes.re_static,
+                                selcx.infcx.tcx.regions.re_static,
                                 &dummy_cause,
                             );
                         }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
@@ -219,7 +219,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {
                         substs[param.index as usize].to_string()
                     }
-                    GenericParamDefKind::Lifetime => continue,
+                    GenericParamDefKind::Region => continue,
                 };
                 let name = param.name;
                 flags.push((name, Some(value)));
@@ -631,7 +631,7 @@ impl<'tcx> OnUnimplementedFormatString {
                     GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {
                         trait_ref.substs[param.index as usize].to_string()
                     }
-                    GenericParamDefKind::Lifetime => return None,
+                    GenericParamDefKind::Region => return None,
                 };
                 let name = param.name;
                 Some((name, value))

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1272,16 +1272,10 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             }
             // We map bounds to `&T` and `&mut T`
             let trait_pred_and_imm_ref = old_pred.map_bound(|trait_pred| {
-                (
-                    trait_pred,
-                    self.tcx.mk_imm_ref(self.tcx.lifetimes.re_static, trait_pred.self_ty()),
-                )
+                (trait_pred, self.tcx.mk_imm_ref(self.tcx.regions.re_static, trait_pred.self_ty()))
             });
             let trait_pred_and_mut_ref = old_pred.map_bound(|trait_pred| {
-                (
-                    trait_pred,
-                    self.tcx.mk_mut_ref(self.tcx.lifetimes.re_static, trait_pred.self_ty()),
-                )
+                (trait_pred, self.tcx.mk_mut_ref(self.tcx.regions.re_static, trait_pred.self_ty()))
             });
 
             let mk_result = |trait_pred_and_new_ty| {
@@ -1440,7 +1434,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         object_ty: Ty<'tcx>,
     ) {
         let ty::Dynamic(predicates, _, ty::Dyn) = object_ty.kind() else { return; };
-        let self_ref_ty = self.tcx.mk_imm_ref(self.tcx.lifetimes.re_erased, self_ty);
+        let self_ref_ty = self.tcx.mk_imm_ref(self.tcx.regions.erased, self_ty);
 
         for predicate in predicates.iter() {
             if !self.predicate_must_hold_modulo_regions(

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3803,7 +3803,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             return prev_ty.into();
                         }
                     }
-                    ty::GenericParamDefKind::Lifetime | ty::GenericParamDefKind::Const { .. } => {}
+                    ty::GenericParamDefKind::Region | ty::GenericParamDefKind::Const { .. } => {}
                 }
                 self.var_for_def(span, param)
             });

--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -549,7 +549,7 @@ fn virtual_call_violation_for_method<'tcx>(
                 }
             }
 
-            let trait_object_ty = object_ty_for_trait(tcx, trait_def_id, tcx.lifetimes.re_static);
+            let trait_object_ty = object_ty_for_trait(tcx, trait_def_id, tcx.regions.re_static);
 
             // e.g., `Rc<dyn Trait>`
             let trait_object_receiver =

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -2177,7 +2177,7 @@ fn check_substs_compatible<'tcx>(
         for (param, arg) in std::iter::zip(&generics.params, own_args) {
             match (&param.kind, arg.unpack()) {
                 (ty::GenericParamDefKind::Type { .. }, ty::GenericArgKind::Type(_))
-                | (ty::GenericParamDefKind::Lifetime, ty::GenericArgKind::Lifetime(_))
+                | (ty::GenericParamDefKind::Lifetime, ty::GenericArgKind::Region(_))
                 | (ty::GenericParamDefKind::Const { .. }, ty::GenericArgKind::Const(_)) => {}
                 _ => return false,
             }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -2177,7 +2177,7 @@ fn check_substs_compatible<'tcx>(
         for (param, arg) in std::iter::zip(&generics.params, own_args) {
             match (&param.kind, arg.unpack()) {
                 (ty::GenericParamDefKind::Type { .. }, ty::GenericArgKind::Type(_))
-                | (ty::GenericParamDefKind::Lifetime, ty::GenericArgKind::Region(_))
+                | (ty::GenericParamDefKind::Region, ty::GenericArgKind::Region(_))
                 | (ty::GenericParamDefKind::Const { .. }, ty::GenericArgKind::Const(_)) => {}
                 _ => return false,
             }

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -536,7 +536,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                 )
                                 .into()
                             }
-                            GenericParamDefKind::Lifetime => {
+                            GenericParamDefKind::Region => {
                                 let kind = ty::BoundRegionKind::BrNamed(param.def_id, param.name);
                                 let bound_var = ty::BoundVariableKind::Region(kind);
                                 bound_vars.push(bound_var);

--- a/compiler/rustc_trait_selection/src/traits/vtable.rs
+++ b/compiler/rustc_trait_selection/src/traits/vtable.rs
@@ -242,7 +242,7 @@ fn vtable_entries<'tcx>(
                     // The method may have some early-bound lifetimes; add regions for those.
                     let substs = trait_ref.map_bound(|trait_ref| {
                         InternalSubsts::for_item(tcx, def_id, |param, _| match param.kind {
-                            GenericParamDefKind::Region => tcx.lifetimes.re_erased.into(),
+                            GenericParamDefKind::Region => tcx.regions.erased.into(),
                             GenericParamDefKind::Type { .. }
                             | GenericParamDefKind::Const { .. } => {
                                 trait_ref.substs[param.index as usize]

--- a/compiler/rustc_trait_selection/src/traits/vtable.rs
+++ b/compiler/rustc_trait_selection/src/traits/vtable.rs
@@ -242,7 +242,7 @@ fn vtable_entries<'tcx>(
                     // The method may have some early-bound lifetimes; add regions for those.
                     let substs = trait_ref.map_bound(|trait_ref| {
                         InternalSubsts::for_item(tcx, def_id, |param, _| match param.kind {
-                            GenericParamDefKind::Lifetime => tcx.lifetimes.re_erased.into(),
+                            GenericParamDefKind::Region => tcx.lifetimes.re_erased.into(),
                             GenericParamDefKind::Type { .. }
                             | GenericParamDefKind::Const { .. } => {
                                 trait_ref.substs[param.index as usize]

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -55,7 +55,7 @@ pub fn obligations<'tcx>(
             .into()
         }
         // There is nothing we have to do for lifetimes.
-        GenericArgKind::Lifetime(..) => return Some(Vec::new()),
+        GenericArgKind::Region(..) => return Some(Vec::new()),
     };
 
     let mut wf = WfPredicates {
@@ -84,7 +84,7 @@ pub fn unnormalized_obligations<'tcx>(
     param_env: ty::ParamEnv<'tcx>,
     arg: GenericArg<'tcx>,
 ) -> Option<Vec<traits::PredicateObligation<'tcx>>> {
-    if let ty::GenericArgKind::Lifetime(..) = arg.unpack() {
+    if let ty::GenericArgKind::Region(..) = arg.unpack() {
         return Some(vec![]);
     }
 
@@ -472,7 +472,7 @@ impl<'tcx> WfPredicates<'tcx> {
 
                 // No WF constraints for lifetimes being present, any outlives
                 // obligations are handled by the parent (e.g. `ty::Ref`).
-                GenericArgKind::Lifetime(_) => continue,
+                GenericArgKind::Region(_) => continue,
 
                 GenericArgKind::Const(ct) => {
                     match ct.kind() {

--- a/compiler/rustc_traits/src/chalk/db.rs
+++ b/compiler/rustc_traits/src/chalk/db.rs
@@ -727,7 +727,7 @@ fn bound_vars_for_item(tcx: TyCtxt<'_>, def_id: DefId) -> SubstsRef<'_> {
             )
             .into(),
 
-        ty::GenericParamDefKind::Lifetime => {
+        ty::GenericParamDefKind::Region => {
             let br = ty::BoundRegion {
                 var: ty::BoundVar::from_usize(substs.len()),
                 kind: ty::BrAnon(None),

--- a/compiler/rustc_traits/src/chalk/db.rs
+++ b/compiler/rustc_traits/src/chalk/db.rs
@@ -751,7 +751,7 @@ fn binders_for<'tcx>(
     chalk_ir::VariableKinds::from_iter(
         interner,
         bound_vars.iter().map(|arg| match arg.unpack() {
-            ty::subst::GenericArgKind::Lifetime(_re) => chalk_ir::VariableKind::Lifetime,
+            ty::subst::GenericArgKind::Region(_re) => chalk_ir::VariableKind::Lifetime,
             ty::subst::GenericArgKind::Type(_ty) => {
                 chalk_ir::VariableKind::Ty(chalk_ir::TyVariableKind::General)
             }

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -556,8 +556,8 @@ impl<'tcx> LowerInto<'tcx, Region<'tcx>> for &chalk_ir::Lifetime<RustInterner<'t
                     kind: ty::BoundRegionKind::BrAnon(None),
                 },
             }),
-            chalk_ir::LifetimeData::Static => tcx.lifetimes.re_static,
-            chalk_ir::LifetimeData::Erased => tcx.lifetimes.re_erased,
+            chalk_ir::LifetimeData::Static => tcx.regions.re_static,
+            chalk_ir::LifetimeData::Erased => tcx.regions.erased,
             chalk_ir::LifetimeData::Phantom(void, _) => match *void {},
         }
     }

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -209,7 +209,7 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::GoalData<RustInterner<'tcx>>> for ty::Predi
                 GenericArgKind::Const(..) => {
                     chalk_ir::GoalData::All(chalk_ir::Goals::empty(interner))
                 }
-                GenericArgKind::Lifetime(lt) => bug!("unexpected well formed predicate: {:?}", lt),
+                GenericArgKind::Region(re) => bug!("unexpected well formed predicate: {:?}", re),
             },
 
             ty::PredicateKind::ObjectSafe(t) => chalk_ir::GoalData::DomainGoal(
@@ -602,7 +602,7 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::GenericArg<RustInterner<'tcx>>> for Generic
             ty::subst::GenericArgKind::Type(ty) => {
                 chalk_ir::GenericArgData::Ty(ty.lower_into(interner))
             }
-            ty::subst::GenericArgKind::Lifetime(lifetime) => {
+            ty::subst::GenericArgKind::Region(lifetime) => {
                 chalk_ir::GenericArgData::Lifetime(lifetime.lower_into(interner))
             }
             ty::subst::GenericArgKind::Const(c) => {

--- a/compiler/rustc_traits/src/implied_outlives_bounds.rs
+++ b/compiler/rustc_traits/src/implied_outlives_bounds.rs
@@ -144,7 +144,7 @@ fn compute_implied_outlives_bounds<'tcx>(
     let implied_bounds = outlives_bounds
         .into_iter()
         .flat_map(|ty::OutlivesPredicate(a, r_b)| match a.unpack() {
-            ty::GenericArgKind::Lifetime(r_a) => vec![OutlivesBound::RegionSubRegion(r_b, r_a)],
+            ty::GenericArgKind::Region(r_a) => vec![OutlivesBound::RegionSubRegion(r_b, r_a)],
             ty::GenericArgKind::Type(ty_a) => {
                 let ty_a = ocx.infcx.resolve_vars_if_possible(ty_a);
                 let mut components = smallvec![];

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -436,7 +436,7 @@ fn well_formed_types_in_env(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::List<Predica
             }
 
             // FIXME(eddyb) no WF conditions from lifetimes?
-            GenericArgKind::Lifetime(_) => None,
+            GenericArgKind::Region(_) => None,
 
             // FIXME(eddyb) support const generics in Chalk
             GenericArgKind::Const(_) => None,
@@ -532,7 +532,7 @@ fn unsizing_params_for_adt<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> BitSet<u32
         },
 
         // We can't unsize a lifetime
-        ty::GenericArgKind::Lifetime(_) => None,
+        ty::GenericArgKind::Region(_) => None,
 
         ty::GenericArgKind::Const(ct) => match ct.kind() {
             ty::ConstKind::Param(p) => Some(p.index),

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -58,7 +58,7 @@ where
                 .params
                 .iter()
                 .filter_map(|param| match param.kind {
-                    ty::GenericParamDefKind::Lifetime => Some(param.name),
+                    ty::GenericParamDefKind::Region => Some(param.name),
                     _ => None,
                 })
                 .map(|name| (name, Lifetime(name)))

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -473,7 +473,7 @@ fn clean_generic_param_def<'tcx>(
     cx: &mut DocContext<'tcx>,
 ) -> GenericParamDef {
     let (name, kind) = match def.kind {
-        ty::GenericParamDefKind::Lifetime => {
+        ty::GenericParamDefKind::Region => {
             (def.name, GenericParamDefKind::Lifetime { outlives: vec![] })
         }
         ty::GenericParamDefKind::Type { has_default, synthetic, .. } => {
@@ -733,8 +733,8 @@ fn clean_ty_generics<'tcx>(
         .params
         .iter()
         .filter_map(|param| match param.kind {
-            ty::GenericParamDefKind::Lifetime if param.is_anonymous_lifetime() => None,
-            ty::GenericParamDefKind::Lifetime => Some(clean_generic_param_def(param, cx)),
+            ty::GenericParamDefKind::Region if param.is_anonymous_lifetime() => None,
+            ty::GenericParamDefKind::Region => Some(clean_generic_param_def(param, cx)),
             ty::GenericParamDefKind::Type { synthetic, .. } => {
                 if param.name == kw::SelfUpper {
                     assert_eq!(param.index, 0);

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -83,8 +83,8 @@ pub(crate) fn substs_to_args<'tcx>(
             0
         }));
     ret_val.extend(substs.iter().filter_map(|kind| match kind.skip_binder().unpack() {
-        GenericArgKind::Lifetime(lt) => {
-            Some(GenericArg::Lifetime(clean_middle_region(lt).unwrap_or(Lifetime::elided())))
+        GenericArgKind::Region(re) => {
+            Some(GenericArg::Lifetime(clean_middle_region(re).unwrap_or(Lifetime::elided())))
         }
         GenericArgKind::Type(_) if skip_first => {
             skip_first = false;

--- a/src/tools/clippy/clippy_lints/src/let_underscore.rs
+++ b/src/tools/clippy/clippy_lints/src/let_underscore.rs
@@ -145,7 +145,7 @@ impl<'tcx> LateLintPass<'tcx> for LetUnderscore {
             let init_ty = cx.typeck_results().expr_ty(init);
             let contains_sync_guard = init_ty.walk().any(|inner| match inner.unpack() {
                 GenericArgKind::Type(inner_ty) => SYNC_GUARD_PATHS.iter().any(|path| match_type(cx, inner_ty, path)),
-                GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => false,
+                GenericArgKind::Region(_) | GenericArgKind::Const(_) => false,
             });
             if contains_sync_guard {
                 span_lint_and_help(

--- a/src/tools/clippy/clippy_lints/src/loops/explicit_iter_loop.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/explicit_iter_loop.rs
@@ -16,7 +16,7 @@ pub(super) fn check(cx: &LateContext<'_>, self_arg: &Expr<'_>, arg: &Expr<'_>, m
             let receiver_ty = cx.typeck_results().expr_ty(self_arg);
             let receiver_ty_adjusted = cx.typeck_results().expr_ty_adjusted(self_arg);
             let ref_receiver_ty = cx.tcx.mk_ref(
-                cx.tcx.lifetimes.re_erased,
+                cx.tcx.regions.erased,
                 ty::TypeAndMut {
                     ty: receiver_ty,
                     mutbl: Mutability::Not,

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_sort_by.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_sort_by.rs
@@ -172,7 +172,7 @@ fn detect_lint(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, arg: &Exp
 
 fn expr_borrows(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
     let ty = cx.typeck_results().expr_ty(expr);
-    matches!(ty.kind(), ty::Ref(..)) || ty.walk().any(|arg| matches!(arg.unpack(), GenericArgKind::Lifetime(_)))
+    matches!(ty.kind(), ty::Ref(..)) || ty.walk().any(|arg| matches!(arg.unpack(), GenericArgKind::Region(_)))
 }
 
 pub(super) fn check<'tcx>(

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
@@ -458,7 +458,7 @@ fn can_change_type<'a>(cx: &LateContext<'a>, mut expr: &'a Expr<'a>, mut ty: Ty<
 }
 
 fn has_lifetime(ty: Ty<'_>) -> bool {
-    ty.walk().any(|t| matches!(t.unpack(), GenericArgKind::Lifetime(_)))
+    ty.walk().any(|t| matches!(t.unpack(), GenericArgKind::Region(_)))
 }
 
 /// Returns true if the named method is `Iterator::cloned` or `Iterator::copied`.

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
@@ -266,7 +266,7 @@ fn check_other_call_arg<'tcx>(
             Some((n_refs, receiver_ty))
         } else if trait_predicate.def_id() != deref_trait_id {
             Some((1, cx.tcx.mk_ref(
-                cx.tcx.lifetimes.re_erased,
+                cx.tcx.regions.erased,
                 ty::TypeAndMut {
                     ty: receiver_ty,
                     mutbl: Mutability::Not,

--- a/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
@@ -176,7 +176,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
                 (
                     preds.iter().any(|t| cx.tcx.is_diagnostic_item(sym::Borrow, t.def_id())),
                     !preds.is_empty() && {
-                        let ty_empty_region = cx.tcx.mk_imm_ref(cx.tcx.lifetimes.re_erased, ty);
+                        let ty_empty_region = cx.tcx.mk_imm_ref(cx.tcx.regions.erased, ty);
                         preds.iter().all(|t| {
                             let ty_params = t.trait_ref.substs.iter().skip(1).collect::<Vec<_>>();
                             implements_trait(cx, ty_empty_region, t.def_id(), &ty_params)

--- a/src/tools/clippy/clippy_lints/src/non_send_fields_in_send_ty.rs
+++ b/src/tools/clippy/clippy_lints/src/non_send_fields_in_send_ty.rs
@@ -212,7 +212,7 @@ fn ty_allowed_with_raw_pointer_heuristic<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'t
                 substs.iter().all(|generic_arg| match generic_arg.unpack() {
                     GenericArgKind::Type(ty) => ty_allowed_with_raw_pointer_heuristic(cx, ty, send_trait),
                     // Lifetimes and const generics are not solid part of ADT and ignored
-                    GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => true,
+                    GenericArgKind::Region(_) | GenericArgKind::Const(_) => true,
                 })
             } else {
                 false

--- a/src/tools/clippy/clippy_lints/src/only_used_in_recursion.rs
+++ b/src/tools/clippy/clippy_lints/src/only_used_in_recursion.rs
@@ -385,7 +385,7 @@ fn has_matching_substs(kind: FnKind, substs: SubstsRef<'_>) -> bool {
     match kind {
         FnKind::Fn => true,
         FnKind::TraitFn => substs.iter().enumerate().all(|(idx, subst)| match subst.unpack() {
-            GenericArgKind::Lifetime(_) => true,
+            GenericArgKind::Region(_) => true,
             GenericArgKind::Type(ty) => matches!(*ty.kind(), ty::Param(ty) if ty.index as usize == idx),
             GenericArgKind::Const(c) => matches!(c.kind(), ConstKind::Param(c) if c.index as usize == idx),
         }),

--- a/src/tools/clippy/clippy_lints/src/returns.rs
+++ b/src/tools/clippy/clippy_lints/src/returns.rs
@@ -333,7 +333,7 @@ fn last_statement_borrows<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) 
                 .skip_binder()
                 .output()
                 .walk()
-                .any(|arg| matches!(arg.unpack(), GenericArgKind::Lifetime(_)))
+                .any(|arg| matches!(arg.unpack(), GenericArgKind::Region(_)))
         {
             ControlFlow::Break(())
         } else {

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -77,7 +77,7 @@ fn check_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, span: Span) -> McfResult {
 
             // No constraints on lifetimes or constants, except potentially
             // constants' types, but `walk` will get to them as well.
-            GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => continue,
+            GenericArgKind::Region(_) | GenericArgKind::Const(_) => continue,
         };
 
         match ty.kind() {

--- a/src/tools/clippy/clippy_utils/src/ty.rs
+++ b/src/tools/clippy/clippy_utils/src/ty.rs
@@ -1070,7 +1070,7 @@ pub fn make_projection<'tcx>(
                 .find(|(_, (param, arg))| {
                     !matches!(
                         (param, arg),
-                        (ty::GenericParamDefKind::Lifetime, GenericArgKind::Region(_))
+                        (ty::GenericParamDefKind::Region, GenericArgKind::Region(_))
                             | (ty::GenericParamDefKind::Type { .. }, GenericArgKind::Type(_))
                             | (ty::GenericParamDefKind::Const { .. }, GenericArgKind::Const(_))
                     )

--- a/src/tools/clippy/clippy_utils/src/ty.rs
+++ b/src/tools/clippy/clippy_utils/src/ty.rs
@@ -59,7 +59,7 @@ pub fn can_partially_move_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool
 pub fn contains_adt_constructor<'tcx>(ty: Ty<'tcx>, adt: AdtDef<'tcx>) -> bool {
     ty.walk().any(|inner| match inner.unpack() {
         GenericArgKind::Type(inner_ty) => inner_ty.ty_adt_def() == Some(adt),
-        GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => false,
+        GenericArgKind::Region(_) | GenericArgKind::Const(_) => false,
     })
 }
 
@@ -121,7 +121,7 @@ pub fn contains_ty_adt_constructor_opaque<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'
 
                 false
             },
-            GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => false,
+            GenericArgKind::Region(_) | GenericArgKind::Const(_) => false,
         })
     }
 
@@ -1070,7 +1070,7 @@ pub fn make_projection<'tcx>(
                 .find(|(_, (param, arg))| {
                     !matches!(
                         (param, arg),
-                        (ty::GenericParamDefKind::Lifetime, GenericArgKind::Lifetime(_))
+                        (ty::GenericParamDefKind::Lifetime, GenericArgKind::Region(_))
                             | (ty::GenericParamDefKind::Type { .. }, GenericArgKind::Type(_))
                             | (ty::GenericParamDefKind::Const { .. }, GenericArgKind::Const(_))
                     )


### PR DESCRIPTION
I started with `GenericArg` and then renamed some other stuff I saw. It looks like in the later compiler stages we almost always use "region" as a term instead of "lifetime". I've renamed some weird occurrences of lifetimes in these stages:

- `GenericArgKind::{Lifetime => Region}` (this one literally hold `ty::Region` as a field...)
- `GenericParamDefKind::{Lifetime => Region}`
- `tcx.{lifetimes => regions}`
  - `CommonLifetimes => CommonRegions`
  - `CommonRegions::{re_erased => erased, re_vars => vars, re_late_bounds => late_bounds}`
    - `re_static` was left as-is (`static` is a keyword...)

@bors rollup=never p=1