### PR TITLE
Add `#[no_coverage]` to the test harness's `fn main`

### DIFF
--- a/compiler/rustc_builtin_macros/src/test_harness.rs
+++ b/compiler/rustc_builtin_macros/src/test_harness.rs
@@ -232,7 +232,7 @@ fn generate_test_harness(
     let expn_id = ext_cx.resolver.expansion_for_ast_pass(
         DUMMY_SP,
         AstPass::TestHarness,
-        &[sym::test, sym::rustc_attrs],
+        &[sym::test, sym::rustc_attrs, sym::no_coverage],
         None,
     );
     let def_site = DUMMY_SP.with_def_site_ctxt(expn_id.to_expn_id());
@@ -313,6 +313,8 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> P<ast::Item> {
 
     // #[rustc_main]
     let main_attr = ecx.attr_word(sym::rustc_main, sp);
+    // #[no_coverage]
+    let no_coverage_attr = ecx.attr_word(sym::no_coverage, sp);
 
     // pub fn main() { ... }
     let main_ret_ty = ecx.ty(sp, ast::TyKind::Tup(ThinVec::new()));
@@ -342,7 +344,7 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> P<ast::Item> {
 
     let main = P(ast::Item {
         ident: main_id,
-        attrs: thin_vec![main_attr],
+        attrs: thin_vec![main_attr, no_coverage_attr],
         id: ast::DUMMY_NODE_ID,
         kind: main,
         vis: ast::Visibility { span: sp, kind: ast::VisibilityKind::Public, tokens: None },

--- a/tests/pretty/tests-are-sorted.pp
+++ b/tests/pretty/tests-are-sorted.pp
@@ -79,6 +79,7 @@ pub const a_test: test::TestDescAndFn =
     };
 fn a_test() {}
 #[rustc_main]
+#[no_coverage]
 pub fn main() -> () {
     extern crate test;
     test::test_main_static(&[&a_test, &m_test, &z_test])

--- a/tests/run-make/coverage-reports/expected_show_coverage.test_harness.txt
+++ b/tests/run-make/coverage-reports/expected_show_coverage.test_harness.txt
@@ -1,0 +1,11 @@
+    1|       |// Verify that the entry point injected by the test harness doesn't cause
+    2|       |// weird artifacts in the coverage report (e.g. issue #10749).
+    3|       |
+    4|       |// compile-flags: --test
+    5|       |
+    6|       |#[allow(dead_code)]
+    7|      0|fn unused() {}
+    8|       |
+    9|      1|#[test]
+   10|      1|fn my_test() {}
+

--- a/tests/run-make/coverage/test_harness.rs
+++ b/tests/run-make/coverage/test_harness.rs
@@ -1,0 +1,10 @@
+// Verify that the entry point injected by the test harness doesn't cause
+// weird artifacts in the coverage report (e.g. issue #10749).
+
+// compile-flags: --test
+
+#[allow(dead_code)]
+fn unused() {}
+
+#[test]
+fn my_test() {}


### PR DESCRIPTION
There are two main motivations for adding `#[no_coverage]` to the test harness's entry point:

- The entry point is trivial compiler-generated code that doesn't correspond to user source, and it always runs, so there's no value in instrumenting it for coverage.
- Because it has dummy spans, it causes the instrumentor implementation to emit invalid coverage mappings that confuse `llvm-cov` and result in strange coverage reports.

Fixes #110749.