### PR TITLE
Ping Nadrieril when changing exhaustiveness checking

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -367,6 +367,10 @@ cc = ["@lcnr", "@compiler-errors"]
 message = "Some changes occurred in diagnostic error codes"
 cc = ["@GuillaumeGomez"]
 
+[mentions."compiler/rustc_mir_build/src/thir/pattern"]
+message = "Some changes might have occurred in exhaustiveness checking"
+cc = ["@Nadrieril"]
+
 [mentions."library"]
 message = """
 Hey! It looks like you've submitted a new PR for the library teams!


### PR DESCRIPTION
Hi!

I don't know what the procedure is but I'd quite like to be pinged when people try to change the exhaustiveness code. It's a tricky piece of code and I'm the de facto expert on it; I'd like to be available to provide feedback to contributors who wish to change it. I occasionally look through the git history and open PRs but a triagebot ping would be much more convenient.

The message says "might have" because `check_match.rs` contains a little bit of exhaustiveness logic and a lot of other match-related checks, so this ping will have false positives.