### PR TITLE
Remove unused `synstructure` dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3348,7 +3348,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.8",
- "synstructure 0.13.0",
  "unic-langid",
 ]
 

--- a/compiler/rustc_fluent_macro/Cargo.toml
+++ b/compiler/rustc_fluent_macro/Cargo.toml
@@ -10,7 +10,6 @@ proc-macro = true
 annotate-snippets = "0.9"
 fluent-bundle = "0.15.2"
 fluent-syntax = "0.11"
-synstructure = "0.13.0"
 syn = { version = "2", features = ["full"] }
 proc-macro2 = "1"
 quote = "1"


### PR DESCRIPTION
`synstructure` is no longer used now that this crate was split out from rustc_macros 

@rustbot label +C-cleanup