### PR TITLE
Make `slice::Iter::next` 154 lines shorter in MIR

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -495,6 +495,20 @@ pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
     unsafe { drop_in_place(to_drop) }
 }
 
+/// [`intrinsics::assume`]s that the `ptr` is not [`null()`].
+///
+/// Equivalent to `assume(!ptr.is_null())`, but more convenient and (because it
+/// only handles `Sized` pointees) substantially simpler in MIR.
+///
+/// # Safety
+///
+/// `ptr` must not be `null()`.
+#[inline(always)]
+pub(crate) unsafe fn assume_not_null<T>(ptr: *const T) {
+    // SAFETY: By our safety precondition, this is ok.
+    unsafe { intrinsics::assume(ptr != const { null::<T>() }) }
+}
+
 /// Creates a null raw pointer.
 ///
 /// # Examples

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -326,6 +326,11 @@ impl<T: ?Sized> NonNull<T> {
         self.pointer as *mut T
     }
 
+    #[inline(always)]
+    pub(crate) const fn as_const_ptr(self) -> *const T {
+        self.pointer
+    }
+
     /// Returns a shared reference to the value. If the value may be uninitialized, [`as_uninit_ref`]
     /// must be used instead.
     ///

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -13,7 +13,7 @@ use crate::iter::{
 use crate::marker::{PhantomData, Send, Sized, Sync};
 use crate::mem::{self, SizedTypeProperties};
 use crate::num::NonZeroUsize;
-use crate::ptr::NonNull;
+use crate::ptr::{assume_not_null, NonNull};
 
 use super::{from_raw_parts, from_raw_parts_mut};
 
@@ -60,10 +60,17 @@ impl<'a, T> IntoIterator for &'a mut [T] {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct Iter<'a, T: 'a> {
+    /// The pointer to the next element to return, or the past-the-end location
+    /// if the iterator is empty.
+    ///
+    /// This address will be used for all ZST elements, never changed.
     ptr: NonNull<T>,
-    end: *const T, // If T is a ZST, this is actually ptr+len. This encoding is picked so that
-    // ptr == end is a quick test for the Iterator being empty, that works
-    // for both ZST and non-ZST.
+    /// For non-ZSTs, the non-null pointer to the past-the-end element.
+    ///
+    /// For ZSTs, this is `ptr.wrapping_byte_add(len)`.
+    ///
+    /// For all types, `ptr == end` tests whether the iterator is empty.
+    end: *const T,
     _marker: PhantomData<&'a T>,
 }
 
@@ -179,10 +186,17 @@ impl<T> AsRef<[T]> for Iter<'_, T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct IterMut<'a, T: 'a> {
+    /// The pointer to the next element to return, or the past-the-end location
+    /// if the iterator is empty.
+    ///
+    /// This address will be used for all ZST elements, never changed.
     ptr: NonNull<T>,
-    end: *mut T, // If T is a ZST, this is actually ptr+len. This encoding is picked so that
-    // ptr == end is a quick test for the Iterator being empty, that works
-    // for both ZST and non-ZST.
+    /// For non-ZSTs, the non-null pointer to the past-the-end element.
+    ///
+    /// For ZSTs, this is `ptr.wrapping_byte_add(len)`.
+    ///
+    /// For all types, `ptr == end` tests whether the iterator is empty.
+    end: *mut T,
     _marker: PhantomData<&'a mut T>,
 }
 

--- a/tests/mir-opt/slice_iter_next.rs
+++ b/tests/mir-opt/slice_iter_next.rs
@@ -1,0 +1,24 @@
+// compile-flags: -O -Z inline-mir-hint-threshold=10000 -C debuginfo=0
+// only-64bit
+// ignore-debug
+
+#![crate_type = "lib"]
+
+// When this test was added, the MIR for `next` was 174 lines just for the basic
+// blocks -- far more if you counted the scopes.  The goal of having this here
+// is to hopefully keep it a reasonable size, ideally eventually small enough
+// that the mir inliner would actually be willing to inline it, since it's an
+// important building block and usually very few *backend* instructions.
+
+// As such, feel free to `--bless` whatever changes you get here, so long as
+// doing so doesn't add substantially more MIR.
+
+// EMIT_MIR slice_iter_next.slice_iter_next.runtime-optimized.after.mir
+pub fn slice_iter_next<'a, T>(it: &mut std::slice::Iter<'a, T>) -> Option<&'a T> {
+    it.next()
+}
+
+// EMIT_MIR slice_iter_next.slice_iter_mut_next_back.runtime-optimized.after.mir
+pub fn slice_iter_mut_next_back<'a, T>(it: &mut std::slice::IterMut<'a, T>) -> Option<&'a mut T> {
+    it.next_back()
+}

--- a/tests/mir-opt/slice_iter_next.rs
+++ b/tests/mir-opt/slice_iter_next.rs
@@ -1,4 +1,4 @@
-// compile-flags: -O -Z inline-mir-hint-threshold=10000 -C debuginfo=0
+// compile-flags: -O -Z inline-mir-hint-threshold=500 -C debuginfo=0 -Zmir-opt-level=2
 // only-64bit
 // ignore-debug
 

