### PR TITLE
Implement FusedIterator for DecodeUtf16 when the inner iterator does

### DIFF
--- a/library/core/src/char/decode.rs
+++ b/library/core/src/char/decode.rs
@@ -2,6 +2,7 @@
 
 use crate::error::Error;
 use crate::fmt;
+use crate::iter::FusedIterator;
 
 /// An iterator that decodes UTF-16 encoded code points from an iterator of `u16`s.
 ///
@@ -104,6 +105,9 @@ impl<I: Iterator<Item = u16>> Iterator for DecodeUtf16<I> {
         (low, high)
     }
 }
+
+#[stable(feature = "decode_utf16_fused_iterator", since = "CURRENT_RUSTC_VERSION")]
+impl<I: Iterator<Item = u16> + FusedIterator> FusedIterator for DecodeUtf16<I> {}
 
 impl DecodeUtf16Error {
     /// Returns the unpaired surrogate which caused this error.


### PR DESCRIPTION
I have just implemented an iterator that wraps `DecodeUtf16` and wanted to implement `FusedIterator` for my iterator when I noticed that `DecodeUtf16` currently doesn't implement `FusedIterator` at all.
A quick look at the code of `DecodeUtf16` revealed that `DecodeUtf16::next` only returns `None` when its inner iterator returns `None`:
https://github.com/rust-lang/rust/blob/3462f79e94f466a56ddaccfcdd3a3d44dd1dda9f/library/core/src/char/decode.rs#L45

As a result, we can implement `FusedIterator` for `DecodeUtf16` when the inner iterator does.

I'm following the example of #96397 here and consider this change minor and non-controversial, which is why I haven't added an RFC. I have also added the required feature name (`"decode_utf16_fused_iterator"`), however without adding a chapter to the Rust Unstable book (same as #96397).