### PR TITLE
Encode def span for foreign return-position `impl Trait` in trait

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -837,11 +837,12 @@ fn should_encode_span(def_kind: DefKind) -> bool {
         | DefKind::AnonConst
         | DefKind::InlineConst
         | DefKind::OpaqueTy
+        | DefKind::ImplTraitPlaceholder
         | DefKind::Field
         | DefKind::Impl { .. }
         | DefKind::Closure
         | DefKind::Generator => true,
-        DefKind::ForeignMod | DefKind::ImplTraitPlaceholder | DefKind::GlobalAsm => false,
+        DefKind::ForeignMod | DefKind::GlobalAsm => false,
     }
 }
 

--- a/tests/ui/impl-trait/in-trait/auxiliary/rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/auxiliary/rpitit.rs
@@ -5,10 +5,10 @@
 use std::ops::Deref;
 
 pub trait Foo {
-    fn bar() -> impl Deref<Target = impl Sized>;
+    fn bar(self) -> impl Deref<Target = impl Sized>;
 }
 
 pub struct Foreign;
 impl Foo for Foreign {
-    fn bar() -> &'static () { &() }
+    fn bar(self) -> &'static () { &() }
 }

--- a/tests/ui/impl-trait/in-trait/foreign-dyn-error.rs
+++ b/tests/ui/impl-trait/in-trait/foreign-dyn-error.rs
@@ -1,0 +1,8 @@
+// aux-build: rpitit.rs
+
+extern crate rpitit;
+
+fn main() {
+    let _: &dyn rpitit::Foo = todo!();
+    //~^ ERROR the trait `Foo` cannot be made into an object
+}

--- a/tests/ui/impl-trait/in-trait/foreign-dyn-error.stderr
+++ b/tests/ui/impl-trait/in-trait/foreign-dyn-error.stderr
@@ -1,0 +1,15 @@
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/foreign-dyn-error.rs:6:12
+   |
+LL |     let _: &dyn rpitit::Foo = todo!();
+   |            ^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/auxiliary/rpitit.rs:8:21
+   |
+LL |     fn bar(self) -> impl Deref<Target = impl Sized>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait cannot be made into an object because method `bar` references an `impl Trait` type in its return type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/in-trait/foreign.rs
+++ b/tests/ui/impl-trait/in-trait/foreign.rs
@@ -5,17 +5,18 @@
 
 extern crate rpitit;
 
+use rpitit::{Foo, Foreign};
 use std::sync::Arc;
 
 // Implement an RPITIT from another crate.
 struct Local;
-impl rpitit::Foo for Local {
-    fn bar() -> Arc<String> { Arc::new(String::new()) }
+impl Foo for Local {
+    fn bar(self) -> Arc<String> { Arc::new(String::new()) }
 }
 
 fn main() {
     // Witness an RPITIT from another crate.
-    let &() = <rpitit::Foreign as rpitit::Foo>::bar();
+    let &() = Foreign.bar();
 
-    let x: Arc<String> = <Local as rpitit::Foo>::bar();
+    let x: Arc<String> = Local.bar();
 }


### PR DESCRIPTION
Fixes #111031, yet another def-span encoding issue :/

Includes a smaller repro than the issue, but I can confirm it ICEs:

```
query stack during panic:
#0 [def_span] looking up span for `rpitit::Foo::bar::{opaque#0}`
#1 [object_safety_violations] determining object safety of trait `rpitit::Foo`
#2 [check_is_object_safe] checking if trait `rpitit::Foo` is object safe
#3 [typeck] type-checking `main`
#4 [used_trait_imports] finding used_trait_imports `main`
#5 [analysis] running analysis passes on this crate
```

Luckily since this only affects nightly, this desn't need to be backported.