### PR TITLE
Use `?0` notation for ty/ct/int/float/region vars

### DIFF
--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -95,7 +95,7 @@ impl<'tcx> fmt::Debug for ty::FnSig<'tcx> {
 
 impl<'tcx> fmt::Debug for ty::ConstVid<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "_#{}c", self.index)
+        write!(f, "?{}c", self.index)
     }
 }
 

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1436,7 +1436,7 @@ pub struct ConstVid<'tcx> {
 rustc_index::newtype_index! {
     /// A **region** (lifetime) **v**ariable **ID**.
     #[derive(HashStable)]
-    #[debug_format = "'_#{}r"]
+    #[debug_format = "'?{}"]
     pub struct RegionVid {}
 }
 

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -537,7 +537,7 @@ pub struct FloatVarValue(pub FloatTy);
 
 rustc_index::newtype_index! {
     /// A **ty**pe **v**ariable **ID**.
-    #[debug_format = "_#{}t"]
+    #[debug_format = "?{}t"]
     pub struct TyVid {}
 }
 
@@ -739,13 +739,13 @@ impl fmt::Debug for FloatVarValue {
 
 impl fmt::Debug for IntVid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "_#{}i", self.index)
+        write!(f, "?{}i", self.index)
     }
 }
 
 impl fmt::Debug for FloatVid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "_#{}f", self.index)
+        write!(f, "?{}f", self.index)
     }
 }
 

--- a/tests/mir-opt/nll/named_lifetimes_basic.use_x.nll.0.mir
+++ b/tests/mir-opt/nll/named_lifetimes_basic.use_x.nll.0.mir
@@ -1,39 +1,39 @@
 // MIR for `use_x` 0 nll
 
 | Free Region Mapping
-| '_#0r | Global | ['_#2r, '_#1r, '_#0r, '_#4r, '_#3r]
-| '_#1r | Local | ['_#1r, '_#4r]
-| '_#2r | Local | ['_#2r, '_#1r, '_#4r]
-| '_#3r | Local | ['_#4r, '_#3r]
-| '_#4r | Local | ['_#4r]
+| '?0 | Global | ['?2, '?1, '?0, '?4, '?3]
+| '?1 | Local | ['?1, '?4]
+| '?2 | Local | ['?2, '?1, '?4]
+| '?3 | Local | ['?4, '?3]
+| '?4 | Local | ['?4]
 |
 | Inferred Region Values
-| '_#0r | U0 | {bb0[0..=1], '_#0r, '_#1r, '_#2r, '_#3r, '_#4r}
-| '_#1r | U0 | {bb0[0..=1], '_#1r}
-| '_#2r | U0 | {bb0[0..=1], '_#2r}
-| '_#3r | U0 | {bb0[0..=1], '_#3r}
-| '_#4r | U0 | {bb0[0..=1], '_#4r}
-| '_#5r | U0 | {bb0[0..=1], '_#1r}
-| '_#6r | U0 | {bb0[0..=1], '_#2r}
-| '_#7r | U0 | {bb0[0..=1], '_#1r}
-| '_#8r | U0 | {bb0[0..=1], '_#3r}
+| '?0 | U0 | {bb0[0..=1], '?0, '?1, '?2, '?3, '?4}
+| '?1 | U0 | {bb0[0..=1], '?1}
+| '?2 | U0 | {bb0[0..=1], '?2}
+| '?3 | U0 | {bb0[0..=1], '?3}
+| '?4 | U0 | {bb0[0..=1], '?4}
+| '?5 | U0 | {bb0[0..=1], '?1}
+| '?6 | U0 | {bb0[0..=1], '?2}
+| '?7 | U0 | {bb0[0..=1], '?1}
+| '?8 | U0 | {bb0[0..=1], '?3}
 |
 | Inference Constraints
