### PR TITLE
Adjust obligation cause code for `find_and_report_unsatisfied_index_impl`

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2821,7 +2821,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // but has nested obligations which are unsatisfied.
                     for (base_t, _) in self.autoderef(base.span, base_t).silence_errors() {
                         if let Some((_, index_ty, element_ty)) =
-                            self.find_and_report_unsatisfied_index_impl(expr.hir_id, base, base_t)
+                            self.find_and_report_unsatisfied_index_impl(base, base_t)
                         {
                             self.demand_coerce(idx, idx_t, index_ty, None, AllowTwoPhase::No);
                             return element_ty;
@@ -2880,7 +2880,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// predicates cause this to be, so that the user can add them to fix their code.
     fn find_and_report_unsatisfied_index_impl(
         &self,
-        index_expr_hir_id: HirId,
         base_expr: &hir::Expr<'_>,
         base_ty: Ty<'tcx>,
     ) -> Option<(ErrorGuaranteed, Ty<'tcx>, Ty<'tcx>)> {
@@ -2913,13 +2912,21 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // in the first place.
             ocx.register_obligations(traits::predicates_for_generics(
                 |idx, span| {
-                    traits::ObligationCause::new(
-                        base_expr.span,
-                        self.body_id,
-                        if span.is_dummy() {
-                            traits::ExprItemObligation(impl_def_id, index_expr_hir_id, idx)
-                        } else {
-                            traits::ExprBindingObligation(impl_def_id, span, index_expr_hir_id, idx)
+                    cause.clone().derived_cause(
+                        ty::Binder::dummy(ty::TraitPredicate {
+                            trait_ref: impl_trait_ref,
+                            polarity: ty::ImplPolarity::Positive,
+                            constness: ty::BoundConstness::NotConst,
+                        }),
+                        |derived| {
+                            traits::ImplDerivedObligation(Box::new(
+                                traits::ImplDerivedObligationCause {
+                                    derived,
+                                    impl_or_alias_def_id: impl_def_id,
+                                    impl_def_predicate_index: Some(idx),
+                                    span,
+                                },
+                            ))
                         },
                     )
                 },

--- a/tests/ui/typeck/bad-index-due-to-nested.stderr
+++ b/tests/ui/typeck/bad-index-due-to-nested.stderr
@@ -4,11 +4,14 @@ error[E0277]: the trait bound `K: Hash` is not satisfied
 LL |     map[k]
    |     ^^^ the trait `Hash` is not implemented for `K`
    |
-note: required by a bound in `<HashMap<K, V> as Index<&K>>`
-  --> $DIR/bad-index-due-to-nested.rs:9:8
+note: required for `HashMap<K, V>` to implement `Index<&K>`
+  --> $DIR/bad-index-due-to-nested.rs:7:12
    |
+LL | impl<K, V> Index<&K> for HashMap<K, V>
+   |            ^^^^^^^^^     ^^^^^^^^^^^^^
+LL | where
 LL |     K: Hash,
-   |        ^^^^ required by this bound in `<HashMap<K, V> as Index<&K>>`
+   |        ---- unsatisfied trait bound introduced here
 help: consider restricting type parameter `K`
    |
 LL | fn index<'a, K: std::hash::Hash, V>(map: &'a HashMap<K, V>, k: K) -> &'a V {
@@ -20,11 +23,14 @@ error[E0277]: the trait bound `V: Copy` is not satisfied
 LL |     map[k]
    |     ^^^ the trait `Copy` is not implemented for `V`
    |
-note: required by a bound in `<HashMap<K, V> as Index<&K>>`
-  --> $DIR/bad-index-due-to-nested.rs:10:8
+note: required for `HashMap<K, V>` to implement `Index<&K>`
+  --> $DIR/bad-index-due-to-nested.rs:7:12
    |
+LL | impl<K, V> Index<&K> for HashMap<K, V>
+   |            ^^^^^^^^^     ^^^^^^^^^^^^^
+...
 LL |     V: Copy,
-   |        ^^^^ required by this bound in `<HashMap<K, V> as Index<&K>>`
+   |        ---- unsatisfied trait bound introduced here
 help: consider restricting type parameter `V`
    |
 LL | fn index<'a, K, V: std::marker::Copy>(map: &'a HashMap<K, V>, k: K) -> &'a V {


### PR DESCRIPTION
Makes the error message a bit easier to read.