### PR TITLE
bootstrap: Fix compile error: unused-mut

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1309,7 +1309,7 @@ impl Config {
         if config.llvm_from_ci {
             let triple = &config.build.triple;
             let ci_llvm_bin = config.ci_llvm_root().join("bin");
-            let mut build_target = config
+            let build_target = config
                 .target_config
                 .entry(config.build)
                 .or_insert_with(|| Target::from_triple(&triple));


### PR DESCRIPTION
Compile errors:

```
   Compiling bootstrap v0.0.0 (/home/hev/rust/rust/src/bootstrap)
error: variable does not need to be mutable
    --> config.rs:1312:17
     |
1312 |             let mut build_target = config
     |                 ----^^^^^^^^^^^^
     |                 |
     |                 help: remove this `mut`
     |
     = note: `-D unused-mut` implied by `-D warnings`

error: could not compile `bootstrap` (lib) due to previous error
```