### PR TITLE
Make PlaceMention a non-mutating use.

### DIFF
--- a/compiler/rustc_borrowck/src/def_use.rs
+++ b/compiler/rustc_borrowck/src/def_use.rs
@@ -54,7 +54,7 @@ pub fn categorize(context: PlaceContext) -> Option<DefUse> {
 
         // `PlaceMention` and `AscribeUserType` both evaluate the place, which must not
         // contain dangling references.
-        PlaceContext::NonUse(NonUseContext::PlaceMention) |
+        PlaceContext::NonMutatingUse(NonMutatingUseContext::PlaceMention) |
         PlaceContext::NonUse(NonUseContext::AscribeUserTy) |
 
         PlaceContext::MutatingUse(MutatingUseContext::AddressOf) |

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -771,12 +771,10 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
 
         match context {
             PlaceContext::MutatingUse(_) => ty::Invariant,
-            PlaceContext::NonUse(StorageDead | StorageLive | PlaceMention | VarDebugInfo) => {
-                ty::Invariant
-            }
+            PlaceContext::NonUse(StorageDead | StorageLive | VarDebugInfo) => ty::Invariant,
             PlaceContext::NonMutatingUse(
-                Inspect | Copy | Move | SharedBorrow | ShallowBorrow | UniqueBorrow | AddressOf
-                | Projection,
+                Inspect | Copy | Move | PlaceMention | SharedBorrow | ShallowBorrow | UniqueBorrow
+                | AddressOf | Projection,
             ) => ty::Covariant,
             PlaceContext::NonUse(AscribeUserTy) => ty::Covariant,
         }

--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -203,7 +203,9 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
                 self.assign(local, DefLocation::Body(location));
             }
 
