### PR TITLE
Rustc shim is now a wrapper

### DIFF
--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -29,6 +29,11 @@ name = "sccache-plus-cl"
 path = "bin/sccache-plus-cl.rs"
 test = false
 
+[[bin]]
+name = "rustc-shim"
+path = "bin/rustc-shim.rs"
+test = false
+
 [dependencies]
 is-terminal = "0.4"
 build_helper = { path = "../tools/build_helper" }

--- a/src/bootstrap/bin/rustc-shim.rs
+++ b/src/bootstrap/bin/rustc-shim.rs
@@ -1,0 +1,10 @@
+fn main() {
+    if std::env::args().any(|v| v == "-vV") {
+        std::process::Command::new(std::env::var("RUSTC_REAL").unwrap())
+            .arg("-vV")
+            .status()
+            .unwrap();
+    } else {
+        todo!("rustc-shim")
+    }
+}

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -24,7 +24,12 @@ use std::str::FromStr;
 use std::time::Instant;
 
 fn main() {
-    let args = env::args_os().skip(1).collect::<Vec<_>>();
+    let mut args = env::args_os().skip(1).collect::<Vec<_>>();
+
+    let _compiler = args.remove(0);
+
+    let args = args;
+
     let arg = |name| args.windows(2).find(|args| args[0] == name).and_then(|args| args[1].to_str());
 
     // Detect whether or not we're a build script depending on whether --target

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -1,4 +1,4 @@
-//! Shim which is passed to Cargo as "rustc" when running the bootstrap.
+//! Shim which is passed to Cargo as "RUSTC_WRAPPER" when running the bootstrap.
 //!
 //! This shim will take care of some various tasks that our build process
 //! requires that Cargo can't quite do through normal configuration:

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1581,6 +1581,7 @@ impl<'a> Builder<'a> {
         // Clippy support is a hack and uses the default `cargo-clippy` in path.
         // Don't override RUSTC so that the `cargo-clippy` in path will be run.
         if cmd != "clippy" {
+            cargo.env("RUSTC", self.bootstrap_out.join("rustc-shim"));
             cargo.env("RUSTC_WRAPPER", self.bootstrap_out.join("rustc"));
         }
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1581,7 +1581,7 @@ impl<'a> Builder<'a> {
         // Clippy support is a hack and uses the default `cargo-clippy` in path.
         // Don't override RUSTC so that the `cargo-clippy` in path will be run.
         if cmd != "clippy" {
-            cargo.env("RUSTC", self.bootstrap_out.join("rustc"));
+            cargo.env("RUSTC_WRAPPER", self.bootstrap_out.join("rustc"));
         }
 
         // Dealing with rpath here is a little special, so let's go into some

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -315,6 +315,7 @@ impl Step for Cargotest {
             cmd.arg(&cargo)
                 .arg(&out_dir)
                 .args(builder.config.cmd.test_args())
+                .env("RUSTC", builder.bootstrap_out.join("rustc-shim"))
                 .env("RUSTC_WRAPPER", builder.rustc(compiler))
                 .env("RUSTDOC", builder.rustdoc(compiler)),
         );
@@ -1094,6 +1095,7 @@ impl Step for RustdocGUI {
                     .arg(&out_dir)
                     .env("RUSTC_BOOTSTRAP", "1")
                     .env("RUSTDOC", builder.rustdoc(self.compiler))
+                    .env("RUSTC", builder.bootstrap_out.join("rustc-shim"))
                     .env("RUSTC_WRAPPER", builder.rustc(self.compiler))
                     .current_dir(path);
                 // FIXME: implement a `// compile-flags` command or similar
@@ -2796,6 +2798,7 @@ impl Step for RustInstaller {
         cmd.current_dir(&tmpdir);
         cmd.env("CARGO_TARGET_DIR", tmpdir.join("cargo-target"));
         cmd.env("CARGO", &builder.initial_cargo);
+        cmd.env("RUSTC", &builder.bootstrap_out.join("rustc-shim"));
         cmd.env("RUSTC_WRAPPER", &builder.initial_rustc);
         cmd.env("TMP_DIR", &tmpdir);
         try_run(builder, &mut cmd);

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -315,7 +315,7 @@ impl Step for Cargotest {
             cmd.arg(&cargo)
                 .arg(&out_dir)
                 .args(builder.config.cmd.test_args())
-                .env("RUSTC", builder.rustc(compiler))
+                .env("RUSTC_WRAPPER", builder.rustc(compiler))
                 .env("RUSTDOC", builder.rustdoc(compiler)),
         );
     }
@@ -1094,7 +1094,7 @@ impl Step for RustdocGUI {
                     .arg(&out_dir)
                     .env("RUSTC_BOOTSTRAP", "1")
                     .env("RUSTDOC", builder.rustdoc(self.compiler))
-                    .env("RUSTC", builder.rustc(self.compiler))
+                    .env("RUSTC_WRAPPER", builder.rustc(self.compiler))
                     .current_dir(path);
                 // FIXME: implement a `// compile-flags` command or similar
                 //        instead of hard-coding this test
@@ -2796,7 +2796,7 @@ impl Step for RustInstaller {
         cmd.current_dir(&tmpdir);
         cmd.env("CARGO_TARGET_DIR", tmpdir.join("cargo-target"));
         cmd.env("CARGO", &builder.initial_cargo);
-        cmd.env("RUSTC", &builder.initial_rustc);
+        cmd.env("RUSTC_WRAPPER", &builder.initial_rustc);
         cmd.env("TMP_DIR", &tmpdir);
         try_run(builder, &mut cmd);
     }

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-14/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-14/Dockerfile
@@ -50,7 +50,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set rust.thin-lto-import-instr-limit=10
 
 # NOTE: intentionally uses all of `x.py`, `x`, and `x.ps1` to make sure they all work on Linux.
-ENV SCRIPT ../x.py --stage 2 test --exclude src/tools/tidy && \
+ENV SCRIPT ../x.py --verbose --stage 2 test --exclude src/tools/tidy && \
            # Run the `mir-opt` tests again but this time for a 32-bit target.
            # This enforces that tests using `// EMIT_MIR_FOR_EACH_BIT_WIDTH` have
            # both 32-bit and 64-bit outputs updated by the PR author, before

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-14/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-14/Dockerfile
@@ -50,7 +50,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set rust.thin-lto-import-instr-limit=10
 
 # NOTE: intentionally uses all of `x.py`, `x`, and `x.ps1` to make sure they all work on Linux.
-ENV SCRIPT ../x.py --verbose --stage 2 test --exclude src/tools/tidy && \
+ENV SCRIPT ../x.py --stage 2 test --exclude src/tools/tidy && \
            # Run the `mir-opt` tests again but this time for a 32-bit target.
            # This enforces that tests using `// EMIT_MIR_FOR_EACH_BIT_WIDTH` have
            # both 32-bit and 64-bit outputs updated by the PR author, before


### PR DESCRIPTION
This is preparatory work to make clippy work in the repo (#107628).
This changes the rustc shim in bootstrap to be RUSTC_WRAPPER, instead of RUSTC.