### PR TITLE
Fix the test directories suggested by `./x.py suggest`

### DIFF
--- a/src/tools/suggest-tests/src/static_suggestions.rs
+++ b/src/tools/suggest-tests/src/static_suggestions.rs
@@ -15,7 +15,7 @@ static_suggestions! {
 
     "compiler/*" => [
         sug!("check"),
-        sug!("test", 1, ["src/test/ui", "src/test/run-make"])
+        sug!("test", 1, ["tests/ui", "tests/run-make"])
     ],
 
     "src/librustdoc/*" => [

--- a/src/tools/suggest-tests/src/tests.rs
+++ b/src/tools/suggest-tests/src/tests.rs
@@ -12,7 +12,7 @@ macro_rules! sugg_test {
 
 sugg_test! {
     test_error_code_docs: ["compiler/rustc_error_codes/src/error_codes/E0000.md"] =>
-        ["check N/A", "test compiler/rustc_error_codes N/A", "test linkchecker 0", "test src/test/ui src/test/run-make 1"],
+        ["check N/A", "test compiler/rustc_error_codes N/A", "test linkchecker 0", "test tests/ui tests/run-make 1"],
 
     test_rustdoc: ["src/librustdoc/src/lib.rs"] => ["test rustdoc 1"],
 


### PR DESCRIPTION
It seems that these paths were correct when #106249 was being written, but since then #106458 has been merged (moving `src/test/` to `tests/`), making the tool's suggestions incorrect.



