### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2976,7 +2976,7 @@ pub enum ItemKind {
 }
 
 impl ItemKind {
-    pub fn article(&self) -> &str {
+    pub fn article(&self) -> &'static str {
         use ItemKind::*;
         match self {
             Use(..) | Static(..) | Const(..) | Fn(..) | Mod(..) | GlobalAsm(..) | TyAlias(..)
@@ -2985,7 +2985,7 @@ impl ItemKind {
         }
     }
 
-    pub fn descr(&self) -> &str {
+    pub fn descr(&self) -> &'static str {
         match self {
             ItemKind::ExternCrate(..) => "extern crate",
             ItemKind::Use(..) => "`use` import",

--- a/compiler/rustc_infer/src/traits/project.rs
+++ b/compiler/rustc_infer/src/traits/project.rs
@@ -20,7 +20,7 @@ pub struct MismatchedProjectionTypes<'tcx> {
     pub err: ty::error::TypeError<'tcx>,
 }
 
-#[derive(Clone, TypeFoldable, TypeVisitable)]
+#[derive(Clone)]
 pub struct Normalized<'tcx, T> {
     pub value: T,
     pub obligations: Vec<PredicateObligation<'tcx>>,

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -1230,17 +1230,40 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         }
     }
 
-    fn check_foreign_fn(&mut self, def_id: LocalDefId, decl: &hir::FnDecl<'_>) {
+    /// Check if a function's argument types and result type are "ffi-safe".
+    ///
+    /// Argument types and the result type are checked for functions with external ABIs.
+    /// For functions with internal ABIs, argument types and the result type are walked to find
+    /// fn-ptr types that have external ABIs, as these still need checked.
+    fn check_maybe_foreign_fn(&mut self, abi: SpecAbi, def_id: LocalDefId, decl: &hir::FnDecl<'_>) {
         let sig = self.cx.tcx.fn_sig(def_id).subst_identity();
         let sig = self.cx.tcx.erase_late_bound_regions(sig);
 
+        let is_internal_abi = self.is_internal_abi(abi);
+        let check_ty = |this: &mut ImproperCTypesVisitor<'a, 'tcx>,
+                        span: Span,
+                        ty: Ty<'tcx>,
+                        is_return_type: bool| {
+            // If this function has an external ABI, then its arguments and return type should be
+            // checked..
+            if !is_internal_abi {
+                this.check_type_for_ffi_and_report_errors(span, ty, false, is_return_type);
+                return;
+            }
+
+            // ..but if this function has an internal ABI, then search the argument or return type
+            // for any fn-ptr types with external ABI, which should be checked..
+            if let Some(fn_ptr_ty) = this.find_fn_ptr_ty_with_external_abi(ty) {
+                this.check_type_for_ffi_and_report_errors(span, fn_ptr_ty, false, is_return_type);
+            }
+        };
+
         for (input_ty, input_hir) in iter::zip(sig.inputs(), decl.inputs) {
-            self.check_type_for_ffi_and_report_errors(input_hir.span, *input_ty, false, false);
+            check_ty(self, input_hir.span, *input_ty, false);
         }
 
         if let hir::FnRetTy::Return(ref ret_hir) = decl.output {
-            let ret_ty = sig.output();
-            self.check_type_for_ffi_and_report_errors(ret_hir.span, ret_ty, false, true);
+            check_ty(self, ret_hir.span, sig.output(), true);
         }
     }
 
@@ -1255,6 +1278,30 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             SpecAbi::Rust | SpecAbi::RustCall | SpecAbi::RustIntrinsic | SpecAbi::PlatformIntrinsic
         )
     }
+
+    /// Find any fn-ptr types with external ABIs in `ty`.
+    ///
+    /// For example, `Option<extern "C" fn()>` returns `extern "C" fn()`
+    fn find_fn_ptr_ty_with_external_abi(&self, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
+        struct FnPtrFinder<'parent, 'a, 'tcx>(&'parent ImproperCTypesVisitor<'a, 'tcx>);
+        impl<'vis, 'a, 'tcx> ty::visit::TypeVisitor<TyCtxt<'tcx>> for FnPtrFinder<'vis, 'a, 'tcx> {
+            type BreakTy = Ty<'tcx>;
+
+            fn visit_ty(&mut self, ty: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
+                if let ty::FnPtr(sig) = ty.kind() && !self.0.is_internal_abi(sig.abi()) {
+                    ControlFlow::Break(ty)
+                } else {
+                    ty.super_visit_with(self)
+                }
+            }
+        }
+
+        self.cx
+            .tcx
+            .normalize_erasing_regions(self.cx.param_env, ty)
+            .visit_with(&mut FnPtrFinder(&*self))
+            .break_value()
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for ImproperCTypesDeclarations {
@@ -1262,16 +1309,14 @@ impl<'tcx> LateLintPass<'tcx> for ImproperCTypesDeclarations {
         let mut vis = ImproperCTypesVisitor { cx, mode: CItemKind::Declaration };
         let abi = cx.tcx.hir().get_foreign_abi(it.hir_id());
 
-        if !vis.is_internal_abi(abi) {
-            match it.kind {
-                hir::ForeignItemKind::Fn(ref decl, _, _) => {
-                    vis.check_foreign_fn(it.owner_id.def_id, decl);
-                }
-                hir::ForeignItemKind::Static(ref ty, _) => {
-                    vis.check_foreign_static(it.owner_id, ty.span);
-                }
-                hir::ForeignItemKind::Type => (),
+        match it.kind {
+            hir::ForeignItemKind::Fn(ref decl, _, _) => {
+                vis.check_maybe_foreign_fn(abi, it.owner_id.def_id, decl);
             }
+            hir::ForeignItemKind::Static(ref ty, _) if !vis.is_internal_abi(abi) => {
+                vis.check_foreign_static(it.owner_id, ty.span);
+            }
+            hir::ForeignItemKind::Static(..) | hir::ForeignItemKind::Type => (),
         }
     }
 }
@@ -1295,9 +1340,7 @@ impl<'tcx> LateLintPass<'tcx> for ImproperCTypesDefinitions {
         };
 
         let mut vis = ImproperCTypesVisitor { cx, mode: CItemKind::Definition };
-        if !vis.is_internal_abi(abi) {
-            vis.check_foreign_fn(id, decl);
-        }
+        vis.check_maybe_foreign_fn(abi, id, decl);
     }
 }
 

--- a/compiler/rustc_middle/src/hir/place.rs
+++ b/compiler/rustc_middle/src/hir/place.rs
@@ -66,7 +66,6 @@ pub struct Place<'tcx> {
 ///
 /// This is an HIR version of [`rustc_middle::mir::Place`].
 #[derive(Clone, Debug, PartialEq, Eq, Hash, TyEncodable, TyDecodable, HashStable)]
-#[derive(TypeFoldable, TypeVisitable)]
 pub struct PlaceWithHirId<'tcx> {
     /// `HirId` of the expression or pattern producing this value.
     pub hir_id: HirId,

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -234,7 +234,6 @@ pub enum StmtKind<'tcx> {
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, HashStable, TyEncodable, TyDecodable)]
-#[derive(TypeFoldable, TypeVisitable)]
 pub struct LocalVarId(pub hir::HirId);
 
 /// A THIR expression.

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -569,7 +569,7 @@ pub struct DerivedObligationCause<'tcx> {
     pub parent_code: InternedObligationCauseCode<'tcx>,
 }
 
