### PR TITLE
rustdoc: Get `repr` information through `AdtDef` for foreign items

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -344,7 +344,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     ungated!(link_name, Normal, template!(NameValueStr: "name"), FutureWarnPreceding),
     ungated!(no_link, Normal, template!(Word), WarnFollowing),
-    ungated!(repr, Normal, template!(List: "C"), DuplicatesOk),
+    ungated!(repr, Normal, template!(List: "C"), DuplicatesOk, @only_local: true),
     ungated!(export_name, Normal, template!(NameValueStr: "name"), FutureWarnPreceding),
     ungated!(link_section, Normal, template!(NameValueStr: "name"), FutureWarnPreceding),
     ungated!(no_mangle, Normal, template!(Word), WarnFollowing, @only_local: true),

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -548,7 +548,7 @@ fn item_function(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, f: &cle
             w,
             "{attrs}{vis}{constness}{asyncness}{unsafety}{abi}fn \
                 {name}{generics}{decl}{notable_traits}{where_clause}",
-            attrs = render_attributes_in_pre(it, ""),
+            attrs = render_attributes_in_pre(it, "", tcx),
             vis = visibility,
             constness = constness,
             asyncness = asyncness,
@@ -589,7 +589,7 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
             it.name.unwrap(),
             t.generics.print(cx),
             bounds,
-            attrs = render_attributes_in_pre(it, ""),
+            attrs = render_attributes_in_pre(it, "", tcx),
         );
 
         if !t.generics.where_predicates.is_empty() {
@@ -1063,7 +1063,7 @@ fn item_trait_alias(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &
             t.generics.print(cx),
             print_where_clause(&t.generics, cx, 0, Ending::Newline),
             bounds(&t.bounds, true, cx),
-            attrs = render_attributes_in_pre(it, ""),
+            attrs = render_attributes_in_pre(it, "", cx.tcx()),
         );
     });
 
@@ -1085,7 +1085,7 @@ fn item_opaque_ty(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &cl
             t.generics.print(cx),
             where_clause = print_where_clause(&t.generics, cx, 0, Ending::Newline),
             bounds = bounds(&t.bounds, false, cx),
-            attrs = render_attributes_in_pre(it, ""),
+            attrs = render_attributes_in_pre(it, "", cx.tcx()),
         );
     });
 
@@ -1109,7 +1109,7 @@ fn item_typedef(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clea
                 t.generics.print(cx),
                 where_clause = print_where_clause(&t.generics, cx, 0, Ending::Newline),
                 type_ = t.type_.print(cx),
-                attrs = render_attributes_in_pre(it, ""),
+                attrs = render_attributes_in_pre(it, "", cx.tcx()),
             );
         });
     }
@@ -1168,7 +1168,8 @@ fn item_union(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean:
             &'b self,
         ) -> impl fmt::Display + Captures<'a> + 'b + Captures<'cx> {
             display_fn(move |f| {
-                let v = render_attributes_in_pre(self.it, "");
+                let tcx = self.cx.borrow().tcx();
+                let v = render_attributes_in_pre(self.it, "", tcx);
                 write!(f, "{v}")
             })
         }
