### PR TITLE
Panic instead of truncating if the incremental on-disk cache is too big

### DIFF
--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -300,7 +300,7 @@ impl<'sess> rustc_middle::ty::OnDiskCache<'sess> for OnDiskCache<'sess> {
                     interpret_alloc_index.reserve(new_n - n);
                     for idx in n..new_n {
                         let id = encoder.interpret_allocs[idx];
-                        let pos = encoder.position() as u32;
+                        let pos: u32 = encoder.position().try_into().unwrap();
                         interpret_alloc_index.push(pos);
                         interpret::specialized_encode_alloc_id(&mut encoder, tcx, id);
                     }


### PR DESCRIPTION
It seems _unlikely_ that anyone would hit this truncation, but if this `as` does actually truncate, that seems incredibly bad.