-#[derive(Clone, Debug, TypeFoldable, TypeVisitable, Lift)]
+#[derive(Clone, Debug, TypeVisitable, Lift)]
 pub enum SelectionError<'tcx> {
     /// The trait is not implemented.
     Unimplemented,

--- a/compiler/rustc_middle/src/traits/select.rs
+++ b/compiler/rustc_middle/src/traits/select.rs
@@ -103,7 +103,7 @@ pub type EvaluationCache<'tcx> = Cache<
 /// required for associated types to work in default impls, as the bounds
 /// are visible both as projection bounds and as where-clauses from the
 /// parameter environment.
-#[derive(PartialEq, Eq, Debug, Clone, TypeFoldable, TypeVisitable)]
+#[derive(PartialEq, Eq, Debug, Clone, TypeVisitable)]
 pub enum SelectionCandidate<'tcx> {
     /// A builtin implementation for some specific traits, used in cases
     /// where we cannot rely an ordinary library implementations.

--- a/compiler/rustc_middle/src/traits/solve.rs
+++ b/compiler/rustc_middle/src/traits/solve.rs
@@ -120,7 +120,7 @@ impl<'tcx> std::ops::Deref for ExternalConstraints<'tcx> {
 }
 
 /// Additional constraints returned on success.
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Default, TypeFoldable, TypeVisitable)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Default)]
 pub struct ExternalConstraintsData<'tcx> {
     // FIXME: implement this.
     pub region_constraints: QueryRegionConstraints<'tcx>,

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -28,7 +28,7 @@ impl<T> ExpectedFound<T> {
 }
 
 // Data structures used in type unification
-#[derive(Copy, Clone, Debug, TypeFoldable, TypeVisitable, Lift, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, TypeVisitable, Lift, PartialEq, Eq)]
 #[rustc_pass_by_value]
 pub enum TypeError<'tcx> {
     Mismatch,

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2690,7 +2690,7 @@ impl<'tcx> ty::PolyTraitPredicate<'tcx> {
     }
 }
 
-#[derive(Debug, Copy, Clone, TypeFoldable, TypeVisitable, Lift)]
+#[derive(Debug, Copy, Clone, Lift)]
 pub struct PrintClosureAsImpl<'tcx> {
     pub closure: ty::ClosureSubsts<'tcx>,
 }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -4,7 +4,6 @@
 //! to help with the tedium.
 
 use crate::mir::interpret;
-use crate::mir::ProjectionKind;
 use crate::ty::fold::{FallibleTypeFolder, TypeFoldable, TypeSuperFoldable};
 use crate::ty::print::{with_no_trimmed_paths, FmtPrinter, Printer};
 use crate::ty::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitor};
@@ -373,16 +372,6 @@ impl<'a, 'tcx> Lift<'tcx> for ty::ParamEnv<'a> {
 ///////////////////////////////////////////////////////////////////////////
 // Traversal implementations.
 
-/// AdtDefs are basically the same as a DefId.
-impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::AdtDef<'tcx> {
-    fn try_fold_with<F: FallibleTypeFolder<TyCtxt<'tcx>>>(
-        self,
-        _folder: &mut F,
-    ) -> Result<Self, F::Error> {
-        Ok(self)
-    }
-}
-
 impl<'tcx> TypeVisitable<TyCtxt<'tcx>> for ty::AdtDef<'tcx> {
     fn visit_with<V: TypeVisitor<TyCtxt<'tcx>>>(
         &self,