--- a/tests/mir-opt/slice_iter_next.slice_iter_mut_next_back.runtime-optimized.after.mir
+++ b/tests/mir-opt/slice_iter_next.slice_iter_mut_next_back.runtime-optimized.after.mir
@@ -1,0 +1,337 @@
+// MIR for `slice_iter_mut_next_back` after runtime-optimized
+
+fn slice_iter_mut_next_back(_1: &mut std::slice::IterMut<'_, T>) -> Option<&mut T> {
+    debug it => _1;                      // in scope 0 at $DIR/slice_iter_next.rs:+0:40: +0:42
+    let mut _0: std::option::Option<&mut T>; // return place in scope 0 at $DIR/slice_iter_next.rs:+0:80: +0:97
+    scope 1 (inlined <std::slice::IterMut<'_, T> as DoubleEndedIterator>::next_back) { // at $DIR/slice_iter_next.rs:23:8: 23:19
+        debug self => _1;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _2: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _3: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _4: *mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _5: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _6: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _7: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _8: *mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _9: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _10: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _11: *mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _12: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _13: *mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _14: &mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _15: *mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _22: usize;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _45: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _46: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        scope 2 {
+            scope 3 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => std::ptr::NonNull<T>{ .0 => _45, }; // in scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+            }
+            scope 4 (inlined ptr::mut_ptr::<impl *mut T>::is_null) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => _4;        // in scope 4 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                let mut _16: *mut u8;    // in scope 4 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                scope 5 {
+                    scope 6 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug ptr => _16; // in scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _17: usize; // in scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        scope 7 (inlined ptr::mut_ptr::<impl *mut u8>::addr) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            debug self => _16; // in scope 7 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            let mut _18: *mut (); // in scope 7 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            scope 8 {
+                                scope 9 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                    debug self => _16; // in scope 9 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            scope 10 (inlined ptr::mut_ptr::<impl *mut T>::is_null) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => _8;        // in scope 10 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                let mut _19: *mut u8;    // in scope 10 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                scope 11 {
+                    scope 12 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug ptr => _19; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _20: usize; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        scope 13 (inlined ptr::mut_ptr::<impl *mut u8>::addr) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            debug self => _19; // in scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            let mut _21: *mut (); // in scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            scope 14 {
+                                scope 15 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                    debug self => _19; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            scope 16 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => std::ptr::NonNull<T>{ .0 => _46, }; // in scope 16 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+            }
+            scope 17 (inlined std::slice::IterMut::<'_, T>::pre_dec_end) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => _1;        // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug offset => _22;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _23: bool;       // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _24: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _25: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _26: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _27: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _47: *const T;   // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                scope 18 {
+                    scope 32 (inlined ptr::mut_ptr::<impl *mut T>::sub) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                        debug self => _27; // in scope 32 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug count => _22; // in scope 32 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _40: isize; // in scope 32 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _41: isize; // in scope 32 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        scope 33 {
+                            scope 34 (inlined core::num::<impl isize>::wrapping_neg) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug self => _41; // in scope 34 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                let mut _42: isize; // in scope 34 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                scope 35 (inlined core::num::<impl isize>::wrapping_sub) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                    debug self => _42; // in scope 35 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                    debug rhs => _41; // in scope 35 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                }
+                            }
+                            scope 36 (inlined ptr::mut_ptr::<impl *mut T>::offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug self => _27; // in scope 36 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug count => _40; // in scope 36 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                let mut _43: *const T; // in scope 36 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                let mut _44: *const T; // in scope 36 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                scope 37 {
+                                }
+                            }
+                        }
+                    }
+                }
+                scope 19 (inlined ptr::mut_ptr::<impl *mut T>::wrapping_byte_sub) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                    debug self => _25;   // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    debug count => _22;  // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    let mut _28: *mut u8; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    let mut _29: *mut u8; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    let mut _30: *const T; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    scope 20 (inlined ptr::mut_ptr::<impl *mut T>::cast::<u8>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug self => _25; // in scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    }
+                    scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::wrapping_sub) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug self => _29; // in scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug count => _22; // in scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _31: isize; // in scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _32: isize; // in scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        scope 22 (inlined core::num::<impl isize>::wrapping_neg) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            debug self => _32; // in scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            let mut _33: isize; // in scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            scope 23 (inlined core::num::<impl isize>::wrapping_sub) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                debug self => _33; // in scope 23 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                debug rhs => _32; // in scope 23 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            }
+                        }
+                        scope 24 (inlined ptr::mut_ptr::<impl *mut u8>::wrapping_offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            debug self => _29; // in scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            debug count => _31; // in scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            let mut _34: *const u8; // in scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            let mut _35: *const u8; // in scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            scope 25 {
+                            }
+                        }
+                    }
+                    scope 26 (inlined ptr::mut_ptr::<impl *mut u8>::with_metadata_of::<T>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug self => _28; // in scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug meta => _30; // in scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _36: *mut (); // in scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        scope 27 (inlined std::ptr::metadata::<T>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            debug ptr => _30; // in scope 27 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                            scope 28 {
+                            }
+                        }
+                        scope 29 (inlined std::ptr::from_raw_parts_mut::<T>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            debug data_address => _36; // in scope 29 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                            debug metadata => const (); // in scope 29 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                            let mut _37: std::ptr::metadata::PtrRepr<T>; // in scope 29 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                            let mut _38: std::ptr::metadata::PtrComponents<T>; // in scope 29 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                            let mut _39: *const (); // in scope 29 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                            scope 30 {
+                            }
+                        }
+                    }
+                }
+                scope 31 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                    debug self => std::ptr::NonNull<T>{ .0 => _47, }; // in scope 31 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_14);                // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:19
+        StorageLive(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _45 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _4 = _45 as *mut T (PtrToPtr);   // scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        _16 = _4 as *mut u8 (PtrToPtr);  // scope 5 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_17);                // scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_18);                // scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _18 = _16 as *mut () (PtrToPtr); // scope 9 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _17 = move _18 as usize (Transmute); // scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_18);                // scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _3 = Eq(move _17, const 0_usize); // scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_17);                // scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _2 = Not(move _3);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        assume(move _2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _5 = Not(const _);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _5) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb1: {
+        StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_8);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _8 = ((*_1).1: *mut T);          // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _19 = _8 as *mut u8 (PtrToPtr);  // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_20);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_21);                // scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _21 = _19 as *mut () (PtrToPtr); // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _20 = move _21 as usize (Transmute); // scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_21);                // scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _7 = Eq(move _20, const 0_usize); // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_20);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_8);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _6 = Not(move _7);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        assume(move _6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        goto -> bb2;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb2: {
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_10);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_11);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _46 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _11 = _46 as *mut T (PtrToPtr);  // scope 16 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        _10 = move _11 as *const T (Pointer(MutToConstPointer)); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_11);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_12);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_13);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _13 = ((*_1).1: *mut T);         // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _12 = move _13 as *const T (Pointer(MutToConstPointer)); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_13);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _9 = Eq(move _10, move _12);     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_12);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_10);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _9) -> [0: bb4, otherwise: bb3]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb3: {
+        _0 = Option::<&mut T>::None;     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        goto -> bb5;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb4: {
+        StorageLive(_15);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_22);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_23);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _23 = const _;                   // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _23) -> [0: bb7, otherwise: bb6]; // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb5: {
+        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_14);                // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:19
+        return;                          // scope 0 at $DIR/slice_iter_next.rs:+2:2: +2:2
+    }
+
+    bb6: {
+        StorageLive(_24);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_25);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _25 = ((*_1).1: *mut T);         // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_28);                // scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_29);                // scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _29 = _25 as *mut u8 (PtrToPtr); // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_31);                // scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_32);                // scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_33);                // scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_33);                // scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_32);                // scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_34);                // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_35);                // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _35 = _29 as *const u8 (Pointer(MutToConstPointer)); // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _34 = arith_offset::<u8>(move _35, const -1_isize) -> [return: bb9, unwind unreachable]; // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const u8, isize) -> *const u8 {arith_offset::<u8>}, val: Value(<ZST>) }
+    }
+
+    bb7: {
+        StorageLive(_26);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_27);                // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _27 = ((*_1).1: *mut T);         // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_40);                // scope 33 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_41);                // scope 33 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_42);                // scope 34 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_42);                // scope 34 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_41);                // scope 33 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_43);                // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_44);                // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _44 = _27 as *const T (Pointer(MutToConstPointer)); // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _43 = offset::<T>(move _44, const -1_isize) -> [return: bb10, unwind unreachable]; // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const T, isize) -> *const T {offset::<T>}, val: Value(<ZST>) }
+    }
+
+    bb8: {
+        StorageDead(_23);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_22);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _14 = &mut (*_15);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _0 = Option::<&mut T>::Some(_14); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_15);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        goto -> bb5;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb9: {
+        StorageDead(_35);                // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _28 = move _34 as *mut u8 (PtrToPtr); // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_34);                // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_31);                // scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_29);                // scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_30);                // scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_36);                // scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _36 = _28 as *mut () (PtrToPtr); // scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_37);                // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageLive(_38);                // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageLive(_39);                // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _39 = _36 as *const () (Pointer(MutToConstPointer)); // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _38 = ptr::metadata::PtrComponents::<T> { data_address: move _39, metadata: const () }; // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_39);                // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _37 = ptr::metadata::PtrRepr::<T> { const_ptr: move _38 }; // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_38);                // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _24 = (_37.1: *mut T);           // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_37);                // scope 29 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_36);                // scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_30);                // scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_28);                // scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_25);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        ((*_1).1: *mut T) = move _24;    // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_24);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _47 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _15 = _47 as *mut T (PtrToPtr);  // scope 31 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        goto -> bb8;                     // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb10: {
+        StorageDead(_44);                // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _26 = move _43 as *mut T (PtrToPtr); // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_43);                // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_40);                // scope 33 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_27);                // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        ((*_1).1: *mut T) = move _26;    // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_26);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _15 = ((*_1).1: *mut T);         // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        goto -> bb8;                     // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+}

--- a/tests/mir-opt/slice_iter_next.slice_iter_mut_next_back.runtime-optimized.after.mir
+++ b/tests/mir-opt/slice_iter_next.slice_iter_mut_next_back.runtime-optimized.after.mir
@@ -5,67 +5,69 @@ fn slice_iter_mut_next_back(_1: &mut std::slice::IterMut<'_, T>) -> Option<&mut 
     let mut _0: std::option::Option<&mut T>; // return place in scope 0 at $DIR/slice_iter_next.rs:+0:80: +0:97
     scope 1 (inlined <std::slice::IterMut<'_, T> as DoubleEndedIterator>::next_back) { // at $DIR/slice_iter_next.rs:23:8: 23:19
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _2: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _3: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _4: *mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _5: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _6: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _7: *mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _8: &mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _9: *mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _12: usize;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _30: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _31: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _2: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _3: std::ptr::NonNull<T>; // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _4: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _5: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _6: *mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _7: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _8: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _9: std::ptr::NonNull<T>; // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _10: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _11: *mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _12: &mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _13: *mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _16: usize;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         scope 2 {
             scope 3 (inlined NonNull::<T>::as_const_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => std::ptr::NonNull<T>{ .0 => _30, }; // in scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                debug self => _3;        // in scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
             }
             scope 4 (inlined ptr::assume_not_null::<T>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug ptr => _30;        // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                let mut _10: bool;       // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                debug ptr => _2;         // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                let mut _14: bool;       // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                 scope 5 {
                 }
             }
             scope 6 (inlined ptr::assume_not_null::<T>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug ptr => _3;         // in scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                let mut _11: bool;       // in scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                debug ptr => _5;         // in scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                let mut _15: bool;       // in scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                 scope 7 {
                 }
             }
             scope 8 (inlined NonNull::<T>::as_const_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => std::ptr::NonNull<T>{ .0 => _31, }; // in scope 8 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                debug self => _9;        // in scope 8 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
             }
             scope 9 (inlined std::slice::IterMut::<'_, T>::pre_dec_end) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
                 debug self => _1;        // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug offset => _12;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _13: bool;       // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _14: *mut T;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _15: *mut u8;    // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _16: *mut u8;    // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _17: *mut T;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug offset => _16;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _17: bool;       // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
                 let mut _18: *mut T;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _19: *mut T;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _32: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _19: *mut u8;    // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _20: *mut u8;    // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _21: *mut T;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _22: std::ptr::NonNull<T>; // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _23: *mut T;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _24: *mut T;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
                 scope 10 {
                     scope 19 (inlined ptr::mut_ptr::<impl *mut T>::sub) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                        debug self => _19; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug count => _12; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        let mut _25: isize; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        let mut _26: isize; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug self => _24; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug count => _16; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _31: isize; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _32: isize; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                         scope 20 {
                             scope 21 (inlined core::num::<impl isize>::wrapping_neg) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                debug self => _26; // in scope 21 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                let mut _27: isize; // in scope 21 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                debug self => _32; // in scope 21 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                let mut _33: isize; // in scope 21 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
                                 scope 22 (inlined core::num::<impl isize>::wrapping_sub) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                    debug self => _27; // in scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                    debug rhs => _26; // in scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                    debug self => _33; // in scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                    debug rhs => _32; // in scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
                                 }
                             }
                             scope 23 (inlined ptr::mut_ptr::<impl *mut T>::offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                debug self => _19; // in scope 23 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                debug count => _25; // in scope 23 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                let mut _28: *const T; // in scope 23 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                let mut _29: *const T; // in scope 23 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug self => _24; // in scope 23 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug count => _31; // in scope 23 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                let mut _34: *const T; // in scope 23 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                let mut _35: *const T; // in scope 23 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                 scope 24 {
                                 }
                             }
@@ -73,84 +75,95 @@ fn slice_iter_mut_next_back(_1: &mut std::slice::IterMut<'_, T>) -> Option<&mut 
                     }
                 }
                 scope 11 (inlined ptr::mut_ptr::<impl *mut T>::cast::<u8>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                    debug self => _17;   // in scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    debug self => _21;   // in scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                 }
                 scope 12 (inlined ptr::mut_ptr::<impl *mut u8>::wrapping_sub) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                    debug self => _16;   // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                    debug count => _12;  // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                    let mut _20: isize;  // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                    let mut _21: isize;  // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    debug self => _20;   // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    debug count => _16;  // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    let mut _25: isize;  // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    let mut _26: isize;  // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                     scope 13 (inlined core::num::<impl isize>::wrapping_neg) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug self => _21; // in scope 13 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                        let mut _22: isize; // in scope 13 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                        debug self => _26; // in scope 13 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                        let mut _27: isize; // in scope 13 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
                         scope 14 (inlined core::num::<impl isize>::wrapping_sub) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                            debug self => _22; // in scope 14 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                            debug rhs => _21; // in scope 14 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            debug self => _27; // in scope 14 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            debug rhs => _26; // in scope 14 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
                         }
                     }
                     scope 15 (inlined ptr::mut_ptr::<impl *mut u8>::wrapping_offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug self => _16; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug count => _20; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        let mut _23: *const u8; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        let mut _24: *const u8; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug self => _20; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug count => _25; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _28: *const u8; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _29: *const u8; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                         scope 16 {
                         }
                     }
                 }
                 scope 17 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<T>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                    debug self => _15;   // in scope 17 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    debug self => _19;   // in scope 17 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                 }
                 scope 18 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                    debug self => std::ptr::NonNull<T>{ .0 => _32, }; // in scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                    debug self => _22;   // in scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                    let mut _30: *const T; // in scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
                 }
             }
         }
     }
 
     bb0: {
-        StorageLive(_8);                 // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:19
-        _30 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_10);                // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _10 = Ne(_30, const _);          // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageLive(_12);                // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:19
+        StorageLive(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _3 = ((*_1).0: std::ptr::NonNull<T>); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _2 = (_3.0: *const T);           // scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_14);                // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _14 = Ne(_2, const _);           // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // + literal: Const { ty: *const T, val: Unevaluated(ptr::assume_not_null::{constant#0}, [T, *const T], None) }
-        assume(move _10);                // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_10);                // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageLive(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _2 = Not(const _);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        assume(move _14);                // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_14);                // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _4 = Not(const _);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _4) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb1: {
-        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _4 = ((*_1).1: *mut T);          // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _3 = move _4 as *const T (Pointer(MutToConstPointer)); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_11);                // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _11 = Ne(_3, const _);           // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _6 = ((*_1).1: *mut T);          // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _5 = move _6 as *const T (Pointer(MutToConstPointer)); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_15);                // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _15 = Ne(_5, const _);           // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // + literal: Const { ty: *const T, val: Unevaluated(ptr::assume_not_null::{constant#0}, [T, *const T], None) }
-        assume(move _11);                // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_11);                // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        assume(move _15);                // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_15);                // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         goto -> bb2;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb2: {
-        StorageDead(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _31 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         StorageLive(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _7 = ((*_1).1: *mut T);          // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _6 = move _7 as *const T (Pointer(MutToConstPointer)); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _5 = Eq(_31, move _6);           // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        switchInt(move _5) -> [0: bb4, otherwise: bb3]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_8);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _9 = ((*_1).0: std::ptr::NonNull<T>); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _8 = (_9.0: *const T);           // scope 8 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_10);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_11);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _11 = ((*_1).1: *mut T);         // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _10 = move _11 as *const T (Pointer(MutToConstPointer)); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_11);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _7 = Eq(move _8, move _10);      // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_10);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_8);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _7) -> [0: bb4, otherwise: bb3]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb3: {
@@ -159,92 +172,99 @@ fn slice_iter_mut_next_back(_1: &mut std::slice::IterMut<'_, T>) -> Option<&mut 
     }
 
     bb4: {
-        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_12);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_13);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _13 = const _;                   // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        switchInt(move _13) -> [0: bb7, otherwise: bb6]; // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_13);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_16);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _17 = const _;                   // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _17) -> [0: bb7, otherwise: bb6]; // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb5: {
-        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_8);                 // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:19
+        StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_12);                // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:19
         return;                          // scope 0 at $DIR/slice_iter_next.rs:+2:2: +2:2
     }
 
     bb6: {
-        StorageLive(_14);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_15);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_16);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _17 = ((*_1).1: *mut T);         // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _16 = _17 as *mut u8 (PtrToPtr); // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_20);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_21);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_22);                // scope 13 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        StorageDead(_22);                // scope 13 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        StorageDead(_21);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_23);                // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_24);                // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _24 = _16 as *const u8 (Pointer(MutToConstPointer)); // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _23 = arith_offset::<u8>(move _24, const -1_isize) -> [return: bb9, unwind unreachable]; // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_18);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_19);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_20);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_21);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _21 = ((*_1).1: *mut T);         // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _20 = _21 as *mut u8 (PtrToPtr); // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_21);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_25);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_26);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_27);                // scope 13 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        _25 = const -1_isize;            // scope 14 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_27);                // scope 13 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_26);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_28);                // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_29);                // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _29 = _20 as *const u8 (Pointer(MutToConstPointer)); // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _28 = arith_offset::<u8>(move _29, _25) -> [return: bb9, unwind unreachable]; // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const u8, isize) -> *const u8 {arith_offset::<u8>}, val: Value(<ZST>) }
     }
 
     bb7: {
-        StorageLive(_18);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_19);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _19 = ((*_1).1: *mut T);         // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_25);                // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_26);                // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_27);                // scope 21 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        StorageDead(_27);                // scope 21 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        StorageDead(_26);                // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_28);                // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_29);                // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _29 = _19 as *const T (Pointer(MutToConstPointer)); // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _28 = offset::<T>(move _29, const -1_isize) -> [return: bb10, unwind unreachable]; // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_23);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_24);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _24 = ((*_1).1: *mut T);         // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_31);                // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_32);                // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_33);                // scope 21 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        _31 = const -1_isize;            // scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_33);                // scope 21 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_32);                // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_34);                // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_35);                // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _35 = _24 as *const T (Pointer(MutToConstPointer)); // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _34 = offset::<T>(move _35, _31) -> [return: bb10, unwind unreachable]; // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const T, isize) -> *const T {offset::<T>}, val: Value(<ZST>) }
     }
 
     bb8: {
-        StorageDead(_13);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_12);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _8 = &mut (*_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _0 = Option::<&mut T>::Some(_8); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_16);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _12 = &mut (*_13);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _0 = Option::<&mut T>::Some(_12); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_13);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         goto -> bb5;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb9: {
-        StorageDead(_24);                // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _15 = move _23 as *mut u8 (PtrToPtr); // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_23);                // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_20);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_16);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _14 = _15 as *mut T (PtrToPtr);  // scope 17 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_15);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        ((*_1).1: *mut T) = move _14;    // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_14);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _32 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _9 = _32 as *mut T (PtrToPtr);   // scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageDead(_29);                // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _19 = move _28 as *mut u8 (PtrToPtr); // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_28);                // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_25);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_20);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _18 = _19 as *mut T (PtrToPtr);  // scope 17 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_19);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        ((*_1).1: *mut T) = move _18;    // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_22);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _22 = ((*_1).0: std::ptr::NonNull<T>); // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_30);                // scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        _30 = (_22.0: *const T);         // scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        _13 = move _30 as *mut T (PtrToPtr); // scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageDead(_30);                // scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageDead(_22);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         goto -> bb8;                     // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb10: {
-        StorageDead(_29);                // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _18 = move _28 as *mut T (PtrToPtr); // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_28);                // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_25);                // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_19);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        ((*_1).1: *mut T) = move _18;    // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _9 = ((*_1).1: *mut T);          // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_35);                // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _23 = move _34 as *mut T (PtrToPtr); // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_34);                // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_31);                // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_24);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        ((*_1).1: *mut T) = move _23;    // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_23);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _13 = ((*_1).1: *mut T);         // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         goto -> bb8;                     // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 }

--- a/tests/mir-opt/slice_iter_next.slice_iter_mut_next_back.runtime-optimized.after.mir
+++ b/tests/mir-opt/slice_iter_next.slice_iter_mut_next_back.runtime-optimized.after.mir
@@ -6,224 +6,151 @@ fn slice_iter_mut_next_back(_1: &mut std::slice::IterMut<'_, T>) -> Option<&mut 
     scope 1 (inlined <std::slice::IterMut<'_, T> as DoubleEndedIterator>::next_back) { // at $DIR/slice_iter_next.rs:23:8: 23:19
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         let mut _2: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _3: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _3: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         let mut _4: *mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         let mut _5: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _6: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _7: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _8: *mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _9: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _10: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _11: *mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _12: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _13: *mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _14: &mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _15: *mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _22: usize;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _45: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _46: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _6: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _7: *mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _8: &mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _9: *mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _12: usize;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _30: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _31: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         scope 2 {
-            scope 3 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => std::ptr::NonNull<T>{ .0 => _45, }; // in scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+            scope 3 (inlined NonNull::<T>::as_const_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => std::ptr::NonNull<T>{ .0 => _30, }; // in scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
             }
-            scope 4 (inlined ptr::mut_ptr::<impl *mut T>::is_null) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => _4;        // in scope 4 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                let mut _16: *mut u8;    // in scope 4 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+            scope 4 (inlined ptr::assume_not_null::<T>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug ptr => _30;        // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                let mut _10: bool;       // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                 scope 5 {
-                    scope 6 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug ptr => _16; // in scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        let mut _17: usize; // in scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        scope 7 (inlined ptr::mut_ptr::<impl *mut u8>::addr) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            debug self => _16; // in scope 7 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            let mut _18: *mut (); // in scope 7 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            scope 8 {
-                                scope 9 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                    debug self => _16; // in scope 9 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                }
-                            }
-                        }
-                    }
                 }
             }
