### PR TITLE
rustdoc: Add regression test for #79468

### DIFF
--- a/tests/rustdoc-ui/issue-79468-too-big-current-arch.rs
+++ b/tests/rustdoc-ui/issue-79468-too-big-current-arch.rs
@@ -1,0 +1,7 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/79468>.
+// only-x86_64
+// failure-status: 101
+
+const HUGE_SIZE: usize = !0usize / 8;
+static MY_TOO_BIG_ARRAY_2: [u8; HUGE_SIZE] = [0x00; HUGE_SIZE];
+//~^ ERROR values of the type `[u8; 2305843009213693951]` are too big

--- a/tests/rustdoc-ui/issue-79468-too-big-current-arch.stderr
+++ b/tests/rustdoc-ui/issue-79468-too-big-current-arch.stderr
@@ -1,0 +1,40 @@
+error: internal compiler error: no errors encountered even though `delay_span_bug` issued
+
+error: internal compiler error: values of the type `[u8; 2305843009213693951]` are too big for the current architecture
+  --> $DIR/issue-79468-too-big-current-arch.rs:6:1
+   |
+LL | static MY_TOO_BIG_ARRAY_2: [u8; HUGE_SIZE] = [0x00; HUGE_SIZE];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: delayed at    0: <rustc_errors::HandlerInner>::emit_diagnostic
+              1: <rustc_errors::Handler>::delay_span_bug::<rustc_span::span_encoding::Span, &alloc::string::String>
+              2: rustc_hir_analysis::check::check::check_static_inhabited
+              3: rustc_hir_analysis::check::check::check_item_type
+              4: rustc_hir_analysis::check::check::check_mod_item_types
+              5: rustc_query_system::query::plumbing::try_execute_query::<rustc_query_impl::queries::check_mod_item_types, rustc_query_impl::plumbing::QueryCtxt>
+              6: <rustc_query_impl::Queries as rustc_middle::ty::query::QueryEngine>::check_mod_item_types
+              7: <rustc_middle::hir::map::Map>::for_each_module::<rustdoc::core::run_global_ctxt::{closure#1}::{closure#0}>
+              8: <rustc_session::session::Session>::time::<(), rustdoc::core::run_global_ctxt::{closure#1}>
+              9: rustdoc::core::run_global_ctxt
+             10: <rustc_session::session::Session>::time::<(rustdoc::clean::types::Crate, rustdoc::config::RenderOptions, rustdoc::formats::cache::Cache), rustdoc::main_args::{closure#1}::{closure#0}::{closure#0}::{closure#0}>
+             11: <std::thread::local::LocalKey<core::cell::Cell<*const ()>>>::with::<rustc_middle::ty::context::tls::enter_context<<rustc_middle::ty::context::GlobalCtxt>::enter<rustdoc::main_args::{closure#1}::{closure#0}::{closure#0}, core::result::Result<(), rustc_span::ErrorGuaranteed>>::{closure#0}, core::result::Result<(), rustc_span::ErrorGuaranteed>>::{closure#0}, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             12: <rustc_interface::queries::QueryResult<&rustc_middle::ty::context::GlobalCtxt>>::enter::<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustdoc::main_args::{closure#1}::{closure#0}::{closure#0}>
+             13: rustc_span::set_source_map::<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_interface::interface::run_compiler<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustdoc::main_args::{closure#1}>::{closure#0}::{closure#0}>
+             14: <scoped_tls::ScopedKey<rustc_span::SessionGlobals>>::set::<rustc_interface::interface::run_compiler<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustdoc::main_args::{closure#1}>::{closure#0}, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             15: std::sys_common::backtrace::__rust_begin_short_backtrace::<rustc_interface::util::run_in_thread_pool_with_globals<rustc_interface::interface::run_compiler<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustdoc::main_args::{closure#1}>::{closure#0}, core::result::Result<(), rustc_span::ErrorGuaranteed>>::{closure#0}::{closure#0}, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             16: <<std::thread::Builder>::spawn_unchecked_<rustc_interface::util::run_in_thread_pool_with_globals<rustc_interface::interface::run_compiler<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustdoc::main_args::{closure#1}>::{closure#0}, core::result::Result<(), rustc_span::ErrorGuaranteed>>::{closure#0}::{closure#0}, core::result::Result<(), rustc_span::ErrorGuaranteed>>::{closure#1} as core::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+             17: std::sys::unix::thread::Thread::new::thread_start
+             18: start_thread
+                        at ./nptl/pthread_create.c:442:8
+             19: clone3
+                        at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
+           
+
+note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md
+
+note: rustc 1.71.0-dev running on x86_64-unknown-linux-gnu
+
+note: compiler flags: -Z threads=1 -C codegen-units=1 -Z ui-testing -Z simulate-remapped-rust-src-base=/rustc/FAKE_PREFIX -Z translate-remapped-path-to-local-path=no -Z deduplicate-diagnostics=no -C strip=debuginfo -C debuginfo=0
+
+query stack during panic:
+end of query stack


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/79468.

It has the same output as `rustc` so I guess it's fine.

r? @matthiaskrgr