### PR TITLE
fix: :bug: etc/bash_complettion -> src/etc/... to avoid copy error

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1068,7 +1068,11 @@ impl Step for Cargo {
 
         tarball.add_file(&cargo, "bin", 0o755);
         tarball.add_file(etc.join("_cargo"), "share/zsh/site-functions", 0o644);
-        tarball.add_renamed_file(etc.join("cargo.bashcomp.sh"), "etc/bash_completion.d", "cargo");
+        tarball.add_renamed_file(
+            etc.join("cargo.bashcomp.sh"),
+            "src/etc/bash_completion.d",
+            "cargo",
+        );
         tarball.add_dir(etc.join("man"), "share/man/man1");
         tarball.add_legal_and_readme_to("share/doc/cargo");
 


### PR DESCRIPTION
## why

I got an error on executing `./x.py build && ./x.py install`.

Found creating some folder in  `/etc/bash_completion.d/`, It appears to be incorrect to attempt to create a folder in `/etc/bash_completion.d/`, as this proccess requires `sudo`.

Fixes #111653

```
Uplifting rustc (stage1 -> stage3)
Building tool cargo (stage2 -> stage3, x86_64-unknown-linux-gnu)
    Finished release [optimized] target(s) in 0.16s
Building tool cargo-credential-1password (stage2 -> stage3, x86_64-unknown-linux-gnu)
    Finished release [optimized] target(s) in 0.06s
Dist cargo-1.71.0-dev-x86_64-unknown-linux-gnu
        finished in 10.700 seconds
Installing stage2 cargo (x86_64-unknown-linux-gnu)
install: uninstalling component 'cargo'
install: creating uninstall script at /home/ekusiadadus/.rustup/toolchains/dev/lib/rustlib/uninstall.sh
install: installing component 'cargo'
/home/ekusiadadus/dev/rust/rust/build/tmp/tarball/cargo/x86_64-unknown-linux-gnu/cargo-1.71.0-dev-x86_64-unknown-linux-gnu/install.sh: 310: cd: can't cd to /etc/bash_completion.d
cp: cannot create regular file '/cargo': Permission denied
chmod: cannot access '/cargo': No such file or directory
install: error: file creation failed. see logs at '/home/ekusiadadus/.rustup/toolchains/dev/lib/rustlib/install.log'
Build completed unsuccessfully in 0:01:11
```

Error Log

```
install: uninstalling component 'cargo'
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/bin/cargo
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/bin/cargo
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/libexec/cargo-credential-1password
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/libexec/cargo-credential-1password
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/doc/rust/LICENSE-APACHE
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/doc/rust/LICENSE-APACHE
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/doc/rust/LICENSE-MIT
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/doc/rust/LICENSE-MIT
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/doc/rust/LICENSE-THIRD-PARTY
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/doc/rust/LICENSE-THIRD-PARTY
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/doc/rust/README.md
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/doc/rust/README.md
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-add.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-add.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-bench.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-bench.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-build.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-build.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-check.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-check.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-clean.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-clean.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-doc.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-doc.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-fetch.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-fetch.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-fix.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-fix.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-generate-lockfile.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-generate-lockfile.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-help.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-help.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-init.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-init.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-install.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-install.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-locate-project.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-locate-project.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-login.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-login.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-logout.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-logout.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-metadata.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-metadata.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-new.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-new.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-owner.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-owner.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-package.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-package.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-pkgid.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-pkgid.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-publish.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-publish.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-remove.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-remove.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-report.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-report.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-run.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-run.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-rustc.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-rustc.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-rustdoc.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-rustdoc.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-search.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-search.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-test.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-test.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-tree.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-tree.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-uninstall.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-uninstall.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-update.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-update.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-vendor.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-vendor.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-verify-project.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-verify-project.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-version.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-version.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-yank.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo-yank.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo.1
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/man/man1/cargo.1
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/share/zsh/site-functions/_cargo
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/share/zsh/site-functions/_cargo
install: removing file /home/ekusiadadus/.rustup/toolchains/dev/src/etc/bash_completion.d/cargo
$ rm -f /home/ekusiadadus/.rustup/toolchains/dev/src/etc/bash_completion.d/cargo
install: removing component manifest /home/ekusiadadus/.rustup/toolchains/dev/lib/rustlib/manifest-cargo
$ rm /home/ekusiadadus/.rustup/toolchains/dev/lib/rustlib/manifest-cargo
$ echo "rust-analyzer-preview
rustfmt-preview
rust-demangler-preview
clippy-preview
miri-preview
llvm-tools-preview
rust-src
rustc
rust-docs
rust-std-x86_64-unknown-linux-gnu" > "/home/ekusiadadus/.rustup/toolchains/dev/lib/rustlib/components"
$ umask 022 && mkdir -p "/home/ekusiadadus/.rustup/toolchains/dev/lib/rustlib"
$ echo "3" > "/home/ekusiadadus/.rustup/toolchains/dev/lib/rustlib/rust-installer-version"
install: creating uninstall script at /home/ekusiadadus/.rustup/toolchains/dev/lib/rustlib/uninstall.sh
$ cp /home/ekusiadadus/dev/rust/rust/build/tmp/tarball/cargo/x86_64-unknown-linux-gnu/cargo-1.71.0-dev-x86_64-unknown-linux-gnu/install.sh /home/ekusiadadus/.rustup/toolchains/dev/lib/rustlib/uninstall.sh
install: installing component 'cargo'
$ echo "cargo" >> "/home/ekusiadadus/.rustup/toolchains/dev/lib/rustlib/components"
$ umask 022 && mkdir -p "/home/ekusiadadus/.rustup/toolchains/dev/bin"
install: copying file /home/ekusiadadus/.rustup/toolchains/dev/bin/cargo
$ cp /home/ekusiadadus/dev/rust/rust/build/tmp/tarball/cargo/x86_64-unknown-linux-gnu/cargo-1.71.0-dev-x86_64-unknown-linux-gnu/cargo/bin/cargo /home/ekusiadadus/.rustup/toolchains/dev/bin/cargo
$ chmod 755 /home/ekusiadadus/.rustup/toolchains/dev/bin/cargo
$ echo "file:/home/ekusiadadus/.rustup/toolchains/dev/bin/cargo" >> "/home/ekusiadadus/.rustup/toolchains/dev/lib/rustlib/manifest-cargo"
$ umask 022 && mkdir -p "/etc/bash_completion.d"
install: copying file /cargo
$ cp /home/ekusiadadus/dev/rust/rust/build/tmp/tarball/cargo/x86_64-unknown-linux-gnu/cargo-1.71.0-dev-x86_64-unknown-linux-gnu/cargo/etc/bash_completion.d/cargo /cargo
$ chmod 644 /cargo
install: error: file creation failed. see logs at '/home/ekusiadadus/.rustup/toolchains/dev/lib/rustlib/install.log'
```
