### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -110,46 +110,44 @@ impl<'tcx> ValueAnalysis<'tcx> for ConstAnalysis<'_, 'tcx> {
                 // we must make sure that all `target as Variant#i` are `Top`.
                 state.flood(target.as_ref(), self.map());
 
-                if let Some(target_idx) = self.map().find(target.as_ref()) {
-                    let (variant_target, variant_index) = match **kind {
-                        AggregateKind::Tuple | AggregateKind::Closure(..) => {
-                            (Some(target_idx), None)
-                        }
-                        AggregateKind::Adt(def_id, variant_index, ..) => {
-                            match self.tcx.def_kind(def_id) {
-                                DefKind::Struct => (Some(target_idx), None),
-                                DefKind::Enum => (
-                                    self.map.apply(target_idx, TrackElem::Variant(variant_index)),
-                                    Some(variant_index),
-                                ),
-                                _ => (None, None),
-                            }
-                        }
-                        _ => (None, None),
-                    };
-                    if let Some(variant_target_idx) = variant_target {
-                        for (field_index, operand) in operands.iter().enumerate() {
-                            if let Some(field) = self.map().apply(
-                                variant_target_idx,
-                                TrackElem::Field(FieldIdx::from_usize(field_index)),
-                            ) {
-                                let result = self.handle_operand(operand, state);
-                                state.insert_idx(field, result, self.map());
-                            }
+                let Some(target_idx) = self.map().find(target.as_ref()) else { return };
+
+                let (variant_target, variant_index) = match **kind {
+                    AggregateKind::Tuple | AggregateKind::Closure(..) => (Some(target_idx), None),
+                    AggregateKind::Adt(def_id, variant_index, ..) => {
+                        match self.tcx.def_kind(def_id) {
+                            DefKind::Struct => (Some(target_idx), None),
+                            DefKind::Enum => (
+                                self.map.apply(target_idx, TrackElem::Variant(variant_index)),
+                                Some(variant_index),
+                            ),
+                            _ => return,
                         }
                     }
-                    if let Some(variant_index) = variant_index
-                        && let Some(discr_idx) = self.map().apply(target_idx, TrackElem::Discriminant)
-                    {
-                        // We are assigning the discriminant as part of an aggregate.
-                        // This discriminant can only alias a variant field's value if the operand
-                        // had an invalid value for that type.
-                        // Using invalid values is UB, so we are allowed to perform the assignment
-                        // without extra flooding.
-                        let enum_ty = target.ty(self.local_decls, self.tcx).ty;
-                        if let Some(discr_val) = self.eval_discriminant(enum_ty, variant_index) {
-                            state.insert_value_idx(discr_idx, FlatSet::Elem(discr_val), &self.map);
+                    _ => return,
+                };
+                if let Some(variant_target_idx) = variant_target {
+                    for (field_index, operand) in operands.iter().enumerate() {
+                        if let Some(field) = self.map().apply(
+                            variant_target_idx,
+                            TrackElem::Field(FieldIdx::from_usize(field_index)),
+                        ) {
+                            let result = self.handle_operand(operand, state);
+                            state.insert_idx(field, result, self.map());
                         }
+                    }
+                }
+                if let Some(variant_index) = variant_index
+                    && let Some(discr_idx) = self.map().apply(target_idx, TrackElem::Discriminant)
+                {
+                    // We are assigning the discriminant as part of an aggregate.
+                    // This discriminant can only alias a variant field's value if the operand
+                    // had an invalid value for that type.
+                    // Using invalid values is UB, so we are allowed to perform the assignment
+                    // without extra flooding.
+                    let enum_ty = target.ty(self.local_decls, self.tcx).ty;
+                    if let Some(discr_val) = self.eval_discriminant(enum_ty, variant_index) {
+                        state.insert_value_idx(discr_idx, FlatSet::Elem(discr_val), &self.map);
                     }
                 }
             }

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -157,12 +157,10 @@ impl<'tcx> ValueAnalysis<'tcx> for ConstAnalysis<'_, 'tcx> {
                 // Flood everything now, so we can use `insert_value_idx` directly later.
                 state.flood(target.as_ref(), self.map());
 
-                let target = self.map().find(target.as_ref());
+                let Some(target) = self.map().find(target.as_ref()) else { return };
 
-                let value_target = target
-                    .and_then(|target| self.map().apply(target, TrackElem::Field(0_u32.into())));
-                let overflow_target = target
-                    .and_then(|target| self.map().apply(target, TrackElem::Field(1_u32.into())));
+                let value_target = self.map().apply(target, TrackElem::Field(0_u32.into()));
+                let overflow_target = self.map().apply(target, TrackElem::Field(1_u32.into()));
 
                 if value_target.is_some() || overflow_target.is_some() {
                     let (val, overflow) = self.binary_op(state, *op, left, right);

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -520,21 +520,6 @@ impl<'tcx, 'map, 'a> Visitor<'tcx> for OperandCollector<'tcx, 'map, 'a> {
             _ => (),
         }
     }
-
-    fn visit_rvalue(&mut self, rvalue: &Rvalue<'tcx>, location: Location) {
-        match rvalue {
-            Rvalue::Discriminant(place) => {
-                match self.state.get_discr(place.as_ref(), self.visitor.map) {
-                    FlatSet::Top => (),
-                    FlatSet::Elem(value) => {
-                        self.visitor.before_effect.insert((location, *place), value);
-                    }
-                    FlatSet::Bottom => (),
-                }
-            }
-            _ => self.super_rvalue(rvalue, location),
-        }
-    }
 }
 
 struct DummyMachine;

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -588,18 +588,18 @@ impl Step for Cargo {
         if self.target.contains("windows") {
             build_cred(
                 "cargo-credential-wincred",
-                "src/tools/cargo/crates/credential/cargo-credential-wincred",
+                "src/tools/cargo/credential/cargo-credential-wincred",
             );
         }
         if self.target.contains("apple-darwin") {
             build_cred(
                 "cargo-credential-macos-keychain",
-                "src/tools/cargo/crates/credential/cargo-credential-macos-keychain",
+                "src/tools/cargo/credential/cargo-credential-macos-keychain",
             );
         }
         build_cred(
             "cargo-credential-1password",
-            "src/tools/cargo/crates/credential/cargo-credential-1password",
+            "src/tools/cargo/credential/cargo-credential-1password",
         );
         cargo_bin_path
     }

--- a/tests/ui/closures/static-closures-with-nonstatic-return.rs
+++ b/tests/ui/closures/static-closures-with-nonstatic-return.rs
@@ -1,0 +1,15 @@
+// check-pass
+// known-bug: #84366
+
+// Should fail. Associated types of 'static types should be `'static`, but
+// argument-free closures can be `'static` and return non-`'static` types.
+
+#[allow(dead_code)]
+fn foo<'a>() {
+    let closure = || -> &'a str { "" };
+    assert_static(closure);
+}
+
+fn assert_static<T: 'static>(_: T) {}
+
+fn main() {}

--- a/tests/ui/coherence/indirect-impl-for-trait-obj-coherence.rs
+++ b/tests/ui/coherence/indirect-impl-for-trait-obj-coherence.rs
@@ -1,0 +1,25 @@
+// check-pass
+// known-bug: #57893
+
+// Should fail. Because we see an impl that uses a certain associated type, we
+// type-check assuming that impl is used. However, this conflicts with the
+// "implicit impl" that we get for trait objects, violating coherence.
+
+trait Object<U> {
+    type Output;
+}
+
+impl<T: ?Sized, U> Object<U> for T {
+    type Output = U;
+}
+
+fn foo<T: ?Sized, U>(x: <T as Object<U>>::Output) -> U {
+    x
+}
+
+#[allow(dead_code)]
+fn transmute<T, U>(x: T) -> U {
+    foo::<dyn Object<U, Output = T>, U>(x)
+}
+
+fn main() {}

--- a/tests/ui/consts/non-sync-references-in-const.rs
+++ b/tests/ui/consts/non-sync-references-in-const.rs
@@ -1,0 +1,38 @@
+// check-pass
+// known-bug: #49206
+
+// Should fail. Compiles and prints 2 identical addresses, which shows 2 threads
+// with the same `'static` reference to non-`Sync` struct. The problem is that
+// promotion to static does not check if the type is `Sync`.
+
+#[allow(dead_code)]
+#[derive(Debug)]
+struct Foo {
+    value: u32,
+}
+
+// stable negative impl trick from https://crates.io/crates/negative-impl
+// see https://github.com/taiki-e/pin-project/issues/102#issuecomment-540472282
+// for details.
+struct Wrapper<'a, T>(::std::marker::PhantomData<&'a ()>, T);
+unsafe impl<T> Sync for Wrapper<'_, T> where T: Sync {}
+unsafe impl<'a> std::marker::Sync for Foo where Wrapper<'a, *const ()>: Sync {}
+fn _assert_sync<T: Sync>() {}
+
+fn inspect() {
+    let foo: &'static Foo = &Foo { value: 1 };
+    println!(
+        "I am in thread {:?}, address: {:p}",
+        std::thread::current().id(),
+        foo as *const Foo,
+    );
+}
+
+fn main() {
+    // _assert_sync::<Foo>(); // uncomment this line causes compile error
+    // "`*const ()` cannot be shared between threads safely"
+
+    let handle = std::thread::spawn(inspect);
+    inspect();
+    handle.join().unwrap();
+}

--- a/tests/ui/fn/fn-item-lifetime-bounds.rs
+++ b/tests/ui/fn/fn-item-lifetime-bounds.rs
@@ -1,0 +1,37 @@
+// check-pass
+// known-bug: #84533
+
+// Should fail. Lifetimes are checked correctly when `foo` is called, but NOT
+// when only the lifetime parameters are instantiated.
+
+use std::marker::PhantomData;
+
+#[allow(dead_code)]
+fn foo<'b, 'a>() -> PhantomData<&'b &'a ()> {
+    PhantomData
+}
+
+#[allow(dead_code)]
+#[allow(path_statements)]
+fn caller<'b, 'a>() {
+    foo::<'b, 'a>;
+}
+
+// In contrast to above, below code correctly does NOT compile.
+// fn caller<'b, 'a>() {
+//     foo::<'b, 'a>();
+// }
+
+// error: lifetime may not live long enough
+//   --> src/main.rs:22:5
+//   |
+// 21 | fn caller<'b, 'a>() {
+//   |           --  -- lifetime `'a` defined here
+//   |           |
+//   |           lifetime `'b` defined here
+// 22 |     foo::<'b, 'a>();
+//   |     ^^^^^^^^^^^^^^^ requires that `'a` must outlive `'b`
+//   |
+//   = help: consider adding the following bound: `'a: 'b`
+
+fn main() {}

--- a/tests/ui/fn/implied-bounds-impl-header-projections.rs
+++ b/tests/ui/fn/implied-bounds-impl-header-projections.rs
@@ -1,0 +1,31 @@
+// check-pass
+// known-bug: #100051
+
+// Should fail. Implied bounds from projections in impl headers can create
+// improper lifetimes.  Variant of issue #98543 which was fixed by #99217.
+
+trait Trait {
+    type Type;
+}
+
+impl<T> Trait for T {
+    type Type = ();
+}
+
+trait Extend<'a, 'b> {
+    fn extend(self, s: &'a str) -> &'b str;
+}
+
+impl<'a, 'b> Extend<'a, 'b> for <&'b &'a () as Trait>::Type
+where
+    for<'what, 'ever> &'what &'ever (): Trait,
+{
+    fn extend(self, s: &'a str) -> &'b str {
+        s
+    }
+}
+
+fn main() {
+    let y = <() as Extend<'_, '_>>::extend((), &String::from("Hello World"));
+    println!("{}", y);
+}

--- a/tests/ui/implied-bounds/implied-bounds-on-nested-references-plus-variance.rs
+++ b/tests/ui/implied-bounds/implied-bounds-on-nested-references-plus-variance.rs
@@ -1,0 +1,16 @@
+// check-pass
+// known-bug: #25860
+
+// Should fail. The combination of variance and implied bounds for nested
+// references allows us to infer a longer lifetime than we can prove.
+
+static UNIT: &'static &'static () = &&();
+
+fn foo<'a, 'b, T>(_: &'a &'b (), v: &'b T) -> &'a T { v }
+
+fn bad<'a, T>(x: &'a T) -> &'static T {
+    let f: fn(_, &'a T) -> &'static T = foo;
+    f(UNIT, x)
+}
+
+fn main() {}

--- a/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy.rs
+++ b/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy.rs
@@ -1,0 +1,39 @@
+// check-pass
+// known-bug: #84591
+
+// Should fail. Subtrait can incorrectly extend supertrait lifetimes even when
+// supertrait has weaker implied bounds than subtrait. Strongly related to
+// issue #25860.
+
+trait Subtrait<T>: Supertrait {}
+trait Supertrait {
+    fn action(self);
+}
+
+fn subs_to_soup<T, U>(x: T)
+where
+    T: Subtrait<U>,
+{
+    soup(x)
+}
+
+fn soup<T: Supertrait>(x: T) {
+    x.action();
+}
+
+impl<'a, 'b: 'a> Supertrait for (&'b str, &mut &'a str) {
+    fn action(self) {
+        *self.1 = self.0;
+    }
+}
+
+impl<'a, 'b> Subtrait<&'a &'b str> for (&'b str, &mut &'a str) {}
+
+fn main() {
+    let mut d = "hi";
+    {
+        let x = "Hello World".to_string();
+        subs_to_soup((x.as_str(), &mut d));
+    }
+    println!("{}", d);
+}

--- a/tests/ui/object-safety/assoc_const_bounds.rs
+++ b/tests/ui/object-safety/assoc_const_bounds.rs
@@ -1,0 +1,13 @@
+trait Foo<T> {
+    const BAR: bool
+        where //~ ERROR: expected one of `!`, `(`, `+`, `::`, `;`, `<`, or `=`, found keyword `where`
+            Self: Sized;
+}
+
+trait Cake {}
+impl Cake for () {}
+
+fn foo(_: &dyn Foo<()>) {}
+fn bar(_: &dyn Foo<i32>) {}
+
+fn main() {}

--- a/tests/ui/object-safety/assoc_const_bounds.stderr
+++ b/tests/ui/object-safety/assoc_const_bounds.stderr
@@ -1,0 +1,15 @@
+error: expected one of `!`, `(`, `+`, `::`, `;`, `<`, or `=`, found keyword `where`
+  --> $DIR/assoc_const_bounds.rs:3:9
+   |
+LL | trait Foo<T> {
+   |              - while parsing this item list starting here
+LL |     const BAR: bool
+   |                    - expected one of 7 possible tokens
+LL |         where
+   |         ^^^^^ unexpected token
+LL |             Self: Sized;
+LL | }
+   | - the item list ends here
+
+error: aborting due to previous error
+

--- a/tests/ui/object-safety/assoc_const_bounds_sized.rs
+++ b/tests/ui/object-safety/assoc_const_bounds_sized.rs
@@ -1,0 +1,9 @@
+trait Foo {
+    const BAR: bool
+        where //~ ERROR: expected one of `!`, `(`, `+`, `::`, `;`, `<`, or `=`, found keyword `where`
+            Self: Sized;
+}
+
+fn foo(_: &dyn Foo) {}
+
+fn main() {}

--- a/tests/ui/object-safety/assoc_const_bounds_sized.stderr
+++ b/tests/ui/object-safety/assoc_const_bounds_sized.stderr
@@ -1,0 +1,15 @@
+error: expected one of `!`, `(`, `+`, `::`, `;`, `<`, or `=`, found keyword `where`
+  --> $DIR/assoc_const_bounds_sized.rs:3:9
+   |
+LL | trait Foo {
+   |           - while parsing this item list starting here
+LL |     const BAR: bool
+   |                    - expected one of 7 possible tokens
+LL |         where
+   |         ^^^^^ unexpected token
+LL |             Self: Sized;
+LL | }
+   | - the item list ends here
+
+error: aborting due to previous error
+

--- a/tests/ui/object-safety/assoc_type_bounds.rs
+++ b/tests/ui/object-safety/assoc_type_bounds.rs
@@ -1,0 +1,13 @@
+trait Foo<T> {
+    type Bar
+    where
+        T: Cake;
+}
+
+trait Cake {}
+impl Cake for () {}
+
+fn foo(_: &dyn Foo<()>) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
+fn bar(_: &dyn Foo<i32>) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
+
+fn main() {}

--- a/tests/ui/object-safety/assoc_type_bounds.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds.stderr
@@ -1,0 +1,21 @@
+error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+  --> $DIR/assoc_type_bounds.rs:10:16
+   |
+LL |     type Bar
+   |     -------- `Bar` defined here
+...
+LL | fn foo(_: &dyn Foo<()>) {}
+   |                ^^^^^^^ help: specify the associated type: `Foo<(), Bar = Type>`
+
+error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+  --> $DIR/assoc_type_bounds.rs:11:16
+   |
+LL |     type Bar
+   |     -------- `Bar` defined here
+...
+LL | fn bar(_: &dyn Foo<i32>) {}
+   |                ^^^^^^^^ help: specify the associated type: `Foo<i32, Bar = Type>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/object-safety/assoc_type_bounds2.rs
+++ b/tests/ui/object-safety/assoc_type_bounds2.rs
@@ -1,0 +1,13 @@
+trait Foo<T> {
+    type Bar
+    where
+        Self: Foo<()>;
+}
+
+trait Cake {}
+impl Cake for () {}
+
+fn foo(_: &dyn Foo<()>) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
+fn bar(_: &dyn Foo<i32>) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
+
+fn main() {}

--- a/tests/ui/object-safety/assoc_type_bounds2.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds2.stderr
@@ -1,0 +1,21 @@
+error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+  --> $DIR/assoc_type_bounds2.rs:10:16
+   |
+LL |     type Bar
+   |     -------- `Bar` defined here
+...
+LL | fn foo(_: &dyn Foo<()>) {}
+   |                ^^^^^^^ help: specify the associated type: `Foo<(), Bar = Type>`
+
+error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+  --> $DIR/assoc_type_bounds2.rs:11:16
+   |
+LL |     type Bar
+   |     -------- `Bar` defined here
+...
+LL | fn bar(_: &dyn Foo<i32>) {}
+   |                ^^^^^^^^ help: specify the associated type: `Foo<i32, Bar = Type>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/object-safety/assoc_type_bounds_sized.rs
+++ b/tests/ui/object-safety/assoc_type_bounds_sized.rs
@@ -1,0 +1,9 @@
+trait Foo {
+    type Bar
+    where
+        Self: Sized;
+}
+
+fn foo(_: &dyn Foo) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
+
+fn main() {}

--- a/tests/ui/object-safety/assoc_type_bounds_sized.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds_sized.stderr
@@ -1,0 +1,12 @@
+error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+  --> $DIR/assoc_type_bounds_sized.rs:7:16
+   |
+LL |     type Bar
+   |     -------- `Bar` defined here
+...
+LL | fn foo(_: &dyn Foo) {}
+   |                ^^^ help: specify the associated type: `Foo<Bar = Type>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/panics/fmt-only-once.rs
+++ b/tests/ui/panics/fmt-only-once.rs
@@ -1,0 +1,21 @@
+// run-fail
+// check-run-results
+// exec-env:RUST_BACKTRACE=0
+
+// Test that we format the panic message only once.
+// Regression test for https://github.com/rust-lang/rust/issues/110717
+
+use std::fmt;
+
+struct PrintOnFmt;
+
+impl fmt::Display for PrintOnFmt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        eprintln!("fmt");
+        f.write_str("PrintOnFmt")
+    }
+}
+
+fn main() {
+    panic!("{}", PrintOnFmt)
+}

--- a/tests/ui/panics/fmt-only-once.run.stderr
+++ b/tests/ui/panics/fmt-only-once.run.stderr
@@ -1,0 +1,3 @@
+fmt
+thread 'main' panicked at 'PrintOnFmt', $DIR/fmt-only-once.rs:20:5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/typeck/pin-unsound-issue-85099-derefmut.rs
+++ b/tests/ui/typeck/pin-unsound-issue-85099-derefmut.rs
@@ -1,0 +1,68 @@
+// check-pass
+// known-bug: #85099
+
+// Should fail. Can coerce `Pin<T>` into `Pin<U>` where
+// `T: Deref<Target: Unpin>` and `U: Deref<Target: !Unpin>`, using the
+// `CoerceUnsized` impl on `Pin` and an unorthodox `DerefMut` impl for
+// `Pin<&_>`.
+
+// This should not be allowed, since one can unpin `T::Target` (since it is
+// `Unpin`) to gain unpinned access to the previously pinned `U::Target` (which
+// is `!Unpin`) and then move it.
+
+use std::{
+    cell::{RefCell, RefMut},
+    future::Future,
+    ops::DerefMut,
+    pin::Pin,
+};
+
+struct SomeLocalStruct<'a, Fut>(&'a RefCell<Fut>);
+
+trait SomeTrait<'a, Fut> {
+    #[allow(clippy::mut_from_ref)]
+    fn deref_helper(&self) -> &mut (dyn SomeTrait<'a, Fut> + 'a) {
+        unimplemented!()
+    }
+    fn downcast(self: Pin<&mut Self>) -> Pin<&mut Fut> {
+        unimplemented!()
+    }
+}
+
+impl<'a, Fut: Future<Output = ()>> SomeTrait<'a, Fut> for SomeLocalStruct<'a, Fut> {
+    fn deref_helper(&self) -> &mut (dyn SomeTrait<'a, Fut> + 'a) {
+        let x = Box::new(self.0.borrow_mut());
+        let x: &'a mut RefMut<'a, Fut> = Box::leak(x);
+        &mut **x
+    }
+}
+impl<'a, Fut: Future<Output = ()>> SomeTrait<'a, Fut> for Fut {
+    fn downcast(self: Pin<&mut Self>) -> Pin<&mut Fut> {
+        self
+    }
+}
+
+impl<'b, 'a, Fut> DerefMut for Pin<&'b dyn SomeTrait<'a, Fut>> {
+    fn deref_mut<'c>(
+        self: &'c mut Pin<&'b dyn SomeTrait<'a, Fut>>,
+    ) -> &'c mut (dyn SomeTrait<'a, Fut> + 'b) {
+        self.deref_helper()
+    }
+}
+
+// obviously a "working" function with this signature is problematic
+pub fn unsound_pin<Fut: Future<Output = ()>>(
+    fut: Fut,
+    callback: impl FnOnce(Pin<&mut Fut>),
+) -> Fut {
+    let cell = RefCell::new(fut);
+    let s: &SomeLocalStruct<'_, Fut> = &SomeLocalStruct(&cell);
+    let p: Pin<Pin<&SomeLocalStruct<'_, Fut>>> = Pin::new(Pin::new(s));
+    let mut p: Pin<Pin<&dyn SomeTrait<'_, Fut>>> = p;
+    let r: Pin<&mut dyn SomeTrait<'_, Fut>> = p.as_mut();
+    let f: Pin<&mut Fut> = r.downcast();
+    callback(f);
+    cell.into_inner()
+}
+
+fn main() {}

--- a/tests/ui/wf/wf-in-fn-type-implicit.rs
+++ b/tests/ui/wf/wf-in-fn-type-implicit.rs
@@ -1,0 +1,37 @@
+// check-pass
+// known-bug: #104005
+
+// Should fail. Function type parameters with implicit type annotations are not
+// checked for well-formedness, which allows incorrect borrowing.
+
+// In contrast, user annotations are always checked for well-formedness, and the
+// commented code below is correctly rejected by the borrow checker.
+
+use std::fmt::Display;
+
+trait Displayable {
+    fn display(self) -> Box<dyn Display>;
+}
+
+impl<T: Display> Displayable for (T, Option<&'static T>) {
+    fn display(self) -> Box<dyn Display> {
+        Box::new(self.0)
+    }
+}
+
+fn extend_lt<T, U>(val: T) -> Box<dyn Display>
+where
+    (T, Option<U>): Displayable,
+{
+    Displayable::display((val, None))
+}
+
+fn main() {
+    // *incorrectly* compiles
+    let val = extend_lt(&String::from("blah blah blah"));
+    println!("{}", val);
+
+    // *correctly* fails to compile
+    // let val = extend_lt::<_, &_>(&String::from("blah blah blah"));
+    // println!("{}", val);
+}

--- a/tests/ui/wf/wf-in-where-clause-static.rs
+++ b/tests/ui/wf/wf-in-where-clause-static.rs
@@ -1,0 +1,23 @@
+// check-pass
+// known-bug: #98117
+
+// Should fail. Functions are responsible for checking the well-formedness of
+// their own where clauses, so this should fail and require an explicit bound
+// `T: 'static`.
+
+use std::fmt::Display;
+
+trait Static: 'static {}
+impl<T> Static for &'static T {}
+
+fn foo<S: Display>(x: S) -> Box<dyn Display>
+where
+    &'static S: Static,
+{
+    Box::new(x)
+}
+
+fn main() {
+    let s = foo(&String::from("blah blah blah"));
+    println!("{}", s);
+}

--- a/tests/ui/wf/wf-normalization-sized.rs
+++ b/tests/ui/wf/wf-normalization-sized.rs
@@ -1,0 +1,19 @@
+// check-pass
+// known-bug: #100041
+
+// Should fail. Normalization can bypass well-formedness checking.
+// `[[[[[[u8]]]]]]` is not a well-formed type since size of type `[u8]` cannot
+// be known at compile time (since `Sized` is not implemented for `[u8]`).
+
+trait WellUnformed {
+    type RequestNormalize;
+}
+
+impl<T: ?Sized> WellUnformed for T {
+    type RequestNormalize = ();
+}
+
+const _: <[[[[[[u8]]]]]] as WellUnformed>::RequestNormalize = ();
+const _: <Vec<str> as WellUnformed>::RequestNormalize = ();
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #106152 (Add LazyCell::into_inner)
 - #110480 (Add `known-bug` tests for 11 unsound issues)
 - #110590 (Add some tests around (lack of) object safety of associated types and consts)
 - #110685 (Some cleanups to DataflowConstProp)
 - #110721 (format panic message only once)
 - #110744 (bootstrap: update paths cargo-credential crate)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=106152,110480,110590,110685,110721,110744)
<!-- homu-ignore:end -->