### PR TITLE
Add `lint_duplicate_trait` for duplicate specified traits in a trait object

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -192,6 +192,10 @@ lint_redundant_semicolons =
         *[false] this semicolon
     }
 
+lint_duplicate_trait =
+    trait `{$trait_name}` was already specified
+    .suggestion = remove duplicate trait
+
 lint_drop_trait_constraints =
     bounds on `{$predicate}` are most likely incorrect, consider instead using `{$needs_drop}` to detect whether a type can be trivially dropped
 

--- a/compiler/rustc_lint/src/duplicate_trait.rs
+++ b/compiler/rustc_lint/src/duplicate_trait.rs
@@ -56,7 +56,7 @@ impl<'tcx> LateLintPass<'tcx> for DuplicateTrait {
                     bound.span,
                     DuplicateTraitDiag {
                         trait_name: cx.tcx.item_name(def_id),
-                        suggestion: bound.span
+                        suggestion: bound.span,
                     },
                 )
             }

--- a/compiler/rustc_lint/src/duplicate_trait.rs
+++ b/compiler/rustc_lint/src/duplicate_trait.rs
@@ -47,7 +47,7 @@ impl<'tcx> LateLintPass<'tcx> for DuplicateTrait {
         let mut last_bound = &bounds[0];
         for bound in bounds.iter().skip(1) {
             if last_bound.trait_ref.trait_def_id() == bound.trait_ref.trait_def_id()
-                && let Some(def_id) = last_bound.trait_ref.trait_def_id() {
+                && let Some(def_id) = bound.trait_ref.trait_def_id() {
                 cx.tcx.emit_spanned_lint(
                     DUPLICATE_TRAIT,
                     bound.trait_ref.hir_ref_id, // is this correct?

--- a/compiler/rustc_lint/src/duplicate_trait.rs
+++ b/compiler/rustc_lint/src/duplicate_trait.rs
@@ -1,0 +1,65 @@
+use crate::hir;
+
+use crate::{lints::DuplicateTraitDiag, LateContext, LateLintPass};
+
+declare_lint! {
+    /// The `lint_duplicate_trait` lints repetition of traits.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// fn foo(_: &(dyn MyTrait + Send + Send>) {}
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Duplicate trait `Send` in trait object.
+    pub DUPLICATE_TRAIT,
+    Warn,
+    "duplicate trait constraint in trait object"
+}
+
+declare_lint_pass!(DuplicateTrait => [DUPLICATE_TRAIT]);
+
+impl<'tcx> LateLintPass<'tcx> for DuplicateTrait {
+    fn check_ty(&mut self, cx: &LateContext<'tcx>, ty: &'tcx hir::Ty<'tcx>) {
+        let hir::TyKind::Ref(
+            ..,
+            hir::MutTy {
+                ty: hir::Ty {
+                    kind: hir::TyKind::TraitObject(bounds, ..),
+                    ..
+                },
+                ..
+            }
+        ) = ty.kind else { return; };
+
+        let mut bounds = (*bounds).to_owned();
+
+        bounds.sort_unstable_by_key(|b| b.trait_ref.trait_def_id());
+
+        if bounds.len() < 2 {
+            return;
+        }
+
+        let mut last_bound = &bounds[0];
+        for bound in bounds.iter().skip(1) {
+            if last_bound.trait_ref.trait_def_id() == bound.trait_ref.trait_def_id()
+                && let Some(def_id) = last_bound.trait_ref.trait_def_id() {
+                cx.tcx.emit_spanned_lint(
+                    DUPLICATE_TRAIT,
+                    bound.trait_ref.hir_ref_id, // is this correct?
+                    bound.span,
+                    DuplicateTraitDiag {
+                        trait_name: cx.tcx.item_name(def_id),
+                        suggestion: bound.span
+                    },
+                )
+            }
+
+            last_bound = bound;
+        }
+    }
+}

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -77,6 +77,7 @@ mod redundant_semicolon;
 mod traits;
 mod types;
 mod unused;
+mod duplicate_trait;
 
 pub use array_into_iter::ARRAY_INTO_ITER;
 
@@ -125,6 +126,7 @@ pub use passes::{EarlyLintPass, LateLintPass};
 pub use rustc_session::lint::Level::{self, *};
 pub use rustc_session::lint::{BufferedEarlyLint, FutureIncompatibleInfo, Lint, LintId};
 pub use rustc_session::lint::{LintArray, LintPass};
+use duplicate_trait::DuplicateTrait;
 
 fluent_messages! { "../messages.ftl" }
 
@@ -242,6 +244,7 @@ late_lint_methods!(
             OpaqueHiddenInferredBound: OpaqueHiddenInferredBound,
             MultipleSupertraitUpcastable: MultipleSupertraitUpcastable,
             MapUnitFn: MapUnitFn,
+            DuplicateTrait: DuplicateTrait,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -52,6 +52,7 @@ mod array_into_iter;
 pub mod builtin;
 mod context;
 mod deref_into_dyn_supertrait;
+mod duplicate_trait;
 mod early;
 mod enum_intrinsics_non_enums;
 mod errors;
@@ -77,7 +78,6 @@ mod redundant_semicolon;
 mod traits;
 mod types;
 mod unused;
-mod duplicate_trait;
 
 pub use array_into_iter::ARRAY_INTO_ITER;
 
@@ -120,13 +120,13 @@ use unused::*;
 pub use builtin::SoftLints;
 pub use context::{CheckLintNameResult, FindLintError, LintStore};
 pub use context::{EarlyContext, LateContext, LintContext};
+use duplicate_trait::DuplicateTrait;
 pub use early::{check_ast_node, EarlyCheckNode};
 pub use late::{check_crate, unerased_lint_store};
 pub use passes::{EarlyLintPass, LateLintPass};
 pub use rustc_session::lint::Level::{self, *};
 pub use rustc_session::lint::{BufferedEarlyLint, FutureIncompatibleInfo, Lint, LintId};
 pub use rustc_session::lint::{LintArray, LintPass};
-use duplicate_trait::DuplicateTrait;
 
 fluent_messages! { "../messages.ftl" }
 

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1168,6 +1168,15 @@ pub struct RedundantSemicolonsDiag {
     pub suggestion: Span,
 }
 
+// duplicate_trait.rs
+#[derive(LintDiagnostic)]
+#[diag(lint_duplicate_trait)]
+pub struct DuplicateTraitDiag {
+    pub trait_name: Symbol,
+    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    pub suggestion: Span,
+}
+
 // traits.rs
 pub struct DropTraitConstraintsDiag<'a> {
     pub predicate: Predicate<'a>,

--- a/tests/ui/lint/duplicate-trait/duplicate-trait.rs
+++ b/tests/ui/lint/duplicate-trait/duplicate-trait.rs
@@ -1,15 +1,16 @@
+// check-fail
 #![warn(duplicate_trait)]
 
 use std::any::Any;
 
 fn main() {}
 
-fn fine(_a: &dyn Any + Send) {}
+fn fine(_a: &(dyn Any + Send)) {}
 
-fn duplicate_once(_a: &(dyn Any + Send + Send)) {}
+fn duplicate_once(_a: &(dyn Any + Send + Send)) {} //~WARNING duplicate trait
 
-fn duplicate_twice(_a: &(dyn Any + Send + Send + Send)) {}
+fn duplicate_twice(_a: &(dyn Any + Send + Send + Send)) {} //~WARNING duplicate trait
 
-fn duplicate_out_of_order(_a: &(dyn Any + Send + Sync + Send)) {}
+fn duplicate_out_of_order(_a: &(dyn Any + Send + Sync + Send)) {} //~WARNING duplicate trait
 
-fn duplicate_multiple(_a: &(dyn Any + Send + Sync + Send + Sync)) {}
+fn duplicate_multiple(_a: &(dyn Any + Send + Sync + Send + Sync)) {} //~WARNING duplicate trait

--- a/tests/ui/lint/duplicate-trait/duplicate-trait.rs
+++ b/tests/ui/lint/duplicate-trait/duplicate-trait.rs
@@ -1,0 +1,15 @@
+#![warn(duplicate_trait)]
+
+use std::any::Any;
+
+fn main() {}
+
+fn fine(_a: &dyn Any + Send) {}
+
+fn duplicate_once(_a: &(dyn Any + Send + Send)) {}
+
+fn duplicate_twice(_a: &(dyn Any + Send + Send + Send)) {}
+
+fn duplicate_out_of_order(_a: &(dyn Any + Send + Sync + Send)) {}
+
+fn duplicate_multiple(_a: &(dyn Any + Send + Sync + Send + Sync)) {}

--- a/tests/ui/lint/duplicate-trait/duplicate-trait.stderr
+++ b/tests/ui/lint/duplicate-trait/duplicate-trait.stderr
@@ -1,0 +1,43 @@
+warning: trait `Send` was already specified
+  --> $DIR/duplicate-trait.rs:9:42
+   |
+LL | fn duplicate_once(_a: &(dyn Any + Send + Send)) {}
+   |                                          ^^^^ help: remove duplicate trait
+   |
+note: the lint level is defined here
+  --> $DIR/duplicate-trait.rs:1:9
+   |
+LL | #![warn(duplicate_trait)]
+   |         ^^^^^^^^^^^^^^^
+
+warning: trait `Send` was already specified
+  --> $DIR/duplicate-trait.rs:11:43
+   |
+LL | fn duplicate_twice(_a: &(dyn Any + Send + Send + Send)) {}
+   |                                           ^^^^ help: remove duplicate trait
+
+warning: trait `Send` was already specified
+  --> $DIR/duplicate-trait.rs:11:50
+   |
+LL | fn duplicate_twice(_a: &(dyn Any + Send + Send + Send)) {}
+   |                                                  ^^^^ help: remove duplicate trait
+
+warning: trait `Send` was already specified
+  --> $DIR/duplicate-trait.rs:13:57
+   |
+LL | fn duplicate_out_of_order(_a: &(dyn Any + Send + Sync + Send)) {}
+   |                                                         ^^^^ help: remove duplicate trait
+
+warning: trait `Send` was already specified
+  --> $DIR/duplicate-trait.rs:15:53
+   |
+LL | fn duplicate_multiple(_a: &(dyn Any + Send + Sync + Send + Sync)) {}
+   |                                                     ^^^^ help: remove duplicate trait
+
+warning: trait `Sync` was already specified
+  --> $DIR/duplicate-trait.rs:15:60
+   |
+LL | fn duplicate_multiple(_a: &(dyn Any + Send + Sync + Send + Sync)) {}
+   |                                                            ^^^^ help: remove duplicate trait
+
+warning: 6 warnings emitted


### PR DESCRIPTION
This adds a new lint, `lint_duplicate_traits`, which warns when traits are duplicately specified, which currently produces no diagnostics. 

```rs
fn duplicate(_a: &(dyn Trait + Send + Send)) {} // Currently generates no warnings, but now will
```

Related to #110961

