### PR TITLE
rustdoc: catch and don't blow up on impl Trait cycles

### DIFF
--- a/tests/rustdoc-ui/issue-110629-private-type-cycle-dyn.rs
+++ b/tests/rustdoc-ui/issue-110629-private-type-cycle-dyn.rs
@@ -1,0 +1,12 @@
+type Bar<'a, 'b> = Box<dyn PartialEq<Bar<'a, 'b>>>;
+//~^ ERROR cycle detected when expanding type alias
+
+fn bar<'a, 'b>(i: &'a i32) -> Bar<'a, 'b> {
+    Box::new(i)
+}
+
+fn main() {
+    let meh = 42;
+    let muh = 42;
+    assert!(bar(&meh) == bar(&muh));
+}

--- a/tests/rustdoc-ui/issue-110629-private-type-cycle-dyn.stderr
+++ b/tests/rustdoc-ui/issue-110629-private-type-cycle-dyn.stderr
@@ -1,0 +1,25 @@
+error[E0391]: cycle detected when expanding type alias `Bar`
+  --> $DIR/issue-110629-private-type-cycle-dyn.rs:1:38
+   |
+LL | type Bar<'a, 'b> = Box<dyn PartialEq<Bar<'a, 'b>>>;
+   |                                      ^^^^^^^^^^^
+   |
+   = note: ...which immediately requires expanding type alias `Bar` again
+   = note: type aliases cannot be recursive
+   = help: consider using a struct, enum, or union instead to break the cycle
+   = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
+note: cycle used when collecting item types in top-level module
+  --> $DIR/issue-110629-private-type-cycle-dyn.rs:1:1
+   |
+LL | / type Bar<'a, 'b> = Box<dyn PartialEq<Bar<'a, 'b>>>;
+LL | |
+LL | |
+LL | | fn bar<'a, 'b>(i: &'a i32) -> Bar<'a, 'b> {
+...  |
+LL | |     assert!(bar(&meh) == bar(&muh));
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/rustdoc-ui/issue-110629-private-type-cycle.rs
+++ b/tests/rustdoc-ui/issue-110629-private-type-cycle.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+type Bar<'a, 'b> = impl PartialEq<Bar<'a, 'b>> + std::fmt::Debug;
+
+fn bar<'a, 'b>(i: &'a i32) -> Bar<'a, 'b> {
+    i
+}
+
+fn main() {
+    let meh = 42;
+    let muh = 42;
+    assert_eq!(bar(&meh), bar(&muh));
+}

--- a/tests/rustdoc/issue-110629-private-type-cycle.rs
+++ b/tests/rustdoc/issue-110629-private-type-cycle.rs
@@ -1,0 +1,19 @@
+// compile-flags: --document-private-items
+
+#![feature(type_alias_impl_trait)]
+
+type Bar<'a, 'b> = impl PartialEq<Bar<'a, 'b>> + std::fmt::Debug;
+
+// @has issue_110629_private_type_cycle/type.Bar.html
+// @has - '//pre[@class="rust item-decl"]' \
+//     "pub(crate) type Bar<'a, 'b> = impl PartialEq<Bar<'a, 'b>> + Debug;"
+
+fn bar<'a, 'b>(i: &'a i32) -> Bar<'a, 'b> {
+    i
+}
+
+fn main() {
+    let meh = 42;
+    let muh = 42;
+    assert_eq!(bar(&meh), bar(&muh));
+}


### PR DESCRIPTION
Fixes #110629

An odd feature of Rust is that `Foo` is invalid, but `Bar` is okay:

    type Foo<'a, 'b> = Box<dyn PartialEq<Foo<'a, 'b>>>;
    type Bar<'a, 'b> = impl PartialEq<Bar<'a, 'b>>;

To get it right, track every time rustdoc descends into a type alias, so if it shows up twice, it can be write the path instead of infinitely expanding it.