@@ -1250,7 +1251,7 @@ fn item_enum(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, e: &clean::
             visibility_print_with_space(it.visibility(tcx), it.item_id, cx),
             it.name.unwrap(),
             e.generics.print(cx),
-            attrs = render_attributes_in_pre(it, ""),
+            attrs = render_attributes_in_pre(it, "", tcx),
         );
         if !print_where_clause_and_check(w, &e.generics, cx) {
             // If there wasn't a `where` clause, we add a whitespace.
@@ -1445,7 +1446,7 @@ fn item_primitive(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item) {
 fn item_constant(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, c: &clean::Constant) {
     wrap_item(w, |w| {
         let tcx = cx.tcx();
-        render_attributes_in_code(w, it);
+        render_attributes_in_code(w, it, tcx);
 
         write!(
             w,
@@ -1492,7 +1493,7 @@ fn item_constant(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, c: &cle
 
 fn item_struct(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean::Struct) {
     wrap_item(w, |w| {
-        render_attributes_in_code(w, it);
+        render_attributes_in_code(w, it, cx.tcx());
         render_struct(w, it, Some(&s.generics), s.ctor_kind, &s.fields, "", true, cx);
     });
 
@@ -1542,7 +1543,7 @@ fn item_struct(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean
 
 fn item_static(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean::Static) {
     wrap_item(w, |w| {
-        render_attributes_in_code(w, it);
+        render_attributes_in_code(w, it, cx.tcx());
         write!(
             w,
             "{vis}static {mutability}{name}: {typ}",
@@ -1558,7 +1559,7 @@ fn item_static(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean
 fn item_foreign_type(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item) {
     wrap_item(w, |w| {
         w.write_str("extern {\n");
-        render_attributes_in_code(w, it);
+        render_attributes_in_code(w, it, cx.tcx());
         write!(
             w,
             "    {}type {};\n}}",

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1245,13 +1245,13 @@ fn item_enum(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, e: &clean::
     let tcx = cx.tcx();
     let count_variants = e.variants().count();
     wrap_item(w, |mut w| {
+        render_attributes_in_code(w, it, tcx);
         write!(
             w,
-            "{attrs}{}enum {}{}",
+            "{}enum {}{}",
             visibility_print_with_space(it.visibility(tcx), it.item_id, cx),
             it.name.unwrap(),
             e.generics.print(cx),
-            attrs = render_attributes_in_pre(it, "", tcx),
         );
         if !print_where_clause_and_check(w, &e.generics, cx) {
             // If there wasn't a `where` clause, we add a whitespace.

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -41,12 +41,7 @@ impl JsonRenderer<'_> {
             })
             .collect();
         let docs = item.attrs.collapsed_doc_value();
-        let attrs = item
-            .attrs
-            .other_attrs
-            .iter()
-            .map(rustc_ast_pretty::pprust::attribute_to_string)
-            .collect();
+        let attrs = item.attributes(self.tcx, true);
         let span = item.span(self.tcx);
         let visibility = item.visibility(self.tcx);
         let clean::Item { name, item_id, .. } = item;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -33,6 +33,7 @@ extern crate tracing;
 // Dependencies listed in Cargo.toml do not need `extern crate`.
 
 extern crate pulldown_cmark;
+extern crate rustc_abi;
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
 extern crate rustc_attr;

--- a/tests/rustdoc/inline_cross/auxiliary/repr.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/repr.rs
@@ -1,4 +1,22 @@
-#[repr(C)]
-pub struct Foo {
+#![feature(repr_simd)]
+
+#[repr(C, align(8))]
+pub struct ReprC {
     field: u8,
+}
+#[repr(simd, packed(2))]
+pub struct ReprSimd {
+    field: u8,
+}
+#[repr(transparent)]
+pub struct ReprTransparent {
+    field: u8,
+}
+#[repr(isize)]
+pub enum ReprIsize {
+    Bla,
+}
+#[repr(u8)]
+pub enum ReprU8 {
+    Bla,
 }

--- a/tests/rustdoc/inline_cross/repr.rs
+++ b/tests/rustdoc/inline_cross/repr.rs
@@ -7,7 +7,23 @@
 
 extern crate repr;
 
-// @has 'foo/struct.Foo.html'
-// @has - '//*[@class="rust item-decl"]//*[@class="code-attribute"]' '#[repr(C)]'
+// @has 'foo/struct.ReprC.html'
+// @has - '//*[@class="rust item-decl"]//*[@class="code-attribute"]' '#[repr(C, align(8))]'
 #[doc(inline)]
-pub use repr::Foo;
+pub use repr::ReprC;
+// @has 'foo/struct.ReprSimd.html'
+// @has - '//*[@class="rust item-decl"]//*[@class="code-attribute"]' '#[repr(simd, packed(2))]'
+#[doc(inline)]
+pub use repr::ReprSimd;
+// @has 'foo/struct.ReprTransparent.html'
+// @has - '//*[@class="rust item-decl"]//*[@class="code-attribute"]' '#[repr(transparent)]'
+#[doc(inline)]
+pub use repr::ReprTransparent;
+// @has 'foo/enum.ReprIsize.html'
+// @has - '//*[@class="rust item-decl"]//*[@class="code-attribute"]' '#[repr(isize)]'
+#[doc(inline)]
+pub use repr::ReprIsize;
+// @has 'foo/enum.ReprU8.html'
+// @has - '//*[@class="rust item-decl"]//*[@class="code-attribute"]' '#[repr(u8)]'
+#[doc(inline)]
+pub use repr::ReprU8;


### PR DESCRIPTION
As suggested by @notriddle, this approach works too. The only downside is that the display of the original attribute isn't kept, but I think it's an acceptable downside.

r? @notriddle 