### PR TITLE
Add support for LibreSSL 3.7.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,9 +2370,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.84"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
This updates the `openssl-sys` crate to 0.9.87 to support building the toolchain against the system libraries provided by LibreSSL version 3.7.x.

LibreSSL 3.7.x has been supported since `openssl-sys` version 0.9.85.