### PR TITLE
Revert "Download the GCC sources insecurely"

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
@@ -22,8 +22,7 @@ cd gcc-$GCC
 # latter host is presented to `wget`! Therefore, we choose to download from the insecure HTTP server
 # instead here.
 #
-# FIXME: use HTTPS (see https://github.com/rust-lang/rust/pull/86586#issuecomment-868355356)
-sed -i'' 's|ftp://gcc\.gnu\.org/|http://gcc.gnu.org/|g' ./contrib/download_prerequisites
+sed -i'' 's|ftp://gcc\.gnu\.org/|https://gcc.gnu.org/|g' ./contrib/download_prerequisites
 
 ./contrib/download_prerequisites
 mkdir ../gcc-build


### PR DESCRIPTION
This reverts commit 3da037f82988b8b3aca2ce13c5c81ba975923cab.

This workaround was added after TLS problems with Debian 6 were noted in <https://github.com/rust-lang/rust/pull/86586#issuecomment-868355356>, but we should be well past that since #95026, where our oldest images are now based on CentOS 7.