### PR TITLE
Add regression tests for const-generic inherent associated types

### DIFF
--- a/tests/ui/associated-inherent-types/const-generics.rs
+++ b/tests/ui/associated-inherent-types/const-generics.rs
@@ -1,0 +1,23 @@
+// Regression test for issue #109759.
+// check-pass
+
+#![feature(inherent_associated_types)]
+#![allow(incomplete_features)]
+
+struct Foo;
+
+struct Bar<const X: usize>([(); X]);
+
+impl<const X: usize> Bar<X> {
+    pub fn new() -> Self {
+        Self([(); X])
+    }
+}
+
+impl Foo {
+    type Bar<const X: usize> = Bar<X>;
+}
+
+fn main() {
+    let _ = Foo::Bar::<10>::new();
+}

--- a/tests/ui/associated-inherent-types/generic-const-exprs.rs
+++ b/tests/ui/associated-inherent-types/generic-const-exprs.rs
@@ -1,0 +1,28 @@
+// check-pass
+
+#![feature(inherent_associated_types, generic_const_exprs)]
+#![allow(incomplete_features)]
+
+struct Parent<const O: usize>;
+
+impl<const O: usize> Parent<O> {
+    type Mapping<const I: usize> = Store<{ O + I }>
+    where
+        [(); O + I]:
+    ;
+}
+
+struct Store<const N: usize>;
+
+impl<const N: usize> Store<N> {
+    const REIFIED: usize = N;
+
+    fn reify() -> usize {
+        N
+    }
+}
+
+fn main() {
+    let _ = Parent::<2>::Mapping::<{ 12 * 2 }>::REIFIED;
+    let _ = Parent::<1>::Mapping::<{ 2 * 5 }>::reify();
+}


### PR DESCRIPTION
Fixes #109759.
The tests are no longer failing since #96840 which was merged recently (#109410 is no longer necessary for them).

@rustbot label F-inherent_associated_types