### PR TITLE
assert_eq! message format (take 2)

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -156,6 +156,7 @@ pub macro assert_matches {
             ref left_val => {
                 $crate::panicking::assert_matches_failed(
                     left_val,
+                    $crate::stringify!($left),
                     $crate::stringify!($($pattern)|+ $(if $guard)?),
                     $crate::option::Option::None
                 );
@@ -168,6 +169,7 @@ pub macro assert_matches {
             ref left_val => {
                 $crate::panicking::assert_matches_failed(
                     left_val,
+                    $crate::stringify!($left),
                     $crate::stringify!($($pattern)|+ $(if $guard)?),
                     $crate::option::Option::Some($crate::format_args!($($arg)+))
                 );

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -44,7 +44,7 @@ macro_rules! assert_eq {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, left_name, right_name, $crate::option::Option::None);
+                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::None, left_name, right_name);
                 }
             }
         }
@@ -59,7 +59,7 @@ macro_rules! assert_eq {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, left_name, right_name, $crate::option::Option::Some($crate::format_args!($($arg)+)));
+                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::Some($crate::format_args!($($arg)+)), left_name, right_name);
                 }
             }
         }
@@ -98,7 +98,7 @@ macro_rules! assert_ne {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, left_name, right_name, $crate::option::Option::None);
+                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::None, left_name, right_name);
                 }
             }
         }
@@ -113,7 +113,7 @@ macro_rules! assert_ne {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, left_name, right_name, $crate::option::Option::Some($crate::format_args!($($arg)+)));
+                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::Some($crate::format_args!($($arg)+)), left_name, right_name);
                 }
             }
         }
@@ -156,9 +156,9 @@ pub macro assert_matches {
             ref left_val => {
                 $crate::panicking::assert_matches_failed(
                     left_val,
-                    $crate::stringify!($left),
                     $crate::stringify!($($pattern)|+ $(if $guard)?),
-                    $crate::option::Option::None
+                    $crate::option::Option::None,
+                    $crate::stringify!($left),
                 );
             }
         }
@@ -169,9 +169,9 @@ pub macro assert_matches {
             ref left_val => {
                 $crate::panicking::assert_matches_failed(
                     left_val,
-                    $crate::stringify!($left),
                     $crate::stringify!($($pattern)|+ $(if $guard)?),
-                    $crate::option::Option::Some($crate::format_args!($($arg)+))
+                    $crate::option::Option::Some($crate::format_args!($($arg)+)),
+                    $crate::stringify!($left),
                 );
             }
         }

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -38,13 +38,11 @@ macro_rules! assert_eq {
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
-                    let kind = $crate::panicking::AssertKind::Eq;
-                    let left_name = stringify!($left);
-                    let right_name = stringify!($right);
+                    let assert = $crate::concat!($crate::stringify!($left), " == ", $crate::stringify!($right));
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::None, left_name, right_name);
+                    $crate::panicking::assert_failed(assert, &*left_val, &*right_val, $crate::option::Option::None);
                 }
             }
         }
@@ -53,13 +51,11 @@ macro_rules! assert_eq {
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
-                    let kind = $crate::panicking::AssertKind::Eq;
-                    let left_name = stringify!($left);
-                    let right_name = stringify!($right);
+                    let assert = $crate::concat!($crate::stringify!($left), " == ", $crate::stringify!($right));
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::Some($crate::format_args!($($arg)+)), left_name, right_name);
+                    $crate::panicking::assert_failed(assert, &*left_val, &*right_val, $crate::option::Option::Some($crate::format_args!($($arg)+)));
                 }
             }
         }
@@ -92,13 +88,11 @@ macro_rules! assert_ne {
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if *left_val == *right_val {
-                    let kind = $crate::panicking::AssertKind::Ne;
-                    let left_name = stringify!($left);
-                    let right_name = stringify!($right);
+                    let assert = $crate::concat!($crate::stringify!($left), " != ", $crate::stringify!($right));
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::None, left_name, right_name);
+                    $crate::panicking::assert_failed(assert, &*left_val, &*right_val, $crate::option::Option::None);
                 }
             }
         }
@@ -107,13 +101,11 @@ macro_rules! assert_ne {
         match (&($left), &($right)) {
             (left_val, right_val) => {
                 if *left_val == *right_val {
-                    let kind = $crate::panicking::AssertKind::Ne;
-                    let left_name = stringify!($left);
-                    let right_name = stringify!($right);
+                    let assert = $crate::concat!($crate::stringify!($left), " != ", $crate::stringify!($right));
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::Some($crate::format_args!($($arg)+)), left_name, right_name);
+                    $crate::panicking::assert_failed(assert, &*left_val, &*right_val, $crate::option::Option::Some($crate::format_args!($($arg)+)));
                 }
             }
         }
@@ -154,11 +146,12 @@ pub macro assert_matches {
         match $left {
             $( $pattern )|+ $( if $guard )? => {}
             ref left_val => {
+                let assert = $crate::concat!($crate::stringify!($left), " matches ", $crate::stringify!($($pattern)|+ $(if $guard)?));
                 $crate::panicking::assert_matches_failed(
                     left_val,
                     $crate::stringify!($($pattern)|+ $(if $guard)?),
                     $crate::option::Option::None,
-                    $crate::stringify!($left),
+                    assert,
                 );
             }
         }
@@ -167,11 +160,12 @@ pub macro assert_matches {
         match $left {
             $( $pattern )|+ $( if $guard )? => {}
             ref left_val => {
+                let assert = $crate::concat!($crate::stringify!($left), " matches ", $crate::stringify!($($pattern)|+ $(if $guard)?));
                 $crate::panicking::assert_matches_failed(
                     left_val,
                     $crate::stringify!($($pattern)|+ $(if $guard)?),
                     $crate::option::Option::Some($crate::format_args!($($arg)+)),
-                    $crate::stringify!($left),
+                    assert,
                 );
             }
         }

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -39,10 +39,12 @@ macro_rules! assert_eq {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
                     let kind = $crate::panicking::AssertKind::Eq;
+                    let left_name = stringify!($left);
+                    let right_name = stringify!($right);
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::None);
+                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, left_name, right_name, $crate::option::Option::None);
                 }
             }
         }
@@ -52,10 +54,12 @@ macro_rules! assert_eq {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
                     let kind = $crate::panicking::AssertKind::Eq;
+                    let left_name = stringify!($left);
+                    let right_name = stringify!($right);
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::Some($crate::format_args!($($arg)+)));
+                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, left_name, right_name, $crate::option::Option::Some($crate::format_args!($($arg)+)));
                 }
             }
         }
@@ -89,10 +93,12 @@ macro_rules! assert_ne {
             (left_val, right_val) => {
                 if *left_val == *right_val {
                     let kind = $crate::panicking::AssertKind::Ne;
+                    let left_name = stringify!($left);
+                    let right_name = stringify!($right);
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::None);
+                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, left_name, right_name, $crate::option::Option::None);
                 }
             }
         }
@@ -102,10 +108,12 @@ macro_rules! assert_ne {
             (left_val, right_val) => {
                 if *left_val == *right_val {
                     let kind = $crate::panicking::AssertKind::Ne;
+                    let left_name = stringify!($left);
+                    let right_name = stringify!($right);
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::Some($crate::format_args!($($arg)+)));
+                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, left_name, right_name, $crate::option::Option::Some($crate::format_args!($($arg)+)));
                 }
             }
         }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -236,7 +236,7 @@ where
 #[track_caller]
 #[doc(hidden)]
 pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
-    left: &T,
+    left_val: &T,
     left_name: &'static str,
     right: &'static str,
     args: Option<fmt::Arguments<'_>>,
@@ -248,14 +248,7 @@ pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
             f.write_str(self.0)
         }
     }
