### PR TITLE
rustdoc: Fix missing `repr` attribute in doc(inline) on foreign items

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -344,7 +344,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     ungated!(link_name, Normal, template!(NameValueStr: "name"), FutureWarnPreceding),
     ungated!(no_link, Normal, template!(Word), WarnFollowing),
-    ungated!(repr, Normal, template!(List: "C"), DuplicatesOk, @only_local: true),
+    ungated!(repr, Normal, template!(List: "C"), DuplicatesOk),
     ungated!(export_name, Normal, template!(NameValueStr: "name"), FutureWarnPreceding),
     ungated!(link_section, Normal, template!(NameValueStr: "name"), FutureWarnPreceding),
     ungated!(no_mangle, Normal, template!(Word), WarnFollowing, @only_local: true),

--- a/tests/rustdoc/inline_cross/auxiliary/repr.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/repr.rs
@@ -1,0 +1,4 @@
+#[repr(C)]
+pub struct Foo {
+    field: u8,
+}

--- a/tests/rustdoc/inline_cross/repr.rs
+++ b/tests/rustdoc/inline_cross/repr.rs
@@ -1,0 +1,13 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/110698>.
+// This test ensures that the re-exported items still have the `#[repr(...)]` attribute.
+
+// aux-build:repr.rs
+
+#![crate_name = "foo"]
+
+extern crate repr;
+
+// @has 'foo/struct.Foo.html'
+// @has - '//*[@class="rust item-decl"]//*[@class="code-attribute"]' '#[repr(C)]'
+#[doc(inline)]
+pub use repr::Foo;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/110698.

r? @notriddle 