### PR TITLE
Guarantee result nonzero for FFI

### DIFF
--- a/tests/ui/abi/nonzero-option-result-ffi.rs
+++ b/tests/ui/abi/nonzero-option-result-ffi.rs
@@ -1,0 +1,125 @@
+// run-pass
+
+use std::mem;
+use std::num::*;
+
+macro_rules! define_with_type {
+    ($namespace: ident, $ty: ty, $abi_ty: ty) => {
+        mod $namespace {
+            #[allow(unused)]
+            use super::*;
+
+            #[inline(never)]
+            pub extern "C" fn option(is_some: bool, value: $ty) -> Option<$ty> {
+                if is_some {
+                    Some(value)
+                } else {
+                    None
+                }
+            }
+
+            #[inline(never)]
+            pub extern "C" fn result_pos(is_ok: bool, value: $ty) -> Result<$ty, ()> {
+                if is_ok {
+                    Ok(value)
+                } else {
+                    Err(())
+                }
+            }
+
+            #[inline(never)]
+            pub extern "C" fn result_neg(is_ok: bool, value: $ty) -> Result<(), $ty> {
+                if is_ok {
+                    Ok(())
+                } else {
+                    Err(value)
+                }
+            }
+
+            #[inline(never)]
+            pub extern "C" fn option_param(value: Option<$ty>) -> $abi_ty {
+                unsafe { mem::transmute(value) }
+            }
+
+            #[inline(never)]
+            pub extern "C" fn result_param_pos(value: Result<$ty, ()>) -> $abi_ty {
+                unsafe { mem::transmute(value) }
+            }
+
+            #[inline(never)]
+            pub extern "C" fn result_param_neg(value: Result<(), $ty>) -> $abi_ty {
+                unsafe { mem::transmute(value) }
+            }
+        }
+    };
+}
+
+define_with_type!(nonzero_i8, NonZeroI8, i8);
+define_with_type!(nonzero_i16, NonZeroI16, i16);
+define_with_type!(nonzero_i32, NonZeroI32, i32);
+define_with_type!(nonzero_i64, NonZeroI64, i64);
+define_with_type!(nonzero_u8, NonZeroU8, u8);
+define_with_type!(nonzero_u16, NonZeroU16, u16);
+define_with_type!(nonzero_u32, NonZeroU32, u32);
+define_with_type!(nonzero_u64, NonZeroU64, u64);
+define_with_type!(nonzero_usize, NonZeroUsize, usize);
+define_with_type!(nonzero_ref, &'static i32, *const i32);
+
+pub fn main() {
+    macro_rules! test_with_type {
+        (
+            $namespace: ident,
+            $ty: ty,
+            $abi_ty: ty,
+            $in_value: expr,
+            $out_value: expr,
+            $null_value:expr
+        ) => {
+            let in_value: $ty = $in_value;
+            let out_value: $abi_ty = $out_value;
+            let null_value: $abi_ty = $null_value;
+            unsafe {
+                let f: extern "C" fn(bool, $ty) -> $abi_ty =
+                    mem::transmute($namespace::option as extern "C" fn(bool, $ty) -> Option<$ty>);
+                assert_eq!(f(true, in_value), out_value);
+                assert_eq!(f(false, in_value), null_value);
+            }
+
+            unsafe {
+                let f: extern "C" fn(bool, $ty) -> $abi_ty = mem::transmute(
+                    $namespace::result_pos as extern "C" fn(bool, $ty) -> Result<$ty, ()>,
+                );
+                assert_eq!(f(true, in_value), out_value);
+                assert_eq!(f(false, in_value), null_value);
+            }
+
+            unsafe {
+                let f: extern "C" fn(bool, $ty) -> $abi_ty = mem::transmute(
+                    $namespace::result_neg as extern "C" fn(bool, $ty) -> Result<(), $ty>,
+                );
+                assert_eq!(f(false, in_value), out_value);
+                assert_eq!(f(true, in_value), null_value);
+            }
+
+            assert_eq!($namespace::option_param(Some(in_value)), out_value);
+            assert_eq!($namespace::option_param(None), null_value);
+
+            assert_eq!($namespace::result_param_pos(Ok(in_value)), out_value);
+            assert_eq!($namespace::result_param_pos(Err(())), null_value);
+
+            assert_eq!($namespace::result_param_neg(Err(in_value)), out_value);
+            assert_eq!($namespace::result_param_neg(Ok(())), null_value);
+        };
+    }
+    test_with_type!(nonzero_i8, NonZeroI8, i8, NonZeroI8::new(123).unwrap(), 123, 0);
+    test_with_type!(nonzero_i16, NonZeroI16, i16, NonZeroI16::new(1234).unwrap(), 1234, 0);
+    test_with_type!(nonzero_i32, NonZeroI32, i32, NonZeroI32::new(1234).unwrap(), 1234, 0);
+    test_with_type!(nonzero_i64, NonZeroI64, i64, NonZeroI64::new(1234).unwrap(), 1234, 0);
+    test_with_type!(nonzero_u8, NonZeroU8, u8, NonZeroU8::new(123).unwrap(), 123, 0);
+    test_with_type!(nonzero_u16, NonZeroU16, u16, NonZeroU16::new(1234).unwrap(), 1234, 0);
+    test_with_type!(nonzero_u32, NonZeroU32, u32, NonZeroU32::new(1234).unwrap(), 1234, 0);
+    test_with_type!(nonzero_u64, NonZeroU64, u64, NonZeroU64::new(1234).unwrap(), 1234, 0);
+    test_with_type!(nonzero_usize, NonZeroUsize, usize, NonZeroUsize::new(1234).unwrap(), 1234, 0);
+    static FOO: i32 = 0xDEADBEE;
+    test_with_type!(nonzero_ref, &'static i32, *const i32, &FOO, &FOO, std::ptr::null());
+}

--- a/tests/ui/lint/lint-ctypes-enum.rs
+++ b/tests/ui/lint/lint-ctypes-enum.rs
@@ -56,37 +56,66 @@ union TransparentUnion<T: Copy> {
 struct Rust<T>(T);
 
 extern "C" {
-   fn zf(x: Z);
-   fn uf(x: U); //~ ERROR `extern` block uses type `U`
-   fn bf(x: B); //~ ERROR `extern` block uses type `B`
-   fn tf(x: T); //~ ERROR `extern` block uses type `T`
-   fn repr_c(x: ReprC);
-   fn repr_u8(x: U8);
-   fn repr_isize(x: Isize);
-   fn option_ref(x: Option<&'static u8>);
-   fn option_fn(x: Option<extern "C" fn()>);
-   fn nonnull(x: Option<std::ptr::NonNull<u8>>);
-   fn unique(x: Option<std::ptr::Unique<u8>>);
-   fn nonzero_u8(x: Option<num::NonZeroU8>);
-   fn nonzero_u16(x: Option<num::NonZeroU16>);
-   fn nonzero_u32(x: Option<num::NonZeroU32>);
-   fn nonzero_u64(x: Option<num::NonZeroU64>);
-   fn nonzero_u128(x: Option<num::NonZeroU128>);
-   //~^ ERROR `extern` block uses type `u128`
-   fn nonzero_usize(x: Option<num::NonZeroUsize>);
-   fn nonzero_i8(x: Option<num::NonZeroI8>);
-   fn nonzero_i16(x: Option<num::NonZeroI16>);
-   fn nonzero_i32(x: Option<num::NonZeroI32>);
-   fn nonzero_i64(x: Option<num::NonZeroI64>);
-   fn nonzero_i128(x: Option<num::NonZeroI128>);
-   //~^ ERROR `extern` block uses type `i128`
-   fn nonzero_isize(x: Option<num::NonZeroIsize>);
-   fn transparent_struct(x: Option<TransparentStruct<num::NonZeroU8>>);
-   fn transparent_enum(x: Option<TransparentEnum<num::NonZeroU8>>);
-   fn transparent_union(x: Option<TransparentUnion<num::NonZeroU8>>);
-   //~^ ERROR `extern` block uses type
-   fn repr_rust(x: Option<Rust<num::NonZeroU8>>); //~ ERROR `extern` block uses type
-   fn no_result(x: Result<(), num::NonZeroI32>); //~ ERROR `extern` block uses type
+    fn zf(x: Z);
+    fn uf(x: U); //~ ERROR `extern` block uses type `U`
+    fn bf(x: B); //~ ERROR `extern` block uses type `B`
+    fn tf(x: T); //~ ERROR `extern` block uses type `T`
+    fn repr_c(x: ReprC);
+    fn repr_u8(x: U8);
+    fn repr_isize(x: Isize);
+    fn option_ref(x: Option<&'static u8>);
+    fn option_fn(x: Option<extern "C" fn()>);
+    fn nonnull(x: Option<std::ptr::NonNull<u8>>);
+    fn unique(x: Option<std::ptr::Unique<u8>>);
+    fn nonzero_u8(x: Option<num::NonZeroU8>);
+    fn nonzero_u16(x: Option<num::NonZeroU16>);
+    fn nonzero_u32(x: Option<num::NonZeroU32>);
+    fn nonzero_u64(x: Option<num::NonZeroU64>);
+    fn nonzero_u128(x: Option<num::NonZeroU128>);
+    //~^ ERROR `extern` block uses type `u128`
+    fn nonzero_usize(x: Option<num::NonZeroUsize>);
+    fn nonzero_i8(x: Option<num::NonZeroI8>);
+    fn nonzero_i16(x: Option<num::NonZeroI16>);
+    fn nonzero_i32(x: Option<num::NonZeroI32>);
+    fn nonzero_i64(x: Option<num::NonZeroI64>);
+    fn nonzero_i128(x: Option<num::NonZeroI128>);
+    //~^ ERROR `extern` block uses type `i128`
+    fn result_nonzero_u8(x: Result<(), num::NonZeroU8>);
+    fn result_nonzero_u16(x: Result<(), num::NonZeroU16>);
+    fn result_nonzero_u32(x: Result<(), num::NonZeroU32>);
+    fn result_nonzero_u64(x: Result<(), num::NonZeroU64>);
+    fn result_nonzero_u128(x: Result<(), num::NonZeroU128>);
+    //~^ ERROR `extern` block uses type `u128`
+    fn result_nonzero_usize(x: Result<(), num::NonZeroUsize>);
+    fn result_nonzero_i8(x: Result<(), num::NonZeroI8>);
+    fn result_nonzero_i16(x: Result<(), num::NonZeroI16>);
+    fn result_nonzero_i32(x: Result<(), num::NonZeroI32>);
+    fn result_nonzero_i64(x: Result<(), num::NonZeroI64>);
+    fn result_nonzero_i128(x: Result<(), num::NonZeroI128>);
+    //~^ ERROR `extern` block uses type `i128`
+    fn left_result_nonzero_u8(x: Result<num::NonZeroU8, ()>);
+    fn left_result_nonzero_u16(x: Result<num::NonZeroU16, ()>);
+    fn left_result_nonzero_u32(x: Result<num::NonZeroU32, ()>);
+    fn left_result_nonzero_u64(x: Result<num::NonZeroU64, ()>);
+    fn left_result_nonzero_u128(x: Result<num::NonZeroU128, ()>);
+    //~^ ERROR `extern` block uses type `u128`
+    fn left_result_nonzero_usize(x: Result<num::NonZeroUsize, ()>);
+    fn left_result_nonzero_i8(x: Result<num::NonZeroI8, ()>);
+    fn left_result_nonzero_i16(x: Result<num::NonZeroI16, ()>);
+    fn left_result_nonzero_i32(x: Result<num::NonZeroI32, ()>);
+    fn left_result_nonzero_i64(x: Result<num::NonZeroI64, ()>);
+    fn left_result_nonzero_i128(x: Result<num::NonZeroI128, ()>);
+    //~^ ERROR `extern` block uses type `i128`
+    fn result_sized(x: Result<i32, num::NonZeroI128>);
+    //~^ ERROR `extern` block uses type `Result<i32, NonZeroI128>`
+    fn left_result_sized(x: Result<num::NonZeroI128, i32>);
+    //~^ ERROR `extern` block uses type `Result<NonZeroI128, i32>`
+    fn nonzero_isize(x: Option<num::NonZeroIsize>);
+    fn transparent_struct(x: Option<TransparentStruct<num::NonZeroU8>>);
+    fn transparent_enum(x: Option<TransparentEnum<num::NonZeroU8>>);
+    fn transparent_union(x: Option<TransparentUnion<num::NonZeroU8>>);
+    //~^ ERROR `extern` block uses type
+    fn repr_rust(x: Option<Rust<num::NonZeroU8>>); //~ ERROR `extern` block uses type
 }
 
 pub fn main() {}

--- a/tests/ui/lint/lint-ctypes-enum.stderr
+++ b/tests/ui/lint/lint-ctypes-enum.stderr
@@ -1,8 +1,8 @@
 error: `extern` block uses type `U`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:60:13
+  --> $DIR/lint-ctypes-enum.rs:60:14
    |
-LL |    fn uf(x: U);
-   |             ^ not FFI-safe
+LL |     fn uf(x: U);
+   |              ^ not FFI-safe
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
@@ -18,10 +18,10 @@ LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
 
 error: `extern` block uses type `B`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:61:13
+  --> $DIR/lint-ctypes-enum.rs:61:14
    |
-LL |    fn bf(x: B);
-   |             ^ not FFI-safe
+LL |     fn bf(x: B);
+   |              ^ not FFI-safe
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
@@ -32,10 +32,10 @@ LL | enum B {
    | ^^^^^^
 
 error: `extern` block uses type `T`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:62:13
+  --> $DIR/lint-ctypes-enum.rs:62:14
    |
-LL |    fn tf(x: T);
-   |             ^ not FFI-safe
+LL |     fn tf(x: T);
+   |              ^ not FFI-safe
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
@@ -46,47 +46,88 @@ LL | enum T {
    | ^^^^^^
 
 error: `extern` block uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:74:23
+  --> $DIR/lint-ctypes-enum.rs:74:24
    |
-LL |    fn nonzero_u128(x: Option<num::NonZeroU128>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+LL |     fn nonzero_u128(x: Option<num::NonZeroU128>);
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` block uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:81:23
+  --> $DIR/lint-ctypes-enum.rs:81:24
    |
-LL |    fn nonzero_i128(x: Option<num::NonZeroI128>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+LL |     fn nonzero_i128(x: Option<num::NonZeroI128>);
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
 
-error: `extern` block uses type `Option<TransparentUnion<NonZeroU8>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:86:28
+error: `extern` block uses type `u128`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:87:31
    |
-LL |    fn transparent_union(x: Option<TransparentUnion<num::NonZeroU8>>);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+LL |     fn result_nonzero_u128(x: Result<(), num::NonZeroU128>);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = note: 128-bit integers don't currently have a known stable ABI
+
+error: `extern` block uses type `i128`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:94:31
+   |
+LL |     fn result_nonzero_i128(x: Result<(), num::NonZeroI128>);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = note: 128-bit integers don't currently have a known stable ABI
+
+error: `extern` block uses type `u128`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:100:36
+   |
+LL |     fn left_result_nonzero_u128(x: Result<num::NonZeroU128, ()>);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = note: 128-bit integers don't currently have a known stable ABI
+
+error: `extern` block uses type `i128`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:107:36
+   |
+LL |     fn left_result_nonzero_i128(x: Result<num::NonZeroI128, ()>);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = note: 128-bit integers don't currently have a known stable ABI
+
+error: `extern` block uses type `Result<i32, NonZeroI128>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:109:24
+   |
+LL |     fn result_sized(x: Result<i32, num::NonZeroI128>);
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Result<NonZeroI128, i32>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:111:29
+   |
+LL |     fn left_result_sized(x: Result<num::NonZeroI128, i32>);
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<TransparentUnion<NonZeroU8>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:116:29
+   |
+LL |     fn transparent_union(x: Option<TransparentUnion<num::NonZeroU8>>);
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
 
 error: `extern` block uses type `Option<Rust<NonZeroU8>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:88:20
+  --> $DIR/lint-ctypes-enum.rs:118:21
    |
-LL |    fn repr_rust(x: Option<Rust<num::NonZeroU8>>);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Result<(), NonZeroI32>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:89:20
-   |
-LL |    fn no_result(x: Result<(), num::NonZeroI32>);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+LL |     fn repr_rust(x: Option<Rust<num::NonZeroU8>>);
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
 
-error: aborting due to 8 previous errors
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
Implements the required comipler changes for result_ffi_guarantees (rust-lang/rfcs#3391)

Allows `Result<T, E>` to be used in `extern "C"` functions where one of (T, E) is a non-zero type and one of (T, E) is a zero sized type. e.g. `Result<NonZeroI32, ()>`

Adds test cases to ensure that the abi for Result and Option types with nonzero representation remains consistent

tracking issue: #110503