### PR TITLE
Bump libffi-sys to 2.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "libffi-sys"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc65067b78c0fc069771e8b9a9e02df71e08858bec92c1f101377c67b9dca7c7"
+checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
Bump libffi-sys to 2.3.0 that includes LoongArch support.

Thanks

Related: https://github.com/rust-lang/miri/pull/2858