### PR TITLE
tidy: remove ENTRY_LIMIT maximum checking and set it to 900

### DIFF
--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -7,10 +7,10 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
-const ENTRY_LIMIT: usize = 885;
-const ROOT_ENTRY_LIMIT: usize = 894;
 const ISSUES_ENTRY_LIMIT: usize = 1953;
+const ROOT_ENTRY_LIMIT: usize = 894;
 
 fn check_entries(tests_path: &Path, bad: &mut bool) {
     let mut directories: HashMap<PathBuf, usize> = HashMap::new();
@@ -45,9 +45,6 @@ fn check_entries(tests_path: &Path, bad: &mut bool) {
                 dir_path.display()
             );
         }
-    }
-    if ENTRY_LIMIT > max {
-        tidy_error!(bad, "`ENTRY_LIMIT` is too high (is {ENTRY_LIMIT}, should be {max})");
     }
     if ROOT_ENTRY_LIMIT > max_root {
         tidy_error!(


### PR DESCRIPTION
Removes checking of `ENTRY_LIMIT` towards an actually reached maximum, and sets it to 900.

The number 900 is safely below github's limit of 1000 entries for a directory.
PRs to move tests can still decrease the sizes of various directories,
but adjusting the limit won't be neccessary any more. In fact, such reduction PRs are a great idea so that no unrelated PR is hitting the limit: ideally there would always be a (manually maintained) safety margin between the actually reached maximum and `ENTRY_LIMIT`, for all directories.

In general, the limit is a bad tool to direct people to put tests into
fitting directories because when those are available, usually the limit
is not hit, while the limit is hit in directories that have a weak
substructure themselves. I got into this situation myself when writing #110694: tests/ui/parser is hitting the limit, but has few directories of its own.

Suggested by @petrochenkov in https://github.com/rust-lang/rust/pull/110694#discussion_r1177694339.

r? @petrochenkov 