### PR TITLE
Remove unused std::sys_common::thread_local_key::Key

### DIFF
--- a/library/std/src/sys_common/thread_local_key.rs
+++ b/library/std/src/sys_common/thread_local_key.rs
@@ -87,31 +87,6 @@ pub struct StaticKey {
     dtor: Option<unsafe extern "C" fn(*mut u8)>,
 }
 
-/// A type for a safely managed OS-based TLS slot.
-///
-/// This type allocates an OS TLS key when it is initialized and will deallocate
-/// the key when it falls out of scope. When compared with `StaticKey`, this
-/// type is entirely safe to use.
-///
-/// Implementations will likely, however, contain unsafe code as this type only
-/// operates on `*mut u8`, a raw pointer.
-///
-/// # Examples
-///
-/// ```ignore (cannot-doctest-private-modules)
-/// use tls::os::Key;
-///
-/// let key = Key::new(None);
-/// assert!(key.get().is_null());
-/// key.set(1 as *mut u8);
-/// assert!(!key.get().is_null());
-///
-/// drop(key); // deallocate this TLS slot.
-/// ```
-pub struct Key {
-    key: imp::Key,
-}
-
 /// Constant initialization value for static TLS keys.
 ///
 /// This value specifies no destructor by default.
@@ -192,41 +167,5 @@ impl StaticKey {
                 n
             }
         }
-    }
-}
-
-impl Key {
-    /// Creates a new managed OS TLS key.
-    ///
-    /// This key will be deallocated when the key falls out of scope.
-    ///
-    /// The argument provided is an optionally-specified destructor for the
-    /// value of this TLS key. When a thread exits and the value for this key
-    /// is non-null the destructor will be invoked. The TLS value will be reset
-    /// to null before the destructor is invoked.
-    ///
-    /// Note that the destructor will not be run when the `Key` goes out of
-    /// scope.
-    #[inline]
-    pub fn new(dtor: Option<unsafe extern "C" fn(*mut u8)>) -> Key {
-        Key { key: unsafe { imp::create(dtor) } }
-    }
-
-    /// See StaticKey::get
-    #[inline]
-    pub fn get(&self) -> *mut u8 {
-        unsafe { imp::get(self.key) }
-    }
-
-    /// See StaticKey::set
-    #[inline]
-    pub fn set(&self, val: *mut u8) {
-        unsafe { imp::set(self.key, val) }
-    }
-}
-
-impl Drop for Key {
-    fn drop(&mut self) {
-        unsafe { imp::destroy(self.key) }
     }
 }

--- a/library/std/src/sys_common/thread_local_key/tests.rs
+++ b/library/std/src/sys_common/thread_local_key/tests.rs
@@ -1,23 +1,5 @@
-use super::{Key, StaticKey};
+use super::StaticKey;
 use core::ptr;
-
-fn assert_sync<T: Sync>() {}
-fn assert_send<T: Send>() {}
-
-#[test]
-fn smoke() {
-    assert_sync::<Key>();
-    assert_send::<Key>();
-
-    let k1 = Key::new(None);
-    let k2 = Key::new(None);
-    assert!(k1.get().is_null());
-    assert!(k2.get().is_null());
-    k1.set(ptr::invalid_mut(1));
-    k2.set(ptr::invalid_mut(2));
-    assert_eq!(k1.get() as usize, 1);
-    assert_eq!(k2.get() as usize, 2);
-}
 
 #[test]
 fn statik() {


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/110897

This `Key` type seems unused. Let's remove it and see if anything explodes. :)