### PR TITLE
Optimize builder sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,10 +260,10 @@ jobs:
             os: ubuntu-20.04-8core-32gb
             env: {}
           - name: i686-gnu
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: i686-gnu-nopt
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-8core-32gb
             env: {}
           - name: mingw-check
             os: ubuntu-20.04-8core-32gb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,16 +275,16 @@ jobs:
             os: ubuntu-20.04-8core-32gb
             env: {}
           - name: x86_64-gnu
-            os: ubuntu-20.04-8core-32gb
+            os: ubuntu-20.04-4core-16gb
             env: {}
           - name: x86_64-gnu-stable
             env:
               IMAGE: x86_64-gnu
               RUST_CI_OVERRIDE_RELEASE_CHANNEL: stable
               CI_ONLY_WHEN_CHANNEL: nightly
-            os: ubuntu-20.04-8core-32gb
+            os: ubuntu-20.04-4core-16gb
           - name: x86_64-gnu-aux
-            os: ubuntu-20.04-8core-32gb
+            os: ubuntu-20.04-4core-16gb
             env: {}
           - name: x86_64-gnu-debug
             os: ubuntu-20.04-8core-32gb
@@ -309,7 +309,7 @@ jobs:
               RUST_BACKTRACE: 1
             os: ubuntu-20.04-8core-32gb
           - name: x86_64-gnu-nopt
-            os: ubuntu-20.04-8core-32gb
+            os: ubuntu-20.04-4core-16gb
             env: {}
           - name: x86_64-gnu-tools
             env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
             os: ubuntu-20.04-8core-32gb
             env: {}
           - name: mingw-check
-            os: ubuntu-20.04-8core-32gb
+            os: ubuntu-20.04-4core-16gb
             env: {}
           - name: test-various
             os: ubuntu-20.04-8core-32gb

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -73,6 +73,10 @@ x--expand-yaml-anchors--remove:
   - &base-job
     env: {}
 
+  - &job-linux-4c
+    os: ubuntu-20.04-4core-16gb
+    <<: *base-job
+
   - &job-linux-8c
     os: ubuntu-20.04-8core-32gb
     <<: *base-job
@@ -422,7 +426,7 @@ jobs:
             <<: *job-linux-8c
 
           - name: mingw-check
-            <<: *job-linux-8c
+            <<: *job-linux-4c
 
           - name: test-various
             <<: *job-linux-8c

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -435,7 +435,7 @@ jobs:
             <<: *job-linux-8c
 
           - name: x86_64-gnu
-            <<: *job-linux-8c
+            <<: *job-linux-4c
 
           # This job ensures commits landing on nightly still pass the full
           # test suite on the stable channel. There are some UI tests that
@@ -450,10 +450,10 @@ jobs:
               # could cause failures when `dev: 1` in `stage0.txt`, and running
               # this on stable is useless.
               CI_ONLY_WHEN_CHANNEL: nightly
-            <<: *job-linux-8c
+            <<: *job-linux-4c
 
           - name: x86_64-gnu-aux
-            <<: *job-linux-8c
+            <<: *job-linux-4c
 
           - name: x86_64-gnu-debug
             <<: *job-linux-8c
@@ -482,7 +482,7 @@ jobs:
             <<: *job-linux-8c
 
           - name: x86_64-gnu-nopt
-            <<: *job-linux-8c
+            <<: *job-linux-4c
 
           - name: x86_64-gnu-tools
             env:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -416,10 +416,10 @@ jobs:
             <<: *job-linux-8c
 
           - name: i686-gnu
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: i686-gnu-nopt
-            <<: *job-linux-16c
+            <<: *job-linux-8c
 
           - name: mingw-check
             <<: *job-linux-8c


### PR DESCRIPTION
The infra-team is continuously monitoring the efficiency of the CI system in an effort to improve overall build times and resource usage. Some builders have used much less than their allocated resources, so we are testing smaller builder sizes for them.

r? @pietroalbini 