### PR TITLE
[DO NOT MERGE] have tag be explicit debug_assert! argument

### DIFF
--- a/compiler/rustc_data_structures/src/tagged_ptr/impl_tag.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/impl_tag.rs
@@ -128,8 +128,9 @@ macro_rules! impl_tag {
                     _ => unsafe {
                         debug_assert!(
                             false,
-                            "invalid tag: {tag}\
-                             (this is a bug in the caller of `from_usize`)"
+                            "invalid tag: {}\
+                             (this is a bug in the caller of `from_usize`)",
+                            tag
                         );
                         std::hint::unreachable_unchecked()
                     },


### PR DESCRIPTION
No functional changes intended.

We've got a custom rustc build. After https://github.com/rust-lang/rust/commit/2b8d27b402b621d20c7c29c500852c727d4cc8cd we're seeing a new build error while building rustc_middle:
```
error: there is no argument named `tag`
    --> <rust>/compiler/rustc_middle/src/ty/mod.rs:1505:1
     |
1505 | / impl_tag! {
1506 | |     impl Tag for ParamTag;
1507 | |     ParamTag { reveal: traits::Reveal::UserFacing, constness: hir::Constness::NotConst },
1508 | |     ParamTag { reveal: traits::Reveal::All,        constness: hir::Constness::NotConst },
1509 | |     ParamTag { reveal: traits::Reveal::UserFacing, constness: hir::Constness::Const    },
1510 | |     ParamTag { reveal: traits::Reveal::All,        constness: hir::Constness::Const    },
1511 | | }
     | |_^
     |
     = note: did you intend to capture a variable `tag` from the surrounding scope?
     = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
     = note: this error originates in the macro `impl_tag` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This patch fixes it. I'm not sure why this doesn't fire with x.py, hence the DO NOT MERGE. I suspect our custom build is a bit more strict than what x.py's. Maybe we're missing come rustc flags that silence this error?