### PR TITLE
Consider polarity in new solver

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -861,6 +861,11 @@ impl<'tcx> PolyTraitPredicate<'tcx> {
     pub fn is_const_if_const(self) -> bool {
         self.skip_binder().is_const_if_const()
     }
+
+    #[inline]
+    pub fn polarity(self) -> ImplPolarity {
+        self.skip_binder().polarity
+    }
 }
 
 /// `A: B`

--- a/tests/ui/traits/new-solver/negative-coherence-bounds.rs
+++ b/tests/ui/traits/new-solver/negative-coherence-bounds.rs
@@ -1,0 +1,40 @@
+// check-pass
+
+// This test verifies that negative trait predicate cannot be satisfied from a
+// positive param-env candidate.
+
+// Negative coherence is one of the only places where we actually construct and
+// evaluate negative predicates. Specifically, when verifying whether the first
+// and second impls below overlap, we do not want to consider them disjoint,
+// otherwise the second impl would be missing an associated type `type Item`
+// which is provided by the first impl that it is specializing.
+
+#![feature(specialization)]
+//~^ WARN the feature `specialization` is incomplete
+#![feature(with_negative_coherence)]
+
+trait BoxIter {
+    type Item;
+
+    fn last(self) -> Option<Self::Item>;
+}
+
+impl<I: Iterator + ?Sized> BoxIter for Box<I> {
+    type Item = I::Item;
+
+    default fn last(self) -> Option<I::Item> {
+        todo!()
+    }
+}
+
+// When checking that this impl does/doesn't overlap the one above, we evaluate
+// a negative version of all of the where-clause predicates of the impl below.
+// For `I: !Iterator`, we should make sure that the param-env clause `I: Iterator`
+// from above doesn't satisfy this predicate.
+impl<I: Iterator> BoxIter for Box<I> {
+    fn last(self) -> Option<I::Item> {
+        (*self).last()
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/new-solver/negative-coherence-bounds.stderr
+++ b/tests/ui/traits/new-solver/negative-coherence-bounds.stderr
@@ -1,0 +1,12 @@
+warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/negative-coherence-bounds.rs:12:12
+   |
+LL | #![feature(specialization)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
+   = help: consider using `min_specialization` instead, which is more stable and complete
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
It's kinda ugly to have a polarity check in all of the builtin impls -- I guess I could consider the polarity at the top of assemble-builtin but that would require adding a polarity fn to `GoalKind`...

:shrug: putting this up just so i dont forget, since it's needed to bootstrap core during coherence (this alone does not allow core to bootstrap though, additional work is needed!)

r? @lcnr