### PR TITLE
rustdoc-json: Time serialization.

### DIFF
--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -279,7 +279,10 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
         p.push(output.index.get(&output.root).unwrap().name.clone().unwrap());
         p.set_extension("json");
         let mut file = BufWriter::new(try_err!(File::create(&p), p));
-        serde_json::ser::to_writer(&mut file, &output).unwrap();
+        self.tcx
+            .sess
+            .time("rustdoc_json_serialization", || serde_json::ser::to_writer(&mut file, &output))
+            .unwrap();
         try_err!(file.flush(), p);
 
         Ok(())


### PR DESCRIPTION
This lets us know how much time is spent in json specific code, and how much performance we could gain by using a different serialization format.

For aws-sdk-ec2, it takes 0.7s, out of a 43s build (of which 6s is spent in json specific code), and makes a 173M json file

```
$ cargo +rust_stage2 rustdoc -p aws-sdk-ec2 -- -Zunstable-options -w json -Ztime-passes
 Documenting aws-sdk-ec2 v0.26.0 (/home/gh-aDotInTheVoid/aws-sdk-rust/sdk/ec2)
time:   5.229; rss:   64MB ->  891MB ( +827MB)  expand_crate
time:   5.230; rss:   61MB ->  891MB ( +830MB)  macro_expand_crate
time:   0.256; rss:  891MB ->  891MB (   +0MB)  AST_validation
time:   0.025; rss:  891MB ->  891MB (   +1MB)  finalize_imports
time:   0.093; rss:  891MB ->  891MB (   +0MB)  compute_effective_visibilities
time:   0.122; rss:  891MB ->  891MB (   +0MB)  finalize_macro_resolutions
time:   2.442; rss:  891MB -> 1188MB ( +297MB)  late_resolve_crate
time:   0.120; rss: 1188MB -> 1190MB (   +2MB)  resolve_check_unused
time:   0.211; rss: 1190MB -> 1190MB (   +0MB)  resolve_postprocess
time:   3.017; rss:  891MB -> 1190MB ( +299MB)  resolve_crate
time:   8.520; rss:   61MB -> 1181MB (+1120MB)  prepare_outputs
time:   0.152; rss: 1181MB -> 1181MB (   +0MB)  complete_gated_feature_checking
time:   0.539; rss: 1633MB -> 1632MB (   -1MB)  drop_ast
time:  15.492; rss:   58MB -> 1621MB (+1563MB)  type_collecting
time:   1.503; rss: 1621MB -> 1705MB (  +84MB)  item_types_checking
time:   1.274; rss: 1705MB -> 1726MB (  +21MB)  crate_lints
time:   1.275; rss: 1705MB -> 1726MB (  +21MB)  missing_docs
time:   0.281; rss: 1726MB -> 1726MB (   +0MB)  check_mod_attrs
time:   0.433; rss: 1744MB -> 1750MB (   +6MB)  clean_crate
time:  11.581; rss: 1750MB -> 2107MB ( +357MB)  collect_synthetic_impls
time:   0.019; rss: 2107MB -> 2107MB (   +0MB)  collect_items_for_trait_impls
time:  12.588; rss: 1750MB -> 2139MB ( +389MB)  collect-trait-impls
time:   0.197; rss: 2139MB -> 2139MB (   +0MB)  check_doc_test_visibility
time:   0.281; rss: 2139MB -> 2150MB (  +11MB)  strip-hidden
time:   0.260; rss: 2150MB -> 2150MB (   +0MB)  strip-private
warning: unresolved link to `date`
 --> sdk/ec2/src/client/describe_instances.rs:7:11184
  |
7 | ...te of the instance (for example, shows "User Initiated [date]" when you stop or terminate the instance). Similar to the state-reason-code filter.<...
  |                                                            ^^^^ no item named `date` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
  = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

time:   0.363; rss: 2150MB -> 2150MB (   +0MB)  collect-intra-doc-links
time:   0.946; rss: 2150MB -> 2150MB (   +0MB)  propagate-doc-cfg
time:   0.494; rss: 2150MB -> 2152MB (   +2MB)  run-lints
time:   0.658; rss: 2152MB -> 2163MB (  +11MB)  create_format_cache
time:  34.818; rss:   58MB -> 2163MB (+2105MB)  run_global_ctxt
time:   0.016; rss: 2163MB -> 2163MB (   +0MB)  create_renderer(json)
time:   0.723; rss: 2780MB -> 2780MB (   +0MB)  rustdoc_json_serialization
time:   2.216; rss: 2399MB -> 2599MB ( +199MB)  renderer_after_krate(json)
time:   6.639; rss: 2163MB -> 2417MB ( +254MB)  render_json
time:   0.312; rss: 2417MB -> 2071MB ( -346MB)  free_global_ctxt
warning: `aws-sdk-ec2` (lib doc) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 43.06s
```

[(Zulip Discussion)](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/JSON.20metadata.20speed/near/352783145)

r? @GuillaumeGomez 