-    assert_failed_inner(
-        AssertKind::Match,
-        &left,
-        &Pattern(right),
-        left_name,
-        right,
-        args,
-    );
+    assert_failed_inner(AssertKind::Match, &left_val, &Pattern(right), left_name, right, args);
 }
 
 /// Non-generic version of the above functions, to avoid code bloat.

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -271,13 +271,13 @@ fn assert_failed_inner(
 
     match args {
         Some(args) => panic!(
-            r#"assertion failed: `({left_name} {op} {right_name})`
+            r#"assertion failed: `{left_name} {op} {right_name}`
  error: {args}
   left: `{left:?}`
  right: `{right:?}`"#
         ),
         None => panic!(
-            r#"assertion failed: `({left_name} {op} {right_name})`
+            r#"assertion failed: `{left_name} {op} {right_name}`
   left: `{left:?}`
  right: `{right:?}`"#
         ),

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -267,8 +267,8 @@ fn assert_failed_inner(
     match args {
         Some(args) => panic!(
             r#"assertion failed: `(left {} right)`
-  left: `{:?}`,
- right: `{:?}`,
+   left: `{:?}`,
+  right: `{:?}`,
 context: `{:?}`"#,
             op, left, right, args
         ),

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -278,14 +278,15 @@ fn assert_failed_inner(
     match args {
         Some(args) => panic!(
             r#"assertion failed: `({left_name} {} {right_name})`
-  {left_name}: `{:?}`,
- {right_name}: `{:?}`: {}"#,
+  left: `{:?}`,
+ right: `{:?}`: 
+    at: {}"#,
             op, left_val, right_val, args
         ),
         None => panic!(
             r#"assertion failed: `({left_name} {} {right_name})`
-  {left_name}: `{:?}`,
- {right_name}: `{:?}`"#,
+  left: `{:?}`,
+ right: `{:?}`"#,
             op, left_val, right_val,
         ),
     }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -277,17 +277,17 @@ fn assert_failed_inner(
 
     match args {
         Some(args) => panic!(
-            r#"assertion failed: `({left_name} {} {right_name})`
-  left: `{:?}`,
- right: `{:?}`: 
-    at: {}"#,
-            op, left_val, right_val, args
+            r#"assertion failed: `({left_name} {op} {right_name})`
+ error: {args},
+  left: `{left_val:?}`,
+ right: `{right_val:?}`
+    at: "#
         ),
         None => panic!(
-            r#"assertion failed: `({left_name} {} {right_name})`
-  left: `{:?}`,
- right: `{:?}`"#,
-            op, left_val, right_val,
+            r#"assertion failed: `({left_name} {op} {right_name})`
+  left: `{left_val:?}`,
+ right: `{right_val:?}`
+    at: "#
         ),
     }
 }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -237,7 +237,8 @@ where
 #[doc(hidden)]
 pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
     left: &T,
-    right: &str,
+    left_name: &'static str,
+    right: &'static str,
     args: Option<fmt::Arguments<'_>>,
 ) -> ! {
     // The pattern is a string so it can be displayed directly.
@@ -251,8 +252,8 @@ pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
         AssertKind::Match,
         &left,
         &Pattern(right),
-        stringify!(&left),
-        stringify!(&right),
+        left_name,
+        right,
         args,
     );
 }
@@ -278,13 +279,13 @@ fn assert_failed_inner(
     match args {
         Some(args) => panic!(
             r#"assertion failed: `({left_name} {op} {right_name})`
- error: {args},
-  left: `{left_val:?}`,
+ error: {args}
+  left: `{left_val:?}`
  right: `{right_val:?}`"#
         ),
         None => panic!(
             r#"assertion failed: `({left_name} {op} {right_name})`
-  left: `{left_val:?}`,
+  left: `{left_val:?}`
  right: `{right_val:?}`"#
         ),
     }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -280,14 +280,12 @@ fn assert_failed_inner(
             r#"assertion failed: `({left_name} {op} {right_name})`
  error: {args},
   left: `{left_val:?}`,
- right: `{right_val:?}`
-    at: "#
+ right: `{right_val:?}`"#
         ),
         None => panic!(
             r#"assertion failed: `({left_name} {op} {right_name})`
   left: `{left_val:?}`,
- right: `{right_val:?}`
-    at: "#
+ right: `{right_val:?}`"#
         ),
     }
 }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -202,14 +202,6 @@ pub const fn const_panic_fmt(fmt: fmt::Arguments<'_>) -> ! {
     }
 }
 
-#[derive(Debug)]
-#[doc(hidden)]
-pub enum AssertKind {
-    Eq,
-    Ne,
-    Match,
-}
-
 /// Internal function for `assert_eq!` and `assert_ne!` macros
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never), cold)]
 #[cfg_attr(feature = "panic_immediate_abort", inline)]

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -267,7 +267,7 @@ fn assert_failed_inner(
     match args {
         Some(args) => panic!(
             r#"assertion failed: `(upper_bounds {} target)`
-   Error: `{:?}`,        
+   Error: `{:?}`,
    upper_bounds: `{:?}`,
    target: `{:?}`"#,
             op, args, upper_bounds, target,

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -268,7 +268,8 @@ fn assert_failed_inner(
         Some(args) => panic!(
             r#"assertion failed: `(left {} right)`
   left: `{:?}`,
- right: `{:?}`: {}"#,
+ right: `{:?}`,
+context: `{:?}`"#,
             op, left, right, args
         ),
         None => panic!(

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -217,17 +217,17 @@ pub enum AssertKind {
 #[doc(hidden)]
 pub fn assert_failed<T, U>(
     kind: AssertKind,
-    left_val: &T,
-    right_val: &U,
+    left: &T,
+    right: &U,
+    args: Option<fmt::Arguments<'_>>,
     left_name: &'static str,
     right_name: &'static str,
-    args: Option<fmt::Arguments<'_>>,
 ) -> !
 where
     T: fmt::Debug + ?Sized,
     U: fmt::Debug + ?Sized,
 {
-    assert_failed_inner(kind, &left_val, &right_val, &left_name, &right_name, args)
+    assert_failed_inner(kind, &left, &right, args, left_name, right_name)
 }
 
 /// Internal function for `assert_match!`
@@ -236,10 +236,10 @@ where
 #[track_caller]
 #[doc(hidden)]
 pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
-    left_val: &T,
-    left_name: &'static str,
+    left: &T,
     right: &'static str,
     args: Option<fmt::Arguments<'_>>,
+    left_name: &'static str,
 ) -> ! {
     // The pattern is a string so it can be displayed directly.
     struct Pattern<'a>(&'a str);
@@ -248,7 +248,7 @@ pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
             f.write_str(self.0)
         }
     }
-    assert_failed_inner(AssertKind::Match, &left_val, &Pattern(right), left_name, right, args);
+    assert_failed_inner(AssertKind::Match, &left, &Pattern(right), args, left_name, right);
 }
 
 /// Non-generic version of the above functions, to avoid code bloat.
@@ -257,11 +257,11 @@ pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
 #[track_caller]
 fn assert_failed_inner(
     kind: AssertKind,
-    left_val: &dyn fmt::Debug,
-    right_val: &dyn fmt::Debug,
+    left: &dyn fmt::Debug,
+    right: &dyn fmt::Debug,
+    args: Option<fmt::Arguments<'_>>,
     left_name: &'static str,
     right_name: &'static str,
-    args: Option<fmt::Arguments<'_>>,
 ) -> ! {
     let op = match kind {
         AssertKind::Eq => "==",
@@ -273,13 +273,13 @@ fn assert_failed_inner(
         Some(args) => panic!(
             r#"assertion failed: `({left_name} {op} {right_name})`
  error: {args}
-  left: `{left_val:?}`
- right: `{right_val:?}`"#
+  left: `{left:?}`
+ right: `{right:?}`"#
         ),
         None => panic!(
             r#"assertion failed: `({left_name} {op} {right_name})`
-  left: `{left_val:?}`
- right: `{right_val:?}`"#
+  left: `{left:?}`
+ right: `{right:?}`"#
         ),
     }
 }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -254,8 +254,8 @@ pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
 #[track_caller]
 fn assert_failed_inner(
     kind: AssertKind,
-    left: &dyn fmt::Debug,
-    right: &dyn fmt::Debug,
+    upper_bounds: &dyn fmt::Debug,
+    target: &dyn fmt::Debug,
     args: Option<fmt::Arguments<'_>>,
 ) -> ! {
     let op = match kind {
@@ -266,17 +266,17 @@ fn assert_failed_inner(
 
     match args {
         Some(args) => panic!(
-            r#"assertion failed: `(left {} right)`
-   left: `{:?}`,
-  right: `{:?}`,
-context: `{:?}`"#,
-            op, left, right, args
+            r#"assertion failed: `(upper_bounds {} target)`
+   Error: `{:?}`,        
+   upper_bounds: `{:?}`,
+   target: `{:?}`"#,
+            op, args, upper_bounds, target,
         ),
         None => panic!(
-            r#"assertion failed: `(left {} right)`
-  left: `{:?}`,
- right: `{:?}`"#,
-            op, left, right,
+            r#"assertion failed: `(upper_bounds {} target)`
+   upper_bounds: `{:?}`,
+   target: `{:?}`"#,
+            op, upper_bounds, target,
         ),
     }
 }

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -257,7 +257,11 @@ fn default_hook(info: &PanicInfo<'_>) {
     let name = thread.as_ref().and_then(|t| t.name()).unwrap_or("<unnamed>");
 
     let write = |err: &mut dyn crate::io::Write| {
-        let _ = writeln!(err, "thread '{name}' panicked at '{msg}', {location}");
+        if msg.contains('\n') {
+            let _ = writeln!(err, "thread '{name}' panicked at {location}:\n{msg}");
+        } else {
+            let _ = writeln!(err, "thread '{name}' panicked at '{msg}', {location}");
+        }
 
         static FIRST_PANIC: AtomicBool = AtomicBool::new(true);
 

--- a/src/tools/clippy/clippy_utils/src/macros.rs
+++ b/src/tools/clippy/clippy_utils/src/macros.rs
@@ -238,7 +238,8 @@ impl<'a> PanicExpn<'a> {
             "assert_failed" => {
                 // It should have 4 arguments in total (we already matched with the first argument,
                 // so we're just checking for 3)
-                if rest.len() != 3 {
+                // Since Rust 1.70, `assert_failed` has two additional args.
+                if rest.len() != 3 && rest.len() != 5 {
                     return None;
                 }
                 // `msg_arg` is either `None` (no custom message) or `Some(format_args!(..))` (custom message)

--- a/src/tools/clippy/clippy_utils/src/macros.rs
+++ b/src/tools/clippy/clippy_utils/src/macros.rs
@@ -239,7 +239,7 @@ impl<'a> PanicExpn<'a> {
                 // It should have 4 arguments in total (we already matched with the first argument,
                 // so we're just checking for 3)
                 // Since Rust 1.70, `assert_failed` has two additional args.
-                if rest.len() != 3 && rest.len() != 5 {
+                if rest.len() != 3 {
                     return None;
                 }
                 // `msg_arg` is either `None` (no custom message) or `Some(format_args!(..))` (custom message)

--- a/tests/mir-opt/issue_99325.main.built.after.mir
+++ b/tests/mir-opt/issue_99325.main.built.after.mir
@@ -20,67 +20,47 @@ fn main() -> () {
     let mut _12: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _13: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _14: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _18: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _19: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _20: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _21: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _22: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _23: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _24: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _25: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _26: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _27: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _28: (&&[u8], &&[u8; 4]);    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _29: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _30: &[u8];                      // in scope 0 at $DIR/issue_99325.rs:+2:16: +2:70
-    let mut _31: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _32: &[u8; 4];                   // in scope 0 at $DIR/issue_99325.rs:+2:72: +2:79
-    let _33: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _34: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _35: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _36: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _37: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _38: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _39: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _43: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _44: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _45: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _46: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _47: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _48: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _49: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _50: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _51: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _16: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _17: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _18: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _19: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _20: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _21: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _22: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _23: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _24: (&&[u8], &&[u8; 4]);    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _25: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _26: &[u8];                      // in scope 0 at $DIR/issue_99325.rs:+2:16: +2:70
+    let mut _27: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _28: &[u8; 4];                   // in scope 0 at $DIR/issue_99325.rs:+2:72: +2:79
+    let _29: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _30: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _31: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _32: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _33: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _34: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _35: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _37: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _38: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _39: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _40: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _41: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _42: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _43: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 {
         debug left_val => _8;            // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         debug right_val => _9;           // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        let _15: core::panicking::AssertKind; // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        let _15: &str;                   // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         scope 2 {
-            debug kind => _15;           // in scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-            let _16: &str;               // in scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-            scope 3 {
-                debug left_name => _16;  // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                let _17: &str;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                scope 4 {
-                    debug right_name => _17; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                }
-            }
+            debug assert => _15;         // in scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         }
     }
-    scope 5 {
-        debug left_val => _33;           // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        debug right_val => _34;          // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        let _40: core::panicking::AssertKind; // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        scope 6 {
-            debug kind => _40;           // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-            let _41: &str;               // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-            scope 7 {
-                debug left_name => _41;  // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                let _42: &str;           // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                scope 8 {
-                    debug right_name => _42; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                }
-            }
+    scope 3 {
+        debug left_val => _29;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        debug right_val => _30;          // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        let _36: &str;                   // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        scope 4 {
+            debug assert => _36;         // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         }
     }
 
@@ -134,41 +114,28 @@ fn main() -> () {
 
     bb3: {
         StorageLive(_15);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _15 = core::panicking::AssertKind::Eq; // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _15 = const "function_with_bytes::<b\"AAAA\">() == &[0x41, 0x41, 0x41, 0x41]"; // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
         FakeRead(ForLet(None), _15);     // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_16);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _16 = const "function_with_bytes::<b\"AAAA\">()"; // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_17);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _17 = &(*_15);                   // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_18);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_19);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _19 = &(*_8);                    // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _18 = &(*_19);                   // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_20);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_21);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _21 = &(*_9);                    // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _20 = &(*_21);                   // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_22);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _22 = Option::<Arguments<'_>>::None; // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _16 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _17, move _18, move _20, move _22) -> bb19; // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        FakeRead(ForLet(None), _16);     // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_17);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _17 = const "&[0x41, 0x41, 0x41, 0x41]"; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        FakeRead(ForLet(None), _17);     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_19);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _19 = move _15;                  // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_21);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _21 = &(*_8);                    // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _20 = &(*_21);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_22);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_23);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _23 = &(*_9);                    // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _22 = &(*_23);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_24);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _24 = Option::<Arguments<'_>>::None; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _25 = &(*_16);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_26);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _26 = &(*_17);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _18 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _19, move _20, move _22, move _24, move _25, move _26) -> bb19; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a &[u8], &'b &[u8; 4], Option<Arguments<'c>>, &'static str, &'static str) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(&'static str, &'a &[u8], &'b &[u8; 4], Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
     }
 
     bb4: {
@@ -176,16 +143,12 @@ fn main() -> () {
     }
 
     bb5: {
-        StorageDead(_26);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_24);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_22);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_19);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_23);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_21);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_17);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_22);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_20);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_18);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_17);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_21);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_19);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_16);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_15);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         unreachable;                     // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -213,11 +176,11 @@ fn main() -> () {
         StorageDead(_4);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_1);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_27);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_28);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_29);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_30);                // scope 0 at $DIR/issue_99325.rs:+2:16: +2:70