-            scope 10 (inlined ptr::mut_ptr::<impl *mut T>::is_null) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => _8;        // in scope 10 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                let mut _19: *mut u8;    // in scope 10 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                scope 11 {
-                    scope 12 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug ptr => _19; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        let mut _20: usize; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        scope 13 (inlined ptr::mut_ptr::<impl *mut u8>::addr) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            debug self => _19; // in scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            let mut _21: *mut (); // in scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            scope 14 {
-                                scope 15 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                    debug self => _19; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                }
-                            }
-                        }
-                    }
+            scope 6 (inlined ptr::assume_not_null::<T>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug ptr => _3;         // in scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                let mut _11: bool;       // in scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                scope 7 {
                 }
             }
-            scope 16 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => std::ptr::NonNull<T>{ .0 => _46, }; // in scope 16 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+            scope 8 (inlined NonNull::<T>::as_const_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => std::ptr::NonNull<T>{ .0 => _31, }; // in scope 8 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
             }
-            scope 17 (inlined std::slice::IterMut::<'_, T>::pre_dec_end) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => _1;        // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug offset => _22;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _23: bool;       // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _24: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _25: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _26: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _27: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _47: *const T;   // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                scope 18 {
-                    scope 32 (inlined ptr::mut_ptr::<impl *mut T>::sub) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                        debug self => _27; // in scope 32 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug count => _22; // in scope 32 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        let mut _40: isize; // in scope 32 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        let mut _41: isize; // in scope 32 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        scope 33 {
-                            scope 34 (inlined core::num::<impl isize>::wrapping_neg) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                debug self => _41; // in scope 34 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                let mut _42: isize; // in scope 34 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                scope 35 (inlined core::num::<impl isize>::wrapping_sub) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                    debug self => _42; // in scope 35 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                    debug rhs => _41; // in scope 35 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+            scope 9 (inlined std::slice::IterMut::<'_, T>::pre_dec_end) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => _1;        // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug offset => _12;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _13: bool;       // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _14: *mut T;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _15: *mut u8;    // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _16: *mut u8;    // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _17: *mut T;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _18: *mut T;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _19: *mut T;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _32: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                scope 10 {
+                    scope 19 (inlined ptr::mut_ptr::<impl *mut T>::sub) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                        debug self => _19; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug count => _12; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _25: isize; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _26: isize; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        scope 20 {
+                            scope 21 (inlined core::num::<impl isize>::wrapping_neg) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug self => _26; // in scope 21 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                let mut _27: isize; // in scope 21 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                scope 22 (inlined core::num::<impl isize>::wrapping_sub) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                    debug self => _27; // in scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                    debug rhs => _26; // in scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
                                 }
                             }
