### PR TITLE
rustdoc: Add search result item types after their name

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -213,7 +213,7 @@ a.anchor,
 h1 a,
 .search-results a,
 .stab,
-.result-name .primitive > i, .result-name .keyword > i {
+.result-name i {
 	color: var(--main-color);
 }
 
@@ -887,7 +887,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 .search-results .result-name span.alias {
 	color: var(--search-results-alias-color);
 }
-.search-results .result-name span.grey {
+.search-results .result-name .grey {
 	color: var(--search-results-grey-color);
 }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1722,6 +1722,14 @@ in source-script.js
 		display: block;
 	}
 
+	.search-results > a > .type-kind {
+		display: inline-block;
+	}
+	.search-results > a > .result-name {
+		display: inline-block;
+		margin-left: 7px;
+	}
+
 	/* Display an alternating layout on tablets and phones */
 	.search-results > a {
 		padding: 5px 0px;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -190,7 +190,6 @@ h1, h2, h3, h4, h5, h6,
 .mobile-topbar,
 .search-input,
 .search-results .result-name,
-.search-results .type-kind,
 .item-name > a,
 .out-of-band,
 span.since,
@@ -871,10 +870,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 }
 
 .search-results > a > div {
-	flex: 3;
-}
-
-.search-results > a > div.type-kind {
 	flex: 1;
 }
 
@@ -1720,14 +1715,6 @@ in source-script.js
 	.item-table, .item-row, .item-table > li, .item-table > li > div,
 	.search-results > a, .search-results > a > div {
 		display: block;
-	}
-
-	.search-results > a > .type-kind {
-		display: inline-block;
-	}
-	.search-results > a > .result-name {
-		display: inline-block;
-		margin-left: 7px;
 	}
 
 	/* Display an alternating layout on tablets and phones */

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -190,6 +190,7 @@ h1, h2, h3, h4, h5, h6,
 .mobile-topbar,
 .search-input,
 .search-results .result-name,
+.search-results .type-kind,
 .item-name > a,
 .out-of-band,
 span.since,
@@ -870,6 +871,10 @@ so that we can apply CSS-filters to change the arrow color in themes */
 }
 
 .search-results > a > div {
+	flex: 3;
+}
+
+.search-results > a > div.type-kind {
 	flex: 1;
 }
 

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -35,6 +35,35 @@ const itemTypes = [
     "traitalias",
 ];
 
+const longItemTypes = [
+    "module",
+    "extern crate",
+    "re-export",
+    "struct",
+    "enum",
+    "function",
+    "type alias",
+    "static",
+    "trait",
+    "",
+    "trait method",
+    "method",
+    "struct field",
+    "enum variant",
+    "macro",
+    "primitive type",
+    "associated type",
+    "constant",
+    "associated constant",
+    "union",
+    "foreign type",
+    "keyword",
+    "existential type",
+    "attribute macro",
+    "derive macro",
+    "trait alias",
+];
+
 // used for special search precedence
 const TY_PRIMITIVE = itemTypes.indexOf("primitive");
 const TY_KEYWORD = itemTypes.indexOf("keyword");
