### PR TITLE
run-make test: using single quotes to not trigger the shell

### DIFF
--- a/tests/run-make/inaccessible-temp-dir/Makefile
+++ b/tests/run-make/inaccessible-temp-dir/Makefile
@@ -25,7 +25,7 @@ all:
 	# Run rustc with `-Ztemps-dir` set to a directory 
 	# *inside* the inaccessible one, so that it can't create it
 	$(RUSTC) program.rs -Ztemps-dir=$(TMPDIR)/inaccessible/tmp 2>&1 \
-		| $(CGREP) "failed to find or create the directory specified by `--temps-dir`"
+		| $(CGREP) 'failed to find or create the directory specified by `--temps-dir`'
 
 	# Make the inaccessible directory accessible,
 	# so that compiletest can delete the temp dir


### PR DESCRIPTION
This test got added in #110801.

I'm no expert on Makefiles, but IIUC this command is passed to the shell, which usually tries to execute commands specified in between backticks in double-quoted strings.

Using single quotes should fix this, I think. (Note: Waiting for CI to test this, since I only have a web browser available right now).

r? @jyn514

cc @WaffleLapkin 

Since this is breaking our build bot, even if it is not directly LLVM related: @rustbot label: +llvm-main