-        _30 = function_with_bytes::<&*b"AAAA">() -> [return: bb10, unwind: bb19]; // scope 0 at $DIR/issue_99325.rs:+2:16: +2:70
+        StorageLive(_23);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_24);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_25);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_26);                // scope 0 at $DIR/issue_99325.rs:+2:16: +2:70
+        _26 = function_with_bytes::<&*b"AAAA">() -> [return: bb10, unwind: bb19]; // scope 0 at $DIR/issue_99325.rs:+2:16: +2:70
                                          // mir::Constant
                                          // + span: $DIR/issue_99325.rs:11:16: 11:68
                                          // + user_ty: UserType(1)
@@ -225,122 +188,105 @@ fn main() -> () {
     }
 
     bb10: {
-        _29 = &_30;                      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_31);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_32);                // scope 0 at $DIR/issue_99325.rs:+2:72: +2:79
-        _32 = const b"AAAA";             // scope 0 at $DIR/issue_99325.rs:+2:72: +2:79
+        _25 = &_26;                      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_27);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_28);                // scope 0 at $DIR/issue_99325.rs:+2:72: +2:79
+        _28 = const b"AAAA";             // scope 0 at $DIR/issue_99325.rs:+2:72: +2:79
                                          // mir::Constant
                                          // + span: $DIR/issue_99325.rs:11:72: 11:79
                                          // + literal: Const { ty: &[u8; 4], val: Value(Scalar(alloc4)) }