-                            scope 36 (inlined ptr::mut_ptr::<impl *mut T>::offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                debug self => _27; // in scope 36 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                debug count => _40; // in scope 36 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                let mut _43: *const T; // in scope 36 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                let mut _44: *const T; // in scope 36 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                scope 37 {
+                            scope 23 (inlined ptr::mut_ptr::<impl *mut T>::offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug self => _19; // in scope 23 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug count => _25; // in scope 23 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                let mut _28: *const T; // in scope 23 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                let mut _29: *const T; // in scope 23 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                scope 24 {
                                 }
                             }
                         }
                     }
                 }
-                scope 19 (inlined ptr::mut_ptr::<impl *mut T>::wrapping_byte_sub) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                    debug self => _25;   // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                    debug count => _22;  // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                    let mut _28: *mut u8; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                    let mut _29: *mut u8; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                    let mut _30: *const T; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                    scope 20 (inlined ptr::mut_ptr::<impl *mut T>::cast::<u8>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug self => _25; // in scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                    }
-                    scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::wrapping_sub) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug self => _29; // in scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug count => _22; // in scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        let mut _31: isize; // in scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        let mut _32: isize; // in scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        scope 22 (inlined core::num::<impl isize>::wrapping_neg) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            debug self => _32; // in scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                            let mut _33: isize; // in scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                            scope 23 (inlined core::num::<impl isize>::wrapping_sub) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                debug self => _33; // in scope 23 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                debug rhs => _32; // in scope 23 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                            }
-                        }
-                        scope 24 (inlined ptr::mut_ptr::<impl *mut u8>::wrapping_offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            debug self => _29; // in scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            debug count => _31; // in scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            let mut _34: *const u8; // in scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            let mut _35: *const u8; // in scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            scope 25 {
-                            }
+                scope 11 (inlined ptr::mut_ptr::<impl *mut T>::cast::<u8>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                    debug self => _17;   // in scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                }
+                scope 12 (inlined ptr::mut_ptr::<impl *mut u8>::wrapping_sub) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                    debug self => _16;   // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    debug count => _12;  // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    let mut _20: isize;  // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    let mut _21: isize;  // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                    scope 13 (inlined core::num::<impl isize>::wrapping_neg) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug self => _21; // in scope 13 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                        let mut _22: isize; // in scope 13 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                        scope 14 (inlined core::num::<impl isize>::wrapping_sub) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            debug self => _22; // in scope 14 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            debug rhs => _21; // in scope 14 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
                         }
                     }
-                    scope 26 (inlined ptr::mut_ptr::<impl *mut u8>::with_metadata_of::<T>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug self => _28; // in scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug meta => _30; // in scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        let mut _36: *mut (); // in scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        scope 27 (inlined std::ptr::metadata::<T>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            debug ptr => _30; // in scope 27 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                            scope 28 {
-                            }
-                        }
-                        scope 29 (inlined std::ptr::from_raw_parts_mut::<T>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            debug data_address => _36; // in scope 29 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                            debug metadata => const (); // in scope 29 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                            let mut _37: std::ptr::metadata::PtrRepr<T>; // in scope 29 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                            let mut _38: std::ptr::metadata::PtrComponents<T>; // in scope 29 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                            let mut _39: *const (); // in scope 29 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                            scope 30 {
-                            }
+                    scope 15 (inlined ptr::mut_ptr::<impl *mut u8>::wrapping_offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug self => _16; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug count => _20; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _23: *const u8; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _24: *const u8; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        scope 16 {
                         }
                     }
                 }
