### PR TITLE
Add test for warning-free builds of `core` under `no_global_oom_handling`

### DIFF
--- a/tests/run-make/core-no-oom-handling/Makefile
+++ b/tests/run-make/core-no-oom-handling/Makefile
@@ -1,0 +1,6 @@
+include ../tools.mk
+
+FAKEROOT=$(TMPDIR)/fakeroot
+
+all:
+	$(RUSTC) --edition=2021 -Dwarnings --crate-type=rlib ../../../library/core/src/lib.rs --sysroot=$(FAKEROOT) --cfg no_global_oom_handling


### PR DESCRIPTION
`tests/run-make/alloc-no-oom-handling` tests that `alloc` under `no_global_oom_handling` builds and is warning-free.

Do the same for `core` to prevent issues such as [1].

Link: https://github.com/rust-lang/rust/pull/110649 [1]