### PR TITLE
Updating Wake example to use new 'pin!' macro

### DIFF
--- a/library/alloc/src/task.rs
+++ b/library/alloc/src/task.rs
@@ -39,6 +39,7 @@ use crate::sync::Arc;
 /// use std::sync::Arc;
 /// use std::task::{Context, Poll, Wake};
 /// use std::thread::{self, Thread};
+/// use core::pin::pin;
 ///
 /// /// A waker that wakes up the current thread when called.
 /// struct ThreadWaker(Thread);
@@ -52,7 +53,7 @@ use crate::sync::Arc;
 /// /// Run a future to completion on the current thread.
 /// fn block_on<T>(fut: impl Future<Output = T>) -> T {
 ///     // Pin the future so it can be polled.
-///     let mut fut = Box::pin(fut);
+///     let mut fut = pin!(fut);
 ///
 ///     // Create a new context to be passed to the future.
 ///     let t = thread::current();


### PR DESCRIPTION
Closes: https://github.com/rust-lang/rust/issues/109965

I have already had this reviewed and approved here: https://github.com/rust-lang/rust/pull/110026 . But because I had some git issues and chose the "nuke it" option as my solution it didn't get merged. I nuked it too quickly. I am sorry for trouble of reviewing twice.