### PR TITLE
BufRead::{split,lines}: don't eat trailing delimiters

### DIFF
--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -77,9 +77,21 @@ fn lines() {
     assert_eq!(s.next().unwrap().unwrap(), "12\r".to_string());
     assert!(s.next().is_none());
 
-    let buf = Cursor::new(&b"12\r\n\n"[..]);
+    // same behavior as &str::split
+    let buf = Cursor::new(&b"\n\r\n36\n\n12\r\n\n"[..]);
     let mut s = buf.lines();
+    assert_eq!(s.next().unwrap().unwrap(), "".to_string());
+    assert_eq!(s.next().unwrap().unwrap(), "".to_string());
+    assert_eq!(s.next().unwrap().unwrap(), "36".to_string());
+    assert_eq!(s.next().unwrap().unwrap(), "".to_string());
     assert_eq!(s.next().unwrap().unwrap(), "12".to_string());
+    assert_eq!(s.next().unwrap().unwrap(), "".to_string());
+    assert_eq!(s.next().unwrap().unwrap(), "".to_string());
+    assert!(s.next().is_none());
+
+    // same behavior as &str::split
+    let buf = Cursor::new(&b""[..]);
+    let mut s = buf.lines();
     assert_eq!(s.next().unwrap().unwrap(), "".to_string());
     assert!(s.next().is_none());
 }

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -32,9 +32,21 @@ fn split() {
     assert_eq!(s.next().unwrap().unwrap(), vec![b'1', b'2']);
     assert!(s.next().is_none());
 
-    let buf = Cursor::new(&b"1233"[..]);
+    // same behavior as &str::split
+    let buf = Cursor::new(&b"3345331233"[..]);
     let mut s = buf.split(b'3');
+    assert_eq!(s.next().unwrap().unwrap(), vec![]);
+    assert_eq!(s.next().unwrap().unwrap(), vec![]);
+    assert_eq!(s.next().unwrap().unwrap(), vec![b'4', b'5']);
+    assert_eq!(s.next().unwrap().unwrap(), vec![]);
     assert_eq!(s.next().unwrap().unwrap(), vec![b'1', b'2']);
+    assert_eq!(s.next().unwrap().unwrap(), vec![]);
+    assert_eq!(s.next().unwrap().unwrap(), vec![]);
+    assert!(s.next().is_none());
+
+    // same behavior as &str::split
+    let buf = Cursor::new(&b""[..]);
+    let mut s = buf.split(b'3');
     assert_eq!(s.next().unwrap().unwrap(), vec![]);
     assert!(s.next().is_none());
 }


### PR DESCRIPTION
this aligns behavior on &str::split

Fixes https://github.com/rust-lang/rust/issues/109907 and a similar issue with BufRead::lines.