-                scope 31 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                    debug self => std::ptr::NonNull<T>{ .0 => _47, }; // in scope 31 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                scope 17 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<T>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                    debug self => _15;   // in scope 17 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                }
+                scope 18 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                    debug self => std::ptr::NonNull<T>{ .0 => _32, }; // in scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
                 }
             }
         }
     }
 
     bb0: {
-        StorageLive(_14);                // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:19
+        StorageLive(_8);                 // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:19
+        _30 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_10);                // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _10 = Ne(_30, const _);          // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                         // + literal: Const { ty: *const T, val: Unevaluated(ptr::assume_not_null::{constant#0}, [T, *const T], None) }
+        assume(move _10);                // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_10);                // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         StorageLive(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _45 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _4 = _45 as *mut T (PtrToPtr);   // scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        _16 = _4 as *mut u8 (PtrToPtr);  // scope 5 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_17);                // scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_18);                // scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _18 = _16 as *mut () (PtrToPtr); // scope 9 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _17 = move _18 as usize (Transmute); // scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_18);                // scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _3 = Eq(move _17, const 0_usize); // scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_17);                // scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _2 = Not(move _3);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        assume(move _2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _5 = Not(const _);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        switchInt(move _5) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _2 = Not(const _);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb1: {
-        StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_8);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _8 = ((*_1).1: *mut T);          // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _19 = _8 as *mut u8 (PtrToPtr);  // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_20);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_21);                // scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _21 = _19 as *mut () (PtrToPtr); // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _20 = move _21 as usize (Transmute); // scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_21);                // scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _7 = Eq(move _20, const 0_usize); // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_20);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_8);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _6 = Not(move _7);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        assume(move _6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _4 = ((*_1).1: *mut T);          // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _3 = move _4 as *const T (Pointer(MutToConstPointer)); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_11);                // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _11 = Ne(_3, const _);           // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                         // + literal: Const { ty: *const T, val: Unevaluated(ptr::assume_not_null::{constant#0}, [T, *const T], None) }
+        assume(move _11);                // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_11);                // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         goto -> bb2;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb2: {
-        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_10);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_11);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _46 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _11 = _46 as *mut T (PtrToPtr);  // scope 16 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        _10 = move _11 as *const T (Pointer(MutToConstPointer)); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_11);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_12);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_13);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _13 = ((*_1).1: *mut T);         // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _12 = move _13 as *const T (Pointer(MutToConstPointer)); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_13);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _9 = Eq(move _10, move _12);     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_12);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_10);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        switchInt(move _9) -> [0: bb4, otherwise: bb3]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _31 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _7 = ((*_1).1: *mut T);          // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _6 = move _7 as *const T (Pointer(MutToConstPointer)); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _5 = Eq(_31, move _6);           // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _5) -> [0: bb4, otherwise: bb3]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb3: {
@@ -232,106 +159,92 @@ fn slice_iter_mut_next_back(_1: &mut std::slice::IterMut<'_, T>) -> Option<&mut 
     }
 
     bb4: {
-        StorageLive(_15);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_22);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_23);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _23 = const _;                   // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        switchInt(move _23) -> [0: bb7, otherwise: bb6]; // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_12);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_13);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _13 = const _;                   // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _13) -> [0: bb7, otherwise: bb6]; // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb5: {
-        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_14);                // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:19
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_8);                 // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:19
         return;                          // scope 0 at $DIR/slice_iter_next.rs:+2:2: +2:2
     }
 
     bb6: {
-        StorageLive(_24);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_25);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _25 = ((*_1).1: *mut T);         // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_28);                // scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_29);                // scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _29 = _25 as *mut u8 (PtrToPtr); // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_31);                // scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_32);                // scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_33);                // scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        StorageDead(_33);                // scope 22 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        StorageDead(_32);                // scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_34);                // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_35);                // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _35 = _29 as *const u8 (Pointer(MutToConstPointer)); // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _34 = arith_offset::<u8>(move _35, const -1_isize) -> [return: bb9, unwind unreachable]; // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_14);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_15);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_16);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _17 = ((*_1).1: *mut T);         // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _16 = _17 as *mut u8 (PtrToPtr); // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_20);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_21);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_22);                // scope 13 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_22);                // scope 13 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_21);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_23);                // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_24);                // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _24 = _16 as *const u8 (Pointer(MutToConstPointer)); // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _23 = arith_offset::<u8>(move _24, const -1_isize) -> [return: bb9, unwind unreachable]; // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const u8, isize) -> *const u8 {arith_offset::<u8>}, val: Value(<ZST>) }
     }
 
     bb7: {
-        StorageLive(_26);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_27);                // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _27 = ((*_1).1: *mut T);         // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_40);                // scope 33 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_41);                // scope 33 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_42);                // scope 34 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        StorageDead(_42);                // scope 34 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        StorageDead(_41);                // scope 33 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_43);                // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_44);                // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _44 = _27 as *const T (Pointer(MutToConstPointer)); // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _43 = offset::<T>(move _44, const -1_isize) -> [return: bb10, unwind unreachable]; // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_18);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_19);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _19 = ((*_1).1: *mut T);         // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_25);                // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_26);                // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_27);                // scope 21 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_27);                // scope 21 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_26);                // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_28);                // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_29);                // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _29 = _19 as *const T (Pointer(MutToConstPointer)); // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _28 = offset::<T>(move _29, const -1_isize) -> [return: bb10, unwind unreachable]; // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const T, isize) -> *const T {offset::<T>}, val: Value(<ZST>) }
     }
 
     bb8: {
-        StorageDead(_23);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_22);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _14 = &mut (*_15);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _0 = Option::<&mut T>::Some(_14); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_15);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_13);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_12);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _8 = &mut (*_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _0 = Option::<&mut T>::Some(_8); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         goto -> bb5;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb9: {
-        StorageDead(_35);                // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _28 = move _34 as *mut u8 (PtrToPtr); // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_34);                // scope 25 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_31);                // scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_29);                // scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_30);                // scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_36);                // scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _36 = _28 as *mut () (PtrToPtr); // scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_37);                // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageLive(_38);                // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageLive(_39);                // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _39 = _36 as *const () (Pointer(MutToConstPointer)); // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _38 = ptr::metadata::PtrComponents::<T> { data_address: move _39, metadata: const () }; // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_39);                // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _37 = ptr::metadata::PtrRepr::<T> { const_ptr: move _38 }; // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_38);                // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _24 = (_37.1: *mut T);           // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_37);                // scope 29 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_36);                // scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_30);                // scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_28);                // scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_25);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        ((*_1).1: *mut T) = move _24;    // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_24);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _47 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _15 = _47 as *mut T (PtrToPtr);  // scope 31 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        goto -> bb8;                     // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_24);                // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _15 = move _23 as *mut u8 (PtrToPtr); // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_23);                // scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_20);                // scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_16);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _14 = _15 as *mut T (PtrToPtr);  // scope 17 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_15);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        ((*_1).1: *mut T) = move _14;    // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_14);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _32 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _9 = _32 as *mut T (PtrToPtr);   // scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        goto -> bb8;                     // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb10: {
-        StorageDead(_44);                // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _26 = move _43 as *mut T (PtrToPtr); // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_43);                // scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_40);                // scope 33 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_27);                // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        ((*_1).1: *mut T) = move _26;    // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_26);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _15 = ((*_1).1: *mut T);         // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        goto -> bb8;                     // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_29);                // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _18 = move _28 as *mut T (PtrToPtr); // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_28);                // scope 24 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_25);                // scope 20 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_19);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        ((*_1).1: *mut T) = move _18;    // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _9 = ((*_1).1: *mut T);          // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        goto -> bb8;                     // scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 }

--- a/tests/mir-opt/slice_iter_next.slice_iter_next.runtime-optimized.after.mir
+++ b/tests/mir-opt/slice_iter_next.slice_iter_next.runtime-optimized.after.mir
@@ -5,55 +5,58 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
     let mut _0: std::option::Option<&T>; // return place in scope 0 at $DIR/slice_iter_next.rs:+0:68: +0:81
     scope 1 (inlined <std::slice::Iter<'_, T> as Iterator>::next) { // at $DIR/slice_iter_next.rs:18:8: 18:14
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _2: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _3: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _2: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _3: std::ptr::NonNull<T>; // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         let mut _4: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         let mut _5: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let _6: &T;                      // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _9: usize;               // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _21: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _22: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _6: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _7: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _8: std::ptr::NonNull<T>; // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _9: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let _10: &T;                     // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let _11: *const T;               // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _14: usize;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         scope 2 {
             scope 3 (inlined NonNull::<T>::as_const_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => std::ptr::NonNull<T>{ .0 => _21, }; // in scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                debug self => _3;        // in scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
             }
             scope 4 (inlined ptr::assume_not_null::<T>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug ptr => _21;        // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                let mut _7: bool;        // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                debug ptr => _2;         // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                let mut _12: bool;       // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                 scope 5 {
                 }
             }
             scope 6 (inlined ptr::assume_not_null::<T>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug ptr => _3;         // in scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                let mut _8: bool;        // in scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                debug ptr => _5;         // in scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                let mut _13: bool;       // in scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                 scope 7 {
                 }
             }
             scope 8 (inlined NonNull::<T>::as_const_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => std::ptr::NonNull<T>{ .0 => _22, }; // in scope 8 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                debug self => _8;        // in scope 8 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
             }
             scope 9 (inlined std::slice::Iter::<'_, T>::post_inc_start) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
                 debug self => _1;        // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug offset => _9;      // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _10: bool;       // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _11: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _12: *const u8;  // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _13: *const u8;  // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _14: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug offset => _14;     // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
                 let mut _15: std::ptr::NonNull<T>; // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _16: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _23: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _16: bool;       // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _17: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _18: *const u8;  // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _19: *const u8;  // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _20: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _21: std::ptr::NonNull<T>; // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _22: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
                 scope 10 {
-                    debug old => _23;    // in scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                    debug old => _11;    // in scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
                     scope 12 {
                         scope 20 (inlined ptr::const_ptr::<impl *const T>::add) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                            debug self => _23; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            debug count => _9; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            let mut _20: isize; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug self => _11; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug count => _14; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            let mut _26: isize; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                             scope 21 {
                                 scope 22 (inlined ptr::const_ptr::<impl *const T>::offset) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                                    debug self => _23; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                                    debug count => _20; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                    debug self => _11; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                    debug count => _26; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                                     scope 23 {
                                     }
                                 }
@@ -61,30 +64,30 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
                         }
                     }
                     scope 13 (inlined ptr::const_ptr::<impl *const T>::cast::<u8>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                        debug self => _14; // in scope 13 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug self => _20; // in scope 13 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                     }
                     scope 14 (inlined ptr::const_ptr::<impl *const u8>::wrapping_sub) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                        debug self => _13; // in scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        debug count => _9; // in scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        let mut _17: isize; // in scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        let mut _18: isize; // in scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug self => _19; // in scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug count => _14; // in scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        let mut _23: isize; // in scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        let mut _24: isize; // in scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                         scope 15 (inlined core::num::<impl isize>::wrapping_neg) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            debug self => _18; // in scope 15 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                            let mut _19: isize; // in scope 15 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            debug self => _24; // in scope 15 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            let mut _25: isize; // in scope 15 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
                             scope 16 (inlined core::num::<impl isize>::wrapping_sub) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                debug self => _19; // in scope 16 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                debug rhs => _18; // in scope 16 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                debug self => _25; // in scope 16 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                debug rhs => _24; // in scope 16 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
                             }
                         }
                         scope 17 (inlined ptr::const_ptr::<impl *const u8>::wrapping_offset) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            debug self => _13; // in scope 17 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            debug count => _17; // in scope 17 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug self => _19; // in scope 17 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug count => _23; // in scope 17 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                             scope 18 {
                             }
                         }
                     }
                     scope 19 (inlined ptr::const_ptr::<impl *const u8>::cast::<T>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                        debug self => _12; // in scope 19 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug self => _18; // in scope 19 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                     }
                 }
                 scope 11 {
@@ -94,43 +97,53 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
     }
 
     bb0: {
-        StorageLive(_6);                 // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:14
-        _21 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_7);                 // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _7 = Ne(_21, const _);           // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageLive(_10);                // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:14
+        StorageLive(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _3 = ((*_1).0: std::ptr::NonNull<T>); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _2 = (_3.0: *const T);           // scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_12);                // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _12 = Ne(_2, const _);           // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // + literal: Const { ty: *const T, val: Unevaluated(ptr::assume_not_null::{constant#0}, [T, *const T], None) }
-        assume(move _7);                 // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_7);                 // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageLive(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _2 = Not(const _);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        assume(move _12);                // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_12);                // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _4 = Not(const _);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _4) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb1: {
-        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _3 = ((*_1).1: *const T);        // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_8);                 // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _8 = Ne(_3, const _);            // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _5 = ((*_1).1: *const T);        // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_13);                // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _13 = Ne(_5, const _);           // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // + literal: Const { ty: *const T, val: Unevaluated(ptr::assume_not_null::{constant#0}, [T, *const T], None) }
-        assume(move _8);                 // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_8);                 // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        assume(move _13);                // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_13);                // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         goto -> bb2;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb2: {
-        StorageDead(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _22 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _5 = ((*_1).1: *const T);        // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _4 = Eq(_22, move _5);           // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        switchInt(move _4) -> [0: bb4, otherwise: bb3]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_8);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _8 = ((*_1).0: std::ptr::NonNull<T>); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _7 = (_8.0: *const T);           // scope 8 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageDead(_8);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _9 = ((*_1).1: *const T);        // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _6 = Eq(move _7, move _9);       // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _6) -> [0: bb4, otherwise: bb3]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb3: {
@@ -139,72 +152,79 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
     }
 
     bb4: {
-        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _23 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 11 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_10);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _10 = const _;                   // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        switchInt(move _10) -> [0: bb7, otherwise: bb6]; // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_11);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_14);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_15);                // scope 11 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _15 = ((*_1).0: std::ptr::NonNull<T>); // scope 11 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _11 = move (_15.0: *const T);    // scope 11 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_15);                // scope 11 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_16);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _16 = const _;                   // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _16) -> [0: bb7, otherwise: bb6]; // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb5: {
-        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_6);                 // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:14
+        StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_10);                // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:14
         return;                          // scope 0 at $DIR/slice_iter_next.rs:+2:2: +2:2
     }
 
     bb6: {
-        StorageLive(_11);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_12);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_13);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_14);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _14 = ((*_1).1: *const T);       // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _13 = _14 as *const u8 (PtrToPtr); // scope 13 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageDead(_14);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_17);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageLive(_18);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageLive(_19);                // scope 15 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        StorageDead(_19);                // scope 15 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        StorageDead(_18);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        _12 = arith_offset::<u8>(_13, const -1_isize) -> [return: bb9, unwind unreachable]; // scope 18 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_17);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_18);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_19);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_20);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _20 = ((*_1).1: *const T);       // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _19 = _20 as *const u8 (PtrToPtr); // scope 13 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_20);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_23);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_24);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_25);                // scope 15 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        _23 = const -1_isize;            // scope 16 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_25);                // scope 15 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_24);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _18 = arith_offset::<u8>(_19, _23) -> [return: bb9, unwind unreachable]; // scope 18 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const u8, isize) -> *const u8 {arith_offset::<u8>}, val: Value(<ZST>) }
     }
 
     bb7: {
-        StorageLive(_15);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_16);                // scope 12 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_20);                // scope 21 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        _16 = offset::<T>(_23, const 1_isize) -> [return: bb10, unwind unreachable]; // scope 23 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_21);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_22);                // scope 12 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_26);                // scope 21 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _26 = const 1_isize;             // scope 21 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _22 = offset::<T>(_11, _26) -> [return: bb10, unwind unreachable]; // scope 23 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const T, isize) -> *const T {offset::<T>}, val: Value(<ZST>) }
     }
 
     bb8: {
-        StorageDead(_10);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _6 = &(*_23);                    // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _0 = Option::<&T>::Some(_6);     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_16);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_14);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _10 = &(*_11);                   // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _0 = Option::<&T>::Some(_10);    // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_11);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         goto -> bb5;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb9: {
-        StorageDead(_17);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageDead(_13);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _11 = _12 as *const T (PtrToPtr); // scope 19 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageDead(_12);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        ((*_1).1: *const T) = move _11;  // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_11);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_23);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_19);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _17 = _18 as *const T (PtrToPtr); // scope 19 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_18);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        ((*_1).1: *const T) = move _17;  // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_17);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         goto -> bb8;                     // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb10: {
-        StorageDead(_20);                // scope 21 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        _15 = move _16 as std::ptr::NonNull<T> (Transmute); // scope 12 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_16);                // scope 12 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        ((*_1).0: std::ptr::NonNull<T>) = move _15; // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_15);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_26);                // scope 21 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _21 = move _22 as std::ptr::NonNull<T> (Transmute); // scope 12 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_22);                // scope 12 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        ((*_1).0: std::ptr::NonNull<T>) = move _21; // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_21);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         goto -> bb8;                     // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 }

--- a/tests/mir-opt/slice_iter_next.slice_iter_next.runtime-optimized.after.mir
+++ b/tests/mir-opt/slice_iter_next.slice_iter_next.runtime-optimized.after.mir
@@ -1,0 +1,364 @@
+// MIR for `slice_iter_next` after runtime-optimized
+
+fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
+    debug it => _1;                      // in scope 0 at $DIR/slice_iter_next.rs:+0:31: +0:33
+    let mut _0: std::option::Option<&T>; // return place in scope 0 at $DIR/slice_iter_next.rs:+0:68: +0:81
+    scope 1 (inlined <std::slice::Iter<'_, T> as Iterator>::next) { // at $DIR/slice_iter_next.rs:18:8: 18:14
+        debug self => _1;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _2: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _3: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _4: *mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _5: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _6: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _7: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _8: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _9: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _10: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _11: *mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _12: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let _13: &T;                     // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let _14: *const T;               // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _21: usize;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _44: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _45: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        scope 2 {
+            scope 3 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => std::ptr::NonNull<T>{ .0 => _44, }; // in scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+            }
+            scope 4 (inlined ptr::mut_ptr::<impl *mut T>::is_null) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => _4;        // in scope 4 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                let mut _15: *mut u8;    // in scope 4 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                scope 5 {
+                    scope 6 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        debug ptr => _15; // in scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        let mut _16: usize; // in scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                        scope 7 (inlined ptr::mut_ptr::<impl *mut u8>::addr) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            debug self => _15; // in scope 7 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            let mut _17: *mut (); // in scope 7 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            scope 8 {
+                                scope 9 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                    debug self => _15; // in scope 9 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            scope 10 (inlined ptr::const_ptr::<impl *const T>::is_null) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => _8;        // in scope 10 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                let mut _18: *const u8;  // in scope 10 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                scope 11 {
+                    scope 12 (inlined ptr::const_ptr::<impl *const T>::is_null::runtime_impl) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug ptr => _18; // in scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        let mut _19: usize; // in scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        scope 13 (inlined ptr::const_ptr::<impl *const u8>::addr) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug self => _18; // in scope 13 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            let mut _20: *const (); // in scope 13 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            scope 14 {
+                                scope 15 (inlined ptr::const_ptr::<impl *const u8>::cast::<()>) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                    debug self => _18; // in scope 15 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            scope 16 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => std::ptr::NonNull<T>{ .0 => _45, }; // in scope 16 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+            }
+            scope 17 (inlined std::slice::Iter::<'_, T>::post_inc_start) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => _1;        // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug offset => _21;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _22: bool;       // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _23: *const T;   // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _24: *const T;   // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _25: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let _26: *mut T;         // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _27: std::ptr::NonNull<T>; // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _28: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _29: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _46: *const T;   // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _47: *const T;   // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _48: *const T;   // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                scope 18 {
+                    debug old => _26;    // in scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                    scope 19 {
+                        scope 34 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                            debug self => std::ptr::NonNull<T>{ .0 => _48, }; // in scope 34 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                        }
+                        scope 35 (inlined ptr::mut_ptr::<impl *mut T>::add) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                            debug self => _29; // in scope 35 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            debug count => _21; // in scope 35 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            let mut _38: isize; // in scope 35 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            scope 36 {
+                                scope 37 (inlined ptr::mut_ptr::<impl *mut T>::offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                    debug self => _29; // in scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                    debug count => _38; // in scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                    let mut _39: *const T; // in scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                    let mut _40: *const T; // in scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                    scope 38 {
+                                    }
+                                }
+                            }
+                        }
+                        scope 39 (inlined NonNull::<T>::new_unchecked) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                            debug ptr => _28; // in scope 39 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                            let mut _41: *const T; // in scope 39 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                            let mut _42: *mut T; // in scope 39 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 40 {
+                                scope 41 (inlined NonNull::<T>::new_unchecked::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug ptr => _42; // in scope 41 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    scope 42 (inlined ptr::mut_ptr::<impl *mut T>::is_null) { // at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                                        debug self => _42; // in scope 42 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        let mut _43: *mut u8; // in scope 42 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        scope 43 {
+                                            scope 44 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                                debug ptr => _43; // in scope 44 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                                scope 45 (inlined ptr::mut_ptr::<impl *mut u8>::addr) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                                    debug self => _43; // in scope 45 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                                    scope 46 {
+                                                        scope 47 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                                            debug self => _43; // in scope 47 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                scope 20 (inlined ptr::const_ptr::<impl *const T>::wrapping_byte_sub) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                    debug self => _24;   // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                    debug count => _21;  // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                    let mut _30: *const u8; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                    let mut _31: *const u8; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                    scope 21 (inlined ptr::const_ptr::<impl *const T>::cast::<u8>) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug self => _24; // in scope 21 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                    }
+                    scope 22 (inlined ptr::const_ptr::<impl *const u8>::wrapping_sub) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug self => _31; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug count => _21; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        let mut _32: isize; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        let mut _33: isize; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        scope 23 (inlined core::num::<impl isize>::wrapping_neg) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug self => _33; // in scope 23 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            let mut _34: isize; // in scope 23 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            scope 24 (inlined core::num::<impl isize>::wrapping_sub) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                debug self => _34; // in scope 24 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                debug rhs => _33; // in scope 24 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            }
+                        }
+                        scope 25 (inlined ptr::const_ptr::<impl *const u8>::wrapping_offset) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug self => _31; // in scope 25 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug count => _32; // in scope 25 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            scope 26 {
+                            }
+                        }
+                    }
+                    scope 27 (inlined ptr::const_ptr::<impl *const u8>::with_metadata_of::<T>) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug self => _30; // in scope 27 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug meta => _24; // in scope 27 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        let mut _35: *const (); // in scope 27 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        scope 28 (inlined std::ptr::metadata::<T>) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug ptr => _24; // in scope 28 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                            scope 29 {
+                            }
+                        }
+                        scope 30 (inlined std::ptr::from_raw_parts::<T>) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug data_address => _35; // in scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                            debug metadata => const (); // in scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                            let mut _36: std::ptr::metadata::PtrRepr<T>; // in scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                            let mut _37: std::ptr::metadata::PtrComponents<T>; // in scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                            scope 31 {
+                            }
+                        }
+                    }
+                }
+                scope 32 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                    debug self => std::ptr::NonNull<T>{ .0 => _46, }; // in scope 32 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                }
+                scope 33 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                    debug self => std::ptr::NonNull<T>{ .0 => _47, }; // in scope 33 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_13);                // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:14
+        StorageLive(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _44 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _4 = _44 as *mut T (PtrToPtr);   // scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        _15 = _4 as *mut u8 (PtrToPtr);  // scope 5 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_16);                // scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_17);                // scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _17 = _15 as *mut () (PtrToPtr); // scope 9 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _16 = move _17 as usize (Transmute); // scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_17);                // scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _3 = Eq(move _16, const 0_usize); // scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_16);                // scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _2 = Not(move _3);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        assume(move _2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _5 = Not(const _);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _5) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb1: {
+        StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_8);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _8 = ((*_1).1: *const T);        // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _18 = _8 as *const u8 (PtrToPtr); // scope 11 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_19);                // scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_20);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _20 = _18 as *const () (PtrToPtr); // scope 15 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _19 = move _20 as usize (Transmute); // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_20);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _7 = Eq(move _19, const 0_usize); // scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_19);                // scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_8);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _6 = Not(move _7);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        assume(move _6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        goto -> bb2;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb2: {
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_10);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_11);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _45 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _11 = _45 as *mut T (PtrToPtr);  // scope 16 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        _10 = move _11 as *const T (Pointer(MutToConstPointer)); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_11);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_12);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _12 = ((*_1).1: *const T);       // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _9 = Eq(move _10, move _12);     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_12);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_10);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _9) -> [0: bb4, otherwise: bb3]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb3: {
+        _0 = Option::<&T>::None;         // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        goto -> bb5;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb4: {
+        StorageLive(_14);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_21);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_26);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_22);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _22 = const _;                   // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _22) -> [0: bb7, otherwise: bb6]; // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb5: {
+        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_13);                // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:14
+        return;                          // scope 0 at $DIR/slice_iter_next.rs:+2:2: +2:2
+    }
+
+    bb6: {
+        StorageLive(_23);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_24);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _24 = ((*_1).1: *const T);       // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_30);                // scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_31);                // scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _31 = _24 as *const u8 (PtrToPtr); // scope 21 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_32);                // scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_33);                // scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_34);                // scope 23 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_34);                // scope 23 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_33);                // scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _30 = arith_offset::<u8>(_31, const -1_isize) -> [return: bb9, unwind unreachable]; // scope 26 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const u8, isize) -> *const u8 {arith_offset::<u8>}, val: Value(<ZST>) }
+    }
+
+    bb7: {
+        _47 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _26 = _47 as *mut T (PtrToPtr);  // scope 33 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageLive(_27);                // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_28);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_29);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _48 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _29 = _48 as *mut T (PtrToPtr);  // scope 34 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageLive(_38);                // scope 36 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_39);                // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_40);                // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _40 = _29 as *const T (Pointer(MutToConstPointer)); // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _39 = offset::<T>(move _40, const 1_isize) -> [return: bb10, unwind unreachable]; // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const T, isize) -> *const T {offset::<T>}, val: Value(<ZST>) }
+    }
+
+    bb8: {
+        StorageDead(_22);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_26);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_21);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _13 = &(*_14);                   // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _0 = Option::<&T>::Some(_13);    // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_14);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        goto -> bb5;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb9: {
+        StorageDead(_32);                // scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_31);                // scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_35);                // scope 27 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _35 = _30 as *const () (PtrToPtr); // scope 27 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_36);                // scope 31 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageLive(_37);                // scope 31 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _37 = ptr::metadata::PtrComponents::<T> { data_address: _35, metadata: const () }; // scope 31 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _36 = ptr::metadata::PtrRepr::<T> { const_ptr: move _37 }; // scope 31 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_37);                // scope 31 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _23 = (_36.0: *const T);         // scope 31 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_36);                // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_35);                // scope 27 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_30);                // scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_24);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        ((*_1).1: *const T) = move _23;  // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_23);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_25);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _46 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _25 = _46 as *mut T (PtrToPtr);  // scope 32 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        _14 = move _25 as *const T (Pointer(MutToConstPointer)); // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_25);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        goto -> bb8;                     // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+
+    bb10: {
+        StorageDead(_40);                // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _28 = move _39 as *mut T (PtrToPtr); // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_39);                // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_38);                // scope 36 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_29);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_41);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_42);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_43);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _41 = _28 as *const T (Pointer(MutToConstPointer)); // scope 40 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        _27 = NonNull::<T> { pointer: _41 }; // scope 40 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageDead(_43);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_42);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_41);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_28);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        ((*_1).0: std::ptr::NonNull<T>) = move _27; // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_27);                // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _14 = _26 as *const T (Pointer(MutToConstPointer)); // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        goto -> bb8;                     // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+    }
+}

