### PR TITLE
Stabilize `ThreadId::as_u64`

### DIFF
--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -24,7 +24,6 @@
 #![feature(rustc_attrs)]
 #![feature(negative_impls)]
 #![feature(test)]
-#![feature(thread_id_value)]
 #![feature(vec_into_raw_parts)]
 #![feature(get_mut_unchecked)]
 #![feature(lint_reasons)]

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1131,7 +1131,7 @@ impl ThreadId {
     /// it is not guaranteed which values new threads will return, and this may
     /// change across Rust versions.
     #[must_use]
-    #[unstable(feature = "thread_id_value", issue = "67939")]
+    #[stable(feature = "thread_id_value", since = "CURRENT_RUSTC_VERSION")]
     pub fn as_u64(&self) -> NonZeroU64 {
         self.0
     }


### PR DESCRIPTION
# Stabilization proposal

This PR proposes to stabilize the following API:

```rust
impl ThreadId {
    pub fn as_u64(&self) -> NonZeroU64;
}
```

Tracking issue: https://github.com/rust-lang/rust/issues/67939

## Implementation History

- Implemented in https://github.com/rust-lang/rust/pull/67566
- Changed to return `NonZeroU64` in https://github.com/rust-lang/rust/pull/70240

## Design Considerations

The big question has been whether `ThreadId` should manage it's own internal counter or expose operating system IDs directly. https://github.com/rust-lang/rust/pull/84083 added the guarantee that `ThreadId` is unique for the lifetime of the process, which makes managing IDs ourselves necessary. Note that this also makes returning a `u64` necessary vs. `usize`.

The IDs being managed internally makes it trivial to guarantee that they are non-zero. This niche makes it possible to store an `Option<ThreadId>` as an `AtomicU64`.

Additionally, https://github.com/rust-lang/rust/pull/110725 proposes applying a permutation sequence to avoid users relying on any internal order. The value is already documented as opaque, so it's not clear whether this is a stabilization concern.

---

Blocked on an FCP for stabilization.