### PR TITLE
Add `known-bug` tests for 4 unsound issues

### DIFF
--- a/tests/ui/coherence/coherence-overlap-negative-impls.rs
+++ b/tests/ui/coherence/coherence-overlap-negative-impls.rs
@@ -1,0 +1,41 @@
+// check-pass
+// known-bug: #74629
+
+// Should fail. The `0` and `1` impls overlap, violating coherence. Eg, with
+// `T = Test, F = ()`, all bounds are true, making both impls applicable.
+// `Test: Fold<Nil>`, `Test: Fold<()>` are true because of `2`.
+// `Is<Test>: NotNil` is true because of `auto trait` and lack of negative impl.
+
+#![feature(negative_impls)]
+#![feature(auto_traits)]
+
+struct Nil;
+struct Cons<H>(H);
+struct Test;
+
+trait Fold<F> {}
+
+impl<T, F> Fold<F> for Cons<T> // 0
+where
+    T: Fold<Nil>,
+{}
+
+impl<T, F> Fold<F> for Cons<T> // 1
+where
+    T: Fold<F>,
+    private::Is<T>: private::NotNil,
+{}
+
+impl<F> Fold<F> for Test {} // 2
+
+mod private {
+    use crate::Nil;
+
+    pub struct Is<T>(T);
+    pub auto trait NotNil {}
+
+    #[allow(suspicious_auto_trait_impls)]
+    impl !NotNil for Is<Nil> {}
+}
+
+fn main() {}

--- a/tests/ui/specialization/issue-40582.rs
+++ b/tests/ui/specialization/issue-40582.rs
@@ -1,0 +1,35 @@
+// check-pass
+// known-bug: #40582
+
+// Should fail. Should not be possible to implement `make_static`.
+
+#![feature(specialization)]
+#![allow(incomplete_features)]
+
+trait FromRef<'a, T: ?Sized> {
+    fn from_ref(r: &'a T) -> Self;
+}
+
+impl<'a, T: ?Sized> FromRef<'a, T> for &'a T {
+    fn from_ref(r: &'a T) -> Self {
+        r
+    }
+}
+
+impl<'a, T: ?Sized, R> FromRef<'a, T> for R {
+    default fn from_ref(_: &'a T) -> Self {
+        unimplemented!()
+    }
+}
+
+fn make_static<T: ?Sized>(data: &T) -> &'static T {
+    fn helper<T: ?Sized, R>(data: &T) -> R {
+        R::from_ref(data)
+    }
+    helper(data)
+}
+
+fn main() {
+    let s = "specialization".to_owned();
+    println!("{:?}", make_static(s.as_str()));
+}

--- a/tests/ui/specialization/specialization-default-items-drop-coherence.rs
+++ b/tests/ui/specialization/specialization-default-items-drop-coherence.rs
@@ -1,0 +1,30 @@
+// check-pass
+// known-bug: #105782
+
+// Should fail. Default items completely drop candidates instead of ambiguity,
+// which is unsound during coherence, since coherence requires completeness.
+
+#![feature(specialization)]
+#![allow(incomplete_features)]
+
+trait Default {
+   type Id;
+}
+
+impl<T> Default for T {
+   default type Id = T;
+}
+
+trait Overlap {
+   type Assoc;
+}
+
+impl Overlap for u32 {
+   type Assoc = usize;
+}
+
+impl Overlap for <u32 as Default>::Id {
+   type Assoc = Box<usize>;
+}
+
+fn main() {}

--- a/tests/ui/thread-local/thread-local-static-ref-use-after-free.rs
+++ b/tests/ui/thread-local/thread-local-static-ref-use-after-free.rs
@@ -1,0 +1,46 @@
+// check-pass
+// known-bug: #49682
+// edition:2021
+
+// Should fail. Keeping references to thread local statics can result in a
+// use-after-free.
+
+#![feature(thread_local)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+#[allow(dead_code)]
+#[thread_local]
+static FOO: AtomicUsize = AtomicUsize::new(0);
+
+#[allow(dead_code)]
+async fn bar() {}
+
+#[allow(dead_code)]
+async fn foo() {
+    let r = &FOO;
+    bar().await;
+    r.load(Ordering::SeqCst);
+}
+
+fn main() {
+    // &FOO = 0x7fd1e9cbf6d0
+    _ = thread::spawn(|| {
+        let g = foo();
+        println!("&FOO = {:p}", &FOO);
+        g
+    })
+    .join()
+    .unwrap();
+
+    // &FOO = 0x7fd1e9cc0f50
+    println!("&FOO = {:p}", &FOO);
+
+    // &FOO = 0x7fd1e9cbf6d0
+    thread::spawn(move || {
+        println!("&FOO = {:p}", &FOO);
+    })
+    .join()
+    .unwrap();
+}


### PR DESCRIPTION
This PR adds `known-bug` tests for 4 unsound issues as part of #105107
- #40582
- #49682
- #74629
- #105782