### PR TITLE
ConstProp into PlaceElem::Index.

### DIFF
--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
@@ -45,7 +45,8 @@
       }
   
       bb1: {
-          _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+-         _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
++         _5 = (*_1)[3 of 4];              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
           StorageDead(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:25: +3:26
           _0 = const ();                   // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+2:5: +4:6
           StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+4:5: +4:6

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
@@ -45,7 +45,8 @@
       }
   
       bb1: {
-          _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+-         _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
++         _5 = (*_1)[3 of 4];              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
           StorageDead(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:25: +3:26
           _0 = const ();                   // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+2:5: +4:6
           StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+4:5: +4:6

--- a/tests/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.diff
+++ b/tests/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.diff
@@ -27,7 +27,8 @@
       }
   
       bb1: {
-          _1 = _2[_3];                     // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
+-         _1 = _2[_3];                     // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
++         _1 = _2[2 of 3];                 // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
           StorageDead(_3);                 // scope 0 at $DIR/large_array_index.rs:+2:32: +2:33
           StorageDead(_2);                 // scope 0 at $DIR/large_array_index.rs:+2:32: +2:33
           _0 = const ();                   // scope 0 at $DIR/large_array_index.rs:+0:11: +3:2

--- a/tests/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.diff
+++ b/tests/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.diff
@@ -27,7 +27,8 @@
       }
   
       bb1: {
-          _1 = _2[_3];                     // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
+-         _1 = _2[_3];                     // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
++         _1 = _2[2 of 3];                 // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
           StorageDead(_3);                 // scope 0 at $DIR/large_array_index.rs:+2:32: +2:33
           StorageDead(_2);                 // scope 0 at $DIR/large_array_index.rs:+2:32: +2:33
           _0 = const ();                   // scope 0 at $DIR/large_array_index.rs:+0:11: +3:2


### PR DESCRIPTION
Noticed this while looking at keccak output MIR.

This pass aims to replace `ProjectionElem::Index` with `ProjectionElem::ConstantIndex` during ConstProp.

r? @ghost