-        _31 = &_32;                      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _28 = (move _29, move _31);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_31);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_29);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        FakeRead(ForMatchedPlace(None), _28); // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_33);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _33 = (_28.0: &&[u8]);           // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_34);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _34 = (_28.1: &&[u8; 4]);        // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_35);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_36);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_37);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _37 = &(*_33);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_38);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _38 = &(*_34);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _36 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _37, move _38) -> [return: bb11, unwind: bb19]; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _27 = &_28;                      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _24 = (move _25, move _27);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_27);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_25);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        FakeRead(ForMatchedPlace(None), _24); // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_29);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _29 = (_24.0: &&[u8]);           // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_30);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _30 = (_24.1: &&[u8; 4]);        // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_31);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_32);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_33);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _33 = &(*_29);                   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_34);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _34 = &(*_30);                   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _32 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _33, move _34) -> [return: bb11, unwind: bb19]; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &[u8], &'b &[u8; 4]) -> bool {<&[u8] as PartialEq<&[u8; 4]>>::eq}, val: Value(<ZST>) }
     }
 
     bb11: {
-        StorageDead(_38);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_37);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _35 = Not(move _36);             // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_36);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        switchInt(move _35) -> [0: bb13, otherwise: bb12]; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_34);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_33);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _31 = Not(move _32);             // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_32);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        switchInt(move _31) -> [0: bb13, otherwise: bb12]; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb12: {
-        StorageLive(_40);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _40 = core::panicking::AssertKind::Eq; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        FakeRead(ForLet(None), _40);     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_41);                // scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _41 = const "function_with_bytes::<{ &[0x41, 0x41, 0x41, 0x41] }>()"; // scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_36);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _36 = const "function_with_bytes::<{ &[0x41, 0x41, 0x41, 0x41] }>() == b\"AAAA\""; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        FakeRead(ForLet(None), _41);     // scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_42);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _42 = const "b\"AAAA\"";         // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        FakeRead(ForLet(None), _36);     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_37);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_38);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _38 = &(*_36);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_39);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_40);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _40 = &(*_29);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _39 = &(*_40);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_41);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_42);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _42 = &(*_30);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _41 = &(*_42);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_43);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _43 = Option::<Arguments<'_>>::None; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _37 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _38, move _39, move _41, move _43) -> bb19; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        FakeRead(ForLet(None), _42);     // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_43);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_44);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _44 = move _40;                  // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_45);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_46);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _46 = &(*_33);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _45 = &(*_46);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_47);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_48);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _48 = &(*_34);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _47 = &(*_48);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_49);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _49 = Option::<Arguments<'_>>::None; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_50);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _50 = &(*_41);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_51);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _51 = &(*_42);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _43 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _44, move _45, move _47, move _49, move _50, move _51) -> bb19; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a &[u8], &'b &[u8; 4], Option<Arguments<'c>>, &'static str, &'static str) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(&'static str, &'a &[u8], &'b &[u8; 4], Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
     }
 
     bb13: {
-        goto -> bb16;                    // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        goto -> bb16;                    // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb14: {
-        StorageDead(_51);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_50);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_49);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_47);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_45);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_44);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_48);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_46);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_43);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_42);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_41);                // scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_40);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        unreachable;                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_43);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_41);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_39);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_38);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_42);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_40);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_37);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_36);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        unreachable;                     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb15: {
-        goto -> bb17;                    // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        goto -> bb17;                    // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb16: {
-        _27 = const ();                  // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        goto -> bb17;                    // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _23 = const ();                  // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        goto -> bb17;                    // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb17: {
-        StorageDead(_35);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_34);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_33);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_31);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_30);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_29);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         goto -> bb18;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb18: {
-        StorageDead(_32);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_30);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_28);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_27);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_26);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_24);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_23);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _0 = const ();                   // scope 0 at $DIR/issue_99325.rs:+0:15: +3:2
         return;                          // scope 0 at $DIR/issue_99325.rs:+3:2: +3:2
     }

--- a/tests/mir-opt/issue_99325.main.built.after.mir
+++ b/tests/mir-opt/issue_99325.main.built.after.mir
@@ -20,47 +20,67 @@ fn main() -> () {
     let mut _12: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _13: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _14: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _16: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _17: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _18: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _19: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _20: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _21: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _22: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _23: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _24: (&&[u8], &&[u8; 4]);    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _25: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _26: &[u8];                      // in scope 0 at $DIR/issue_99325.rs:+2:16: +2:70
-    let mut _27: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _28: &[u8; 4];                   // in scope 0 at $DIR/issue_99325.rs:+2:72: +2:79
-    let _29: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _30: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _31: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _32: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _33: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _34: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _35: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _37: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _38: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _39: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _40: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _41: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _42: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _43: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _18: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _19: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _20: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _21: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _22: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _23: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _24: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _25: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _26: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _27: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _28: (&&[u8], &&[u8; 4]);    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _29: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _30: &[u8];                      // in scope 0 at $DIR/issue_99325.rs:+2:16: +2:70
+    let mut _31: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _32: &[u8; 4];                   // in scope 0 at $DIR/issue_99325.rs:+2:72: +2:79
+    let _33: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _34: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _35: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _36: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _37: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _38: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _39: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _43: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _44: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _45: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _46: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _47: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _48: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _49: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _50: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _51: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 {
         debug left_val => _8;            // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         debug right_val => _9;           // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         let _15: core::panicking::AssertKind; // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         scope 2 {
             debug kind => _15;           // in scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+            let _16: &str;               // in scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+            scope 3 {
+                debug left_name => _16;  // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                let _17: &str;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                scope 4 {
+                    debug right_name => _17; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                }
+            }
         }
     }
-    scope 3 {
-        debug left_val => _29;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        debug right_val => _30;          // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        let _36: core::panicking::AssertKind; // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        scope 4 {
-            debug kind => _36;           // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    scope 5 {
+        debug left_val => _33;           // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        debug right_val => _34;          // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        let _40: core::panicking::AssertKind; // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        scope 6 {
+            debug kind => _40;           // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+            let _41: &str;               // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+            scope 7 {
+                debug left_name => _41;  // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                let _42: &str;           // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                scope 8 {
+                    debug right_name => _42; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                }
+            }
         }
     }
 
