### PR TITLE
Add comment about `__thread_local_inner` in `thread_local`

### DIFF
--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -152,6 +152,7 @@ macro_rules! thread_local {
     // empty (base case for the recursion)
     () => {};
 
+    // the `__thread_local_inner` macro is declared in `sys::common::thread_local`
     ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const { $init:expr }; $($rest:tt)*) => (
         $crate::__thread_local_inner!($(#[$attr])* $vis $name, $t, const $init);
         $crate::thread_local!($($rest)*);


### PR DESCRIPTION
Since #108927, the `__thread_local_inner` macro is not declared directly after `thread_local` anymore, nor is the import present in the source file due to it being exported with `#[macro_export]`. 
This PR adds a comment to `thread_local` to help any curious reader in finding the definition of said inner macro.