### PR TITLE
Remove wrong assertion in match checking.

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -334,9 +334,6 @@ impl<'p, 'tcx> MatchVisitor<'_, 'p, 'tcx> {
                     let refutable = !is_let_irrefutable(&mut ncx, local_lint_level, tpat);
                     Some((expr.span, refutable))
                 }
-                ExprKind::LogicalOp { op: LogicalOp::And, .. } => {
-                    bug!()
-                }
                 _ => None,
             }
         };

--- a/tests/ui/match/guards-parenthesized-and.rs
+++ b/tests/ui/match/guards-parenthesized-and.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+fn main() {
+    let c = 1;
+    let w = "T";
+    match Some(5) {
+        None if c == 1 && (w != "Y" && w != "E") => {}
+        _ => panic!(),
+    }
+}


### PR DESCRIPTION
This assertions is completely misguided, introduced by https://github.com/rust-lang/rust/pull/108504. The responsible PR is on beta, nominating for backport.

Instead of checking that this is not a `&&`, it would make sense to check that neither arms of that `&&` is a `let`. This seems like a lot of code for unclear benefit.

r? @saethlin 