### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "libffi-sys"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc65067b78c0fc069771e8b9a9e02df71e08858bec92c1f101377c67b9dca7c7"
+checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,9 +2370,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.84"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -1087,7 +1087,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// ```ignore (illustrative)
     /// opt.map(|param| { takes_ref(param) });
     /// ```
-    fn can_use_as_ref(&self, expr: &hir::Expr<'_>) -> Option<(Span, &'static str, String)> {
+    fn can_use_as_ref(&self, expr: &hir::Expr<'_>) -> Option<(Vec<(Span, String)>, &'static str)> {
         let hir::ExprKind::Path(hir::QPath::Resolved(_, ref path)) = expr.kind else {
             return None;
         };
@@ -1133,12 +1133,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             _ => false,
         };
-        match (is_as_ref_able, self.sess().source_map().span_to_snippet(method_path.ident.span)) {
-            (true, Ok(src)) => {
-                let suggestion = format!("as_ref().{}", src);
-                Some((method_path.ident.span, "consider using `as_ref` instead", suggestion))
-            }
-            _ => None,
+        if is_as_ref_able {
+            Some((
+                vec![(method_path.ident.span.shrink_to_lo(), "as_ref().".to_string())],
+                "consider using `as_ref` instead",
+            ))
+        } else {
+            None
         }
     }
 
@@ -1223,8 +1224,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         checked_ty: Ty<'tcx>,
         expected: Ty<'tcx>,
     ) -> Option<(
-        Span,
-        String,
+        Vec<(Span, String)>,
         String,
         Applicability,
         bool, /* verbose */
@@ -1254,30 +1254,28 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         && let Ok(src) = sm.span_to_snippet(sp)
                         && replace_prefix(&src, "b\"", "\"").is_some()
                     {
-                                let pos = sp.lo() + BytePos(1);
-                                return Some((
-                                    sp.with_hi(pos),
-                                    "consider removing the leading `b`".to_string(),
-                                    String::new(),
-                                    Applicability::MachineApplicable,
-                                    true,
-                                    false,
-                                ));
-                            }
-                        }
+                        let pos = sp.lo() + BytePos(1);
+                        return Some((
+                            vec![(sp.with_hi(pos), String::new())],
+                            "consider removing the leading `b`".to_string(),
+                            Applicability::MachineApplicable,
+                            true,
+                            false,
+                        ));
+                    }
+                }
                 (&ty::Array(arr, _) | &ty::Slice(arr), &ty::Str) if arr == self.tcx.types.u8 => {
                     if let hir::ExprKind::Lit(_) = expr.kind
                         && let Ok(src) = sm.span_to_snippet(sp)
                         && replace_prefix(&src, "\"", "b\"").is_some()
                     {
-                                return Some((
-                                    sp.shrink_to_lo(),
-                                    "consider adding a leading `b`".to_string(),
-                                    "b".to_string(),
-                                    Applicability::MachineApplicable,
-                                    true,
-                                    false,
-                                ));
+                        return Some((
+                            vec![(sp.shrink_to_lo(), "b".to_string())],
+                            "consider adding a leading `b`".to_string(),
+                            Applicability::MachineApplicable,
+                            true,
+                            false,
+                        ));
                     }
                 }
                 _ => {}
@@ -1320,14 +1318,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
 
                     if let hir::ExprKind::Unary(hir::UnOp::Deref, ref inner) = expr.kind
