### PR TITLE
Use &dyn Any rather than &(dyn Any + Send) for PanicInfo::payload()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,9 +4826,9 @@ dependencies = [
 
 [[package]]
 name = "tester"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0639d10d8f4615f223a57275cf40f9bdb7cfbb806bcb7f7cc56e3beb55a576eb"
+checksum = "89e8bf7e0eb2dd7b4228cc1b6821fc5114cd6841ae59f652a85488c016091e5f"
 dependencies = [
  "cfg-if",
  "getopts",

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -24,7 +24,7 @@ use crate::panic::Location;
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 #[derive(Debug)]
 pub struct PanicInfo<'a> {
-    payload: &'a (dyn Any + Send),
+    payload: &'a dyn Any,
     message: Option<&'a fmt::Arguments<'a>>,
     location: &'a Location<'a>,
     can_unwind: bool,
@@ -81,7 +81,7 @@ impl<'a> PanicInfo<'a> {
     /// ```
     #[must_use]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
-    pub fn payload(&self) -> &(dyn Any + Send) {
+    pub fn payload(&self) -> &dyn Any {
         self.payload
     }
 

--- a/library/test/src/test_result.rs
+++ b/library/test/src/test_result.rs
@@ -27,7 +27,7 @@ pub enum TestResult {
 /// and associated data.
 pub fn calc_result<'a>(
     desc: &TestDesc,
-    task_result: Result<(), &'a (dyn Any + 'static + Send)>,
+    task_result: Result<(), &'a dyn Any>,
     time_opts: &Option<time::TestTimeOptions>,
     exec_time: &Option<time::TestExecTime>,
 ) -> TestResult {

--- a/src/tools/clippy/Cargo.toml
+++ b/src/tools/clippy/Cargo.toml
@@ -28,7 +28,7 @@ termize = "0.1"
 
 [dev-dependencies]
 compiletest_rs = { version = "0.10", features = ["tmp"] }
-tester = "0.9"
+tester = "0.9.1"
 regex = "1.5"
 toml = "0.5"
 walkdir = "2.3"


### PR DESCRIPTION
The `Send` in `&(dyn Any + Send)` is basically useless, because it's a reference. Removing it from `PanicInfo::payload()` allows for some new possibilities in the future, if the type behind it no longer needs to be `Send`. (We could just safely transmute the `+ Send` into the `&dyn` because it's meaningless for references, but it'd be nicer to just remove the needless `+ Send` from the public API to clean things up.

Removing it will break some other places that (needlessly) have the same `+ Send` though, luckily there don't seem to many cases of that in the Rust ecosystem.