### PR TITLE
Update awscli

### DIFF
--- a/src/ci/scripts/install-awscli.sh
+++ b/src/ci/scripts/install-awscli.sh
@@ -10,15 +10,14 @@
 #
 # Before compressing please make sure all the wheels end with `-none-any.whl`.
 # If that's not the case you'll need to remove the non-cross-platform ones and
-# replace them with the .tar.gz downloaded from https://pypi.org. Also make
-# sure it's possible to call this script with both Python 2 and Python 3.
+# replace them with the .tar.gz downloaded from https://pypi.org.
 
 set -euo pipefail
 IFS=$'\n\t'
 
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
-MIRROR="${MIRRORS_BASE}/2019-07-27-awscli.tar"
+MIRROR="${MIRRORS_BASE}/2023-04-28-awscli.tar"
 DEPS_DIR="/tmp/awscli-deps"
 
 pip="pip"
@@ -29,6 +28,8 @@ if isLinux; then
 
     sudo apt-get install -y python3-setuptools python3-wheel
     ciCommandAddPath "${HOME}/.local/bin"
+elif isMacOS; then
+    pip="pip3"
 fi
 
 mkdir -p "${DEPS_DIR}"


### PR DESCRIPTION
The Windows GitHub Actions image just updated to pip 23.1.1 which broke the PyYaml installer in the current AWS CLI mirror.  It now requires setuptools, wheel, and Cython to be installed manually.  This updates to include that, as well as updating the versions of all the packages. This also now uses python3 on macOS since python2 doesn't work with the newer versions.

I have only tested that these install correctly, but not that they work correctly.

Pietro mentioned that we should just switch to aws cli 2, which I agree is probably the better solution. I'm posting this PR in case it helps unblock CI.