@@ -1836,15 +1865,10 @@ function initSearch(rawSearchIndex) {
             array.forEach(item => {
                 const name = item.name;
                 const type = itemTypes[item.ty];
+                const longType = longItemTypes[item.ty];
+                let extra = longType.length !== 0 ? ` <i>(${longType})</i>` : "";
 
                 length += 1;
-
-                let extra = "";
-                if (type === "primitive") {
-                    extra = " <i>(primitive type)</i>";
-                } else if (type === "keyword") {
-                    extra = " <i>(keyword)</i>";
-                }
 
                 const link = document.createElement("a");
                 link.className = "result-" + type;
@@ -1854,6 +1878,7 @@ function initSearch(rawSearchIndex) {
                 resultName.className = "result-name";
 
                 if (item.is_alias) {
+                    extra = "";
                     const alias = document.createElement("span");
                     alias.className = "alias";
 
@@ -1863,13 +1888,13 @@ function initSearch(rawSearchIndex) {
 
                     alias.insertAdjacentHTML(
                         "beforeend",
-                        "<span class=\"grey\"><i>&nbsp;- see&nbsp;</i></span>");
+                        "<i class=\"grey\">&nbsp;- see&nbsp;</i>");
 
                     resultName.appendChild(alias);
                 }
                 resultName.insertAdjacentHTML(
                     "beforeend",
-                    item.displayPath + "<span class=\"" + type + "\">" + name + extra + "</span>");
+                    item.displayPath + "<span class=\"" + type + "\">" + name + "</span>" + extra);
                 link.appendChild(resultName);
 
                 const description = document.createElement("div");

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1892,14 +1892,9 @@ function initSearch(rawSearchIndex) {
                     resultName.appendChild(alias);
                 }
 
-                const typeDisplay = document.createElement("div");
-                typeDisplay.innerText = typeName;
-                typeDisplay.className = "type-kind";
-                link.appendChild(typeDisplay);
-
                 resultName.insertAdjacentHTML(
                     "beforeend",
-                    item.displayPath + "<span class=\"" + type + "\">" + name + "</span>");
+                    `${typeName} ${item.displayPath}<span class="${type}">${name}</span>`);
                 link.appendChild(resultName);
 
                 const description = document.createElement("div");

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1866,7 +1866,7 @@ function initSearch(rawSearchIndex) {
                 const name = item.name;
                 const type = itemTypes[item.ty];
                 const longType = longItemTypes[item.ty];
-                let extra = longType.length !== 0 ? ` <i>(${longType})</i>` : "";
+                const typeName = longType.length !== 0 ? `${longType}` : "?";
 
                 length += 1;
 
@@ -1878,7 +1878,6 @@ function initSearch(rawSearchIndex) {
                 resultName.className = "result-name";
 
                 if (item.is_alias) {
-                    extra = "";
                     const alias = document.createElement("span");
                     alias.className = "alias";
 
@@ -1892,9 +1891,15 @@ function initSearch(rawSearchIndex) {
 
                     resultName.appendChild(alias);
                 }
+
+                const typeDisplay = document.createElement("div");
+                typeDisplay.innerText = typeName;
+                typeDisplay.className = "type-kind";
+                link.appendChild(typeDisplay);
+
                 resultName.insertAdjacentHTML(
                     "beforeend",
-                    item.displayPath + "<span class=\"" + type + "\">" + name + "</span>" + extra);
+                    item.displayPath + "<span class=\"" + type + "\">" + name + "</span>");
                 link.appendChild(resultName);
 
                 const description = document.createElement("div");

--- a/tests/rustdoc-gui/search-reexport.goml
+++ b/tests/rustdoc-gui/search-reexport.goml
@@ -14,7 +14,8 @@ assert-attribute: (
     "//a[@class='result-import']",
     {"href": "../test_docs/index.html#reexport.TheStdReexport"},
 )
-assert-text: ("//a[@class='result-import']", "test_docs::TheStdReexport (re-export)")
+assert-text: ("a.result-import .result-name", "test_docs::TheStdReexport")
+assert-text: ("a.result-import .type-kind", "re-export")
 click: "//a[@class='result-import']"
 // We check that it has the background modified thanks to the focus.
 wait-for-css: ("//*[@id='reexport.TheStdReexport']", {"background-color": "rgb(73, 74, 61)"})
@@ -25,7 +26,7 @@ press-key: 'Enter'
 write: (".search-input", "AliasForTheStdReexport")
 wait-for: "//a[@class='result-import']"
 assert-text: (
-    "//a[@class='result-import']",
+    "a.result-import .result-name",
     "AliasForTheStdReexport - see test_docs::TheStdReexport",
 )
 // Same thing again, we click on it to ensure the background is once again set as expected.

--- a/tests/rustdoc-gui/search-reexport.goml
+++ b/tests/rustdoc-gui/search-reexport.goml
@@ -14,8 +14,7 @@ assert-attribute: (
     "//a[@class='result-import']",
     {"href": "../test_docs/index.html#reexport.TheStdReexport"},
 )
-assert-text: ("a.result-import .result-name", "test_docs::TheStdReexport")
-assert-text: ("a.result-import .type-kind", "re-export")
+assert-text: ("a.result-import .result-name", "re-export test_docs::TheStdReexport")
 click: "//a[@class='result-import']"
 // We check that it has the background modified thanks to the focus.
 wait-for-css: ("//*[@id='reexport.TheStdReexport']", {"background-color": "rgb(73, 74, 61)"})
@@ -27,7 +26,7 @@ write: (".search-input", "AliasForTheStdReexport")
 wait-for: "//a[@class='result-import']"
 assert-text: (
     "a.result-import .result-name",
-    "AliasForTheStdReexport - see test_docs::TheStdReexport",
+    "AliasForTheStdReexport - see re-export test_docs::TheStdReexport",
 )
 // Same thing again, we click on it to ensure the background is once again set as expected.
 click: "//a[@class='result-import']"

--- a/tests/rustdoc-gui/search-reexport.goml
+++ b/tests/rustdoc-gui/search-reexport.goml
@@ -14,7 +14,7 @@ assert-attribute: (
     "//a[@class='result-import']",
     {"href": "../test_docs/index.html#reexport.TheStdReexport"},
 )
-assert-text: ("//a[@class='result-import']", "test_docs::TheStdReexport")
+assert-text: ("//a[@class='result-import']", "test_docs::TheStdReexport (re-export)")
 click: "//a[@class='result-import']"
 // We check that it has the background modified thanks to the focus.
 wait-for-css: ("//*[@id='reexport.TheStdReexport']", {"background-color": "rgb(73, 74, 61)"})

--- a/tests/rustdoc-gui/search-result-color.goml
+++ b/tests/rustdoc-gui/search-result-color.goml
@@ -5,6 +5,7 @@ define-function: (
     (result_kind, color, hover_color),
     block {
         assert-css: (".result-" + |result_kind| + " ." + |result_kind|, {"color": |color|}, ALL)
+        assert-css: (".result-" + |result_kind| + " i", {"color": |default_color|})
         assert-css: (
             ".result-" + |result_kind|,
             {"color": |entry_color|, "background-color": |background_color|},
@@ -18,6 +19,7 @@ define-function: (
             ".result-" + |result_kind| + ":hover ." + |result_kind|,
             {"color": |hover_color|},
         )
+        assert-css: (".result-" + |result_kind| + ":hover i", {"color": |default_color|})
         move-cursor-to: ".search-input"
         focus: ".result-" + |result_kind|
         assert-css: (
@@ -65,10 +67,12 @@ assert-css: (
     {"border-bottom-color": "#aaa3"}
 )
 
+store-value: (default_color, "rgb(197, 197, 197)")
+
 // Checking the color of "keyword" text.
 assert-css: (
     "//*[@class='result-name']//*[text()='(keyword)']",
-    {"color": "#788797"},
+    {"color": |default_color|},
 )
 
 store-value: (entry_color, "#0096cf") // color of the search entry
@@ -182,10 +186,12 @@ assert-css: (
     {"border-bottom-color": "#aaa3"}
 )
 
+store-value: (default_color, "rgb(221, 221, 221)")
+
 // Checking the color for "keyword" text.
 assert-css: (
     "//*[@class='result-name']//*[text()='(keyword)']",
-    {"color": "#ddd"},
+    {"color": |default_color|},
 )
 
 store-value: (entry_color, "#ddd") // color of the search entry
@@ -284,10 +290,12 @@ assert-css: (
     {"border-bottom-color": "#aaa3"}
 )
 
+store-value: (default_color, "rgb(0, 0, 0)")
+
 // Checking the color for "keyword" text.
 assert-css: (
     "//*[@class='result-name']//*[text()='(keyword)']",
-    {"color": "#000"},
+    {"color": |default_color|},
 )
 
 store-value: (entry_color, "#000") // color of the search entry

--- a/tests/rustdoc-gui/search-result-color.goml
+++ b/tests/rustdoc-gui/search-result-color.goml
@@ -5,7 +5,7 @@ define-function: (
     (result_kind, color, hover_color),
     block {
         assert-css: (".result-" + |result_kind| + " ." + |result_kind|, {"color": |color|}, ALL)
-        assert-css: (".result-" + |result_kind| + " i", {"color": |default_color|})
+        assert-css: (".result-" + |result_kind| + " .type-kind", {"color": |entry_color|})
         assert-css: (
             ".result-" + |result_kind|,
             {"color": |entry_color|, "background-color": |background_color|},
@@ -19,7 +19,7 @@ define-function: (
             ".result-" + |result_kind| + ":hover ." + |result_kind|,
             {"color": |hover_color|},
         )
-        assert-css: (".result-" + |result_kind| + ":hover i", {"color": |default_color|})
+        assert-css: (".result-" + |result_kind| + ":hover .type-kind", {"color": |hover_entry_color|})
         move-cursor-to: ".search-input"
         focus: ".result-" + |result_kind|
         assert-css: (
@@ -65,14 +65,6 @@ assert-css: (
 assert-css: (
     ".search-results > a",
     {"border-bottom-color": "#aaa3"}
-)
-
-store-value: (default_color, "rgb(197, 197, 197)")
-
-// Checking the color of "keyword" text.
-assert-css: (
-    "//*[@class='result-name']//*[text()='(keyword)']",
-    {"color": |default_color|},
 )
 
 store-value: (entry_color, "#0096cf") // color of the search entry
@@ -186,14 +178,6 @@ assert-css: (
     {"border-bottom-color": "#aaa3"}
 )
 
-store-value: (default_color, "rgb(221, 221, 221)")
-
-// Checking the color for "keyword" text.
-assert-css: (
-    "//*[@class='result-name']//*[text()='(keyword)']",
-    {"color": |default_color|},
-)
-
 store-value: (entry_color, "#ddd") // color of the search entry
 store-value: (hover_entry_color, "#ddd") // color of the hovered/focused search entry
 store-value: (background_color, "transparent") // background color
@@ -288,14 +272,6 @@ assert-css: (
 assert-css: (
     ".search-results > a",
     {"border-bottom-color": "#aaa3"}
-)
-
-store-value: (default_color, "rgb(0, 0, 0)")
-
-// Checking the color for "keyword" text.
-assert-css: (
-    "//*[@class='result-name']//*[text()='(keyword)']",
-    {"color": |default_color|},
 )
 
 store-value: (entry_color, "#000") // color of the search entry

--- a/tests/rustdoc-gui/search-result-color.goml
+++ b/tests/rustdoc-gui/search-result-color.goml
@@ -5,7 +5,6 @@ define-function: (
     (result_kind, color, hover_color),
     block {
         assert-css: (".result-" + |result_kind| + " ." + |result_kind|, {"color": |color|}, ALL)
-        assert-css: (".result-" + |result_kind| + " .type-kind", {"color": |entry_color|})
         assert-css: (
             ".result-" + |result_kind|,
             {"color": |entry_color|, "background-color": |background_color|},
@@ -19,7 +18,6 @@ define-function: (
             ".result-" + |result_kind| + ":hover ." + |result_kind|,
             {"color": |hover_color|},
         )
-        assert-css: (".result-" + |result_kind| + ":hover .type-kind", {"color": |hover_entry_color|})
         move-cursor-to: ".search-input"
         focus: ".result-" + |result_kind|
         assert-css: (

--- a/tests/rustdoc-gui/search-result-display.goml
+++ b/tests/rustdoc-gui/search-result-display.goml
@@ -7,7 +7,7 @@ press-key: 'Enter'
 wait-for: "#crate-search"
 // The width is returned by "getComputedStyle" which returns the exact number instead of the
 // CSS rule which is "50%"...
-assert-size: (".search-results div.desc", {"width": 259})
+assert-size: (".search-results div.desc", {"width": 310})
 set-window-size: (600, 100)
 // As counter-intuitive as it may seem, in this width, the width is "100%", which is why
 // when computed it's larger.

--- a/tests/rustdoc-gui/search-result-display.goml
+++ b/tests/rustdoc-gui/search-result-display.goml
@@ -7,11 +7,11 @@ press-key: 'Enter'
 wait-for: "#crate-search"
 // The width is returned by "getComputedStyle" which returns the exact number instead of the
 // CSS rule which is "50%"...
-assert-css: (".search-results div.desc", {"width": "310px"})
+assert-size: (".search-results div.desc", {"width": 259})
 set-window-size: (600, 100)
 // As counter-intuitive as it may seem, in this width, the width is "100%", which is why
 // when computed it's larger.
-assert-css: (".search-results div.desc", {"width": "566px"})
+assert-size: (".search-results div.desc", {"width": 566})
 
 // The result set is all on one line.
 assert-css: (".search-results .result-name > span", {"display": "inline"})

--- a/tests/rustdoc-gui/search-result-keyword.goml
+++ b/tests/rustdoc-gui/search-result-keyword.goml
@@ -9,5 +9,5 @@ wait-for: "#search-tabs"
 // less good.
 //
 // Checking that the CSS is displaying " (keyword)" in italic.
-assert-text: (".result-keyword span.keyword + i", "(keyword)")
-assert-text: (".result-keyword .result-name", "CookieMonster (keyword)")
+assert-text: (".result-keyword .type-kind", "keyword")
+assert-text: (".result-keyword .result-name", "CookieMonster")

--- a/tests/rustdoc-gui/search-result-keyword.goml
+++ b/tests/rustdoc-gui/search-result-keyword.goml
@@ -9,5 +9,5 @@ wait-for: "#search-tabs"
 // less good.
 //
 // Checking that the CSS is displaying " (keyword)" in italic.
-assert-text: (".result-name span.keyword > i", "(keyword)")
-assert-text: (".result-name span.keyword", "CookieMonster (keyword)")
+assert-text: (".result-keyword span.keyword + i", "(keyword)")
+assert-text: (".result-keyword .result-name", "CookieMonster (keyword)")

--- a/tests/rustdoc-gui/search-result-keyword.goml
+++ b/tests/rustdoc-gui/search-result-keyword.goml
@@ -5,9 +5,4 @@ write: (".search-input", "CookieMonster")
 press-key: 'Enter'
 // Waiting for the search results to appear...
 wait-for: "#search-tabs"
-// Note: The two next assert commands could be merged as one but readability would be
-// less good.
-//
-// Checking that the CSS is displaying " (keyword)" in italic.
-assert-text: (".result-keyword .type-kind", "keyword")
-assert-text: (".result-keyword .result-name", "CookieMonster")
+assert-text: (".result-keyword .result-name", "keyword CookieMonster")


### PR DESCRIPTION
Here what it looks like:

![Screenshot from 2023-04-22 15-16-58](https://user-images.githubusercontent.com/3050060/233789566-b5f3f625-3b78-4c56-a7ee-0a4f2d62e667.png)

The idea is to improve accessibility by providing this information directly in the text and not only in the text color. Currently we already use it for doc aliases and for primitive types, so I extended it to all types.

r? @notriddle 