### PR TITLE
Limit lifetime of format_args!() with inlined args.

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1033,6 +1033,7 @@ symbols! {
         non_exhaustive_omitted_patterns_lint,
         non_lifetime_binders,
         non_modrs_mods,
+        none,
         nontemporal_store,
         noop_method_borrow,
         noop_method_clone,

--- a/library/core/src/fmt/rt.rs
+++ b/library/core/src/fmt/rt.rs
@@ -152,6 +152,21 @@ impl<'a> Argument<'a> {
             None
         }
     }
+
+    /// Used by `format_args` when all arguments are gone after inlining,
+    /// when using `&[]` would incorrectly allow for a bigger lifetime.
+    ///
+    /// This fails without format argument inlining, and that shouldn't be different
+    /// when the argument is inlined:
+    ///
+    /// ```compile_fail,E0716
+    /// let f = format_args!("{}", "a");
+    /// println!("{f}");
+    /// ```
+    #[inline(always)]
+    pub fn none() -> [Self; 0] {
+        []
+    }
 }
 
 /// This struct represents the unsafety of constructing an `Arguments`.


### PR DESCRIPTION
Fixes #110769