### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -88,7 +88,11 @@ Compatibility Notes
 - [When `default-features` is set to false of a workspace dependency, and an inherited dependency of a member has `default-features = true`, Cargo will enable default features of that dependency.](https://github.com/rust-lang/cargo/pull/11409/)
 - [Cargo denies `CARGO_HOME` in the `[env]` configuration table. Cargo itself doesn't pick up this value, but recursive calls to cargo would, which was not intended.](https://github.com/rust-lang/cargo/pull/11644/)
 - [Debuginfo for build dependencies is now off if not explicitly set. This is expected to improve the overall build time.](https://github.com/rust-lang/cargo/pull/11252/)
-
+- [The Rust distribution no longer always includes rustdoc](https://github.com/rust-lang/rust/pull/106886)
+  If `tools = [...]` is set in config.toml, we will respect a missing rustdoc in that list. By
+  default rustdoc remains included. To retain the prior behavior explicitly add `"rustdoc"` to the
+  list.
+  
 <a id="1.69.0-Internal-Changes"></a>
 
 Internal Changes

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -310,12 +310,14 @@ static size_t getLongestEntryLength(ArrayRef<KV> Table) {
 extern "C" void LLVMRustPrintTargetCPUs(LLVMTargetMachineRef TM) {
   const TargetMachine *Target = unwrap(TM);
   const MCSubtargetInfo *MCInfo = Target->getMCSubtargetInfo();
-  const Triple::ArchType HostArch = Triple(sys::getProcessTriple()).getArch();
+  const Triple::ArchType HostArch = Triple(sys::getDefaultTargetTriple()).getArch();
   const Triple::ArchType TargetArch = Target->getTargetTriple().getArch();
   const ArrayRef<SubtargetSubTypeKV> CPUTable = MCInfo->getCPUTable();
   unsigned MaxCPULen = getLongestEntryLength(CPUTable);
 
   printf("Available CPUs for this target:\n");
+  // Don't print the "native" entry when the user specifies --target with a
+  // different arch since that could be wrong or misleading.
   if (HostArch == TargetArch) {
     const StringRef HostCPU = sys::getHostCPUName();
     printf("    %-*s - Select the CPU of the current host (currently %.*s).\n",

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -73,8 +73,8 @@ use crate::intrinsics;
 /// ```
 ///
 /// While using `unreachable_unchecked()` is perfectly sound in the following
-/// example, the compiler is able to prove that a division by zero is not
-/// possible. Benchmarking reveals that `unreachable_unchecked()` provides
+/// example, as the compiler is able to prove that a division by zero is not
+/// possible, benchmarking reveals that `unreachable_unchecked()` provides
 /// no benefit over using [`unreachable!`], while the latter does not introduce
 /// the possibility of Undefined Behavior.
 ///

--- a/src/bootstrap/format.rs
+++ b/src/bootstrap/format.rs
@@ -145,10 +145,8 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
             let untracked_paths = untracked_paths_output
                 .lines()
                 .filter(|entry| entry.starts_with("??"))
-                .filter_map(|entry| {
-                    let path =
-                        entry.split(' ').nth(1).expect("every git status entry should list a path");
-                    path.ends_with(".rs").then_some(path)
+                .map(|entry| {
+                    entry.split(' ').nth(1).expect("every git status entry should list a path")
                 });
             for untracked_path in untracked_paths {
                 println!("skip untracked path {} during rustfmt invocations", untracked_path);

--- a/src/librustdoc/html/static/css/settings.css
+++ b/src/librustdoc/html/static/css/settings.css
@@ -7,7 +7,6 @@
 	margin-right: 0.3em;
 	height: 1.2rem;
 	width: 1.2rem;
-	color: inherit;
 	border: 2px solid var(--settings-input-border-color);
 	outline: none;
 	-webkit-appearance: none;

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -1,5 +1,5 @@
 // Local js definitions:
-/* global getSettingValue, getVirtualKey, updateLocalStorage, updateTheme */
+/* global getSettingValue, updateLocalStorage, updateTheme */
 /* global addClass, removeClass, onEach, onEachLazy, blurHandler, elemIsInParent */
 /* global MAIN_ID, getVar, getSettingsButton */
 
@@ -28,21 +28,6 @@
                 } else {
                     window.rustdoc_remove_line_numbers_from_examples();
                 }
-                break;
-        }
-    }
-
-    function handleKey(ev) {
-        // Don't interfere with browser shortcuts
-        if (ev.ctrlKey || ev.altKey || ev.metaKey) {
-            return;
-        }
-        switch (getVirtualKey(ev)) {
-            case "Enter":
-            case "Return":
-            case "Space":
-                ev.target.checked = !ev.target.checked;
-                ev.preventDefault();
                 break;
         }
     }
@@ -77,8 +62,6 @@
             toggle.onchange = function() {
                 changeSetting(this.id, this.checked);
             };
-            toggle.onkeyup = handleKey;
-            toggle.onkeyrelease = handleKey;
         });
         onEachLazy(settingsElement.querySelectorAll("input[type=\"radio\"]"), elem => {
             const settingId = elem.name;

--- a/tests/rustdoc-gui/settings.goml
+++ b/tests/rustdoc-gui/settings.goml
@@ -256,6 +256,15 @@ set-local-storage: {"rustdoc-disable-shortcuts": "false"}
 click: ".setting-line:last-child .setting-check span"
 assert-local-storage: {"rustdoc-disable-shortcuts": "true"}
 
+// We now check that focusing a toggle and pressing Space is like clicking on it.
+assert-local-storage: {"rustdoc-disable-shortcuts": "true"}
+focus: ".setting-line:last-child .setting-check input"
+press-key: "Space"
+assert-local-storage: {"rustdoc-disable-shortcuts": "false"}
+focus: ".setting-line:last-child .setting-check input"
+press-key: "Space"
+assert-local-storage: {"rustdoc-disable-shortcuts": "true"}
+
 // Make sure that "Disable keyboard shortcuts" actually took effect.
 press-key: "Escape"
 press-key: "?"

--- a/tests/ui/typeck/bad-recursive-type-sig-infer.rs
+++ b/tests/ui/typeck/bad-recursive-type-sig-infer.rs
@@ -1,0 +1,11 @@
+fn a() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    &a
+}
+
+fn b() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    &a
+}
+
+fn main() {}

--- a/tests/ui/typeck/bad-recursive-type-sig-infer.stderr
+++ b/tests/ui/typeck/bad-recursive-type-sig-infer.stderr
@@ -1,0 +1,15 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/bad-recursive-type-sig-infer.rs:1:11
+   |
+LL | fn a() -> _ {
+   |           ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/bad-recursive-type-sig-infer.rs:6:11
+   |
+LL | fn b() -> _ {
+   |           ^ not allowed in type signatures
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
Successful merges:

 - #110661 (rustdoc: clean up settings.css and settings.js)
 - #110663 (Add note about change in bootstrap defaults)
 - #110664 (stop `x fmt` formatting untracked directories)
 - #110668 (Fix printing native CPU on cross-compiled compiler.)
 - #110689 (Fix grammar in core::hint::unreachable_unchecked() docs)
 - #110700 (Don't infer fn return type to return itself)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=110661,110663,110664,110668,110689,110700)
<!-- homu-ignore:end -->