### PR TITLE
Do not recurse into const generic args when resolving self lifetime elision.

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2075,6 +2075,10 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
                 }
                 visit::walk_ty(self, ty)
             }
+
+            // A type may have an expression as a const generic argument.
+            // We do not want to recurse into those.
+            fn visit_expr(&mut self, _: &'a Expr) {}
         }
 
         let impl_self = self

--- a/tests/ui/self/elision/nested-item.rs
+++ b/tests/ui/self/elision/nested-item.rs
@@ -1,0 +1,13 @@
+// Regression test for #110899.
+// When looking for the elided lifetime for `wrap`,
+// we must not consider the lifetimes in `bar` as candidates.
+
+fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &() {
+    //~^ ERROR `self` parameter is only allowed in associated functions
+    //~| ERROR `self` parameter is only allowed in associated functions
+    //~| ERROR missing lifetime specifier
+    //~| ERROR cannot find type `Wrap` in this scope
+    &()
+}
+
+fn main() {}

--- a/tests/ui/self/elision/nested-item.stderr
+++ b/tests/ui/self/elision/nested-item.stderr
@@ -1,0 +1,38 @@
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/nested-item.rs:5:9
+   |
+LL | fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &() {
+   |         ^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/nested-item.rs:5:29
+   |
+LL | fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &() {
+   |                             ^^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/nested-item.rs:5:46
+   |
+LL | fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &() {
+   |                                              ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+help: consider using the `'static` lifetime
+   |
+LL | fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &'static () {
+   |                                               +++++++
+
+error[E0412]: cannot find type `Wrap` in this scope
+  --> $DIR/nested-item.rs:5:15
+   |
+LL | fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &() {
+   |               ^^^^ not found in this scope
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0106, E0412.
+For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/110899

r? @petrochenkov 