@@ -117,22 +137,38 @@ fn main() -> () {
         _15 = core::panicking::AssertKind::Eq; // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         FakeRead(ForLet(None), _15);     // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_16);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_17);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _17 = move _15;                  // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_18);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_19);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _19 = &(*_8);                    // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _18 = &(*_19);                   // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_20);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_21);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _21 = &(*_9);                    // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _20 = &(*_21);                   // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_22);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _22 = Option::<Arguments<'_>>::None; // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _16 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _17, move _18, move _20, move _22) -> bb19; // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _16 = const "function_with_bytes::<b\"AAAA\">()"; // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a &[u8], &'b &[u8; 4], Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
+        FakeRead(ForLet(None), _16);     // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_17);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _17 = const "&[0x41, 0x41, 0x41, 0x41]"; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
+        FakeRead(ForLet(None), _17);     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_19);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _19 = move _15;                  // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_21);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _21 = &(*_8);                    // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _20 = &(*_21);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_22);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_23);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _23 = &(*_9);                    // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _22 = &(*_23);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_24);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _24 = &(*_16);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _25 = &(*_17);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_26);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _26 = Option::<Arguments<'_>>::None; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _18 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _19, move _20, move _22, move _24, move _25, move _26) -> bb19; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a &[u8], &'b &[u8; 4], &'static str, &'static str, Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
     }
 
     bb4: {
@@ -140,12 +176,16 @@ fn main() -> () {
     }
 
     bb5: {
-        StorageDead(_22);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_20);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_18);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_17);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_21);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_19);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_26);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_24);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_22);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_19);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_23);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_21);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_17);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_16);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_15);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         unreachable;                     // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -173,11 +213,11 @@ fn main() -> () {
         StorageDead(_4);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_1);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_23);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_24);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_25);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_26);                // scope 0 at $DIR/issue_99325.rs:+2:16: +2:70
-        _26 = function_with_bytes::<&*b"AAAA">() -> [return: bb10, unwind: bb19]; // scope 0 at $DIR/issue_99325.rs:+2:16: +2:70
+        StorageLive(_27);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_28);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_29);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_30);                // scope 0 at $DIR/issue_99325.rs:+2:16: +2:70
+        _30 = function_with_bytes::<&*b"AAAA">() -> [return: bb10, unwind: bb19]; // scope 0 at $DIR/issue_99325.rs:+2:16: +2:70
                                          // mir::Constant
                                          // + span: $DIR/issue_99325.rs:11:16: 11:68
                                          // + user_ty: UserType(1)
@@ -185,102 +225,122 @@ fn main() -> () {
     }
 
     bb10: {
-        _25 = &_26;                      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_27);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_28);                // scope 0 at $DIR/issue_99325.rs:+2:72: +2:79
-        _28 = const b"AAAA";             // scope 0 at $DIR/issue_99325.rs:+2:72: +2:79
+        _29 = &_30;                      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_31);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_32);                // scope 0 at $DIR/issue_99325.rs:+2:72: +2:79
+        _32 = const b"AAAA";             // scope 0 at $DIR/issue_99325.rs:+2:72: +2:79
                                          // mir::Constant
                                          // + span: $DIR/issue_99325.rs:11:72: 11:79
                                          // + literal: Const { ty: &[u8; 4], val: Value(Scalar(alloc4)) }
-        _27 = &_28;                      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _24 = (move _25, move _27);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_27);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_25);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        FakeRead(ForMatchedPlace(None), _24); // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_29);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _29 = (_24.0: &&[u8]);           // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_30);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _30 = (_24.1: &&[u8; 4]);        // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_31);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_32);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_33);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _33 = &(*_29);                   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_34);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _34 = &(*_30);                   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _32 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _33, move _34) -> [return: bb11, unwind: bb19]; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _31 = &_32;                      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _28 = (move _29, move _31);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_31);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_29);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        FakeRead(ForMatchedPlace(None), _28); // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_33);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _33 = (_28.0: &&[u8]);           // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_34);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _34 = (_28.1: &&[u8; 4]);        // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_35);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_36);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_37);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _37 = &(*_33);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_38);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _38 = &(*_34);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _36 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _37, move _38) -> [return: bb11, unwind: bb19]; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // + literal: Const { ty: for<'a, 'b> fn(&'a &[u8], &'b &[u8; 4]) -> bool {<&[u8] as PartialEq<&[u8; 4]>>::eq}, val: Value(<ZST>) }
     }
 
     bb11: {
-        StorageDead(_34);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_33);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _31 = Not(move _32);             // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_32);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        switchInt(move _31) -> [0: bb13, otherwise: bb12]; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_38);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_37);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _35 = Not(move _36);             // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_36);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        switchInt(move _35) -> [0: bb13, otherwise: bb12]; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb12: {
-        StorageLive(_36);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _36 = core::panicking::AssertKind::Eq; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        FakeRead(ForLet(None), _36);     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_37);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_38);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _38 = move _36;                  // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_39);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_40);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _40 = &(*_29);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _39 = &(*_40);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_41);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_42);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _42 = &(*_30);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _41 = &(*_42);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_43);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _43 = Option::<Arguments<'_>>::None; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _37 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _38, move _39, move _41, move _43) -> bb19; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_40);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _40 = core::panicking::AssertKind::Eq; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        FakeRead(ForLet(None), _40);     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_41);                // scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _41 = const "function_with_bytes::<{ &[0x41, 0x41, 0x41, 0x41] }>()"; // scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a &[u8], &'b &[u8; 4], Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
+        FakeRead(ForLet(None), _41);     // scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_42);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _42 = const "b\"AAAA\"";         // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
+        FakeRead(ForLet(None), _42);     // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_43);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_44);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _44 = move _40;                  // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_45);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_46);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _46 = &(*_33);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _45 = &(*_46);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_47);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_48);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _48 = &(*_34);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _47 = &(*_48);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_49);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _49 = &(*_41);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_50);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _50 = &(*_42);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_51);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _51 = Option::<Arguments<'_>>::None; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _43 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _44, move _45, move _47, move _49, move _50, move _51) -> bb19; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a &[u8], &'b &[u8; 4], &'static str, &'static str, Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
     }
 
     bb13: {
-        goto -> bb16;                    // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        goto -> bb16;                    // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb14: {
-        StorageDead(_43);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_41);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_39);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_38);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_42);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_40);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_37);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_36);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        unreachable;                     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_51);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_50);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_49);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_47);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_45);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_44);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_48);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_46);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_43);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_42);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_41);                // scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_40);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        unreachable;                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb15: {
-        goto -> bb17;                    // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        goto -> bb17;                    // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb16: {
-        _23 = const ();                  // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        goto -> bb17;                    // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _27 = const ();                  // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        goto -> bb17;                    // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb17: {
-        StorageDead(_31);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_30);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_29);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_35);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_34);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_33);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         goto -> bb18;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb18: {
+        StorageDead(_32);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_30);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_28);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_26);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_24);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_23);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_27);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _0 = const ();                   // scope 0 at $DIR/issue_99325.rs:+0:15: +3:2
         return;                          // scope 0 at $DIR/issue_99325.rs:+3:2: +3:2
     }

