### PR TITLE
rustdoc: clean up settings.css and settings.js

### DIFF
--- a/src/librustdoc/html/static/css/settings.css
+++ b/src/librustdoc/html/static/css/settings.css
@@ -7,7 +7,6 @@
 	margin-right: 0.3em;
 	height: 1.2rem;
 	width: 1.2rem;
-	color: inherit;
 	border: 2px solid var(--settings-input-border-color);
 	outline: none;
 	-webkit-appearance: none;

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -1,5 +1,5 @@
 // Local js definitions:
-/* global getSettingValue, getVirtualKey, updateLocalStorage, updateTheme */
+/* global getSettingValue, updateLocalStorage, updateTheme */
 /* global addClass, removeClass, onEach, onEachLazy, blurHandler, elemIsInParent */
 /* global MAIN_ID, getVar, getSettingsButton */
 
@@ -28,21 +28,6 @@
                 } else {
                     window.rustdoc_remove_line_numbers_from_examples();
                 }
-                break;
-        }
-    }
-
-    function handleKey(ev) {
-        // Don't interfere with browser shortcuts
-        if (ev.ctrlKey || ev.altKey || ev.metaKey) {
-            return;
-        }
-        switch (getVirtualKey(ev)) {
-            case "Enter":
-            case "Return":
-            case "Space":
-                ev.target.checked = !ev.target.checked;
-                ev.preventDefault();
                 break;
         }
     }
@@ -77,8 +62,6 @@
             toggle.onchange = function() {
                 changeSetting(this.id, this.checked);
             };
-            toggle.onkeyup = handleKey;
-            toggle.onkeyrelease = handleKey;
         });
         onEachLazy(settingsElement.querySelectorAll("input[type=\"radio\"]"), elem => {
             const settingId = elem.name;

--- a/tests/rustdoc-gui/settings.goml
+++ b/tests/rustdoc-gui/settings.goml
@@ -256,6 +256,15 @@ set-local-storage: {"rustdoc-disable-shortcuts": "false"}
 click: ".setting-line:last-child .setting-check span"
 assert-local-storage: {"rustdoc-disable-shortcuts": "true"}
 
+// We now check that focusing a toggle and pressing Space is like clicking on it.
+assert-local-storage: {"rustdoc-disable-shortcuts": "true"}
+focus: ".setting-line:last-child .setting-check input"
+press-key: "Space"
+assert-local-storage: {"rustdoc-disable-shortcuts": "false"}
+focus: ".setting-line:last-child .setting-check input"
+press-key: "Space"
+assert-local-storage: {"rustdoc-disable-shortcuts": "true"}
+
 // Make sure that "Disable keyboard shortcuts" actually took effect.
 press-key: "Escape"
 press-key: "?"


### PR DESCRIPTION
`handleKey` was added in 9dc5dfb97504c538bc72f367a77bb9f714c30097 and 704050da2334c465784954d81c8990c4bc7a92c5 because the browser-native checkbox was `display: none`, breaking native keyboard accessibility.

The native checkbox is now merely `appearance: none`, which does not turn off [behavior semantics], so JavaScript to reimplement it isn't needed any more.

[behavior semantics]: https://w3c.github.io/csswg-drafts/css-ui/#appearance-semantics

The other, one line change to settings.css is follow-up to #110205