### PR TITLE
(do not merge) perf.rlo run for v0 symbol mangling

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -849,7 +849,7 @@ impl Options {
     }
 
     pub fn get_symbol_mangling_version(&self) -> SymbolManglingVersion {
-        self.cg.symbol_mangling_version.unwrap_or(SymbolManglingVersion::Legacy)
+        self.cg.symbol_mangling_version.unwrap_or(SymbolManglingVersion::V0)
     }
 
     #[allow(rustc::bad_opt_access)]


### PR DESCRIPTION
Let's see if we can get perf.rlo results in time for the compiler team steering meeting today.

r? @ghost