### PR TITLE
Use the upper bound of an iterator in Vec::extend

### DIFF
--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -1,3 +1,4 @@
+use core::iter::Iterator;
 use rand::RngCore;
 use std::iter::repeat;
 use test::{black_box, Bencher};
@@ -594,10 +595,20 @@ fn bench_chain_extend_value(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_extend_upper_size_hint(b: &mut Bencher) {
+fn bench_extend_upper_size_hint_filter(b: &mut Bencher) {
     b.iter(|| {
         let mut v = Vec::new();
         let it = (0..LEN).filter(|_| true);
+        v.extend(it);
+        v
+    });
+}
+
+#[bench]
+fn bench_extend_upper_size_hint_filter_map(b: &mut Bencher) {
+    b.iter(|| {
+        let mut v = Vec::new();
+        let it = (0..LEN).filter_map(|i| Some(i));
         v.extend(it);
         v
     });

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -594,6 +594,16 @@ fn bench_chain_extend_value(b: &mut Bencher) {
 }
 
 #[bench]
+fn bench_extend_upper_size_hint(b: &mut Bencher) {
+    b.iter(|| {
+        let mut v = Vec::new();
+        let it = (0..LEN).filter(|_| true);
+        v.extend(it);
+        v
+    });
+}
+
+#[bench]
 fn bench_rev_1(b: &mut Bencher) {
     let data = black_box([0; LEN]);
     b.iter(|| {

--- a/library/core/src/iter/adapters/filter.rs
+++ b/library/core/src/iter/adapters/filter.rs
@@ -1,6 +1,9 @@
 use crate::fmt;
 use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable};
 use crate::ops::Try;
+use core::array;
+use core::mem::{ManuallyDrop, MaybeUninit};
+use core::ops::ControlFlow;
 
 /// An iterator that filters the elements of `iter` with `predicate`.
 ///
@@ -54,6 +57,55 @@ where
     #[inline]
     fn next(&mut self) -> Option<I::Item> {
         self.iter.find(&mut self.predicate)
+    }
+
+    #[inline]
+    fn next_chunk<const N: usize>(
+        &mut self,
+    ) -> Result<[Self::Item; N], array::IntoIter<Self::Item, N>> {
+        let mut array: [MaybeUninit<Self::Item>; N] = MaybeUninit::uninit_array();
+
+        struct Guard<'a, T> {
+            array: &'a mut [MaybeUninit<T>],
+            initialized: usize,
+        }
+
+        impl<T> Drop for Guard<'_, T> {
+            fn drop(&mut self) {
+                // SAFETY: self.initialized is always <= N, which also is the length of the array.
+                unsafe {
+                    core::ptr::drop_in_place(MaybeUninit::slice_assume_init_mut(
+                        self.array.get_unchecked_mut(..self.initialized),
+                    ));
+                }
+            }
+        }
+
+        let mut guard = Guard { array: &mut array, initialized: 0 };
+
+        let result = self.iter.try_for_each(|element| {
+            let idx = guard.initialized;
+            guard.initialized = idx + (self.predicate)(&element) as usize;
+
+            // SAFETY: Loop conditions ensure the index is in bounds.
+            unsafe { guard.array.get_unchecked_mut(idx) }.write(element);
+
+            if guard.initialized < N { ControlFlow::Continue(()) } else { ControlFlow::Break(()) }
+        });
+
+        let guard = ManuallyDrop::new(guard);
+
+        match result {
+            ControlFlow::Break(()) => {
+                // SAFETY: The loop above is only explicitly broken when the array has been fully initialized
+                Ok(unsafe { MaybeUninit::array_assume_init(array) })
+            }
+            ControlFlow::Continue(()) => {
+                let initialized = guard.initialized;
+                // SAFETY: The range is in bounds since the loop breaks when reaching N elements.
+                Err(unsafe { array::IntoIter::new_unchecked(array, 0..initialized) })
+            }
+        }
     }
 
     #[inline]

--- a/library/core/src/iter/adapters/filter_map.rs
+++ b/library/core/src/iter/adapters/filter_map.rs
@@ -1,5 +1,6 @@
-use crate::fmt;
+use crate::{fmt, array};
 use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable};
+use crate::mem::{MaybeUninit, ManuallyDrop};
 use crate::ops::{ControlFlow, Try};
 
 /// An iterator that uses `f` to both filter and map elements from `iter`.
@@ -59,6 +60,62 @@ where
     #[inline]
     fn next(&mut self) -> Option<B> {
         self.iter.find_map(&mut self.f)
+    }
+
+    #[inline]
+    fn next_chunk<const N: usize>(
+        &mut self,
+    ) -> Result<[Self::Item; N], array::IntoIter<Self::Item, N>> {
+        let mut array: [MaybeUninit<Self::Item>; N] = MaybeUninit::uninit_array();
+
+        struct Guard<'a, T> {
+            array: &'a mut [MaybeUninit<T>],
+            initialized: usize,
+        }
+
+        impl<T> Drop for Guard<'_, T> {
+            fn drop(&mut self) {
+                // SAFETY: self.initialized is always <= N, which also is the length of the array.
+                unsafe {
+                    core::ptr::drop_in_place(MaybeUninit::slice_assume_init_mut(
+                        self.array.get_unchecked_mut(..self.initialized),
+                    ));
+                }
+            }
+        }
+
+        let mut guard = Guard { array: &mut array, initialized: 0 };
+
+        let result = self.iter.try_for_each(|element| {
+            let idx = guard.initialized;
+            let val = (self.f)(element);
+            guard.initialized = idx + val.is_some() as usize;
+
+            // SAFETY: Loop conditions ensure the index is in bounds.
+            
+            unsafe {
+                let opt_payload_at = core::intrinsics::option_payload_ptr(&val);
+                let dst = guard.array.as_mut_ptr().add(idx);
+                crate::ptr::copy_nonoverlapping(opt_payload_at.cast(), dst, 1);
+                crate::mem::forget(val);
+            };
+
+            if guard.initialized < N { ControlFlow::Continue(()) } else { ControlFlow::Break(()) }
+        });
+
+        let guard = ManuallyDrop::new(guard);
+
+        match result {
+            ControlFlow::Break(()) => {
+                // SAFETY: The loop above is only explicitly broken when the array has been fully initialized
+                Ok(unsafe { MaybeUninit::array_assume_init(array) })
+            }
+            ControlFlow::Continue(()) => {
+                let initialized = guard.initialized;
+                // SAFETY: The range is in bounds since the loop breaks when reaching N elements.
+                Err(unsafe { array::IntoIter::new_unchecked(array, 0..initialized) })
+            }
+        }
     }
 
     #[inline]


### PR DESCRIPTION
```
OLD: vec::bench_extend_upper_size_hint  32.80µs/iter +/- 430.00ns
NEW: vec::bench_extend_upper_size_hint  5.61µs/iter +/- 59.00ns
```

r? @ghost