### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/impls_ty.rs
+++ b/compiler/rustc_middle/src/ty/impls_ty.rs
@@ -73,34 +73,6 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ty::subst::GenericArg<'t
     }
 }
 
-impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ty::subst::GenericArgKind<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-        match self {
-            // WARNING: We dedup cache the `HashStable` results for `List`
-            // while ignoring types and freely transmute
-            // between `List<Ty<'tcx>>` and `List<GenericArg<'tcx>>`.
-            // See `fn mk_type_list` for more details.
-            //
-            // We therefore hash types without adding a hash for their discriminant.
-            //
-            // In order to make it very unlikely for the sequence of bytes being hashed for
-            // a `GenericArgKind::Type` to be the same as the sequence of bytes being
-            // hashed for one of the other variants, we hash some very high number instead
-            // of their actual discriminant since `TyKind` should never start with anything
-            // that high.
-            ty::subst::GenericArgKind::Type(ty) => ty.hash_stable(hcx, hasher),
-            ty::subst::GenericArgKind::Const(ct) => {
-                0xF3u8.hash_stable(hcx, hasher);
-                ct.hash_stable(hcx, hasher);
-            }
-            ty::subst::GenericArgKind::Lifetime(lt) => {
-                0xF5u8.hash_stable(hcx, hasher);
-                lt.hash_stable(hcx, hasher);
-            }
-        }
-    }
-}
-
 // AllocIds get resolved to whatever they point to (to be stable)
 impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::AllocId {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -738,7 +738,9 @@ pub trait PrettyPrinter<'tcx>:
                 }
             }
             ty::Placeholder(placeholder) => match placeholder.bound.kind {
-                ty::BoundTyKind::Anon => p!(write("Placeholder({:?})", placeholder)),
+                ty::BoundTyKind::Anon => {
+                    self.pretty_print_placeholder_var(placeholder.universe, placeholder.bound.var)?
+                }
                 ty::BoundTyKind::Param(_, name) => p!(write("{}", name)),
             },
             ty::Alias(ty::Opaque, ty::AliasTy { def_id, substs, .. }) => {
@@ -1169,6 +1171,18 @@ pub trait PrettyPrinter<'tcx>:
             write!(self, "^{}", var.index())
         } else {
             write!(self, "^{}_{}", debruijn.index(), var.index())
+        }
+    }
+
+    fn pretty_print_placeholder_var(
+        &mut self,
+        ui: ty::UniverseIndex,
+        var: ty::BoundVar,
+    ) -> Result<(), Self::Error> {
+        if ui == ty::UniverseIndex::ROOT {
+            write!(self, "!{}", var.index())
+        } else {
+            write!(self, "!{}_{}", ui.index(), var.index())
         }
     }
 

--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -48,7 +48,7 @@ const TYPE_TAG: usize = 0b00;
 const REGION_TAG: usize = 0b01;
 const CONST_TAG: usize = 0b10;
 
