### PR TITLE
Close parentheses for `offset_of` in AST pretty printing

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -566,7 +566,7 @@ impl<'a> State<'a> {
                         self.print_ident(field);
                     }
                 }
-
+                self.pclose();
                 self.end();
             }
             ast::ExprKind::MacCall(m) => self.print_mac(m),

--- a/tests/pretty/offset_of.rs
+++ b/tests/pretty/offset_of.rs
@@ -1,0 +1,4 @@
+// pp-exact
+#![feature(offset_of)]
+
+fn main() { std::mem::offset_of!(std :: ops :: Range < usize >, end); }


### PR DESCRIPTION
HIR pretty printing already handles it correctly.

This will conflict with #110694 but it seems like that PR is gonna take bit more time.