### PR TITLE
[LLVM17] Adapt to `ExplicitEmulatedTLS` removal.

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -410,10 +410,15 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
   }
   Options.RelaxELFRelocations = RelaxELFRelocations;
   Options.UseInitArray = UseInitArray;
+
+#if LLVM_VERSION_LT(17, 0)
   if (ForceEmulatedTls) {
     Options.ExplicitEmulatedTLS = true;
     Options.EmulatedTLS = true;
   }
+#else
+  Options.EmulatedTLS = ForceEmulatedTls || Trip.hasDefaultEmulatedTLS();
+#endif
 
   if (TrapUnreachable) {
     // Tell LLVM to codegen `unreachable` into an explicit trap instruction.


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/0d333bf0e3aa37e2e6ae211e3aa80631c3e01b85 removed the `ExplicitEmulatedTLS` field from `TargetOptions`.

Before that commit, `TargetMachine::useEmulatedTLS()` fell back to `TheTriple.hasDefaultEmulatedTLS()` if `ExplicitEmulatedTLS` was `false`/unset.

After that commit, `TargetMachine::useEmulatedTLS()` directly returns `Options.EmulatedTLS`, and the fallback to `TheTriple.hasDefaultEmulatedTLS()` was moved to `InitTargetOptionsFromCodeGenFlags`.

Since `rustc` does not use `InitTargetOptionsFromCodeGenFlags` (AFAICT) and instead manually builds `TargetOptions`, this PR initializes `EmulatedTLS` to `TheTriple.hasDefaultEmulatedTLS()`.

(I'm not really familiar with the details of what this option does, or if there are any tests that depend on `hasDefaultEmulatedTLS` being used correctly, so this PR is mostly untested (it does compile against LLVM17, though)).


@rustbot label: +llvm-main