### PR TITLE
Use MIR's `Offset` for pointer `add` too

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -215,7 +215,8 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
 
             sym::type_name => (1, Vec::new(), tcx.mk_static_str()),
             sym::type_id => (1, Vec::new(), tcx.types.u64),
-            sym::offset | sym::arith_offset => (
+            sym::offset => (2, vec![param(0), param(1)], param(0)),
+            sym::arith_offset => (
                 1,
                 vec![
                     tcx.mk_ptr(ty::TypeAndMut { ty: param(0), mutbl: hir::Mutability::Not }),

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1413,6 +1413,10 @@ extern "rust-intrinsic" {
     /// This is implemented as an intrinsic to avoid converting to and from an
     /// integer, since the conversion would throw away aliasing information.
     ///
+    /// This can only be used with `Ptr` as a raw pointer type (`*mut` or `*const`)
+    /// to a `Sized` pointee and with `Delta` as `usize` or `isize`.  Any other
+    /// instantiations may arbitrarily misbehave, and that's *not* a compiler bug.
+    ///
     /// # Safety
     ///
     /// Both the starting and resulting pointer must be either in bounds or one
@@ -1421,6 +1425,14 @@ extern "rust-intrinsic" {
     /// returned value will result in undefined behavior.
     ///
     /// The stabilized version of this intrinsic is [`pointer::offset`].
+    #[cfg(not(bootstrap))]
+    #[must_use = "returns a new pointer rather than modifying its argument"]
+    #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
+    #[rustc_nounwind]
+    pub fn offset<Ptr, Delta>(dst: Ptr, offset: Delta) -> Ptr;
+
+    /// The bootstrap version of this is more restricted.
+    #[cfg(bootstrap)]
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[rustc_nounwind]

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -916,8 +916,16 @@ impl<T: ?Sized> *const T {
     where
         T: Sized,
     {
+        #[cfg(bootstrap)]
         // SAFETY: the caller must uphold the safety contract for `offset`.
-        unsafe { self.offset(count as isize) }
+        unsafe {
+            self.offset(count as isize)
+        }
+        #[cfg(not(bootstrap))]
+        // SAFETY: the caller must uphold the safety contract for `offset`.
+        unsafe {
+            intrinsics::offset(self, count)
+        }
     }
 
     /// Calculates the offset from a pointer in bytes (convenience for `.byte_offset(count as isize)`).

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -473,10 +473,20 @@ impl<T: ?Sized> *mut T {
     where
         T: Sized,
     {
+        #[cfg(bootstrap)]
         // SAFETY: the caller must uphold the safety contract for `offset`.
         // The obtained pointer is valid for writes since the caller must
         // guarantee that it points to the same allocated object as `self`.
-        unsafe { intrinsics::offset(self, count) as *mut T }
+        unsafe {
+            intrinsics::offset(self, count) as *mut T
+        }
+        #[cfg(not(bootstrap))]
+        // SAFETY: the caller must uphold the safety contract for `offset`.
+        // The obtained pointer is valid for writes since the caller must
+        // guarantee that it points to the same allocated object as `self`.
+        unsafe {
+            intrinsics::offset(self, count)
+        }
     }
 
     /// Calculates the offset from a pointer in bytes.
@@ -1016,8 +1026,16 @@ impl<T: ?Sized> *mut T {
     where
         T: Sized,
     {
+        #[cfg(bootstrap)]
         // SAFETY: the caller must uphold the safety contract for `offset`.
-        unsafe { self.offset(count as isize) }
+        unsafe {
+            self.offset(count as isize)
+        }
+        #[cfg(not(bootstrap))]
+        // SAFETY: the caller must uphold the safety contract for `offset`.
+        unsafe {
+            intrinsics::offset(self, count)
+        }
     }
 
     /// Calculates the offset from a pointer in bytes (convenience for `.byte_offset(count as isize)`).

--- a/src/doc/unstable-book/src/language-features/intrinsics.md
+++ b/src/doc/unstable-book/src/language-features/intrinsics.md
@@ -22,7 +22,7 @@ via a declaration like
 extern "rust-intrinsic" {
     fn transmute<T, U>(x: T) -> U;
 
-    fn offset<T>(dst: *const T, offset: isize) -> *const T;
+    fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
 }
 ```
 

--- a/tests/codegen/intrinsics/offset.rs
+++ b/tests/codegen/intrinsics/offset.rs
@@ -1,0 +1,34 @@
+// compile-flags: -O -C no-prepopulate-passes
+// min-llvm-version: 15.0 (because we're using opaque pointers)
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics)]
+
+use std::intrinsics::offset;
+
+// CHECK-LABEL: ptr @offset_zst
+// CHECK-SAME: (ptr noundef %p, [[SIZE:i[0-9]+]] noundef %d)
+#[no_mangle]
+pub unsafe fn offset_zst(p: *const (), d: usize) -> *const () {
+    // CHECK-NOT: getelementptr
+    // CHECK: ret ptr %p
+    offset(p, d)
+}
+
+// CHECK-LABEL: ptr @offset_isize
+// CHECK-SAME: (ptr noundef %p, [[SIZE]] noundef %d)
+#[no_mangle]
+pub unsafe fn offset_isize(p: *const u32, d: isize) -> *const u32 {
+    // CHECK: %[[R:.*]] = getelementptr inbounds i32, ptr %p, [[SIZE]] %d
+    // CHECK-NEXT: ret ptr %[[R]]
+    offset(p, d)
+}
+
+// CHECK-LABEL: ptr @offset_usize
+// CHECK-SAME: (ptr noundef %p, [[SIZE]] noundef %d)
+#[no_mangle]
+pub unsafe fn offset_usize(p: *const u64, d: usize) -> *const u64 {
+    // CHECK: %[[R:.*]] = getelementptr inbounds i64, ptr %p, [[SIZE]] %d
+    // CHECK-NEXT: ret ptr %[[R]]
+    offset(p, d)
+}

--- a/tests/mir-opt/lower_intrinsics.ptr_offset.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.ptr_offset.LowerIntrinsics.diff
@@ -13,10 +13,10 @@
           _3 = _1;                         // scope 0 at $DIR/lower_intrinsics.rs:+1:30: +1:31
           StorageLive(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:33: +1:34
           _4 = _2;                         // scope 0 at $DIR/lower_intrinsics.rs:+1:33: +1:34
--         _0 = offset::<i32>(move _3, move _4) -> [return: bb1, unwind unreachable]; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:35
+-         _0 = offset::<*const i32, isize>(move _3, move _4) -> [return: bb1, unwind unreachable]; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:35
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:140:5: 140:29
--                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const i32, isize) -> *const i32 {offset::<i32>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const i32, isize) -> *const i32 {offset::<*const i32, isize>}, val: Value(<ZST>) }
 +         _0 = Offset(move _3, move _4);   // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:35
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:35
       }

--- a/tests/mir-opt/pre-codegen/slice_index.rs
+++ b/tests/mir-opt/pre-codegen/slice_index.rs
@@ -1,0 +1,27 @@
+// compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
+// only-64bit
+// ignore-debug
+
+#![crate_type = "lib"]
+
+use std::ops::Range;
+
+// EMIT_MIR slice_index.slice_index_usize.PreCodegen.after.mir
+pub fn slice_index_usize(slice: &[u32], index: usize) -> u32 {
+    slice[index]
+}
+
+// EMIT_MIR slice_index.slice_get_mut_usize.PreCodegen.after.mir
+pub fn slice_get_mut_usize(slice: &mut [u32], index: usize) -> Option<&mut u32> {
+    slice.get_mut(index)
+}
+
+// EMIT_MIR slice_index.slice_index_range.PreCodegen.after.mir
+pub fn slice_index_range(slice: &[u32], index: Range<usize>) -> &[u32] {
+    &slice[index]
+}
+
+// EMIT_MIR slice_index.slice_get_unchecked_mut_range.PreCodegen.after.mir
+pub unsafe fn slice_get_unchecked_mut_range(slice: &mut [u32], index: Range<usize>) -> &mut [u32] {
+    slice.get_unchecked_mut(index)
+}

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.mir
@@ -45,16 +45,7 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
                             scope 12 (inlined ptr::mut_ptr::<impl *mut u32>::add) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
                                 debug self => _9; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                 debug count => _2; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                let mut _13: isize; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                 scope 13 {
-                                    scope 14 (inlined ptr::mut_ptr::<impl *mut u32>::offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        debug self => _9; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        debug count => _13; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        let mut _14: *const u32; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        let mut _15: *const u32; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        scope 15 {
-                                        }
-                                    }
                                 }
                             }
                         }
@@ -86,16 +77,7 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
         StorageLive(_12);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         _9 = _8 as *mut u32 (PtrToPtr);  // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_13);                // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _13 = _2 as isize (IntToInt);    // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_14);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_15);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _15 = _9 as *const u32 (Pointer(MutToConstPointer)); // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _14 = Offset(move _15, _13);     // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_15);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _7 = move _14 as *mut u32 (PtrToPtr); // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_14);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_13);                // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _7 = Offset(_9, _2);             // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
         StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageDead(_12);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.mir
@@ -1,0 +1,123 @@
+// MIR for `slice_get_mut_usize` after PreCodegen
+
+fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
+    debug slice => _1;                   // in scope 0 at $DIR/slice_index.rs:+0:28: +0:33
+    debug index => _2;                   // in scope 0 at $DIR/slice_index.rs:+0:47: +0:52
+    let mut _0: std::option::Option<&mut u32>; // return place in scope 0 at $DIR/slice_index.rs:+0:64: +0:80
+    scope 1 (inlined core::slice::<impl [u32]>::get_mut::<usize>) { // at $DIR/slice_index.rs:16:11: 16:25
+        debug self => _1;                // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        debug index => _2;               // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        scope 2 (inlined <usize as SliceIndex<[u32]>>::get_mut) { // at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+            debug self => _2;            // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            debug slice => _1;           // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _3: bool;            // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _4: usize;           // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _5: &[u32];          // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _6: &mut u32;        // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _7: *mut u32;        // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _8: *mut [u32];      // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            scope 3 {
+                scope 4 (inlined <usize as SliceIndex<[u32]>>::get_unchecked_mut) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    debug self => _2;    // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    debug slice => _8;   // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    let mut _9: *mut u32; // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    let mut _10: usize;  // in scope 4 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                    let mut _11: *mut [u32]; // in scope 4 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                    scope 5 {
+                        debug this => _2; // in scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                        scope 6 {
+                            scope 7 (inlined <usize as SliceIndex<[T]>>::get_unchecked_mut::runtime::<u32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                debug this => _10; // in scope 7 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                debug slice => _11; // in scope 7 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                scope 8 (inlined ptr::mut_ptr::<impl *mut [u32]>::len) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                    debug self => _11; // in scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                    let mut _12: *const [u32]; // in scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                    scope 9 (inlined std::ptr::metadata::<[u32]>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        debug ptr => _12; // in scope 9 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                        scope 10 {
+                                        }
+                                    }
+                                }
+                            }
+                            scope 11 (inlined ptr::mut_ptr::<impl *mut [u32]>::as_mut_ptr) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                debug self => _8; // in scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            }
+                            scope 12 (inlined ptr::mut_ptr::<impl *mut u32>::add) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                debug self => _9; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug count => _2; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                let mut _13: isize; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                scope 13 {
+                                    scope 14 (inlined ptr::mut_ptr::<impl *mut u32>::offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        debug self => _9; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        debug count => _13; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        let mut _14: *const u32; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        let mut _15: *const u32; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        scope 15 {
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _5 = &(*_1);                     // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _4 = Len((*_5));                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _3 = Lt(_2, move _4);            // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+    }
+
+    bb1: {
+        StorageLive(_7);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _8 = &raw mut (*_1);             // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_11);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_12);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _9 = _8 as *mut u32 (PtrToPtr);  // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_13);                // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _13 = _2 as isize (IntToInt);    // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_14);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_15);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _15 = _9 as *const u32 (Pointer(MutToConstPointer)); // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _14 = Offset(move _15, _13);     // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_15);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _7 = move _14 as *mut u32 (PtrToPtr); // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_14);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_13);                // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_12);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _6 = &mut (*_7);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _0 = Option::<&mut u32>::Some(_6); // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        goto -> bb3;                     // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+    }
+
+    bb2: {
+        _0 = const Option::<&mut u32>::None; // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: no-location
+                                         // + literal: Const { ty: Option<&mut u32>, val: Value(Scalar(0x0000000000000000)) }
+        goto -> bb3;                     // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+    }
+
+    bb3: {
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        return;                          // scope 0 at $DIR/slice_index.rs:+2:2: +2:2
+    }
+}

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.mir
@@ -1,0 +1,152 @@
+// MIR for `slice_get_unchecked_mut_range` after PreCodegen
+
+fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> &mut [u32] {
+    debug slice => _1;                   // in scope 0 at $DIR/slice_index.rs:+0:45: +0:50
+    debug index => _2;                   // in scope 0 at $DIR/slice_index.rs:+0:64: +0:69
+    let mut _0: &mut [u32];              // return place in scope 0 at $DIR/slice_index.rs:+1:5: +1:35
+    scope 1 (inlined core::slice::<impl [u32]>::get_unchecked_mut::<std::ops::Range<usize>>) { // at $DIR/slice_index.rs:26:11: 26:35
+        debug self => _1;                // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        debug index => _2;               // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        let mut _3: *mut [u32];          // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        let mut _4: *mut [u32];          // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        scope 2 {
+            scope 3 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut) { // at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+                debug self => _2;        // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                debug slice => _4;       // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let _5: std::ops::Range<usize>; // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let mut _7: usize;       // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let mut _8: usize;       // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let mut _9: *mut u32;    // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let mut _10: *mut u32;   // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let mut _11: usize;      // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let mut _12: usize;      // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let mut _13: std::ops::Range<usize>; // in scope 3 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                let mut _14: *mut [u32]; // in scope 3 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                scope 4 {
+                    debug this => _5;    // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    scope 5 {
+                        let _6: usize;   // in scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                        scope 6 {
+                            debug new_len => _6; // in scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                            scope 11 (inlined ptr::mut_ptr::<impl *mut [u32]>::as_mut_ptr) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                debug self => _4; // in scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            }
+                            scope 12 (inlined ptr::mut_ptr::<impl *mut u32>::add) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                debug self => _10; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug count => _11; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                let mut _16: isize; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                scope 13 {
+                                    scope 14 (inlined ptr::mut_ptr::<impl *mut u32>::offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        debug self => _10; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        debug count => _16; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        let mut _17: *const u32; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        let mut _18: *const u32; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        scope 15 {
+                                        }
+                                    }
+                                }
+                            }
+                            scope 16 (inlined slice_from_raw_parts_mut::<u32>) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                debug data => _9; // in scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                debug len => _12; // in scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                let mut _19: *mut (); // in scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                scope 17 (inlined ptr::mut_ptr::<impl *mut u32>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    debug self => _9; // in scope 17 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                }
+                                scope 18 (inlined std::ptr::from_raw_parts_mut::<[u32]>) { // at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    debug data_address => _19; // in scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    debug metadata => _12; // in scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    let mut _20: std::ptr::metadata::PtrRepr<[u32]>; // in scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    let mut _21: std::ptr::metadata::PtrComponents<[u32]>; // in scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    let mut _22: *const (); // in scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    scope 19 {
+                                    }
+                                }
+                            }
+                        }
+                        scope 7 (inlined <std::ops::Range<usize> as SliceIndex<[T]>>::get_unchecked_mut::runtime::<u32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            debug this => _13; // in scope 7 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            debug slice => _14; // in scope 7 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 8 (inlined ptr::mut_ptr::<impl *mut [u32]>::len) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                debug self => _14; // in scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                let mut _15: *const [u32]; // in scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                scope 9 (inlined std::ptr::metadata::<[u32]>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                    debug ptr => _15; // in scope 9 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    scope 10 {
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        _4 = &raw mut (*_1);             // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_13);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_14);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_15);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_6);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_7);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _7 = (_2.1: usize);              // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_8);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _8 = (_2.0: usize);              // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _6 = unchecked_sub::<usize>(move _7, move _8) -> [return: bb1, unwind unreachable]; // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(usize, usize) -> usize {unchecked_sub::<usize>}, val: Value(<ZST>) }
+    }
+
+    bb1: {
+        StorageDead(_8);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_7);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_10);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _10 = _4 as *mut u32 (PtrToPtr); // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _11 = (_2.0: usize);             // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_16);                // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _16 = _11 as isize (IntToInt);   // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_17);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_18);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _18 = _10 as *const u32 (Pointer(MutToConstPointer)); // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _17 = Offset(move _18, _16);     // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_18);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _9 = move _17 as *mut u32 (PtrToPtr); // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_17);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_16);                // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_10);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _12 = _6;                        // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_19);                // scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _19 = _9 as *mut () (PtrToPtr);  // scope 17 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_20);                // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageLive(_21);                // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageLive(_22);                // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _22 = _19 as *const () (Pointer(MutToConstPointer)); // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _21 = ptr::metadata::PtrComponents::<[u32]> { data_address: move _22, metadata: _12 }; // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_22);                // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _20 = ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _21 }; // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_21);                // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _3 = (_20.1: *mut [u32]);        // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_20);                // scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_19);                // scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_6);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_15);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_14);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_13);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        _0 = &mut (*_3);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        return;                          // scope 0 at $DIR/slice_index.rs:+2:2: +2:2
+    }
+}

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.mir
@@ -34,32 +34,23 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
                             scope 12 (inlined ptr::mut_ptr::<impl *mut u32>::add) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
                                 debug self => _10; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                 debug count => _11; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                let mut _16: isize; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                 scope 13 {
-                                    scope 14 (inlined ptr::mut_ptr::<impl *mut u32>::offset) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        debug self => _10; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        debug count => _16; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        let mut _17: *const u32; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        let mut _18: *const u32; // in scope 14 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        scope 15 {
-                                        }
-                                    }
                                 }
                             }
-                            scope 16 (inlined slice_from_raw_parts_mut::<u32>) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                                debug data => _9; // in scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                debug len => _12; // in scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                let mut _19: *mut (); // in scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                scope 17 (inlined ptr::mut_ptr::<impl *mut u32>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                    debug self => _9; // in scope 17 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                            scope 14 (inlined slice_from_raw_parts_mut::<u32>) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                debug data => _9; // in scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                debug len => _12; // in scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                let mut _16: *mut (); // in scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                scope 15 (inlined ptr::mut_ptr::<impl *mut u32>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    debug self => _9; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                 }
-                                scope 18 (inlined std::ptr::from_raw_parts_mut::<[u32]>) { // at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                    debug data_address => _19; // in scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                                    debug metadata => _12; // in scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                                    let mut _20: std::ptr::metadata::PtrRepr<[u32]>; // in scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                                    let mut _21: std::ptr::metadata::PtrComponents<[u32]>; // in scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                                    let mut _22: *const (); // in scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                                    scope 19 {
+                                scope 16 (inlined std::ptr::from_raw_parts_mut::<[u32]>) { // at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    debug data_address => _16; // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    debug metadata => _12; // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    let mut _17: std::ptr::metadata::PtrRepr<[u32]>; // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    let mut _18: std::ptr::metadata::PtrComponents<[u32]>; // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    let mut _19: *const (); // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    scope 17 {
                                     }
                                 }
                             }
@@ -110,33 +101,24 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
         _10 = _4 as *mut u32 (PtrToPtr); // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
         StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         _11 = (_2.0: usize);             // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageLive(_16);                // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _16 = _11 as isize (IntToInt);   // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_17);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_18);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _18 = _10 as *const u32 (Pointer(MutToConstPointer)); // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _17 = Offset(move _18, _16);     // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_18);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _9 = move _17 as *mut u32 (PtrToPtr); // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_17);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_16);                // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _9 = Offset(_10, _11);           // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
         StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageDead(_10);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         _12 = _6;                        // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageLive(_19);                // scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _19 = _9 as *mut () (PtrToPtr);  // scope 17 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_20);                // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageLive(_21);                // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageLive(_22);                // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _22 = _19 as *const () (Pointer(MutToConstPointer)); // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _21 = ptr::metadata::PtrComponents::<[u32]> { data_address: move _22, metadata: _12 }; // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_22);                // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _20 = ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _21 }; // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_21);                // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _3 = (_20.1: *mut [u32]);        // scope 19 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_20);                // scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_19);                // scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageLive(_16);                // scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _16 = _9 as *mut () (PtrToPtr);  // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_17);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageLive(_18);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageLive(_19);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _19 = _16 as *const () (Pointer(MutToConstPointer)); // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _18 = ptr::metadata::PtrComponents::<[u32]> { data_address: move _19, metadata: _12 }; // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_19);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _17 = ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _18 }; // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_18);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _3 = (_17.1: *mut [u32]);        // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_17);                // scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_16);                // scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageDead(_6);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL

--- a/tests/mir-opt/pre-codegen/slice_index.slice_index_range.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_index_range.PreCodegen.after.mir
@@ -1,0 +1,26 @@
+// MIR for `slice_index_range` after PreCodegen
+
+fn slice_index_range(_1: &[u32], _2: std::ops::Range<usize>) -> &[u32] {
+    debug slice => _1;                   // in scope 0 at $DIR/slice_index.rs:+0:26: +0:31
+    debug index => _2;                   // in scope 0 at $DIR/slice_index.rs:+0:41: +0:46
+    let mut _0: &[u32];                  // return place in scope 0 at $DIR/slice_index.rs:+1:5: +1:18
+    let _3: &[u32];                      // in scope 0 at $DIR/slice_index.rs:+1:6: +1:18
+    scope 1 (inlined #[track_caller] core::slice::index::<impl Index<std::ops::Range<usize>> for [u32]>::index) { // at $DIR/slice_index.rs:21:6: 21:18
+        debug self => _1;                // in scope 1 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        debug index => _2;               // in scope 1 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+    }
+
+    bb0: {
+        StorageLive(_3);                 // scope 0 at $DIR/slice_index.rs:+1:6: +1:18
+        _3 = <std::ops::Range<usize> as SliceIndex<[u32]>>::index(move _2, _1) -> bb1; // scope 1 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                         // + literal: Const { ty: for<'a> fn(std::ops::Range<usize>, &'a [u32]) -> &'a <std::ops::Range<usize> as SliceIndex<[u32]>>::Output {<std::ops::Range<usize> as SliceIndex<[u32]>>::index}, val: Value(<ZST>) }
+    }
+
+    bb1: {
+        _0 = _3;                         // scope 0 at $DIR/slice_index.rs:+1:5: +1:18
+        StorageDead(_3);                 // scope 0 at $DIR/slice_index.rs:+2:1: +2:2
+        return;                          // scope 0 at $DIR/slice_index.rs:+2:2: +2:2
+    }
+}

--- a/tests/mir-opt/pre-codegen/slice_index.slice_index_usize.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_index_usize.PreCodegen.after.mir
@@ -1,0 +1,20 @@
+// MIR for `slice_index_usize` after PreCodegen
+
+fn slice_index_usize(_1: &[u32], _2: usize) -> u32 {
+    debug slice => _1;                   // in scope 0 at $DIR/slice_index.rs:+0:26: +0:31
+    debug index => _2;                   // in scope 0 at $DIR/slice_index.rs:+0:41: +0:46
+    let mut _0: u32;                     // return place in scope 0 at $DIR/slice_index.rs:+0:58: +0:61
+    let mut _3: usize;                   // in scope 0 at $DIR/slice_index.rs:+1:5: +1:17
+    let mut _4: bool;                    // in scope 0 at $DIR/slice_index.rs:+1:5: +1:17
+
+    bb0: {
+        _3 = Len((*_1));                 // scope 0 at $DIR/slice_index.rs:+1:5: +1:17
+        _4 = Lt(_2, _3);                 // scope 0 at $DIR/slice_index.rs:+1:5: +1:17
+        assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> bb1; // scope 0 at $DIR/slice_index.rs:+1:5: +1:17
+    }
+
+    bb1: {
+        _0 = (*_1)[_2];                  // scope 0 at $DIR/slice_index.rs:+1:5: +1:17
+        return;                          // scope 0 at $DIR/slice_index.rs:+2:2: +2:2
+    }
+}

--- a/tests/ui/const-ptr/forbidden_slices.stderr
+++ b/tests/ui/const-ptr/forbidden_slices.stderr
@@ -131,8 +131,6 @@ error[E0080]: could not evaluate static initializer
    |
    = note: out-of-bounds pointer arithmetic: allocN has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
    |
-note: inside `ptr::const_ptr::<impl *const u32>::offset`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `ptr::const_ptr::<impl *const u32>::add`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `R2`
@@ -195,8 +193,6 @@ error[E0080]: could not evaluate static initializer
    |
    = note: out-of-bounds pointer arithmetic: allocN has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
    |
-note: inside `ptr::const_ptr::<impl *const u64>::offset`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `ptr::const_ptr::<impl *const u64>::add`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `R8`


### PR DESCRIPTION
~~Status: draft while waiting for #110822 to land, since this is built atop that.~~
~~r? @ghost~~

Canonical Rust code has mostly moved to `add`/`sub` on pointers, which take `usize`, instead of `offset` which takes `isize`.  (And, relatedly, when `sub_ptr` was added it turned out it replaced every single in-tree use of `offset_from`, because `usize` is just so much more useful than `isize` in Rust.)

Unfortunately, `intrinsics::offset` could only accept `*const` and `isize`, so there's a *huge* amount of type conversions back and forth being done.  They're identity conversions in the backend, but still end up producing quite a lot of unhelpful MIR.

This PR changes `intrinsics::offset` to accept `*const` *and* `*mut` along with `isize` *and* `usize`.  Conveniently, the backends and CTFE already handle this, since MIR's `BinOp::Offset` [already supports all four combinations](https://github.com/rust-lang/rust/blob/adaac6b166df57ea5a20d56e4cce503b55aca927/compiler/rustc_const_eval/src/transform/validate.rs#L523-L528).

To demonstrate the difference, I added some `mir-opt/pre-codegen/` tests around slice indexing.  Here's the difference to `[T]::get_mut`, since it uses `<*mut _>::add` internally:
```diff
@@ -79,30 +70,21 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
         StorageLive(_12);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         _9 = _8 as *mut u32 (PtrToPtr);  // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_13);                // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _13 = _2 as isize (IntToInt);    // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_14);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_15);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _15 = _9 as *const u32 (Pointer(MutToConstPointer)); // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _14 = Offset(move _15, _13);     // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_15);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _7 = move _14 as *mut u32 (PtrToPtr); // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_14);                // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_13);                // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _7 = Offset(_9, _2);             // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
         StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageDead(_12);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
```
https://github.com/rust-lang/rust/pull/110837/commits/1c1c8e442add0f46905a57a25a6cba52b8b0c54d#diff-a841b6a4538657add3f39bc895744331453d0625e7aace128b1f604f0b63c8fdR80