-                        && let Some(1) = self.deref_steps(expected, checked_ty) {
+                        && let Some(1) = self.deref_steps(expected, checked_ty)
+                    {
                         // We have `*&T`, check if what was expected was `&T`.
                         // If so, we may want to suggest removing a `*`.
                         sugg_sp = sugg_sp.with_hi(inner.span.lo());
                         return Some((
-                            sugg_sp,
+                            vec![(sugg_sp, String::new())],
                             "consider removing deref here".to_string(),
-                            "".to_string(),
                             Applicability::MachineApplicable,
                             true,
                             false,
@@ -1342,13 +1340,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         _ => false,
                     };
 
-                    if let Some(sugg) = self.can_use_as_ref(expr) {
+                    if let Some((sugg, msg)) = self.can_use_as_ref(expr) {
                         return Some((
-                            sugg.0,
-                            sugg.1.to_string(),
-                            sugg.2,
+                            sugg,
+                            msg.to_string(),
                             Applicability::MachineApplicable,
-                            false,
+                            true,
                             false,
                         ));
                     }
@@ -1369,16 +1366,21 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         }
                     }
 
-                    let (sp, sugg_expr, verbose) = if needs_parens {
-                        let src = sm.span_to_snippet(sugg_sp).ok()?;
-                        (sp, format!("({src})"), false)
+                    let sugg = mutability.ref_prefix_str();
+                    let (sugg, verbose) = if needs_parens {
+                        (
+                            vec![
+                                (sp.shrink_to_lo(), format!("{prefix}{sugg}(")),
+                                (sp.shrink_to_hi(), ")".to_string()),
+                            ],
+                            false,
+                        )
                     } else {
-                        (sp.shrink_to_lo(), "".to_string(), true)
+                        (vec![(sp.shrink_to_lo(), format!("{prefix}{sugg}"))], true)
                     };
                     return Some((
-                        sp,
+                        sugg,
                         format!("consider {}borrowing here", mutability.mutably_str()),
-                        format!("{prefix}{}{sugg_expr}", mutability.ref_prefix_str()),
                         Applicability::MachineApplicable,
                         verbose,
                         false,
@@ -1404,23 +1406,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         && sm.is_span_accessible(call_span)
                     {
                         return Some((
-                            sp.with_hi(call_span.lo()),
+                            vec![(sp.with_hi(call_span.lo()), String::new())],
                             "consider removing the borrow".to_string(),
-                            String::new(),
                             Applicability::MachineApplicable,
                             true,
-                            true
+                            true,
                         ));
                     }
                     return None;
                 }
-                if sp.contains(expr.span)
-                    && sm.is_span_accessible(expr.span)
-                {
+                if sp.contains(expr.span) && sm.is_span_accessible(expr.span) {
                     return Some((
-                        sp.with_hi(expr.span.lo()),
+                        vec![(sp.with_hi(expr.span.lo()), String::new())],
                         "consider removing the borrow".to_string(),
-                        String::new(),
                         Applicability::MachineApplicable,
                         true,
                         true,
@@ -1444,23 +1442,30 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                     let suggestion = replace_prefix(&src, old_prefix, &new_prefix).map(|_| {
                         // skip `&` or `&mut ` if both mutabilities are mutable
-                        let lo = sp.lo() + BytePos(min(old_prefix.len(), mutbl_b.ref_prefix_str().len()) as _);
+                        let lo = sp.lo()
+                            + BytePos(min(old_prefix.len(), mutbl_b.ref_prefix_str().len()) as _);
                         // skip `&` or `&mut `
                         let hi = sp.lo() + BytePos(old_prefix.len() as _);
                         let sp = sp.with_lo(lo).with_hi(hi);
 
                         (
                             sp,
-                            format!("{}{derefs}", if mutbl_a != mutbl_b { mutbl_b.prefix_str() } else { "" }),
-                            if mutbl_b <= mutbl_a { Applicability::MachineApplicable } else { Applicability::MaybeIncorrect }
+                            format!(
+                                "{}{derefs}",
+                                if mutbl_a != mutbl_b { mutbl_b.prefix_str() } else { "" }
+                            ),
+                            if mutbl_b <= mutbl_a {
+                                Applicability::MachineApplicable
+                            } else {
+                                Applicability::MaybeIncorrect
+                            },
                         )
                     });
 
                     if let Some((span, src, applicability)) = suggestion {
                         return Some((
-                            span,
+                            vec![(span, src)],
                             "consider dereferencing".to_string(),
-                            src,
                             applicability,
                             true,
                             false,
@@ -1489,9 +1494,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // If we've reached our target type with just removing `&`, then just print now.
                     if steps == 0 && !remove.trim().is_empty() {
                         return Some((
-                            prefix_span,
+                            vec![(prefix_span, String::new())],
                             format!("consider removing the `{}`", remove.trim()),
-                            String::new(),
                             // Do not remove `&&` to get to bool, because it might be something like
                             // { a } && b, which we have a separate fixup suggestion that is more
                             // likely correct...
@@ -1551,9 +1555,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         }
 
                         return Some((
-                            span,
+                            vec![(span, suggestion)],
                             message,
-                            suggestion,
                             Applicability::MachineApplicable,
                             true,
                             false,

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -86,9 +86,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.emit_type_mismatch_suggestions(err, expr, expr_ty, expected, expected_ty_expr, error);
         self.note_type_is_not_clone(err, expected, expr_ty, expr);
         self.note_internal_mutation_in_method(err, expr, Some(expected), expr_ty);
-        self.check_for_range_as_method_call(err, expr, expr_ty, expected);
-        self.check_for_binding_assigned_block_without_tail_expression(err, expr, expr_ty, expected);
-        self.check_wrong_return_type_due_to_generic_arg(err, expr, expr_ty);
+        self.suggest_method_call_on_range_literal(err, expr, expr_ty, expected);
+        self.suggest_return_binding_for_missing_tail_expr(err, expr, expr_ty, expected);
+        self.note_wrong_return_ty_due_to_generic_arg(err, expr, expr_ty);
     }
 
     /// Requires that the two types unify, and prints an error message if
@@ -1217,7 +1217,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// In addition of this check, it also checks between references mutability state. If the
     /// expected is mutable but the provided isn't, maybe we could just say "Hey, try with
     /// `&mut`!".
-    pub fn check_ref(
+    pub fn suggest_deref_or_ref(
         &self,
         expr: &hir::Expr<'tcx>,
         checked_ty: Ty<'tcx>,
@@ -1566,7 +1566,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         None
     }
 
-    pub fn check_for_cast(
+    pub fn suggest_cast(
         &self,
         err: &mut Diagnostic,
         expr: &hir::Expr<'_>,
@@ -1936,7 +1936,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     /// Identify when the user has written `foo..bar()` instead of `foo.bar()`.
-    pub fn check_for_range_as_method_call(
+    pub fn suggest_method_call_on_range_literal(
         &self,
         err: &mut Diagnostic,
         expr: &hir::Expr<'tcx>,
@@ -2005,7 +2005,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     /// Identify when the type error is because `()` is found in a binding that was assigned a
     /// block without a tail expression.
-    fn check_for_binding_assigned_block_without_tail_expression(
+    fn suggest_return_binding_for_missing_tail_expr(
         &self,
         err: &mut Diagnostic,
         expr: &hir::Expr<'_>,
@@ -2047,7 +2047,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    fn check_wrong_return_type_due_to_generic_arg(
+    fn note_wrong_return_ty_due_to_generic_arg(
         &self,
         err: &mut Diagnostic,
         expr: &hir::Expr<'_>,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -275,7 +275,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> bool {
         let expr = expr.peel_blocks();
         if let Some((sp, msg, suggestion, applicability, verbose, annotation)) =
-            self.check_ref(expr, found, expected)
+            self.suggest_deref_or_ref(expr, found, expected)
         {
             if verbose {
                 err.span_suggestion_verbose(sp, &msg, suggestion, applicability);
@@ -342,7 +342,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 err.span_label(sp, format!("{descr} `{name}` defined here"));
             }
             return true;
-        } else if self.check_for_cast(err, expr, found, expected, expected_ty_expr) {
+        } else if self.suggest_cast(err, expr, found, expected, expected_ty_expr) {
             return true;
         } else {
             let methods = self.get_conversion_methods(expr.span, expected, found, expr.hir_id);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -274,13 +274,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected_ty_expr: Option<&'tcx hir::Expr<'tcx>>,
     ) -> bool {
         let expr = expr.peel_blocks();
-        if let Some((sp, msg, suggestion, applicability, verbose, annotation)) =
+        if let Some((suggestion, msg, applicability, verbose, annotation)) =
             self.suggest_deref_or_ref(expr, found, expected)
         {
             if verbose {
-                err.span_suggestion_verbose(sp, &msg, suggestion, applicability);
+                err.multipart_suggestion_verbose(&msg, suggestion, applicability);
             } else {
-                err.span_suggestion(sp, &msg, suggestion, applicability);
+                err.multipart_suggestion(&msg, suggestion, applicability);
             }
             if annotation {
                 let suggest_annotation = match expr.peel_drop_temps().kind {

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1044,7 +1044,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             );
         }
 
-        self.check_for_inner_self(&mut err, source, rcvr_ty, item_name);
+        self.suggest_unwrapping_inner_self(&mut err, source, rcvr_ty, item_name);
 
         bound_spans.sort();
         bound_spans.dedup();
@@ -1131,7 +1131,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
 
-        self.check_for_deref_method(&mut err, source, rcvr_ty, item_name, expected);
+        self.note_derefed_ty_has_method(&mut err, source, rcvr_ty, item_name, expected);
         return Some(err);
     }
 
@@ -1804,7 +1804,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    fn check_for_inner_self(
+    fn suggest_unwrapping_inner_self(
         &self,
         err: &mut Diagnostic,
         source: SelfSource<'tcx>,
@@ -2161,7 +2161,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    fn check_for_deref_method(
+    fn note_derefed_ty_has_method(
         &self,
         err: &mut Diagnostic,
         self_source: SelfSource<'tcx>,

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -27,6 +27,7 @@ use rustc_span::{Span, DUMMY_SP};
 use rustc_target::spec::{PanicStrategy, TargetTriple};
 
 use proc_macro::bridge::client::ProcMacro;
+use std::error::Error;
 use std::ops::Fn;
 use std::path::Path;
 use std::time::Duration;
@@ -1094,5 +1095,12 @@ fn load_dylib(path: &Path, max_attempts: usize) -> Result<libloading::Library, S
     }
 
     debug!("Failed to load proc-macro `{}` even after {} attempts.", path.display(), max_attempts);
-    Err(format!("{} (retried {} times)", last_error.unwrap(), max_attempts))
+
+    let last_error = last_error.unwrap();
+    let message = if let Some(src) = last_error.source() {
+        format!("{last_error} ({src}) (retried {max_attempts} times)")
+    } else {
+        format!("{last_error} (retried {max_attempts} times)")
+    };
+    Err(message)
 }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -859,13 +859,9 @@ impl<'a: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast,
                             sig.decl.inputs.iter().map(|Param { ty, .. }| (None, &**ty)),
                             &sig.decl.output,
                         );
-
-                        this.record_lifetime_params_for_async(
-                            fn_id,
-                            sig.header.asyncness.opt_return_id(),
-                        );
                     },
                 );
+                self.record_lifetime_params_for_async(fn_id, sig.header.asyncness.opt_return_id());
                 return;
             }
             FnKind::Fn(..) => {

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
@@ -16,7 +16,7 @@ use rustc_infer::infer::canonical::query_response::make_query_region_constraints
 use rustc_infer::infer::canonical::CanonicalVarValues;
 use rustc_infer::infer::canonical::{CanonicalExt, QueryRegionConstraints};
 use rustc_middle::traits::query::NoSolution;
-use rustc_middle::traits::solve::{ExternalConstraints, ExternalConstraintsData};
+use rustc_middle::traits::solve::{ExternalConstraints, ExternalConstraintsData, MaybeCause};
 use rustc_middle::ty::{self, BoundVar, GenericArgKind};
 use rustc_span::DUMMY_SP;
 use std::iter;
@@ -60,9 +60,38 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
 
         let certainty = certainty.unify_with(goals_certainty);
 
-        let external_constraints = self.compute_external_query_constraints()?;
+        let response = match certainty {
+            Certainty::Yes | Certainty::Maybe(MaybeCause::Ambiguity) => {
+                let external_constraints = self.compute_external_query_constraints()?;
+                Response { var_values: self.var_values, external_constraints, certainty }
+            }
+            Certainty::Maybe(MaybeCause::Overflow) => {
+                // If we have overflow, it's probable that we're substituting a type
+                // into itself infinitely and any partial substitutions in the query
+                // response are probably not useful anyways, so just return an empty
+                // query response.
+                Response {
+                    var_values: CanonicalVarValues {
+                        var_values: self.tcx().mk_substs_from_iter(
+                            self.var_values.var_values.iter().map(|arg| -> ty::GenericArg<'tcx> {
+                                match arg.unpack() {
+                                    GenericArgKind::Lifetime(_) => self.next_region_infer().into(),
+                                    GenericArgKind::Type(_) => self.next_ty_infer().into(),
+                                    GenericArgKind::Const(ct) => {
+                                        self.next_const_infer(ct.ty()).into()
+                                    }
+                                }
+                            }),
+                        ),
+                    },
+                    external_constraints: self
+                        .tcx()
+                        .mk_external_constraints(ExternalConstraintsData::default()),
+                    certainty,
+                }
+            }
+        };
 
-        let response = Response { var_values: self.var_values, external_constraints, certainty };
         let canonical = Canonicalizer::canonicalize(
             self.infcx,
             CanonicalizeMode::Response { max_input_universe: self.max_input_universe },

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1543,11 +1543,17 @@ impl<'a, K: 'a, V: 'a> Iterator for Iter<'a, K, V> {
         self.next_back()
     }
 
-    fn min(mut self) -> Option<(&'a K, &'a V)> {
+    fn min(mut self) -> Option<(&'a K, &'a V)>
+    where
+        (&'a K, &'a V): Ord,
+    {
         self.next()
     }
 
-    fn max(mut self) -> Option<(&'a K, &'a V)> {
+    fn max(mut self) -> Option<(&'a K, &'a V)>
+    where
+        (&'a K, &'a V): Ord,
+    {
         self.next_back()
     }
 }
@@ -1612,11 +1618,17 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
         self.next_back()
     }
 
-    fn min(mut self) -> Option<(&'a K, &'a mut V)> {
+    fn min(mut self) -> Option<(&'a K, &'a mut V)>
+    where
+        (&'a K, &'a mut V): Ord,
+    {
         self.next()
     }
 
-    fn max(mut self) -> Option<(&'a K, &'a mut V)> {
+    fn max(mut self) -> Option<(&'a K, &'a mut V)>
+    where
+        (&'a K, &'a mut V): Ord,
+    {
         self.next_back()
     }
 }
@@ -1779,11 +1791,17 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> {
         self.next_back()
     }
 
-    fn min(mut self) -> Option<&'a K> {
+    fn min(mut self) -> Option<&'a K>
+    where
+        &'a K: Ord,
+    {
         self.next()
     }
 
-    fn max(mut self) -> Option<&'a K> {
+    fn max(mut self) -> Option<&'a K>
+    where
+        &'a K: Ord,
+    {
         self.next_back()
     }
 }
@@ -2008,11 +2026,17 @@ impl<'a, K, V> Iterator for Range<'a, K, V> {
         self.next_back()
     }
 
-    fn min(mut self) -> Option<(&'a K, &'a V)> {
+    fn min(mut self) -> Option<(&'a K, &'a V)>
+    where
+        (&'a K, &'a V): Ord,
+    {
         self.next()
     }
 
-    fn max(mut self) -> Option<(&'a K, &'a V)> {
+    fn max(mut self) -> Option<(&'a K, &'a V)>
+    where
+        (&'a K, &'a V): Ord,
+    {
         self.next_back()
     }
 }
@@ -2081,11 +2105,17 @@ impl<K, V, A: Allocator + Clone> Iterator for IntoKeys<K, V, A> {
         self.next_back()
     }
 
-    fn min(mut self) -> Option<K> {
+    fn min(mut self) -> Option<K>
+    where
+        K: Ord,
+    {
         self.next()
     }
 
-    fn max(mut self) -> Option<K> {
+    fn max(mut self) -> Option<K>
+    where
+        K: Ord,
+    {
         self.next_back()
     }
 }
@@ -2204,11 +2234,17 @@ impl<'a, K, V> Iterator for RangeMut<'a, K, V> {
         self.next_back()
     }
 
-    fn min(mut self) -> Option<(&'a K, &'a mut V)> {
+    fn min(mut self) -> Option<(&'a K, &'a mut V)>
+    where
+        (&'a K, &'a mut V): Ord,
+    {
         self.next()
     }
 
-    fn max(mut self) -> Option<(&'a K, &'a mut V)> {
+    fn max(mut self) -> Option<(&'a K, &'a mut V)>
+    where
+        (&'a K, &'a mut V): Ord,
+    {
         self.next_back()
     }
 }

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -1501,11 +1501,17 @@ impl<'a, T> Iterator for Iter<'a, T> {
         self.next_back()
     }
 
-    fn min(mut self) -> Option<&'a T> {
+    fn min(mut self) -> Option<&'a T>
+    where
+        &'a T: Ord,
+    {
         self.next()
     }
 
-    fn max(mut self) -> Option<&'a T> {
+    fn max(mut self) -> Option<&'a T>
+    where
+        &'a T: Ord,
+    {
         self.next_back()
     }
 }
@@ -1604,11 +1610,17 @@ impl<'a, T> Iterator for Range<'a, T> {
         self.next_back()
     }
 
-    fn min(mut self) -> Option<&'a T> {
+    fn min(mut self) -> Option<&'a T>
+    where
+        &'a T: Ord,
+    {
         self.next()
     }
 
-    fn max(mut self) -> Option<&'a T> {
+    fn max(mut self) -> Option<&'a T>
+    where
+        &'a T: Ord,
+    {
         self.next_back()
     }
 }

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2815,7 +2815,7 @@ impl<'a, T: 'a + Copy, A: Allocator> Extend<&'a T> for VecDeque<T, A> {
     }
 
     #[inline]
-    fn extend_one(&mut self, &elem: &T) {
+    fn extend_one(&mut self, &elem: &'a T) {
         self.push_back(elem);
     }
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -248,7 +248,7 @@ where
 impl<'a, T, const N: usize> TryFrom<&'a [T]> for &'a [T; N] {
     type Error = TryFromSliceError;
 
-    fn try_from(slice: &[T]) -> Result<&[T; N], TryFromSliceError> {
+    fn try_from(slice: &'a [T]) -> Result<&'a [T; N], TryFromSliceError> {
         if slice.len() == N {
             let ptr = slice.as_ptr() as *const [T; N];
             // SAFETY: ok because we just checked that the length fits
@@ -275,7 +275,7 @@ impl<'a, T, const N: usize> TryFrom<&'a [T]> for &'a [T; N] {
 impl<'a, T, const N: usize> TryFrom<&'a mut [T]> for &'a mut [T; N] {
     type Error = TryFromSliceError;
 
-    fn try_from(slice: &mut [T]) -> Result<&mut [T; N], TryFromSliceError> {
+    fn try_from(slice: &'a mut [T]) -> Result<&'a mut [T; N], TryFromSliceError> {
         if slice.len() == N {
             let ptr = slice.as_mut_ptr() as *mut [T; N];
             // SAFETY: ok because we just checked that the length fits

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -732,12 +732,18 @@ impl<A: Step> Iterator for ops::Range<A> {
     }
 
     #[inline]
-    fn min(mut self) -> Option<A> {
+    fn min(mut self) -> Option<A>
+    where
+        A: Ord,
+    {
         self.next()
     }
 
     #[inline]
-    fn max(mut self) -> Option<A> {
+    fn max(mut self) -> Option<A>
+    where
+        A: Ord,
+    {
         self.next_back()
     }
 
@@ -1158,12 +1164,18 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
     }
 
     #[inline]
-    fn min(mut self) -> Option<A> {
+    fn min(mut self) -> Option<A>
+    where
+        A: Ord,
+    {
         self.next()
     }
 
     #[inline]
-    fn max(mut self) -> Option<A> {
+    fn max(mut self) -> Option<A>
+    where
+        A: Ord,
+    {
         self.next_back()
     }
 

--- a/library/portable-simd/crates/core_simd/src/ops/deref.rs
+++ b/library/portable-simd/crates/core_simd/src/ops/deref.rs
@@ -71,7 +71,7 @@ macro_rules! deref_ops {
 
                 #[inline]
                 #[must_use = "operator returns a new vector without mutating the inputs"]
-                fn $call(self, rhs: &$simd) -> Self::Output {
+                fn $call(self, rhs: &'rhs $simd) -> Self::Output {
                     (*self).$call(*rhs)
                 }
             }

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -90,6 +90,9 @@ pub struct TestProps {
     pub unset_rustc_env: Vec<String>,
     // Environment settings to use during execution
     pub exec_env: Vec<(String, String)>,
+    // Environment variables to unset prior to execution.
+    // Variables are unset before applying 'exec_env'
+    pub unset_exec_env: Vec<String>,
     // Build documentation for all specified aux-builds as well
     pub build_aux_docs: bool,
     // Flag to force a crate to be built with the host architecture
@@ -198,6 +201,7 @@ mod directives {
     pub const AUX_CRATE: &'static str = "aux-crate";
     pub const EXEC_ENV: &'static str = "exec-env";
     pub const RUSTC_ENV: &'static str = "rustc-env";
+    pub const UNSET_EXEC_ENV: &'static str = "unset-exec-env";
     pub const UNSET_RUSTC_ENV: &'static str = "unset-rustc-env";
     pub const FORBID_OUTPUT: &'static str = "forbid-output";
     pub const CHECK_TEST_LINE_NUMBERS_MATCH: &'static str = "check-test-line-numbers-match";
@@ -231,6 +235,7 @@ impl TestProps {
             rustc_env: vec![],
             unset_rustc_env: vec![],
             exec_env: vec![],
+            unset_exec_env: vec![],
             build_aux_docs: false,
             force_host: false,
             check_stdout: false,
@@ -381,6 +386,12 @@ impl TestProps {
                     EXEC_ENV,
                     &mut self.exec_env,
                     Config::parse_env,
+                );
+                config.push_name_value_directive(
+                    ln,
+                    UNSET_EXEC_ENV,
+                    &mut self.unset_exec_env,
+                    |r| r,
                 );
                 config.push_name_value_directive(
                     ln,

--- a/src/tools/compiletest/src/header/cfg.rs
+++ b/src/tools/compiletest/src/header/cfg.rs
@@ -165,11 +165,15 @@ pub(super) fn parse_cfg_name_directive<'a>(
         message: "when the architecture is part of the Thumb family"
     }
 
+    // Technically the locally built compiler uses the "dev" channel rather than the "nightly"
+    // channel, even though most people don't know or won't care about it. To avoid confusion, we
+    // treat the "dev" channel as the "nightly" channel when processing the directive.
     condition! {
-        name: &config.channel,
+        name: if config.channel == "dev" { "nightly" } else { &config.channel },
         allowed_names: &["stable", "beta", "nightly"],
         message: "when the release channel is {name}",
     }
+
     condition! {
         name: "cross-compile",
         condition: config.target != config.host,

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1613,8 +1613,13 @@ impl<'test> TestCx<'test> {
                 test_client
                     .args(&["run", &support_libs.len().to_string(), &prog])
                     .args(support_libs)
-                    .args(args)
-                    .envs(env.clone());
+                    .args(args);
+
+                for key in &self.props.unset_exec_env {
+                    test_client.env_remove(key);
+                }
+                test_client.envs(env.clone());
+
                 self.compose_and_run(
                     test_client,
                     self.config.run_lib_path.to_str().unwrap(),
@@ -1626,7 +1631,13 @@ impl<'test> TestCx<'test> {
                 let aux_dir = self.aux_output_dir_name();
                 let ProcArgs { prog, args } = self.make_run_args();
                 let mut wr_run = Command::new("wr-run");
-                wr_run.args(&[&prog]).args(args).envs(env.clone());
+                wr_run.args(&[&prog]).args(args);
+
+                for key in &self.props.unset_exec_env {
+                    wr_run.env_remove(key);
+                }
+                wr_run.envs(env.clone());
+
                 self.compose_and_run(
                     wr_run,
                     self.config.run_lib_path.to_str().unwrap(),
@@ -1638,7 +1649,13 @@ impl<'test> TestCx<'test> {
                 let aux_dir = self.aux_output_dir_name();
                 let ProcArgs { prog, args } = self.make_run_args();
                 let mut program = Command::new(&prog);
-                program.args(args).current_dir(&self.output_base_dir()).envs(env.clone());
+                program.args(args).current_dir(&self.output_base_dir());
+
+                for key in &self.props.unset_exec_env {
+                    program.env_remove(key);
+                }
+                program.envs(env.clone());
+
                 self.compose_and_run(
                     program,
                     self.config.run_lib_path.to_str().unwrap(),

--- a/tests/mir-opt/issue_41888.main.ElaborateDrops.diff
+++ b/tests/mir-opt/issue_41888.main.ElaborateDrops.diff
@@ -22,9 +22,9 @@
       }
   
       bb0: {
-+         _9 = const false;                // scope 0 at $DIR/issue_41888.rs:+1:9: +1:10
 +         _7 = const false;                // scope 0 at $DIR/issue_41888.rs:+1:9: +1:10
 +         _8 = const false;                // scope 0 at $DIR/issue_41888.rs:+1:9: +1:10
++         _9 = const false;                // scope 0 at $DIR/issue_41888.rs:+1:9: +1:10
           StorageLive(_1);                 // scope 0 at $DIR/issue_41888.rs:+1:9: +1:10
           StorageLive(_2);                 // scope 1 at $DIR/issue_41888.rs:+2:8: +2:14
           _2 = cond() -> [return: bb1, unwind: bb11]; // scope 1 at $DIR/issue_41888.rs:+2:8: +2:14

--- a/tests/ui/argument-suggestions/issue-97484.stderr
+++ b/tests/ui/argument-suggestions/issue-97484.stderr
@@ -16,7 +16,7 @@ LL | fn foo(a: &A, d: D, e: &E, g: G) {}
 help: consider borrowing here
    |
 LL |     foo(&&A, B, C, D, &E, F, G);
-   |                       ~~
+   |                       +
 help: remove the extra arguments
    |
 LL -     foo(&&A, B, C, D, E, F, G);

--- a/tests/ui/async-await/in-trait/nested-rpit.rs
+++ b/tests/ui/async-await/in-trait/nested-rpit.rs
@@ -1,7 +1,5 @@
 // edition: 2021
-// known-bug: #105197
-// failure-status:101
-// dont-check-compiler-stderr
+// check-pass
 
 #![feature(async_fn_in_trait)]
 #![feature(return_position_impl_trait_in_trait)]

--- a/tests/ui/async-await/issues/issue-102206.stderr
+++ b/tests/ui/async-await/issues/issue-102206.stderr
@@ -2,14 +2,16 @@ error[E0308]: mismatched types
   --> $DIR/issue-102206.rs:6:27
    |
 LL |     std::mem::size_of_val(foo());
-   |     --------------------- ^^^^^
-   |     |                     |
-   |     |                     expected `&_`, found future
-   |     |                     help: consider borrowing here: `&foo()`
+   |     --------------------- ^^^^^ expected `&_`, found future
+   |     |
    |     arguments to this function are incorrect
    |
 note: function defined here
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
+help: consider borrowing here
+   |
+LL |     std::mem::size_of_val(&foo());
+   |                           +
 
 error: aborting due to previous error
 

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.rs
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.rs
@@ -1,0 +1,48 @@
+// edition: 2021
+// known-bug: #110963
+
+#![feature(return_type_notation)]
+#![feature(async_fn_in_trait)]
+
+trait HealthCheck {
+    async fn check<'a: 'a>(&'a mut self) -> bool;
+}
+
+async fn do_health_check_par<HC>(hc: HC)
+where
+    HC: HealthCheck<check(): Send> + Send + 'static,
+{
+    spawn(async move {
+        let mut hc = hc;
+        if !hc.check().await {
+            log_health_check_failure().await;
+        }
+    });
+}
+
+async fn log_health_check_failure() {}
+
+fn main() {}
+
+// Fake tokio spawn
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+fn spawn<F>(future: F) -> JoinHandle
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    loop {}
+}
+
+struct JoinHandle;
+
+impl Future for JoinHandle {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {}
+    }
+}

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.stderr
@@ -1,0 +1,45 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-110963-early.rs:4:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-110963-early.rs:5:12
+   |
+LL | #![feature(async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+
+error: higher-ranked lifetime error
+  --> $DIR/issue-110963-early.rs:15:5
+   |
+LL | /     spawn(async move {
+LL | |         let mut hc = hc;
+LL | |         if !hc.check().await {
+LL | |             log_health_check_failure().await;
+LL | |         }
+LL | |     });
+   | |______^
+   |
+   = note: could not prove `[async block@$DIR/issue-110963-early.rs:15:11: 20:6]: Send`
+
+error: higher-ranked lifetime error
+  --> $DIR/issue-110963-early.rs:15:5
+   |
+LL | /     spawn(async move {
+LL | |         let mut hc = hc;
+LL | |         if !hc.check().await {
+LL | |             log_health_check_failure().await;
+LL | |         }
+LL | |     });
+   | |______^
+   |
+   = note: could not prove `[async block@$DIR/issue-110963-early.rs:15:11: 20:6]: Send`
+
+error: aborting due to 2 previous errors; 2 warnings emitted
+

--- a/tests/ui/async-await/return-type-notation/issue-110963-late.rs
+++ b/tests/ui/async-await/return-type-notation/issue-110963-late.rs
@@ -1,0 +1,50 @@
+// edition: 2021
+// check-pass
+
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+#![feature(async_fn_in_trait)]
+//~^ WARN the feature `async_fn_in_trait` is incomplete
+
+trait HealthCheck {
+    async fn check(&mut self) -> bool;
+}
+
+async fn do_health_check_par<HC>(hc: HC)
+where
+    HC: HealthCheck<check(): Send> + Send + 'static,
+{
+    spawn(async move {
+        let mut hc = hc;
+        if !hc.check().await {
+            log_health_check_failure().await;
+        }
+    });
+}
+
+async fn log_health_check_failure() {}
+
+fn main() {}
+
+// Fake tokio spawn
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+fn spawn<F>(future: F) -> JoinHandle
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    loop {}
+}
+
+struct JoinHandle;
+
+impl Future for JoinHandle {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {}
+    }
+}

--- a/tests/ui/async-await/return-type-notation/issue-110963-late.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-late.stderr
@@ -1,0 +1,19 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-110963-late.rs:4:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: the feature `async_fn_in_trait` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-110963-late.rs:6:12
+   |
+LL | #![feature(async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+
+warning: 2 warnings emitted
+

--- a/tests/ui/coercion/coercion-slice.stderr
+++ b/tests/ui/coercion/coercion-slice.stderr
@@ -2,11 +2,14 @@ error[E0308]: mismatched types
   --> $DIR/coercion-slice.rs:4:21
    |
 LL |     let _: &[i32] = [0];
-   |            ------   ^^^
-   |            |        |
-   |            |        expected `&[i32]`, found `[{integer}; 1]`
-   |            |        help: consider borrowing here: `&[0]`
+   |            ------   ^^^ expected `&[i32]`, found `[{integer}; 1]`
+   |            |
    |            expected due to this
+   |
+help: consider borrowing here
+   |
+LL |     let _: &[i32] = &[0];
+   |                     +
 
 error: aborting due to previous error
 

--- a/tests/ui/feature-gates/test-listing-format-json.rs
+++ b/tests/ui/feature-gates/test-listing-format-json.rs
@@ -1,13 +1,10 @@
 // no-prefer-dynamic
 // compile-flags: --test
 // run-flags: --list --format json -Zunstable-options
-// run-pass
+// run-fail
 // check-run-results
-// only-nightly
-// normalize-stdout-test: "fake-test-src-base/test-attrs/" -> "$$DIR/"
-// normalize-stdout-test: "fake-test-src-base\\test-attrs\\" -> "$$DIR/"
-
-// Checks the listing of tests with --format json.
+// ignore-nightly
+// unset-exec-env:RUSTC_BOOTSTRAP
 
 #![cfg(test)]
 #[test]

--- a/tests/ui/feature-gates/test-listing-format-json.run.stderr
+++ b/tests/ui/feature-gates/test-listing-format-json.run.stderr
@@ -1,0 +1,1 @@
+error: the option `Z` is only accepted on the nightly compiler

--- a/tests/ui/inference/deref-suggestion.stderr
+++ b/tests/ui/inference/deref-suggestion.stderr
@@ -98,19 +98,23 @@ error[E0308]: mismatched types
   --> $DIR/deref-suggestion.rs:40:17
    |
 LL |     let s = S { u };
-   |                 ^
-   |                 |
-   |                 expected `&u32`, found integer
-   |                 help: consider borrowing here: `u: &u`
+   |                 ^ expected `&u32`, found integer
+   |
+help: consider borrowing here
+   |
+LL |     let s = S { u: &u };
+   |                 ++++
 
 error[E0308]: mismatched types
   --> $DIR/deref-suggestion.rs:42:20
    |
 LL |     let s = S { u: u };
-   |                    ^
-   |                    |
-   |                    expected `&u32`, found integer
-   |                    help: consider borrowing here: `&u`
+   |                    ^ expected `&u32`, found integer
+   |
+help: consider borrowing here
+   |
+LL |     let s = S { u: &u };
+   |                    +
 
 error[E0308]: mismatched types
   --> $DIR/deref-suggestion.rs:45:17

--- a/tests/ui/issues/issue-11374.stderr
+++ b/tests/ui/issues/issue-11374.stderr
@@ -2,10 +2,8 @@ error[E0308]: mismatched types
   --> $DIR/issue-11374.rs:26:15
    |
 LL |     c.read_to(v);
-   |       ------- ^
-   |       |       |
-   |       |       expected `&mut [u8]`, found `Vec<_>`
-   |       |       help: consider mutably borrowing here: `&mut v`
+   |       ------- ^ expected `&mut [u8]`, found `Vec<_>`
+   |       |
    |       arguments to this method are incorrect
    |
    = note: expected mutable reference `&mut [u8]`
@@ -15,6 +13,10 @@ note: method defined here
    |
 LL |     pub fn read_to(&mut self, vec: &mut [u8]) {
    |            ^^^^^^^            --------------
+help: consider mutably borrowing here
+   |
+LL |     c.read_to(&mut v);
+   |               ++++
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-17033.stderr
+++ b/tests/ui/issues/issue-17033.stderr
@@ -2,11 +2,14 @@ error[E0308]: mismatched types
   --> $DIR/issue-17033.rs:2:10
    |
 LL |     (*p)(())
-   |     ---- ^^
-   |     |    |
-   |     |    expected `&mut ()`, found `()`
-   |     |    help: consider mutably borrowing here: `&mut ()`
+   |     ---- ^^ expected `&mut ()`, found `()`
+   |     |
    |     arguments to this function are incorrect
+   |
+help: consider mutably borrowing here
+   |
+LL |     (*p)(&mut ())
+   |          ++++
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-18819.stderr
+++ b/tests/ui/issues/issue-18819.stderr
@@ -19,7 +19,7 @@ LL | fn print_x(_: &dyn Foo<Item=bool>, extra: &str) {
 help: consider borrowing here
    |
 LL |     print_x(&X);
-   |             ~~
+   |             +
 help: provide the argument
    |
 LL |     print_x(/* &dyn Foo<Item = bool> */, /* &str */);

--- a/tests/ui/issues/issue-46302.stderr
+++ b/tests/ui/issues/issue-46302.stderr
@@ -2,10 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/issue-46302.rs:3:27
    |
 LL |   let u: &str = if true { s[..2] } else { s };
-   |                           ^^^^^^
-   |                           |
-   |                           expected `&str`, found `str`
-   |                           help: consider borrowing here: `&s[..2]`
+   |                           ^^^^^^ expected `&str`, found `str`
+   |
+help: consider borrowing here
+   |
+LL |   let u: &str = if true { &s[..2] } else { s };
+   |                           +
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-46756-consider-borrowing-cast-or-binexpr.stderr
+++ b/tests/ui/issues/issue-46756-consider-borrowing-cast-or-binexpr.stderr
@@ -2,10 +2,8 @@ error[E0308]: mismatched types
   --> $DIR/issue-46756-consider-borrowing-cast-or-binexpr.rs:12:42
    |
 LL |     light_flows_our_war_of_mocking_words(behold as usize);
-   |     ------------------------------------ ^^^^^^^^^^^^^^^
-   |     |                                    |
-   |     |                                    expected `&usize`, found `usize`
-   |     |                                    help: consider borrowing here: `&(behold as usize)`
+   |     ------------------------------------ ^^^^^^^^^^^^^^^ expected `&usize`, found `usize`
+   |     |
    |     arguments to this function are incorrect
    |
 note: function defined here
@@ -13,15 +11,17 @@ note: function defined here
    |
 LL | fn light_flows_our_war_of_mocking_words(and_yet: &usize) -> usize {
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---------------
+help: consider borrowing here
+   |
+LL |     light_flows_our_war_of_mocking_words(&(behold as usize));
+   |                                          ++               +
 
 error[E0308]: mismatched types
   --> $DIR/issue-46756-consider-borrowing-cast-or-binexpr.rs:14:42
    |
 LL |     light_flows_our_war_of_mocking_words(with_tears + 4);
-   |     ------------------------------------ ^^^^^^^^^^^^^^
-   |     |                                    |
-   |     |                                    expected `&usize`, found `usize`
-   |     |                                    help: consider borrowing here: `&(with_tears + 4)`
+   |     ------------------------------------ ^^^^^^^^^^^^^^ expected `&usize`, found `usize`
+   |     |
    |     arguments to this function are incorrect
    |
 note: function defined here
@@ -29,6 +29,10 @@ note: function defined here
    |
 LL | fn light_flows_our_war_of_mocking_words(and_yet: &usize) -> usize {
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---------------
+help: consider borrowing here
+   |
+LL |     light_flows_our_war_of_mocking_words(&(with_tears + 4));
+   |                                          ++              +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-61106.stderr
+++ b/tests/ui/issues/issue-61106.stderr
@@ -2,10 +2,8 @@ error[E0308]: mismatched types
   --> $DIR/issue-61106.rs:3:9
    |
 LL |     foo(x.clone());
-   |     --- ^^^^^^^^^
-   |     |   |
-   |     |   expected `&str`, found `String`
-   |     |   help: consider borrowing here: `&x`
+   |     --- ^^^^^^^^^ expected `&str`, found `String`
+   |     |
    |     arguments to this function are incorrect
    |
 note: function defined here
@@ -13,6 +11,10 @@ note: function defined here
    |
 LL | fn foo(_: &str) {}
    |    ^^^ -------
+help: consider borrowing here
+   |
+LL |     foo(&x.clone());
+   |         +
 
 error: aborting due to previous error
 

--- a/tests/ui/methods/method-not-found-generic-arg-elision.stderr
+++ b/tests/ui/methods/method-not-found-generic-arg-elision.stderr
@@ -24,6 +24,8 @@ error[E0599]: no method named `extend` found for struct `Map` in the current sco
    |
 LL |     v.iter().map(|x| x * x).extend(std::iter::once(100));
    |                             ^^^^^^ method not found in `Map<Iter<'_, i32>, [closure@method-not-found-generic-arg-elision.rs:87:18]>`
+   |
+   = note: the full type name has been written to '$TEST_BUILD_DIR/methods/method-not-found-generic-arg-elision/method-not-found-generic-arg-elision.long-type-5032081584140815090.txt'
 
 error[E0599]: no method named `method` found for struct `Wrapper<bool>` in the current scope
   --> $DIR/method-not-found-generic-arg-elision.rs:90:13

--- a/tests/ui/methods/method-not-found-generic-arg-elision.stderr
+++ b/tests/ui/methods/method-not-found-generic-arg-elision.stderr
@@ -24,8 +24,6 @@ error[E0599]: no method named `extend` found for struct `Map` in the current sco
    |
 LL |     v.iter().map(|x| x * x).extend(std::iter::once(100));
    |                             ^^^^^^ method not found in `Map<Iter<'_, i32>, [closure@method-not-found-generic-arg-elision.rs:87:18]>`
-   |
-   = note: the full type name has been written to '$TEST_BUILD_DIR/methods/method-not-found-generic-arg-elision/method-not-found-generic-arg-elision.long-type-5032081584140815090.txt'
 
 error[E0599]: no method named `method` found for struct `Wrapper<bool>` in the current scope
   --> $DIR/method-not-found-generic-arg-elision.rs:90:13

--- a/tests/ui/methods/method-self-arg-1.stderr
+++ b/tests/ui/methods/method-self-arg-1.stderr
@@ -2,10 +2,8 @@ error[E0308]: mismatched types
   --> $DIR/method-self-arg-1.rs:11:14
    |
 LL |     Foo::bar(x);
-   |     -------- ^
-   |     |        |
-   |     |        expected `&Foo`, found `Foo`
-   |     |        help: consider borrowing here: `&x`
+   |     -------- ^ expected `&Foo`, found `Foo`
+   |     |
    |     arguments to this function are incorrect
    |
 note: method defined here
@@ -13,6 +11,10 @@ note: method defined here
    |
 LL |     fn bar(&self) {}
    |        ^^^ -----
+help: consider borrowing here
+   |
+LL |     Foo::bar(&x);
+   |              +
 
 error[E0308]: mismatched types
   --> $DIR/method-self-arg-1.rs:13:14

--- a/tests/ui/mismatched_types/dont-point-return-on-E0308.stderr
+++ b/tests/ui/mismatched_types/dont-point-return-on-E0308.stderr
@@ -2,10 +2,8 @@ error[E0308]: mismatched types
   --> $DIR/dont-point-return-on-E0308.rs:11:11
    |
 LL |         f(());
-   |         - ^^
-   |         | |
-   |         | expected `&()`, found `()`
-   |         | help: consider borrowing here: `&()`
+   |         - ^^ expected `&()`, found `()`
+   |         |
    |         arguments to this function are incorrect
    |
 note: function defined here
@@ -13,6 +11,10 @@ note: function defined here
    |
 LL | async fn f(_: &()) {}
    |          ^ ------
+help: consider borrowing here
+   |
+LL |         f(&());
+   |           +
 
 error: aborting due to previous error
 

--- a/tests/ui/mut/mut-cross-borrowing.stderr
+++ b/tests/ui/mut/mut-cross-borrowing.stderr
@@ -2,10 +2,8 @@ error[E0308]: mismatched types
   --> $DIR/mut-cross-borrowing.rs:7:7
    |
 LL |     f(x)
-   |     - ^
-   |     | |
-   |     | expected `&mut isize`, found `Box<{integer}>`
-   |     | help: consider mutably borrowing here: `&mut x`
+   |     - ^ expected `&mut isize`, found `Box<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected mutable reference `&mut isize`
@@ -15,6 +13,10 @@ note: function defined here
    |
 LL | fn f(_: &mut isize) {}
    |    ^ -------------
+help: consider mutably borrowing here
+   |
+LL |     f(&mut x)
+   |       ++++
 
 error: aborting due to previous error
 

--- a/tests/ui/range/issue-54505-no-literals.fixed
+++ b/tests/ui/range/issue-54505-no-literals.fixed
@@ -16,60 +16,60 @@ fn main() {
     take_range(&std::ops::Range { start: 0, end: 1 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &std::ops::Range { start: 0, end: 1 }
+    //~| SUGGESTION &
 
     take_range(&::std::ops::Range { start: 0, end: 1 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &::std::ops::Range { start: 0, end: 1 }
+    //~| SUGGESTION &
 
     take_range(&std::ops::RangeFrom { start: 1 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &std::ops::RangeFrom { start: 1 }
+    //~| SUGGESTION &
 
     take_range(&::std::ops::RangeFrom { start: 1 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &::std::ops::RangeFrom { start: 1 }
+    //~| SUGGESTION &
 
     take_range(&std::ops::RangeFull {});
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &std::ops::RangeFull {}
+    //~| SUGGESTION &
 
     take_range(&::std::ops::RangeFull {});
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &::std::ops::RangeFull {}
+    //~| SUGGESTION &
 
     take_range(&std::ops::RangeInclusive::new(0, 1));
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &std::ops::RangeInclusive::new(0, 1)
+    //~| SUGGESTION &
 
     take_range(&::std::ops::RangeInclusive::new(0, 1));
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &::std::ops::RangeInclusive::new(0, 1)
+    //~| SUGGESTION &
 
     take_range(&std::ops::RangeTo { end: 5 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &std::ops::RangeTo { end: 5 }
+    //~| SUGGESTION &
 
     take_range(&::std::ops::RangeTo { end: 5 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &::std::ops::RangeTo { end: 5 }
+    //~| SUGGESTION &
 
     take_range(&std::ops::RangeToInclusive { end: 5 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &std::ops::RangeToInclusive { end: 5 }
+    //~| SUGGESTION &
 
     take_range(&::std::ops::RangeToInclusive { end: 5 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &::std::ops::RangeToInclusive { end: 5 }
+    //~| SUGGESTION &
 }

--- a/tests/ui/range/issue-54505-no-literals.rs
+++ b/tests/ui/range/issue-54505-no-literals.rs
@@ -16,60 +16,60 @@ fn main() {
     take_range(std::ops::Range { start: 0, end: 1 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &std::ops::Range { start: 0, end: 1 }
+    //~| SUGGESTION &
 
     take_range(::std::ops::Range { start: 0, end: 1 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &::std::ops::Range { start: 0, end: 1 }
+    //~| SUGGESTION &
 
     take_range(std::ops::RangeFrom { start: 1 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &std::ops::RangeFrom { start: 1 }
+    //~| SUGGESTION &
 
     take_range(::std::ops::RangeFrom { start: 1 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &::std::ops::RangeFrom { start: 1 }
+    //~| SUGGESTION &
 
     take_range(std::ops::RangeFull {});
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &std::ops::RangeFull {}
+    //~| SUGGESTION &
 
     take_range(::std::ops::RangeFull {});
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &::std::ops::RangeFull {}
+    //~| SUGGESTION &
 
     take_range(std::ops::RangeInclusive::new(0, 1));
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &std::ops::RangeInclusive::new(0, 1)
+    //~| SUGGESTION &
 
     take_range(::std::ops::RangeInclusive::new(0, 1));
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &::std::ops::RangeInclusive::new(0, 1)
+    //~| SUGGESTION &
 
     take_range(std::ops::RangeTo { end: 5 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &std::ops::RangeTo { end: 5 }
+    //~| SUGGESTION &
 
     take_range(::std::ops::RangeTo { end: 5 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &::std::ops::RangeTo { end: 5 }
+    //~| SUGGESTION &
 
     take_range(std::ops::RangeToInclusive { end: 5 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &std::ops::RangeToInclusive { end: 5 }
+    //~| SUGGESTION &
 
     take_range(::std::ops::RangeToInclusive { end: 5 });
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &::std::ops::RangeToInclusive { end: 5 }
+    //~| SUGGESTION &
 }

--- a/tests/ui/range/issue-54505-no-literals.stderr
+++ b/tests/ui/range/issue-54505-no-literals.stderr
@@ -2,10 +2,8 @@ error[E0308]: mismatched types
   --> $DIR/issue-54505-no-literals.rs:16:16
    |
 LL |     take_range(std::ops::Range { start: 0, end: 1 });
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |          |
-   |     |          expected `&_`, found `Range<{integer}>`
-   |     |          help: consider borrowing here: `&std::ops::Range { start: 0, end: 1 }`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&_`, found `Range<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -15,15 +13,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&std::ops::Range { start: 0, end: 1 });
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-literals.rs:21:16
    |
 LL |     take_range(::std::ops::Range { start: 0, end: 1 });
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |          |
-   |     |          expected `&_`, found `Range<{integer}>`
-   |     |          help: consider borrowing here: `&::std::ops::Range { start: 0, end: 1 }`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&_`, found `Range<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -33,15 +33,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&::std::ops::Range { start: 0, end: 1 });
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-literals.rs:26:16
    |
 LL |     take_range(std::ops::RangeFrom { start: 1 });
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeFrom<{integer}>`
-   |     |          help: consider borrowing here: `&std::ops::RangeFrom { start: 1 }`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&_`, found `RangeFrom<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -51,15 +53,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&std::ops::RangeFrom { start: 1 });
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-literals.rs:31:16
    |
 LL |     take_range(::std::ops::RangeFrom { start: 1 });
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeFrom<{integer}>`
-   |     |          help: consider borrowing here: `&::std::ops::RangeFrom { start: 1 }`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&_`, found `RangeFrom<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -69,15 +73,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&::std::ops::RangeFrom { start: 1 });
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-literals.rs:36:16
    |
 LL |     take_range(std::ops::RangeFull {});
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeFull`
-   |     |          help: consider borrowing here: `&std::ops::RangeFull {}`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^ expected `&_`, found `RangeFull`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -87,15 +93,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&std::ops::RangeFull {});
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-literals.rs:41:16
    |
 LL |     take_range(::std::ops::RangeFull {});
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeFull`
-   |     |          help: consider borrowing here: `&::std::ops::RangeFull {}`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^ expected `&_`, found `RangeFull`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -105,15 +113,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&::std::ops::RangeFull {});
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-literals.rs:46:16
    |
 LL |     take_range(std::ops::RangeInclusive::new(0, 1));
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeInclusive<{integer}>`
-   |     |          help: consider borrowing here: `&std::ops::RangeInclusive::new(0, 1)`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&_`, found `RangeInclusive<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -123,15 +133,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&std::ops::RangeInclusive::new(0, 1));
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-literals.rs:51:16
    |
 LL |     take_range(::std::ops::RangeInclusive::new(0, 1));
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeInclusive<{integer}>`
-   |     |          help: consider borrowing here: `&::std::ops::RangeInclusive::new(0, 1)`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&_`, found `RangeInclusive<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -141,15 +153,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&::std::ops::RangeInclusive::new(0, 1));
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-literals.rs:56:16
    |
 LL |     take_range(std::ops::RangeTo { end: 5 });
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeTo<{integer}>`
-   |     |          help: consider borrowing here: `&std::ops::RangeTo { end: 5 }`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&_`, found `RangeTo<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -159,15 +173,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&std::ops::RangeTo { end: 5 });
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-literals.rs:61:16
    |
 LL |     take_range(::std::ops::RangeTo { end: 5 });
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeTo<{integer}>`
-   |     |          help: consider borrowing here: `&::std::ops::RangeTo { end: 5 }`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&_`, found `RangeTo<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -177,15 +193,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&::std::ops::RangeTo { end: 5 });
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-literals.rs:66:16
    |
 LL |     take_range(std::ops::RangeToInclusive { end: 5 });
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeToInclusive<{integer}>`
-   |     |          help: consider borrowing here: `&std::ops::RangeToInclusive { end: 5 }`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&_`, found `RangeToInclusive<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -195,15 +213,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&std::ops::RangeToInclusive { end: 5 });
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-literals.rs:71:16
    |
 LL |     take_range(::std::ops::RangeToInclusive { end: 5 });
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeToInclusive<{integer}>`
-   |     |          help: consider borrowing here: `&::std::ops::RangeToInclusive { end: 5 }`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&_`, found `RangeToInclusive<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -213,6 +233,10 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&::std::ops::RangeToInclusive { end: 5 });
+   |                +
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/range/issue-54505-no-std.rs
+++ b/tests/ui/range/issue-54505-no-std.rs
@@ -29,30 +29,30 @@ fn main() {
     take_range(0..1);
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(0..1)
+    //~| SUGGESTION &(
 
     take_range(1..);
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(1..)
+    //~| SUGGESTION &(
 
     take_range(..);
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(..)
+    //~| SUGGESTION &(
 
     take_range(0..=1);
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(0..=1)
+    //~| SUGGESTION &(
 
     take_range(..5);
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(..5)
+    //~| SUGGESTION &(
 
     take_range(..=42);
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(..=42)
+    //~| SUGGESTION &(
 }

--- a/tests/ui/range/issue-54505-no-std.stderr
+++ b/tests/ui/range/issue-54505-no-std.stderr
@@ -14,10 +14,8 @@ error[E0308]: mismatched types
   --> $DIR/issue-54505-no-std.rs:29:16
    |
 LL |     take_range(0..1);
-   |     ---------- ^^^^
-   |     |          |
-   |     |          expected `&_`, found `Range<{integer}>`
-   |     |          help: consider borrowing here: `&(0..1)`
+   |     ---------- ^^^^ expected `&_`, found `Range<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -27,15 +25,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&(0..1));
+   |                ++    +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-std.rs:34:16
    |
 LL |     take_range(1..);
-   |     ---------- ^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeFrom<{integer}>`
-   |     |          help: consider borrowing here: `&(1..)`
+   |     ---------- ^^^ expected `&_`, found `RangeFrom<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -45,15 +45,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&(1..));
+   |                ++   +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-std.rs:39:16
    |
 LL |     take_range(..);
-   |     ---------- ^^
-   |     |          |
-   |     |          expected `&_`, found `RangeFull`
-   |     |          help: consider borrowing here: `&(..)`
+   |     ---------- ^^ expected `&_`, found `RangeFull`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -63,15 +65,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&(..));
+   |                ++  +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-std.rs:44:16
    |
 LL |     take_range(0..=1);
-   |     ---------- ^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeInclusive<{integer}>`
-   |     |          help: consider borrowing here: `&(0..=1)`
+   |     ---------- ^^^^^ expected `&_`, found `RangeInclusive<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -81,15 +85,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&(0..=1));
+   |                ++     +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-std.rs:49:16
    |
 LL |     take_range(..5);
-   |     ---------- ^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeTo<{integer}>`
-   |     |          help: consider borrowing here: `&(..5)`
+   |     ---------- ^^^ expected `&_`, found `RangeTo<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -99,15 +105,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&(..5));
+   |                ++   +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505-no-std.rs:54:16
    |
 LL |     take_range(..=42);
-   |     ---------- ^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeToInclusive<{integer}>`
-   |     |          help: consider borrowing here: `&(..=42)`
+   |     ---------- ^^^^^ expected `&_`, found `RangeToInclusive<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -117,6 +125,10 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&(..=42));
+   |                ++     +
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/range/issue-54505.fixed
+++ b/tests/ui/range/issue-54505.fixed
@@ -14,30 +14,30 @@ fn main() {
     take_range(&(0..1));
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(0..1)
+    //~| SUGGESTION &(
 
     take_range(&(1..));
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(1..)
+    //~| SUGGESTION &(
 
     take_range(&(..));
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(..)
+    //~| SUGGESTION &(
 
     take_range(&(0..=1));
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(0..=1)
+    //~| SUGGESTION &(
 
     take_range(&(..5));
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(..5)
+    //~| SUGGESTION &(
 
     take_range(&(..=42));
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(..=42)
+    //~| SUGGESTION &(
 }

--- a/tests/ui/range/issue-54505.rs
+++ b/tests/ui/range/issue-54505.rs
@@ -14,30 +14,30 @@ fn main() {
     take_range(0..1);
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(0..1)
+    //~| SUGGESTION &(
 
     take_range(1..);
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(1..)
+    //~| SUGGESTION &(
 
     take_range(..);
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(..)
+    //~| SUGGESTION &(
 
     take_range(0..=1);
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(0..=1)
+    //~| SUGGESTION &(
 
     take_range(..5);
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(..5)
+    //~| SUGGESTION &(
 
     take_range(..=42);
     //~^ ERROR mismatched types [E0308]
     //~| HELP consider borrowing here
-    //~| SUGGESTION &(..=42)
+    //~| SUGGESTION &(
 }

--- a/tests/ui/range/issue-54505.stderr
+++ b/tests/ui/range/issue-54505.stderr
@@ -2,10 +2,8 @@ error[E0308]: mismatched types
   --> $DIR/issue-54505.rs:14:16
    |
 LL |     take_range(0..1);
-   |     ---------- ^^^^
-   |     |          |
-   |     |          expected `&_`, found `Range<{integer}>`
-   |     |          help: consider borrowing here: `&(0..1)`
+   |     ---------- ^^^^ expected `&_`, found `Range<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -15,15 +13,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&(0..1));
+   |                ++    +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505.rs:19:16
    |
 LL |     take_range(1..);
-   |     ---------- ^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeFrom<{integer}>`
-   |     |          help: consider borrowing here: `&(1..)`
+   |     ---------- ^^^ expected `&_`, found `RangeFrom<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -33,15 +33,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&(1..));
+   |                ++   +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505.rs:24:16
    |
 LL |     take_range(..);
-   |     ---------- ^^
-   |     |          |
-   |     |          expected `&_`, found `RangeFull`
-   |     |          help: consider borrowing here: `&(..)`
+   |     ---------- ^^ expected `&_`, found `RangeFull`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -51,15 +53,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&(..));
+   |                ++  +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505.rs:29:16
    |
 LL |     take_range(0..=1);
-   |     ---------- ^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeInclusive<{integer}>`
-   |     |          help: consider borrowing here: `&(0..=1)`
+   |     ---------- ^^^^^ expected `&_`, found `RangeInclusive<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -69,15 +73,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&(0..=1));
+   |                ++     +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505.rs:34:16
    |
 LL |     take_range(..5);
-   |     ---------- ^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeTo<{integer}>`
-   |     |          help: consider borrowing here: `&(..5)`
+   |     ---------- ^^^ expected `&_`, found `RangeTo<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -87,15 +93,17 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&(..5));
+   |                ++   +
 
 error[E0308]: mismatched types
   --> $DIR/issue-54505.rs:39:16
    |
 LL |     take_range(..=42);
-   |     ---------- ^^^^^
-   |     |          |
-   |     |          expected `&_`, found `RangeToInclusive<{integer}>`
-   |     |          help: consider borrowing here: `&(..=42)`
+   |     ---------- ^^^^^ expected `&_`, found `RangeToInclusive<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -105,6 +113,10 @@ note: function defined here
    |
 LL | fn take_range(_r: &impl RangeBounds<i8>) {}
    |    ^^^^^^^^^^ -------------------------
+help: consider borrowing here
+   |
+LL |     take_range(&(..=42));
+   |                ++     +
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/range/issue-73553-misinterp-range-literal.stderr
+++ b/tests/ui/range/issue-73553-misinterp-range-literal.stderr
@@ -2,10 +2,8 @@ error[E0308]: mismatched types
   --> $DIR/issue-73553-misinterp-range-literal.rs:12:10
    |
 LL |     demo(tell(1)..tell(10));
-   |     ---- ^^^^^^^^^^^^^^^^^
-   |     |    |
-   |     |    expected `&Range<usize>`, found `Range<usize>`
-   |     |    help: consider borrowing here: `&(tell(1)..tell(10))`
+   |     ---- ^^^^^^^^^^^^^^^^^ expected `&Range<usize>`, found `Range<usize>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&std::ops::Range<usize>`
@@ -15,15 +13,17 @@ note: function defined here
    |
 LL | fn demo(r: &Range) {
    |    ^^^^ ---------
+help: consider borrowing here
+   |
+LL |     demo(&(tell(1)..tell(10)));
+   |          ++                 +
 
 error[E0308]: mismatched types
   --> $DIR/issue-73553-misinterp-range-literal.rs:14:10
    |
 LL |     demo(1..10);
-   |     ---- ^^^^^
-   |     |    |
-   |     |    expected `&Range<usize>`, found `Range<{integer}>`
-   |     |    help: consider borrowing here: `&(1..10)`
+   |     ---- ^^^^^ expected `&Range<usize>`, found `Range<{integer}>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&std::ops::Range<usize>`
@@ -33,6 +33,10 @@ note: function defined here
    |
 LL | fn demo(r: &Range) {
    |    ^^^^ ---------
+help: consider borrowing here
+   |
+LL |     demo(&(1..10));
+   |          ++     +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/span/coerce-suggestions.stderr
+++ b/tests/ui/span/coerce-suggestions.stderr
@@ -10,11 +10,14 @@ error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:9:19
    |
 LL |     let x: &str = String::new();
-   |            ----   ^^^^^^^^^^^^^
-   |            |      |
-   |            |      expected `&str`, found `String`
-   |            |      help: consider borrowing here: `&String::new()`
+   |            ----   ^^^^^^^^^^^^^ expected `&str`, found `String`
+   |            |
    |            expected due to this
+   |
+help: consider borrowing here
+   |
+LL |     let x: &str = &String::new();
+   |                   +
 
 error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:12:10

--- a/tests/ui/span/issue-39018.stderr
+++ b/tests/ui/span/issue-39018.stderr
@@ -78,10 +78,12 @@ error[E0308]: mismatched types
   --> $DIR/issue-39018.rs:29:17
    |
 LL |     let _ = a + b;
-   |                 ^
-   |                 |
-   |                 expected `&str`, found `String`
-   |                 help: consider borrowing here: `&b`
+   |                 ^ expected `&str`, found `String`
+   |
+help: consider borrowing here
+   |
+LL |     let _ = a + &b;
+   |                 +
 
 error[E0369]: cannot add `String` to `&String`
   --> $DIR/issue-39018.rs:30:15

--- a/tests/ui/str/str-array-assignment.stderr
+++ b/tests/ui/str/str-array-assignment.stderr
@@ -10,10 +10,12 @@ error[E0308]: mismatched types
   --> $DIR/str-array-assignment.rs:5:27
    |
 LL |   let u: &str = if true { s[..2] } else { s };
-   |                           ^^^^^^
-   |                           |
-   |                           expected `&str`, found `str`
-   |                           help: consider borrowing here: `&s[..2]`
+   |                           ^^^^^^ expected `&str`, found `str`
+   |
+help: consider borrowing here
+   |
+LL |   let u: &str = if true { &s[..2] } else { s };
+   |                           +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/str-array-assignment.rs:7:7
@@ -33,11 +35,14 @@ error[E0308]: mismatched types
   --> $DIR/str-array-assignment.rs:9:17
    |
 LL |   let w: &str = s[..2];
-   |          ----   ^^^^^^
-   |          |      |
-   |          |      expected `&str`, found `str`
-   |          |      help: consider borrowing here: `&s[..2]`
+   |          ----   ^^^^^^ expected `&str`, found `str`
+   |          |
    |          expected due to this
+   |
+help: consider borrowing here
+   |
+LL |   let w: &str = &s[..2];
+   |                 +
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/suggestions/as-ref.stderr
+++ b/tests/ui/suggestions/as-ref.stderr
@@ -2,61 +2,73 @@ error[E0308]: mismatched types
   --> $DIR/as-ref.rs:7:29
    |
 LL |     opt.map(|arg| takes_ref(arg));
-   |         ---       --------- ^^^ expected `&Foo`, found `Foo`
-   |         |         |
-   |         |         arguments to this function are incorrect
-   |         help: consider using `as_ref` instead: `as_ref().map`
+   |                   --------- ^^^ expected `&Foo`, found `Foo`
+   |                   |
+   |                   arguments to this function are incorrect
    |
 note: function defined here
   --> $DIR/as-ref.rs:3:4
    |
 LL | fn takes_ref(_: &Foo) {}
    |    ^^^^^^^^^ -------
+help: consider using `as_ref` instead
+   |
+LL |     opt.as_ref().map(|arg| takes_ref(arg));
+   |         +++++++++
 
 error[E0308]: mismatched types
   --> $DIR/as-ref.rs:8:39
    |
 LL |     opt.and_then(|arg| Some(takes_ref(arg)));
-   |         --------            --------- ^^^ expected `&Foo`, found `Foo`
-   |         |                   |
-   |         |                   arguments to this function are incorrect
-   |         help: consider using `as_ref` instead: `as_ref().and_then`
+   |                             --------- ^^^ expected `&Foo`, found `Foo`
+   |                             |
+   |                             arguments to this function are incorrect
    |
 note: function defined here
   --> $DIR/as-ref.rs:3:4
    |
 LL | fn takes_ref(_: &Foo) {}
    |    ^^^^^^^^^ -------
+help: consider using `as_ref` instead
+   |
+LL |     opt.as_ref().and_then(|arg| Some(takes_ref(arg)));
+   |         +++++++++
 
 error[E0308]: mismatched types
   --> $DIR/as-ref.rs:10:29
    |
 LL |     opt.map(|arg| takes_ref(arg));
-   |         ---       --------- ^^^ expected `&Foo`, found `Foo`
-   |         |         |
-   |         |         arguments to this function are incorrect
-   |         help: consider using `as_ref` instead: `as_ref().map`
+   |                   --------- ^^^ expected `&Foo`, found `Foo`
+   |                   |
+   |                   arguments to this function are incorrect
    |
 note: function defined here
   --> $DIR/as-ref.rs:3:4
    |
 LL | fn takes_ref(_: &Foo) {}
    |    ^^^^^^^^^ -------
+help: consider using `as_ref` instead
+   |
+LL |     opt.as_ref().map(|arg| takes_ref(arg));
+   |         +++++++++
 
 error[E0308]: mismatched types
   --> $DIR/as-ref.rs:11:37
    |
 LL |     opt.and_then(|arg| Ok(takes_ref(arg)));
-   |         --------          --------- ^^^ expected `&Foo`, found `Foo`
-   |         |                 |
-   |         |                 arguments to this function are incorrect
-   |         help: consider using `as_ref` instead: `as_ref().and_then`
+   |                           --------- ^^^ expected `&Foo`, found `Foo`
+   |                           |
+   |                           arguments to this function are incorrect
    |
 note: function defined here
   --> $DIR/as-ref.rs:3:4
    |
 LL | fn takes_ref(_: &Foo) {}
    |    ^^^^^^^^^ -------
+help: consider using `as_ref` instead
+   |
+LL |     opt.as_ref().and_then(|arg| Ok(takes_ref(arg)));
+   |         +++++++++
 
 error[E0308]: mismatched types
   --> $DIR/as-ref.rs:13:29
@@ -101,61 +113,73 @@ error[E0308]: mismatched types
   --> $DIR/as-ref.rs:22:42
    |
 LL |     multiple_ref_opt.map(|arg| takes_ref(arg));
-   |                      ---       --------- ^^^ expected `&Foo`, found `Foo`
-   |                      |         |
-   |                      |         arguments to this function are incorrect
-   |                      help: consider using `as_ref` instead: `as_ref().map`
+   |                                --------- ^^^ expected `&Foo`, found `Foo`
+   |                                |
+   |                                arguments to this function are incorrect
    |
 note: function defined here
   --> $DIR/as-ref.rs:3:4
    |
 LL | fn takes_ref(_: &Foo) {}
    |    ^^^^^^^^^ -------
+help: consider using `as_ref` instead
+   |
+LL |     multiple_ref_opt.as_ref().map(|arg| takes_ref(arg));
+   |                      +++++++++
 
 error[E0308]: mismatched types
   --> $DIR/as-ref.rs:23:52
    |
 LL |     multiple_ref_opt.and_then(|arg| Some(takes_ref(arg)));
-   |                      --------            --------- ^^^ expected `&Foo`, found `Foo`
-   |                      |                   |
-   |                      |                   arguments to this function are incorrect
-   |                      help: consider using `as_ref` instead: `as_ref().and_then`
+   |                                          --------- ^^^ expected `&Foo`, found `Foo`
+   |                                          |
+   |                                          arguments to this function are incorrect
    |
 note: function defined here
   --> $DIR/as-ref.rs:3:4
    |
 LL | fn takes_ref(_: &Foo) {}
    |    ^^^^^^^^^ -------
+help: consider using `as_ref` instead
+   |
+LL |     multiple_ref_opt.as_ref().and_then(|arg| Some(takes_ref(arg)));
+   |                      +++++++++
 
 error[E0308]: mismatched types
   --> $DIR/as-ref.rs:25:45
    |
 LL |     multiple_ref_result.map(|arg| takes_ref(arg));
-   |                         ---       --------- ^^^ expected `&Foo`, found `Foo`
-   |                         |         |
-   |                         |         arguments to this function are incorrect
-   |                         help: consider using `as_ref` instead: `as_ref().map`
+   |                                   --------- ^^^ expected `&Foo`, found `Foo`
+   |                                   |
+   |                                   arguments to this function are incorrect
    |
 note: function defined here
   --> $DIR/as-ref.rs:3:4
    |
 LL | fn takes_ref(_: &Foo) {}
    |    ^^^^^^^^^ -------
+help: consider using `as_ref` instead
+   |
+LL |     multiple_ref_result.as_ref().map(|arg| takes_ref(arg));
+   |                         +++++++++
 
 error[E0308]: mismatched types
   --> $DIR/as-ref.rs:26:53
    |
 LL |     multiple_ref_result.and_then(|arg| Ok(takes_ref(arg)));
-   |                         --------          --------- ^^^ expected `&Foo`, found `Foo`
-   |                         |                 |
-   |                         |                 arguments to this function are incorrect
-   |                         help: consider using `as_ref` instead: `as_ref().and_then`
+   |                                           --------- ^^^ expected `&Foo`, found `Foo`
+   |                                           |
+   |                                           arguments to this function are incorrect
    |
 note: function defined here
   --> $DIR/as-ref.rs:3:4
    |
 LL | fn takes_ref(_: &Foo) {}
    |    ^^^^^^^^^ -------
+help: consider using `as_ref` instead
+   |
+LL |     multiple_ref_result.as_ref().and_then(|arg| Ok(takes_ref(arg)));
+   |                         +++++++++
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/suggestions/suggest-ref-macro.rs
+++ b/tests/ui/suggestions/suggest-ref-macro.rs
@@ -14,7 +14,7 @@ macro_rules! bla {
     () => {
         x(123);
         //~^ ERROR mismatched types
-        //~| SUGGESTION &mut 123
+        //~| SUGGESTION &mut
     };
     ($v:expr) => {
         x($v)
@@ -25,5 +25,5 @@ fn main() {
     bla!();
     bla!(456);
     //~^ ERROR mismatched types
-    //~| SUGGESTION &mut 456
+    //~| SUGGESTION &mut
 }

--- a/tests/ui/suggestions/suggest-ref-macro.stderr
+++ b/tests/ui/suggestions/suggest-ref-macro.stderr
@@ -18,10 +18,8 @@ error[E0308]: mismatched types
   --> $DIR/suggest-ref-macro.rs:15:11
    |
 LL |         x(123);
-   |         - ^^^
-   |         | |
-   |         | expected `&mut i32`, found integer
-   |         | help: consider mutably borrowing here: `&mut 123`
+   |         - ^^^ expected `&mut i32`, found integer
+   |         |
    |         arguments to this function are incorrect
 ...
 LL |     bla!();
@@ -33,6 +31,10 @@ note: function defined here
 LL | fn x(_: &mut i32) {}
    |    ^ -----------
    = note: this error originates in the macro `bla` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider mutably borrowing here
+   |
+LL |         x(&mut 123);
+   |           ++++
 
 error[E0308]: mismatched types
   --> $DIR/suggest-ref-macro.rs:26:10
@@ -41,16 +43,17 @@ LL |         x($v)
    |         - arguments to this function are incorrect
 ...
 LL |     bla!(456);
-   |          ^^^
-   |          |
-   |          expected `&mut i32`, found integer
-   |          help: consider mutably borrowing here: `&mut 456`
+   |          ^^^ expected `&mut i32`, found integer
    |
 note: function defined here
   --> $DIR/suggest-ref-macro.rs:11:4
    |
 LL | fn x(_: &mut i32) {}
    |    ^ -----------
+help: consider mutably borrowing here
+   |
+LL |     bla!(&mut 456);
+   |          ++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/test-attrs/tests-listing-format-json.run.stdout
+++ b/tests/ui/test-attrs/tests-listing-format-json.run.stdout
@@ -1,5 +1,5 @@
 { "type": "suite", "event": "discovery" }
-{ "type": "test", "event": "discovered", "name": "a_test", "ignore": false, "ignore_message": "", "source_path": "$DIR/tests-listing-format-json.rs", "start_line": 20, "start_col": 4, "end_line": 20, "end_col": 10 }
-{ "type": "test", "event": "discovered", "name": "m_test", "ignore": false, "ignore_message": "", "source_path": "$DIR/tests-listing-format-json.rs", "start_line": 13, "start_col": 4, "end_line": 13, "end_col": 10 }
-{ "type": "test", "event": "discovered", "name": "z_test", "ignore": true, "ignore_message": "not yet implemented", "source_path": "$DIR/tests-listing-format-json.rs", "start_line": 17, "start_col": 4, "end_line": 17, "end_col": 10 }
+{ "type": "test", "event": "discovered", "name": "a_test", "ignore": false, "ignore_message": "", "source_path": "$DIR/tests-listing-format-json.rs", "start_line": 21, "start_col": 4, "end_line": 21, "end_col": 10 }
+{ "type": "test", "event": "discovered", "name": "m_test", "ignore": false, "ignore_message": "", "source_path": "$DIR/tests-listing-format-json.rs", "start_line": 14, "start_col": 4, "end_line": 14, "end_col": 10 }
+{ "type": "test", "event": "discovered", "name": "z_test", "ignore": true, "ignore_message": "not yet implemented", "source_path": "$DIR/tests-listing-format-json.rs", "start_line": 18, "start_col": 4, "end_line": 18, "end_col": 10 }
 { "type": "suite", "event": "completed", "tests": 3, "benchmarks": 0, "total": 3, "ignored": 1 }

--- a/tests/ui/traits/new-solver/exponential-trait-goals.rs
+++ b/tests/ui/traits/new-solver/exponential-trait-goals.rs
@@ -1,0 +1,20 @@
+// compile-flags: -Ztrait-solver=next
+
+trait Trait {}
+
+struct W<T>(T);
+
+impl<T, U> Trait for W<(W<T>, W<U>)>
+where
+    W<T>: Trait,
+    W<U>: Trait,
+{
+}
+
+fn impls<T: Trait>() {}
+
+fn main() {
+    impls::<W<_>>();
+    //~^ ERROR type annotations needed
+    //~| ERROR overflow evaluating the requirement `W<_>: Trait`
+}

--- a/tests/ui/traits/new-solver/exponential-trait-goals.stderr
+++ b/tests/ui/traits/new-solver/exponential-trait-goals.stderr
@@ -1,0 +1,23 @@
+error[E0282]: type annotations needed
+  --> $DIR/exponential-trait-goals.rs:17:5
+   |
+LL |     impls::<W<_>>();
+   |     ^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `impls`
+
+error[E0275]: overflow evaluating the requirement `W<_>: Trait`
+  --> $DIR/exponential-trait-goals.rs:17:5
+   |
+LL |     impls::<W<_>>();
+   |     ^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`exponential_trait_goals`)
+note: required by a bound in `impls`
+  --> $DIR/exponential-trait-goals.rs:14:13
+   |
+LL | fn impls<T: Trait>() {}
+   |             ^^^^^ required by this bound in `impls`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0275, E0282.
+For more information about an error, try `rustc --explain E0275`.

--- a/tests/ui/type/type-mismatch.stderr
+++ b/tests/ui/type/type-mismatch.stderr
@@ -378,10 +378,8 @@ error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:47:23
    |
 LL |     want::<&Foo<foo>>(f);
-   |     ----------------- ^
-   |     |                 |
-   |     |                 expected `&Foo<foo>`, found `Foo<foo>`
-   |     |                 help: consider borrowing here: `&f`
+   |     ----------------- ^ expected `&Foo<foo>`, found `Foo<foo>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&Foo<foo>`
@@ -391,6 +389,10 @@ note: function defined here
    |
 LL | fn want<T>(t: T) {}
    |    ^^^^    ----
+help: consider borrowing here
+   |
+LL |     want::<&Foo<foo>>(&f);
+   |                       +
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:48:26
@@ -556,10 +558,8 @@ error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:61:26
    |
 LL |     want::<&Foo<foo, B>>(f);
-   |     -------------------- ^
-   |     |                    |
-   |     |                    expected `&Foo<foo, B>`, found `Foo<foo, B>`
-   |     |                    help: consider borrowing here: `&f`
+   |     -------------------- ^ expected `&Foo<foo, B>`, found `Foo<foo, B>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&Foo<foo, B>`
@@ -569,6 +569,10 @@ note: function defined here
    |
 LL | fn want<T>(t: T) {}
    |    ^^^^    ----
+help: consider borrowing here
+   |
+LL |     want::<&Foo<foo, B>>(&f);
+   |                          +
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:65:19

--- a/tests/ui/typeck/bad-type-in-vec-contains.stderr
+++ b/tests/ui/typeck/bad-type-in-vec-contains.stderr
@@ -2,16 +2,18 @@ error[E0308]: mismatched types
   --> $DIR/bad-type-in-vec-contains.rs:5:21
    |
 LL |     primes.contains(3);
-   |            -------- ^
-   |            |        |
-   |            |        expected `&_`, found integer
-   |            |        help: consider borrowing here: `&3`
+   |            -------- ^ expected `&_`, found integer
+   |            |
    |            arguments to this method are incorrect
    |
    = note: expected reference `&_`
                    found type `{integer}`
 note: method defined here
   --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
+help: consider borrowing here
+   |
+LL |     primes.contains(&3);
+   |                     +
 
 error: aborting due to previous error
 

--- a/tests/ui/typeck/issue-13853.stderr
+++ b/tests/ui/typeck/issue-13853.stderr
@@ -20,10 +20,8 @@ error[E0308]: mismatched types
   --> $DIR/issue-13853.rs:37:13
    |
 LL |     iterate(graph);
-   |     ------- ^^^^^
-   |     |       |
-   |     |       expected `&_`, found `Vec<Stuff>`
-   |     |       help: consider borrowing here: `&graph`
+   |     ------- ^^^^^ expected `&_`, found `Vec<Stuff>`
+   |     |
    |     arguments to this function are incorrect
    |
    = note: expected reference `&_`
@@ -33,6 +31,10 @@ note: function defined here
    |
 LL | fn iterate<N: Node, G: Graph<N>>(graph: &G) {
    |    ^^^^^^^                       ---------
+help: consider borrowing here
+   |
+LL |     iterate(&graph);
+   |             +
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/unsized-locals/suggest-borrow.stderr
+++ b/tests/ui/unsized-locals/suggest-borrow.stderr
@@ -16,11 +16,14 @@ error[E0308]: mismatched types
   --> $DIR/suggest-borrow.rs:3:20
    |
 LL |     let x: &[u8] = vec!(1, 2, 3)[..];
-   |            -----   ^^^^^^^^^^^^^^^^^
-   |            |       |
-   |            |       expected `&[u8]`, found `[{integer}]`
-   |            |       help: consider borrowing here: `&vec!(1, 2, 3)[..]`
+   |            -----   ^^^^^^^^^^^^^^^^^ expected `&[u8]`, found `[{integer}]`
+   |            |
    |            expected due to this
+   |
+help: consider borrowing here
+   |
+LL |     let x: &[u8] = &vec!(1, 2, 3)[..];
+   |                    +
 
 error[E0308]: mismatched types
   --> $DIR/suggest-borrow.rs:4:19


### PR DESCRIPTION
Successful merges:

 - #110504 (Tweak borrow suggestion span)
 - #110614 (Clear response values for overflow in new solver)
 - #110644 (Update tests for libtest `--format json`)
 - #110894 (Bump libffi-sys to 2.3.0)
 - #110932 (include source error for LoadLibraryExW)
 - #110951 (Add support for LibreSSL 3.7.x)
 - #110958 (Make sure that some stdlib method signatures aren't accidental refinements)
 - #110962 (Make drop_flags an IndexVec.)
 - #110965 (Don't duplicate anonymous lifetimes for async fn in traits)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=110504,110614,110644,110894,110932,110951,110958,110962,110965)
<!-- homu-ignore:end -->