### PR TITLE
Make `method-not-found-generic-arg-elision.rs` error message not path dependent

### DIFF
--- a/tests/ui/methods/method-not-found-generic-arg-elision.rs
+++ b/tests/ui/methods/method-not-found-generic-arg-elision.rs
@@ -83,8 +83,8 @@ fn main() {
     //~^ ERROR no method named `distance` found for struct `Point<i32>
     let d = point_i32.other();
     //~^ ERROR no method named `other` found for struct `Point
-    let v = vec![1_i32, 2, 3];
-    v.iter().map(|x| x * x).extend(std::iter::once(100));
+    let v = vec![1, 2, 3];
+    v.iter().map(Box::new(|x| x * x) as Box<dyn Fn(&i32) -> i32>).extend(std::iter::once(100));
     //~^ ERROR no method named `extend` found for struct `Map
     let wrapper = Wrapper(true);
     wrapper.method();

--- a/tests/ui/methods/method-not-found-generic-arg-elision.stderr
+++ b/tests/ui/methods/method-not-found-generic-arg-elision.stderr
@@ -20,10 +20,10 @@ LL |     let d = point_i32.other();
    |                       ^^^^^ method not found in `Point<i32>`
 
 error[E0599]: no method named `extend` found for struct `Map` in the current scope
-  --> $DIR/method-not-found-generic-arg-elision.rs:87:29
+  --> $DIR/method-not-found-generic-arg-elision.rs:87:67
    |
-LL |     v.iter().map(|x| x * x).extend(std::iter::once(100));
-   |                             ^^^^^^ method not found in `Map<Iter<'_, i32>, [closure@method-not-found-generic-arg-elision.rs:87:18]>`
+LL |     v.iter().map(Box::new(|x| x * x) as Box<dyn Fn(&i32) -> i32>).extend(std::iter::once(100));
+   |                                                                   ^^^^^^ method not found in `Map<Iter<'_, i32>, Box<dyn Fn(&i32) -> i32>>`
 
 error[E0599]: no method named `method` found for struct `Wrapper<bool>` in the current scope
   --> $DIR/method-not-found-generic-arg-elision.rs:90:13


### PR DESCRIPTION
Every time I bless `tests/ui/methods/method-not-found-generic-arg-elision.rs`, I get some nonsense "type is too long" + "written to disk" that shows up and have to manually revert because the combination of my rustc repo path + the UI test directory hits the length limit for printing types spilling to disk (since this happens before UI test path sanitization).

The fact that we use a closure in this test doesn't have to do with the UI test, so just box the closure to make the type name smaller and not path dependent.