-#[derive(Debug, TyEncodable, TyDecodable, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, TyEncodable, TyDecodable, PartialEq, Eq, PartialOrd, Ord, HashStable)]
 pub enum GenericArgKind<'tcx> {
     Lifetime(ty::Region<'tcx>),
     Type(Ty<'tcx>),

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -507,12 +507,12 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             //
             // Const-prop runs unconditionally, but doesn't mutate the MIR at mir-opt-level=0.
             &const_debuginfo::ConstDebugInfo,
-            &o1(simplify_branches::SimplifyConstConditionPassName::AfterConstProp),
+            &o1(simplify_branches::SimplifyConstCondition::AfterConstProp),
             &early_otherwise_branch::EarlyOtherwiseBranch,
             &simplify_comparison_integral::SimplifyComparisonIntegral,
             &dead_store_elimination::DeadStoreElimination,
             &dest_prop::DestinationPropagation,
-            &o1(simplify_branches::SimplifyConstConditionPassName::Final),
+            &o1(simplify_branches::SimplifyConstCondition::Final),
             &o1(remove_noop_landing_pads::RemoveNoopLandingPads),
             &o1(simplify::SimplifyCfg::Final),
             &nrvo::RenameReturnPlace,

--- a/compiler/rustc_mir_transform/src/simplify_branches.rs
+++ b/compiler/rustc_mir_transform/src/simplify_branches.rs
@@ -2,18 +2,16 @@ use crate::MirPass;
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 
-pub enum SimplifyConstConditionPassName {
+pub enum SimplifyConstCondition {
     AfterConstProp,
     Final,
 }
 /// A pass that replaces a branch with a goto when its condition is known.
-impl<'tcx> MirPass<'tcx> for SimplifyConstConditionPassName {
+impl<'tcx> MirPass<'tcx> for SimplifyConstCondition {
     fn name(&self) -> &'static str {
         match self {
-            SimplifyConstConditionPassName::AfterConstProp => {
-                "SimplifyConstCondition-after-const-prop"
-            }
-            SimplifyConstConditionPassName::Final => "SimplifyConstCondition-final",
+            SimplifyConstCondition::AfterConstProp => "SimplifyConstCondition-after-const-prop",
+            SimplifyConstCondition::Final => "SimplifyConstCondition-final",
         }
     }
 

--- a/compiler/rustc_target/src/spec/m68k_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/m68k_unknown_linux_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::{Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut base = super::linux_gnu_base::opts();
+    base.cpu = "M68020".into();
     base.max_atomic_width = Some(32);
 
     Target {

--- a/compiler/rustc_type_ir/src/sty.rs
+++ b/compiler/rustc_type_ir/src/sty.rs
@@ -203,6 +203,10 @@ pub enum TyKind<I: Interner> {
     /// `for<'a, T> &'a (): Trait<T>` and then convert the introduced bound variables
     /// back to inference variables in a new inference context when inside of the query.
     ///
+    /// It is conventional to render anonymous bound types like `^N` or `^D_N`,
+    /// where `N` is the bound variable's anonymous index into the binder, and
+    /// `D` is the debruijn index, or totally omitted if the debruijn index is zero.
+    ///
     /// See the `rustc-dev-guide` for more details about
     /// [higher-ranked trait bounds][1] and [canonical queries][2].
     ///
@@ -212,6 +216,12 @@ pub enum TyKind<I: Interner> {
 
     /// A placeholder type, used during higher ranked subtyping to instantiate
     /// bound variables.
+    ///
+    /// It is conventional to render anonymous placeholer types like `!N` or `!U_N`,
+    /// where `N` is the placeholder variable's anonymous index (which corresponds
+    /// to the bound variable's index from the binder from which it was instantiated),
+    /// and `U` is the universe index in which it is instantiated, or totally omitted
+    /// if the universe index is zero.
     Placeholder(I::PlaceholderType),
 
     /// A type variable used during type checking.

--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -7,7 +7,7 @@ use core::fmt::{self, Debug, Display, Formatter};
 use core::marker::PhantomData;
 #[cfg(not(no_global_oom_handling))]
 use core::marker::Unsize;
-use core::mem;
+use core::mem::{self, SizedTypeProperties};
 use core::ops::{Deref, DerefMut};
 use core::ptr::Pointee;
 use core::ptr::{self, NonNull};
@@ -202,9 +202,7 @@ impl<H> WithHeader<H> {
             let ptr = if layout.size() == 0 {
                 // Some paranoia checking, mostly so that the ThinBox tests are
                 // more able to catch issues.
-                debug_assert!(
-                    value_offset == 0 && mem::size_of::<T>() == 0 && mem::size_of::<H>() == 0
-                );
+                debug_assert!(value_offset == 0 && T::IS_ZST && H::IS_ZST);
                 layout.dangling()
             } else {
                 let ptr = alloc::alloc(layout);
@@ -249,9 +247,7 @@ impl<H> WithHeader<H> {
                         alloc::dealloc(self.ptr.as_ptr().sub(value_offset), layout);
                     } else {
                         debug_assert!(
-                            value_offset == 0
-                                && mem::size_of::<H>() == 0
-                                && self.value_layout.size() == 0
+                            value_offset == 0 && H::IS_ZST && self.value_layout.size() == 0
                         );
                     }
                 }

--- a/library/alloc/src/vec/drain.rs
+++ b/library/alloc/src/vec/drain.rs
@@ -112,9 +112,7 @@ impl<'a, T, A: Allocator> Drain<'a, T, A> {
             let unyielded_ptr = this.iter.as_slice().as_ptr();
 
             // ZSTs have no identity, so we don't need to move them around.
-            let needs_move = mem::size_of::<T>() != 0;
-
-            if needs_move {
+            if !T::IS_ZST {
                 let start_ptr = source_vec.as_mut_ptr().add(start);
 
                 // memmove back unyielded elements

--- a/library/alloc/src/vec/drain_filter.rs
+++ b/library/alloc/src/vec/drain_filter.rs
@@ -1,5 +1,5 @@
 use crate::alloc::{Allocator, Global};
-use core::mem::{self, ManuallyDrop};
+use core::mem::{ManuallyDrop, SizedTypeProperties};
 use core::ptr;
 use core::slice;
 
@@ -96,9 +96,7 @@ where
 
         unsafe {
             // ZSTs have no identity, so we don't need to move them around.
-            let needs_move = mem::size_of::<T>() != 0;
-
-            if needs_move && this.idx < this.old_len && this.del > 0 {
+            if !T::IS_ZST && this.idx < this.old_len && this.del > 0 {
                 let ptr = this.vec.as_mut_ptr();
                 let src = ptr.add(this.idx);
                 let dst = src.sub(this.del);

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -73,7 +73,7 @@ macro_rules! iterator {
             // Unsafe because the offset must not exceed `self.len()`.
             #[inline(always)]
             unsafe fn post_inc_start(&mut self, offset: usize) -> * $raw_mut T {
-                if mem::size_of::<T>() == 0 {
+                if T::IS_ZST {
                     zst_shrink!(self, offset);
                     self.ptr.as_ptr()
                 } else {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -32,6 +32,7 @@ mod context;
 mod print_item;
 mod sidebar;
 mod span_map;
+mod type_layout;
 mod write_shared;
 
 pub(crate) use self::context::*;

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -6,16 +6,14 @@ use rustc_hir as hir;
 use rustc_hir::def::CtorKind;
 use rustc_hir::def_id::DefId;
 use rustc_middle::middle::stability;
-use rustc_middle::span_bug;
-use rustc_middle::ty::layout::LayoutError;
-use rustc_middle::ty::{self, Adt, TyCtxt};
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::hygiene::MacroKind;
 use rustc_span::symbol::{kw, sym, Symbol};
-use rustc_target::abi::{Primitive, TagEncoding, Variants};
 use std::cmp::Ordering;
 use std::fmt;
 use std::rc::Rc;
 
+use super::type_layout::document_type_layout;
 use super::{
     collect_paths_for_type, document, ensure_trailing_slash, get_filtered_impls_for_reference,
     item_ty_to_section, notable_traits_button, notable_traits_json, render_all_impls,
@@ -1929,79 +1927,6 @@ fn document_non_exhaustive<'a>(item: &'a clean::Item) -> impl fmt::Display + 'a 
             f.write_str("</div></details>")?;
         }
         Ok(())
-    })
-}
-
-fn document_type_layout<'a, 'cx: 'a>(
-    cx: &'a Context<'cx>,
-    ty_def_id: DefId,
-) -> impl fmt::Display + 'a + Captures<'cx> {
-    #[derive(Template)]
-    #[template(path = "type_layout.html")]
-    struct TypeLayout<'cx> {
-        variants: Vec<(Symbol, TypeLayoutSize)>,
-        type_layout_size: Result<TypeLayoutSize, LayoutError<'cx>>,
-    }
-
-    #[derive(Template)]
-    #[template(path = "type_layout_size.html")]
-    struct TypeLayoutSize {
-        is_unsized: bool,
-        is_uninhabited: bool,
-        size: u64,
-    }
-
-    display_fn(move |f| {
-        if !cx.shared.show_type_layout {
-            return Ok(());
-        }
-
-        let tcx = cx.tcx();
-        let param_env = tcx.param_env(ty_def_id);
-        let ty = tcx.type_of(ty_def_id).subst_identity();
-        let type_layout = tcx.layout_of(param_env.and(ty));
-
-        let variants =
-            if let Ok(type_layout) = type_layout &&
-                let Variants::Multiple { variants, tag, tag_encoding, .. } =
-                    type_layout.layout.variants() &&
-                !variants.is_empty()
-            {
-                let tag_size =
-                    if let TagEncoding::Niche { .. } = tag_encoding {
-                        0
-                    } else if let Primitive::Int(i, _) = tag.primitive() {
-                        i.size().bytes()
-                    } else {
-                        span_bug!(cx.tcx().def_span(ty_def_id), "tag is neither niche nor int")
-                    };
-                let variants = variants
-                    .iter_enumerated()
-                    .map(|(variant_idx, variant_layout)| {
-                        let Adt(adt, _) = type_layout.ty.kind() else {
-                            span_bug!(cx.tcx().def_span(ty_def_id), "not an adt")
-                        };
-                        let name = adt.variant(variant_idx).name;
-                        let is_unsized = variant_layout.abi.is_unsized();
-                        let is_uninhabited = variant_layout.abi.is_uninhabited();
-                        let size = variant_layout.size.bytes() - tag_size;
-                        let type_layout_size = TypeLayoutSize { is_unsized, is_uninhabited, size };
-                        (name, type_layout_size)
-                    }).collect();
-                variants
-            } else {
-                Vec::new()
-            }
-        ;
-
-        let type_layout_size = tcx.layout_of(param_env.and(ty)).map(|layout| {
-            let is_unsized = layout.abi.is_unsized();
-            let is_uninhabited = layout.abi.is_uninhabited();
-            let size = layout.size.bytes();
-            TypeLayoutSize { is_unsized, is_uninhabited, size }
-        });
-
-        Ok(TypeLayout { variants, type_layout_size }.render_into(f).unwrap())
     })
 }
 

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1945,6 +1945,14 @@ fn document_type_layout<'a, 'cx: 'a>(
         ty_def_id: DefId,
     }
 
+    #[derive(Template)]
+    #[template(path = "type_layout_size.html")]
+    struct TypeLayoutSize {
+        is_unsized: bool,
+        is_uninhabited: bool,
+        size: u64,
+    }
+
     impl<'a, 'cx: 'a> TypeLayout<'a, 'cx> {
         fn variants<'b: 'a>(&'b self) -> Option<&'b IndexVec<VariantIdx, LayoutS>> {
             if let Variants::Multiple { variants, .. } =
@@ -1986,18 +1994,10 @@ fn document_type_layout<'a, 'cx: 'a>(
             tag_size: u64,
         ) -> impl fmt::Display + Captures<'cx> + Captures<'b> {
             display_fn(move |f| {
-                if layout.abi.is_unsized() {
-                    write!(f, "(unsized)")?;
-                } else {
-                    let size = layout.size.bytes() - tag_size;
-                    write!(f, "{size} byte{pl}", pl = if size == 1 { "" } else { "s" })?;
-                    if layout.abi.is_uninhabited() {
-                        write!(
-                            f,
-                            " (<a href=\"https://doc.rust-lang.org/stable/reference/glossary.html#uninhabited\">uninhabited</a>)"
-                        )?;
-                    }
-                }
+                let is_unsized = layout.abi.is_unsized();
+                let is_uninhabited = layout.abi.is_uninhabited();
+                let size = layout.size.bytes() - tag_size;
+                TypeLayoutSize { is_unsized, is_uninhabited, size }.render_into(f).unwrap();
                 Ok(())
             })
         }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1956,11 +1956,12 @@ fn document_type_layout<'a, 'cx: 'a>(
             return Ok(());
         }
 
-        let variants = {
-            let tcx = cx.tcx();
-            let param_env = tcx.param_env(ty_def_id);
-            let ty = tcx.type_of(ty_def_id).subst_identity();
-            let type_layout = tcx.layout_of(param_env.and(ty));
+        let tcx = cx.tcx();
+        let param_env = tcx.param_env(ty_def_id);
+        let ty = tcx.type_of(ty_def_id).subst_identity();
+        let type_layout = tcx.layout_of(param_env.and(ty));
+
+        let variants =
             if let Ok(type_layout) = type_layout &&
                 let Variants::Multiple { variants, tag, tag_encoding, .. } =
                     type_layout.layout.variants() &&
@@ -1991,19 +1992,14 @@ fn document_type_layout<'a, 'cx: 'a>(
             } else {
                 Vec::new()
             }
-        };
+        ;
 
-        let type_layout_size = {
-            let tcx = cx.tcx();
-            let param_env = tcx.param_env(ty_def_id);
-            let ty = tcx.type_of(ty_def_id).subst_identity();
-            tcx.layout_of(param_env.and(ty)).map(|layout| {
-                let is_unsized = layout.abi.is_unsized();
-                let is_uninhabited = layout.abi.is_uninhabited();
-                let size = layout.size.bytes();
-                TypeLayoutSize { is_unsized, is_uninhabited, size }
-            })
-        };
+        let type_layout_size = tcx.layout_of(param_env.and(ty)).map(|layout| {
+            let is_unsized = layout.abi.is_unsized();
+            let is_uninhabited = layout.abi.is_uninhabited();
+            let size = layout.size.bytes();
+            TypeLayoutSize { is_unsized, is_uninhabited, size }
+        });
 
         Ok(TypeLayout { variants, type_layout_size }.render_into(f).unwrap())
     })

--- a/src/librustdoc/html/render/type_layout.rs
+++ b/src/librustdoc/html/render/type_layout.rs
@@ -1,0 +1,87 @@
+use askama::Template;
+
+use rustc_data_structures::captures::Captures;
+use rustc_hir::def_id::DefId;
+use rustc_middle::span_bug;
+use rustc_middle::ty::layout::LayoutError;
+use rustc_middle::ty::Adt;
+use rustc_span::symbol::Symbol;
+use rustc_target::abi::{Primitive, TagEncoding, Variants};
+
+use std::fmt;
+
+use crate::html::format::display_fn;
+use crate::html::render::Context;
+
+#[derive(Template)]
+#[template(path = "type_layout.html")]
+struct TypeLayout<'cx> {
+    variants: Vec<(Symbol, TypeLayoutSize)>,
+    type_layout_size: Result<TypeLayoutSize, LayoutError<'cx>>,
+}
+
+#[derive(Template)]
+#[template(path = "type_layout_size.html")]
+struct TypeLayoutSize {
+    is_unsized: bool,
+    is_uninhabited: bool,
+    size: u64,
+}
+
+pub(crate) fn document_type_layout<'a, 'cx: 'a>(
+    cx: &'a Context<'cx>,
+    ty_def_id: DefId,
+) -> impl fmt::Display + 'a + Captures<'cx> {
+    display_fn(move |f| {
+        if !cx.shared.show_type_layout {
+            return Ok(());
+        }
+
+        let tcx = cx.tcx();
+        let param_env = tcx.param_env(ty_def_id);
+        let ty = tcx.type_of(ty_def_id).subst_identity();
+        let type_layout = tcx.layout_of(param_env.and(ty));
+
+        let variants =
+            if let Ok(type_layout) = type_layout &&
+                let Variants::Multiple { variants, tag, tag_encoding, .. } =
+                    type_layout.layout.variants() &&
+                !variants.is_empty()
+            {
+                let tag_size =
+                    if let TagEncoding::Niche { .. } = tag_encoding {
+                        0
+                    } else if let Primitive::Int(i, _) = tag.primitive() {
+                        i.size().bytes()
+                    } else {
+                        span_bug!(cx.tcx().def_span(ty_def_id), "tag is neither niche nor int")
+                    };
+                let variants = variants
+                    .iter_enumerated()
+                    .map(|(variant_idx, variant_layout)| {
+                        let Adt(adt, _) = type_layout.ty.kind() else {
+                            span_bug!(cx.tcx().def_span(ty_def_id), "not an adt")
+                        };
+                        let name = adt.variant(variant_idx).name;
+                        let is_unsized = variant_layout.abi.is_unsized();
+                        let is_uninhabited = variant_layout.abi.is_uninhabited();
+                        let size = variant_layout.size.bytes() - tag_size;
+                        let type_layout_size = TypeLayoutSize { is_unsized, is_uninhabited, size };
+                        (name, type_layout_size)
+                    }).collect();
+                variants
+            } else {
+                Vec::new()
+            }
+        ;
+
+        let type_layout_size = tcx.layout_of(param_env.and(ty)).map(|layout| {
+            let is_unsized = layout.abi.is_unsized();
+            let is_uninhabited = layout.abi.is_uninhabited();
+            let size = layout.size.bytes();
+            TypeLayoutSize { is_unsized, is_uninhabited, size }
+        });
+
+        Ok(TypeLayout { variants, type_layout_size }.render_into(f).unwrap())
+    })
+}

--- a/src/librustdoc/html/render/type_layout.rs
+++ b/src/librustdoc/html/render/type_layout.rs
@@ -56,7 +56,7 @@ pub(crate) fn document_type_layout<'a, 'cx: 'a>(
                     } else {
                         span_bug!(cx.tcx().def_span(ty_def_id), "tag is neither niche nor int")
                     };
-                let variants = variants
+                variants
                     .iter_enumerated()
                     .map(|(variant_idx, variant_layout)| {
                         let Adt(adt, _) = type_layout.ty.kind() else {
@@ -68,12 +68,11 @@ pub(crate) fn document_type_layout<'a, 'cx: 'a>(
                         let size = variant_layout.size.bytes() - tag_size;
                         let type_layout_size = TypeLayoutSize { is_unsized, is_uninhabited, size };
                         (name, type_layout_size)
-                    }).collect();
-                variants
+                    })
+                    .collect()
             } else {
                 Vec::new()
-            }
-        ;
+            };
 
         let type_layout_size = tcx.layout_of(param_env.and(ty)).map(|layout| {
             let is_unsized = layout.abi.is_unsized();

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -533,9 +533,11 @@ function preLoadCss(cssUrl) {
         // ignored are included in the attribute `data-ignore-extern-crates`.
         const script = document
             .querySelector("script[data-ignore-extern-crates]");
-        const ignoreExternCrates = script ? script.getAttribute("data-ignore-extern-crates") : "";
+        const ignoreExternCrates = new Set(
+            (script ? script.getAttribute("data-ignore-extern-crates") : "").split(",")
+        );
         for (const lib of libs) {
-            if (lib === window.currentCrate || ignoreExternCrates.indexOf(lib) !== -1) {
+            if (lib === window.currentCrate || ignoreExternCrates.has(lib)) {
                 continue;
             }
             const structs = imp[lib];

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -375,10 +375,7 @@ function preLoadCss(cssUrl) {
 
     function handleEscape(ev) {
         searchState.clearInputTimeout();
-        switchDisplayedElement(null);
-        if (browserSupportsHistoryApi()) {
-            history.replaceState(null, "", getNakedUrl() + window.location.hash);
-        }
+        searchState.hideResults();
         ev.preventDefault();
         searchState.defocus();
         window.hideAllModals(true); // true = reset focus for tooltips

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2412,10 +2412,6 @@ function initSearch(rawSearchIndex) {
         const searchAfter500ms = () => {
             searchState.clearInputTimeout();
             if (searchState.input.value.length === 0) {
-                if (browserSupportsHistoryApi()) {
-                    history.replaceState(null, window.currentCrate + " - Rust",
-                        getNakedUrl() + window.location.hash);
-                }
                 searchState.hideResults();
             } else {
                 searchState.timeout = setTimeout(search, 500);

--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -52,12 +52,12 @@ function createDirEntry(elem, parent, fullPath, hasFoundFile) {
     const files = document.createElement("div");
     files.className = "files";
     if (elem[FILES_OFFSET]) {
+        const w = window.location.href.split("#")[0];
         for (const file_text of elem[FILES_OFFSET]) {
             const file = document.createElement("a");
             file.innerText = file_text;
             file.href = rootPath + "src/" + fullPath + file_text + ".html";
             file.addEventListener("click", closeSidebarIfMobile);
-            const w = window.location.href.split("#")[0];
             if (!hasFoundFile && w === file.href) {
                 file.className = "selected";
                 dirEntry.open = true;

--- a/src/librustdoc/html/templates/type_layout.html
+++ b/src/librustdoc/html/templates/type_layout.html
@@ -16,7 +16,9 @@
             </div> {# #}
             <p><strong>Size:</strong> {{ type_layout_size|safe }}</p> {# #}
             {% if !variants.is_empty() %}
-                <p><strong>Size for each variant:</strong></p> {# #}
+                <p> {# #}
+                    <strong>Size for each variant:</strong> {# #}
+                </p> {# #}
                 <ul> {# #}
                     {% for (name, layout_size) in variants %}
                         <li> {# #}
@@ -29,17 +31,23 @@
         {# This kind of layout error can occur with valid code, e.g. if you try to
            get the layout of a generic type such as `Vec<T>`. #}
         {% when Err(LayoutError::Unknown(_)) %}
-            <p><strong>Note:</strong> Unable to compute type layout, {#+ #}
-            possibly due to this type having generic parameters. {#+ #}
-            Layout can only be computed for concrete, fully-instantiated types.</p> {# #}
+            <p> {# #}
+                <strong>Note:</strong> Unable to compute type layout, {#+ #}
+                possibly due to this type having generic parameters. {#+ #}
+                Layout can only be computed for concrete, fully-instantiated types. {# #}
+            </p> {# #}
         {# This kind of error probably can't happen with valid code, but we don't
            want to panic and prevent the docs from building, so we just let the
            user know that we couldn't compute the layout. #}
         {% when Err(LayoutError::SizeOverflow(_)) %}
-            <p><strong>Note:</strong> Encountered an error during type layout; {#+ #}
-            the type was too big.</p> {# #}
+            <p> {# #}
+                <strong>Note:</strong> Encountered an error during type layout; {#+ #}
+                the type was too big. {# #}
+            </p> {# #}
         {% when Err(LayoutError::NormalizationFailure(_, _)) %}
-            <p><strong>Note:</strong> Encountered an error during type layout; {#+ #}
-            the type failed to be normalized.</p> {# #}
+            <p> {# #}
+                <strong>Note:</strong> Encountered an error during type layout; {#+ #}
+                the type failed to be normalized. {# #}
+            </p> {# #}
     {% endmatch %}
 </div> {# #}

--- a/src/librustdoc/html/templates/type_layout.html
+++ b/src/librustdoc/html/templates/type_layout.html
@@ -1,0 +1,45 @@
+<h2 id="layout" class="small-section-header">  {# #}
+    Layout<a href="#layout" class="anchor">§</a> {# #}
+</h2> {# #}
+<div class="docblock"> {# #}
+    {% match self.type_layout() %}
+        {% when Ok(ty_layout) %}
+            <div class="warning"> {# #}
+                <p> {# #}
+                    <strong>Note:</strong> Most layout information is <strong>completely {#+ #}
+                    unstable</strong> and may even differ between compilations. {#+ #}
+                    The only exception is types with certain <code>repr(...)</code> {#+ #}
+                    attributes. Please see the Rust Reference’s {#+ #}
+                    <a href="https://doc.rust-lang.org/reference/type-layout.html">“Type Layout”</a> {#+ #}
+                    chapter for details on type layout guarantees. {# #}
+                </p> {# #}
+            </div> {# #}
+            <p><strong>Size:</strong> {{ self.write_size(ty_layout.layout.0.borrow(), 0) | safe }}</p> {# #}
+            {% if let Some(variants) = self.variants() %}
+                <p><strong>Size for each variant:</strong></p> {# #}
+                <ul> {# #}
+                    {% for (index, layout) in variants.iter_enumerated() %}
+                        <li> {# #}
+                            <code>{{ self.variant_name(index.clone()) }}</code>: {#+ #}
+                            {{ self.write_size(layout, self.tag_size()) | safe }}
+                        </li> {# #}
+                    {% endfor %}
+                </ul> {# #}
+            {% endif %}
+        {# This kind of layout error can occur with valid code, e.g. if you try to
+           get the layout of a generic type such as `Vec<T>`. #}
+        {% when Err(LayoutError::Unknown(_)) %}
+            <p><strong>Note:</strong> Unable to compute type layout, {#+ #}
+            possibly due to this type having generic parameters. {#+ #}
+            Layout can only be computed for concrete, fully-instantiated types.</p> {# #}
+        {# This kind of error probably can't happen with valid code, but we don't
+           want to panic and prevent the docs from building, so we just let the
+           user know that we couldn't compute the layout. #}
+        {% when Err(LayoutError::SizeOverflow(_)) %}
+            <p><strong>Note:</strong> Encountered an error during type layout; {#+ #}
+            the type was too big.</p> {# #}
+        {% when Err(LayoutError::NormalizationFailure(_, _)) %}
+            <p><strong>Note:</strong> Encountered an error during type layout; {#+ #}
+            the type failed to be normalized.</p> {# #}
+    {% endmatch %}
+</div> {# #}

--- a/src/librustdoc/html/templates/type_layout.html
+++ b/src/librustdoc/html/templates/type_layout.html
@@ -2,8 +2,8 @@
     Layout<a href="#layout" class="anchor">§</a> {# #}
 </h2> {# #}
 <div class="docblock"> {# #}
-    {% match self.type_layout() %}
-        {% when Ok(ty_layout) %}
+    {% match type_layout_size %}
+        {% when Ok(type_layout_size) %}
             <div class="warning"> {# #}
                 <p> {# #}
                     <strong>Note:</strong> Most layout information is <strong>completely {#+ #}
@@ -14,14 +14,14 @@
                     chapter for details on type layout guarantees. {# #}
                 </p> {# #}
             </div> {# #}
-            <p><strong>Size:</strong> {{ self.write_size(ty_layout.layout.0.borrow(), 0) | safe }}</p> {# #}
-            {% if let Some(variants) = self.variants() %}
+            <p><strong>Size:</strong> {{ type_layout_size|safe }}</p> {# #}
+            {% if !variants.is_empty() %}
                 <p><strong>Size for each variant:</strong></p> {# #}
                 <ul> {# #}
-                    {% for (index, layout) in variants.iter_enumerated() %}
+                    {% for (name, layout_size) in variants %}
                         <li> {# #}
-                            <code>{{ self.variant_name(index.clone()) }}</code>: {#+ #}
-                            {{ self.write_size(layout, self.tag_size()) | safe }}
+                            <code>{{ name }}</code>: {#+ #}
+                            {{ layout_size|safe }}
                         </li> {# #}
                     {% endfor %}
                 </ul> {# #}

--- a/src/librustdoc/html/templates/type_layout_size.html
+++ b/src/librustdoc/html/templates/type_layout_size.html
@@ -1,0 +1,12 @@
+{% if is_unsized %}
+  (unsized)
+{% else %}
+  {% if size == 1 %}
+    1 byte
+  {% else %}
+    {{ size +}} bytes
+  {% endif %}
+  {% if is_uninhabited %}
+    {# +#} (<a href="https://doc.rust-lang.org/stable/reference/glossary.html#uninhabited">uninhabited</a>)
+  {% endif %}
+{% endif %}


### PR DESCRIPTION
Successful merges:

 - #109949 (rustdoc: migrate `document_type_layout` to askama)
 - #110622 (Stable hash tag (discriminant) of `GenericArg`)
 - #110635 (More `IS_ZST` in `library`)
 - #110640 (compiler/rustc_target: Raise m68k-linux-gnu baseline to 68020)
 - #110657 (nit: consistent naming for SimplifyConstCondition)
 - #110659 (rustdoc: clean up JS)
 - #110660 (Print ty placeholders pretty)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=109949,110622,110635,110640,110657,110659,110660)
<!-- homu-ignore:end -->