--- a/tests/mir-opt/slice_iter_next.slice_iter_next.runtime-optimized.after.mir
+++ b/tests/mir-opt/slice_iter_next.slice_iter_next.runtime-optimized.after.mir
@@ -6,248 +6,131 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
     scope 1 (inlined <std::slice::Iter<'_, T> as Iterator>::next) { // at $DIR/slice_iter_next.rs:18:8: 18:14
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         let mut _2: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _3: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _4: *mut T;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _5: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _6: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _7: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _8: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _9: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _10: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _11: *mut T;             // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _12: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let _13: &T;                     // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let _14: *const T;               // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _21: usize;              // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _44: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        let mut _45: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _3: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _4: bool;                // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _5: *const T;            // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let _6: &T;                      // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _9: usize;               // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _21: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        let mut _22: *const T;           // in scope 1 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         scope 2 {
-            scope 3 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => std::ptr::NonNull<T>{ .0 => _44, }; // in scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+            scope 3 (inlined NonNull::<T>::as_const_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => std::ptr::NonNull<T>{ .0 => _21, }; // in scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
             }
-            scope 4 (inlined ptr::mut_ptr::<impl *mut T>::is_null) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => _4;        // in scope 4 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                let mut _15: *mut u8;    // in scope 4 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+            scope 4 (inlined ptr::assume_not_null::<T>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug ptr => _21;        // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                let mut _7: bool;        // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                 scope 5 {
-                    scope 6 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        debug ptr => _15; // in scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        let mut _16: usize; // in scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                        scope 7 (inlined ptr::mut_ptr::<impl *mut u8>::addr) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            debug self => _15; // in scope 7 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            let mut _17: *mut (); // in scope 7 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            scope 8 {
-                                scope 9 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                    debug self => _15; // in scope 9 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                }
+            }
+            scope 6 (inlined ptr::assume_not_null::<T>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug ptr => _3;         // in scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                let mut _8: bool;        // in scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                scope 7 {
+                }
+            }
+            scope 8 (inlined NonNull::<T>::as_const_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => std::ptr::NonNull<T>{ .0 => _22, }; // in scope 8 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+            }
+            scope 9 (inlined std::slice::Iter::<'_, T>::post_inc_start) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug self => _1;        // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                debug offset => _9;      // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _10: bool;       // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _11: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _12: *const u8;  // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _13: *const u8;  // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _14: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _15: std::ptr::NonNull<T>; // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _16: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                let mut _23: *const T;   // in scope 9 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                scope 10 {
+                    debug old => _23;    // in scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                    scope 12 {
+                        scope 20 (inlined ptr::const_ptr::<impl *const T>::add) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                            debug self => _23; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug count => _9; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            let mut _20: isize; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            scope 21 {
+                                scope 22 (inlined ptr::const_ptr::<impl *const T>::offset) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                    debug self => _23; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                    debug count => _20; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                    scope 23 {
+                                    }
                                 }
                             }
                         }
                     }