--- a/tests/mir-opt/issue_99325.main.built.after.mir
+++ b/tests/mir-opt/issue_99325.main.built.after.mir
@@ -26,9 +26,9 @@ fn main() -> () {
     let _21: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _22: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _23: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _24: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _24: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _25: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _26: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _26: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _27: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _28: (&&[u8], &&[u8; 4]);    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _29: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -48,9 +48,9 @@ fn main() -> () {
     let _46: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _47: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _48: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _49: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _49: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _50: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _51: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _51: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 {
         debug left_val => _8;            // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         debug right_val => _9;           // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -160,15 +160,15 @@ fn main() -> () {
         _23 = &(*_9);                    // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _22 = &(*_23);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_24);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _24 = &(*_16);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _24 = Option::<Arguments<'_>>::None; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _25 = &(*_17);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _25 = &(*_16);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_26);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _26 = Option::<Arguments<'_>>::None; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _26 = &(*_17);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _18 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _19, move _20, move _22, move _24, move _25, move _26) -> bb19; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a &[u8], &'b &[u8; 4], &'static str, &'static str, Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a &[u8], &'b &[u8; 4], Option<Arguments<'c>>, &'static str, &'static str) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
     }
 
     bb4: {
@@ -289,15 +289,15 @@ fn main() -> () {
         _48 = &(*_34);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _47 = &(*_48);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_49);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _49 = &(*_41);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _49 = Option::<Arguments<'_>>::None; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_50);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _50 = &(*_42);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _50 = &(*_41);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_51);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _51 = Option::<Arguments<'_>>::None; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _51 = &(*_42);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _43 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _44, move _45, move _47, move _49, move _50, move _51) -> bb19; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a &[u8], &'b &[u8; 4], &'static str, &'static str, Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a &[u8], &'b &[u8; 4], Option<Arguments<'c>>, &'static str, &'static str) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
     }
 
     bb13: {

--- a/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+++ b/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
@@ -23,13 +23,15 @@ fn array_casts() -> () {
     let mut _24: usize;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _25: usize;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _26: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _28: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _29: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _30: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _31: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _30: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _31: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _32: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _33: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _34: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _34: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _35: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _36: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _37: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _38: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 {
         debug x => _1;                   // in scope 1 at $DIR/retag.rs:+1:9: +1:14
         let _2: *mut usize;              // in scope 1 at $DIR/retag.rs:+2:9: +2:10
@@ -45,7 +47,7 @@ fn array_casts() -> () {
                     debug p => _9;       // in scope 5 at $DIR/retag.rs:+6:9: +6:10
                     let _20: &usize;     // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                     let _21: &usize;     // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                    let mut _35: &usize; // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                    let mut _39: &usize; // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                     scope 6 {
                     }
                     scope 7 {
@@ -54,6 +56,14 @@ fn array_casts() -> () {
                         let _27: core::panicking::AssertKind; // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                         scope 8 {
                             debug kind => _27; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                            let _28: &str; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                            scope 9 {
+                                debug left_name => _28; // in scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                let _29: &str; // in scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                scope 10 {
+                                    debug right_name => _29; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                }
+                            }
                         }
                     }
                 }
@@ -116,12 +126,12 @@ fn array_casts() -> () {
         _15 = (*_16);                    // scope 6 at $DIR/retag.rs:+7:25: +7:34
         _14 = &_15;                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _35 = const _;                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _39 = const _;                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // + literal: Const { ty: &usize, val: Unevaluated(array_casts, [], Some(promoted[0])) }
-        Retag(_35);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _18 = &(*_35);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag(_39);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _18 = &(*_39);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _13 = (move _14, move _18);      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         Retag(_13);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -150,23 +160,39 @@ fn array_casts() -> () {
         StorageLive(_27);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _27 = core::panicking::AssertKind::Eq; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_28);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_29);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _29 = move _27;                  // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_30);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_31);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _31 = &(*_20);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _30 = &(*_31);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_32);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_33);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _33 = &(*_21);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _32 = &(*_33);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_34);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _34 = Option::<Arguments<'_>>::None; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        Retag(_34);                      // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _28 = core::panicking::assert_failed::<usize, usize>(move _29, move _30, move _32, move _34); // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _28 = const "unsafe { *p.add(1) }"; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a usize, &'b usize, Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<usize, usize>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
+        Retag(_28);                      // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_29);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _29 = const "1";                 // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
+        Retag(_29);                      // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_30);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_31);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _31 = move _27;                  // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_32);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_33);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _33 = &(*_20);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _32 = &(*_33);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_34);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_35);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _35 = &(*_21);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _34 = &(*_35);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_36);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _36 = &(*_28);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_37);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _37 = &(*_29);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_38);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _38 = Option::<Arguments<'_>>::None; // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag(_38);                      // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _30 = core::panicking::assert_failed::<usize, usize>(move _31, move _32, move _34, move _36, move _37, move _38); // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a usize, &'b usize, &'static str, &'static str, Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<usize, usize>}, val: Value(<ZST>) }
     }
 
     bb4: {

--- a/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+++ b/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
@@ -23,15 +23,13 @@ fn array_casts() -> () {
     let mut _24: usize;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _25: usize;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _26: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _30: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _31: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _28: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _29: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _30: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _31: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _32: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _33: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _34: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _35: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _36: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _37: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _38: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _34: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 {
         debug x => _1;                   // in scope 1 at $DIR/retag.rs:+1:9: +1:14
         let _2: *mut usize;              // in scope 1 at $DIR/retag.rs:+2:9: +2:10
@@ -47,23 +45,15 @@ fn array_casts() -> () {
                     debug p => _9;       // in scope 5 at $DIR/retag.rs:+6:9: +6:10
                     let _20: &usize;     // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                     let _21: &usize;     // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                    let mut _39: &usize; // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                    let mut _35: &usize; // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                     scope 6 {
                     }
                     scope 7 {
                         debug left_val => _20; // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                         debug right_val => _21; // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                        let _27: core::panicking::AssertKind; // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                        let _27: &str;   // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                         scope 8 {
-                            debug kind => _27; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                            let _28: &str; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                            scope 9 {
-                                debug left_name => _28; // in scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                let _29: &str; // in scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                scope 10 {
-                                    debug right_name => _29; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                }
-                            }
+                            debug assert => _27; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                         }
                     }
                 }
@@ -126,12 +116,12 @@ fn array_casts() -> () {
         _15 = (*_16);                    // scope 6 at $DIR/retag.rs:+7:25: +7:34
         _14 = &_15;                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _39 = const _;                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _35 = const _;                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // + literal: Const { ty: &usize, val: Unevaluated(array_casts, [], Some(promoted[0])) }
-        Retag(_39);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _18 = &(*_39);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag(_35);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _18 = &(*_35);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _13 = (move _14, move _18);      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         Retag(_13);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -158,41 +148,29 @@ fn array_casts() -> () {
 
     bb3: {
         StorageLive(_27);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _27 = core::panicking::AssertKind::Eq; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _27 = const "unsafe { *p.add(1) } == 1"; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
+        Retag(_27);                      // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_28);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _28 = const "unsafe { *p.add(1) }"; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_29);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _29 = &(*_27);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_30);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_31);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _31 = &(*_20);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _30 = &(*_31);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_32);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_33);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _33 = &(*_21);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _32 = &(*_33);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_34);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _34 = Option::<Arguments<'_>>::None; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag(_34);                      // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _28 = core::panicking::assert_failed::<usize, usize>(move _29, move _30, move _32, move _34); // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        Retag(_28);                      // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_29);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _29 = const "1";                 // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        Retag(_29);                      // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_30);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_31);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _31 = move _27;                  // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_32);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_33);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _33 = &(*_20);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _32 = &(*_33);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_34);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_35);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _35 = &(*_21);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _34 = &(*_35);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_36);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _36 = Option::<Arguments<'_>>::None; // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        Retag(_36);                      // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_37);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _37 = &(*_28);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_38);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _38 = &(*_29);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _30 = core::panicking::assert_failed::<usize, usize>(move _31, move _32, move _34, move _36, move _37, move _38); // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a usize, &'b usize, Option<Arguments<'c>>, &'static str, &'static str) -> ! {core::panicking::assert_failed::<usize, usize>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(&'static str, &'a usize, &'b usize, Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<usize, usize>}, val: Value(<ZST>) }
     }
 
     bb4: {

--- a/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+++ b/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
@@ -29,9 +29,9 @@ fn array_casts() -> () {
     let _33: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _34: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _35: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _36: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _36: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _37: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _38: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _38: &str;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 {
         debug x => _1;                   // in scope 1 at $DIR/retag.rs:+1:9: +1:14
         let _2: *mut usize;              // in scope 1 at $DIR/retag.rs:+2:9: +2:10
@@ -183,16 +183,16 @@ fn array_casts() -> () {
         _35 = &(*_21);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _34 = &(*_35);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_36);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _36 = &(*_28);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _36 = Option::<Arguments<'_>>::None; // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag(_36);                      // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_37);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _37 = &(*_29);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _37 = &(*_28);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_38);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _38 = Option::<Arguments<'_>>::None; // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        Retag(_38);                      // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _38 = &(*_29);                   // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _30 = core::panicking::assert_failed::<usize, usize>(move _31, move _32, move _34, move _36, move _37, move _38); // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a usize, &'b usize, &'static str, &'static str, Option<Arguments<'c>>) -> ! {core::panicking::assert_failed::<usize, usize>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a usize, &'b usize, Option<Arguments<'c>>, &'static str, &'static str) -> ! {core::panicking::assert_failed::<usize, usize>}, val: Value(<ZST>) }
     }
 
     bb4: {

--- a/tests/ui/macros/assert-eq-macro-msg.rs
+++ b/tests/ui/macros/assert-eq-macro-msg.rs
@@ -1,7 +1,9 @@
 // run-fail
-// error-pattern:panicked at 'assertion failed: `(left == right)`
-// error-pattern: left: `2`
-// error-pattern:right: `3`: 1 + 1 definitely should be 3'
+// error-pattern:thread 'main' panicked at
+// error-pattern:assertion failed: `(1 + 1 == 3)`
+// error-pattern: error: 1 + 1 definitely should be 3
+// error-pattern:  left: `2`
+// error-pattern: right: `3`
 // ignore-emscripten no processes
 
 fn main() {

--- a/tests/ui/macros/assert-eq-macro-msg.rs
+++ b/tests/ui/macros/assert-eq-macro-msg.rs
@@ -1,9 +1,5 @@
 // run-fail
-// error-pattern:thread 'main' panicked at
-// error-pattern:assertion failed: `(1 + 1 == 3)`
-// error-pattern: error: 1 + 1 definitely should be 3
-// error-pattern:  left: `2`
-// error-pattern: right: `3`
+// check-run-results
 // ignore-emscripten no processes
 
 fn main() {

--- a/tests/ui/macros/assert-eq-macro-msg.run.stderr
+++ b/tests/ui/macros/assert-eq-macro-msg.run.stderr
@@ -1,0 +1,6 @@
+thread 'main' panicked at $DIR/assert-eq-macro-msg.rs:6:5:
+assertion failed: `(1 + 1 == 3)`
+ error: 1 + 1 definitely should be 3
+  left: `2`
+ right: `3`
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/macros/assert-eq-macro-msg.run.stderr
+++ b/tests/ui/macros/assert-eq-macro-msg.run.stderr
@@ -1,5 +1,5 @@
 thread 'main' panicked at $DIR/assert-eq-macro-msg.rs:6:5:
-assertion failed: `(1 + 1 == 3)`
+assertion failed: `1 + 1 == 3`
  error: 1 + 1 definitely should be 3
   left: `2`
  right: `3`

--- a/tests/ui/macros/assert-eq-macro-panic.rs
+++ b/tests/ui/macros/assert-eq-macro-panic.rs
@@ -1,8 +1,5 @@
 // run-fail
-// error-pattern:thread 'main' panicked at
-// error-pattern:assertion failed: `(14 == 15)`
-// error-pattern: left: `14`
-// error-pattern:right: `15`
+// check-run-results
 // ignore-emscripten no processes
 
 fn main() {

--- a/tests/ui/macros/assert-eq-macro-panic.rs
+++ b/tests/ui/macros/assert-eq-macro-panic.rs
@@ -1,5 +1,6 @@
 // run-fail
-// error-pattern:assertion failed: `(left == right)`
+// error-pattern:thread 'main' panicked at
+// error-pattern:assertion failed: `(14 == 15)`
 // error-pattern: left: `14`
 // error-pattern:right: `15`
 // ignore-emscripten no processes

--- a/tests/ui/macros/assert-eq-macro-panic.run.stderr
+++ b/tests/ui/macros/assert-eq-macro-panic.run.stderr
@@ -1,5 +1,5 @@
 thread 'main' panicked at $DIR/assert-eq-macro-panic.rs:6:5:
-assertion failed: `(14 == 15)`
+assertion failed: `14 == 15`
   left: `14`
  right: `15`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/macros/assert-eq-macro-panic.run.stderr
+++ b/tests/ui/macros/assert-eq-macro-panic.run.stderr
@@ -1,0 +1,5 @@
+thread 'main' panicked at $DIR/assert-eq-macro-panic.rs:6:5:
+assertion failed: `(14 == 15)`
+  left: `14`
+ right: `15`
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/macros/assert-eq-macro-vars.rs
+++ b/tests/ui/macros/assert-eq-macro-vars.rs
@@ -3,6 +3,6 @@
 // ignore-emscripten no processes
 
 fn main() {
-    let var = 1;
+    let var = 2;
     assert_eq!(var * 2, 3);
 }

--- a/tests/ui/macros/assert-eq-macro-vars.rs
+++ b/tests/ui/macros/assert-eq-macro-vars.rs
@@ -3,5 +3,6 @@
 // ignore-emscripten no processes
 
 fn main() {
-    assert_ne!(14, 14);
+    let var = 1;
+    assert_eq!(var * 2, 3);
 }

--- a/tests/ui/macros/assert-eq-macro-vars.run.stderr
+++ b/tests/ui/macros/assert-eq-macro-vars.run.stderr
@@ -1,0 +1,5 @@
+thread 'main' panicked at $DIR/assert-eq-macro-vars.rs:7:5:
+assertion failed: `(var * 2 == 3)`
+  left: `2`
+ right: `3`
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/macros/assert-eq-macro-vars.run.stderr
+++ b/tests/ui/macros/assert-eq-macro-vars.run.stderr
@@ -1,5 +1,5 @@
 thread 'main' panicked at $DIR/assert-eq-macro-vars.rs:7:5:
-assertion failed: `(var * 2 == 3)`
-  left: `2`
+assertion failed: `var * 2 == 3`
+  left: `4`
  right: `3`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/macros/assert-matches-macro-msg.rs
+++ b/tests/ui/macros/assert-matches-macro-msg.rs
@@ -1,7 +1,9 @@
 // run-fail
-// error-pattern:panicked at 'assertion failed: `(left matches right)`
-// error-pattern: left: `2`
-// error-pattern:right: `3`: 1 + 1 definitely should be 3'
+// error-pattern:thread 'main' panicked at
+// error-pattern:assertion failed: `(1 + 1 matches 3)`
+// error-pattern: error: 1 + 1 definitely should be 3
+// error-pattern:  left: `2`
+// error-pattern: right: `3`
 // ignore-emscripten no processes
 
 #![feature(assert_matches)]

--- a/tests/ui/macros/assert-matches-macro-msg.rs
+++ b/tests/ui/macros/assert-matches-macro-msg.rs
@@ -1,9 +1,5 @@
 // run-fail
-// error-pattern:thread 'main' panicked at
-// error-pattern:assertion failed: `(1 + 1 matches 3)`
-// error-pattern: error: 1 + 1 definitely should be 3
-// error-pattern:  left: `2`
-// error-pattern: right: `3`
+// check-run-results
 // ignore-emscripten no processes
 
 #![feature(assert_matches)]

--- a/tests/ui/macros/assert-matches-macro-msg.run.stderr
+++ b/tests/ui/macros/assert-matches-macro-msg.run.stderr
@@ -1,0 +1,6 @@
+thread 'main' panicked at $DIR/assert-matches-macro-msg.rs:10:5:
+assertion failed: `(1 + 1 matches 3)`
+ error: 1 + 1 definitely should be 3
+  left: `2`
+ right: `3`
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/macros/assert-matches-macro-msg.run.stderr
+++ b/tests/ui/macros/assert-matches-macro-msg.run.stderr
@@ -1,5 +1,5 @@
 thread 'main' panicked at $DIR/assert-matches-macro-msg.rs:10:5:
-assertion failed: `(1 + 1 matches 3)`
+assertion failed: `1 + 1 matches 3`
  error: 1 + 1 definitely should be 3
   left: `2`
  right: `3`

--- a/tests/ui/macros/assert-ne-macro-msg.rs
+++ b/tests/ui/macros/assert-ne-macro-msg.rs
@@ -1,9 +1,5 @@
 // run-fail
-// error-pattern:thread 'main' panicked at
-// error-pattern:assertion failed: `(1 + 1 != 2)`
-// error-pattern: error: 1 + 1 definitely should not be 2
-// error-pattern:  left: `2`
-// error-pattern: right: `2`
+// check-run-results
 // ignore-emscripten no processes
 
 fn main() {

--- a/tests/ui/macros/assert-ne-macro-msg.rs
+++ b/tests/ui/macros/assert-ne-macro-msg.rs
@@ -1,7 +1,9 @@
 // run-fail
-// error-pattern:panicked at 'assertion failed: `(left != right)`
-// error-pattern: left: `2`
-// error-pattern:right: `2`: 1 + 1 definitely should not be 2'
+// error-pattern:thread 'main' panicked at
+// error-pattern:assertion failed: `(1 + 1 != 2)`
+// error-pattern: error: 1 + 1 definitely should not be 2
+// error-pattern:  left: `2`
+// error-pattern: right: `2`
 // ignore-emscripten no processes
 
 fn main() {

--- a/tests/ui/macros/assert-ne-macro-msg.run.stderr
+++ b/tests/ui/macros/assert-ne-macro-msg.run.stderr
@@ -1,5 +1,5 @@
 thread 'main' panicked at $DIR/assert-ne-macro-msg.rs:6:5:
-assertion failed: `(1 + 1 != 2)`
+assertion failed: `1 + 1 != 2`
  error: 1 + 1 definitely should not be 2
   left: `2`
  right: `2`

--- a/tests/ui/macros/assert-ne-macro-msg.run.stderr
+++ b/tests/ui/macros/assert-ne-macro-msg.run.stderr
@@ -1,0 +1,6 @@
+thread 'main' panicked at $DIR/assert-ne-macro-msg.rs:6:5:
+assertion failed: `(1 + 1 != 2)`
+ error: 1 + 1 definitely should not be 2
+  left: `2`
+ right: `2`
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/macros/assert-ne-macro-panic.rs
+++ b/tests/ui/macros/assert-ne-macro-panic.rs
@@ -1,5 +1,6 @@
 // run-fail
-// error-pattern:assertion failed: `(left != right)`
+// error-pattern:thread 'main' panicked at
+// error-pattern:assertion failed: `(14 != 14)`
 // error-pattern: left: `14`
 // error-pattern:right: `14`
 // ignore-emscripten no processes

--- a/tests/ui/macros/assert-ne-macro-panic.run.stderr
+++ b/tests/ui/macros/assert-ne-macro-panic.run.stderr
@@ -1,0 +1,5 @@
+thread 'main' panicked at $DIR/assert-ne-macro-panic.rs:6:5:
+assertion failed: `(14 != 14)`
+  left: `14`
+ right: `14`
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/macros/assert-ne-macro-panic.run.stderr
+++ b/tests/ui/macros/assert-ne-macro-panic.run.stderr
@@ -1,5 +1,5 @@
 thread 'main' panicked at $DIR/assert-ne-macro-panic.rs:6:5:
-assertion failed: `(14 != 14)`
+assertion failed: `14 != 14`
   left: `14`
  right: `14`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/test-attrs/test-panic-abort-nocapture.run.stderr
+++ b/tests/ui/test-attrs/test-panic-abort-nocapture.run.stderr
@@ -1,10 +1,10 @@
 thread 'main' panicked at $DIR/test-panic-abort-nocapture.rs:33:5:
-assertion failed: `(1 + 1 == 4)`
+assertion failed: `1 + 1 == 4`
   left: `2`
  right: `4`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread 'main' panicked at $DIR/test-panic-abort-nocapture.rs:27:5:
-assertion failed: `(1 + 1 == 4)`
+assertion failed: `1 + 1 == 4`
   left: `2`
  right: `4`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/test-attrs/test-panic-abort-nocapture.run.stderr
+++ b/tests/ui/test-attrs/test-panic-abort-nocapture.run.stderr
@@ -1,11 +1,11 @@
 thread 'main' panicked at $DIR/test-panic-abort-nocapture.rs:33:5:
 assertion failed: `(1 + 1 == 4)`
-  left: `2`,
+  left: `2`
  right: `4`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread 'main' panicked at $DIR/test-panic-abort-nocapture.rs:27:5:
 assertion failed: `(1 + 1 == 4)`
-  left: `2`,
+  left: `2`
  right: `4`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 testing321

--- a/tests/ui/test-attrs/test-panic-abort-nocapture.run.stderr
+++ b/tests/ui/test-attrs/test-panic-abort-nocapture.run.stderr
@@ -1,9 +1,11 @@
-thread 'main' panicked at 'assertion failed: `(left == right)`
+thread 'main' panicked at $DIR/test-panic-abort-nocapture.rs:33:5:
+assertion failed: `(1 + 1 == 4)`
   left: `2`,
- right: `4`', $DIR/test-panic-abort-nocapture.rs:33:5
+ right: `4`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-thread 'main' panicked at 'assertion failed: `(left == right)`
+thread 'main' panicked at $DIR/test-panic-abort-nocapture.rs:27:5:
+assertion failed: `(1 + 1 == 4)`
   left: `2`,
- right: `4`', $DIR/test-panic-abort-nocapture.rs:27:5
+ right: `4`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 testing321

--- a/tests/ui/test-attrs/test-panic-abort.run.stdout
+++ b/tests/ui/test-attrs/test-panic-abort.run.stdout
@@ -17,7 +17,7 @@ testing123
 ---- it_fails stderr ----
 testing321
 thread 'main' panicked at $DIR/test-panic-abort.rs:34:5:
-assertion failed: `(1 + 1 == 5)`
+assertion failed: `1 + 1 == 5`
   left: `2`
  right: `5`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/test-attrs/test-panic-abort.run.stdout
+++ b/tests/ui/test-attrs/test-panic-abort.run.stdout
@@ -18,7 +18,7 @@ testing123
 testing321
 thread 'main' panicked at $DIR/test-panic-abort.rs:34:5:
 assertion failed: `(1 + 1 == 5)`
-  left: `2`,
+  left: `2`
  right: `5`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 

--- a/tests/ui/test-attrs/test-panic-abort.run.stdout
+++ b/tests/ui/test-attrs/test-panic-abort.run.stdout
@@ -16,9 +16,10 @@ hello, world
 testing123
 ---- it_fails stderr ----
 testing321
-thread 'main' panicked at 'assertion failed: `(left == right)`
+thread 'main' panicked at $DIR/test-panic-abort.rs:34:5:
+assertion failed: `(1 + 1 == 5)`
   left: `2`,
- right: `5`', $DIR/test-panic-abort.rs:34:5
+ right: `5`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 


### PR DESCRIPTION
This takes over the stale #94016 by @MakitaToki (thx for amazing work!), and addresses comments by @yaahc. The code was rebased on the primary branch, preserving the history/contributions.

Fixes #94005

```rust
assert_eq!(1 + 1, 3, "this is clearly correct!");
```

```plain
thread 'main' panicked at $DIR/assert-eq-macro-msg.rs:6:5:
assertion failed: `1 + 1 == 3`
 error: this is clearly correct!
  left: `2`
 right: `3`
```

Note that there is a simpler alternative #111071 which does not improve the `assertion failed` message, only the formatting of the entire output.