### PR TITLE
rustdoc-search: add slices and arrays to index

### DIFF
--- a/tests/rustdoc-js/slice-array.js
+++ b/tests/rustdoc-js/slice-array.js
@@ -1,0 +1,65 @@
+// exact-check
+
+const QUERY = [
+    'R<primitive:slice<P>>',
+    'primitive:slice<R<P>>',
+    'R<primitive:slice<Q>>',
+    'primitive:slice<R<Q>>',
+    'R<primitive:array<Q>>',
+    'primitive:array<R<Q>>',
+    'primitive:array<TraitCat>',
+    'primitive:array<TraitDog>',
+];
+
+const EXPECTED = [
+    {
+        // R<primitive:slice<P>>
+        'returned': [],
+        'in_args': [
+            { 'path': 'slice_array', 'name': 'alpha' },
+        ],
+    },
+    {
+        // primitive:slice<R<P>>
+        'returned': [
+            { 'path': 'slice_array', 'name': 'alef' },
+        ],
+        'in_args': [],
+    },
+    {
+        // R<primitive:slice<Q>>
+        'returned': [],
+        'in_args': [],
+    },
+    {
+        // primitive:slice<R<Q>>
+        'returned': [],
+        'in_args': [],
+    },
+    {
+        // R<primitive:array<Q>>
+        'returned': [
+            { 'path': 'slice_array', 'name': 'bet' },
+        ],
+        'in_args': [],
+    },
+    {
+        // primitive:array<R<Q>>
+        'returned': [],
+        'in_args': [
+            { 'path': 'slice_array', 'name': 'beta' },
+        ],
+    },
+    {
+        // primitive::array<TraitCat>
+        'in_args': [
+            { 'path': 'slice_array', 'name': 'gamma' },
+        ],
+    },
+    {
+        // primitive::array<TraitDog>
+        'in_args': [
+            { 'path': 'slice_array', 'name': 'gamma' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/slice-array.rs
+++ b/tests/rustdoc-js/slice-array.rs
@@ -1,0 +1,16 @@
+pub struct P;
+pub struct Q;
+pub struct R<T>(T);
+
+// returns test
+pub fn alef() -> &'static [R<P>] { loop {} }
+pub fn bet() -> R<[Q; 32]> { loop {} }
+
+// in_args test
+pub fn alpha(_x: R<&'static [P]>) { loop {} }
+pub fn beta(_x: [R<Q>; 32]) { loop {} }
+
+pub trait TraitCat {}
+pub trait TraitDog {}
+
+pub fn gamma<T: TraitCat + TraitDog>(t: [T; 32]) {}


### PR DESCRIPTION
This indexes them as primitives with generics, so `slice<u32>` is how you search for `[u32]`, and `array<u32>` for `[u32; 1]`. A future commit will desugar the square bracket syntax to search both arrays and slices at once.