-| '_#0r live at {bb0[0..=1]}
-| '_#1r live at {bb0[0..=1]}
-| '_#2r live at {bb0[0..=1]}
-| '_#3r live at {bb0[0..=1]}
-| '_#4r live at {bb0[0..=1]}
-| '_#1r: '_#5r due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:26: 12:27) ($DIR/named_lifetimes_basic.rs:12:26: 12:27 (#0)
-| '_#1r: '_#7r due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:54: 12:55) ($DIR/named_lifetimes_basic.rs:12:54: 12:55 (#0)
-| '_#2r: '_#6r due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:42: 12:43) ($DIR/named_lifetimes_basic.rs:12:42: 12:43 (#0)
-| '_#3r: '_#8r due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:66: 12:67) ($DIR/named_lifetimes_basic.rs:12:66: 12:67 (#0)
-| '_#5r: '_#1r due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:26: 12:27) ($DIR/named_lifetimes_basic.rs:12:26: 12:27 (#0)
-| '_#6r: '_#2r due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:42: 12:43) ($DIR/named_lifetimes_basic.rs:12:42: 12:43 (#0)
-| '_#7r: '_#1r due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:54: 12:55) ($DIR/named_lifetimes_basic.rs:12:54: 12:55 (#0)
-| '_#8r: '_#3r due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:66: 12:67) ($DIR/named_lifetimes_basic.rs:12:66: 12:67 (#0)
+| '?0 live at {bb0[0..=1]}
+| '?1 live at {bb0[0..=1]}
+| '?2 live at {bb0[0..=1]}
+| '?3 live at {bb0[0..=1]}
+| '?4 live at {bb0[0..=1]}
+| '?1: '?5 due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:26: 12:27) ($DIR/named_lifetimes_basic.rs:12:26: 12:27 (#0)
+| '?1: '?7 due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:54: 12:55) ($DIR/named_lifetimes_basic.rs:12:54: 12:55 (#0)
+| '?2: '?6 due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:42: 12:43) ($DIR/named_lifetimes_basic.rs:12:42: 12:43 (#0)
+| '?3: '?8 due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:66: 12:67) ($DIR/named_lifetimes_basic.rs:12:66: 12:67 (#0)
+| '?5: '?1 due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:26: 12:27) ($DIR/named_lifetimes_basic.rs:12:26: 12:27 (#0)
+| '?6: '?2 due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:42: 12:43) ($DIR/named_lifetimes_basic.rs:12:42: 12:43 (#0)
+| '?7: '?1 due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:54: 12:55) ($DIR/named_lifetimes_basic.rs:12:54: 12:55 (#0)
+| '?8: '?3 due to BoringNoLocation at All($DIR/named_lifetimes_basic.rs:12:66: 12:67) ($DIR/named_lifetimes_basic.rs:12:66: 12:67 (#0)
 |
-fn use_x(_1: &'_#5r mut i32, _2: &'_#6r u32, _3: &'_#7r u32, _4: &'_#8r u32) -> bool {
+fn use_x(_1: &'?5 mut i32, _2: &'?6 u32, _3: &'?7 u32, _4: &'?8 u32) -> bool {
     debug w => _1;                       // in scope 0 at $DIR/named_lifetimes_basic.rs:+0:26: +0:27
     debug x => _2;                       // in scope 0 at $DIR/named_lifetimes_basic.rs:+0:42: +0:43
     debug y => _3;                       // in scope 0 at $DIR/named_lifetimes_basic.rs:+0:54: +0:55

--- a/tests/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
+++ b/tests/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
@@ -1,24 +1,24 @@
 // MIR for `main` 0 nll
 
 | Free Region Mapping
-| '_#0r | Global | ['_#0r, '_#1r]
-| '_#1r | Local | ['_#1r]
+| '?0 | Global | ['?0, '?1]
+| '?1 | Local | ['?1]
 |
 | Inferred Region Values
-| '_#0r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '_#0r, '_#1r}
-| '_#1r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '_#1r}
-| '_#2r | U0 | {bb1[0..=7], bb2[0..=2]}
-| '_#3r | U0 | {bb1[1..=7], bb2[0..=2]}
-| '_#4r | U0 | {bb1[4..=7], bb2[0..=2]}
+| '?0 | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '?0, '?1}
+| '?1 | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '?1}
+| '?2 | U0 | {bb1[0..=7], bb2[0..=2]}
+| '?3 | U0 | {bb1[1..=7], bb2[0..=2]}
+| '?4 | U0 | {bb1[4..=7], bb2[0..=2]}
 |
 | Inference Constraints
-| '_#0r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
-| '_#1r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
-| '_#2r live at {bb1[0]}
-| '_#3r live at {bb1[1..=3]}
-| '_#4r live at {bb1[4..=7], bb2[0..=2]}
-| '_#2r: '_#3r due to Assignment at Single(bb1[0]) ($DIR/region_subtyping_basic.rs:18:13: 18:18 (#0)
-| '_#3r: '_#4r due to Assignment at Single(bb1[3]) ($DIR/region_subtyping_basic.rs:19:13: 19:14 (#0)
+| '?0 live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
+| '?1 live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
+| '?2 live at {bb1[0]}
+| '?3 live at {bb1[1..=3]}
+| '?4 live at {bb1[4..=7], bb2[0..=2]}
+| '?2: '?3 due to Assignment at Single(bb1[0]) ($DIR/region_subtyping_basic.rs:18:13: 18:18 (#0)
+| '?3: '?4 due to Assignment at Single(bb1[3]) ($DIR/region_subtyping_basic.rs:19:13: 19:14 (#0)
 |
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/region_subtyping_basic.rs:+0:11: +0:11
@@ -32,10 +32,10 @@ fn main() -> () {
     let _10: bool;                       // in scope 0 at $DIR/region_subtyping_basic.rs:+7:9: +7:18
     scope 1 {
         debug v => _1;                   // in scope 1 at $DIR/region_subtyping_basic.rs:+1:9: +1:14
-        let _2: &'_#3r usize;            // in scope 1 at $DIR/region_subtyping_basic.rs:+2:9: +2:10
+        let _2: &'?3 usize;              // in scope 1 at $DIR/region_subtyping_basic.rs:+2:9: +2:10
         scope 2 {
             debug p => _2;               // in scope 2 at $DIR/region_subtyping_basic.rs:+2:9: +2:10
-            let _6: &'_#4r usize;        // in scope 2 at $DIR/region_subtyping_basic.rs:+3:9: +3:10
+            let _6: &'?4 usize;          // in scope 2 at $DIR/region_subtyping_basic.rs:+3:9: +3:10
             scope 3 {
                 debug q => _6;           // in scope 3 at $DIR/region_subtyping_basic.rs:+3:9: +3:10
             }
@@ -55,7 +55,7 @@ fn main() -> () {
     }
 
     bb1: {
-        _2 = &'_#2r _1[_3];              // bb1[0]: scope 1 at $DIR/region_subtyping_basic.rs:+2:13: +2:18
+        _2 = &'?2 _1[_3];                // bb1[0]: scope 1 at $DIR/region_subtyping_basic.rs:+2:13: +2:18
         FakeRead(ForLet(None), _2);      // bb1[1]: scope 1 at $DIR/region_subtyping_basic.rs:+2:9: +2:10
         StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region_subtyping_basic.rs:+3:9: +3:10
         _6 = _2;                         // bb1[3]: scope 2 at $DIR/region_subtyping_basic.rs:+3:13: +3:14

--- a/tests/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
+++ b/tests/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
@@ -1,24 +1,24 @@
 // MIR for `main` 0 nll
 
 | Free Region Mapping
-| '_#0r | Global | ['_#0r, '_#1r]
-| '_#1r | Local | ['_#1r]
+| '?0 | Global | ['?0, '?1]
+| '?1 | Local | ['?1]
 |
 | Inferred Region Values
-| '_#0r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '_#0r, '_#1r}
-| '_#1r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '_#1r}
-| '_#2r | U0 | {bb1[0..=7], bb2[0..=2]}
-| '_#3r | U0 | {bb1[1..=7], bb2[0..=2]}
-| '_#4r | U0 | {bb1[4..=7], bb2[0..=2]}
+| '?0 | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '?0, '?1}
+| '?1 | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '?1}
+| '?2 | U0 | {bb1[0..=7], bb2[0..=2]}
+| '?3 | U0 | {bb1[1..=7], bb2[0..=2]}
+| '?4 | U0 | {bb1[4..=7], bb2[0..=2]}
 |
 | Inference Constraints
-| '_#0r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
-| '_#1r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
-| '_#2r live at {bb1[0]}
-| '_#3r live at {bb1[1..=3]}
-| '_#4r live at {bb1[4..=7], bb2[0..=2]}
-| '_#2r: '_#3r due to Assignment at Single(bb1[0]) ($DIR/region_subtyping_basic.rs:18:13: 18:18 (#0)
-| '_#3r: '_#4r due to Assignment at Single(bb1[3]) ($DIR/region_subtyping_basic.rs:19:13: 19:14 (#0)
+| '?0 live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
+| '?1 live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
+| '?2 live at {bb1[0]}
+| '?3 live at {bb1[1..=3]}
+| '?4 live at {bb1[4..=7], bb2[0..=2]}
+| '?2: '?3 due to Assignment at Single(bb1[0]) ($DIR/region_subtyping_basic.rs:18:13: 18:18 (#0)
+| '?3: '?4 due to Assignment at Single(bb1[3]) ($DIR/region_subtyping_basic.rs:19:13: 19:14 (#0)
 |
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/region_subtyping_basic.rs:+0:11: +0:11
@@ -32,10 +32,10 @@ fn main() -> () {
     let _10: bool;                       // in scope 0 at $DIR/region_subtyping_basic.rs:+7:9: +7:18
     scope 1 {
         debug v => _1;                   // in scope 1 at $DIR/region_subtyping_basic.rs:+1:9: +1:14
-        let _2: &'_#3r usize;            // in scope 1 at $DIR/region_subtyping_basic.rs:+2:9: +2:10
+        let _2: &'?3 usize;              // in scope 1 at $DIR/region_subtyping_basic.rs:+2:9: +2:10
         scope 2 {
             debug p => _2;               // in scope 2 at $DIR/region_subtyping_basic.rs:+2:9: +2:10
-            let _6: &'_#4r usize;        // in scope 2 at $DIR/region_subtyping_basic.rs:+3:9: +3:10
+            let _6: &'?4 usize;          // in scope 2 at $DIR/region_subtyping_basic.rs:+3:9: +3:10
             scope 3 {
                 debug q => _6;           // in scope 3 at $DIR/region_subtyping_basic.rs:+3:9: +3:10
             }
@@ -55,7 +55,7 @@ fn main() -> () {
     }
 
     bb1: {
-        _2 = &'_#2r _1[_3];              // bb1[0]: scope 1 at $DIR/region_subtyping_basic.rs:+2:13: +2:18
+        _2 = &'?2 _1[_3];                // bb1[0]: scope 1 at $DIR/region_subtyping_basic.rs:+2:13: +2:18
         FakeRead(ForLet(None), _2);      // bb1[1]: scope 1 at $DIR/region_subtyping_basic.rs:+2:9: +2:10
         StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region_subtyping_basic.rs:+3:9: +3:10
         _6 = _2;                         // bb1[3]: scope 2 at $DIR/region_subtyping_basic.rs:+3:13: +3:14

--- a/tests/mir-opt/storage_ranges.main.nll.0.mir
+++ b/tests/mir-opt/storage_ranges.main.nll.0.mir
@@ -1,21 +1,21 @@
 // MIR for `main` 0 nll
 
 | Free Region Mapping
-| '_#0r | Global | ['_#0r, '_#1r]
-| '_#1r | Local | ['_#1r]
+| '?0 | Global | ['?0, '?1]
+| '?1 | Local | ['?1]
 |
 | Inferred Region Values
-| '_#0r | U0 | {bb0[0..=22], '_#0r, '_#1r}
-| '_#1r | U0 | {bb0[0..=22], '_#1r}
-| '_#2r | U0 | {bb0[10..=11]}
-| '_#3r | U0 | {bb0[11]}
+| '?0 | U0 | {bb0[0..=22], '?0, '?1}
+| '?1 | U0 | {bb0[0..=22], '?1}
+| '?2 | U0 | {bb0[10..=11]}
+| '?3 | U0 | {bb0[11]}
 |
 | Inference Constraints
-| '_#0r live at {bb0[0..=22]}
-| '_#1r live at {bb0[0..=22]}
-| '_#2r live at {bb0[10]}
-| '_#3r live at {bb0[11]}
-| '_#2r: '_#3r due to Assignment at Single(bb0[10]) ($DIR/storage_ranges.rs:6:17: 6:25 (#0)
+| '?0 live at {bb0[0..=22]}
+| '?1 live at {bb0[0..=22]}
+| '?2 live at {bb0[10]}
+| '?3 live at {bb0[11]}
+| '?2: '?3 due to Assignment at Single(bb0[10]) ($DIR/storage_ranges.rs:6:17: 6:25 (#0)
 |
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/storage_ranges.rs:+0:11: +0:11

--- a/tests/ui/associated-types/substs-ppaux.verbose.stderr
+++ b/tests/ui/associated-types/substs-ppaux.verbose.stderr
@@ -77,7 +77,7 @@ LL |     <str as Foo<u8>>::bar;
    |     ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-note: required for `str` to implement `Foo<'_#0r, '_#1r, u8>`
+note: required for `str` to implement `Foo<'?0, '?1, u8>`
   --> $DIR/substs-ppaux.rs:11:17
    |
 LL | impl<'a,'b,T,S> Foo<'a, 'b, S> for T {}

--- a/tests/ui/closures/binder/nested-closures-regions.stderr
+++ b/tests/ui/closures/binder/nested-closures-regions.stderr
@@ -9,11 +9,11 @@ LL |     for<'a> || -> () { for<'c> |_: &'a ()| -> () {}; };
                extern "rust-call" fn((&(),)),
                (),
            ]
-   = note: late-bound region is '_#4r
-   = note: late-bound region is '_#2r
+   = note: late-bound region is '?4
+   = note: late-bound region is '?2
    = note: number of external vids: 3
-   = note: where '_#1r: '_#2r
-   = note: where '_#2r: '_#1r
+   = note: where '?1: '?2
+   = note: where '?2: '?1
 
 note: no external requirements
   --> $DIR/nested-closures-regions.rs:8:5
@@ -26,7 +26,7 @@ LL |     for<'a> || -> () { for<'c> |_: &'a ()| -> () {}; };
                extern "rust-call" fn(()),
                (),
            ]
-   = note: late-bound region is '_#2r
+   = note: late-bound region is '?2
 
 note: no external requirements
   --> $DIR/nested-closures-regions.rs:7:1

--- a/tests/ui/closures/print/closure-print-generic-trim-off-verbose-2.stderr
+++ b/tests/ui/closures/print/closure-print-generic-trim-off-verbose-2.stderr
@@ -9,7 +9,7 @@ LL |         let c1 : () = c;
    |                  expected due to this
    |
    = note: expected unit type `()`
-                found closure `[mod1::f<T>::{closure#0} closure_substs=(unavailable) substs=[T, _#16t, extern "rust-call" fn(()), _#15t]]`
+                found closure `[mod1::f<T>::{closure#0} closure_substs=(unavailable) substs=[T, ?16t, extern "rust-call" fn(()), ?15t]]`
 help: use parentheses to call this closure
    |
 LL |         let c1 : () = c();

--- a/tests/ui/closures/print/closure-print-generic-verbose-1.stderr
+++ b/tests/ui/closures/print/closure-print-generic-verbose-1.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `c`
   --> $DIR/closure-print-generic-verbose-1.rs:17:5
    |
 LL |     let c = to_fn_once(move|| {
-   |         - move occurs because `c` has type `[f<T>::{closure#0} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'_#9r str>, T)]`, which does not implement the `Copy` trait
+   |         - move occurs because `c` has type `[f<T>::{closure#0} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'?9 str>, T)]`, which does not implement the `Copy` trait
 ...
 LL |     c();
    |     --- `c` moved due to this call

--- a/tests/ui/closures/print/closure-print-generic-verbose-2.stderr
+++ b/tests/ui/closures/print/closure-print-generic-verbose-2.stderr
@@ -9,7 +9,7 @@ LL |         let c1 : () = c;
    |                  expected due to this
    |
    = note: expected unit type `()`
-                found closure `[f<T>::{closure#0} closure_substs=(unavailable) substs=[T, _#16t, extern "rust-call" fn(()), _#15t]]`
+                found closure `[f<T>::{closure#0} closure_substs=(unavailable) substs=[T, ?16t, extern "rust-call" fn(()), ?15t]]`
 help: use parentheses to call this closure
    |
 LL |         let c1 : () = c();

--- a/tests/ui/closures/print/closure-print-verbose.stderr
+++ b/tests/ui/closures/print/closure-print-verbose.stderr
@@ -7,7 +7,7 @@ LL |     let foo: fn(u8) -> u8 = |v: u8| { a += v; a };
    |              expected due to this
    |
    = note: expected fn pointer `fn(u8) -> u8`
-                 found closure `[main::{closure#0} closure_substs=(unavailable) substs=[i8, extern "rust-call" fn((u8,)) -> u8, _#6t]]`
+                 found closure `[main::{closure#0} closure_substs=(unavailable) substs=[i8, extern "rust-call" fn((u8,)) -> u8, ?6t]]`
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-print-verbose.rs:10:39
    |

--- a/tests/ui/const-generics/occurs-check/unused-substs-2.rs
+++ b/tests/ui/const-generics/occurs-check/unused-substs-2.rs
@@ -1,9 +1,9 @@
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
 
-// The goal is to get an unevaluated const `ct` with a `Ty::Infer(TyVar(_#1t)` subst.
+// The goal is to get an unevaluated const `ct` with a `Ty::Infer(TyVar(?1t)` subst.
 //
-// If we are then able to infer `ty::Infer(TyVar(_#1t) := Ty<ct>` we introduced an
+// If we are then able to infer `ty::Infer(TyVar(?1t) := Ty<ct>` we introduced an
 // artificial inference cycle.
 struct Foo<const N: usize>;
 
@@ -20,8 +20,8 @@ impl<T> Bind<T> for Foo<{ 6 + 1 }> {
 
 fn main() {
     let (mut t, foo) = Foo::bind();
-    // `t` is `ty::Infer(TyVar(_#1t))`
-    // `foo` contains `ty::Infer(TyVar(_#1t))` in its substs
+    // `t` is `ty::Infer(TyVar(?1t))`
+    // `foo` contains `ty::Infer(TyVar(?1t))` in its substs
     t = foo;
     //~^ ERROR mismatched types
     //~| NOTE cyclic type

--- a/tests/ui/const-generics/occurs-check/unused-substs-3.rs
+++ b/tests/ui/const-generics/occurs-check/unused-substs-3.rs
@@ -1,9 +1,9 @@
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
 
-// The goal is to get an unevaluated const `ct` with a `Ty::Infer(TyVar(_#1t)` subst.
+// The goal is to get an unevaluated const `ct` with a `Ty::Infer(TyVar(?1t)` subst.
 //
-// If we are then able to infer `ty::Infer(TyVar(_#1t) := Ty<ct>` we introduced an
+// If we are then able to infer `ty::Infer(TyVar(?1t) := Ty<ct>` we introduced an
 // artificial inference cycle.
 fn bind<T>() -> (T, [u8; 6 + 1]) {
     todo!()
@@ -11,8 +11,8 @@ fn bind<T>() -> (T, [u8; 6 + 1]) {
 
 fn main() {
     let (mut t, foo) = bind();
-    // `t` is `ty::Infer(TyVar(_#1t))`
-    // `foo` contains `ty::Infer(TyVar(_#1t))` in its substs
+    // `t` is `ty::Infer(TyVar(?1t))`
+    // `foo` contains `ty::Infer(TyVar(?1t))` in its substs
     t = foo;
     //~^ ERROR mismatched types
     //~| NOTE cyclic type

--- a/tests/ui/generator/issue-57084.rs
+++ b/tests/ui/generator/issue-57084.rs
@@ -1,5 +1,5 @@
 // This issue reproduces an ICE on compile (E.g. fails on 2018-12-19 nightly).
-// "cannot relate bound region: ReLateBound(DebruijnIndex(1), BrAnon(1)) <= '_#1r"
+// "cannot relate bound region: ReLateBound(DebruijnIndex(1), BrAnon(1)) <= '?1"
 // run-pass
 // edition:2018
 #![feature(generators,generator_trait)]

--- a/tests/ui/impl-trait/wf-eval-order.rs
+++ b/tests/ui/impl-trait/wf-eval-order.rs
@@ -31,9 +31,9 @@ fn main() {
     //
     // - `wf(typeof(x))` because we use a projection candidate.
     // - `<i32 as B>::V: Clone` because that's a bound on the trait.
-    // - `<i32 as B>::V` normalizes to `_#1` where `<i32 as A>::U == _#1`
+    // - `<i32 as B>::V` normalizes to `?1t` where `<i32 as A>::U == ?1t`
     //
-    // This all works if we evaluate `<i32 as A>::U == _#1` before
+    // This all works if we evaluate `<i32 as A>::U == ?1t` before
     // `<i32 as B>::V`, but we previously had the opposite order.
     let x = hide(X(0));
 }

--- a/tests/ui/nll/closure-requirements/escape-argument-callee.stderr
+++ b/tests/ui/nll/closure-requirements/escape-argument-callee.stderr
@@ -17,7 +17,7 @@ LL |         let mut closure = expect_sig(|p, y| *p = y);
    |                                       -  -  ^^^^^^ assignment requires that `'1` must outlive `'2`
    |                                       |  |
    |                                       |  has type `&'1 i32`
-   |                                       has type `&'_#2r mut &'2 i32`
+   |                                       has type `&'?2 mut &'2 i32`
 
 note: no external requirements
   --> $DIR/escape-argument-callee.rs:20:1

--- a/tests/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/tests/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -7,10 +7,10 @@ LL |             let mut closure1 = || p = &y;
    = note: defining type: test::{closure#0}::{closure#0} with closure substs [
                i16,
                extern "rust-call" fn(()),
-               (&'_#1r mut &'_#2r i32, &'_#3r i32),
+               (&'?1 mut &'?2 i32, &'?3 i32),
            ]
    = note: number of external vids: 4
-   = note: where '_#3r: '_#2r
+   = note: where '?3: '?2
 
 note: external requirements
   --> $DIR/escape-upvar-nested.rs:20:27
@@ -21,10 +21,10 @@ LL |         let mut closure = || {
    = note: defining type: test::{closure#0} with closure substs [
                i16,
                extern "rust-call" fn(()),
-               (&'_#1r mut &'_#2r i32, &'_#3r i32),
+               (&'?1 mut &'?2 i32, &'?3 i32),
            ]
    = note: number of external vids: 4
-   = note: where '_#3r: '_#2r
+   = note: where '?3: '?2
 
 note: no external requirements
   --> $DIR/escape-upvar-nested.rs:13:1

--- a/tests/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/tests/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -7,10 +7,10 @@ LL |         let mut closure = || p = &y;
    = note: defining type: test::{closure#0} with closure substs [
                i16,
                extern "rust-call" fn(()),
-               (&'_#1r mut &'_#2r i32, &'_#3r i32),
+               (&'?1 mut &'?2 i32, &'?3 i32),
            ]
    = note: number of external vids: 4
-   = note: where '_#3r: '_#2r
+   = note: where '?3: '?2
 
 note: no external requirements
   --> $DIR/escape-upvar-ref.rs:17:1

--- a/tests/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
@@ -6,20 +6,20 @@ LL |         |_outlives1, _outlives2, _outlives3, x, y| {
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
-               for<Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&'_#2r &ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) &'_#3r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>)),
+               for<Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((std::cell::Cell<&'?1 &ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&'?2 &ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) &'?3 u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>)),
                (),
            ]
-   = note: late-bound region is '_#4r
-   = note: late-bound region is '_#5r
-   = note: late-bound region is '_#6r
+   = note: late-bound region is '?4
+   = note: late-bound region is '?5
+   = note: late-bound region is '?6
 
 error: lifetime may not live long enough
   --> $DIR/propagate-approximated-fail-no-postdom.rs:46:13
    |
 LL |         |_outlives1, _outlives2, _outlives3, x, y| {
-   |          ----------              ---------- has type `Cell<&'2 &'_#3r u32>`
+   |          ----------              ---------- has type `Cell<&'2 &'?3 u32>`
    |          |
-   |          has type `Cell<&'_#1r &'1 u32>`
+   |          has type `Cell<&'?1 &'1 u32>`
 ...
 LL |             demand_y(x, y, p)
    |             ^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`

--- a/tests/ui/nll/closure-requirements/propagate-approximated-ref.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-ref.stderr
@@ -6,13 +6,13 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
-               for<Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 2, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) &'_#2r u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 4, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 5, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) u32>)),
+               for<Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) std::cell::Cell<&'?1 &ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 2, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) &'?2 u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 4, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 5, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) u32>)),
                (),
            ]
-   = note: late-bound region is '_#3r
-   = note: late-bound region is '_#4r
+   = note: late-bound region is '?3
+   = note: late-bound region is '?4
    = note: number of external vids: 5
-   = note: where '_#1r: '_#2r
+   = note: where '?1: '?2
 
 note: no external requirements
   --> $DIR/propagate-approximated-ref.rs:42:1

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -6,7 +6,7 @@ LL |     foo(cell, |cell_a, cell_x| {
    |
    = note: defining type: case1::{closure#0} with closure substs [
                i32,
-               for<Region(BrAnon(None))> extern "rust-call" fn((std::cell::Cell<&'_#1r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>)),
+               for<Region(BrAnon(None))> extern "rust-call" fn((std::cell::Cell<&'?1 u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>)),
                (),
            ]
 
@@ -36,11 +36,11 @@ LL |     foo(cell, |cell_a, cell_x| {
    |
    = note: defining type: case2::{closure#0} with closure substs [
                i32,
-               for<Region(BrAnon(None))> extern "rust-call" fn((std::cell::Cell<&'_#1r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>)),
+               for<Region(BrAnon(None))> extern "rust-call" fn((std::cell::Cell<&'?1 u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>)),
                (),
            ]
    = note: number of external vids: 2
-   = note: where '_#1r: '_#0r
+   = note: where '?1: '?0
 
 note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:28:1

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -6,13 +6,13 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
-               for<Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 2, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 4, kind: BrAnon(None) }) u32>)),
+               for<Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) std::cell::Cell<&'?1 &ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 2, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 4, kind: BrAnon(None) }) u32>)),
                (),
            ]
-   = note: late-bound region is '_#2r
-   = note: late-bound region is '_#3r
+   = note: late-bound region is '?2
+   = note: late-bound region is '?3
    = note: number of external vids: 4
-   = note: where '_#1r: '_#0r
+   = note: where '?1: '?0
 
 note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:31:1
@@ -40,7 +40,7 @@ LL | |     });
    | |______`cell_a` escapes the function body here
    |        argument requires that `'a` must outlive `'static`
    |
-   = note: requirement occurs because of the type `Cell<&'_#9r u32>`, which makes the generic argument `&'_#9r u32` invariant
+   = note: requirement occurs because of the type `Cell<&'?9 u32>`, which makes the generic argument `&'?9 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -6,13 +6,13 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
-               for<Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 2, kind: BrAnon(None) }) std::cell::Cell<&'_#2r &ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 4, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 5, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) u32>)),
+               for<Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) std::cell::Cell<&'?1 &ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 2, kind: BrAnon(None) }) std::cell::Cell<&'?2 &ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 4, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 5, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) u32>)),
                (),
            ]
-   = note: late-bound region is '_#3r
-   = note: late-bound region is '_#4r
+   = note: late-bound region is '?3
+   = note: late-bound region is '?4
    = note: number of external vids: 5
-   = note: where '_#1r: '_#0r
+   = note: where '?1: '?0
 
 note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:34:1
@@ -40,7 +40,7 @@ LL | |     });
    | |______`cell_a` escapes the function body here
    |        argument requires that `'a` must outlive `'static`
    |
-   = note: requirement occurs because of the type `Cell<&'_#10r u32>`, which makes the generic argument `&'_#10r u32` invariant
+   = note: requirement occurs because of the type `Cell<&'?10 u32>`, which makes the generic argument `&'?10 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-val.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-val.stderr
@@ -6,13 +6,13 @@ LL |     establish_relationships(cell_a, cell_b, |outlives1, outlives2, x, y| {
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,
-               for<Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) &'_#2r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>)),
+               for<Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((std::cell::Cell<&'?1 &ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) &'?2 u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>)),
                (),
            ]
-   = note: late-bound region is '_#3r
-   = note: late-bound region is '_#4r
+   = note: late-bound region is '?3
+   = note: late-bound region is '?4
    = note: number of external vids: 5
-   = note: where '_#1r: '_#2r
+   = note: where '?1: '?2
 
 note: no external requirements
   --> $DIR/propagate-approximated-val.rs:35:1

--- a/tests/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
@@ -6,12 +6,12 @@ LL |         |_outlives1, _outlives2, x, y| {
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
-               for<Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) &'_#2r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>)),
+               for<Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((std::cell::Cell<&'?1 &ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) &'?2 u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>)),
                (),
            ]
-   = note: late-bound region is '_#3r
+   = note: late-bound region is '?3
    = note: number of external vids: 4
-   = note: where '_#1r: '_#2r
+   = note: where '?1: '?2
 
 note: no external requirements
   --> $DIR/propagate-despite-same-free-region.rs:39:1

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -6,19 +6,19 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
-               for<Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) &'_#1r u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 2, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 4, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>)),
+               for<Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) &'?1 u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 2, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 4, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>)),
                (),
            ]
-   = note: late-bound region is '_#2r
-   = note: late-bound region is '_#3r
+   = note: late-bound region is '?2
+   = note: late-bound region is '?3
 
 error: lifetime may not live long enough
   --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:37:9
    |
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-   |                                                ---------  - has type `&'_#7r Cell<&'1 u32>`
+   |                                                ---------  - has type `&'?7 Cell<&'1 u32>`
    |                                                |
-   |                                                has type `&'_#5r Cell<&'2 &'_#1r u32>`
+   |                                                has type `&'?5 Cell<&'2 &'?1 u32>`
 LL |         // Only works if 'x: 'y:
 LL |         demand_y(x, y, x.get())
    |         ^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
@@ -6,19 +6,19 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
-               for<Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) &'_#1r u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 2, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) &'_#2r u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 4, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 5, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) u32>)),
+               for<Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) &'?1 u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 2, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) &'?2 u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 4, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) u32>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 5, kind: BrAnon(None) }) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BoundRegion { var: 3, kind: BrAnon(None) }) u32>)),
                (),
            ]
-   = note: late-bound region is '_#3r
-   = note: late-bound region is '_#4r
+   = note: late-bound region is '?3
+   = note: late-bound region is '?4
 
 error: lifetime may not live long enough
   --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:41:9
    |
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-   |                                                ----------  ---------- has type `&'_#8r Cell<&'2 &'_#2r u32>`
+   |                                                ----------  ---------- has type `&'?8 Cell<&'2 &'?2 u32>`
    |                                                |
-   |                                                has type `&'_#6r Cell<&'1 &'_#1r u32>`
+   |                                                has type `&'?6 Cell<&'1 &'?1 u32>`
 LL |         // Only works if 'x: 'y:
 LL |         demand_y(x, y, x.get())
    |         ^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`

--- a/tests/ui/nll/closure-requirements/propagate-from-trait-match.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-from-trait-match.stderr
@@ -4,13 +4,13 @@ note: external requirements
 LL |     establish_relationships(value, |value| {
    |                                    ^^^^^^^
    |
-   = note: defining type: supply::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: supply::<'?1, T>::{closure#0} with closure substs [
                i32,
                extern "rust-call" fn((T,)),
                (),
            ]
    = note: number of external vids: 2
-   = note: where T: '_#1r
+   = note: where T: '?1
 
 note: no external requirements
   --> $DIR/propagate-from-trait-match.rs:28:1
@@ -20,7 +20,7 @@ LL | | where
 LL | |     T: Trait<'a>,
    | |_________________^
    |
-   = note: defining type: supply::<'_#1r, T>
+   = note: defining type: supply::<'?1, T>
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/propagate-from-trait-match.rs:43:9

--- a/tests/ui/nll/member-constraints/min-choice.rs
+++ b/tests/ui/nll/member-constraints/min-choice.rs
@@ -1,5 +1,5 @@
-// Assuming that the hidden type in these tests is `&'_#15r u8`,
-// we have a member constraint: `'_#15r member ['static, 'a, 'b, 'c]`.
+// Assuming that the hidden type in these tests is `&'?15 u8`,
+// we have a member constraint: `'?15 member ['static, 'a, 'b, 'c]`.
 //
 // Make sure we pick up the minimum non-ambiguous region among them.
 // We will have to exclude `['b, 'c]` because they're incomparable,

--- a/tests/ui/nll/member-constraints/nested-impl-trait-fail.rs
+++ b/tests/ui/nll/member-constraints/nested-impl-trait-fail.rs
@@ -5,9 +5,9 @@
 trait Cap<'a> {}
 impl<T> Cap<'_> for T {}
 
-// Assuming the hidden type is `[&'_#15r u8; 1]`, we have two distinct member constraints:
-// - '_#15r member ['static, 'a, 'b] // from outer impl-trait
-// - '_#15r member ['static, 'a, 'b] // from inner impl-trait
+// Assuming the hidden type is `[&'?15 u8; 1]`, we have two distinct member constraints:
+// - '?15 member ['static, 'a, 'b] // from outer impl-trait
+// - '?15 member ['static, 'a, 'b] // from inner impl-trait
 // To satisfy both we can choose 'a or 'b, so it's a failure due to ambiguity.
 fn fail_early_bound<'s, 'a, 'b>(a: &'s u8) -> impl IntoIterator<Item = impl Cap<'a> + Cap<'b>>
 where

--- a/tests/ui/nll/member-constraints/nested-impl-trait-pass.rs
+++ b/tests/ui/nll/member-constraints/nested-impl-trait-pass.rs
@@ -5,9 +5,9 @@
 trait Cap<'a> {}
 impl<T> Cap<'_> for T {}
 
-// Assuming the hidden type is `[&'_#15r u8; 1]`, we have two distinct member constraints:
-// - '_#15r member ['static, 'a, 'b] // from outer impl-trait
-// - '_#15r member ['static, 'a]     // from inner impl-trait
+// Assuming the hidden type is `[&'?15 u8; 1]`, we have two distinct member constraints:
+// - '?15 member ['static, 'a, 'b] // from outer impl-trait
+// - '?15 member ['static, 'a]     // from inner impl-trait
 // To satisfy both we can only choose 'a.
 fn pass_early_bound<'s, 'a, 'b>(a: &'s u8) -> impl IntoIterator<Item = impl Cap<'a>> + Cap<'b>
 where

--- a/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -4,13 +4,13 @@ note: external requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^
    |
-   = note: defining type: no_region::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: no_region::<'?1, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '_#2r)>,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?2)>,
                (),
            ]
    = note: number of external vids: 3
-   = note: where <T as std::iter::Iterator>::Item: '_#2r
+   = note: where <T as std::iter::Iterator>::Item: '?2
 
 note: no external requirements
   --> $DIR/projection-no-regions-closure.rs:21:1
@@ -20,7 +20,7 @@ LL | | where
 LL | |     T: Iterator,
    | |________________^
    |
-   = note: defining type: no_region::<'_#1r, T>
+   = note: defining type: no_region::<'?1, T>
 
 error[E0309]: the associated type `<T as Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-closure.rs:25:31
@@ -37,13 +37,13 @@ note: external requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^
    |
-   = note: defining type: correct_region::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: correct_region::<'?1, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '_#2r)>,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?2)>,
                (),
            ]
    = note: number of external vids: 3
-   = note: where <T as std::iter::Iterator>::Item: '_#2r
+   = note: where <T as std::iter::Iterator>::Item: '?2
 
 note: no external requirements
   --> $DIR/projection-no-regions-closure.rs:30:1
@@ -53,7 +53,7 @@ LL | | where
 LL | |     T: 'a + Iterator,
    | |_____________________^
    |
-   = note: defining type: correct_region::<'_#1r, T>
+   = note: defining type: correct_region::<'?1, T>
 
 note: external requirements
   --> $DIR/projection-no-regions-closure.rs:42:23
@@ -61,13 +61,13 @@ note: external requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^
    |
-   = note: defining type: wrong_region::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: wrong_region::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '_#3r)>,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?3)>,
                (),
            ]
    = note: number of external vids: 4
-   = note: where <T as std::iter::Iterator>::Item: '_#3r
+   = note: where <T as std::iter::Iterator>::Item: '?3
 
 note: no external requirements
   --> $DIR/projection-no-regions-closure.rs:38:1
@@ -77,7 +77,7 @@ LL | | where
 LL | |     T: 'b + Iterator,
    | |_____________________^
    |
-   = note: defining type: wrong_region::<'_#1r, '_#2r, T>
+   = note: defining type: wrong_region::<'?1, '?2, T>
 
 error[E0309]: the associated type `<T as Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-closure.rs:42:31
@@ -94,13 +94,13 @@ note: external requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^
    |
-   = note: defining type: outlives_region::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: outlives_region::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '_#3r)>,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?3)>,
                (),
            ]
    = note: number of external vids: 4
-   = note: where <T as std::iter::Iterator>::Item: '_#3r
+   = note: where <T as std::iter::Iterator>::Item: '?3
 
 note: no external requirements
   --> $DIR/projection-no-regions-closure.rs:47:1
@@ -111,7 +111,7 @@ LL | |     T: 'b + Iterator,
 LL | |     'b: 'a,
    | |___________^
    |
-   = note: defining type: outlives_region::<'_#1r, '_#2r, T>
+   = note: defining type: outlives_region::<'?1, '?2, T>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -4,15 +4,15 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_late::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: no_relationships_late::<'?1, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
            ]
-   = note: late-bound region is '_#3r
+   = note: late-bound region is '?3
    = note: number of external vids: 4
-   = note: where T: '_#2r
-   = note: where '_#1r: '_#2r
+   = note: where T: '?2
+   = note: where '?1: '?2
 
 note: no external requirements
   --> $DIR/projection-one-region-closure.rs:41:1
@@ -22,7 +22,7 @@ LL | | where
 LL | |     T: Anything<'b>,
    | |____________________^
    |
-   = note: defining type: no_relationships_late::<'_#1r, T>
+   = note: defining type: no_relationships_late::<'?1, T>
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/projection-one-region-closure.rs:45:39
@@ -54,14 +54,14 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: no_relationships_early::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
            ]
    = note: number of external vids: 4
-   = note: where T: '_#3r
-   = note: where '_#2r: '_#3r
+   = note: where T: '?3
+   = note: where '?2: '?3
 
 note: no external requirements
   --> $DIR/projection-one-region-closure.rs:51:1
@@ -72,7 +72,7 @@ LL | |     T: Anything<'b>,
 LL | |     'a: 'a,
    | |___________^
    |
-   = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>
+   = note: defining type: no_relationships_early::<'?1, '?2, T>
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/projection-one-region-closure.rs:56:39
@@ -104,13 +104,13 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: projection_outlives::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: projection_outlives::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
            ]
    = note: number of external vids: 4
-   = note: where <T as Anything<'_#2r>>::AssocType: '_#3r
+   = note: where <T as Anything<'?2>>::AssocType: '?3
 
 note: no external requirements
   --> $DIR/projection-one-region-closure.rs:62:1
@@ -121,7 +121,7 @@ LL | |     T: Anything<'b>,
 LL | |     T::AssocType: 'a,
    | |_____________________^
    |
-   = note: defining type: projection_outlives::<'_#1r, '_#2r, T>
+   = note: defining type: projection_outlives::<'?1, '?2, T>
 
 note: external requirements
   --> $DIR/projection-one-region-closure.rs:80:29
@@ -129,14 +129,14 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: elements_outlive::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
            ]
    = note: number of external vids: 4
-   = note: where T: '_#3r
-   = note: where '_#2r: '_#3r
+   = note: where T: '?3
+   = note: where '?2: '?3
 
 note: no external requirements
   --> $DIR/projection-one-region-closure.rs:74:1
@@ -148,7 +148,7 @@ LL | |     T: 'a,
 LL | |     'b: 'a,
    | |___________^
    |
-   = note: defining type: elements_outlive::<'_#1r, '_#2r, T>
+   = note: defining type: elements_outlive::<'?1, '?2, T>
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -4,14 +4,14 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_late::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: no_relationships_late::<'?1, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
            ]
-   = note: late-bound region is '_#3r
+   = note: late-bound region is '?3
    = note: number of external vids: 4
-   = note: where '_#1r: '_#2r
+   = note: where '?1: '?2
 
 note: no external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:33:1
@@ -21,7 +21,7 @@ LL | | where
 LL | |     T: Anything<'b>,
    | |____________________^
    |
-   = note: defining type: no_relationships_late::<'_#1r, T>
+   = note: defining type: no_relationships_late::<'?1, T>
 
 error: lifetime may not live long enough
   --> $DIR/projection-one-region-trait-bound-closure.rs:37:39
@@ -42,13 +42,13 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: no_relationships_early::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
            ]
    = note: number of external vids: 4
-   = note: where '_#2r: '_#3r
+   = note: where '?2: '?3
 
 note: no external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:42:1
@@ -59,7 +59,7 @@ LL | |     T: Anything<'b>,
 LL | |     'a: 'a,
    | |___________^
    |
-   = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>
+   = note: defining type: no_relationships_early::<'?1, '?2, T>
 
 error: lifetime may not live long enough
   --> $DIR/projection-one-region-trait-bound-closure.rs:47:39
@@ -80,13 +80,13 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: projection_outlives::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: projection_outlives::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
            ]
    = note: number of external vids: 4
-   = note: where <T as Anything<'_#2r>>::AssocType: '_#3r
+   = note: where <T as Anything<'?2>>::AssocType: '?3
 
 note: no external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:52:1
@@ -97,7 +97,7 @@ LL | |     T: Anything<'b>,
 LL | |     T::AssocType: 'a,
    | |_____________________^
    |
-   = note: defining type: projection_outlives::<'_#1r, '_#2r, T>
+   = note: defining type: projection_outlives::<'?1, '?2, T>
 
 note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:69:29
@@ -105,13 +105,13 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: elements_outlive::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
            ]
    = note: number of external vids: 4
-   = note: where '_#2r: '_#3r
+   = note: where '?2: '?3
 
 note: no external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:64:1
@@ -122,7 +122,7 @@ LL | |     T: Anything<'b>,
 LL | |     'b: 'a,
    | |___________^
    |
-   = note: defining type: elements_outlive::<'_#1r, '_#2r, T>
+   = note: defining type: elements_outlive::<'?1, '?2, T>
 
 note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:81:29
@@ -130,13 +130,13 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: one_region::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: one_region::<'?1, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
            ]
    = note: number of external vids: 3
-   = note: where '_#1r: '_#2r
+   = note: where '?1: '?2
 
 note: no external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:73:1
@@ -146,7 +146,7 @@ LL | | where
 LL | |     T: Anything<'a>,
    | |____________________^
    |
-   = note: defining type: one_region::<'_#1r, T>
+   = note: defining type: one_region::<'?1, T>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
@@ -4,12 +4,12 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_late::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: no_relationships_late::<'?1, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
            ]
-   = note: late-bound region is '_#3r
+   = note: late-bound region is '?3
 
 note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:32:1
@@ -19,7 +19,7 @@ LL | | where
 LL | |     T: Anything<'b>,
    | |____________________^
    |
-   = note: defining type: no_relationships_late::<'_#1r, T>
+   = note: defining type: no_relationships_late::<'?1, T>
 
 note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:45:29
@@ -27,9 +27,9 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: no_relationships_early::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
            ]
 
@@ -42,7 +42,7 @@ LL | |     T: Anything<'b>,
 LL | |     'a: 'a,
    | |___________^
    |
-   = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>
+   = note: defining type: no_relationships_early::<'?1, '?2, T>
 
 note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:64:29
@@ -50,9 +50,9 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: projection_outlives::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: projection_outlives::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
            ]
 
@@ -65,7 +65,7 @@ LL | |     T: Anything<'b>,
 LL | |     T::AssocType: 'a,
    | |_____________________^
    |
-   = note: defining type: projection_outlives::<'_#1r, '_#2r, T>
+   = note: defining type: projection_outlives::<'?1, '?2, T>
 
 note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:73:29
@@ -73,9 +73,9 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: elements_outlive::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
            ]
 
@@ -88,7 +88,7 @@ LL | |     T: Anything<'b>,
 LL | |     'b: 'a,
    | |___________^
    |
-   = note: defining type: elements_outlive::<'_#1r, '_#2r, T>
+   = note: defining type: elements_outlive::<'?1, '?2, T>
 
 note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:85:29
@@ -96,9 +96,9 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: one_region::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: one_region::<'?1, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
            ]
 
@@ -110,5 +110,5 @@ LL | | where
 LL | |     T: Anything<'a>,
    | |____________________^
    |
-   = note: defining type: one_region::<'_#1r, T>
+   = note: defining type: one_region::<'?1, T>
 

--- a/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -4,14 +4,14 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_late::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: no_relationships_late::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
            ]
-   = note: late-bound region is '_#4r
+   = note: late-bound region is '?4
    = note: number of external vids: 5
-   = note: where <T as Anything<'_#1r, '_#2r>>::AssocType: '_#3r
+   = note: where <T as Anything<'?1, '?2>>::AssocType: '?3
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:34:1
@@ -21,16 +21,16 @@ LL | | where
 LL | |     T: Anything<'b, 'c>,
    | |________________________^
    |
-   = note: defining type: no_relationships_late::<'_#1r, '_#2r, T>
+   = note: defining type: no_relationships_late::<'?1, '?2, T>
 
-error[E0309]: the associated type `<T as Anything<'_#5r, '_#6r>>::AssocType` may not live long enough
+error[E0309]: the associated type `<T as Anything<'?5, '?6>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:38:39
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                                       ^^^^^^^^^^^^^^^^
    |
-   = help: consider adding an explicit lifetime bound `<T as Anything<'_#5r, '_#6r>>::AssocType: 'a`...
-   = note: ...so that the type `<T as Anything<'_#5r, '_#6r>>::AssocType` will meet its required lifetime bounds
+   = help: consider adding an explicit lifetime bound `<T as Anything<'?5, '?6>>::AssocType: 'a`...
+   = note: ...so that the type `<T as Anything<'?5, '?6>>::AssocType` will meet its required lifetime bounds
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
@@ -38,13 +38,13 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_early::<'_#1r, '_#2r, '_#3r, T>::{closure#0} with closure substs [
+   = note: defining type: no_relationships_early::<'?1, '?2, '?3, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?4 ()>, T)),
                (),
            ]
    = note: number of external vids: 5
-   = note: where <T as Anything<'_#2r, '_#3r>>::AssocType: '_#4r
+   = note: where <T as Anything<'?2, '?3>>::AssocType: '?4
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:43:1
@@ -55,16 +55,16 @@ LL | |     T: Anything<'b, 'c>,
 LL | |     'a: 'a,
    | |___________^
    |
-   = note: defining type: no_relationships_early::<'_#1r, '_#2r, '_#3r, T>
+   = note: defining type: no_relationships_early::<'?1, '?2, '?3, T>
 
-error[E0309]: the associated type `<T as Anything<'_#6r, '_#7r>>::AssocType` may not live long enough
+error[E0309]: the associated type `<T as Anything<'?6, '?7>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:39
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                                       ^^^^^^^^^^^^^^^^
    |
-   = help: consider adding an explicit lifetime bound `<T as Anything<'_#6r, '_#7r>>::AssocType: 'a`...
-   = note: ...so that the type `<T as Anything<'_#6r, '_#7r>>::AssocType` will meet its required lifetime bounds
+   = help: consider adding an explicit lifetime bound `<T as Anything<'?6, '?7>>::AssocType: 'a`...
+   = note: ...so that the type `<T as Anything<'?6, '?7>>::AssocType` will meet its required lifetime bounds
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:61:29
@@ -72,13 +72,13 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: projection_outlives::<'_#1r, '_#2r, '_#3r, T>::{closure#0} with closure substs [
+   = note: defining type: projection_outlives::<'?1, '?2, '?3, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?4 ()>, T)),
                (),
            ]
    = note: number of external vids: 5
-   = note: where <T as Anything<'_#2r, '_#3r>>::AssocType: '_#4r
+   = note: where <T as Anything<'?2, '?3>>::AssocType: '?4
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:53:1
@@ -89,7 +89,7 @@ LL | |     T: Anything<'b, 'c>,
 LL | |     T::AssocType: 'a,
    | |_____________________^
    |
-   = note: defining type: projection_outlives::<'_#1r, '_#2r, '_#3r, T>
+   = note: defining type: projection_outlives::<'?1, '?2, '?3, T>
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:70:29
@@ -97,13 +97,13 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive1::<'_#1r, '_#2r, '_#3r, T>::{closure#0} with closure substs [
+   = note: defining type: elements_outlive1::<'?1, '?2, '?3, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?4 ()>, T)),
                (),
            ]
    = note: number of external vids: 5
-   = note: where <T as Anything<'_#2r, '_#3r>>::AssocType: '_#4r
+   = note: where <T as Anything<'?2, '?3>>::AssocType: '?4
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:65:1
@@ -114,7 +114,7 @@ LL | |     T: Anything<'b, 'c>,
 LL | |     'b: 'a,
    | |___________^
    |
-   = note: defining type: elements_outlive1::<'_#1r, '_#2r, '_#3r, T>
+   = note: defining type: elements_outlive1::<'?1, '?2, '?3, T>
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:79:29
@@ -122,13 +122,13 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive2::<'_#1r, '_#2r, '_#3r, T>::{closure#0} with closure substs [
+   = note: defining type: elements_outlive2::<'?1, '?2, '?3, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?4 ()>, T)),
                (),
            ]
    = note: number of external vids: 5
-   = note: where <T as Anything<'_#2r, '_#3r>>::AssocType: '_#4r
+   = note: where <T as Anything<'?2, '?3>>::AssocType: '?4
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:74:1
@@ -139,7 +139,7 @@ LL | |     T: Anything<'b, 'c>,
 LL | |     'c: 'a,
    | |___________^
    |
-   = note: defining type: elements_outlive2::<'_#1r, '_#2r, '_#3r, T>
+   = note: defining type: elements_outlive2::<'?1, '?2, '?3, T>
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:87:29
@@ -147,14 +147,14 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: two_regions::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: two_regions::<'?1, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
            ]
-   = note: late-bound region is '_#3r
+   = note: late-bound region is '?3
    = note: number of external vids: 4
-   = note: where <T as Anything<'_#1r, '_#1r>>::AssocType: '_#2r
+   = note: where <T as Anything<'?1, '?1>>::AssocType: '?2
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:83:1
@@ -164,7 +164,7 @@ LL | | where
 LL | |     T: Anything<'b, 'b>,
    | |________________________^
    |
-   = note: defining type: two_regions::<'_#1r, T>
+   = note: defining type: two_regions::<'?1, T>
 
 error: lifetime may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:87:5
@@ -178,7 +178,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of the type `Cell<&'_#8r ()>`, which makes the generic argument `&'_#8r ()` invariant
+   = note: requirement occurs because of the type `Cell<&'?8 ()>`, which makes the generic argument `&'?8 ()` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
@@ -188,13 +188,13 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: two_regions_outlive::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: two_regions_outlive::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
            ]
    = note: number of external vids: 4
-   = note: where <T as Anything<'_#2r, '_#2r>>::AssocType: '_#3r
+   = note: where <T as Anything<'?2, '?2>>::AssocType: '?3
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:92:1
@@ -205,7 +205,7 @@ LL | |     T: Anything<'b, 'b>,
 LL | |     'b: 'a,
    | |___________^
    |
-   = note: defining type: two_regions_outlive::<'_#1r, '_#2r, T>
+   = note: defining type: two_regions_outlive::<'?1, '?2, T>
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:109:29
@@ -213,13 +213,13 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: one_region::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: one_region::<'?1, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
            ]
    = note: number of external vids: 3
-   = note: where <T as Anything<'_#1r, '_#1r>>::AssocType: '_#2r
+   = note: where <T as Anything<'?1, '?1>>::AssocType: '?2
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:101:1
@@ -229,7 +229,7 @@ LL | | where
 LL | |     T: Anything<'a, 'a>,
    | |________________________^
    |
-   = note: defining type: one_region::<'_#1r, T>
+   = note: defining type: one_region::<'?1, T>
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -6,11 +6,11 @@ LL |     twice(cell, value, |a, b| invoke(a, b));
    |
    = note: defining type: generic::<T>::{closure#0} with closure substs [
                i16,
-               for<Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((std::option::Option<std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) ()>>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) T)),
+               for<Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((std::option::Option<std::cell::Cell<&'?1 &ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) ()>>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) T)),
                (),
            ]
    = note: number of external vids: 2
-   = note: where T: '_#1r
+   = note: where T: '?1
 
 note: no external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:22:1
@@ -28,12 +28,12 @@ LL |     twice(cell, value, |a, b| invoke(a, b));
    |
    = note: defining type: generic_fail::<T>::{closure#0} with closure substs [
                i16,
-               for<Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((std::option::Option<std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) ()>>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) T)),
+               for<Region(BrAnon(None)), Region(BrAnon(None))> extern "rust-call" fn((std::option::Option<std::cell::Cell<&'?1 &ReLateBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrAnon(None) }) ()>>, &ReLateBound(DebruijnIndex(0), BoundRegion { var: 1, kind: BrAnon(None) }) T)),
                (),
            ]
-   = note: late-bound region is '_#2r
+   = note: late-bound region is '?2
    = note: number of external vids: 3
-   = note: where T: '_#1r
+   = note: where T: '?1
 
 note: no external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:28:1

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.rs
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.rs
@@ -19,8 +19,8 @@ where
     // Here, the closure winds up being required to prove that `T:
     // 'a`.  In principle, it could know that, except that it is
     // type-checked in a fully generic way, and hence it winds up with
-    // a propagated requirement that `T: '_#2`, where `'_#2` appears
-    // in the return type. The caller makes the mapping from `'_#2` to
+    // a propagated requirement that `T: '?2`, where `'?2` appears
+    // in the return type. The caller makes the mapping from `'?2` to
     // `'a` (and subsequently reports an error).
 
     with_signature(x, |y| y)

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -4,13 +4,13 @@ note: external requirements
 LL |     with_signature(x, |y| y)
    |                       ^^^
    |
-   = note: defining type: no_region::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: no_region::<'?1, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn std::fmt::Debug + '_#2r)>,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn std::fmt::Debug + '?2)>,
                (),
            ]
    = note: number of external vids: 3
-   = note: where T: '_#2r
+   = note: where T: '?2
 
 note: no external requirements
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:15:1
@@ -20,7 +20,7 @@ LL | | where
 LL | |     T: Debug,
    | |_____________^
    |
-   = note: defining type: no_region::<'_#1r, T>
+   = note: defining type: no_region::<'?1, T>
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:26:27

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
@@ -6,12 +6,12 @@ LL |     with_signature(a, b, |x, y| {
    |
    = note: defining type: no_region::<T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#1r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?1 ()>, T)),
                (),
            ]
-   = note: late-bound region is '_#2r
+   = note: late-bound region is '?2
    = note: number of external vids: 3
-   = note: where T: '_#1r
+   = note: where T: '?1
 
 note: no external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:26:1
@@ -38,13 +38,13 @@ note: external requirements
 LL |     with_signature(a, b, |x, y| {
    |                          ^^^^^^
    |
-   = note: defining type: correct_region::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: correct_region::<'?1, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
            ]
    = note: number of external vids: 3
-   = note: where T: '_#2r
+   = note: where T: '?2
 
 note: no external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:38:1
@@ -54,7 +54,7 @@ LL | | where
 LL | |     T: 'a,
    | |__________^
    |
-   = note: defining type: correct_region::<'_#1r, T>
+   = note: defining type: correct_region::<'?1, T>
 
 note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:63:26
@@ -62,14 +62,14 @@ note: external requirements
 LL |     with_signature(a, b, |x, y| {
    |                          ^^^^^^
    |
-   = note: defining type: wrong_region::<'_#1r, T>::{closure#0} with closure substs [
+   = note: defining type: wrong_region::<'?1, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
            ]
-   = note: late-bound region is '_#3r
+   = note: late-bound region is '?3
    = note: number of external vids: 4
-   = note: where T: '_#2r
+   = note: where T: '?2
 
 note: no external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:59:1
@@ -79,7 +79,7 @@ LL | | where
 LL | |     T: 'b,
    | |__________^
    |
-   = note: defining type: wrong_region::<'_#1r, T>
+   = note: defining type: wrong_region::<'?1, T>
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:65:9
@@ -98,13 +98,13 @@ note: external requirements
 LL |     with_signature(a, b, |x, y| {
    |                          ^^^^^^
    |
-   = note: defining type: outlives_region::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
+   = note: defining type: outlives_region::<'?1, '?2, T>::{closure#0} with closure substs [
                i32,
-               extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
+               extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
            ]
    = note: number of external vids: 4
-   = note: where T: '_#3r
+   = note: where T: '?3
 
 note: no external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:71:1
@@ -115,7 +115,7 @@ LL | |     T: 'b,
 LL | |     'b: 'a,
    | |___________^
    |
-   = note: defining type: outlives_region::<'_#1r, '_#2r, T>
+   = note: defining type: outlives_region::<'?1, '?2, T>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/infer-from-object-issue-26952.rs
+++ b/tests/ui/traits/infer-from-object-issue-26952.rs
@@ -1,8 +1,8 @@
 // run-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
-// Test that when we match a trait reference like `Foo<A>: Foo<_#0t>`,
-// we unify with `_#0t` with `A`. In this code, if we failed to do
+// Test that when we match a trait reference like `Foo<A>: Foo<?0t>`,
+// we unify with `?0t` with `A`. In this code, if we failed to do
 // that, then you get an unconstrained type-variable in `call`.
 //
 // Also serves as a regression test for issue #26952, though the test

--- a/tests/ui/traits/new-solver/int-var-alias-eq.rs
+++ b/tests/ui/traits/new-solver/int-var-alias-eq.rs
@@ -1,7 +1,7 @@
 // check-pass
 // compile-flags: -Ztrait-solver=next
 
-// HIR typeck ends up equating `<_#0i as Add>::Output == _#0i`.
+// HIR typeck ends up equating `<?0i as Add>::Output == ?0i`.
 // Want to make sure that we emit an alias-eq goal for this,
 // instead of treating it as a type error and bailing.
 

--- a/tests/ui/traits/new-solver/two-projection-param-candidates-are-ambiguous.rs
+++ b/tests/ui/traits/new-solver/two-projection-param-candidates-are-ambiguous.rs
@@ -1,7 +1,7 @@
 // compile-flags: -Ztrait-solver=next
 
 // When we're solving `<T as Foo>::Assoc = i32`, we actually first solve
-// `<T as Foo>::Assoc = _#1t`, then unify `_#1t` with `i32`. That goal
+// `<T as Foo>::Assoc = ?1t`, then unify `?1t` with `i32`. That goal
 // with the inference variable is ambiguous when there are >1 param-env
 // candidates.
 

--- a/tests/ui/type-alias-impl-trait/closure_parent_substs.rs
+++ b/tests/ui/type-alias-impl-trait/closure_parent_substs.rs
@@ -12,7 +12,7 @@
 
 // Basic test
 mod test1 {
-    // Hidden type = Closure['_#0r]
+    // Hidden type = Closure['?0]
     type Opaque = impl Sized;
 
     fn define<'a: 'a>() -> Opaque {
@@ -24,8 +24,8 @@ mod test1 {
 mod test2 {
     trait Trait {}
 
-    // Hidden type = Closure['a, '_#0r, '_#1r]
-    // Constraints = [('_#0r: 'a), ('a: '_#1r)]
+    // Hidden type = Closure['a, '?0, '?1]
+    // Constraints = [('?0: 'a), ('a: '?1)]
     type Opaque<'a>
     where
         &'a (): Trait,
@@ -45,8 +45,8 @@ mod test2 {
 mod test3 {
     trait Trait {}
 
-    // Hidden type = Closure['a, 'b, '_#0r]
-    // Constraints = [('_#0r: 'a), ('_#0r: 'b)]
+    // Hidden type = Closure['a, 'b, '?0]
+    // Constraints = [('?0: 'a), ('?0: 'b)]
     type Opaque<'a, 'b>
     where
         (&'a (), &'b ()): Trait,


### PR DESCRIPTION
Aligns the notation for infer vars that T-types and friends most often uses for inference variables with the notation in the compiler (which is kinda a sigil nightmare IMO: `_#`) by adopting `?0` style infer vars. 

This mostly affects debug output since verbose infer vars shouldn't show up in user-facing places.

Does this need an MCP? It's debug output, so I'm thinking no, but happy to open one. :thinking: 

r? types