@@ -442,15 +431,6 @@ impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for &'tcx ty::List<ty::Const<'tcx>> {
         folder: &mut F,
     ) -> Result<Self, F::Error> {
         ty::util::fold_list(self, folder, |tcx, v| tcx.mk_const_list(v))
-    }
-}
-
-impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for &'tcx ty::List<ProjectionKind> {
-    fn try_fold_with<F: FallibleTypeFolder<TyCtxt<'tcx>>>(
-        self,
-        folder: &mut F,
-    ) -> Result<Self, F::Error> {
-        ty::util::fold_list(self, folder, |tcx, v| tcx.mk_projs(v))
     }
 }
 

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -631,7 +631,7 @@ impl<'tcx> UpvarSubsts<'tcx> {
 /// type of the constant. The reason that `R` is represented as an extra type parameter
 /// is the same reason that [`ClosureSubsts`] have `CS` and `U` as type parameters:
 /// inline const can reference lifetimes that are internal to the creating function.
-#[derive(Copy, Clone, Debug, TypeFoldable, TypeVisitable)]
+#[derive(Copy, Clone, Debug)]
 pub struct InlineConstSubsts<'tcx> {
     /// Generic parameters from the enclosing item,
     /// concatenated with the inferred type of the constant.

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -772,3 +772,75 @@ parse_const_bounds_missing_tilde = const bounds must start with `~`
     .suggestion = add `~`
 
 parse_underscore_literal_suffix = underscore literal suffix is not allowed
+
+parse_expect_label_found_ident = expected a label, found an identifier
+    .suggestion = labels start with a tick
+
+parse_inappropriate_default = {$article} {$descr} cannot be `default`
+    .label = `default` because of this
+    .note = only associated `fn`, `const`, and `type` items can be `default`
+
+parse_recover_import_as_use = expected item, found {$token_name}
+    .suggestion = items are imported using the `use` keyword
+
+parse_single_colon_import_path = expected `::`, found `:`
+    .suggestion = use double colon
+    .note = import paths are delimited using `::`
+
+parse_bad_item_kind = {$descr} is not supported in {$ctx}
+    .help = consider moving the {$descr} out to a nearby module scope
+
+parse_single_colon_struct_type = found single colon in a struct field type path
+    .suggestion = write a path separator here
+
+parse_equals_struct_default = default values on `struct` fields aren't supported
+    .suggestion = remove this unsupported default value
+
+parse_macro_rules_missing_bang = expected `!` after `macro_rules`
+    .suggestion = add a `!`
+
+parse_macro_name_remove_bang = macro names aren't followed by a `!`
+    .suggestion = remove the `!`
+
+parse_macro_rules_visibility = can't qualify macro_rules invocation with `{$vis}`
+    .suggestion = try exporting the macro
+
+parse_macro_invocation_visibility = can't qualify macro invocation with `pub`
+    .suggestion = remove the visibility
+    .help = try adjusting the macro to put `{$vis}` inside the invocation
+
+parse_nested_adt = `{$kw_str}` definition cannot be nested inside `{$keyword}`
+    .suggestion = consider creating a new `{$kw_str}` definition instead of nesting
+
+parse_function_body_equals_expr = function body cannot be `= expression;`
+    .suggestion = surround the expression with `{"{"}` and `{"}"}` instead of `=` and `;`
+
+parse_box_not_pat = expected pattern, found {$descr}
+    .note = `box` is a reserved keyword
+    .suggestion = escape `box` to use it as an identifier
+
+parse_unmatched_angle = unmatched angle {$plural ->
+    [true] brackets
+    *[false] bracket
+    }
+    .suggestion = remove extra angle {$plural ->
+    [true] brackets
+    *[false] bracket
+    }
+
+parse_missing_plus_in_bounds = expected `+` between lifetime and {$sym}
+    .suggestion = add `+`
+
+parse_incorrect_braces_trait_bounds = incorrect braces around trait bounds
+    .suggestion = remove the parentheses
+
+parse_kw_bad_case = keyword `{$kw}` is written in the wrong case
+    .suggestion = write it in the correct case
+
+parse_meta_bad_delim = wrong meta list delimiters
+parse_cfg_attr_bad_delim = wrong `cfg_attr` delimiters
+parse_meta_bad_delim_suggestion = the delimiters should be `(` and `)`
+
+parse_malformed_cfg_attr = malformed `cfg_attr` attribute input
+    .suggestion = missing condition and attribute
+    .note = for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2421,3 +2421,227 @@ pub(crate) struct UnderscoreLiteralSuffix {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(parse_expect_label_found_ident)]
+pub(crate) struct ExpectedLabelFoundIdent {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(code = "'", applicability = "machine-applicable", style = "short")]
+    pub start: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_inappropriate_default)]
+#[note]
+pub(crate) struct InappropriateDefault {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub article: &'static str,
+    pub descr: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_recover_import_as_use)]
+pub(crate) struct RecoverImportAsUse {
+    #[primary_span]
+    #[suggestion(code = "use", applicability = "machine-applicable", style = "short")]
+    pub span: Span,
+    pub token_name: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_single_colon_import_path)]
+#[note]
+pub(crate) struct SingleColonImportPath {
+    #[primary_span]
+    #[suggestion(code = "::", applicability = "machine-applicable", style = "short")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_bad_item_kind)]
+#[help]
+pub(crate) struct BadItemKind {
+    #[primary_span]
+    pub span: Span,
+    pub descr: &'static str,
+    pub ctx: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_single_colon_struct_type)]
+pub(crate) struct SingleColonStructType {
+    #[primary_span]
+    #[suggestion(code = "::", applicability = "maybe-incorrect", style = "verbose")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_equals_struct_default)]
+pub(crate) struct EqualsStructDefault {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "machine-applicable")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_macro_rules_missing_bang)]
+pub(crate) struct MacroRulesMissingBang {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(code = "!", applicability = "machine-applicable", style = "verbose")]
+    pub hi: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_macro_name_remove_bang)]
+pub(crate) struct MacroNameRemoveBang {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "machine-applicable")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_macro_rules_visibility)]
+pub(crate) struct MacroRulesVisibility<'a> {
+    #[primary_span]
+    #[suggestion(code = "#[macro_export]", applicability = "maybe-incorrect")]
+    pub span: Span,
+    pub vis: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_macro_invocation_visibility)]
+#[help]
+pub(crate) struct MacroInvocationVisibility<'a> {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "machine-applicable")]
+    pub span: Span,
+    pub vis: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_nested_adt)]
+pub(crate) struct NestedAdt<'a> {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    pub item: Span,
+    pub keyword: &'a str,
+    pub kw_str: Cow<'a, str>,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_function_body_equals_expr)]
+pub(crate) struct FunctionBodyEqualsExpr {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: FunctionBodyEqualsExprSugg,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parse_suggestion, applicability = "machine-applicable")]
+pub(crate) struct FunctionBodyEqualsExprSugg {
+    #[suggestion_part(code = "{{")]
+    pub eq: Span,
+    #[suggestion_part(code = " }}")]
+    pub semi: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_box_not_pat)]
+pub(crate) struct BoxNotPat {
+    #[primary_span]
+    pub span: Span,
+    #[note]
+    pub kw: Span,
+    #[suggestion(code = "r#", applicability = "maybe-incorrect", style = "verbose")]
+    pub lo: Span,
+    pub descr: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_unmatched_angle)]
+pub(crate) struct UnmatchedAngle {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "machine-applicable")]
+    pub span: Span,
+    pub plural: bool,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_missing_plus_in_bounds)]
+pub(crate) struct MissingPlusBounds {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(code = " +", applicability = "maybe-incorrect", style = "verbose")]
+    pub hi: Span,
+    pub sym: Symbol,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_incorrect_braces_trait_bounds)]
+pub(crate) struct IncorrectBracesTraitBounds {
+    #[primary_span]
+    pub span: Vec<Span>,
+    #[subdiagnostic]
+    pub sugg: IncorrectBracesTraitBoundsSugg,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parse_suggestion, applicability = "machine-applicable")]
+pub(crate) struct IncorrectBracesTraitBoundsSugg {
+    #[suggestion_part(code = " ")]
+    pub l: Span,
+    #[suggestion_part(code = "")]
+    pub r: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_kw_bad_case)]
+pub(crate) struct KwBadCase<'a> {
+    #[primary_span]
+    #[suggestion(code = "{kw}", applicability = "machine-applicable")]
+    pub span: Span,
+    pub kw: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_meta_bad_delim)]
+pub(crate) struct MetaBadDelim {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: MetaBadDelimSugg,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_cfg_attr_bad_delim)]
+pub(crate) struct CfgAttrBadDelim {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: MetaBadDelimSugg,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parse_meta_bad_delim_suggestion, applicability = "machine-applicable")]
+pub(crate) struct MetaBadDelimSugg {
+    #[suggestion_part(code = "(")]
+    pub open: Span,
+    #[suggestion_part(code = ")")]
+    pub close: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_malformed_cfg_attr)]
+#[note]
+pub(crate) struct MalformedCfgAttr {
+    #[primary_span]
+    #[suggestion(code = "{sugg}")]
+    pub span: Span,
+    pub sugg: &'static str,
+}

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3151,14 +3151,10 @@ impl<'a> Parser<'a> {
         let label = format!("'{}", ident.name);
         let ident = Ident { name: Symbol::intern(&label), span: ident.span };
 
-        self.struct_span_err(ident.span, "expected a label, found an identifier")
-            .span_suggestion(
-                ident.span,
-                "labels start with a tick",
-                label,
-                Applicability::MachineApplicable,
-            )
-            .emit();
+        self.sess.emit_err(errors::ExpectedLabelFoundIdent {
+            span: ident.span,
+            start: ident.span.shrink_to_lo(),
+        });
 
         Label { ident }
     }

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -43,7 +43,7 @@ use thin_vec::ThinVec;
 use tracing::debug;
 
 use crate::errors::{
-    IncorrectVisibilityRestriction, MismatchedClosingDelimiter, NonStringAbiLiteral,
+    self, IncorrectVisibilityRestriction, MismatchedClosingDelimiter, NonStringAbiLiteral,
 };
 
 bitflags::bitflags! {
@@ -663,15 +663,10 @@ impl<'a> Parser<'a> {
         if case == Case::Insensitive
         && let Some((ident, /* is_raw */ false)) = self.token.ident()
         && ident.as_str().to_lowercase() == kw.as_str().to_lowercase() {
-            self
-                .struct_span_err(ident.span, format!("keyword `{kw}` is written in a wrong case"))
-                .span_suggestion(
-                    ident.span,
-                    "write it in the correct case",
-                    kw,
-                    Applicability::MachineApplicable
-                ).emit();
-
+            self.sess.emit_err(errors::KwBadCase {
+                span: ident.span,
+                kw: kw.as_str()
+            });
             self.bump();
             return true;
         }

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -8,7 +8,7 @@ use rustc_ast::{
     AssocConstraintKind, BlockCheckMode, GenericArg, GenericArgs, Generics, ParenthesizedArgs,
     Path, PathSegment, QSelf,
 };
-use rustc_errors::{pluralize, Applicability, PResult};
+use rustc_errors::{Applicability, PResult};
 use rustc_span::source_map::{BytePos, Span};
 use rustc_span::symbol::{kw, sym, Ident};
 use std::mem;
@@ -464,23 +464,10 @@ impl<'a> Parser<'a> {
                     // i.e. no multibyte characters, in this range.
                     let span =
                         lo.with_hi(lo.lo() + BytePos(snapshot.unmatched_angle_bracket_count));
-                    self.struct_span_err(
+                    self.sess.emit_err(errors::UnmatchedAngle {
                         span,
-                        &format!(
-                            "unmatched angle bracket{}",
-                            pluralize!(snapshot.unmatched_angle_bracket_count)
-                        ),
-                    )
-                    .span_suggestion(
-                        span,
-                        &format!(
-                            "remove extra angle bracket{}",
-                            pluralize!(snapshot.unmatched_angle_bracket_count)
-                        ),
-                        "",
-                        Applicability::MachineApplicable,
-                    )
-                    .emit();
+                        plural: snapshot.unmatched_angle_bracket_count > 1,
+                    });
 
                     // Try again without unmatched angle bracket characters.
                     self.parse_angle_args(ty_generics)

--- a/compiler/rustc_target/src/abi/call/x86_64.rs
+++ b/compiler/rustc_target/src/abi/call/x86_64.rs
@@ -153,9 +153,9 @@ fn reg_component(cls: &[Option<Class>], i: &mut usize, size: Size) -> Option<Reg
     }
 }
 
-fn cast_target(cls: &[Option<Class>], size: Size) -> CastTarget {
+fn cast_target(cls: &[Option<Class>], size: Size) -> Option<CastTarget> {
     let mut i = 0;
-    let lo = reg_component(cls, &mut i, size).unwrap();
+    let lo = reg_component(cls, &mut i, size)?;
     let offset = Size::from_bytes(8) * (i as u64);
     let mut target = CastTarget::from(lo);
     if size > offset {
@@ -164,7 +164,7 @@ fn cast_target(cls: &[Option<Class>], size: Size) -> CastTarget {
         }
     }
     assert_eq!(reg_component(cls, &mut i, Size::ZERO), None);
-    target
+    Some(target)
 }
 
 const MAX_INT_REGS: usize = 6; // RDI, RSI, RDX, RCX, R8, R9
@@ -227,7 +227,9 @@ where
                 // split into sized chunks passed individually
                 if arg.layout.is_aggregate() {
                     let size = arg.layout.size;
-                    arg.cast_to(cast_target(cls, size))
+                    if let Some(cast_target) = cast_target(cls, size) {
+                        arg.cast_to(cast_target);
+                    }
                 } else {
                     arg.extend_integer_width_to(32);
                 }

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
@@ -16,7 +16,7 @@ use rustc_infer::infer::canonical::query_response::make_query_region_constraints
 use rustc_infer::infer::canonical::CanonicalVarValues;
 use rustc_infer::infer::canonical::{CanonicalExt, QueryRegionConstraints};
 use rustc_middle::traits::query::NoSolution;
-use rustc_middle::traits::solve::{ExternalConstraints, ExternalConstraintsData};
+use rustc_middle::traits::solve::{ExternalConstraints, ExternalConstraintsData, MaybeCause};
 use rustc_middle::ty::{self, BoundVar, GenericArgKind};
 use rustc_span::DUMMY_SP;
 use std::iter;
@@ -60,9 +60,38 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
 
         let certainty = certainty.unify_with(goals_certainty);
 
-        let external_constraints = self.compute_external_query_constraints()?;
+        let response = match certainty {
+            Certainty::Yes | Certainty::Maybe(MaybeCause::Ambiguity) => {
+                let external_constraints = self.compute_external_query_constraints()?;
+                Response { var_values: self.var_values, external_constraints, certainty }
+            }
+            Certainty::Maybe(MaybeCause::Overflow) => {
+                // If we have overflow, it's probable that we're substituting a type
+                // into itself infinitely and any partial substitutions in the query
+                // response are probably not useful anyways, so just return an empty
+                // query response.
+                Response {
+                    var_values: CanonicalVarValues {
+                        var_values: self.tcx().mk_substs_from_iter(
+                            self.var_values.var_values.iter().map(|arg| -> ty::GenericArg<'tcx> {
+                                match arg.unpack() {
+                                    GenericArgKind::Lifetime(_) => self.next_region_infer().into(),
+                                    GenericArgKind::Type(_) => self.next_ty_infer().into(),
+                                    GenericArgKind::Const(ct) => {
+                                        self.next_const_infer(ct.ty()).into()
+                                    }
+                                }
+                            }),
+                        ),
+                    },
+                    external_constraints: self
+                        .tcx()
+                        .mk_external_constraints(ExternalConstraintsData::default()),
+                    certainty,
+                }
+            }
+        };
 
-        let response = Response { var_values: self.var_values, external_constraints, certainty };
         let canonical = Canonicalizer::canonicalize(
             self.infcx,
             CanonicalizeMode::Response { max_input_universe: self.max_input_universe },

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -62,7 +62,7 @@ mod rustc {
 
     use rustc_hir::lang_items::LangItem;
     use rustc_infer::infer::InferCtxt;
-    use rustc_macros::{TypeFoldable, TypeVisitable};
+    use rustc_macros::TypeVisitable;
     use rustc_middle::traits::ObligationCause;
     use rustc_middle::ty::Const;
     use rustc_middle::ty::ParamEnv;
@@ -70,7 +70,7 @@ mod rustc {
     use rustc_middle::ty::TyCtxt;
 
     /// The source and destination types of a transmutation.
-    #[derive(TypeFoldable, TypeVisitable, Debug, Clone, Copy)]
+    #[derive(TypeVisitable, Debug, Clone, Copy)]
     pub struct Types<'tcx> {
         /// The source type.
         pub src: Ty<'tcx>,

--- a/compiler/rustc_type_ir/src/structural_impls.rs
+++ b/compiler/rustc_type_ir/src/structural_impls.rs
@@ -6,11 +6,10 @@ use crate::fold::{FallibleTypeFolder, TypeFoldable};
 use crate::visit::{TypeVisitable, TypeVisitor};
 use crate::Interner;
 use rustc_data_structures::functor::IdFunctor;
+use rustc_data_structures::sync::Lrc;
 use rustc_index::{Idx, IndexVec};
 
 use std::ops::ControlFlow;
-use std::rc::Rc;
-use std::sync::Arc;
 
 ///////////////////////////////////////////////////////////////////////////
 // Atomic structs
@@ -106,25 +105,13 @@ impl<I: Interner, T: TypeVisitable<I>, E: TypeVisitable<I>> TypeVisitable<I> for
     }
 }
 
-impl<I: Interner, T: TypeFoldable<I>> TypeFoldable<I> for Rc<T> {
+impl<I: Interner, T: TypeFoldable<I>> TypeFoldable<I> for Lrc<T> {
     fn try_fold_with<F: FallibleTypeFolder<I>>(self, folder: &mut F) -> Result<Self, F::Error> {
         self.try_map_id(|value| value.try_fold_with(folder))
     }
 }
 
-impl<I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for Rc<T> {
-    fn visit_with<V: TypeVisitor<I>>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
-        (**self).visit_with(visitor)
-    }
-}
-
-impl<I: Interner, T: TypeFoldable<I>> TypeFoldable<I> for Arc<T> {
-    fn try_fold_with<F: FallibleTypeFolder<I>>(self, folder: &mut F) -> Result<Self, F::Error> {
-        self.try_map_id(|value| value.try_fold_with(folder))
-    }
-}
-
-impl<I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for Arc<T> {
+impl<I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for Lrc<T> {
     fn visit_with<V: TypeVisitor<I>>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
         (**self).visit_with(visitor)
     }
@@ -155,18 +142,6 @@ impl<I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for Vec<T> {
 }
 
 impl<I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for &[T] {
-    fn visit_with<V: TypeVisitor<I>>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
-        self.iter().try_for_each(|t| t.visit_with(visitor))
-    }
-}
-
-impl<I: Interner, T: TypeFoldable<I>> TypeFoldable<I> for Box<[T]> {
-    fn try_fold_with<F: FallibleTypeFolder<I>>(self, folder: &mut F) -> Result<Self, F::Error> {
-        self.try_map_id(|t| t.try_fold_with(folder))
-    }
-}
-
-impl<I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for Box<[T]> {
     fn visit_with<V: TypeVisitor<I>>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
         self.iter().try_for_each(|t| t.visit_with(visitor))
     }

--- a/compiler/rustc_type_ir/src/structural_impls.rs
+++ b/compiler/rustc_type_ir/src/structural_impls.rs
@@ -141,6 +141,10 @@ impl<I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for Vec<T> {
     }
 }
 
+// `TypeFoldable` isn't impl'd for `&[T]`. It doesn't make sense in the general
+// case, because we can't return a new slice. But note that there are a couple
+// of trivial impls of `TypeFoldable` for specific slice types elsewhere.
+
 impl<I: Interner, T: TypeVisitable<I>> TypeVisitable<I> for &[T] {
     fn visit_with<V: TypeVisitor<I>>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
         self.iter().try_for_each(|t| t.visit_with(visitor))

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -93,7 +93,7 @@ pub use alloc_crate::alloc::*;
 ///
 /// ```rust
 /// use std::alloc::{System, GlobalAlloc, Layout};
-/// use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+/// use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 ///
 /// struct Counter;
 ///
@@ -103,14 +103,14 @@ pub use alloc_crate::alloc::*;
 ///     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
 ///         let ret = System.alloc(layout);
 ///         if !ret.is_null() {
-///             ALLOCATED.fetch_add(layout.size(), SeqCst);
+///             ALLOCATED.fetch_add(layout.size(), Relaxed);
 ///         }
 ///         ret
 ///     }
 ///
 ///     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
 ///         System.dealloc(ptr, layout);
-///         ALLOCATED.fetch_sub(layout.size(), SeqCst);
+///         ALLOCATED.fetch_sub(layout.size(), Relaxed);
 ///     }
 /// }
 ///
@@ -118,7 +118,7 @@ pub use alloc_crate::alloc::*;
 /// static A: Counter = Counter;
 ///
 /// fn main() {
-///     println!("allocated bytes before main: {}", ALLOCATED.load(SeqCst));
+///     println!("allocated bytes before main: {}", ALLOCATED.load(Relaxed));
 /// }
 /// ```
 ///

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2284,6 +2284,11 @@ pub fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 ///
 /// See [`fs::remove_file`] and [`fs::remove_dir`].
 ///
+/// `remove_dir_all` will fail if `remove_dir` or `remove_file` fail on any constituent paths, including the root path.
+/// As a result, the directory you are deleting must exist, meaning that this function is not idempotent.
+///
+/// Consider ignoring the error if validating the removal is not required for your use case.
+///
 /// [`fs::remove_file`]: remove_file
 /// [`fs::remove_dir`]: remove_dir
 ///

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2332,7 +2332,7 @@ impl<'test> TestCx<'test> {
                 // No extra flags needed.
             }
 
-            Some(_) => self.fatal("unknown 'assembly-output' header"),
+            Some(header) => self.fatal(&format!("unknown 'assembly-output' header: {header}")),
             None => self.fatal("missing 'assembly-output' header"),
         }
 

--- a/tests/ui/abi/foreign/foreign-fn-with-byval.rs
+++ b/tests/ui/abi/foreign/foreign-fn-with-byval.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![allow(improper_ctypes)]
+#![allow(improper_ctypes, improper_ctypes_definitions)]
 
 // ignore-wasm32-bare no libc to test ffi with
 

--- a/tests/ui/abi/issue-94223.rs
+++ b/tests/ui/abi/issue-94223.rs
@@ -1,0 +1,8 @@
+// check-pass
+#![allow(improper_ctypes_definitions)]
+#![crate_type = "lib"]
+
+// Check that computing the fn abi for `bad`, with a external ABI fn ptr that is not FFI-safe, does
+// not ICE.
+
+pub fn bad(f: extern "C" fn([u8])) {}

--- a/tests/ui/coherence/coherence-overlap-negative-impls.rs
+++ b/tests/ui/coherence/coherence-overlap-negative-impls.rs
@@ -1,0 +1,41 @@
+// check-pass
+// known-bug: #74629
+
+// Should fail. The `0` and `1` impls overlap, violating coherence. Eg, with
+// `T = Test, F = ()`, all bounds are true, making both impls applicable.
+// `Test: Fold<Nil>`, `Test: Fold<()>` are true because of `2`.
+// `Is<Test>: NotNil` is true because of `auto trait` and lack of negative impl.
+
+#![feature(negative_impls)]
+#![feature(auto_traits)]
+
+struct Nil;
+struct Cons<H>(H);
+struct Test;
+
+trait Fold<F> {}
+
+impl<T, F> Fold<F> for Cons<T> // 0
+where
+    T: Fold<Nil>,
+{}
+
+impl<T, F> Fold<F> for Cons<T> // 1
+where
+    T: Fold<F>,
+    private::Is<T>: private::NotNil,
+{}
+
+impl<F> Fold<F> for Test {} // 2
+
+mod private {
+    use crate::Nil;
+
+    pub struct Is<T>(T);
+    pub auto trait NotNil {}
+
+    #[allow(suspicious_auto_trait_impls)]
+    impl !NotNil for Is<Nil> {}
+}
+
+fn main() {}

--- a/tests/ui/hashmap/hashmap-memory.rs
+++ b/tests/ui/hashmap/hashmap-memory.rs
@@ -1,5 +1,6 @@
 // run-pass
 
+#![allow(improper_ctypes_definitions)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 #![allow(unused_mut)]

--- a/tests/ui/lint/lint-ctypes-94223.rs
+++ b/tests/ui/lint/lint-ctypes-94223.rs
@@ -7,3 +7,36 @@ pub fn bad(f: extern "C" fn([u8])) {}
 pub fn bad_twice(f: Result<extern "C" fn([u8]), extern "C" fn([u8])>) {}
 //~^ ERROR `extern` fn uses type `[u8]`, which is not FFI-safe
 //~^^ ERROR `extern` fn uses type `[u8]`, which is not FFI-safe
+
+struct BadStruct(extern "C" fn([u8]));
+//~^ ERROR `extern` fn uses type `[u8]`, which is not FFI-safe
+
+enum BadEnum {
+    A(extern "C" fn([u8])),
+    //~^ ERROR `extern` fn uses type `[u8]`, which is not FFI-safe
+}
+
+enum BadUnion {
+    A(extern "C" fn([u8])),
+    //~^ ERROR `extern` fn uses type `[u8]`, which is not FFI-safe
+}
+
+type Foo = extern "C" fn([u8]);
+//~^ ERROR `extern` fn uses type `[u8]`, which is not FFI-safe
+
+pub struct FfiUnsafe;
+
+#[allow(improper_ctypes_definitions)]
+extern "C" fn f(_: FfiUnsafe) {
+    unimplemented!()
+}
+
+pub static BAD: extern "C" fn(FfiUnsafe) = f;
+//~^ ERROR `extern` fn uses type `FfiUnsafe`, which is not FFI-safe
+
+pub static BAD_TWICE: Result<extern "C" fn(FfiUnsafe), extern "C" fn(FfiUnsafe)> = Ok(f);
+//~^ ERROR `extern` fn uses type `FfiUnsafe`, which is not FFI-safe
+//~^^ ERROR `extern` fn uses type `FfiUnsafe`, which is not FFI-safe
+
+pub const BAD_CONST: extern "C" fn(FfiUnsafe) = f;
+//~^ ERROR `extern` fn uses type `FfiUnsafe`, which is not FFI-safe

--- a/tests/ui/lint/lint-ctypes-94223.rs
+++ b/tests/ui/lint/lint-ctypes-94223.rs
@@ -3,3 +3,7 @@
 
 pub fn bad(f: extern "C" fn([u8])) {}
 //~^ ERROR `extern` fn uses type `[u8]`, which is not FFI-safe
+
+pub fn bad_twice(f: Result<extern "C" fn([u8]), extern "C" fn([u8])>) {}
+//~^ ERROR `extern` fn uses type `[u8]`, which is not FFI-safe
+//~^^ ERROR `extern` fn uses type `[u8]`, which is not FFI-safe

--- a/tests/ui/lint/lint-ctypes-94223.rs
+++ b/tests/ui/lint/lint-ctypes-94223.rs
@@ -1,0 +1,5 @@
+#![crate_type = "lib"]
+#![deny(improper_ctypes_definitions)]
+
+pub fn bad(f: extern "C" fn([u8])) {}
+//~^ ERROR `extern` fn uses type `[u8]`, which is not FFI-safe

--- a/tests/ui/lint/lint-ctypes-94223.stderr
+++ b/tests/ui/lint/lint-ctypes-94223.stderr
@@ -12,5 +12,23 @@ note: the lint level is defined here
 LL | #![deny(improper_ctypes_definitions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: `extern` fn uses type `[u8]`, which is not FFI-safe
+  --> $DIR/lint-ctypes-94223.rs:7:28
+   |
+LL | pub fn bad_twice(f: Result<extern "C" fn([u8]), extern "C" fn([u8])>) {}
+   |                            ^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider using a raw pointer instead
+   = note: slices have no C equivalent
+
+error: `extern` fn uses type `[u8]`, which is not FFI-safe
+  --> $DIR/lint-ctypes-94223.rs:7:49
+   |
+LL | pub fn bad_twice(f: Result<extern "C" fn([u8]), extern "C" fn([u8])>) {}
+   |                                                 ^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider using a raw pointer instead
+   = note: slices have no C equivalent
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/lint/lint-ctypes-94223.stderr
+++ b/tests/ui/lint/lint-ctypes-94223.stderr
@@ -1,0 +1,16 @@
+error: `extern` fn uses type `[u8]`, which is not FFI-safe
+  --> $DIR/lint-ctypes-94223.rs:4:15
+   |
+LL | pub fn bad(f: extern "C" fn([u8])) {}
+   |               ^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider using a raw pointer instead
+   = note: slices have no C equivalent
+note: the lint level is defined here
+  --> $DIR/lint-ctypes-94223.rs:2:9
+   |
+LL | #![deny(improper_ctypes_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/lint/lint-ctypes-94223.stderr
+++ b/tests/ui/lint/lint-ctypes-94223.stderr
@@ -30,5 +30,97 @@ LL | pub fn bad_twice(f: Result<extern "C" fn([u8]), extern "C" fn([u8])>) {}
    = help: consider using a raw pointer instead
    = note: slices have no C equivalent
 
-error: aborting due to 3 previous errors
+error: `extern` fn uses type `[u8]`, which is not FFI-safe
+  --> $DIR/lint-ctypes-94223.rs:11:18
+   |
+LL | struct BadStruct(extern "C" fn([u8]));
+   |                  ^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider using a raw pointer instead
+   = note: slices have no C equivalent
+
+error: `extern` fn uses type `[u8]`, which is not FFI-safe
+  --> $DIR/lint-ctypes-94223.rs:15:7
+   |
+LL |     A(extern "C" fn([u8])),
+   |       ^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider using a raw pointer instead
+   = note: slices have no C equivalent
+
+error: `extern` fn uses type `[u8]`, which is not FFI-safe
+  --> $DIR/lint-ctypes-94223.rs:20:7
+   |
+LL |     A(extern "C" fn([u8])),
+   |       ^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider using a raw pointer instead
+   = note: slices have no C equivalent
+
+error: `extern` fn uses type `[u8]`, which is not FFI-safe
+  --> $DIR/lint-ctypes-94223.rs:24:12
+   |
+LL | type Foo = extern "C" fn([u8]);
+   |            ^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider using a raw pointer instead
+   = note: slices have no C equivalent
+
+error: `extern` fn uses type `FfiUnsafe`, which is not FFI-safe
+  --> $DIR/lint-ctypes-94223.rs:34:17
+   |
+LL | pub static BAD: extern "C" fn(FfiUnsafe) = f;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
+   = note: this struct has unspecified layout
+note: the type is defined here
+  --> $DIR/lint-ctypes-94223.rs:27:1
+   |
+LL | pub struct FfiUnsafe;
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: `extern` fn uses type `FfiUnsafe`, which is not FFI-safe
+  --> $DIR/lint-ctypes-94223.rs:37:30
+   |
+LL | pub static BAD_TWICE: Result<extern "C" fn(FfiUnsafe), extern "C" fn(FfiUnsafe)> = Ok(f);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
+   = note: this struct has unspecified layout
+note: the type is defined here
+  --> $DIR/lint-ctypes-94223.rs:27:1
+   |
+LL | pub struct FfiUnsafe;
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: `extern` fn uses type `FfiUnsafe`, which is not FFI-safe
+  --> $DIR/lint-ctypes-94223.rs:37:56
+   |
+LL | pub static BAD_TWICE: Result<extern "C" fn(FfiUnsafe), extern "C" fn(FfiUnsafe)> = Ok(f);
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
+   = note: this struct has unspecified layout
+note: the type is defined here
+  --> $DIR/lint-ctypes-94223.rs:27:1
+   |
+LL | pub struct FfiUnsafe;
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: `extern` fn uses type `FfiUnsafe`, which is not FFI-safe
+  --> $DIR/lint-ctypes-94223.rs:41:22
+   |
+LL | pub const BAD_CONST: extern "C" fn(FfiUnsafe) = f;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
+   = note: this struct has unspecified layout
+note: the type is defined here
+  --> $DIR/lint-ctypes-94223.rs:27:1
+   |
+LL | pub struct FfiUnsafe;
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 11 previous errors
 

--- a/tests/ui/macros/missing-bang-in-decl.stderr
+++ b/tests/ui/macros/missing-bang-in-decl.stderr
@@ -2,13 +2,23 @@ error: expected `!` after `macro_rules`
   --> $DIR/missing-bang-in-decl.rs:5:1
    |
 LL | macro_rules foo {
-   | ^^^^^^^^^^^ help: add a `!`: `macro_rules!`
+   | ^^^^^^^^^^^
+   |
+help: add a `!`
+   |
+LL | macro_rules! foo {
+   |            +
 
 error: expected `!` after `macro_rules`
   --> $DIR/missing-bang-in-decl.rs:10:1
    |
 LL | macro_rules bar! {
-   | ^^^^^^^^^^^ help: add a `!`: `macro_rules!`
+   | ^^^^^^^^^^^
+   |
+help: add a `!`
+   |
+LL | macro_rules! bar! {
+   |            +
 
 error: macro names aren't followed by a `!`
   --> $DIR/missing-bang-in-decl.rs:10:16

--- a/tests/ui/parser/item-kw-case-mismatch.fixed
+++ b/tests/ui/parser/item-kw-case-mismatch.fixed
@@ -4,31 +4,31 @@
 
 fn main() {}
 
-use std::ptr::read;  //~ ERROR keyword `use` is written in a wrong case
-use std::ptr::write; //~ ERROR keyword `use` is written in a wrong case
+use std::ptr::read;  //~ ERROR keyword `use` is written in the wrong case
+use std::ptr::write; //~ ERROR keyword `use` is written in the wrong case
 
 async fn _a() {}
-//~^ ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `fn` is written in the wrong case
 
 fn _b() {}
-//~^ ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `fn` is written in the wrong case
 
 async fn _c() {}
-//~^ ERROR keyword `async` is written in a wrong case
-//~| ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `async` is written in the wrong case
+//~| ERROR keyword `fn` is written in the wrong case
 
 async fn _d() {}
-//~^ ERROR keyword `async` is written in a wrong case
+//~^ ERROR keyword `async` is written in the wrong case
 
 const unsafe fn _e() {}
-//~^ ERROR keyword `const` is written in a wrong case
-//~| ERROR keyword `unsafe` is written in a wrong case
-//~| ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `const` is written in the wrong case
+//~| ERROR keyword `unsafe` is written in the wrong case
+//~| ERROR keyword `fn` is written in the wrong case
 
 unsafe extern fn _f() {}
-//~^ ERROR keyword `unsafe` is written in a wrong case
-//~| ERROR keyword `extern` is written in a wrong case
+//~^ ERROR keyword `unsafe` is written in the wrong case
+//~| ERROR keyword `extern` is written in the wrong case
 
 extern "C" fn _g() {}
-//~^ ERROR keyword `extern` is written in a wrong case
-//~| ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `extern` is written in the wrong case
+//~| ERROR keyword `fn` is written in the wrong case

--- a/tests/ui/parser/item-kw-case-mismatch.rs
+++ b/tests/ui/parser/item-kw-case-mismatch.rs
@@ -4,31 +4,31 @@
 
 fn main() {}
 
-Use std::ptr::read;  //~ ERROR keyword `use` is written in a wrong case
-USE std::ptr::write; //~ ERROR keyword `use` is written in a wrong case
+Use std::ptr::read;  //~ ERROR keyword `use` is written in the wrong case
+USE std::ptr::write; //~ ERROR keyword `use` is written in the wrong case
 
 async Fn _a() {}
-//~^ ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `fn` is written in the wrong case
 
 Fn _b() {}
-//~^ ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `fn` is written in the wrong case
 
 aSYNC fN _c() {}
-//~^ ERROR keyword `async` is written in a wrong case
-//~| ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `async` is written in the wrong case
+//~| ERROR keyword `fn` is written in the wrong case
 
 Async fn _d() {}
-//~^ ERROR keyword `async` is written in a wrong case
+//~^ ERROR keyword `async` is written in the wrong case
 
 CONST UNSAFE FN _e() {}
-//~^ ERROR keyword `const` is written in a wrong case
-//~| ERROR keyword `unsafe` is written in a wrong case
-//~| ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `const` is written in the wrong case
+//~| ERROR keyword `unsafe` is written in the wrong case
+//~| ERROR keyword `fn` is written in the wrong case
 
 unSAFE EXTern fn _f() {}
-//~^ ERROR keyword `unsafe` is written in a wrong case
-//~| ERROR keyword `extern` is written in a wrong case
+//~^ ERROR keyword `unsafe` is written in the wrong case
+//~| ERROR keyword `extern` is written in the wrong case
 
 EXTERN "C" FN _g() {}
-//~^ ERROR keyword `extern` is written in a wrong case
-//~| ERROR keyword `fn` is written in a wrong case
+//~^ ERROR keyword `extern` is written in the wrong case
+//~| ERROR keyword `fn` is written in the wrong case

--- a/tests/ui/parser/item-kw-case-mismatch.stderr
+++ b/tests/ui/parser/item-kw-case-mismatch.stderr
@@ -1,82 +1,82 @@
-error: keyword `use` is written in a wrong case
+error: keyword `use` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:7:1
    |
 LL | Use std::ptr::read;
    | ^^^ help: write it in the correct case (notice the capitalization): `use`
 
-error: keyword `use` is written in a wrong case
+error: keyword `use` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:8:1
    |
 LL | USE std::ptr::write;
    | ^^^ help: write it in the correct case: `use`
 
-error: keyword `fn` is written in a wrong case
+error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:10:7
    |
 LL | async Fn _a() {}
    |       ^^ help: write it in the correct case (notice the capitalization): `fn`
 
-error: keyword `fn` is written in a wrong case
+error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:13:1
    |
 LL | Fn _b() {}
    | ^^ help: write it in the correct case (notice the capitalization): `fn`
 
-error: keyword `async` is written in a wrong case
+error: keyword `async` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:16:1
    |
 LL | aSYNC fN _c() {}
    | ^^^^^ help: write it in the correct case: `async`
 
-error: keyword `fn` is written in a wrong case
+error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:16:7
    |
 LL | aSYNC fN _c() {}
    |       ^^ help: write it in the correct case: `fn`
 
-error: keyword `async` is written in a wrong case
+error: keyword `async` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:20:1
    |
 LL | Async fn _d() {}
    | ^^^^^ help: write it in the correct case: `async`
 
-error: keyword `const` is written in a wrong case
+error: keyword `const` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:23:1
    |
 LL | CONST UNSAFE FN _e() {}
    | ^^^^^ help: write it in the correct case: `const`
 
-error: keyword `unsafe` is written in a wrong case
+error: keyword `unsafe` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:23:7
    |
 LL | CONST UNSAFE FN _e() {}
    |       ^^^^^^ help: write it in the correct case: `unsafe`
 
-error: keyword `fn` is written in a wrong case
+error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:23:14
    |
 LL | CONST UNSAFE FN _e() {}
    |              ^^ help: write it in the correct case: `fn`
 
-error: keyword `unsafe` is written in a wrong case
+error: keyword `unsafe` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:28:1
    |
 LL | unSAFE EXTern fn _f() {}
    | ^^^^^^ help: write it in the correct case: `unsafe`
 
-error: keyword `extern` is written in a wrong case
+error: keyword `extern` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:28:8
    |
 LL | unSAFE EXTern fn _f() {}
    |        ^^^^^^ help: write it in the correct case: `extern`
 
-error: keyword `extern` is written in a wrong case
+error: keyword `extern` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:32:1
    |
 LL | EXTERN "C" FN _g() {}
    | ^^^^^^ help: write it in the correct case: `extern`
 
-error: keyword `fn` is written in a wrong case
+error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:32:12
    |
 LL | EXTERN "C" FN _g() {}

--- a/tests/ui/parser/recover-unticked-labels.stderr
+++ b/tests/ui/parser/recover-unticked-labels.stderr
@@ -2,13 +2,17 @@ error: expected a label, found an identifier
   --> $DIR/recover-unticked-labels.rs:5:26
    |
 LL |     'label: loop { break label 0 };
-   |                          ^^^^^ help: labels start with a tick: `'label`
+   |                          -^^^^
+   |                          |
+   |                          help: labels start with a tick
 
 error: expected a label, found an identifier
   --> $DIR/recover-unticked-labels.rs:6:29
    |
 LL |     'label: loop { continue label };
-   |                             ^^^^^ help: labels start with a tick: `'label`
+   |                             -^^^^
+   |                             |
+   |                             help: labels start with a tick
 
 error[E0425]: cannot find value `label` in this scope
   --> $DIR/recover-unticked-labels.rs:4:26

--- a/tests/ui/parser/use-colon-as-mod-sep.stderr
+++ b/tests/ui/parser/use-colon-as-mod-sep.stderr
@@ -11,18 +11,24 @@ error: expected `::`, found `:`
    |
 LL | use std:fs::File;
    |        ^ help: use double colon
+   |
+   = note: import paths are delimited using `::`
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:7:8
    |
 LL | use std:collections:HashMap;
    |        ^ help: use double colon
+   |
+   = note: import paths are delimited using `::`
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:7:20
    |
 LL | use std:collections:HashMap;
    |                    ^ help: use double colon
+   |
+   = note: import paths are delimited using `::`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/specialization/issue-40582.rs
+++ b/tests/ui/specialization/issue-40582.rs
@@ -1,0 +1,35 @@
+// check-pass
+// known-bug: #40582
+
+// Should fail. Should not be possible to implement `make_static`.
+
+#![feature(specialization)]
+#![allow(incomplete_features)]
+
+trait FromRef<'a, T: ?Sized> {
+    fn from_ref(r: &'a T) -> Self;
+}
+
+impl<'a, T: ?Sized> FromRef<'a, T> for &'a T {
+    fn from_ref(r: &'a T) -> Self {
+        r
+    }
+}
+
+impl<'a, T: ?Sized, R> FromRef<'a, T> for R {
+    default fn from_ref(_: &'a T) -> Self {
+        unimplemented!()
+    }
+}
+
+fn make_static<T: ?Sized>(data: &T) -> &'static T {
+    fn helper<T: ?Sized, R>(data: &T) -> R {
+        R::from_ref(data)
+    }
+    helper(data)
+}
+
+fn main() {
+    let s = "specialization".to_owned();
+    println!("{:?}", make_static(s.as_str()));
+}

--- a/tests/ui/specialization/specialization-default-items-drop-coherence.rs
+++ b/tests/ui/specialization/specialization-default-items-drop-coherence.rs
@@ -1,0 +1,30 @@
+// check-pass
+// known-bug: #105782
+
+// Should fail. Default items completely drop candidates instead of ambiguity,
+// which is unsound during coherence, since coherence requires completeness.
+
+#![feature(specialization)]
+#![allow(incomplete_features)]
+
+trait Default {
+   type Id;
+}
+
+impl<T> Default for T {
+   default type Id = T;
+}
+
+trait Overlap {
+   type Assoc;
+}
+
+impl Overlap for u32 {
+   type Assoc = usize;
+}
+
+impl Overlap for <u32 as Default>::Id {
+   type Assoc = Box<usize>;
+}
+
+fn main() {}

--- a/tests/ui/thread-local/thread-local-static-ref-use-after-free.rs
+++ b/tests/ui/thread-local/thread-local-static-ref-use-after-free.rs
@@ -1,0 +1,46 @@
+// check-pass
+// known-bug: #49682
+// edition:2021
+
+// Should fail. Keeping references to thread local statics can result in a
+// use-after-free.
+
+#![feature(thread_local)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+#[allow(dead_code)]
+#[thread_local]
+static FOO: AtomicUsize = AtomicUsize::new(0);
+
+#[allow(dead_code)]
+async fn bar() {}
+
+#[allow(dead_code)]
+async fn foo() {
+    let r = &FOO;
+    bar().await;
+    r.load(Ordering::SeqCst);
+}
+
+fn main() {
+    // &FOO = 0x7fd1e9cbf6d0
+    _ = thread::spawn(|| {
+        let g = foo();
+        println!("&FOO = {:p}", &FOO);
+        g
+    })
+    .join()
+    .unwrap();
+
+    // &FOO = 0x7fd1e9cc0f50
+    println!("&FOO = {:p}", &FOO);
+
+    // &FOO = 0x7fd1e9cbf6d0
+    thread::spawn(move || {
+        println!("&FOO = {:p}", &FOO);
+    })
+    .join()
+    .unwrap();
+}

--- a/tests/ui/traits/new-solver/exponential-trait-goals.rs
+++ b/tests/ui/traits/new-solver/exponential-trait-goals.rs
@@ -1,0 +1,20 @@
+// compile-flags: -Ztrait-solver=next
+
+trait Trait {}
+
+struct W<T>(T);
+
+impl<T, U> Trait for W<(W<T>, W<U>)>
+where
+    W<T>: Trait,
+    W<U>: Trait,
+{
+}
+
+fn impls<T: Trait>() {}
+
+fn main() {
+    impls::<W<_>>();
+    //~^ ERROR type annotations needed
+    //~| ERROR overflow evaluating the requirement `W<_>: Trait`
+}

--- a/tests/ui/traits/new-solver/exponential-trait-goals.stderr
+++ b/tests/ui/traits/new-solver/exponential-trait-goals.stderr
@@ -1,0 +1,23 @@
+error[E0282]: type annotations needed
+  --> $DIR/exponential-trait-goals.rs:17:5
+   |
+LL |     impls::<W<_>>();
+   |     ^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `impls`
+
+error[E0275]: overflow evaluating the requirement `W<_>: Trait`
+  --> $DIR/exponential-trait-goals.rs:17:5
+   |
+LL |     impls::<W<_>>();
+   |     ^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`exponential_trait_goals`)
+note: required by a bound in `impls`
+  --> $DIR/exponential-trait-goals.rs:14:13
+   |
+LL | fn impls<T: Trait>() {}
+   |             ^^^^^ required by this bound in `impls`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0275, E0282.
+For more information about an error, try `rustc --explain E0275`.


### PR DESCRIPTION
Successful merges:

 - #105745 (docs(std): clarify remove_dir_all errors)
 - #106599 (Change memory ordering in System wrapper example)
 - #108611 (lint/ctypes: ext. abi fn-ptr in internal abi fn)
 - #110614 (Clear response values for overflow in new solver)
 - #110838 (More `Typefoldable`/`TypeVisitable` cleanups)
 - #110851 (compiletest: emit assembly-output header in error)
 - #110873 (Migrate trivially translatable `rustc_parse` diagnostics)
 - #110878 (Add `known-bug` tests for 4 unsound issues)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=105745,106599,108611,110614,110838,110851,110873,110878)
<!-- homu-ignore:end -->