### PR TITLE
compiler/rustc_target: Raise m68k-linux-gnu baseline to 68020

### DIFF
--- a/compiler/rustc_target/src/spec/m68k_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/m68k_unknown_linux_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::{Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut base = super::linux_gnu_base::opts();
+    base.cpu = "M68020".into();
     base.max_atomic_width = Some(32);
 
     Target {


### PR DESCRIPTION
Atomic operations require 68020 or later on m68k-linux-gnu.