-            PlaceContext::NonUse(_) | PlaceContext::MutatingUse(MutatingUseContext::Retag) => {}
+            PlaceContext::NonUse(_)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::PlaceMention)
+            | PlaceContext::MutatingUse(MutatingUseContext::Retag) => {}
 
             PlaceContext::NonMutatingUse(
                 NonMutatingUseContext::Copy | NonMutatingUseContext::Move,

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -410,7 +410,7 @@ macro_rules! make_mir_visitor {
                     StatementKind::PlaceMention(place) => {
                         self.visit_place(
                             place,
-                            PlaceContext::NonUse(NonUseContext::PlaceMention),
+                            PlaceContext::NonMutatingUse(NonMutatingUseContext::PlaceMention),
                             location
                         );
                     }
@@ -1251,6 +1251,8 @@ pub enum NonMutatingUseContext {
     UniqueBorrow,
     /// AddressOf for *const pointer.
     AddressOf,
+    /// PlaceMention statement.
+    PlaceMention,
     /// Used as base for another place, e.g., `x` in `x.y`. Will not mutate the place.
     /// For example, the projection `x.y` is not marked as a mutation in these cases:
     /// ```ignore (illustrative)
@@ -1301,8 +1303,6 @@ pub enum NonUseContext {
     AscribeUserTy,
     /// The data of a user variable, for debug info.
     VarDebugInfo,
-    /// PlaceMention statement.
-    PlaceMention,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -1252,6 +1252,9 @@ pub enum NonMutatingUseContext {
     /// AddressOf for *const pointer.
     AddressOf,
     /// PlaceMention statement.
+    ///
+    /// This statement is executed as a check that the `Place` is live without reading from it,
+    /// so it must be considered as a non-mutating use.
     PlaceMention,
     /// Used as base for another place, e.g., `x` in `x.y`. Will not mutate the place.
     /// For example, the projection `x.y` is not marked as a mutation in these cases:

--- a/compiler/rustc_mir_dataflow/src/impls/liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/liveness.rs
@@ -197,6 +197,7 @@ impl DefUse {
                 | NonMutatingUseContext::Copy
                 | NonMutatingUseContext::Inspect
                 | NonMutatingUseContext::Move
+                | NonMutatingUseContext::PlaceMention
                 | NonMutatingUseContext::ShallowBorrow
                 | NonMutatingUseContext::SharedBorrow
                 | NonMutatingUseContext::UniqueBorrow,

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -774,6 +774,7 @@ impl Visitor<'_> for CanConstProp {
             | NonMutatingUse(NonMutatingUseContext::Move)
             | NonMutatingUse(NonMutatingUseContext::Inspect)
             | NonMutatingUse(NonMutatingUseContext::Projection)
+            | NonMutatingUse(NonMutatingUseContext::PlaceMention)
             | NonUse(_) => {}
 
             // These could be propagated with a smarter analysis or just some careful thinking about

--- a/tests/mir-opt/dead-store-elimination/place_mention.main.DeadStoreElimination.diff
+++ b/tests/mir-opt/dead-store-elimination/place_mention.main.DeadStoreElimination.diff
@@ -9,13 +9,13 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/place_mention.rs:+3:18: +3:36
--         _1 = (const "Hello", const "World"); // scope 0 at $DIR/place_mention.rs:+3:18: +3:36
--                                          // mir::Constant
--                                          // + span: $DIR/place_mention.rs:8:19: 8:26
--                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
--                                          // mir::Constant
--                                          // + span: $DIR/place_mention.rs:8:28: 8:35
--                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
+          _1 = (const "Hello", const "World"); // scope 0 at $DIR/place_mention.rs:+3:18: +3:36
+                                           // mir::Constant
+                                           // + span: $DIR/place_mention.rs:8:19: 8:26
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
+                                           // mir::Constant
+                                           // + span: $DIR/place_mention.rs:8:28: 8:35
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           PlaceMention(_1);                // scope 0 at $DIR/place_mention.rs:+3:18: +3:36
           StorageDead(_1);                 // scope 0 at $DIR/place_mention.rs:+3:36: +3:37
           _0 = const ();                   // scope 0 at $DIR/place_mention.rs:+0:11: +4:2

--- a/tests/mir-opt/dead-store-elimination/place_mention.main.DeadStoreElimination.diff
+++ b/tests/mir-opt/dead-store-elimination/place_mention.main.DeadStoreElimination.diff
@@ -1,0 +1,25 @@
+- // MIR for `main` before DeadStoreElimination
++ // MIR for `main` after DeadStoreElimination
+  
+  fn main() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/place_mention.rs:+0:11: +0:11
+      let mut _1: (&str, &str);            // in scope 0 at $DIR/place_mention.rs:+3:18: +3:36
+      scope 1 {
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/place_mention.rs:+3:18: +3:36
+-         _1 = (const "Hello", const "World"); // scope 0 at $DIR/place_mention.rs:+3:18: +3:36
+-                                          // mir::Constant
+-                                          // + span: $DIR/place_mention.rs:8:19: 8:26
+-                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
+-                                          // mir::Constant
+-                                          // + span: $DIR/place_mention.rs:8:28: 8:35
+-                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
+          PlaceMention(_1);                // scope 0 at $DIR/place_mention.rs:+3:18: +3:36
+          StorageDead(_1);                 // scope 0 at $DIR/place_mention.rs:+3:36: +3:37
+          _0 = const ();                   // scope 0 at $DIR/place_mention.rs:+0:11: +4:2
+          return;                          // scope 0 at $DIR/place_mention.rs:+4:2: +4:2
+      }
+  }
+  

--- a/tests/mir-opt/dead-store-elimination/place_mention.rs
+++ b/tests/mir-opt/dead-store-elimination/place_mention.rs
@@ -1,0 +1,9 @@
+// unit-test: DeadStoreElimination
+// compile-flags: -Zmir-keep-place-mention
+
+// EMIT_MIR place_mention.main.DeadStoreElimination.diff
+fn main() {
+    // Verify that we account for the `PlaceMention` statement as a use of the tuple,
+    // and don't remove it as a dead store.
+    let (_, _) = ("Hello", "World");
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/110781

r? @JakobDegen 

I don't agree with your statement in https://github.com/rust-lang/rust/issues/110781#issuecomment-1520841434. I suggest that we start fixing `PlaceContext` to be accurate enough for optimizations to use it. This structure is very convenient to use in visitors, and we perhaps have an opportunity to make it less of a footgun.