### PR TITLE
format panic message only once

### DIFF
--- a/tests/ui/panics/fmt-only-once.rs
+++ b/tests/ui/panics/fmt-only-once.rs
@@ -1,0 +1,21 @@
+// run-fail
+// check-run-results
+// exec-env:RUST_BACKTRACE=0
+
+// Test that we format the panic message only once.
+// Regression test for https://github.com/rust-lang/rust/issues/110717
+
+use std::fmt;
+
+struct PrintOnFmt;
+
+impl fmt::Display for PrintOnFmt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        eprintln!("fmt");
+        f.write_str("PrintOnFmt")
+    }
+}
+
+fn main() {
+    panic!("{}", PrintOnFmt)
+}

--- a/tests/ui/panics/fmt-only-once.run.stderr
+++ b/tests/ui/panics/fmt-only-once.run.stderr
@@ -1,0 +1,3 @@
+fmt
+thread 'main' panicked at 'PrintOnFmt', $DIR/fmt-only-once.rs:20:5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
Formatting the panic message multiple times can cause problems for some real-world crates, so here's a test to ensure that we don't do that.

This was regressed in https://github.com/rust-lang/rust/pull/109507 and reverted in https://github.com/rust-lang/rust/pull/110782.

fixes https://github.com/rust-lang/rust/issues/110717
fixes https://github.com/rust-itertools/itertools/issues/694