### PR TITLE
fix false negative for `unused_mut`

### DIFF
--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -360,7 +360,7 @@ impl Printer {
 
     fn check_stack(&mut self, mut depth: usize) {
         while let Some(&index) = self.scan_stack.back() {
-            let mut entry = &mut self.buf[index];
+            let entry = &mut self.buf[index];
             match entry.token {
                 Token::Begin(_) => {
                     if depth == 0 {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -935,6 +935,7 @@ enum InitializationRequiringAction {
     PartialAssignment,
 }
 
+#[derive(Debug)]
 struct RootPlace<'tcx> {
     place_local: Local,
     place_projection: &'tcx [PlaceElem<'tcx>],
@@ -1848,11 +1849,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         // is allowed, remove this match arm.
                         ty::Adt(..) | ty::Tuple(..) => {
                             check_parent_of_field(self, location, place_base, span, flow_state);
-
-                            // rust-lang/rust#21232, #54499, #54986: during period where we reject
-                            // partial initialization, do not complain about unnecessary `mut` on
-                            // an attempt to do a partial initialization.
-                            self.used_mut.insert(place.local);
                         }
 
                         _ => {}
@@ -1940,6 +1936,11 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     (prefix, base, span),
                     mpi,
                 );
+
+                // rust-lang/rust#21232, #54499, #54986: during period where we reject
+                // partial initialization, do not complain about unnecessary `mut` on
+                // an attempt to do a partial initialization.
+                this.used_mut.insert(base.local);
             }
         }
     }

--- a/compiler/rustc_borrowck/src/member_constraints.rs
+++ b/compiler/rustc_borrowck/src/member_constraints.rs
@@ -221,7 +221,7 @@ fn append_list(
 ) {
     let mut p = target_list;
     loop {
-        let mut r = &mut constraints[p];
+        let r = &mut constraints[p];
         match r.next_constraint {
             Some(q) => p = q,
             None => {

--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -421,7 +421,7 @@ fn resolve_expr<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, expr: &'tcx h
             let target_scopes = visitor.fixup_scopes.drain(start_point..);
 
             for scope in target_scopes {
-                let mut yield_data =
+                let yield_data =
                     visitor.scope_tree.yield_in_scope.get_mut(&scope).unwrap().last_mut().unwrap();
                 let count = yield_data.expr_and_pat_count;
                 let span = yield_data.span;

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -917,7 +917,7 @@ mod parse {
             }
         }
 
-        let mut options = slot.get_or_insert_default();
+        let options = slot.get_or_insert_default();
         let mut seen_always = false;
         let mut seen_never = false;
         let mut seen_ignore_loops = false;

--- a/tests/ui/lint/unused/lint-unused-mut-variables.rs
+++ b/tests/ui/lint/unused/lint-unused-mut-variables.rs
@@ -205,3 +205,11 @@ fn bar() {
     let mut b = vec![2]; //~ ERROR: variable does not need to be mutable
 
 }
+
+struct Arg(i32);
+
+// Regression test for https://github.com/rust-lang/rust/issues/110849
+fn write_through_reference(mut arg: &mut Arg) {
+    //~^ WARN: variable does not need to be mutable
+    arg.0 = 1
+}

--- a/tests/ui/lint/unused/lint-unused-mut-variables.stderr
+++ b/tests/ui/lint/unused/lint-unused-mut-variables.stderr
@@ -218,5 +218,13 @@ note: the lint level is defined here
 LL | #[deny(unused_mut)]
    |        ^^^^^^^^^^
 
-error: aborting due to previous error; 25 warnings emitted
+warning: variable does not need to be mutable
+  --> $DIR/lint-unused-mut-variables.rs:212:28
+   |
+LL | fn write_through_reference(mut arg: &mut Arg) {
+   |                            ----^^^
+   |                            |
+   |                            help: remove this `mut`
+
+error: aborting due to previous error; 26 warnings emitted
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
@@ -11,7 +11,7 @@ fn main() {
     let mut map = HashMap::new();
     map.insert("a", Test { v: 0 });
 
-    for (_k, mut v) in map.iter_mut() {
+    for (_k, v) in map.iter_mut() {
         //~^ HELP use mutable method
         //~| NOTE this iterator yields `&` references
         v.v += 1;

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
@@ -11,7 +11,7 @@ fn main() {
     let mut map = HashMap::new();
     map.insert("a", Test { v: 0 });
 
-    for (_k, mut v) in map.iter() {
+    for (_k, v) in map.iter() {
         //~^ HELP use mutable method
         //~| NOTE this iterator yields `&` references
         v.v += 1;

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
@@ -1,11 +1,11 @@
 error[E0594]: cannot assign to `v.v`, which is behind a `&` reference
   --> $DIR/suggest-mut-method-for-loop-hashmap.rs:17:9
    |
-LL |     for (_k, mut v) in map.iter() {
-   |                        ----------
-   |                        |   |
-   |                        |   help: use mutable method: `iter_mut()`
-   |                        this iterator yields `&` references
+LL |     for (_k, v) in map.iter() {
+   |                    ----------
+   |                    |   |
+   |                    |   help: use mutable method: `iter_mut()`
+   |                    this iterator yields `&` references
 ...
 LL |         v.v += 1;
    |         ^^^^^^^^ `v` is a `&` reference, so the data it refers to cannot be written


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/110849

We want to avoid double diagnostics for code like this, but only if an error actually occurs:
```rust
fn main() {
    let mut x: (i32, i32);
    x.0 = 1;
}
```

The first commit fixes the lint and the second one removes all the unused `mut`s it found.