### PR TITLE
Safe Transmute: Pass ErrorGuaranteed up to error reporting

### DIFF
--- a/compiler/rustc_middle/src/ty/context/tls.rs
+++ b/compiler/rustc_middle/src/ty/context/tls.rs
@@ -4,6 +4,7 @@ use crate::dep_graph::TaskDepsRef;
 use crate::ty::query;
 use rustc_data_structures::sync::{self, Lock};
 use rustc_errors::Diagnostic;
+use rustc_errors::ErrorGuaranteed;
 #[cfg(not(parallel_compiler))]
 use std::cell::Cell;
 use std::mem;
@@ -152,4 +153,12 @@ where
     F: for<'tcx> FnOnce(Option<TyCtxt<'tcx>>) -> R,
 {
     with_context_opt(|opt_context| f(opt_context.map(|context| context.tcx)))
+}
+
+pub fn expect_compilation_to_fail() -> ErrorGuaranteed {
+    if let Some(guar) = with(|tcx| tcx.sess.is_compilation_going_to_fail()) {
+        guar
+    } else {
+        bug!("expect tcx.sess.is_compilation_going_to_fail() to return `Some`");
+    }
 }

--- a/compiler/rustc_middle/src/ty/visit.rs
+++ b/compiler/rustc_middle/src/ty/visit.rs
@@ -59,15 +59,7 @@ pub trait TypeVisitableExt<'tcx>: TypeVisitable<TyCtxt<'tcx>> {
         self.has_type_flags(TypeFlags::HAS_ERROR)
     }
     fn error_reported(&self) -> Result<(), ErrorGuaranteed> {
-        if self.references_error() {
-            if let Some(reported) = ty::tls::with(|tcx| tcx.sess.is_compilation_going_to_fail()) {
-                Err(reported)
-            } else {
-                bug!("expect tcx.sess.is_compilation_going_to_fail return `Some`");
-            }
-        } else {
-            Ok(())
-        }
+        if self.references_error() { Err(ty::tls::expect_compilation_to_fail()) } else { Ok(()) }
     }
     fn has_non_region_param(&self) -> bool {
         self.has_type_flags(TypeFlags::NEEDS_SUBST - TypeFlags::HAS_RE_PARAM)

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -672,7 +672,9 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             rustc_transmute::Answer::No(_)
             | rustc_transmute::Answer::IfTransmutable { .. }
             | rustc_transmute::Answer::IfAll(_)
-            | rustc_transmute::Answer::IfAny(_) => Err(NoSolution),
+            | rustc_transmute::Answer::IfAny(_)
+            // FIXME(bryangarza): Pass the `ErrorGuaranteed` along instead of losing it?
+            | rustc_transmute::Answer::Err(_) => Err(NoSolution),
         }
     }
 }

--- a/compiler/rustc_transmute/src/layout/tree.rs
+++ b/compiler/rustc_transmute/src/layout/tree.rs
@@ -187,15 +187,15 @@ pub(crate) mod rustc {
     pub(crate) enum Err {
         /// The layout of the type is unspecified.
         Unspecified,
-        /// This error will be surfaced elsewhere by rustc, so don't surface it.
-        Unknown,
+        Unknown(ErrorGuaranteed),
         TypeError(ErrorGuaranteed),
     }
 
     impl<'tcx> From<LayoutError<'tcx>> for Err {
         fn from(err: LayoutError<'tcx>) -> Self {
+            let guar = rustc_middle::ty::tls::expect_compilation_to_fail();
             match err {
-                LayoutError::Unknown(..) => Self::Unknown,
+                LayoutError::Unknown(..) => Self::Unknown(guar),
                 err => unimplemented!("{:?}", err),
             }
         }

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -39,6 +39,9 @@ where
 
     /// `Src` is transmutable into `Dst` if any of the enclosed requirements are met.
     IfAny(Vec<Answer<R>>),
+
+    /// Encountered an error during safe transmute computation
+    Err(ErrorGuaranteed),
 }
 
 /// Answers: Why wasn't the source type transmutable into the destination type?
@@ -162,3 +165,4 @@ mod rustc {
 
 #[cfg(feature = "rustc")]
 pub use rustc::*;
+use rustc_span::ErrorGuaranteed;

--- a/compiler/rustc_transmute/src/maybe_transmutable/mod.rs
+++ b/compiler/rustc_transmute/src/maybe_transmutable/mod.rs
@@ -75,12 +75,10 @@ mod rustc {
                 let dst = Tree::from_ty(dst, context);
 
                 match (src, dst) {
-                    // Answer `Yes` here, because 'unknown layout' and type errors will already
-                    // be reported by rustc. No need to spam the user with more errors.
-                    (Err(Err::TypeError(_)), _) => Err(Answer::Yes),
-                    (_, Err(Err::TypeError(_))) => Err(Answer::Yes),
-                    (Err(Err::Unknown), _) => Err(Answer::Yes),
-                    (_, Err(Err::Unknown)) => Err(Answer::Yes),
+                    (Err(Err::TypeError(guar)), _) => Err(Answer::Err(guar)),
+                    (_, Err(Err::TypeError(guar))) => Err(Answer::Err(guar)),
+                    (Err(Err::Unknown(guar)), _) => Err(Answer::Err(guar)),
+                    (_, Err(Err::Unknown(guar))) => Err(Answer::Err(guar)),
                     (Err(Err::Unspecified), _) => Err(Answer::No(Reason::SrcIsUnspecified)),
                     (_, Err(Err::Unspecified)) => Err(Answer::No(Reason::DstIsUnspecified)),
                     (Ok(src), Ok(dst)) => Ok((src, dst)),


### PR DESCRIPTION
This patch updates the `Answer` enum used by Safe Transmute to have a variant for errors, and includes the `ErrorGuaranteed` type so that we know that an error was already emitted. Before this change, we would return `Answer::Yes` for failures, which gives the same end-result, but is confusing because `Answer::Yes` is supposed to mean that safe transmutation is possible. Now, it's clear when we have an error, and we can decide what to do with it during error reporting. Also, we now know for sure that an error was emitted for `LayoutError` (previously, we just assumed without confirming).