### PR TITLE
Provide better type hints when a type doesn't support a binary operator

### DIFF
--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -461,15 +461,9 @@ fn fatally_break_rust(sess: &Session) {
     ));
 }
 
-fn has_expected_num_generic_args(
-    tcx: TyCtxt<'_>,
-    trait_did: Option<DefId>,
-    expected: usize,
-) -> bool {
-    trait_did.map_or(true, |trait_did| {
-        let generics = tcx.generics_of(trait_did);
-        generics.count() == expected + if generics.has_self { 1 } else { 0 }
-    })
+fn has_expected_num_generic_args(tcx: TyCtxt<'_>, trait_did: DefId, expected: usize) -> bool {
+    let generics = tcx.generics_of(trait_did);
+    generics.count() == expected + if generics.has_self { 1 } else { 0 }
 }
 
 pub fn provide(providers: &mut Providers) {

--- a/tests/ui/binop/eq-arr.rs
+++ b/tests/ui/binop/eq-arr.rs
@@ -1,0 +1,7 @@
+fn main() {
+    struct X;
+    //~^ HELP consider annotating `X` with `#[derive(PartialEq)]`
+    let xs = [X, X, X];
+    let eq = xs == [X, X, X];
+    //~^ ERROR binary operation `==` cannot be applied to type `[X; 3]`
+}

--- a/tests/ui/binop/eq-arr.stderr
+++ b/tests/ui/binop/eq-arr.stderr
@@ -1,0 +1,22 @@
+error[E0369]: binary operation `==` cannot be applied to type `[X; 3]`
+  --> $DIR/eq-arr.rs:5:17
+   |
+LL |     let eq = xs == [X, X, X];
+   |              -- ^^ --------- [X; 3]
+   |              |
+   |              [X; 3]
+   |
+note: an implementation of `PartialEq` might be missing for `X`
+  --> $DIR/eq-arr.rs:2:5
+   |
+LL |     struct X;
+   |     ^^^^^^^^ must implement `PartialEq`
+help: consider annotating `X` with `#[derive(PartialEq)]`
+   |
+LL +     #[derive(PartialEq)]
+LL |     struct X;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0369`.

--- a/tests/ui/binop/eq-vec.rs
+++ b/tests/ui/binop/eq-vec.rs
@@ -1,0 +1,13 @@
+fn main() {
+    #[derive(Debug)]
+    enum Foo {
+        //~^ HELP consider annotating `Foo` with `#[derive(PartialEq)]`
+        Bar,
+        Qux,
+    }
+
+    let vec1 = vec![Foo::Bar, Foo::Qux];
+    let vec2 = vec![Foo::Bar, Foo::Qux];
+    assert_eq!(vec1, vec2);
+    //~^ ERROR binary operation `==` cannot be applied to type `Vec<Foo>`
+}

