### PR TITLE
rustdoc: fix position of `default` in method rendering

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -820,6 +820,7 @@ fn assoc_method(
     let header = meth.fn_header(tcx).expect("Trying to get header from a non-function item");
     let name = meth.name.as_ref().unwrap();
     let vis = visibility_print_with_space(meth.visibility(tcx), meth.item_id, cx).to_string();
+    let defaultness = print_default_space(meth.is_default());
     // FIXME: Once https://github.com/rust-lang/rust/issues/67792 is implemented, we can remove
     // this condition.
     let constness = match render_mode {
@@ -830,7 +831,6 @@ fn assoc_method(
     };
     let asyncness = header.asyncness.print_with_space();
     let unsafety = header.unsafety.print_with_space();
-    let defaultness = print_default_space(meth.is_default());
     let abi = print_abi_with_space(header.abi).to_string();
     let href = assoc_href_attr(meth, link, cx);
 
@@ -838,10 +838,10 @@ fn assoc_method(
     let generics_len = format!("{:#}", g.print(cx)).len();
     let mut header_len = "fn ".len()
         + vis.len()
+        + defaultness.len()
         + constness.len()
         + asyncness.len()
         + unsafety.len()
-        + defaultness.len()
         + abi.len()
         + name.as_str().len()
         + generics_len;
@@ -860,14 +860,14 @@ fn assoc_method(
     w.reserve(header_len + "<a href=\"\" class=\"fn\">{".len() + "</a>".len());
     write!(
         w,
-        "{indent}{vis}{constness}{asyncness}{unsafety}{defaultness}{abi}fn \
+        "{indent}{vis}{defaultness}{constness}{asyncness}{unsafety}{abi}fn \
          <a{href} class=\"fn\">{name}</a>{generics}{decl}{notable_traits}{where_clause}",
         indent = indent_str,
         vis = vis,
+        defaultness = defaultness,
         constness = constness,
         asyncness = asyncness,
         unsafety = unsafety,
-        defaultness = defaultness,
         abi = abi,
         href = href,
         name = name,

--- a/tests/rustdoc/default-trait-method.rs
+++ b/tests/rustdoc/default-trait-method.rs
@@ -1,26 +1,45 @@
 #![feature(min_specialization)]
 
 // @has default_trait_method/trait.Item.html
-// @has - '//*[@id="tymethod.foo"]' 'fn foo()'
-// @!has - '//*[@id="tymethod.foo"]' 'default fn foo()'
-// @has - '//*[@id="tymethod.bar"]' 'fn bar()'
-// @!has - '//*[@id="tymethod.bar"]' 'default fn bar()'
-// @has - '//*[@id="method.baz"]' 'fn baz()'
-// @!has - '//*[@id="method.baz"]' 'default fn baz()'
 pub trait Item {
+    // @has - '//*[@id="tymethod.foo"]' 'fn foo()'
+    // @!has - '//*[@id="tymethod.foo"]' 'default fn foo()'
     fn foo();
+
+    // @has - '//*[@id="tymethod.bar"]' 'fn bar()'
+    // @!has - '//*[@id="tymethod.bar"]' 'default fn bar()'
     fn bar();
-    fn baz() {}
+
+    // @has - '//*[@id="tymethod.baz"]' 'unsafe fn baz()'
+    // @!has - '//*[@id="tymethod.baz"]' 'default unsafe fn baz()'
+    unsafe fn baz();
+
+    // @has - '//*[@id="tymethod.quux"]' 'unsafe fn quux()'
+    // @!has - '//*[@id="tymethod.quux"]' 'default unsafe fn quux()'
+    unsafe fn quux();
+
+    // @has - '//*[@id="method.xyzzy"]' 'fn xyzzy()'
+    // @!has - '//*[@id="method.xyzzy"]' 'default fn xyzzy()'
+    fn xyzzy() {}
 }
 
 // @has default_trait_method/struct.Foo.html
-// @has - '//*[@id="method.foo"]' 'default fn foo()'
-// @has - '//*[@id="method.bar"]' 'fn bar()'
-// @!has - '//*[@id="method.bar"]' 'default fn bar()'
-// @has - '//*[@id="method.baz"]' 'fn baz()'
-// @!has - '//*[@id="method.baz"]' 'default fn baz()'
 pub struct Foo;
 impl Item for Foo {
+    // @has - '//*[@id="method.foo"]' 'default fn foo()'
     default fn foo() {}
+
+    // @has - '//*[@id="method.bar"]' 'fn bar()'
+    // @!has - '//*[@id="method.bar"]' 'default fn bar()'
     fn bar() {}
+
+    // @has - '//*[@id="method.baz"]' 'default unsafe fn baz()'
+    default unsafe fn baz() {}
+
+    // @has - '//*[@id="method.quux"]' 'unsafe fn quux()'
+    // @!has - '//*[@id="method.quux"]' 'default unsafe fn quux()'
+    unsafe fn quux() {}
+
+    // @has - '//*[@id="method.xyzzy"]' 'fn xyzzy()'
+    // @!has - '//*[@id="method.xyzzy"]' 'default fn xyzzy()'
 }


### PR DESCRIPTION
With the following code:
```rs
#![feature(specialization)]

pub trait A {
    unsafe fn a();
}

impl A for () {
    default unsafe fn a() {}
}
```
rustdoc would render the `impl` of `a` as
```rs
unsafe default fn a()
```
which is inconsistent with the actual position of `default`.
This PR fixes this issue.