### PR TITLE
Migrate trivially translatable `rustc_parse` diagnostics

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2976,7 +2976,7 @@ pub enum ItemKind {
 }
 
 impl ItemKind {
-    pub fn article(&self) -> &str {
+    pub fn article(&self) -> &'static str {
         use ItemKind::*;
         match self {
             Use(..) | Static(..) | Const(..) | Fn(..) | Mod(..) | GlobalAsm(..) | TyAlias(..)
@@ -2985,7 +2985,7 @@ impl ItemKind {
         }
     }
 
-    pub fn descr(&self) -> &str {
+    pub fn descr(&self) -> &'static str {
         match self {
             ItemKind::ExternCrate(..) => "extern crate",
             ItemKind::Use(..) => "`use` import",

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -772,3 +772,75 @@ parse_const_bounds_missing_tilde = const bounds must start with `~`
     .suggestion = add `~`
 
 parse_underscore_literal_suffix = underscore literal suffix is not allowed
+
+parse_expect_label_found_ident = expected a label, found an identifier
+    .suggestion = labels start with a tick
+
+parse_inappropriate_default = {$article} {$descr} cannot be `default`
+    .label = `default` because of this
+    .note = only associated `fn`, `const`, and `type` items can be `default`
+
+parse_recover_import_as_use = expected item, found {$token_name}
+    .suggestion = items are imported using the `use` keyword
+
+parse_single_colon_import_path = expected `::`, found `:`
+    .suggestion = use double colon
+    .note = import paths are delimited using `::`
+
+parse_bad_item_kind = {$descr} is not supported in {$ctx}
+    .help = consider moving the {$descr} out to a nearby module scope
+
+parse_single_colon_struct_type = found single colon in a struct field type path
+    .suggestion = write a path separator here
+
+parse_equals_struct_default = default values on `struct` fields aren't supported
+    .suggestion = remove this unsupported default value
+
+parse_macro_rules_missing_bang = expected `!` after `macro_rules`
+    .suggestion = add a `!`
+
+parse_macro_name_remove_bang = macro names aren't followed by a `!`
+    .suggestion = remove the `!`
+
+parse_macro_rules_visibility = can't qualify macro_rules invocation with `{$vis}`
+    .suggestion = try exporting the macro
+
+parse_macro_invocation_visibility = can't qualify macro invocation with `pub`
+    .suggestion = remove the visibility
+    .help = try adjusting the macro to put `{$vis}` inside the invocation
+
+parse_nested_adt = `{$kw_str}` definition cannot be nested inside `{$keyword}`
+    .suggestion = consider creating a new `{$kw_str}` definition instead of nesting
+
+parse_function_body_equals_expr = function body cannot be `= expression;`
+    .suggestion = surround the expression with `{"{"}` and `{"}"}` instead of `=` and `;`
+
+parse_box_not_pat = expected pattern, found {$descr}
+    .note = `box` is a reserved keyword
+    .suggestion = escape `box` to use it as an identifier
+
+parse_unmatched_angle = unmatched angle {$plural ->
+    [true] brackets
+    *[false] bracket
+    }
+    .suggestion = remove extra angle {$plural ->
+    [true] brackets
+    *[false] bracket
+    }
+
+parse_missing_plus_in_bounds = expected `+` between lifetime and {$sym}
+    .suggestion = add `+`
+
+parse_incorrect_braces_trait_bounds = incorrect braces around trait bounds
+    .suggestion = remove the parentheses
+
+parse_kw_bad_case = keyword `{$kw}` is written in the wrong case
+    .suggestion = write it in the correct case
+
+parse_meta_bad_delim = wrong meta list delimiters
+parse_cfg_attr_bad_delim = wrong `cfg_attr` delimiters
+parse_meta_bad_delim_suggestion = the delimiters should be `(` and `)`
+
+parse_malformed_cfg_attr = malformed `cfg_attr` attribute input
+    .suggestion = missing condition and attribute
+    .note = for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2421,3 +2421,227 @@ pub(crate) struct UnderscoreLiteralSuffix {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(parse_expect_label_found_ident)]
+pub(crate) struct ExpectedLabelFoundIdent {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(code = "'", applicability = "machine-applicable", style = "short")]
+    pub start: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_inappropriate_default)]
+#[note]
+pub(crate) struct InappropriateDefault {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub article: &'static str,
+    pub descr: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_recover_import_as_use)]
+pub(crate) struct RecoverImportAsUse {
+    #[primary_span]
+    #[suggestion(code = "use", applicability = "machine-applicable", style = "short")]
+    pub span: Span,
+    pub token_name: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_single_colon_import_path)]
+#[note]
+pub(crate) struct SingleColonImportPath {
+    #[primary_span]
+    #[suggestion(code = "::", applicability = "machine-applicable", style = "short")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_bad_item_kind)]
+#[help]
+pub(crate) struct BadItemKind {
+    #[primary_span]
+    pub span: Span,
+    pub descr: &'static str,
+    pub ctx: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_single_colon_struct_type)]
+pub(crate) struct SingleColonStructType {
+    #[primary_span]
+    #[suggestion(code = "::", applicability = "maybe-incorrect", style = "verbose")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_equals_struct_default)]
+pub(crate) struct EqualsStructDefault {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "machine-applicable")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_macro_rules_missing_bang)]
+pub(crate) struct MacroRulesMissingBang {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(code = "!", applicability = "machine-applicable", style = "verbose")]
+    pub hi: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_macro_name_remove_bang)]
+pub(crate) struct MacroNameRemoveBang {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "machine-applicable")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_macro_rules_visibility)]
+pub(crate) struct MacroRulesVisibility<'a> {
+    #[primary_span]
+    #[suggestion(code = "#[macro_export]", applicability = "maybe-incorrect")]
+    pub span: Span,
+    pub vis: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_macro_invocation_visibility)]
+#[help]
+pub(crate) struct MacroInvocationVisibility<'a> {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "machine-applicable")]
+    pub span: Span,
+    pub vis: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_nested_adt)]
+pub(crate) struct NestedAdt<'a> {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    pub item: Span,
+    pub keyword: &'a str,
+    pub kw_str: Cow<'a, str>,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_function_body_equals_expr)]
+pub(crate) struct FunctionBodyEqualsExpr {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: FunctionBodyEqualsExprSugg,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parse_suggestion, applicability = "machine-applicable")]
+pub(crate) struct FunctionBodyEqualsExprSugg {
+    #[suggestion_part(code = "{{")]
+    pub eq: Span,
+    #[suggestion_part(code = " }}")]
+    pub semi: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_box_not_pat)]
+pub(crate) struct BoxNotPat {
+    #[primary_span]
+    pub span: Span,
+    #[note]
+    pub kw: Span,
+    #[suggestion(code = "r#", applicability = "maybe-incorrect", style = "verbose")]
+    pub lo: Span,
+    pub descr: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_unmatched_angle)]
+pub(crate) struct UnmatchedAngle {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "machine-applicable")]
+    pub span: Span,
+    pub plural: bool,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_missing_plus_in_bounds)]
+pub(crate) struct MissingPlusBounds {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(code = " +", applicability = "maybe-incorrect", style = "verbose")]
+    pub hi: Span,
+    pub sym: Symbol,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_incorrect_braces_trait_bounds)]
+pub(crate) struct IncorrectBracesTraitBounds {
+    #[primary_span]
+    pub span: Vec<Span>,
+    #[subdiagnostic]
+    pub sugg: IncorrectBracesTraitBoundsSugg,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parse_suggestion, applicability = "machine-applicable")]
+pub(crate) struct IncorrectBracesTraitBoundsSugg {
+    #[suggestion_part(code = " ")]
+    pub l: Span,
+    #[suggestion_part(code = "")]
+    pub r: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_kw_bad_case)]
+pub(crate) struct KwBadCase<'a> {
+    #[primary_span]
+    #[suggestion(code = "{kw}", applicability = "machine-applicable")]
+    pub span: Span,
+    pub kw: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_meta_bad_delim)]
+pub(crate) struct MetaBadDelim {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: MetaBadDelimSugg,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_cfg_attr_bad_delim)]
+pub(crate) struct CfgAttrBadDelim {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: MetaBadDelimSugg,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parse_meta_bad_delim_suggestion, applicability = "machine-applicable")]
+pub(crate) struct MetaBadDelimSugg {
+    #[suggestion_part(code = "(")]
+    pub open: Span,
+    #[suggestion_part(code = ")")]
+    pub close: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_malformed_cfg_attr)]
+#[note]
+pub(crate) struct MalformedCfgAttr {
+    #[primary_span]
+    #[suggestion(code = "{sugg}")]
+    pub span: Span,
+    pub sugg: &'static str,
+}

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3151,14 +3151,10 @@ impl<'a> Parser<'a> {
         let label = format!("'{}", ident.name);
         let ident = Ident { name: Symbol::intern(&label), span: ident.span };
 
-        self.struct_span_err(ident.span, "expected a label, found an identifier")
-            .span_suggestion(
-                ident.span,
-                "labels start with a tick",
-                label,
-                Applicability::MachineApplicable,
-            )
-            .emit();
+        self.sess.emit_err(errors::ExpectedLabelFoundIdent {
+            span: ident.span,
+            start: ident.span.shrink_to_lo(),
+        });
 
         Label { ident }
     }

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -43,7 +43,7 @@ use thin_vec::ThinVec;
 use tracing::debug;
 
 use crate::errors::{
-    IncorrectVisibilityRestriction, MismatchedClosingDelimiter, NonStringAbiLiteral,
+    self, IncorrectVisibilityRestriction, MismatchedClosingDelimiter, NonStringAbiLiteral,
 };
 
 bitflags::bitflags! {
@@ -663,15 +663,10 @@ impl<'a> Parser<'a> {
         if case == Case::Insensitive
         && let Some((ident, /* is_raw */ false)) = self.token.ident()
         && ident.as_str().to_lowercase() == kw.as_str().to_lowercase() {
-            self
-                .struct_span_err(ident.span, format!("keyword `{kw}` is written in a wrong case"))
-                .span_suggestion(
-                    ident.span,
-                    "write it in the correct case",
-                    kw,
-                    Applicability::MachineApplicable
-                ).emit();
-
+            self.sess.emit_err(errors::KwBadCase {
+                span: ident.span,
+                kw: kw.as_str()
+            });
             self.bump();
             return true;
         }

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -8,7 +8,7 @@ use rustc_ast::{
     AssocConstraintKind, BlockCheckMode, GenericArg, GenericArgs, Generics, ParenthesizedArgs,
     Path, PathSegment, QSelf,
 };
-use rustc_errors::{pluralize, Applicability, PResult};
+use rustc_errors::{Applicability, PResult};
 use rustc_span::source_map::{BytePos, Span};
 use rustc_span::symbol::{kw, sym, Ident};
 use std::mem;
@@ -464,23 +464,10 @@ impl<'a> Parser<'a> {
                     // i.e. no multibyte characters, in this range.
                     let span =
                         lo.with_hi(lo.lo() + BytePos(snapshot.unmatched_angle_bracket_count));
-                    self.struct_span_err(
+                    self.sess.emit_err(errors::UnmatchedAngle {
                         span,
-                        &format!(
-                            "unmatched angle bracket{}",
-                            pluralize!(snapshot.unmatched_angle_bracket_count)
-                        ),
-                    )
-                    .span_suggestion(
-                        span,
-                        &format!(
-                            "remove extra angle bracket{}",
-                            pluralize!(snapshot.unmatched_angle_bracket_count)
-                        ),
-                        "",
-                        Applicability::MachineApplicable,
-                    )
-                    .emit();
+                        plural: snapshot.unmatched_angle_bracket_count > 1,
+                    });
 
                     // Try again without unmatched angle bracket characters.
                     self.parse_angle_args(ty_generics)

--- a/tests/ui/macros/missing-bang-in-decl.stderr
+++ b/tests/ui/macros/missing-bang-in-decl.stderr
@@ -2,13 +2,23 @@ error: expected `!` after `macro_rules`
   --> $DIR/missing-bang-in-decl.rs:5:1
    |
 LL | macro_rules foo {
-   | ^^^^^^^^^^^ help: add a `!`: `macro_rules!`
+   | ^^^^^^^^^^^
+   |
+help: add a `!`
+   |
+LL | macro_rules! foo {
+   |            +
 
 error: expected `!` after `macro_rules`
   --> $DIR/missing-bang-in-decl.rs:10:1
    |
 LL | macro_rules bar! {
-   | ^^^^^^^^^^^ help: add a `!`: `macro_rules!`
+   | ^^^^^^^^^^^
+   |
+help: add a `!`
+   |
+LL | macro_rules! bar! {
+   |            +
 
 error: macro names aren't followed by a `!`
   --> $DIR/missing-bang-in-decl.rs:10:16

--- a/tests/ui/parser/item-kw-case-mismatch.fixed
+++ b/tests/ui/parser/item-kw-case-mismatch.fixed
@@ -4,31 +4,31 @@
 
 fn main() {}
 
-use std::ptr::read;  //~ ERROR keyword `use` is written in a wrong case
-use std::ptr::write; //~ ERROR keyword `use` is written in a wrong case
+use std::ptr::read;  //~ ERROR keyword `use` is written in the wrong case
+use std::ptr::write; //~ ERROR keyword `use` is written in the wrong case
 
 async fn _a() {}
-//~^ ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `fn` is written in the wrong case
 
 fn _b() {}
-//~^ ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `fn` is written in the wrong case
 
 async fn _c() {}
-//~^ ERROR keyword `async` is written in a wrong case
-//~| ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `async` is written in the wrong case
+//~| ERROR keyword `fn` is written in the wrong case
 
 async fn _d() {}
-//~^ ERROR keyword `async` is written in a wrong case
+//~^ ERROR keyword `async` is written in the wrong case
 
 const unsafe fn _e() {}
-//~^ ERROR keyword `const` is written in a wrong case
-//~| ERROR keyword `unsafe` is written in a wrong case
-//~| ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `const` is written in the wrong case
+//~| ERROR keyword `unsafe` is written in the wrong case
+//~| ERROR keyword `fn` is written in the wrong case
 
 unsafe extern fn _f() {}
-//~^ ERROR keyword `unsafe` is written in a wrong case
-//~| ERROR keyword `extern` is written in a wrong case
+//~^ ERROR keyword `unsafe` is written in the wrong case
+//~| ERROR keyword `extern` is written in the wrong case
 
 extern "C" fn _g() {}
-//~^ ERROR keyword `extern` is written in a wrong case
-//~| ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `extern` is written in the wrong case
+//~| ERROR keyword `fn` is written in the wrong case

--- a/tests/ui/parser/item-kw-case-mismatch.rs
+++ b/tests/ui/parser/item-kw-case-mismatch.rs
@@ -4,31 +4,31 @@
 
 fn main() {}
 
-Use std::ptr::read;  //~ ERROR keyword `use` is written in a wrong case
-USE std::ptr::write; //~ ERROR keyword `use` is written in a wrong case
+Use std::ptr::read;  //~ ERROR keyword `use` is written in the wrong case
+USE std::ptr::write; //~ ERROR keyword `use` is written in the wrong case
 
 async Fn _a() {}
-//~^ ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `fn` is written in the wrong case
 
 Fn _b() {}
-//~^ ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `fn` is written in the wrong case
 
 aSYNC fN _c() {}
-//~^ ERROR keyword `async` is written in a wrong case
-//~| ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `async` is written in the wrong case
+//~| ERROR keyword `fn` is written in the wrong case
 
 Async fn _d() {}
-//~^ ERROR keyword `async` is written in a wrong case
+//~^ ERROR keyword `async` is written in the wrong case
 
 CONST UNSAFE FN _e() {}
-//~^ ERROR keyword `const` is written in a wrong case
-//~| ERROR keyword `unsafe` is written in a wrong case
-//~| ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `const` is written in the wrong case
+//~| ERROR keyword `unsafe` is written in the wrong case
+//~| ERROR keyword `fn` is written in the wrong case
 
 unSAFE EXTern fn _f() {}
-//~^ ERROR keyword `unsafe` is written in a wrong case
-//~| ERROR keyword `extern` is written in a wrong case
+//~^ ERROR keyword `unsafe` is written in the wrong case
+//~| ERROR keyword `extern` is written in the wrong case
 
 EXTERN "C" FN _g() {}
-//~^ ERROR keyword `extern` is written in a wrong case
-//~| ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `extern` is written in the wrong case
+//~| ERROR keyword `fn` is written in the wrong case

--- a/tests/ui/parser/item-kw-case-mismatch.stderr
+++ b/tests/ui/parser/item-kw-case-mismatch.stderr
@@ -1,82 +1,82 @@
-error: keyword `use` is written in a wrong case
+error: keyword `use` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:7:1
    |
 LL | Use std::ptr::read;
    | ^^^ help: write it in the correct case (notice the capitalization): `use`
 
-error: keyword `use` is written in a wrong case
+error: keyword `use` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:8:1
    |
 LL | USE std::ptr::write;
    | ^^^ help: write it in the correct case: `use`
 
-error: keyword `fn` is written in a wrong case
+error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:10:7
    |
 LL | async Fn _a() {}
    |       ^^ help: write it in the correct case (notice the capitalization): `fn`
 
-error: keyword `fn` is written in a wrong case
+error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:13:1
    |
 LL | Fn _b() {}
    | ^^ help: write it in the correct case (notice the capitalization): `fn`
 
-error: keyword `async` is written in a wrong case
+error: keyword `async` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:16:1
    |
 LL | aSYNC fN _c() {}
    | ^^^^^ help: write it in the correct case: `async`
 
-error: keyword `fn` is written in a wrong case
+error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:16:7
    |
 LL | aSYNC fN _c() {}
    |       ^^ help: write it in the correct case: `fn`
 
-error: keyword `async` is written in a wrong case
+error: keyword `async` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:20:1
    |
 LL | Async fn _d() {}
    | ^^^^^ help: write it in the correct case: `async`
 
-error: keyword `const` is written in a wrong case
+error: keyword `const` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:23:1
    |
 LL | CONST UNSAFE FN _e() {}
    | ^^^^^ help: write it in the correct case: `const`
 
-error: keyword `unsafe` is written in a wrong case
+error: keyword `unsafe` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:23:7
    |
 LL | CONST UNSAFE FN _e() {}
    |       ^^^^^^ help: write it in the correct case: `unsafe`
 
-error: keyword `fn` is written in a wrong case
+error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:23:14
    |
 LL | CONST UNSAFE FN _e() {}
    |              ^^ help: write it in the correct case: `fn`
 
-error: keyword `unsafe` is written in a wrong case
+error: keyword `unsafe` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:28:1
    |
 LL | unSAFE EXTern fn _f() {}
    | ^^^^^^ help: write it in the correct case: `unsafe`
 
-error: keyword `extern` is written in a wrong case
+error: keyword `extern` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:28:8
    |
 LL | unSAFE EXTern fn _f() {}
    |        ^^^^^^ help: write it in the correct case: `extern`
 
-error: keyword `extern` is written in a wrong case
+error: keyword `extern` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:32:1
    |
 LL | EXTERN "C" FN _g() {}
    | ^^^^^^ help: write it in the correct case: `extern`
 
-error: keyword `fn` is written in a wrong case
+error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:32:12
    |
 LL | EXTERN "C" FN _g() {}

--- a/tests/ui/parser/recover-unticked-labels.stderr
+++ b/tests/ui/parser/recover-unticked-labels.stderr
@@ -2,13 +2,17 @@ error: expected a label, found an identifier
   --> $DIR/recover-unticked-labels.rs:5:26
    |
 LL |     'label: loop { break label 0 };
-   |                          ^^^^^ help: labels start with a tick: `'label`
+   |                          -^^^^
+   |                          |
+   |                          help: labels start with a tick
 
 error: expected a label, found an identifier
   --> $DIR/recover-unticked-labels.rs:6:29
    |
 LL |     'label: loop { continue label };
-   |                             ^^^^^ help: labels start with a tick: `'label`
+   |                             -^^^^
+   |                             |
+   |                             help: labels start with a tick
 
 error[E0425]: cannot find value `label` in this scope
   --> $DIR/recover-unticked-labels.rs:4:26

--- a/tests/ui/parser/use-colon-as-mod-sep.stderr
+++ b/tests/ui/parser/use-colon-as-mod-sep.stderr
@@ -11,18 +11,24 @@ error: expected `::`, found `:`
    |
 LL | use std:fs::File;
    |        ^ help: use double colon
+   |
+   = note: import paths are delimited using `::`
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:7:8
    |
 LL | use std:collections:HashMap;
    |        ^ help: use double colon
+   |
+   = note: import paths are delimited using `::`
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:7:20
    |
 LL | use std:collections:HashMap;
    |                    ^ help: use double colon
+   |
+   = note: import paths are delimited using `::`
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
cc #100717 

Migrate diagnostics in `rustc_parse` which are emitted in a single statement. I worked on this by expanding the lint introduced in #108760, although that isn't included here as there is much more work to be done to satisfy it