### PR TITLE
Leave promoteds untainted by errors when borrowck fails

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -616,13 +616,10 @@ fn promoted_mir(tcx: TyCtxt<'_>, def: LocalDefId) -> &IndexVec<Promoted, Body<'_
         return tcx.arena.alloc(IndexVec::new());
     }
 
-    let tainted_by_errors = tcx.mir_borrowck(def).tainted_by_errors;
+    tcx.ensure_with_value().mir_borrowck(def);
     let mut promoted = tcx.mir_promoted(def).1.steal();
 
     for body in &mut promoted {
-        if let Some(error_reported) = tainted_by_errors {
-            body.tainted_by_errors = Some(error_reported);
-        }
         run_analysis_to_runtime_passes(tcx, body);
     }
 

--- a/tests/ui/borrowck/tainted-promoteds.rs
+++ b/tests/ui/borrowck/tainted-promoteds.rs
@@ -1,0 +1,12 @@
+// Regression test for issue #110856, where a borrowck error for a MIR tainted
+// all promoteds within. This in turn generated a spurious "erroneous constant
+// used" note when trying to evaluate a promoted.
+
+pub fn f() -> u32 {
+    let a = 0;
+    a = &0 * &1 * &2 * &3;
+    //~^ ERROR: cannot assign twice to immutable variable
+    a
+}
+
+fn main() {}

--- a/tests/ui/borrowck/tainted-promoteds.stderr
+++ b/tests/ui/borrowck/tainted-promoteds.stderr
@@ -1,0 +1,14 @@
+error[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/tainted-promoteds.rs:7:5
+   |
+LL |     let a = 0;
+   |         -
+   |         |
+   |         first assignment to `a`
+   |         help: consider making this binding mutable: `mut a`
+LL |     a = &0 * &1 * &2 * &3;
+   |     ^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0384`.


### PR DESCRIPTION
Previously, when borrowck failed it would taint all promoteds within the MIR body. An attempt to evaluated the promoteds would subsequently fail with spurious "note: erroneous constant used". For example:

```console
...
note: erroneous constant used
 --> tests/ui/borrowck/tainted-promoteds.rs:7:9
  |
7 |     a = &0 * &1 * &2 * &3;
  |         ^^

note: erroneous constant used
 --> tests/ui/borrowck/tainted-promoteds.rs:7:14
  |
7 |     a = &0 * &1 * &2 * &3;
  |              ^^

note: erroneous constant used
 --> tests/ui/borrowck/tainted-promoteds.rs:7:19
  |
7 |     a = &0 * &1 * &2 * &3;
  |                   ^^

note: erroneous constant used
 --> tests/ui/borrowck/tainted-promoteds.rs:7:24
  |
7 |     a = &0 * &1 * &2 * &3;
  |                        ^^
```

Borrowck failure doesn't indicate that there is anything wrong with promoteds. Leave them untainted.

Fixes #110856.