--- a/tests/ui/binop/eq-vec.stderr
+++ b/tests/ui/binop/eq-vec.stderr
@@ -1,0 +1,24 @@
+error[E0369]: binary operation `==` cannot be applied to type `Vec<Foo>`
+  --> $DIR/eq-vec.rs:11:5
+   |
+LL |     assert_eq!(vec1, vec2);
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     Vec<Foo>
+   |     Vec<Foo>
+   |
+note: an implementation of `PartialEq` might be missing for `Foo`
+  --> $DIR/eq-vec.rs:3:5
+   |
+LL |     enum Foo {
+   |     ^^^^^^^^ must implement `PartialEq`
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Foo` with `#[derive(PartialEq)]`
+   |
+LL +     #[derive(PartialEq)]
+LL |     enum Foo {
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0369`.

--- a/tests/ui/binop/issue-28837.stderr
+++ b/tests/ui/binop/issue-28837.stderr
@@ -6,11 +6,11 @@ LL |     a + a;
    |     |
    |     A
    |
-note: an implementation of `Add<_>` might be missing for `A`
+note: an implementation of `Add` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `Add<_>`
+   | ^^^^^^^^ must implement `Add`
 note: the trait `Add` must be implemented
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 
@@ -22,11 +22,11 @@ LL |     a - a;
    |     |
    |     A
    |
-note: an implementation of `Sub<_>` might be missing for `A`
+note: an implementation of `Sub` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `Sub<_>`
+   | ^^^^^^^^ must implement `Sub`
 note: the trait `Sub` must be implemented
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 
@@ -38,11 +38,11 @@ LL |     a * a;
    |     |
    |     A
    |
-note: an implementation of `Mul<_>` might be missing for `A`
+note: an implementation of `Mul` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `Mul<_>`
+   | ^^^^^^^^ must implement `Mul`
 note: the trait `Mul` must be implemented
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 
@@ -54,11 +54,11 @@ LL |     a / a;
    |     |
    |     A
    |
-note: an implementation of `Div<_>` might be missing for `A`
+note: an implementation of `Div` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `Div<_>`
+   | ^^^^^^^^ must implement `Div`
 note: the trait `Div` must be implemented
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 
@@ -70,11 +70,11 @@ LL |     a % a;
    |     |
    |     A
    |
-note: an implementation of `Rem<_>` might be missing for `A`
+note: an implementation of `Rem` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `Rem<_>`
+   | ^^^^^^^^ must implement `Rem`
 note: the trait `Rem` must be implemented
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 
@@ -86,11 +86,11 @@ LL |     a & a;
    |     |
    |     A
    |
-note: an implementation of `BitAnd<_>` might be missing for `A`
+note: an implementation of `BitAnd` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `BitAnd<_>`
+   | ^^^^^^^^ must implement `BitAnd`
 note: the trait `BitAnd` must be implemented
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
 
@@ -102,11 +102,11 @@ LL |     a | a;
    |     |
    |     A
    |
-note: an implementation of `BitOr<_>` might be missing for `A`
+note: an implementation of `BitOr` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `BitOr<_>`
+   | ^^^^^^^^ must implement `BitOr`
 note: the trait `BitOr` must be implemented
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
 
@@ -118,11 +118,11 @@ LL |     a << a;
    |     |
    |     A
    |
-note: an implementation of `Shl<_>` might be missing for `A`
+note: an implementation of `Shl` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `Shl<_>`
+   | ^^^^^^^^ must implement `Shl`
 note: the trait `Shl` must be implemented
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
 
@@ -134,11 +134,11 @@ LL |     a >> a;
    |     |
    |     A
    |
-note: an implementation of `Shr<_>` might be missing for `A`
+note: an implementation of `Shr` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `Shr<_>`
+   | ^^^^^^^^ must implement `Shr`
 note: the trait `Shr` must be implemented
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
 
@@ -150,11 +150,11 @@ LL |     a == a;
    |     |
    |     A
    |
-note: an implementation of `PartialEq<_>` might be missing for `A`
+note: an implementation of `PartialEq` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `PartialEq<_>`
+   | ^^^^^^^^ must implement `PartialEq`
 help: consider annotating `A` with `#[derive(PartialEq)]`
    |
 LL + #[derive(PartialEq)]
@@ -169,11 +169,11 @@ LL |     a != a;
    |     |
    |     A
    |
-note: an implementation of `PartialEq<_>` might be missing for `A`
+note: an implementation of `PartialEq` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `PartialEq<_>`
+   | ^^^^^^^^ must implement `PartialEq`
 help: consider annotating `A` with `#[derive(PartialEq)]`
    |
 LL + #[derive(PartialEq)]
@@ -188,11 +188,11 @@ LL |     a < a;
    |     |
    |     A
    |
-note: an implementation of `PartialOrd<_>` might be missing for `A`
+note: an implementation of `PartialOrd` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `PartialOrd<_>`
+   | ^^^^^^^^ must implement `PartialOrd`
 help: consider annotating `A` with `#[derive(PartialEq, PartialOrd)]`
    |
 LL + #[derive(PartialEq, PartialOrd)]
@@ -207,11 +207,11 @@ LL |     a <= a;
    |     |
    |     A
    |
-note: an implementation of `PartialOrd<_>` might be missing for `A`
+note: an implementation of `PartialOrd` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `PartialOrd<_>`
+   | ^^^^^^^^ must implement `PartialOrd`
 help: consider annotating `A` with `#[derive(PartialEq, PartialOrd)]`
    |
 LL + #[derive(PartialEq, PartialOrd)]
@@ -226,11 +226,11 @@ LL |     a > a;
    |     |
    |     A
    |
-note: an implementation of `PartialOrd<_>` might be missing for `A`
+note: an implementation of `PartialOrd` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `PartialOrd<_>`
+   | ^^^^^^^^ must implement `PartialOrd`
 help: consider annotating `A` with `#[derive(PartialEq, PartialOrd)]`
    |
 LL + #[derive(PartialEq, PartialOrd)]
@@ -245,11 +245,11 @@ LL |     a >= a;
    |     |
    |     A
    |
-note: an implementation of `PartialOrd<_>` might be missing for `A`
+note: an implementation of `PartialOrd` might be missing for `A`
   --> $DIR/issue-28837.rs:1:1
    |
 LL | struct A;
-   | ^^^^^^^^ must implement `PartialOrd<_>`
+   | ^^^^^^^^ must implement `PartialOrd`
 help: consider annotating `A` with `#[derive(PartialEq, PartialOrd)]`
    |
 LL + #[derive(PartialEq, PartialOrd)]

--- a/tests/ui/binop/issue-3820.stderr
+++ b/tests/ui/binop/issue-3820.stderr
@@ -6,11 +6,11 @@ LL |     let w = u * 3;
    |             |
    |             Thing
    |
-note: an implementation of `Mul<_>` might be missing for `Thing`
+note: an implementation of `Mul<{integer}>` might be missing for `Thing`
   --> $DIR/issue-3820.rs:1:1
    |
 LL | struct Thing {
-   | ^^^^^^^^^^^^ must implement `Mul<_>`
+   | ^^^^^^^^^^^^ must implement `Mul<{integer}>`
 note: the trait `Mul` must be implemented
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 

--- a/tests/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
+++ b/tests/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
@@ -7,11 +7,11 @@ LL | #[derive(PartialEq)]
 LL |      x: Error
    |      ^^^^^^^^
    |
-note: an implementation of `PartialEq<_>` might be missing for `Error`
+note: an implementation of `PartialEq` might be missing for `Error`
   --> $DIR/derives-span-PartialEq-enum-struct-variant.rs:4:1
    |
 LL | struct Error;
-   | ^^^^^^^^^^^^ must implement `PartialEq<_>`
+   | ^^^^^^^^^^^^ must implement `PartialEq`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(PartialEq)]`
    |

--- a/tests/ui/derives/derives-span-PartialEq-enum.stderr
+++ b/tests/ui/derives/derives-span-PartialEq-enum.stderr
@@ -7,11 +7,11 @@ LL | #[derive(PartialEq)]
 LL |      Error
    |      ^^^^^
    |
-note: an implementation of `PartialEq<_>` might be missing for `Error`
+note: an implementation of `PartialEq` might be missing for `Error`
   --> $DIR/derives-span-PartialEq-enum.rs:4:1
    |
 LL | struct Error;
-   | ^^^^^^^^^^^^ must implement `PartialEq<_>`
+   | ^^^^^^^^^^^^ must implement `PartialEq`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(PartialEq)]`
    |

--- a/tests/ui/derives/derives-span-PartialEq-struct.stderr
+++ b/tests/ui/derives/derives-span-PartialEq-struct.stderr
@@ -7,11 +7,11 @@ LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^
    |
-note: an implementation of `PartialEq<_>` might be missing for `Error`
+note: an implementation of `PartialEq` might be missing for `Error`
   --> $DIR/derives-span-PartialEq-struct.rs:4:1
    |
 LL | struct Error;
-   | ^^^^^^^^^^^^ must implement `PartialEq<_>`
+   | ^^^^^^^^^^^^ must implement `PartialEq`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(PartialEq)]`
    |

--- a/tests/ui/derives/derives-span-PartialEq-tuple-struct.stderr
+++ b/tests/ui/derives/derives-span-PartialEq-tuple-struct.stderr
@@ -7,11 +7,11 @@ LL | struct Struct(
 LL |     Error
    |     ^^^^^
    |
-note: an implementation of `PartialEq<_>` might be missing for `Error`
+note: an implementation of `PartialEq` might be missing for `Error`
   --> $DIR/derives-span-PartialEq-tuple-struct.rs:4:1
    |
 LL | struct Error;
-   | ^^^^^^^^^^^^ must implement `PartialEq<_>`
+   | ^^^^^^^^^^^^ must implement `PartialEq`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(PartialEq)]`
    |

--- a/tests/ui/derives/deriving-no-inner-impl-error-message.stderr
+++ b/tests/ui/derives/deriving-no-inner-impl-error-message.stderr
@@ -7,11 +7,11 @@ LL | struct E {
 LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
    |
-note: an implementation of `PartialEq<_>` might be missing for `NoCloneOrEq`
+note: an implementation of `PartialEq` might be missing for `NoCloneOrEq`
   --> $DIR/deriving-no-inner-impl-error-message.rs:1:1
    |
 LL | struct NoCloneOrEq;
-   | ^^^^^^^^^^^^^^^^^^ must implement `PartialEq<_>`
+   | ^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NoCloneOrEq` with `#[derive(PartialEq)]`
    |

--- a/tests/ui/destructuring-assignment/note-unsupported.stderr
+++ b/tests/ui/destructuring-assignment/note-unsupported.stderr
@@ -44,11 +44,11 @@ LL |     S { x: a, y: b } += s;
    |     |
    |     cannot use `+=` on type `S`
    |
-note: an implementation of `AddAssign<_>` might be missing for `S`
+note: an implementation of `AddAssign` might be missing for `S`
   --> $DIR/note-unsupported.rs:1:1
    |
 LL | struct S { x: u8, y: u8 }
-   | ^^^^^^^^ must implement `AddAssign<_>`
+   | ^^^^^^^^ must implement `AddAssign`
 note: the trait `AddAssign` must be implemented
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 

--- a/tests/ui/issues/issue-62375.stderr
+++ b/tests/ui/issues/issue-62375.stderr
@@ -6,11 +6,11 @@ LL |     a == A::Value;
    |     |
    |     A
    |
-note: an implementation of `PartialEq<_>` might be missing for `A`
+note: an implementation of `PartialEq<fn(()) -> A {A::Value}>` might be missing for `A`
   --> $DIR/issue-62375.rs:1:1
    |
 LL | enum A {
-   | ^^^^^^ must implement `PartialEq<_>`
+   | ^^^^^^ must implement `PartialEq<fn(()) -> A {A::Value}>`
 help: consider annotating `A` with `#[derive(PartialEq)]`
    |
 LL + #[derive(PartialEq)]

--- a/tests/ui/issues/issue-62375.stderr
+++ b/tests/ui/issues/issue-62375.stderr
@@ -11,11 +11,12 @@ note: an implementation of `PartialEq<fn(()) -> A {A::Value}>` might be missing 
    |
 LL | enum A {
    | ^^^^^^ must implement `PartialEq<fn(()) -> A {A::Value}>`
-help: consider annotating `A` with `#[derive(PartialEq)]`
+note: the trait `PartialEq` must be implemented
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+help: use parentheses to construct this tuple variant
    |
-LL + #[derive(PartialEq)]
-LL | enum A {
-   |
+LL |     a == A::Value(/* () */);
+   |                  ++++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/mismatched_types/assignment-operator-unimplemented.stderr
+++ b/tests/ui/mismatched_types/assignment-operator-unimplemented.stderr
@@ -6,11 +6,11 @@ LL |   a += *b;
    |   |
    |   cannot use `+=` on type `Foo`
    |
-note: an implementation of `AddAssign<_>` might be missing for `Foo`
+note: an implementation of `AddAssign` might be missing for `Foo`
   --> $DIR/assignment-operator-unimplemented.rs:1:1
    |
 LL | struct Foo;
-   | ^^^^^^^^^^ must implement `AddAssign<_>`
+   | ^^^^^^^^^^ must implement `AddAssign`
 note: the trait `AddAssign` must be implemented
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 

--- a/tests/ui/or-patterns/or-patterns-syntactic-fail.stderr
+++ b/tests/ui/or-patterns/or-patterns-syntactic-fail.stderr
@@ -30,11 +30,11 @@ LL |     let _ = |A | B: E| ();
    |                  |
    |                  E
    |
-note: an implementation of `BitOr<_>` might be missing for `E`
+note: an implementation of `BitOr<()>` might be missing for `E`
   --> $DIR/or-patterns-syntactic-fail.rs:6:1
    |
 LL | enum E { A, B }
-   | ^^^^^^ must implement `BitOr<_>`
+   | ^^^^^^ must implement `BitOr<()>`
 note: the trait `BitOr` must be implemented
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
 

--- a/tests/ui/span/issue-39018.stderr
+++ b/tests/ui/span/issue-39018.stderr
@@ -21,11 +21,11 @@ LL |     let y = World::Hello + World::Goodbye;
    |             |
    |             World
    |
-note: an implementation of `Add<_>` might be missing for `World`
+note: an implementation of `Add` might be missing for `World`
   --> $DIR/issue-39018.rs:15:1
    |
 LL | enum World {
-   | ^^^^^^^^^^ must implement `Add<_>`
+   | ^^^^^^^^^^ must implement `Add`
 note: the trait `Add` must be implemented
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 

--- a/tests/ui/suggestions/invalid-bin-op.stderr
+++ b/tests/ui/suggestions/invalid-bin-op.stderr
@@ -6,11 +6,11 @@ LL |     let _ = s == t;
    |             |
    |             S<T>
    |
-note: an implementation of `PartialEq<_>` might be missing for `S<T>`
+note: an implementation of `PartialEq` might be missing for `S<T>`
   --> $DIR/invalid-bin-op.rs:5:1
    |
 LL | struct S<T>(T);
-   | ^^^^^^^^^^^ must implement `PartialEq<_>`
+   | ^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `S<T>` with `#[derive(PartialEq)]`
    |
 LL + #[derive(PartialEq)]

--- a/tests/ui/suggestions/restrict-type-not-param.stderr
+++ b/tests/ui/suggestions/restrict-type-not-param.stderr
@@ -6,11 +6,11 @@ LL |     a + b
    |     |
    |     Wrapper<T>
    |
-note: an implementation of `Add<_>` might be missing for `Wrapper<T>`
+note: an implementation of `Add<T>` might be missing for `Wrapper<T>`
   --> $DIR/restrict-type-not-param.rs:3:1
    |
 LL | struct Wrapper<T>(T);
-   | ^^^^^^^^^^^^^^^^^ must implement `Add<_>`
+   | ^^^^^^^^^^^^^^^^^ must implement `Add<T>`
 note: the trait `Add` must be implemented
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement

--- a/tests/ui/type/type-unsatisfiable.usage.stderr
+++ b/tests/ui/type/type-unsatisfiable.usage.stderr
@@ -1,8 +1,8 @@
-error[E0369]: cannot subtract `(dyn Vector2<ScalarType = i32> + 'static)` from `dyn Vector2<ScalarType = i32>`
+error[E0369]: cannot subtract `dyn Vector2<ScalarType = i32>` from `dyn Vector2<ScalarType = i32>`
   --> $DIR/type-unsatisfiable.rs:57:20
    |
 LL |     let bar = *hey - *word;
-   |               ---- ^ ----- (dyn Vector2<ScalarType = i32> + 'static)
+   |               ---- ^ ----- dyn Vector2<ScalarType = i32>
    |               |
    |               dyn Vector2<ScalarType = i32>
 


### PR DESCRIPTION
For example, when checking whether `vec![A] == vec![A]` holds, we first evaluate the LHS's ty, then probe for any `PartialEq` implementations for that. If none is found, we report an error by evaluating `Vec<A>: PartialEq<?0>` for fulfillment errors, but the RHS is not yet evaluated and remains an inference variable `?0`!

To fix this, we evaluate the RHS and equate it to that RHS infer var `?0`, so that we are able to provide more detailed fulfillment errors for why `Vec<A>: PartialEq<Vec<A>>` doesn't hold (namely, the nested obligation `A: PartialEq<A>` doesn't hold).

Fixes #95285
Fixes #110867