### PR TITLE
rustdoc: render visibility on associated types

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -787,10 +787,12 @@ fn assoc_type(
     indent: usize,
     cx: &Context<'_>,
 ) {
+    let tcx = cx.tcx();
     write!(
         w,
-        "{indent}type <a{href} class=\"associatedtype\">{name}</a>{generics}",
+        "{indent}{vis}type <a{href} class=\"associatedtype\">{name}</a>{generics}",
         indent = " ".repeat(indent),
+        vis = visibility_print_with_space(it.visibility(tcx), it.item_id, cx),
         href = assoc_href_attr(it, link, cx),
         name = it.name.as_ref().unwrap(),
         generics = generics.print(cx),

--- a/tests/rustdoc/anchors.no_type_anchor2.html
+++ b/tests/rustdoc/anchors.no_type_anchor2.html
@@ -1,1 +1,1 @@
-<section id="associatedtype.Y" class="associatedtype"><h4 class="code-header">type <a href="#associatedtype.Y" class="associatedtype">Y</a> = <a class="primitive" href="{{channel}}/std/primitive.u32.html">u32</a></h4></section>
+<section id="associatedtype.Y" class="associatedtype"><h4 class="code-header">pub type <a href="#associatedtype.Y" class="associatedtype">Y</a> = <a class="primitive" href="https://doc.rust-lang.org/nightly/std/primitive.u32.html">u32</a></h4></section>

--- a/tests/rustdoc/anchors.no_type_anchor2.html
+++ b/tests/rustdoc/anchors.no_type_anchor2.html
@@ -1,1 +1,1 @@
-<section id="associatedtype.Y" class="associatedtype"><h4 class="code-header">pub type <a href="#associatedtype.Y" class="associatedtype">Y</a> = <a class="primitive" href="https://doc.rust-lang.org/nightly/std/primitive.u32.html">u32</a></h4></section>
+<section id="associatedtype.Y" class="associatedtype"><h4 class="code-header">pub type <a href="#associatedtype.Y" class="associatedtype">Y</a> = <a class="primitive" href="{{channel}}/std/primitive.u32.html">u32</a></h4></section>

--- a/tests/rustdoc/visibility.rs
+++ b/tests/rustdoc/visibility.rs
@@ -1,6 +1,8 @@
 // compile-flags: --document-private-items
 
 #![crate_name = "foo"]
+#![feature(inherent_associated_types)]
+#![allow(incomplete_features)]
 
 // @!has 'foo/index.html' '//a[@href="struct.FooPublic.html"]/..' 'FooPublic 🔒'
 // @has 'foo/struct.FooPublic.html' '//pre' 'pub struct FooPublic'
@@ -102,4 +104,27 @@ impl PubTrait for FooPublic {
     type Type = usize;
     const CONST: usize = 0;
     fn function() {}
+}
+
+pub struct Assoc;
+
+// @has foo/struct.Assoc.html
+impl Assoc {
+    // @has - '//*[@id="associatedtype.TypePub"]' 'pub type TypePub'
+    pub type TypePub = usize;
+
+    // @has - '//*[@id="associatedtype.TypePriv"]' 'pub(crate) type TypePriv'
+    type TypePriv = usize;
+
+    // @has - '//*[@id="associatedconstant.CONST_PUB"]' 'pub const CONST_PUB'
+    pub const CONST_PUB: usize = 0;
+
+    // @has - '//*[@id="associatedconstant.CONST_PRIV"]' 'pub(crate) const CONST_PRIV'
+    const CONST_PRIV: usize = 0;
+
+    // @has - '//*[@id="method.function_pub"]' 'pub fn function_pub()'
+    pub fn function_pub() {}
+
+    // @has - '//*[@id="method.function_priv"]' 'pub(crate) fn function_priv()'
+    fn function_priv() {}
 }


### PR DESCRIPTION
This should only affect inherent associated types (#8995).