### PR TITLE
Recommend the `home` crate in env::home_dir()'s deprecation

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -569,6 +569,7 @@ impl Error for JoinPathsError {
 /// The 'HOME' environment variable is not standard on Windows, and may not produce
 /// desired results; for instance, under Cygwin or Mingw it will return `/home/you`
 /// when it should return `C:\Users\you`.
+/// Consider using a crate from crates.io such as [`home`](https://crates.io/crates/home).
 ///
 /// # Examples
 ///
@@ -583,7 +584,7 @@ impl Error for JoinPathsError {
 #[deprecated(
     since = "1.29.0",
     note = "This function's behavior may be unexpected on Windows. \
-            Consider using a crate from crates.io instead."
+            Consider using a crate from crates.io such as [`home`](https://crates.io/crates/home)."
 )]
 #[must_use]
 #[stable(feature = "env", since = "1.0.0")]


### PR DESCRIPTION
The [`home`](crates.io/crates/home) is now maintained by the cargo & rustup teams, so it seems like a no-brainer to recommend it in the standard library.

See also: https://github.com/rust-lang/rust/issues/71684#issuecomment-622651337.

Closes #71684.

@rustbot label +T-libs-api -T-lib

r? @joshtriplett
r? @Dylan-DPC