+                    scope 13 (inlined ptr::const_ptr::<impl *const T>::cast::<u8>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                        debug self => _14; // in scope 13 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                    }
+                    scope 14 (inlined ptr::const_ptr::<impl *const u8>::wrapping_sub) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                        debug self => _13; // in scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug count => _9; // in scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        let mut _17: isize; // in scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        let mut _18: isize; // in scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        scope 15 (inlined core::num::<impl isize>::wrapping_neg) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug self => _18; // in scope 15 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            let mut _19: isize; // in scope 15 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            scope 16 (inlined core::num::<impl isize>::wrapping_sub) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                debug self => _19; // in scope 16 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                debug rhs => _18; // in scope 16 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                            }
+                        }
+                        scope 17 (inlined ptr::const_ptr::<impl *const u8>::wrapping_offset) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug self => _13; // in scope 17 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            debug count => _17; // in scope 17 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                            scope 18 {
+                            }
+                        }
+                    }
+                    scope 19 (inlined ptr::const_ptr::<impl *const u8>::cast::<T>) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+                        debug self => _12; // in scope 19 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                    }
                 }
-            }
-            scope 10 (inlined ptr::const_ptr::<impl *const T>::is_null) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => _8;        // in scope 10 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                let mut _18: *const u8;  // in scope 10 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                 scope 11 {
-                    scope 12 (inlined ptr::const_ptr::<impl *const T>::is_null::runtime_impl) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        debug ptr => _18; // in scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        let mut _19: usize; // in scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        scope 13 (inlined ptr::const_ptr::<impl *const u8>::addr) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            debug self => _18; // in scope 13 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            let mut _20: *const (); // in scope 13 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            scope 14 {
-                                scope 15 (inlined ptr::const_ptr::<impl *const u8>::cast::<()>) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                                    debug self => _18; // in scope 15 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            scope 16 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => std::ptr::NonNull<T>{ .0 => _45, }; // in scope 16 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-            }
-            scope 17 (inlined std::slice::Iter::<'_, T>::post_inc_start) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug self => _1;        // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                debug offset => _21;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _22: bool;       // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _23: *const T;   // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _24: *const T;   // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _25: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let _26: *mut T;         // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _27: std::ptr::NonNull<T>; // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _28: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _29: *mut T;     // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _46: *const T;   // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _47: *const T;   // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                let mut _48: *const T;   // in scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                scope 18 {
-                    debug old => _26;    // in scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                    scope 19 {
-                        scope 34 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                            debug self => std::ptr::NonNull<T>{ .0 => _48, }; // in scope 34 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-                        }
-                        scope 35 (inlined ptr::mut_ptr::<impl *mut T>::add) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                            debug self => _29; // in scope 35 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            debug count => _21; // in scope 35 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            let mut _38: isize; // in scope 35 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                            scope 36 {
-                                scope 37 (inlined ptr::mut_ptr::<impl *mut T>::offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                    debug self => _29; // in scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                    debug count => _38; // in scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                    let mut _39: *const T; // in scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                    let mut _40: *const T; // in scope 37 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                    scope 38 {
-                                    }
-                                }
-                            }
-                        }
-                        scope 39 (inlined NonNull::<T>::new_unchecked) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                            debug ptr => _28; // in scope 39 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-                            let mut _41: *const T; // in scope 39 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-                            let mut _42: *mut T; // in scope 39 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            scope 40 {
-                                scope 41 (inlined NonNull::<T>::new_unchecked::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                                    debug ptr => _42; // in scope 41 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                                    scope 42 (inlined ptr::mut_ptr::<impl *mut T>::is_null) { // at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-                                        debug self => _42; // in scope 42 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        let mut _43: *mut u8; // in scope 42 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        scope 43 {
-                                            scope 44 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                                debug ptr => _43; // in scope 44 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                                scope 45 (inlined ptr::mut_ptr::<impl *mut u8>::addr) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                                    debug self => _43; // in scope 45 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                                    scope 46 {
-                                                        scope 47 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                                            debug self => _43; // in scope 47 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                scope 20 (inlined ptr::const_ptr::<impl *const T>::wrapping_byte_sub) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                    debug self => _24;   // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                    debug count => _21;  // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                    let mut _30: *const u8; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                    let mut _31: *const u8; // in scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                    scope 21 (inlined ptr::const_ptr::<impl *const T>::cast::<u8>) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        debug self => _24; // in scope 21 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                    }
-                    scope 22 (inlined ptr::const_ptr::<impl *const u8>::wrapping_sub) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        debug self => _31; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        debug count => _21; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        let mut _32: isize; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        let mut _33: isize; // in scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        scope 23 (inlined core::num::<impl isize>::wrapping_neg) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            debug self => _33; // in scope 23 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                            let mut _34: isize; // in scope 23 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                            scope 24 (inlined core::num::<impl isize>::wrapping_sub) { // at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                debug self => _34; // in scope 24 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                debug rhs => _33; // in scope 24 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                            }
-                        }
-                        scope 25 (inlined ptr::const_ptr::<impl *const u8>::wrapping_offset) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            debug self => _31; // in scope 25 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            debug count => _32; // in scope 25 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            scope 26 {
-                            }
-                        }
-                    }
-                    scope 27 (inlined ptr::const_ptr::<impl *const u8>::with_metadata_of::<T>) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        debug self => _30; // in scope 27 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        debug meta => _24; // in scope 27 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        let mut _35: *const (); // in scope 27 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        scope 28 (inlined std::ptr::metadata::<T>) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            debug ptr => _24; // in scope 28 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                            scope 29 {
-                            }
-                        }
-                        scope 30 (inlined std::ptr::from_raw_parts::<T>) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                            debug data_address => _35; // in scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                            debug metadata => const (); // in scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                            let mut _36: std::ptr::metadata::PtrRepr<T>; // in scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                            let mut _37: std::ptr::metadata::PtrComponents<T>; // in scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                            scope 31 {
-                            }
-                        }
-                    }
-                }
-                scope 32 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                    debug self => std::ptr::NonNull<T>{ .0 => _46, }; // in scope 32 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-                }
-                scope 33 (inlined NonNull::<T>::as_ptr) { // at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-                    debug self => std::ptr::NonNull<T>{ .0 => _47, }; // in scope 33 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
                 }
             }
         }
     }
 
     bb0: {
-        StorageLive(_13);                // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:14
+        StorageLive(_6);                 // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:14
+        _21 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_7);                 // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _7 = Ne(_21, const _);           // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                         // + literal: Const { ty: *const T, val: Unevaluated(ptr::assume_not_null::{constant#0}, [T, *const T], None) }
+        assume(move _7);                 // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_7);                 // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         StorageLive(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _44 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _4 = _44 as *mut T (PtrToPtr);   // scope 3 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        _15 = _4 as *mut u8 (PtrToPtr);  // scope 5 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_16);                // scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_17);                // scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _17 = _15 as *mut () (PtrToPtr); // scope 9 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _16 = move _17 as usize (Transmute); // scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_17);                // scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _3 = Eq(move _16, const 0_usize); // scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_16);                // scope 6 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _2 = Not(move _3);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        assume(move _2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _5 = Not(const _);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        switchInt(move _5) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _2 = Not(const _);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb1: {
-        StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_8);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _8 = ((*_1).1: *const T);        // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _18 = _8 as *const u8 (PtrToPtr); // scope 11 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageLive(_19);                // scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageLive(_20);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        _20 = _18 as *const () (PtrToPtr); // scope 15 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        _19 = move _20 as usize (Transmute); // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageDead(_20);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        _7 = Eq(move _19, const 0_usize); // scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageDead(_19);                // scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageDead(_8);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _6 = Not(move _7);               // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        assume(move _6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _3 = ((*_1).1: *const T);        // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_8);                 // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _8 = Ne(_3, const _);            // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                         // + literal: Const { ty: *const T, val: Unevaluated(ptr::assume_not_null::{constant#0}, [T, *const T], None) }
+        assume(move _8);                 // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_8);                 // scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         goto -> bb2;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb2: {
+        StorageDead(_2);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _22 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _5 = ((*_1).1: *const T);        // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _4 = Eq(_22, move _5);           // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_10);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_11);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _45 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _11 = _45 as *mut T (PtrToPtr);  // scope 16 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        _10 = move _11 as *const T (Pointer(MutToConstPointer)); // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_11);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_12);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _12 = ((*_1).1: *const T);       // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _9 = Eq(move _10, move _12);     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_12);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_10);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        switchInt(move _9) -> [0: bb4, otherwise: bb3]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _4) -> [0: bb4, otherwise: bb3]; // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb3: {
@@ -256,109 +139,72 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
     }
 
     bb4: {
-        StorageLive(_14);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_21);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_26);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_22);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _22 = const _;                   // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        switchInt(move _22) -> [0: bb7, otherwise: bb6]; // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _23 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 11 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_10);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _10 = const _;                   // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        switchInt(move _10) -> [0: bb7, otherwise: bb6]; // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb5: {
-        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_13);                // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:14
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_6);                 // scope 0 at $DIR/slice_iter_next.rs:+1:8: +1:14
         return;                          // scope 0 at $DIR/slice_iter_next.rs:+2:2: +2:2
     }
 
     bb6: {
-        StorageLive(_23);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_24);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _24 = ((*_1).1: *const T);       // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_30);                // scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageLive(_31);                // scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        _31 = _24 as *const u8 (PtrToPtr); // scope 21 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageLive(_32);                // scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageLive(_33);                // scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageLive(_34);                // scope 23 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        StorageDead(_34);                // scope 23 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        StorageDead(_33);                // scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        _30 = arith_offset::<u8>(_31, const -1_isize) -> [return: bb9, unwind unreachable]; // scope 26 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_11);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_12);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_13);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_14);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _14 = ((*_1).1: *const T);       // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _13 = _14 as *const u8 (PtrToPtr); // scope 13 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_14);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_17);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_18);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_19);                // scope 15 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_19);                // scope 15 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_18);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _12 = arith_offset::<u8>(_13, const -1_isize) -> [return: bb9, unwind unreachable]; // scope 18 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const u8, isize) -> *const u8 {arith_offset::<u8>}, val: Value(<ZST>) }
     }
 
     bb7: {
-        _47 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _26 = _47 as *mut T (PtrToPtr);  // scope 33 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        StorageLive(_27);                // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_28);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_29);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _48 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _29 = _48 as *mut T (PtrToPtr);  // scope 34 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        StorageLive(_38);                // scope 36 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_39);                // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_40);                // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _40 = _29 as *const T (Pointer(MutToConstPointer)); // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _39 = offset::<T>(move _40, const 1_isize) -> [return: bb10, unwind unreachable]; // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_15);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_16);                // scope 12 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageLive(_20);                // scope 21 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _16 = offset::<T>(_23, const 1_isize) -> [return: bb10, unwind unreachable]; // scope 23 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                                          // mir::Constant
-                                         // + span: $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                         // + span: $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const T, isize) -> *const T {offset::<T>}, val: Value(<ZST>) }
     }
 
     bb8: {
-        StorageDead(_22);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_26);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_21);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _13 = &(*_14);                   // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _0 = Option::<&T>::Some(_13);    // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_14);                // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_10);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _6 = &(*_23);                    // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _0 = Option::<&T>::Some(_6);     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
         goto -> bb5;                     // scope 2 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb9: {
