### PR TITLE
bootstrap: update paths cargo-credential crate

### DIFF
--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -588,18 +588,18 @@ impl Step for Cargo {
         if self.target.contains("windows") {
             build_cred(
                 "cargo-credential-wincred",
-                "src/tools/cargo/crates/credential/cargo-credential-wincred",
+                "src/tools/cargo/credential/cargo-credential-wincred",
             );
         }
         if self.target.contains("apple-darwin") {
             build_cred(
                 "cargo-credential-macos-keychain",
-                "src/tools/cargo/crates/credential/cargo-credential-macos-keychain",
+                "src/tools/cargo/credential/cargo-credential-macos-keychain",
             );
         }
         build_cred(
             "cargo-credential-1password",
-            "src/tools/cargo/crates/credential/cargo-credential-1password",
+            "src/tools/cargo/credential/cargo-credential-1password",
         );
         cargo_bin_path
     }


### PR DESCRIPTION
This should be done in #110653 but forgot.

Fixes #110742

## How to verify this patch

Run `./x.py build cargo`. Previously it would fail with

```console
error: manifest path `/projects/rust/src/tools/cargo/crates/credential/cargo-credential-1password/Cargo.toml` does not exist
```