### PR TITLE
configure.py: add flag for riscv{64,32}gc musl-root

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -139,6 +139,10 @@ v("musl-root-mips64", "target.mips64-unknown-linux-muslabi64.musl-root",
   "mips64-unknown-linux-muslabi64 install directory")
 v("musl-root-mips64el", "target.mips64el-unknown-linux-muslabi64.musl-root",
   "mips64el-unknown-linux-muslabi64 install directory")
+v("musl-root-riscv32gc", "target.riscv32gc-unknown-linux-musl.musl-root",
+  "riscv32gc-unknown-linux-musl install directory")
+v("musl-root-riscv64gc", "target.riscv64gc-unknown-linux-musl.musl-root",
+  "riscv64gc-unknown-linux-musl install directory")
 v("qemu-armhf-rootfs", "target.arm-unknown-linux-gnueabihf.qemu-rootfs",
   "rootfs in qemu testing, you probably don't want to use this")
 v("qemu-aarch64-rootfs", "target.aarch64-unknown-linux-gnu.qemu-rootfs",


### PR DESCRIPTION
Add the corresponding flag for detecting `--musl-root-riscv64gc` and `--musl-root-riscv32gc` with ./configure, which is beneficial for downstream Linux distros to create the rust package with the same "recipe" from other architectures.