-        StorageDead(_32);                // scope 22 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageDead(_31);                // scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageLive(_35);                // scope 27 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        _35 = _30 as *const () (PtrToPtr); // scope 27 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageLive(_36);                // scope 31 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageLive(_37);                // scope 31 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _37 = ptr::metadata::PtrComponents::<T> { data_address: _35, metadata: const () }; // scope 31 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _36 = ptr::metadata::PtrRepr::<T> { const_ptr: move _37 }; // scope 31 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_37);                // scope 31 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _23 = (_36.0: *const T);         // scope 31 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_36);                // scope 30 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_35);                // scope 27 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageDead(_30);                // scope 20 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageDead(_24);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        ((*_1).1: *const T) = move _23;  // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_23);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_25);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _46 = (((*_1).0: std::ptr::NonNull<T>).0: *const T); // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _25 = _46 as *mut T (PtrToPtr);  // scope 32 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        _14 = move _25 as *const T (Pointer(MutToConstPointer)); // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_25);                // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        goto -> bb8;                     // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_17);                // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_13);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        _11 = _12 as *const T (PtrToPtr); // scope 19 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_12);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        ((*_1).1: *const T) = move _11;  // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_11);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        goto -> bb8;                     // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 
     bb10: {
-        StorageDead(_40);                // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _28 = move _39 as *mut T (PtrToPtr); // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_39);                // scope 38 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_38);                // scope 36 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_29);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_41);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_42);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageLive(_43);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _41 = _28 as *const T (Pointer(MutToConstPointer)); // scope 40 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        _27 = NonNull::<T> { pointer: _41 }; // scope 40 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        StorageDead(_43);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_42);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_41);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_28);                // scope 19 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        ((*_1).0: std::ptr::NonNull<T>) = move _27; // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        StorageDead(_27);                // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        _14 = _26 as *const T (Pointer(MutToConstPointer)); // scope 18 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
-        goto -> bb8;                     // scope 17 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_20);                // scope 21 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        _15 = move _16 as std::ptr::NonNull<T> (Transmute); // scope 12 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_16);                // scope 12 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        ((*_1).0: std::ptr::NonNull<T>) = move _15; // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        StorageDead(_15);                // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
+        goto -> bb8;                     // scope 10 at $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
     }
 }


### PR DESCRIPTION
I was talking with @saethlin [on discord](https://discord.com/channels/273534239310479360/957720175619215380/1099048088305422429) about how `slice::Iter::next` didn't inline, and they mentioned that it's because it's gigantic in MIR.

So here's a couple minor tweaks that make it about 60 statements shorter, as well as using far fewer scopes and instantiating less.  It's still not under the inline threshold, AFAICT, but hopefully it's on its way.

First commit just adds a test, so this is probably best looked at by looking at the second commit, which had the code changes and shows the diff for how the MIR changed: https://github.com/rust-lang/rust/commit/6c032ecf6e9d5a2bebd8d540cf9489931f96cecf?diff=split#diff-d521311207542ebfd41ce85ce355918f34b75ec303cfdcf8cd829a883733bde8